### PR TITLE
fix: prioritize .google.com cookies over regional domains

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -273,7 +273,10 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
         if _is_allowed_auth_domain(domain):
             name = cookie.get("name")
             if name:
-                cookies[name] = cookie.get("value", "")
+                # Prioritize .google.com cookies over regional domains (e.g., .google.de)
+                # to prevent wrong cookie values when the same name exists in multiple domains
+                if name not in cookies or domain == ".google.com":
+                    cookies[name] = cookie.get("value", "")
 
     missing = MINIMUM_REQUIRED_COOKIES - set(cookies.keys())
     if missing:


### PR DESCRIPTION
## Problem

When users have cookies from multiple Google domains (e.g., both `.google.com` and `.google.de`), the same cookie name like `NID` can exist with different values. The previous implementation would simply overwrite cookies as it iterated through the storage state, causing regional domain cookies to override the correct `.google.com` cookies.

This resulted in authentication failures with the error:
```
Authentication expired or invalid. Redirected to: https://accounts.google.com/...
```

## Root Cause

In `extract_cookies_from_storage()`, cookies were stored in a dict by name only:
```python
cookies[name] = cookie.get("value", "")
```

When multiple cookies with the same name existed (from different domains), the last one would win. If `.google.de`'s `NID` cookie came after `.google.com`'s, the wrong value would be used.

## Solution

Prioritize `.google.com` domain cookies over regional domains:
```python
if name not in cookies or domain == ".google.com":
    cookies[name] = cookie.get("value", "")
```

This ensures:
1. First cookie of each name is kept (unless overridden by `.google.com`)
2. `.google.com` cookies always take priority over regional domains

## Testing

Verified locally with a storage state containing both `.google.com` and `.google.de` NID cookies. Before the fix: authentication failed. After the fix: `notebooklm list` works correctly.