### PR TITLE
feat(history): group conversations by ID with parallel fetching

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -4,6 +4,7 @@ Provides operations for asking questions, managing conversations, and
 retrieving conversation history.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -225,54 +226,81 @@ class ChatAPI:
         Returns:
             The most recent conversation ID, or None if no conversations exist.
         """
-        logger.debug("Getting last conversation ID for notebook %s", notebook_id)
-        params: list[Any] = [[], None, notebook_id, 1]
+        ids = await self._get_conversation_ids(notebook_id, limit=1)
+        return ids[0] if ids else None
+
+    async def _get_conversation_ids(self, notebook_id: str, limit: int = 20) -> list[str]:
+        """Fetch up to ``limit`` conversation IDs for a notebook (newest-first).
+
+        Args:
+            notebook_id: The notebook ID.
+            limit: Maximum number of conversation IDs to retrieve.
+
+        Returns:
+            List of conversation ID strings, most recent first.
+        """
+        logger.debug("Getting conversation IDs for notebook %s (limit=%d)", notebook_id, limit)
+        params: list[Any] = [[], None, notebook_id, limit]
         raw = await self._core.rpc_call(
             RPCMethod.GET_LAST_CONVERSATION_ID,
             params,
             source_path=f"/notebook/{notebook_id}",
         )
-        # Response structure: [[[conv_id]]]
+        # Response structure: [[[conv_id_1], [conv_id_2], ...]]
+        ids: list[str] = []
         if raw and isinstance(raw, list):
             for group in raw:
                 if isinstance(group, list):
                     for conv in group:
-                        if isinstance(conv, list) and conv:
-                            return str(conv[0])
-        return None
+                        if isinstance(conv, list) and conv and isinstance(conv[0], str):
+                            ids.append(conv[0])
+        return ids
 
     async def get_history(
         self, notebook_id: str, limit: int = 100
-    ) -> tuple[str | None, list[tuple[str, str]]]:
-        """Get conversation history (all Q&A turns) from the server.
+    ) -> list[tuple[str, list[tuple[str, str]]]]:
+        """Get conversation history grouped by conversation, newest-first.
 
-        Fetches the most recent conversation and retrieves all turns.
+        Fetches all available conversations and their Q&A turns.
 
         Args:
             notebook_id: The notebook ID.
-            limit: Maximum number of turns to retrieve.
+            limit: Maximum number of Q&A turns to retrieve per conversation.
 
         Returns:
-            Tuple of (conversation_id, list of (question, answer) tuples ordered oldest-first).
-            conversation_id is None if no conversations exist.
+            List of (conversation_id, qa_pairs) tuples, newest conversation first.
+            Each qa_pairs list is ordered oldest-first within the conversation.
+            Returns an empty list if no conversations exist.
         """
         logger.debug("Getting conversation history for notebook %s (limit=%d)", notebook_id, limit)
-        conv_id = await self.get_last_conversation_id(notebook_id)
-        if not conv_id:
-            return None, []
+        conv_ids = await self._get_conversation_ids(notebook_id)
+        if not conv_ids:
+            return []
 
-        turns_data = await self.get_conversation_turns(notebook_id, conv_id, limit=limit)
-        # API returns individual turns newest-first: [A2, Q2, A1, Q1, ...]
-        # Reverse to chronological order [Q1, A1, Q2, A2, ...] so the
-        # Q→A forward-pairing parser works correctly.
-        if (
-            turns_data
-            and isinstance(turns_data, list)
-            and turns_data[0]
-            and isinstance(turns_data[0], list)
-        ):
-            turns_data = [list(reversed(turns_data[0]))]
-        return conv_id, self._parse_turns_to_qa_pairs(turns_data)
+        all_turns = await asyncio.gather(
+            *[
+                self.get_conversation_turns(notebook_id, conv_id, limit=limit)
+                for conv_id in conv_ids
+            ],
+            return_exceptions=True,
+        )
+        result: list[tuple[str, list[tuple[str, str]]]] = []
+        for conv_id, turns_data in zip(conv_ids, all_turns, strict=True):
+            if isinstance(turns_data, Exception):
+                logger.warning("Failed to fetch turns for conversation %s: %s", conv_id, turns_data)
+                continue
+            # API returns individual turns newest-first: [A2, Q2, A1, Q1, ...]
+            # Reverse to chronological order [Q1, A1, Q2, A2, ...] so the
+            # Q→A forward-pairing parser works correctly.
+            if (
+                turns_data
+                and isinstance(turns_data, list)
+                and turns_data[0]
+                and isinstance(turns_data[0], list)
+            ):
+                turns_data = [list(reversed(turns_data[0]))]
+            result.append((conv_id, self._parse_turns_to_qa_pairs(turns_data)))
+        return result
 
     @staticmethod
     def _parse_turns_to_qa_pairs(turns_data: Any) -> list[tuple[str, str]]:

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -356,14 +356,14 @@ def register_chat_commands(cli):
 
                 nb_id = require_notebook(notebook_id)
                 nb_id_resolved = await resolve_notebook_id(client, nb_id)
-                conv_id, qa_pairs = await client.chat.get_history(nb_id_resolved, limit=limit)
+                conversations = await client.chat.get_history(nb_id_resolved, limit=limit)
 
                 if save_as_note:
-                    if not qa_pairs:
+                    if not conversations:
                         raise click.ClickException(
                             "No conversation history found for this notebook."
                         )
-                    content = _format_all_qa(qa_pairs)
+                    content = _format_conversations(conversations)
                     title = note_title or "Chat History"
                     note = await client.notes.create(nb_id_resolved, title, content)
                     console.print(f"[green]Saved as note: {note.title} ({note.id[:8]}...)[/green]")
@@ -372,38 +372,44 @@ def register_chat_commands(cli):
                 if json_output:
                     data = {
                         "notebook_id": nb_id_resolved,
-                        "conversation_id": conv_id,
-                        "count": len(qa_pairs),
-                        "qa_pairs": [
-                            {"turn": i, "question": q, "answer": a}
-                            for i, (q, a) in enumerate(qa_pairs, 1)
+                        "conversations": [
+                            {
+                                "conversation_id": conv_id,
+                                "count": len(qa_pairs),
+                                "qa_pairs": [
+                                    {"turn": i, "question": q, "answer": a}
+                                    for i, (q, a) in enumerate(qa_pairs, 1)
+                                ],
+                            }
+                            for conv_id, qa_pairs in conversations
                         ],
                     }
                     json_output_response(data)
                     return
 
-                if not qa_pairs:
+                if not conversations:
                     console.print("[yellow]No conversation history[/yellow]")
                     return
 
-                header = "[bold cyan]Conversation History:[/bold cyan]"
-                if conv_id:
-                    header += f" [dim]{conv_id}[/dim]"
-                console.print(header)
+                console.print("[bold cyan]Conversation History:[/bold cyan]")
 
                 if show_all:
-                    for i, (question, answer) in enumerate(qa_pairs, 1):
-                        console.print(f"[bold]#{i} Q:[/bold] {question}")
-                        console.print(f"   A: {answer}\n")
+                    for conv_id, qa_pairs in conversations:
+                        console.print(f"\n[bold]── {conv_id} ──[/bold]")
+                        for i, (question, answer) in enumerate(qa_pairs, 1):
+                            console.print(f"[bold]#{i} Q:[/bold] {question}")
+                            console.print(f"   A: {answer}\n")
                     return
 
-                table = Table()
-                table.add_column("#", style="dim")
-                table.add_column("Question", style="white", max_width=50)
-                table.add_column("Answer preview", style="dim", max_width=50)
-                for i, (question, answer) in enumerate(qa_pairs, 1):
-                    table.add_row(str(i), question[:50], answer[:50])
-                console.print(table)
+                for conv_id, qa_pairs in conversations:
+                    console.print(f"\n[dim]── {conv_id} ──[/dim]")
+                    table = Table()
+                    table.add_column("#", style="dim", width=4)
+                    table.add_column("Question", style="white", max_width=50)
+                    table.add_column("Answer preview", style="dim", max_width=50)
+                    for i, (question, answer) in enumerate(qa_pairs, 1):
+                        table.add_row(str(i), question[:50], answer[:50])
+                    console.print(table)
                 console.print("\n[dim]Use 'notebooklm history --save' to save as a note.[/dim]")
 
         return _run()
@@ -419,10 +425,12 @@ def _format_single_qa(question: str, answer: str) -> str:
     return "\n\n".join(parts)
 
 
-def _format_all_qa(qa_results: list[tuple[str, str]]) -> str:
-    """Format multiple Q&A pairs as note content."""
-    sections = []
-    for i, (question, answer) in enumerate(qa_results, 1):
-        section = f"## Turn {i}\n\n{_format_single_qa(question, answer)}"
-        sections.append(section)
-    return "\n\n---\n\n".join(sections)
+def _format_conversations(conversations: list[tuple[str, list[tuple[str, str]]]]) -> str:
+    """Format conversation history preserving conversation boundaries."""
+    conv_sections = []
+    for conv_id, qa_pairs in conversations:
+        turns = []
+        for i, (question, answer) in enumerate(qa_pairs, 1):
+            turns.append(f"### Turn {i}\n\n{_format_single_qa(question, answer)}")
+        conv_sections.append(f"## Conversation {conv_id}\n\n" + "\n\n---\n\n".join(turns))
+    return "\n\n===\n\n".join(conv_sections)

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -237,10 +237,11 @@ class TestChatHistoryE2E:
         ask_result = await client.chat.ask(multi_source_notebook_id, question)
         assert ask_result.conversation_id
 
-        conv_id, qa_pairs = await client.chat.get_history(multi_source_notebook_id)
-        assert qa_pairs, "get_history returned no Q&A pairs"
-        assert isinstance(qa_pairs, list)
-        assert conv_id is not None, "get_history should return a conversation ID"
+        conversations = await client.chat.get_history(multi_source_notebook_id)
+        assert conversations, "get_history returned no conversations"
+        conv_id, qa_pairs = conversations[0]
+        assert conv_id is not None
+        assert qa_pairs, "conversation has no Q&A pairs"
 
         # Each entry is a (question, answer) tuple
         q, a = qa_pairs[-1]  # most recent Q&A

--- a/tests/e2e/test_notebooks.py
+++ b/tests/e2e/test_notebooks.py
@@ -40,8 +40,8 @@ class TestNotebookOperations:
 
     @pytest.mark.asyncio
     async def test_get_conversation_history(self, client, read_only_notebook_id):
-        conv_id, qa_pairs = await client.chat.get_history(read_only_notebook_id)
-        assert isinstance(qa_pairs, list)
+        conversations = await client.chat.get_history(read_only_notebook_id)
+        assert isinstance(conversations, list)
 
 
 @requires_auth

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -62,13 +62,96 @@ class TestChatAPI:
         httpx_mock.add_response(content=turns_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            conv_id, result = await client.chat.get_history("nb_123")
+            conversations = await client.chat.get_history("nb_123")
 
+        assert len(conversations) == 1
+        conv_id, qa_pairs = conversations[0]
         assert conv_id == "conv_001"
         # get_history reverses API order to return oldest-first
-        assert len(result) == 2
-        assert result[0] == ("First question?", "Answer to first question.")
-        assert result[1] == ("Second question?", "Answer to second question.")
+        assert len(qa_pairs) == 2
+        assert qa_pairs[0] == ("First question?", "Answer to first question.")
+        assert qa_pairs[1] == ("Second question?", "Answer to second question.")
+
+    @pytest.mark.asyncio
+    async def test_get_history_multiple_conversations(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history returns multiple conversations when the API provides them."""
+        # First call: _get_conversation_ids returns two IDs
+        id_response = build_rpc_response(
+            RPCMethod.GET_LAST_CONVERSATION_ID,
+            [[["conv_001"], ["conv_002"]]],
+        )
+        # Parallel turn fetches (asyncio.gather) — order matches conv_ids
+        turns_conv1 = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [
+                [
+                    [None, None, 2, None, [["Answer A."]]],
+                    [None, None, 1, "Question A?"],
+                ]
+            ],
+        )
+        turns_conv2 = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [
+                [
+                    [None, None, 2, None, [["Answer B."]]],
+                    [None, None, 1, "Question B?"],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=id_response.encode())
+        httpx_mock.add_response(content=turns_conv1.encode())
+        httpx_mock.add_response(content=turns_conv2.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            conversations = await client.chat.get_history("nb_123")
+
+        assert len(conversations) == 2
+        conv_id1, qa1 = conversations[0]
+        conv_id2, qa2 = conversations[1]
+        assert conv_id1 == "conv_001"
+        assert conv_id2 == "conv_002"
+        assert qa1 == [("Question A?", "Answer A.")]
+        assert qa2 == [("Question B?", "Answer B.")]
+
+    @pytest.mark.asyncio
+    async def test_get_history_skips_failed_conversations(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history skips individual conversations whose turn fetch fails."""
+        id_response = build_rpc_response(
+            RPCMethod.GET_LAST_CONVERSATION_ID,
+            [[["conv_001"], ["conv_002"]]],
+        )
+        turns_conv1 = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [
+                [
+                    [None, None, 2, None, [["Good answer."]]],
+                    [None, None, 1, "Good question?"],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=id_response.encode())
+        httpx_mock.add_response(content=turns_conv1.encode())
+        httpx_mock.add_response(status_code=500)  # conv_002 fails
+
+        async with NotebookLMClient(auth_tokens) as client:
+            conversations = await client.chat.get_history("nb_123")
+
+        # Only the successful conversation is returned
+        assert len(conversations) == 1
+        conv_id, qa_pairs = conversations[0]
+        assert conv_id == "conv_001"
+        assert qa_pairs == [("Good question?", "Good answer.")]
 
     @pytest.mark.asyncio
     async def test_get_conversation_turns(
@@ -134,57 +217,6 @@ class TestChatAPI:
         assert result[0] == []
 
     @pytest.mark.asyncio
-    async def test_history_save_as_note(
-        self,
-        auth_tokens,
-        httpx_mock: HTTPXMock,
-        build_rpc_response,
-    ):
-        """Test the combined get_history + notes.create flow for 'history --save'."""
-        from notebooklm.cli.chat import _format_all_qa
-
-        # get_last_conversation_id
-        id_response = build_rpc_response(
-            RPCMethod.GET_LAST_CONVERSATION_ID,
-            [[["conv_001"]]],
-        )
-        # get_conversation_turns (chronological: Q, A, Q, A)
-        turns_response = build_rpc_response(
-            RPCMethod.GET_CONVERSATION_TURNS,
-            [
-                [
-                    [None, None, 1, "What is ML?"],
-                    [None, None, 2, None, [["Machine learning is a type of AI."]]],
-                    [None, None, 1, "Explain AI"],
-                    [None, None, 2, None, [["AI stands for Artificial Intelligence."]]],
-                ]
-            ],
-        )
-        create_response = build_rpc_response(RPCMethod.CREATE_NOTE, [["new_note_id"]])
-        update_response = build_rpc_response(RPCMethod.UPDATE_NOTE, None)
-
-        httpx_mock.add_response(content=id_response.encode())
-        httpx_mock.add_response(content=turns_response.encode())
-        httpx_mock.add_response(content=create_response.encode())
-        httpx_mock.add_response(content=update_response.encode())
-
-        async with NotebookLMClient(auth_tokens) as client:
-            _, qa_pairs = await client.chat.get_history("nb_123")
-            content = _format_all_qa(qa_pairs)
-            note = await client.notes.create("nb_123", "Chat History", content)
-
-        assert note.id == "new_note_id"
-        assert note.title == "Chat History"
-        assert "What is ML?" in note.content
-        assert "Machine learning" in note.content
-        assert "Explain AI" in note.content
-
-        requests = httpx_mock.get_requests()
-        assert RPCMethod.GET_LAST_CONVERSATION_ID in str(requests[0].url)
-        assert RPCMethod.GET_CONVERSATION_TURNS in str(requests[1].url)
-        assert RPCMethod.CREATE_NOTE in str(requests[2].url)
-
-    @pytest.mark.asyncio
     async def test_get_history_empty(
         self,
         auth_tokens,
@@ -198,7 +230,7 @@ class TestChatAPI:
         async with NotebookLMClient(auth_tokens) as client:
             result = await client.chat.get_history("nb_123")
 
-        assert result == (None, [])
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_configure_default_mode(

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -27,11 +27,13 @@ def make_ask_result(answer="The answer is 42.") -> AskResult:
     )
 
 
-# get_history now returns list of (question, answer) tuples
+# get_history returns list of (conversation_id, [(question, answer), ...])
+MOCK_CONV_ID = "conv-abc123"
 MOCK_QA_PAIRS = [
     ("What is ML?", "ML is a type of AI."),
     ("Explain AI", "AI stands for Artificial Intelligence."),
 ]
+MOCK_HISTORY = [(MOCK_CONV_ID, MOCK_QA_PAIRS)]
 
 
 @pytest.fixture
@@ -121,7 +123,7 @@ class TestHistoryCommand:
     def test_history_shows_qa_pairs(self, runner, mock_auth):
         with patch_client_for_module("chat") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=("conv_test_id", MOCK_QA_PAIRS))
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
@@ -135,7 +137,7 @@ class TestHistoryCommand:
     def test_history_save_creates_note(self, runner, mock_auth):
         with patch_client_for_module("chat") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=("conv_test_id", MOCK_QA_PAIRS))
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
             mock_client.notes.create = AsyncMock(return_value=make_note())
             mock_client_cls.return_value = mock_client
 
@@ -149,7 +151,7 @@ class TestHistoryCommand:
     def test_history_empty_shows_message(self, runner, mock_auth):
         with patch_client_for_module("chat") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=(None, []))
+            mock_client.chat.get_history = AsyncMock(return_value=[])
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
@@ -162,7 +164,7 @@ class TestHistoryCommand:
     def test_history_json_outputs_valid_json(self, runner, mock_auth):
         with patch_client_for_module("chat") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=("conv_test_id", MOCK_QA_PAIRS))
+            mock_client.chat.get_history = AsyncMock(return_value=MOCK_HISTORY)
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
@@ -173,19 +175,20 @@ class TestHistoryCommand:
             import json
 
             data = json.loads(result.output)
-            assert data["count"] == 2
             assert data["notebook_id"] == "nb_123"
-            assert data["conversation_id"] == "conv_test_id"
-            assert len(data["qa_pairs"]) == 2
-            assert data["qa_pairs"][0]["turn"] == 1
-            assert data["qa_pairs"][0]["question"] == "What is ML?"
-            assert data["qa_pairs"][0]["answer"] == "ML is a type of AI."
-            assert data["qa_pairs"][1]["turn"] == 2
+            assert len(data["conversations"]) == 1
+            conv = data["conversations"][0]
+            assert conv["conversation_id"] == MOCK_CONV_ID
+            assert conv["count"] == 2
+            assert conv["qa_pairs"][0]["turn"] == 1
+            assert conv["qa_pairs"][0]["question"] == "What is ML?"
+            assert conv["qa_pairs"][0]["answer"] == "ML is a type of AI."
+            assert conv["qa_pairs"][1]["turn"] == 2
 
     def test_history_json_empty(self, runner, mock_auth):
         with patch_client_for_module("chat") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=(None, []))
+            mock_client.chat.get_history = AsyncMock(return_value=[])
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
@@ -196,8 +199,7 @@ class TestHistoryCommand:
             import json
 
             data = json.loads(result.output)
-            assert data["count"] == 0
-            assert data["qa_pairs"] == []
+            assert data["conversations"] == []
 
     def test_history_show_all_outputs_full_text(self, runner, mock_auth):
         long_q = "Q" * 100
@@ -206,7 +208,7 @@ class TestHistoryCommand:
 
         with patch_client_for_module("chat") as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=("conv_test_id", pairs))
+            mock_client.chat.get_history = AsyncMock(return_value=[(MOCK_CONV_ID, pairs)])
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -375,7 +375,7 @@ class TestNotebookHistory:
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.chat.get_history = AsyncMock(
-                return_value=("conv_001", [("Q1?", "A1"), ("Q2?", "A2")])
+                return_value=[("conv_001", [("Q1?", "A1"), ("Q2?", "A2")])]
             )
             mock_client_cls.return_value = mock_client
 
@@ -389,7 +389,7 @@ class TestNotebookHistory:
     def test_notebook_history_empty(self, runner, mock_auth):
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
-            mock_client.chat.get_history = AsyncMock(return_value=(None, []))
+            mock_client.chat.get_history = AsyncMock(return_value=[])
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:

--- a/tests/unit/test_chat_history.py
+++ b/tests/unit/test_chat_history.py
@@ -212,32 +212,6 @@ class TestFormatHelpers:
         result = _format_single_qa("", "")
         assert result == ""
 
-    def test_format_all_qa_single_pair(self):
-        from notebooklm.cli.chat import _format_all_qa
-
-        result = _format_all_qa([("Q1?", "A1.")])
-        assert "## Turn 1" in result
-        assert "**Q:** Q1?" in result
-        assert "**A:** A1." in result
-        assert "---" not in result  # no separator for single item
-
-    def test_format_all_qa_multiple_pairs(self):
-        from notebooklm.cli.chat import _format_all_qa
-
-        pairs = [("Q1?", "A1."), ("Q2?", "A2.")]
-        result = _format_all_qa(pairs)
-        assert "## Turn 1" in result
-        assert "## Turn 2" in result
-        assert "**Q:** Q1?" in result
-        assert "**Q:** Q2?" in result
-        assert "---" in result  # separator between turns
-
-    def test_format_all_qa_empty_list(self):
-        from notebooklm.cli.chat import _format_all_qa
-
-        result = _format_all_qa([])
-        assert result == ""
-
 
 class TestDetermineConversationId:
     """Tests for _determine_conversation_id CLI helper."""


### PR DESCRIPTION
## Summary

Expands `notebooklm history` to display all available conversations grouped by conversation UUID, with turns numbered 1..N within each group.

- **Multi-conversation history**: `get_history()` now returns `list[tuple[str, list[tuple[str, str]]]]` instead of a single conversation tuple. Each conversation is displayed under its own `── <conv_id> ──` header.
- **Parallel fetching**: Conversation turns are fetched concurrently via `asyncio.gather()` instead of sequentially, reducing latency when multiple conversations exist.
- **Resilient error handling**: `asyncio.gather(return_exceptions=True)` ensures a single failed conversation turn fetch does not crash the entire call — failed conversations are logged as warnings and skipped.
- **Updated `--save` output**: History saved as a note preserves conversation boundaries using `_format_conversations()`.
- **Updated `--json` schema**: Output changed from `{conversation_id, count, qa_pairs}` to `{conversations: [{conversation_id, count, qa_pairs}]}`.
- **Removed dead code**: `_format_all_qa` was no longer called by production code after `--save` was updated; removed it and all associated tests.
- **Incorporates #138 improvements**: `_DEFAULT_BL` constant and fixed-position params layout with comments for `GenerateFreeFormStreamed`.

Cleanly rebased on top of current main (after #138 merged).

## Test plan

- [x] All 1510 unit + integration tests pass (`pytest tests/unit tests/integration`)
- [x] New integration test: `test_get_history_multiple_conversations`
- [x] New integration test: `test_get_history_skips_failed_conversations`
- [x] `ruff format`, `ruff check`, `mypy` all clean
- [ ] E2E tests (requires auth)