### PR TITLE
fix(scripts): handle null response in RPC health check

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -344,6 +344,14 @@ async def test_rpc_method_with_data(
             found_ids=[],
             error=error,
         ), None
+    if response_text is None:
+        return CheckResult(
+            method=method,
+            status=CheckStatus.ERROR,
+            expected_id=expected_id,
+            found_ids=[],
+            error="Empty response from server",
+        ), None
 
     try:
         cleaned = strip_anti_xssi(response_text)


### PR DESCRIPTION
## Summary
- Add null check for `response_text` in `make_rpc_call()` to prevent `AttributeError` when the server returns an empty/null response

## Problem
The RPC health check script crashed with:
```
AttributeError: 'NoneType' object has no attribute 'startswith'
  File ".../check_rpc_health.py", line 264, in make_rpc_call
    cleaned = strip_anti_xssi(response_text)
```

This caused the CI to fail and incorrectly create issue #69 with title "RPC ID Mismatch Detected" when there was no actual RPC ID mismatch - just a missing null check.

## Fix
Added a defensive check for `response_text is None` before calling `strip_anti_xssi()`.

## Test plan
- [ ] CI passes
- [ ] Manually verified the fix handles the edge case

Fixes #69

🤖 Generated with [Claude Code](https://claude.ai/code)