### PR TITLE
fix(e2e): use item.path.name instead of item.fspath.name in teardown hook

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -116,7 +116,7 @@ def pytest_runtest_teardown(item, nextitem):
     import time
 
     # Only add delay for generation tests
-    if item.fspath.name != "test_generation.py":
+    if item.path.name != "test_generation.py":
         return
 
     # Only add delay if using generation_notebook_id fixture


### PR DESCRIPTION
## Summary

- Fix AttributeError in `pytest_runtest_teardown` hook that broke all e2e tests
- Change `item.fspath.name` to `item.path.name` for correct filename access

## Root Cause

PR #95 introduced a `pytest_runtest_teardown` hook with a bug from an incorrect code review suggestion:

> gemini-code-assist suggested using `item.fspath.name` for "robust filename matching"

However, `item.fspath` returns a `py.path.local` object which uses `.basename`, not `.name`. The correct approach is `item.path.name` which returns a `pathlib.Path` (pytest 7+).

**Error:**
```
AttributeError: 'LocalPath' object has no attribute 'name'
```

## Test plan

- [x] Verified fix locally - all 29 e2e tests pass
- [x] `ruff format` and `ruff check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)