### PR TITLE
feat(types): add FAILED status (code 4) for artifact generation failures

### DIFF
--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -119,12 +119,14 @@ class ArtifactStatus(int, Enum):
     PROCESSING = 1  # Artifact is being generated
     PENDING = 2  # Artifact is queued
     COMPLETED = 3  # Artifact is ready for use/download
+    FAILED = 4  # Generation failed
 
 
 _ARTIFACT_STATUS_MAP: dict[int, str] = {
     ArtifactStatus.PROCESSING: "in_progress",
     ArtifactStatus.PENDING: "pending",
     ArtifactStatus.COMPLETED: "completed",
+    ArtifactStatus.FAILED: "failed",
 }
 
 
@@ -138,7 +140,7 @@ def artifact_status_to_str(status_code: int) -> str:
         status_code: Numeric status from API response (artifact_data[4]).
 
     Returns:
-        String status: "in_progress", "pending", "completed", or "unknown".
+        String status: "in_progress", "pending", "completed", "failed", or "unknown".
         Returns "unknown" for unrecognized codes (future-proofing).
     """
     return _ARTIFACT_STATUS_MAP.get(status_code, "unknown")

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -31,6 +31,7 @@ from .exceptions import (
 
 # Re-export enums from rpc/types.py for convenience
 from .rpc.types import (
+    ArtifactStatus,
     AudioFormat,
     AudioLength,
     ChatGoal,
@@ -249,6 +250,7 @@ __all__ = [
     "SourceType",
     "ArtifactType",
     # Re-exported enums (configuration/RPC)
+    "ArtifactStatus",
     "StudioContentType",
     "AudioFormat",
     "AudioLength",
@@ -575,7 +577,7 @@ class Artifact:
         id: Unique artifact identifier.
         title: Artifact title.
         kind: Artifact type as ArtifactType enum (str enum, comparable to strings).
-        status: Processing status (1=processing, 2=pending, 3=completed).
+        status: Processing status (1=processing, 2=pending, 3=completed, 4=failed).
         created_at: When the artifact was created.
         url: Download URL (if available).
 
@@ -588,7 +590,7 @@ class Artifact:
     id: str
     title: str
     _artifact_type: int = field(repr=False)  # StudioContentType enum value
-    status: int  # 1=processing, 2=pending, 3=completed
+    status: int  # 1=processing, 2=pending, 3=completed, 4=failed
     created_at: datetime | None = None
     url: str | None = None
     _variant: int | None = field(default=None, repr=False)  # For type 4: 1=flashcards, 2=quiz
@@ -699,25 +701,30 @@ class Artifact:
 
     @property
     def is_completed(self) -> bool:
-        """Check if artifact generation is complete (status=3)."""
-        return self.status == 3
+        """Check if artifact generation is complete (status=COMPLETED)."""
+        return self.status == ArtifactStatus.COMPLETED
 
     @property
     def is_processing(self) -> bool:
-        """Check if artifact is being generated (status=1)."""
-        return self.status == 1
+        """Check if artifact is being generated (status=PROCESSING)."""
+        return self.status == ArtifactStatus.PROCESSING
 
     @property
     def is_pending(self) -> bool:
-        """Check if artifact is queued/transitional (status=2)."""
-        return self.status == 2
+        """Check if artifact is queued/transitional (status=PENDING)."""
+        return self.status == ArtifactStatus.PENDING
+
+    @property
+    def is_failed(self) -> bool:
+        """Check if artifact generation failed (status=FAILED)."""
+        return self.status == ArtifactStatus.FAILED
 
     @property
     def status_str(self) -> str:
         """Get human-readable status string.
 
         Returns:
-            "in_progress", "pending", "completed", or "unknown".
+            "in_progress", "pending", "completed", "failed", or "unknown".
         """
         return artifact_status_to_str(self.status)
 

--- a/tests/unit/test_rpc_types.py
+++ b/tests/unit/test_rpc_types.py
@@ -110,10 +110,15 @@ class TestArtifactStatusToStr:
         assert artifact_status_to_str(ArtifactStatus.COMPLETED) == "completed"
         assert artifact_status_to_str(3) == "completed"
 
+    def test_failed_status(self):
+        """Test status code 4 (FAILED) returns 'failed'."""
+        assert artifact_status_to_str(ArtifactStatus.FAILED) == "failed"
+        assert artifact_status_to_str(4) == "failed"
+
     def test_unknown_status_codes(self):
         """Test unknown status codes return 'unknown'."""
         assert artifact_status_to_str(0) == "unknown"
-        assert artifact_status_to_str(4) == "unknown"
+        assert artifact_status_to_str(5) == "unknown"
         assert artifact_status_to_str(99) == "unknown"
         assert artifact_status_to_str(-1) == "unknown"
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -357,16 +357,28 @@ class TestArtifact:
         assert processing.is_pending is False
         assert completed.is_pending is False
 
+    def test_is_failed_property(self):
+        """Test is_failed property for status=4 (generation failed)."""
+        failed = Artifact.from_api_response(["id", "title", 1, None, 4])
+        processing = Artifact.from_api_response(["id", "title", 1, None, 1])
+        completed = Artifact.from_api_response(["id", "title", 1, None, 3])
+
+        assert failed.is_failed is True
+        assert processing.is_failed is False
+        assert completed.is_failed is False
+
     def test_status_str_property(self):
         """Test status_str property returns correct human-readable strings."""
         processing = Artifact.from_api_response(["id", "title", 1, None, 1])
         pending = Artifact.from_api_response(["id", "title", 1, None, 2])
         completed = Artifact.from_api_response(["id", "title", 1, None, 3])
+        failed = Artifact.from_api_response(["id", "title", 1, None, 4])
         unknown = Artifact.from_api_response(["id", "title", 1, None, 99])
 
         assert processing.status_str == "in_progress"
         assert pending.status_str == "pending"
         assert completed.status_str == "completed"
+        assert failed.status_str == "failed"
         assert unknown.status_str == "unknown"
 
     def test_report_subtype_briefing_doc(self):


### PR DESCRIPTION
## Summary

- Add `FAILED = 4` to `ArtifactStatus` enum for properly recognizing failed artifact generation
- Add `is_failed` property to `Artifact` class for easy status checking  
- Export `ArtifactStatus` enum from `types.py` for user convenience
- Replace magic numbers (1, 2, 3, 4) with enum constants in status properties
- Add comprehensive test coverage for new status

## Context

When artifact generation fails, Google's NotebookLM API returns status code 4. Previously this mapped to "unknown" since only codes 1-3 were recognized. Now the library properly detects failed artifacts, matching what the UI shows as "generation failed".

## Test plan

- [x] Unit tests for `ArtifactStatus.FAILED` enum mapping
- [x] Unit tests for `artifact_status_to_str(4)` returning "failed"
- [x] Unit tests for `Artifact.is_failed` property
- [x] Unit tests for `Artifact.status_str` including failed
- [x] Pre-commit checks pass (ruff, mypy, pytest)

🤖 Generated with [Claude Code](https://claude.ai/code)