### PR TITLE
fix(sources): correct get_guide response parsing for 3-level nesting

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -631,19 +631,22 @@ class SourcesAPI:
             allow_null=True,
         )
 
-        # Parse response structure: [[null, [summary], [keywords]]]
+        # Parse response structure: [[[null, [summary], [[keywords]], []]]]
+        # Real API returns 3 levels of nesting before the data array
         summary = ""
         keywords: list[str] = []
 
         if result and isinstance(result, list) and len(result) > 0:
-            inner = result[0]
-            if isinstance(inner, list):
-                # Summary at [1][0]
-                if len(inner) > 1 and isinstance(inner[1], list) and len(inner[1]) > 0:
-                    summary = inner[1][0] if isinstance(inner[1][0], str) else ""
-                # Keywords at [2][0]
-                if len(inner) > 2 and isinstance(inner[2], list) and len(inner[2]) > 0:
-                    keywords = inner[2][0] if isinstance(inner[2][0], list) else []
+            outer = result[0]
+            if isinstance(outer, list) and len(outer) > 0:
+                inner = outer[0]
+                if isinstance(inner, list):
+                    # Summary at [1][0]
+                    if len(inner) > 1 and isinstance(inner[1], list) and len(inner[1]) > 0:
+                        summary = inner[1][0] if isinstance(inner[1][0], str) else ""
+                    # Keywords at [2][0]
+                    if len(inner) > 2 and isinstance(inner[2], list) and len(inner[2]) > 0:
+                        keywords = inner[2][0] if isinstance(inner[2][0], list) else []
 
         return {"summary": summary, "keywords": keywords}
 

--- a/tests/e2e/test_sources.py
+++ b/tests/e2e/test_sources.py
@@ -104,6 +104,10 @@ class TestSourceRetrieval:
         assert isinstance(guide, dict)
         assert "summary" in guide
         assert "keywords" in guide
+        # Verify values are actually populated (not empty due to parsing bugs)
+        assert guide["summary"], "Expected non-empty summary from source guide"
+        assert isinstance(guide["keywords"], list)
+        assert len(guide["keywords"]) > 0, "Expected non-empty keywords from source guide"
 
 
 @requires_auth

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -351,13 +351,17 @@ class TestSourcesAPI:
         build_rpc_response,
     ):
         """Test getting source guide."""
+        # Real API returns 3 levels of nesting: [[[null, [summary], [[keywords]], []]]]
         response = build_rpc_response(
             RPCMethod.GET_SOURCE_GUIDE,
             [
                 [
-                    None,
-                    ["This is a **summary** of the source content..."],
-                    [["keyword1", "keyword2", "keyword3"]],
+                    [
+                        None,
+                        ["This is a **summary** of the source content..."],
+                        [["keyword1", "keyword2", "keyword3"]],
+                        [],
+                    ]
                 ]
             ],
         )
@@ -369,6 +373,7 @@ class TestSourcesAPI:
         assert "summary" in guide
         assert "keywords" in guide
         assert "**summary**" in guide["summary"]
+        assert guide["keywords"] == ["keyword1", "keyword2", "keyword3"]
 
     @pytest.mark.asyncio
     async def test_get_guide_empty(
@@ -378,7 +383,8 @@ class TestSourcesAPI:
         build_rpc_response,
     ):
         """Test getting guide for source with no AI analysis."""
-        response = build_rpc_response(RPCMethod.GET_SOURCE_GUIDE, [[None, [], []]])
+        # Real API returns 3 levels of nesting even for empty responses
+        response = build_rpc_response(RPCMethod.GET_SOURCE_GUIDE, [[[None, [], [], []]]])
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -146,6 +146,10 @@ class TestSourcesAPI:
                 pytest.skip("No sources available")
             guide = await client.sources.get_guide(READONLY_NOTEBOOK_ID, sources[0].id)
         assert guide is not None
+        # Verify values are actually populated (catches parsing bugs like issue #70)
+        assert guide["summary"], "Expected non-empty summary from source guide"
+        assert isinstance(guide["keywords"], list)
+        assert len(guide["keywords"]) > 0, "Expected non-empty keywords from source guide"
 
     @pytest.mark.vcr
     @pytest.mark.asyncio

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -129,11 +129,15 @@ class TestGetSourceGuide:
     @pytest.mark.asyncio
     async def test_get_source_guide_parses_response(self, mock_client):
         """Test get_source_guide correctly parses API response."""
+        # Real API returns 3 levels of nesting: [[[null, [summary], [[keywords]], []]]]
         mock_response = [
             [
-                None,
-                ["This is a **summary** of the document."],
-                [["Topic 1", "Topic 2", "Topic 3"]],
+                [
+                    None,
+                    ["This is a **summary** of the document."],
+                    [["Topic 1", "Topic 2", "Topic 3"]],
+                    [],
+                ]
             ]
         ]
         mock_client._core.rpc_call = AsyncMock(return_value=mock_response)


### PR DESCRIPTION
## Summary
- Fix `client.sources.get_guide()` returning empty `summary` and `keywords` fields
- The API returns responses with 3 levels of array nesting `[[[null, [summary], [[keywords]], []]]]` but the parser only unwrapped 2 levels
- Add additional array unwrapping level in the parsing code
- Update all test mocks to match real API response structure
- Add non-empty value assertions to E2E and VCR tests to catch future regressions

## Root Cause
The real API response structure is:
```
[[[null, ["summary..."], [["keyword1", "keyword2"]], []]]]
```

The old parsing code did `result[0]` expecting the data at that level, but the actual data is at `result[0][0]`.

## Test plan
- [x] All 1396 tests pass
- [x] VCR test validates against real recorded API response
- [x] Pre-commit checks pass (ruff format, ruff check, mypy)
- [ ] E2E test validates against live API (requires auth)

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)