### PR TITLE
feat(cli): add --save-as-note to ask and --save to history commands

### DIFF
--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -109,6 +109,8 @@ def register_chat_commands(cli):
     @click.option(
         "--json", "json_output", is_flag=True, help="Output as JSON (includes references)"
     )
+    @click.option("--save-as-note", is_flag=True, help="Save response as a note")
+    @click.option("--note-title", default=None, help="Note title (use with --save-as-note)")
     @with_client
     def ask_cmd(
         ctx,
@@ -118,6 +120,8 @@ def register_chat_commands(cli):
         new_conversation,
         source_ids,
         json_output,
+        save_as_note,
+        note_title,
         client_auth,
     ):
         """Ask a notebook a question.
@@ -132,7 +136,8 @@ def register_chat_commands(cli):
           notebooklm ask --new "start fresh question"
           notebooklm ask -c <id> "continue this one"
           notebooklm ask -s src_001 -s src_002 "question about specific sources"
-          notebooklm ask "explain X" --json     # Get answer with source references
+          notebooklm ask "explain X" --json             # Get answer with source references
+          notebooklm ask "explain X" --save-as-note     # Save response as a note
         """
         nb_id = require_notebook(notebook_id)
 
@@ -168,16 +173,30 @@ def register_chat_commands(cli):
                     # Exclude raw_response from CLI output for brevity
                     del data["raw_response"]
                     json_output_response(data)
-                    return
-
-                console.print("[bold cyan]Answer:[/bold cyan]")
-                console.print(result.answer)
-                if result.is_follow_up:
-                    console.print(
-                        f"\n[dim]Conversation: {result.conversation_id} (turn {result.turn_number or '?'})[/dim]"
-                    )
+                    if not save_as_note:
+                        return
                 else:
-                    console.print(f"\n[dim]New conversation: {result.conversation_id}[/dim]")
+                    console.print("[bold cyan]Answer:[/bold cyan]")
+                    console.print(result.answer)
+                    if result.is_follow_up:
+                        console.print(
+                            f"\n[dim]Conversation: {result.conversation_id} (turn {result.turn_number or '?'})[/dim]"
+                        )
+                    else:
+                        console.print(f"\n[dim]New conversation: {result.conversation_id}[/dim]")
+
+                if save_as_note:
+                    if not result.answer:
+                        console.print("[yellow]Warning: No answer to save as note[/yellow]")
+                        return
+                    try:
+                        title = note_title or f"Chat: {question[:50]}"
+                        note = await client.notes.create(nb_id_resolved, title, result.answer)
+                        console.print(
+                            f"\n[dim]Saved as note: {note.title} ({note.id[:8]}...)[/dim]"
+                        )
+                    except Exception as e:
+                        console.print(f"[yellow]Warning: Failed to save note: {e}[/yellow]")
 
         return _run()
 
@@ -278,17 +297,30 @@ def register_chat_commands(cli):
         default=None,
         help="Notebook ID (uses current if not set)",
     )
-    @click.option("--limit", "-l", default=20, help="Number of messages")
+    @click.option("--limit", "-l", default=20, help="Number of conversations to show")
     @click.option("--clear", "clear_cache", is_flag=True, help="Clear local conversation cache")
+    @click.option("--save", "save_as_note", is_flag=True, help="Save history as a note")
+    @click.option(
+        "-c",
+        "--conversation-id",
+        default=None,
+        help="With --save: save only this specific conversation",
+    )
+    @click.option("-t", "--note-title", "note_title", default=None, help="Note title (with --save)")
     @with_client
-    def history_cmd(ctx, notebook_id, limit, clear_cache, client_auth):
-        """Get conversation history or clear local cache.
+    def history_cmd(
+        ctx, notebook_id, limit, clear_cache, save_as_note, conversation_id, note_title, client_auth
+    ):
+        """Get conversation history or save it as a note.
 
         \b
         Example:
-          notebooklm history              # Show history for current notebook
-          notebooklm history -n nb123     # Show history for specific notebook
-          notebooklm history --clear      # Clear local cache
+          notebooklm history                      # Show history for current notebook
+          notebooklm history -n nb123             # Show history for specific notebook
+          notebooklm history --clear              # Clear local cache
+          notebooklm history --save               # Save all history as a note
+          notebooklm history --save -c <id>       # Save one conversation as a note
+          notebooklm history --save --note-title "Summary"  # Save with custom title
         """
 
         async def _run():
@@ -303,28 +335,87 @@ def register_chat_commands(cli):
 
                 nb_id = require_notebook(notebook_id)
                 nb_id_resolved = await resolve_notebook_id(client, nb_id)
-                history = await client.chat.get_history(nb_id_resolved, limit=limit)
+                # When saving, fetch a large history to avoid truncating with the display limit
+                fetch_limit = 1000 if save_as_note else limit
+                history = await client.chat.get_history(nb_id_resolved, limit=fetch_limit)
+                conversations = history[0] if history and isinstance(history[0], list) else []
 
-                if history:
-                    console.print("[bold cyan]Conversation History:[/bold cyan]")
-                    try:
-                        conversations = history[0] if history else []
-                        if conversations:
-                            table = Table()
-                            table.add_column("#", style="dim")
-                            table.add_column("Conversation ID", style="cyan")
-                            for i, conv in enumerate(conversations, 1):
-                                conv_id = conv[0] if isinstance(conv, list) and conv else str(conv)
-                                table.add_row(str(i), conv_id)
-                            console.print(table)
-                            console.print(
-                                "\n[dim]Note: Only conversation IDs available. Use 'notebooklm ask -c <id>' to continue.[/dim]"
+                if save_as_note:
+                    if not conversations:
+                        raise click.ClickException(
+                            "No conversation history found for this notebook."
+                        )
+                    if conversation_id:
+                        conv = _find_conversation(conversations, conversation_id)
+                        if conv is None:
+                            raise click.ClickException(
+                                f"Conversation '{conversation_id}' not found. "
+                                "Run 'notebooklm history' to see available IDs."
                             )
-                        else:
-                            console.print("[yellow]No conversations found[/yellow]")
-                    except (IndexError, TypeError):
-                        console.print(history)
-                else:
+                        content = _format_single_conversation(conv)
+                        title = (
+                            note_title
+                            or f"Chat: {str(conv[1])[:50] if len(conv) > 1 and conv[1] else 'Conversation'}"
+                        )
+                    else:
+                        content = _format_all_conversations(conversations)
+                        title = note_title or "Chat History"
+                    note = await client.notes.create(nb_id_resolved, title, content)
+                    console.print(f"[green]Saved as note: {note.title} ({note.id[:8]}...)[/green]")
+                    return
+
+                if not conversations:
                     console.print("[yellow]No conversation history[/yellow]")
+                    return
+
+                console.print("[bold cyan]Conversation History:[/bold cyan]")
+                table = Table()
+                table.add_column("#", style="dim")
+                table.add_column("Conversation ID", style="cyan")
+                table.add_column("Question", style="white", max_width=40)
+                table.add_column("Answer preview", style="dim", max_width=40)
+                for i, conv in enumerate(conversations, 1):
+                    if not isinstance(conv, list) or len(conv) < 1:
+                        continue
+                    conv_id = str(conv[0])
+                    question = str(conv[1])[:40] if len(conv) > 1 and conv[1] else ""
+                    answer = str(conv[2])[:40] if len(conv) > 2 and conv[2] else ""
+                    table.add_row(str(i), conv_id, question, answer)
+                console.print(table)
+                console.print(
+                    "\n[dim]Use 'notebooklm ask -c <id>' to continue a conversation. "
+                    "Use 'notebooklm history --save' to save as a note.[/dim]"
+                )
 
         return _run()
+
+
+def _find_conversation(conversations: list, conversation_id: str) -> list | None:
+    """Find a conversation entry by ID."""
+    for conv in conversations:
+        if isinstance(conv, list) and conv and str(conv[0]) == conversation_id:
+            return conv
+    return None
+
+
+def _format_single_conversation(conv: list) -> str:
+    """Format one conversation as note content."""
+    question = str(conv[1]) if len(conv) > 1 and conv[1] else ""
+    answer = str(conv[2]) if len(conv) > 2 and conv[2] else ""
+    parts = []
+    if question:
+        parts.append(f"**Q:** {question}")
+    if answer:
+        parts.append(f"**A:** {answer}")
+    return "\n\n".join(parts)
+
+
+def _format_all_conversations(conversations: list) -> str:
+    """Format all conversations as note content."""
+    sections = []
+    for i, conv in enumerate(conversations, 1):
+        if not isinstance(conv, list) or not conv:
+            continue
+        section = f"## Conversation {i}\n\n{_format_single_conversation(conv)}"
+        sections.append(section)
+    return "\n\n---\n\n".join(sections)

--- a/src/notebooklm/data/SKILL.md
+++ b/src/notebooklm/data/SKILL.md
@@ -100,7 +100,8 @@ Before starting workflows, verify the CLI is ready:
 - `notebooklm research wait` - wait for research (in subagent context)
 - `notebooklm use <id>` - set context (⚠️ SINGLE-AGENT ONLY - use `-n` flag in parallel workflows)
 - `notebooklm create` - create notebook
-- `notebooklm ask "..."` - chat queries
+- `notebooklm ask "..."` - chat queries (without `--save-as-note`)
+- `notebooklm history` - display conversation history (read-only)
 - `notebooklm source add` - add sources
 
 **Ask before running:**
@@ -110,6 +111,8 @@ Before starting workflows, verify the CLI is ready:
 - `notebooklm artifact wait` - long-running (when in main conversation)
 - `notebooklm source wait` - long-running (when in main conversation)
 - `notebooklm research wait` - long-running (when in main conversation)
+- `notebooklm ask "..." --save-as-note` - writes a note
+- `notebooklm history --save` - writes a note
 
 ## Quick Reference
 
@@ -135,6 +138,12 @@ Before starting workflows, verify the CLI is ready:
 | Chat (new conversation) | `notebooklm ask "question" --new` |
 | Chat (specific sources) | `notebooklm ask "question" -s src_id1 -s src_id2` |
 | Chat (with references) | `notebooklm ask "question" --json` |
+| Chat (save answer as note) | `notebooklm ask "question" --save-as-note` |
+| Chat (save with title) | `notebooklm ask "question" --save-as-note --note-title "Title"` |
+| Show conversation history | `notebooklm history` |
+| Save all history as note | `notebooklm history --save` |
+| Save one conversation as note | `notebooklm history --save -c <conversation_id>` |
+| Save history with title | `notebooklm history --save --note-title "My Research"` |
 | Get source fulltext | `notebooklm source fulltext <source_id>` |
 | Get source guide | `notebooklm source guide <source_id>` |
 | Generate podcast | `notebooklm generate audio "instructions"` |
@@ -243,6 +252,7 @@ These capabilities are available via CLI but not in NotebookLM's web interface:
 | **Slide deck as PPTX** | `download slide-deck --format pptx` | Download slide deck as editable .pptx (web UI only offers PDF) |
 | **Slide revision** | `generate revise-slide "prompt" --artifact <id> --slide N` | Modify individual slides with a natural-language prompt |
 | **Source fulltext** | `source fulltext <id>` | Retrieve the indexed text content of any source |
+| **Save chat to note** | `ask "..." --save-as-note` / `history --save` | Save Q&A answers or conversation history as notebook notes |
 | **Programmatic sharing** | `share` commands | Manage sharing permissions without the UI |
 
 ## Common Workflows

--- a/tests/integration/cli_vcr/test_chat.py
+++ b/tests/integration/cli_vcr/test_chat.py
@@ -40,7 +40,52 @@ class TestHistoryCommand:
 
     @notebooklm_vcr.use_cassette("chat_get_history.yaml")
     def test_history(self, runner, mock_auth_for_vcr, mock_context):
-        """History command shows chat history from real client."""
+        """History command shows chat history with Q&A previews."""
         result = runner.invoke(cli, ["history"])
-        # allow_no_context=True: cassette may not match mock notebook ID
         assert_command_success(result)
+
+    @pytest.mark.skip(
+        reason=(
+            "Cassette not yet recorded. To record: set NOTEBOOKLM_VCR_RECORD=1 and run "
+            "'notebooklm history --save' against real API. "
+            "Cassette must capture GET_CONVERSATION_HISTORY + CREATE_NOTE + UPDATE_NOTE."
+        )
+    )
+    def test_history_save(self, runner, mock_auth_for_vcr, mock_context):
+        """'history --save' saves all conversation history as a note."""
+        with notebooklm_vcr.use_cassette("chat_history_save.yaml"):
+            result = runner.invoke(cli, ["history", "--save"])
+            assert result.exit_code == 0
+            assert "Saved as note" in result.output
+
+    @pytest.mark.skip(
+        reason=(
+            "Cassette not yet recorded. To record: set NOTEBOOKLM_VCR_RECORD=1 and run "
+            "'notebooklm history --save -c <id>' against real API. "
+            "Cassette must capture GET_CONVERSATION_HISTORY + CREATE_NOTE + UPDATE_NOTE."
+        )
+    )
+    def test_history_save_single_conversation(self, runner, mock_auth_for_vcr, mock_context):
+        """'history --save -c <id>' saves one conversation as a note."""
+        with notebooklm_vcr.use_cassette("chat_history_save_single.yaml"):
+            result = runner.invoke(cli, ["history", "--save", "-c", "conv_001"])
+            assert result.exit_code == 0
+            assert "Saved as note" in result.output
+
+
+class TestAskSaveAsNoteCommand:
+    """Test 'notebooklm ask --save-as-note' command."""
+
+    @pytest.mark.skip(
+        reason=(
+            "Cassette not yet recorded. To record: set NOTEBOOKLM_VCR_RECORD=1 and run "
+            "'notebooklm ask \"...\" --save-as-note' against real API. "
+            "Cassette must capture GenerateFreeFormStreamed + CREATE_NOTE + UPDATE_NOTE."
+        )
+    )
+    def test_ask_save_as_note(self, runner, mock_auth_for_vcr, mock_context):
+        """'ask --save-as-note' saves the answer as a note."""
+        with notebooklm_vcr.use_cassette("chat_ask_save_as_note.yaml"):
+            result = runner.invoke(cli, ["ask", "What is this about?", "--save-as-note"])
+            assert result.exit_code == 0
+            assert "Saved as note" in result.output

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -22,8 +22,10 @@ class TestChatAPI:
         response = build_rpc_response(
             RPCMethod.GET_CONVERSATION_HISTORY,
             [
-                ["conv_001", "What is ML?", "Machine learning is...", 1704067200],
-                ["conv_002", "Explain AI", "Artificial intelligence...", 1704153600],
+                [
+                    ["conv_001", "What is ML?", "Machine learning is...", 1704067200],
+                    ["conv_002", "Explain AI", "Artificial intelligence...", 1704153600],
+                ]
             ],
         )
         httpx_mock.add_response(content=response.encode())
@@ -32,8 +34,108 @@ class TestChatAPI:
             result = await client.chat.get_history("nb_123")
 
         assert result is not None
+        # history[0] is the list of conversations
+        assert len(result[0]) == 2
+        assert result[0][0][0] == "conv_001"
+        assert result[0][1][0] == "conv_002"
         request = httpx_mock.get_request()
         assert RPCMethod.GET_CONVERSATION_HISTORY in str(request.url)
+
+    @pytest.mark.asyncio
+    async def test_history_save_all_as_note(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test the combined get_history + notes.create flow for 'history --save'."""
+        history_response = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_HISTORY,
+            [
+                [
+                    ["conv_001", "What is ML?", "Machine learning is a type of AI.", 1704067200],
+                    [
+                        "conv_002",
+                        "Explain AI",
+                        "AI stands for Artificial Intelligence.",
+                        1704153600,
+                    ],
+                ]
+            ],
+        )
+        create_response = build_rpc_response(RPCMethod.CREATE_NOTE, [["new_note_id"]])
+        update_response = build_rpc_response(RPCMethod.UPDATE_NOTE, None)
+
+        httpx_mock.add_response(content=history_response.encode())
+        httpx_mock.add_response(content=create_response.encode())
+        httpx_mock.add_response(content=update_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            history = await client.chat.get_history("nb_123")
+            conversations = history[0]
+
+            # Simulate what 'history --save' does: format and create note
+            content_parts = []
+            for i, conv in enumerate(conversations, 1):
+                q = str(conv[1]) if len(conv) > 1 else ""
+                a = str(conv[2]) if len(conv) > 2 else ""
+                content_parts.append(f"## Conversation {i}\n\n**Q:** {q}\n\n**A:** {a}")
+            content = "\n\n---\n\n".join(content_parts)
+
+            note = await client.notes.create("nb_123", "Chat History", content)
+
+        assert note.id == "new_note_id"
+        assert note.title == "Chat History"
+        assert "What is ML?" in note.content
+        assert "Explain AI" in note.content
+
+        requests = httpx_mock.get_requests()
+        assert RPCMethod.GET_CONVERSATION_HISTORY in str(requests[0].url)
+        assert RPCMethod.CREATE_NOTE in str(requests[1].url)
+        assert RPCMethod.UPDATE_NOTE in str(requests[2].url)
+
+    @pytest.mark.asyncio
+    async def test_history_save_single_conversation_as_note(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test the combined get_history + notes.create flow for 'history --save -c <id>'."""
+        history_response = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_HISTORY,
+            [
+                [
+                    ["conv_001", "What is ML?", "Machine learning is a type of AI.", 1704067200],
+                    [
+                        "conv_002",
+                        "Explain AI",
+                        "AI stands for Artificial Intelligence.",
+                        1704153600,
+                    ],
+                ]
+            ],
+        )
+        create_response = build_rpc_response(RPCMethod.CREATE_NOTE, [["note_from_conv"]])
+        update_response = build_rpc_response(RPCMethod.UPDATE_NOTE, None)
+
+        httpx_mock.add_response(content=history_response.encode())
+        httpx_mock.add_response(content=create_response.encode())
+        httpx_mock.add_response(content=update_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            history = await client.chat.get_history("nb_123")
+            # Find only conv_001
+            conv = next(c for c in history[0] if c[0] == "conv_001")
+            content = f"**Q:** {conv[1]}\n\n**A:** {conv[2]}"
+            note = await client.notes.create("nb_123", f"Chat: {conv[1][:50]}", content)
+
+        assert note.id == "note_from_conv"
+        assert "What is ML?" in note.title
+        assert "What is ML?" in note.content
+        assert "Machine learning" in note.content
+        # Should NOT contain the second conversation
+        assert "Explain AI" not in note.content
 
     @pytest.mark.asyncio
     async def test_get_history_empty(

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -1,0 +1,177 @@
+"""Tests for chat CLI commands (save-as-note, enhanced history)."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import AskResult, Note
+
+from .conftest import create_mock_client, patch_client_for_module
+
+
+def make_note(id="note_abc", title="Chat Note", content="The answer") -> Note:
+    return Note(id=id, notebook_id="nb_123", title=title, content=content)
+
+
+def make_ask_result(answer="The answer is 42.") -> AskResult:
+    return AskResult(
+        answer=answer,
+        conversation_id="conv_abc",
+        turn_number=1,
+        is_follow_up=False,
+        references=[],
+        raw_response="",
+    )
+
+
+# Realistic history: history[0] = list of conversations
+MOCK_HISTORY = [
+    [
+        ["conv_001", "What is ML?", "ML is a type of AI.", 1704067200],
+        ["conv_002", "Explain AI", "AI stands for Artificial Intelligence.", 1704153600],
+    ]
+]
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth():
+    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
+        mock.return_value = {
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        yield mock
+
+
+class TestAskSaveAsNote:
+    def test_ask_save_as_note_creates_note(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+            mock_client.chat.get_history = AsyncMock(return_value=None)
+            mock_client.notes.create = AsyncMock(return_value=make_note())
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["ask", "What is 42?", "--save-as-note", "-n", "nb_123"]
+                )
+
+            assert result.exit_code == 0, result.output
+            mock_client.notes.create.assert_awaited_once()
+            call = mock_client.notes.create.call_args
+            all_args = list(call.args) + list(call.kwargs.values())
+            assert any("The answer is 42." in str(a) for a in all_args)
+
+    def test_ask_save_as_note_uses_custom_title(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+            mock_client.chat.get_history = AsyncMock(return_value=None)
+            mock_client.notes.create = AsyncMock(return_value=make_note(title="My Title"))
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "ask",
+                        "What is 42?",
+                        "--save-as-note",
+                        "--note-title",
+                        "My Title",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+            assert result.exit_code == 0, result.output
+            call = mock_client.notes.create.call_args
+            all_args = list(call.args) + list(call.kwargs.values())
+            assert any("My Title" in str(a) for a in all_args)
+
+    def test_ask_without_flag_does_not_create_note(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+            mock_client.chat.get_history = AsyncMock(return_value=None)
+            mock_client.notes.create = AsyncMock(return_value=make_note())
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["ask", "What is 42?", "-n", "nb_123"])
+
+            assert result.exit_code == 0, result.output
+            mock_client.notes.create.assert_not_awaited()
+
+
+class TestHistoryCommand:
+    def test_history_shows_conversations_with_previews(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["history", "-n", "nb_123"])
+
+            assert result.exit_code == 0, result.output
+            assert "conv_001" in result.output
+            assert "conv_002" in result.output
+            assert "What is ML?" in result.output
+
+    def test_history_save_all_creates_note(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
+            mock_client.notes.create = AsyncMock(return_value=make_note())
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["history", "--save", "-n", "nb_123"])
+
+            assert result.exit_code == 0, result.output
+            mock_client.notes.create.assert_awaited_once()
+
+    def test_history_save_by_conversation_id(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
+            mock_client.notes.create = AsyncMock(return_value=make_note())
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["history", "--save", "-c", "conv_001", "-n", "nb_123"])
+
+            assert result.exit_code == 0, result.output
+            mock_client.notes.create.assert_awaited_once()
+
+    def test_history_save_unknown_conversation_id_fails(self, runner, mock_auth):
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["history", "--save", "-c", "conv_unknown", "-n", "nb_123"]
+                )
+
+            assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Adds `notebooklm ask "..." --save-as-note [--note-title "Title"]` — saves the Q&A answer as a notebook note inline after asking. Works with or without `--json`. Gracefully handles note creation failure (warning instead of traceback).
- Adds `notebooklm history --save [-c <conv_id>] [--note-title "Title"]` — saves all conversation history (or a single conversation by ID) as a note. Fetches up to 1000 conversations when saving to avoid display-limit truncation.
- Enhances `history` display: now shows **Question** and **Answer preview** columns alongside Conversation ID.
- Fixes pre-existing bug: `GET_CONVERSATION_HISTORY` integration test mock had wrong nesting (`[conv1, conv2]` instead of `[[conv1, conv2]]`).

Closes #116 (item 2).

## Test plan

- [x] 7 new unit tests (`tests/unit/cli/test_chat.py`) covering `--save-as-note` and `history --save` happy paths + error cases
- [x] 2 new httpx-mock integration tests verifying combined `get_history` + `notes.create` API flow
- [x] 3 VCR stubs added (marked `skip` with recording instructions — require real credentials to record cassettes)
- [x] All 1458 tests pass; ruff + mypy clean

Generated with [Claude Code](https://claude.com/claude-code)