### PR TITLE
Fix Windows CLI hanging due to asyncio ProactorEventLoop

### DIFF
--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -23,6 +23,7 @@ LLM-friendly design:
   notebooklm ask "what are the key themes?"
 """
 
+import asyncio
 import logging
 import os
 import sys
@@ -124,11 +125,16 @@ cli.add_command(language)
 
 
 def main():
-    # Force UTF-8 encoding for Unicode output on non-English Windows systems
-    # Prevents UnicodeEncodeError when displaying Unicode characters (✓, ✗, box drawing)
-    # on systems with legacy encodings (cp950, cp932, cp936, etc.)
+    # Windows-specific fixes
     if sys.platform == "win32":
+        # Force UTF-8 encoding for Unicode output on non-English Windows systems
+        # Prevents UnicodeEncodeError when displaying Unicode characters (✓, ✗, box drawing)
+        # on systems with legacy encodings (cp950, cp932, cp936, etc.)
         os.environ.setdefault("PYTHONUTF8", "1")
+
+        # Fix asyncio hanging issue - use WindowsSelectorEventLoopPolicy instead of
+        # default ProactorEventLoop to avoid IOCP blocking on network operations
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     cli()
 


### PR DESCRIPTION
Fixes #75

## Issue

CLI commands hang indefinitely on Windows after successful authentication. Affects all network-based commands: `list`, `create`, `source add`, `generate`, etc.

## Symptoms

```bash
$ notebooklm list
# Hangs forever with no output or error
```

Debug output shows successful authentication followed by hang:
```
DEBUG [notebooklm.auth] Authentication tokens obtained successfully
# Then nothing - process hangs
```

## Root Cause

Python's default `ProactorEventLoop` on Windows blocks indefinitely at `_overlapped.GetQueuedCompletionStatus()` during IOCP (I/O Completion Port) operations. This is a known Windows asyncio issue affecting network requests.

## Solution

Switch to `WindowsSelectorEventLoopPolicy` on Windows platforms. This event loop implementation is more reliable for network I/O on Windows.

## Testing

Tested on Windows 11 with Chinese locale:
- ✅ `notebooklm list` completes in <5 seconds (was hanging indefinitely)
- ✅ All CLI commands work correctly
- ✅ No impact on Linux/macOS (fix is Windows-specific)
- ✅ No breaking changes

## Impact

This is a critical bug fix that makes the CLI unusable on Windows systems. Without this fix, users must create wrapper scripts to work around the issue.