### PR TITLE
fix(cli): add missing --language option to generate report command

### DIFF
--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -934,6 +934,7 @@ def _output_mind_map_result(result: Any, json_output: bool) -> None:
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
+@click.option("--language", default=None, help="Output language (default: from config or 'en')")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
 @retry_option
 @json_option
@@ -944,6 +945,7 @@ def generate_report_cmd(
     report_format,
     notebook_id,
     source_ids,
+    language,
     wait,
     max_retries,
     json_output,
@@ -997,6 +999,7 @@ def generate_report_cmd(
                 return await client.artifacts.generate_report(
                     nb_id_resolved,
                     source_ids=sources,
+                    language=resolve_language(language),
                     report_format=report_format_enum,
                     custom_prompt=custom_prompt,
                 )


### PR DESCRIPTION
## Summary

Fixes #105 by adding the missing `--language` option to the `generate report` CLI command.

## Changes

**Added `--language` option to `generate report` CLI**
- The underlying API (`client.artifacts.generate_report()`) already supported the language parameter
- CLI was missing the option to expose this functionality  
- Users can now specify output language per-request: `notebooklm generate report --language zh_Hant`

## Testing

✅ **Pre-commit checks:**
```bash
ruff format src/ tests/  # All files formatted
ruff check src/ tests/   # All checks passed
mypy src/notebooklm      # No type errors
```

✅ **CLI verification:**
```bash
notebooklm generate report --help
# Shows: --language TEXT  Output language (default: from config or 'en')
```

## Notes

During investigation, I also tested quiz, flashcards, and mind-map generation commands. These artifact types only use the global language setting (`notebooklm language set <code>`) and do not support per-request language parameters.

## Test plan

- [x] Run pre-commit checks (ruff format, ruff check, mypy)
- [x] Verify CLI help text displays correctly
- [x] Confirm changes target correct base branch (main, not develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)