### PR TITLE
fix(e2e): add 15-second delay between generation tests to avoid rate limits

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,5 +1,6 @@
 """E2E test fixtures and configuration."""
 
+import logging
 import os
 import warnings
 from collections.abc import AsyncGenerator
@@ -115,7 +116,7 @@ def pytest_runtest_teardown(item, nextitem):
     import time
 
     # Only add delay for generation tests
-    if "test_generation.py" not in str(item.fspath):
+    if item.fspath.name != "test_generation.py":
         return
 
     # Only add delay if using generation_notebook_id fixture
@@ -127,6 +128,9 @@ def pytest_runtest_teardown(item, nextitem):
         return
 
     # Add delay to spread out API calls
+    logging.info(
+        "Delaying %ss between generation tests to avoid rate limiting", GENERATION_TEST_DELAY
+    )
     time.sleep(GENERATION_TEST_DELAY)
 
 


### PR DESCRIPTION
## Summary

Fixes rate limit failures in nightly E2E tests for infographic and slide deck generation.

- Add `GENERATION_TEST_DELAY = 15.0` constant
- Add `pytest_runtest_teardown` hook that adds delay between generation tests
- Delay only applies to tests using `generation_notebook_id` fixture in `test_generation.py`

## Root Cause

The CI test account was hitting Google's rate limits when running 10 generation tests in quick succession. Infographics and slide decks are expensive operations that require more compute time.

**Evidence:**
- Tests pass locally (different account, no rate limit)
- Tests fail consistently in CI after 3 retries
- Error: "Generation failed - no artifact_id returned" (API returns empty response)

## Changes

| File | Change |
|------|--------|
| `tests/e2e/conftest.py` | Add 15-second delay between generation tests |

## Test plan

- [x] All unit tests pass (1406 tests)
- [ ] Wait for nightly E2E run to verify rate limit issue is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)