### PR TITLE
fix(scripts): use correct params for GET_SUGGESTED_REPORTS in health check

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -412,11 +412,14 @@ def get_test_params(method: RPCMethod, notebook_id: str | None) -> list[Any] | N
     if method in (
         RPCMethod.GET_NOTEBOOK,
         RPCMethod.GET_SOURCE_GUIDE,
-        RPCMethod.GET_SUGGESTED_REPORTS,
         RPCMethod.GET_SHARE_STATUS,
         RPCMethod.REMOVE_RECENTLY_VIEWED,
     ):
         return [notebook_id]
+
+    # GET_SUGGESTED_REPORTS has special params: [[2], notebook_id]
+    if method == RPCMethod.GET_SUGGESTED_REPORTS:
+        return [[2], notebook_id]
 
     # Methods that take [[notebook_id]] as the only param
     if method in (


### PR DESCRIPTION
## Summary

- Fix `GET_SUGGESTED_REPORTS` params in `check_rpc_health.py` to use `[[2], notebook_id]` instead of `[notebook_id]`
- This aligns with the implementation in `_artifacts.py::suggest_reports()`

## Context

This fix was discovered during the RPC alias cleanup in PR #65. The health check was using the wrong param format which would cause the RPC call to fail or return incorrect results.

## Test plan

- [x] Ruff format/lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)