### PR TITLE
chore: remove duplicate test fixtures from CLI tests

### DIFF
--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -204,7 +204,14 @@ def patch_main_cli_client():
 
 @pytest.fixture
 def mock_context_file(tmp_path):
-    """Provide a temporary context file for testing context commands."""
+    """Provide a temporary context file for testing context commands.
+
+    Patches get_context_path in both helpers and session modules since both
+    import the function directly and need consistent behavior.
+    """
     context_file = tmp_path / "context.json"
-    with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+    with (
+        patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.session.get_context_path", return_value=context_file),
+    ):
         yield context_file

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -5,31 +5,11 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Artifact
 
 from .conftest import create_mock_client, patch_client_for_module
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def mock_auth():
-    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
-        mock.return_value = {
-            "SID": "test",
-            "HSID": "test",
-            "SSID": "test",
-            "APISID": "test",
-            "SAPISID": "test",
-        }
-        yield mock
-
 
 # =============================================================================
 # ARTIFACT LIST TESTS

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Artifact
@@ -27,11 +26,6 @@ def make_artifact(
         status=status,
         created_at=created_at or datetime.fromtimestamp(1234567890),
     )
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 @pytest.fixture

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -4,30 +4,10 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
 
 from .conftest import create_mock_client, patch_client_for_module
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def mock_auth():
-    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
-        mock.return_value = {
-            "SID": "test",
-            "HSID": "test",
-            "SSID": "test",
-            "APISID": "test",
-            "SAPISID": "test",
-        }
-        yield mock
-
 
 # =============================================================================
 # GENERATE AUDIO TESTS

--- a/tests/unit/cli/test_grouped.py
+++ b/tests/unit/cli/test_grouped.py
@@ -1,14 +1,6 @@
 """Tests for SectionedGroup CLI help formatting."""
 
-import pytest
-from click.testing import CliRunner
-
 from notebooklm.notebooklm_cli import cli
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 class TestSectionedHelp:

--- a/tests/unit/cli/test_language.py
+++ b/tests/unit/cli/test_language.py
@@ -5,18 +5,12 @@ import json
 from unittest.mock import patch
 
 import pytest
-from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
 
 # Import the module explicitly to avoid confusion with the Click group
 # (notebooklm.cli exports 'language' as a Click Group, which shadows the module)
 language_module = importlib.import_module("notebooklm.cli.language")
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 @pytest.fixture

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -2,9 +2,6 @@
 
 from unittest.mock import AsyncMock, patch
 
-import pytest
-from click.testing import CliRunner
-
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Note
 
@@ -19,24 +16,6 @@ def make_note(id: str, title: str, content: str, notebook_id: str = "nb_123") ->
         title=title,
         content=content,
     )
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def mock_auth():
-    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
-        mock.return_value = {
-            "SID": "test",
-            "HSID": "test",
-            "SSID": "test",
-            "APISID": "test",
-            "SAPISID": "test",
-        }
-        yield mock
 
 
 # =============================================================================

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -5,32 +5,10 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-from click.testing import CliRunner
-
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import AskResult, Notebook
 
 from .conftest import create_mock_client, patch_client_for_module, patch_main_cli_client
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def mock_auth():
-    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
-        mock.return_value = {
-            "SID": "test",
-            "HSID": "test",
-            "SSID": "test",
-            "APISID": "test",
-            "SAPISID": "test",
-        }
-        yield mock
-
 
 # =============================================================================
 # NOTEBOOK LIST TESTS

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -6,42 +6,11 @@ from unittest.mock import AsyncMock, patch
 
 import click
 import pytest
-from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Notebook
 
 from .conftest import create_mock_client, patch_main_cli_client
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def mock_auth():
-    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
-        mock.return_value = {
-            "SID": "test",
-            "HSID": "test",
-            "SSID": "test",
-            "APISID": "test",
-            "SAPISID": "test",
-        }
-        yield mock
-
-
-@pytest.fixture
-def mock_context_file(tmp_path):
-    """Provide a temporary context file for testing context commands."""
-    context_file = tmp_path / "context.json"
-    with (
-        patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
-        patch("notebooklm.cli.session.get_context_path", return_value=context_file),
-    ):
-        yield context_file
-
 
 # =============================================================================
 # LOGIN COMMAND TESTS

--- a/tests/unit/cli/test_skill.py
+++ b/tests/unit/cli/test_skill.py
@@ -2,20 +2,12 @@
 
 from unittest.mock import patch
 
-import pytest
-from click.testing import CliRunner
-
 from notebooklm.notebooklm_cli import cli
 
 from .conftest import get_cli_module
 
 # Get the actual skill module (not the click group that shadows it)
 skill_module = get_cli_module("skill")
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
 
 
 class TestSkillInstall:

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -4,32 +4,10 @@ import json
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-from click.testing import CliRunner
-
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Source
 
 from .conftest import create_mock_client, patch_client_for_module
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-@pytest.fixture
-def mock_auth():
-    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
-        mock.return_value = {
-            "SID": "test",
-            "HSID": "test",
-            "SSID": "test",
-            "APISID": "test",
-            "SAPISID": "test",
-        }
-        yield mock
-
 
 # =============================================================================
 # SOURCE LIST TESTS


### PR DESCRIPTION
## Summary
- Remove duplicate `runner` and `mock_auth` fixtures from 10 CLI test files
- Enhance `mock_context_file()` in conftest.py to patch both helpers and session modules
- Keep specialized fixtures (mock_download_auth, mock_config_file) that have intentionally different implementations

## Impact
- **157 lines removed** (net)
- **393 CLI tests pass** (8 login tests require playwright - pre-existing)
- Single source of truth for common fixtures
- Reduced maintenance burden

## Test plan
- [x] `ruff format tests/unit/cli/` - No changes needed
- [x] `ruff check tests/unit/cli/` - All checks pass
- [x] `pytest tests/unit/cli/` - 393 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)