### PR TITLE
test: add type instance checks to VCR integration tests

### DIFF
--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -70,8 +70,8 @@ def assert_list_of_type(items: list, item_type: type, description: str = "") -> 
 
 def assert_references(references: list) -> None:
     """Assert that all references are valid ChatReference objects with required fields."""
+    assert_list_of_type(references, ChatReference, "of references")
     for ref in references:
-        assert isinstance(ref, ChatReference)
         assert ref.source_id is not None
         assert ref.citation_number is not None
 
@@ -1635,8 +1635,8 @@ class TestChatReferencesAPI:
             )
 
             # Verify type and that all reference source IDs exist in the notebook
+            assert_list_of_type(result.references, ChatReference)
             for ref in result.references:
-                assert isinstance(ref, ChatReference)
                 assert ref.source_id in source_ids, (
                     f"Reference source_id {ref.source_id} not found in notebook"
                 )
@@ -1653,7 +1653,7 @@ class TestChatReferencesAPI:
             )
 
             if result.references:
-                assert_list_of_type(result.references, ChatReference)
+                assert_references(result.references)
                 citation_numbers = [ref.citation_number for ref in result.references]
                 # Should be sequential starting from 1
                 assert citation_numbers == list(range(1, len(citation_numbers) + 1))


### PR DESCRIPTION
## Summary

Improve VCR integration tests to better match E2E test patterns by adding proper type instance checks.

### Changes:
- Add imports for type classes (`Artifact`, `ChatReference`, `GenerationStatus`, `Note`, `Notebook`, `Source`)
- Add `isinstance` checks for list operations (notebooks, sources, notes, artifacts)
- Add `isinstance` checks for get/create/update operations
- Update `_assert_generation_started` to validate actual status values (`"pending"`, `"in_progress"`) and handle rate limiting
- Add `ChatReference` type checks in chat reference tests
- Add helper functions (`assert_list_of_type`, `assert_references`) to reduce code duplication

### Benefits:
- Catches type parsing mismatches that could go undetected with just list/None checks
- Improves test reliability by verifying return types
- Better parity between VCR and E2E tests

## Test plan

- [x] All VCR tests pass (85 passed, 6 skipped)
- [x] Full test suite passes (1444 passed, 6 skipped)
- [x] Ruff format/lint passes
- [x] Mypy type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)