### PR TITLE
fix(auth): support regional Google domains for SID cookie extraction

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -243,12 +243,8 @@ def _is_allowed_auth_domain(domain: str) -> bool:
     Returns:
         True if domain is allowed for auth cookies.
     """
-    # Exact match against primary allowlist (includes notebooklm.google.com, etc.)
-    if domain in ALLOWED_COOKIE_DOMAINS:
-        return True
-
-    # Check if it's a valid Google domain (base or regional)
-    return _is_google_domain(domain)
+    # Check if domain is in the primary allowlist or is a valid Google domain (base or regional)
+    return domain in ALLOWED_COOKIE_DOMAINS or _is_google_domain(domain)
 
 
 def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str]:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1020,7 +1020,7 @@ class TestExtractCookiesRegionalDomains:
 class TestLoadHttpxCookiesRegional:
     """Test load_httpx_cookies with regional Google domains."""
 
-    def test_loads_cookies_from_regional_domain(self):
+    def test_loads_cookies_from_regional_domain(self, tmp_path):
         """Test loading httpx cookies from regional Google domain."""
         storage_state = {
             "cookies": [
@@ -1029,24 +1029,14 @@ class TestLoadHttpxCookiesRegional:
             ]
         }
 
-        import json
-        import tempfile
-        from pathlib import Path
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text(json.dumps(storage_state))
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json.dump(storage_state, f)
-            temp_path = Path(f.name)
-
-        try:
-            cookies = load_httpx_cookies(path=temp_path)
-            assert cookies.get("SID", domain=".google.co.uk") == "sid_from_uk"
-        finally:
-            temp_path.unlink()
+        cookies = load_httpx_cookies(path=storage_file)
+        assert cookies.get("SID", domain=".google.co.uk") == "sid_from_uk"
 
     def test_loads_cookies_from_all_regional_patterns(self, tmp_path):
         """Test loading httpx cookies from all regional patterns."""
-        import json
-
         # Test with .google.de (single ccTLD)
         storage_state = {
             "cookies": [


### PR DESCRIPTION
## Summary
- Fix "Missing required cookies: {'SID'}" error for users in regional Google domains
- Add `GOOGLE_REGIONAL_CCTLDS` whitelist with 70+ regional domains
- Create unified `_is_google_domain()` function for consistent validation
- Update both `_is_allowed_auth_domain` and `_is_allowed_cookie_domain`

Fixes #20

## Regional Domain Support

| Pattern | Examples | Countries |
|---------|----------|-----------|
| `.google.com.XX` | .google.com.sg, .google.com.au | Singapore, Australia, Brazil, etc. |
| `.google.co.XX` | .google.co.uk, .google.co.jp | UK, Japan, India, Korea, etc. |
| `.google.XX` | .google.de, .google.fr | Germany, France, Italy, Spain, etc. |

## Security

Uses whitelist approach (safer than regex):
- Only explicit domains in `GOOGLE_REGIONAL_CCTLDS` accepted
- Leading dot required (`.google.com` not `google.com`)
- Case-sensitive matching (browsers normalize to lowercase)
- No subdomain leakage (`evil.google.de` rejected)

## Test plan
- [x] 128 unit tests for auth module (+65 new tests)
- [x] Parametrized tests for all 70+ regional domains
- [x] Edge case tests (uppercase, whitespace, malformed, suffix exploits)
- [x] Integration tests for cookie extraction and httpx cookies
- [x] All 1101 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)