### PR TITLE
test: increase coverage from 88% to 94% with comprehensive test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 70
+fail_under = 90
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -2,15 +2,17 @@
 
 import csv
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
+from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import AudioFormat, AudioLength, RPCError, RPCMethod, VideoFormat, VideoStyle
 from notebooklm.types import (
     ArtifactNotReadyError,
+    ArtifactParseError,
 )
 
 
@@ -1077,3 +1079,1282 @@ class TestDownloadDataTable:
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(ArtifactNotReadyError):
                 await client.artifacts.download_data_table("nb_123", "/tmp/data.csv")
+
+
+# =============================================================================
+# New tests for uncovered lines
+# =============================================================================
+
+
+class TestExtractAppData:
+    """Tests for _extract_app_data error path (line 78)."""
+
+    @pytest.mark.asyncio
+    async def test_download_quiz_html_without_app_data_attribute(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """download_quiz raises ArtifactParseError when HTML lacks data-app-data attribute."""
+        # Build a completed quiz artifact - variant at data[9][1][0] = 2 for quiz
+        # (variant=1 is flashcards, variant=2 is quiz)
+        artifact_data = [
+            "quiz_001",  # [0] id
+            "My Quiz",  # [1] title
+            4,  # [2] QUIZ type
+            None,  # [3]
+            3,  # [4] COMPLETED
+            None,  # [5]
+            None,  # [6]
+            None,  # [7]
+            None,  # [8]
+            [None, [2]],  # [9] options: [9][1][0] = 2 => quiz variant
+            None,  # [10]
+            None,  # [11]
+            None,  # [12]
+            None,  # [13]
+            None,  # [14]
+            [[1704067200]],  # [15] created_at
+        ]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        httpx_mock.add_response(content=list_response.encode())
+
+        # HTML that has NO data-app-data attribute
+        html_without_data = "<html><body><div>No app data here</div></body></html>"
+
+        output_path = str(tmp_path / "quiz.json")
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts,
+                "_get_artifact_content",
+                AsyncMock(return_value=html_without_data),
+            ):
+                with pytest.raises(ArtifactParseError, match="data-app-data"):
+                    await client.artifacts.download_quiz("nb_123", output_path)
+
+
+class TestListMindMapErrorHandling:
+    """Tests for list() mind map error handling (lines 288-295)."""
+
+    @pytest.mark.asyncio
+    async def test_list_continues_when_mind_map_rpc_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """list() returns studio artifacts when mind map fetch raises RPCError."""
+        # Return a report artifact from studio
+        artifact_data = ["art_001", "My Report", 2, None, 3]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        httpx_mock.add_response(content=list_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts._notes,
+                "list_mind_maps",
+                AsyncMock(side_effect=RPCError("mind map fetch failed")),
+            ):
+                result = await client.artifacts.list("nb_123")
+
+        # Should still return the studio artifact despite mind map failure
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        assert any(a.id == "art_001" for a in result)
+
+    @pytest.mark.asyncio
+    async def test_list_continues_when_mind_map_http_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """list() returns studio artifacts when mind map fetch raises HTTPError."""
+        import httpx
+
+        artifact_data = ["art_002", "Audio Overview", 1, None, 3]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        httpx_mock.add_response(content=list_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts._notes,
+                "list_mind_maps",
+                AsyncMock(side_effect=httpx.HTTPError("connection failed")),
+            ):
+                result = await client.artifacts.list("nb_123")
+
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        assert any(a.id == "art_002" for a in result)
+
+
+class TestGetArtifactReturnsNone:
+    """Tests for get() returning None (lines 312-313)."""
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_not_found(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """get() returns None when the artifact_id is not in the list."""
+        # Return one artifact with a different ID
+        artifact_data = ["art_exists", "My Report", 2, None, 3]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        notes_response = build_rpc_response(RPCMethod.GET_NOTES_AND_MIND_MAPS, [[]])
+        httpx_mock.add_response(content=list_response.encode())
+        httpx_mock.add_response(content=notes_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.get("nb_123", "art_does_not_exist")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_returns_artifact_when_found(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """get() returns the artifact when found by ID."""
+        artifact_data = ["art_found", "My Report", 2, None, 3]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        notes_response = build_rpc_response(RPCMethod.GET_NOTES_AND_MIND_MAPS, [[]])
+        httpx_mock.add_response(content=list_response.encode())
+        httpx_mock.add_response(content=notes_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.get("nb_123", "art_found")
+
+        assert result is not None
+        assert result.id == "art_found"
+
+
+class TestReviseSlide:
+    """Tests for revise_slide() paths (lines 836, 851, 853-861)."""
+
+    @pytest.mark.asyncio
+    async def test_revise_slide_negative_index_raises_validation_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """revise_slide raises ValidationError for slide_index < 0."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValidationError, match="slide_index must be >= 0"):
+                await client.artifacts.revise_slide(
+                    notebook_id="nb_123",
+                    artifact_id="artifact_456",
+                    slide_index=-1,
+                    prompt="Move title up",
+                )
+
+    @pytest.mark.asyncio
+    async def test_revise_slide_null_result_returns_generation_status(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """revise_slide logs warning and returns GenerationStatus when RPC returns null."""
+        # Build a null response (allow_null=True path)
+        null_response = build_rpc_response(RPCMethod.REVISE_SLIDE, None)
+        httpx_mock.add_response(content=null_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.revise_slide(
+                notebook_id="nb_123",
+                artifact_id="artifact_456",
+                slide_index=0,
+                prompt="Remove taxonomy section",
+            )
+
+        assert result is not None
+        assert result.status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_revise_slide_user_displayable_error_returns_failed_status(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """revise_slide returns failed GenerationStatus on USER_DISPLAYABLE_ERROR."""
+        async with NotebookLMClient(auth_tokens) as client:
+            err = RPCError("Rate limit exceeded")
+            err.rpc_code = "USER_DISPLAYABLE_ERROR"
+            with patch.object(
+                client.artifacts._core,
+                "rpc_call",
+                AsyncMock(side_effect=err),
+            ):
+                result = await client.artifacts.revise_slide(
+                    notebook_id="nb_123",
+                    artifact_id="artifact_456",
+                    slide_index=2,
+                    prompt="Make it simpler",
+                )
+
+        assert result is not None
+        assert result.status == "failed"
+        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_revise_slide_other_rpc_error_reraises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """revise_slide re-raises non-USER_DISPLAYABLE_ERROR RPCErrors."""
+        async with NotebookLMClient(auth_tokens) as client:
+            err = RPCError("Internal error")
+            err.rpc_code = "INTERNAL_ERROR"
+            with (
+                patch.object(
+                    client.artifacts._core,
+                    "rpc_call",
+                    AsyncMock(side_effect=err),
+                ),
+                pytest.raises(RPCError),
+            ):
+                await client.artifacts.revise_slide(
+                    notebook_id="nb_123",
+                    artifact_id="artifact_456",
+                    slide_index=0,
+                    prompt="Fix this",
+                )
+
+
+class TestGenerateMindMapParsing:
+    """Tests for generate_mind_map() result parsing (lines 957-986)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_mind_map_returns_none_on_empty_result(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_mind_map returns {'mind_map': None, 'note_id': None} when RPC returns None."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        mindmap_response = build_rpc_response(RPCMethod.GENERATE_MIND_MAP, None)
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=mindmap_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_mind_map("nb_123")
+
+        assert result == {"mind_map": None, "note_id": None}
+
+    @pytest.mark.asyncio
+    async def test_generate_mind_map_parses_json_string(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_mind_map parses JSON string in RPC result and creates a note."""
+        mind_map_dict = {"name": "Root Topic", "children": [{"name": "Child 1"}]}
+        mind_map_json_str = json.dumps(mind_map_dict)
+
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        # RPC response: [[json_string]]
+        mindmap_response = build_rpc_response(RPCMethod.GENERATE_MIND_MAP, [[mind_map_json_str]])
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=mindmap_response.encode())
+
+        mock_note = MagicMock()
+        mock_note.id = "note_created_001"
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts._notes,
+                "create",
+                AsyncMock(return_value=mock_note),
+            ):
+                result = await client.artifacts.generate_mind_map("nb_123")
+
+        assert result["mind_map"] == mind_map_dict
+        assert result["note_id"] == "note_created_001"
+
+    @pytest.mark.asyncio
+    async def test_generate_mind_map_handles_dict_not_string(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_mind_map handles case where mind_map_json is already a dict."""
+        mind_map_dict = {"name": "Topic", "children": []}
+
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        # RPC response: [[dict_object]] — not a string, already parsed
+        mindmap_response = build_rpc_response(RPCMethod.GENERATE_MIND_MAP, [[mind_map_dict]])
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=mindmap_response.encode())
+
+        mock_note = MagicMock()
+        mock_note.id = "note_dict_001"
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts._notes,
+                "create",
+                AsyncMock(return_value=mock_note),
+            ):
+                result = await client.artifacts.generate_mind_map("nb_123")
+
+        assert result["mind_map"] == mind_map_dict
+        assert result["note_id"] == "note_dict_001"
+
+    @pytest.mark.asyncio
+    async def test_generate_mind_map_with_source_ids_none_fetches_sources(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_mind_map with source_ids=None fetches source IDs from GET_NOTEBOOK."""
+
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        mindmap_response = build_rpc_response(RPCMethod.GENERATE_MIND_MAP, None)
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=mindmap_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_mind_map("nb_123", source_ids=None)
+
+        assert result == {"mind_map": None, "note_id": None}
+
+
+class TestDownloadAudioErrorPaths:
+    """Tests for download_audio error paths (lines 1098-1147, 1177-1179)."""
+
+    @pytest.mark.asyncio
+    async def test_download_audio_empty_list_raises_not_ready(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_audio raises ArtifactNotReadyError when no audio artifacts found."""
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactNotReadyError):
+                await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
+
+    @pytest.mark.asyncio
+    async def test_download_audio_artifact_id_not_found_raises_not_ready(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_audio raises ArtifactNotReadyError when specified artifact_id not found."""
+        # Completed audio artifact but with a different ID
+        audio_art = [
+            "other_audio_001",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            [None, None, None, None, None, [[]]],  # metadata at [6]
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_art]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactNotReadyError):
+                await client.artifacts.download_audio(
+                    "nb_123", "/tmp/audio.mp4", artifact_id="requested_but_missing"
+                )
+
+    @pytest.mark.asyncio
+    async def test_download_audio_invalid_metadata_structure_raises_parse_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_audio raises ArtifactParseError when metadata[6] has wrong structure."""
+        # Audio artifact with art[6] being a short list (len <= 5)
+        audio_art = [
+            "audio_001",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            [None, None],  # art[6] — too short, len <= 5
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_art]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactParseError, match="Invalid audio metadata structure"):
+                await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
+
+    @pytest.mark.asyncio
+    async def test_download_audio_no_media_urls_raises_parse_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_audio raises ArtifactParseError when media_list is empty."""
+        # Audio artifact with art[6][5] being an empty list
+        audio_art = [
+            "audio_001",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            [None, None, None, None, None, []],  # art[6], art[6][5] = []
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_art]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactParseError, match="No media URLs found"):
+                await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
+
+    @pytest.mark.asyncio
+    async def test_download_audio_index_error_raises_parse_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_audio wraps IndexError/TypeError in ArtifactParseError."""
+        # art[6] is a string, not a list — will cause TypeError
+        audio_art = [
+            "audio_001",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            "not_a_list",  # art[6] is wrong type, causes TypeError
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_art]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactParseError, match="Failed to parse audio artifact"):
+                await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
+
+
+class TestGenerateMindMapSourceIdsNone:
+    """Tests for generate methods with source_ids=None (lines 1189-1211)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_audio_source_ids_none_fetches_sources(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_audio with source_ids=None calls GET_NOTEBOOK to fetch source IDs."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_abc"], "Source A", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        audio_response = build_rpc_response(
+            RPCMethod.CREATE_ARTIFACT, [["audio_new", "Audio Overview", None, None, 1]]
+        )
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=audio_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_audio("nb_123", source_ids=None)
+
+        assert result.task_id == "audio_new"
+
+    @pytest.mark.asyncio
+    async def test_generate_data_table_source_ids_none_fetches_sources(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_data_table with source_ids=None calls GET_NOTEBOOK to fetch source IDs."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_xyz"], "Source X", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        table_response = build_rpc_response(
+            RPCMethod.CREATE_ARTIFACT, [["dt_new", "Data Table", None, None, 1]]
+        )
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=table_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_data_table("nb_123", source_ids=None)
+
+        assert result.task_id == "dt_new"
+
+
+class TestPollStatusVariousPaths:
+    """Tests for poll_status() various status paths (lines 1412-1518)."""
+
+    @pytest.mark.asyncio
+    async def test_poll_status_pending_artifact_not_in_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'pending' when task_id not found in artifact list."""
+        # Return artifacts that don't include the task_id we're polling
+        artifact = ["some_other_artifact", "Report", 2, None, 3]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "unknown_task_id")
+
+        assert result.status == "pending"
+        assert result.task_id == "unknown_task_id"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_completed_audio_without_url_downgrades_to_processing(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status downgrades audio from COMPLETED to in_progress when URLs missing."""
+        # Audio artifact with COMPLETED status but no media URLs (art[6] missing)
+        artifact = [
+            "audio_task",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED status
+            # No art[6] — missing media URL data
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "audio_task")
+
+        # Should be downgraded to in_progress since URL is not ready
+        assert result.status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_completed_report_no_url_check(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'completed' for non-media types without URL check."""
+        # Report artifact (non-media) — status=COMPLETED should pass through directly
+        artifact = [
+            "report_task",
+            "Briefing Doc",
+            2,  # REPORT type — non-media
+            None,
+            3,  # COMPLETED
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "report_task")
+
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_completed_audio_with_valid_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'completed' for audio when URLs are ready."""
+        # Audio artifact with proper media URL structure
+        audio_artifact = [
+            "audio_ready",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                [["https://storage.googleapis.com/audio.mp4", None, "audio/mp4"]],
+            ],
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "audio_ready")
+
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_empty_list_returns_pending(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'pending' when artifact list is empty."""
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "some_task_id")
+
+        assert result.status == "pending"
+
+
+class TestCallGenerateErrorHandling:
+    """Tests for _call_generate() error handling (USER_DISPLAYABLE_ERROR path)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_audio_user_displayable_error_returns_failed(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_call_generate returns failed GenerationStatus on USER_DISPLAYABLE_ERROR."""
+        async with NotebookLMClient(auth_tokens) as client:
+            err = RPCError("You have exceeded your quota")
+            err.rpc_code = "USER_DISPLAYABLE_ERROR"
+            # Pass source_ids explicitly so get_source_ids (GET_NOTEBOOK) is NOT called.
+            # Then patch _core.rpc_call so the CREATE_ARTIFACT call raises the error.
+            with patch.object(
+                client.artifacts._core,
+                "rpc_call",
+                AsyncMock(side_effect=err),
+            ):
+                result = await client.artifacts.generate_audio("nb_123", source_ids=["src_001"])
+
+        assert result.status == "failed"
+        assert result.error_code == "USER_DISPLAYABLE_ERROR"
+
+    @pytest.mark.asyncio
+    async def test_generate_audio_other_rpc_error_reraises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_call_generate re-raises non-USER_DISPLAYABLE_ERROR RPCErrors."""
+        async with NotebookLMClient(auth_tokens) as client:
+            err = RPCError("Server error")
+            err.rpc_code = "INTERNAL_ERROR"
+            # Pass source_ids explicitly so get_source_ids (GET_NOTEBOOK) is NOT called.
+            # Then patch _core.rpc_call so the CREATE_ARTIFACT call raises the error.
+            with (
+                patch.object(
+                    client.artifacts._core,
+                    "rpc_call",
+                    AsyncMock(side_effect=err),
+                ),
+                pytest.raises(RPCError),
+            ):
+                await client.artifacts.generate_audio("nb_123", source_ids=["src_001"])
+
+
+class TestDownloadUrlValidation:
+    """Tests for _download_url security validation (lines 2041-2044)."""
+
+    @pytest.mark.asyncio
+    async def test_download_url_non_https_raises_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_download_url raises ArtifactDownloadError for non-HTTPS URLs."""
+        from notebooklm.types import ArtifactDownloadError
+
+        # Build completed audio artifact with HTTP (not HTTPS) URL
+        audio_artifact = [
+            "audio_insecure",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                [["http://storage.googleapis.com/audio.mp4", None, "audio/mp4"]],
+            ],
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactDownloadError, match="must use HTTPS"):
+                await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
+
+    @pytest.mark.asyncio
+    async def test_download_url_untrusted_domain_raises_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_download_url raises ArtifactDownloadError for untrusted domains."""
+        from notebooklm.types import ArtifactDownloadError
+
+        audio_artifact = [
+            "audio_untrusted",
+            "Audio Overview",
+            1,  # AUDIO type
+            None,
+            3,  # COMPLETED
+            None,
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                [["https://evil.example.com/audio.mp4", None, "audio/mp4"]],
+            ],
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[audio_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactDownloadError, match="Untrusted download domain"):
+                await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
+
+
+class TestParseGenerationResult:
+    """Tests for _parse_generation_result (lines 2092-2095, 2117-2123)."""
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_failed_status_when_no_artifact_id(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_parse_generation_result returns failed status when result has no artifact_id."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        # CREATE_ARTIFACT returns an empty list — no artifact_id
+        empty_response = build_rpc_response(RPCMethod.CREATE_ARTIFACT, [])
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=empty_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_audio("nb_123")
+
+        assert result.status == "failed"
+        assert result.task_id == ""
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_failed_status_when_result_is_none(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_parse_generation_result returns failed status when result is None."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        # CREATE_ARTIFACT returns null result
+        null_response = build_rpc_response(RPCMethod.CREATE_ARTIFACT, None)
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=null_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_audio("nb_123")
+
+        assert result.status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_status_from_artifact_data(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """_parse_generation_result reads status_code from artifact_data[4]."""
+        notebook_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [[["src_001"], "Source 1", [None, 0], [None, 2]]],
+                    "nb_123",
+                    None,
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        # CREATE_ARTIFACT returns artifact with status_code=3 (COMPLETED)
+        completed_response = build_rpc_response(
+            RPCMethod.CREATE_ARTIFACT, [["art_done", "Audio", 1, None, 3]]
+        )
+        httpx_mock.add_response(content=notebook_response.encode())
+        httpx_mock.add_response(content=completed_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.generate_audio("nb_123")
+
+        assert result.task_id == "art_done"
+        assert result.status == "completed"
+
+
+class TestGetArtifactTypeNameAndIsMediaReady:
+    """Tests for _get_artifact_type_name and _is_media_ready helper methods."""
+
+    @pytest.mark.asyncio
+    async def test_poll_status_quiz_completed_no_url_check(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'completed' for quiz without URL check (non-media type)."""
+        artifact = [
+            "quiz_task",
+            "Quiz",
+            4,  # QUIZ type
+            None,
+            3,  # COMPLETED
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "quiz_task")
+
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_data_table_completed_no_url_check(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'completed' for data table without URL check."""
+        artifact = [
+            "table_task",
+            "Data Table",
+            9,  # DATA_TABLE type
+            None,
+            3,  # COMPLETED
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "table_task")
+
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_video_completed_with_valid_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'completed' for video when art[8] has valid URL."""
+        # Video artifact with art[8] containing a URL
+        video_artifact = [
+            "video_task",
+            "Video Overview",
+            3,  # VIDEO type
+            None,
+            3,  # COMPLETED
+            None,
+            None,
+            None,
+            [["https://storage.googleapis.com/video.mp4"]],  # art[8]
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[video_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "video_task")
+
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_video_completed_without_url_downgrades(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status downgrades video from COMPLETED to in_progress when URL missing."""
+        video_artifact = [
+            "video_task",
+            "Video Overview",
+            3,  # VIDEO type
+            None,
+            3,  # COMPLETED — but no art[8]
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[video_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "video_task")
+
+        assert result.status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_infographic_completed_without_url_downgrades(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status downgrades infographic from COMPLETED to in_progress when URL missing."""
+        infographic_artifact = [
+            "ig_task",
+            "Infographic",
+            7,  # INFOGRAPHIC type
+            None,
+            3,  # COMPLETED — but no nested URL structure
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[infographic_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "ig_task")
+
+        assert result.status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_slide_deck_completed_with_valid_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status returns 'completed' for slide deck when art[16][3] has valid URL."""
+        slide_artifact = [
+            "slide_task",
+            "Slide Deck",
+            8,  # SLIDE_DECK type
+            None,
+            3,  # COMPLETED
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [None, "Title", None, "https://docs.googleusercontent.com/slides.pdf"],  # art[16]
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[slide_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "slide_task")
+
+        assert result.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_slide_deck_completed_without_url_downgrades(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """poll_status downgrades slide deck from COMPLETED to in_progress when URL missing."""
+        slide_artifact = [
+            "slide_task",
+            "Slide Deck",
+            8,  # SLIDE_DECK type
+            None,
+            3,  # COMPLETED — but no art[16]
+        ]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[slide_artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.artifacts.poll_status("nb_123", "slide_task")
+
+        assert result.status == "in_progress"
+
+
+class TestDownloadQuizFlashcardParsing:
+    """Tests for download_quiz/flashcard parsing error paths."""
+
+    @pytest.mark.asyncio
+    async def test_download_flashcards_html_without_app_data(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_flashcards raises ArtifactParseError when HTML lacks data-app-data."""
+        artifact_data = [
+            "fc_001",  # [0] id
+            "My Flashcards",  # [1] title
+            4,  # [2] QUIZ type (also used for flashcards)
+            None,  # [3]
+            3,  # [4] COMPLETED
+            None,  # [5]
+            None,  # [6]
+            None,  # [7]
+            None,  # [8]
+            [None, [1]],  # [9] options: [9][1][0] = 1 => flashcards variant
+            None,  # [10]
+            None,  # [11]
+            None,  # [12]
+            None,  # [13]
+            None,  # [14]
+            [[1704067200]],  # [15] created_at
+        ]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        httpx_mock.add_response(content=list_response.encode())
+
+        html_without_data = "<html><body><p>No app data</p></body></html>"
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts,
+                "_get_artifact_content",
+                AsyncMock(return_value=html_without_data),
+            ):
+                with pytest.raises(ArtifactParseError, match="data-app-data"):
+                    await client.artifacts.download_flashcards("nb_123", "/tmp/flashcards.json")
+
+    @pytest.mark.asyncio
+    async def test_download_quiz_invalid_output_format_raises_validation_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_quiz raises ValidationError for invalid output_format."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValidationError, match="Invalid output_format"):
+                await client.artifacts.download_quiz("nb_123", "/tmp/quiz.xyz", output_format="xyz")
+
+    @pytest.mark.asyncio
+    async def test_download_flashcards_invalid_output_format_raises_validation_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_flashcards raises ValidationError for invalid output_format."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValidationError, match="Invalid output_format"):
+                await client.artifacts.download_flashcards(
+                    "nb_123", "/tmp/flashcards.bad", output_format="csv"
+                )
+
+    @pytest.mark.asyncio
+    async def test_download_quiz_no_completed_raises_not_ready(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """download_quiz raises ArtifactNotReadyError when no completed quiz exists."""
+        # Return empty list — no quiz artifacts
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ArtifactNotReadyError):
+                await client.artifacts.download_quiz("nb_123", "/tmp/quiz.json")
+
+    @pytest.mark.asyncio
+    async def test_download_quiz_html_format_returns_raw_html(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """download_quiz with output_format='html' writes raw HTML content."""
+        artifact_data = [
+            "quiz_html_001",  # [0] id
+            "HTML Quiz",  # [1] title
+            4,  # [2] QUIZ type
+            None,  # [3]
+            3,  # [4] COMPLETED
+            None,  # [5]
+            None,  # [6]
+            None,  # [7]
+            None,  # [8]
+            [None, [2]],  # [9] options: [9][1][0] = 2 => quiz variant
+            None,  # [10]
+            None,  # [11]
+            None,  # [12]
+            None,  # [13]
+            None,  # [14]
+            [[1704067200]],  # [15] created_at
+        ]
+        list_response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact_data]])
+        httpx_mock.add_response(content=list_response.encode())
+
+        raw_html = '<html><body data-app-data="{&quot;quiz&quot;:[]}">content</body></html>'
+
+        output_path = str(tmp_path / "quiz.html")
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.artifacts,
+                "_get_artifact_content",
+                AsyncMock(return_value=raw_html),
+            ):
+                result = await client.artifacts.download_quiz(
+                    "nb_123", output_path, output_format="html"
+                )
+
+        assert result == output_path
+        from pathlib import Path
+
+        assert Path(output_path).read_text() == raw_html
+
+
+class TestWaitForCompletionDeprecated:
+    """Tests for wait_for_completion deprecated poll_interval parameter."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_completion_deprecated_poll_interval_warning(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """wait_for_completion issues DeprecationWarning for poll_interval parameter."""
+        import warnings
+
+        # Return a completed artifact immediately so it doesn't loop
+        artifact = ["task_dep", "Report", 2, None, 3]
+        response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[artifact]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                result = await client.artifacts.wait_for_completion(
+                    "nb_123", "task_dep", poll_interval=1.0
+                )
+                assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+
+        assert result.status == "completed"

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -1,5 +1,7 @@
 """Integration tests for ChatAPI."""
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from pytest_httpx import HTTPXMock
 
@@ -593,3 +595,1179 @@ class TestChatReferences:
             )
 
         assert result.answer == "The real answer."
+
+
+class TestChatAskErrorHandling:
+    """Tests for ask() HTTP error handling (lines 127-158, 170)."""
+
+    @pytest.mark.asyncio
+    async def test_ask_timeout_raises_network_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test ask() raises NetworkError on httpx.TimeoutException."""
+        import re
+
+        import httpx
+
+        from notebooklm.exceptions import NetworkError
+
+        httpx_mock.add_exception(
+            httpx.TimeoutException("timed out"),
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(NetworkError, match="timed out"):
+                await client.chat.ask(
+                    "nb_123",
+                    "What is this?",
+                    source_ids=["src_001"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_ask_http_status_error_raises_chat_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test ask() raises ChatError on httpx.HTTPStatusError."""
+        import re
+
+        from notebooklm.exceptions import ChatError
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            status_code=403,
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ChatError, match="403"):
+                await client.chat.ask(
+                    "nb_123",
+                    "What is this?",
+                    source_ids=["src_001"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_ask_request_error_raises_network_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test ask() raises NetworkError on httpx.RequestError."""
+        import re
+
+        import httpx
+
+        from notebooklm.exceptions import NetworkError
+
+        httpx_mock.add_exception(
+            httpx.ConnectError("connection refused"),
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(NetworkError, match="connection refused"):
+                await client.chat.ask(
+                    "nb_123",
+                    "What is this?",
+                    source_ids=["src_001"],
+                )
+
+    @pytest.mark.asyncio
+    async def test_ask_without_csrf_token_skips_at_param(
+        self,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test ask() without csrf_token omits the 'at' param (line 127 branch)."""
+        import json
+        import re
+
+        from notebooklm.auth import AuthTokens
+
+        # Auth tokens without csrf_token
+        auth_no_csrf = AuthTokens(
+            cookies={"SID": "sid"},
+            csrf_token=None,
+            session_id=None,
+        )
+
+        inner_data = [
+            [
+                "Answer without csrf.",
+                None,
+                [12345],
+                None,
+                [[], None, None, [], 1],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=response_body.encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_no_csrf) as client:
+            result = await client.chat.ask(
+                "nb_123",
+                "What is this?",
+                source_ids=["src_001"],
+            )
+
+        assert result.answer == "Answer without csrf."
+
+    @pytest.mark.asyncio
+    async def test_ask_with_session_id_adds_fsid_param(
+        self,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test ask() with session_id adds f.sid param (line 140-143)."""
+        import json
+        import re
+
+        from notebooklm.auth import AuthTokens
+
+        auth_with_session = AuthTokens(
+            cookies={"SID": "sid"},
+            csrf_token="test_token",
+            session_id="my_session_id",
+        )
+
+        inner_data = [
+            [
+                "Answer with session.",
+                None,
+                [12345],
+                None,
+                [[], None, None, [], 1],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=response_body.encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_with_session) as client:
+            result = await client.chat.ask(
+                "nb_123",
+                "What is this?",
+                source_ids=["src_001"],
+            )
+
+        assert result.answer == "Answer with session."
+        request = httpx_mock.get_request()
+        assert "f.sid" in str(request.url)
+
+    @pytest.mark.asyncio
+    async def test_ask_empty_answer_does_not_cache_turn(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that empty answer response does not cache a turn (lines 150-158)."""
+        import re
+
+        # Return totally empty/unparseable response
+        response_body = ")]}'\n"
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=response_body.encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.ask(
+                "nb_123",
+                "What is this?",
+                source_ids=["src_001"],
+            )
+
+        # Empty answer: turn_number equals len(turns) (0), not len(turns)+1
+        assert result.answer == ""
+        assert result.turn_number == 0
+        # Conversation ID is still generated
+        assert result.conversation_id is not None
+
+    @pytest.mark.asyncio
+    async def test_ask_follow_up_sets_is_follow_up(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Test ask() with existing conversation_id sets is_follow_up=True (line 170)."""
+        import json
+        import re
+
+        inner_data = [
+            [
+                "Follow-up answer.",
+                None,
+                [12345],
+                None,
+                [[], None, None, [], 1],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=response_body.encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.ask(
+                "nb_123",
+                "Follow-up question?",
+                source_ids=["src_001"],
+                conversation_id="existing-conv-id",
+            )
+
+        assert result.is_follow_up is True
+        assert result.conversation_id == "existing-conv-id"
+
+
+class TestGetConversationIdEdgeCases:
+    """Tests for get_conversation_id edge cases (lines 231-235)."""
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_id_returns_none_on_empty_response(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_conversation_id returns None when RPC response is empty list."""
+        response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_conversation_id("nb_123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_id_returns_none_on_empty_nested(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_conversation_id returns None when response has no valid ID."""
+        # Non-empty response but no valid conv_id in it
+        response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[[]]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_conversation_id("nb_123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_id_returns_none_on_non_string_conv(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_conversation_id returns None when conv entry is not a string."""
+        # Response with non-string first element in conv list
+        response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[[42]]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_conversation_id("nb_123")
+
+        assert result is None
+
+
+class TestGetHistoryErrorHandling:
+    """Tests for get_history error handling (lines 266-279)."""
+
+    @pytest.mark.asyncio
+    async def test_get_history_returns_empty_on_chat_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history returns [] when get_conversation_turns raises ChatError."""
+        from notebooklm.exceptions import ChatError
+
+        id_response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[["conv_001"]]])
+        httpx_mock.add_response(content=id_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.chat,
+                "get_conversation_turns",
+                new_callable=AsyncMock,
+                side_effect=ChatError("API error"),
+            ):
+                result = await client.chat.get_history("nb_123")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_returns_empty_on_network_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history returns [] when get_conversation_turns raises NetworkError."""
+        from notebooklm.exceptions import NetworkError
+
+        id_response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[["conv_001"]]])
+        httpx_mock.add_response(content=id_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.chat,
+                "get_conversation_turns",
+                new_callable=AsyncMock,
+                side_effect=NetworkError("connection error"),
+            ):
+                result = await client.chat.get_history("nb_123")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_returns_empty_when_no_conversation(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history returns [] when get_conversation_id returns None."""
+        response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_history("nb_123")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_history_reverses_turns(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history reverses turns_data when turns_data[0][0] is a list (lines 272-279)."""
+        id_response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[["conv_001"]]])
+        # Newest-first: [A1, Q1]
+        turns_response = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [
+                [
+                    [None, None, 2, None, [["The answer."]]],
+                    [None, None, 1, "The question?"],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=id_response.encode())
+        httpx_mock.add_response(content=turns_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_history("nb_123")
+
+        assert len(result) == 1
+        assert result[0] == ("The question?", "The answer.")
+
+    @pytest.mark.asyncio
+    async def test_get_history_with_provided_conversation_id(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history uses provided conversation_id without fetching it."""
+        turns_response = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [
+                [
+                    [None, None, 2, None, [["Direct answer."]]],
+                    [None, None, 1, "Direct question?"],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=turns_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_history("nb_123", conversation_id="conv_direct")
+
+        assert len(result) == 1
+        assert result[0] == ("Direct question?", "Direct answer.")
+
+
+class TestBuildConversationHistory:
+    """Tests for _build_conversation_history (line 422)."""
+
+    def test_build_conversation_history_returns_none_when_no_cached_turns(self, auth_tokens):
+        """Test _build_conversation_history returns None for unknown conversation_id."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._build_conversation_history("nonexistent-conv-id")
+        assert result is None
+
+    def test_build_conversation_history_returns_list_when_turns_cached(self, auth_tokens):
+        """Test _build_conversation_history returns history list when turns exist."""
+        client = NotebookLMClient(auth_tokens)
+        # Manually cache a turn
+        client._core.cache_conversation_turn(
+            "test-conv", "What is AI?", "AI is artificial intelligence.", 1
+        )
+        result = client.chat._build_conversation_history("test-conv")
+        assert result is not None
+        assert len(result) == 2
+        # History format: [[answer, None, 2], [query, None, 1]]
+        assert result[0] == ["AI is artificial intelligence.", None, 2]
+        assert result[1] == ["What is AI?", None, 1]
+
+
+class TestParseAskResponseEdgeCases:
+    """Tests for _parse_ask_response_with_references edge cases (lines 439-489)."""
+
+    def test_parse_response_with_stripped_prefix(self, auth_tokens):
+        """Test that response starting with )]}' has the prefix stripped (line 439-442)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        inner_data = [["Answer text.", None, [12345], None, [[], None, None, [], 1]]]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        assert answer == "Answer text."
+
+    def test_parse_response_without_prefix(self, auth_tokens):
+        """Test response not starting with )]}' is parsed directly."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        inner_data = [["Answer without prefix.", None, [12345], None, [[], None, None, [], 1]]]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f"{len(chunk_json)}\n{chunk_json}\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        assert answer == "Answer without prefix."
+
+    def test_parse_empty_response_returns_empty_string(self, auth_tokens):
+        """Test that completely empty response returns empty string (line 489)."""
+        client = NotebookLMClient(auth_tokens)
+        answer, refs = client.chat._parse_ask_response_with_references(")]}'\n")
+        assert answer == ""
+        assert refs == []
+
+    def test_parse_response_no_marked_answer_falls_back_to_unmarked(self, auth_tokens):
+        """Test fallback to unmarked text when no marked answer exists (line 486)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # Response with no trailing 1 marker in type_info
+        inner_data = [
+            [
+                "This is unmarked text content.",
+                None,
+                [12345],
+                None,
+                [[], None, None],  # no trailing 1 = unmarked
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        assert answer == "This is unmarked text content."
+
+    def test_parse_response_assigns_citation_numbers(self, auth_tokens):
+        """Test that citation_number is assigned based on order of appearance (line 462-463)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        inner_data = [
+            [
+                "Answer with citation.",
+                None,
+                [12345],
+                None,
+                [
+                    [],
+                    None,
+                    None,
+                    [
+                        [
+                            ["chunk-001"],
+                            [
+                                None,
+                                None,
+                                0.9,
+                                [[None]],
+                                [[[100, 200, [[[50, 150, "cited text"]]]]]],
+                                [[[["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"]]]],
+                                ["chunk-001"],
+                            ],
+                        ],
+                    ],
+                    1,
+                ],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        assert len(refs) == 1
+        assert refs[0].citation_number == 1
+
+
+class TestExtractAnswerAndRefsFromChunk:
+    """Tests for _extract_answer_and_refs_from_chunk edge cases (lines 496-561)."""
+
+    def test_invalid_json_returns_none(self, auth_tokens):
+        """Test that invalid JSON input returns (None, False, []) (line 496-527)."""
+        client = NotebookLMClient(auth_tokens)
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk("not-valid-json")
+        assert text is None
+        assert is_answer is False
+        assert refs == []
+
+    def test_non_list_data_returns_none(self, auth_tokens):
+        """Test that non-list JSON data returns (None, False, []) (line 530)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(
+            json.dumps("a string value")
+        )
+        assert text is None
+        assert is_answer is False
+        assert refs == []
+
+    def test_item_not_wrb_fr_is_skipped(self, auth_tokens):
+        """Test that items where item[0] != 'wrb.fr' are skipped (line 540)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        data = [["other.fr", "method_id", json.dumps([[["answer"]]])]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+
+    def test_inner_json_not_string_is_skipped(self, auth_tokens):
+        """Test that non-string inner_json is skipped (line 544)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # item[2] is an integer, not a string
+        data = [["wrb.fr", "method_id", 42, None, None]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+
+    def test_inner_data_first_not_list_is_skipped(self, auth_tokens):
+        """Test that inner_data[0] that is not a list is skipped (line 546)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # inner_data[0] is a string, not a list
+        inner_data = ["not a list"]
+        data = [["wrb.fr", "method_id", json.dumps(inner_data)]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+
+    def test_inner_data_first_text_not_string_is_skipped(self, auth_tokens):
+        """Test that non-string first[0] text is skipped (line 546)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # first[0] is None, not a string
+        inner_data = [[[None, None, [12345]]]]
+        data = [["wrb.fr", "method_id", json.dumps(inner_data)]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+
+    def test_inner_json_invalid_json_continues(self, auth_tokens):
+        """Test that invalid inner JSON is caught and processing continues (line 560-561)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # item[2] is a string but not valid JSON
+        data = [["wrb.fr", "method_id", "{not valid json}"]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+        assert refs == []
+
+    def test_returns_none_when_no_wrb_fr_items(self, auth_tokens):
+        """Test that empty list or no matching items returns (None, False, [])."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps([]))
+        assert text is None
+        assert is_answer is False
+        assert refs == []
+
+    def test_item_with_too_few_elements_is_skipped(self, auth_tokens):
+        """Test items with len < 3 are skipped."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        data = [["wrb.fr", "only_two"]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+
+
+class TestParseCitationsEdgeCases:
+    """Tests for _parse_citations edge cases (lines 599-605)."""
+
+    def test_parse_citations_returns_empty_on_type_error(self, auth_tokens):
+        """Test _parse_citations returns [] when first causes TypeError (lines 599-605)."""
+        client = NotebookLMClient(auth_tokens)
+        # Passing None triggers TypeError in len(first) at the guard check
+        refs = client.chat._parse_citations(None)  # type: ignore[arg-type]
+        assert refs == []
+
+    def test_parse_citations_returns_empty_when_first_too_short(self, auth_tokens):
+        """Test _parse_citations returns [] when first has <= 4 elements."""
+        client = NotebookLMClient(auth_tokens)
+        first = ["text", None, None, None]  # len == 4, no index 4
+        refs = client.chat._parse_citations(first)
+        assert refs == []
+
+    def test_parse_citations_returns_empty_when_type_info_too_short(self, auth_tokens):
+        """Test _parse_citations returns [] when type_info has <= 3 elements."""
+        client = NotebookLMClient(auth_tokens)
+        first = ["text", None, None, None, [1, 2, 3]]  # type_info has no index 3
+        refs = client.chat._parse_citations(first)
+        assert refs == []
+
+    def test_parse_citations_returns_empty_when_type_info_3_not_list(self, auth_tokens):
+        """Test _parse_citations returns [] when type_info[3] is not a list."""
+        client = NotebookLMClient(auth_tokens)
+        first = ["text", None, None, None, [1, 2, 3, "not_a_list"]]
+        refs = client.chat._parse_citations(first)
+        assert refs == []
+
+
+class TestParseSingleCitationEdgeCases:
+    """Tests for _parse_single_citation edge cases (lines 617, 621)."""
+
+    def test_parse_single_citation_returns_none_when_not_list(self, auth_tokens):
+        """Test _parse_single_citation returns None when cite is not a list (line 617)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._parse_single_citation("not a list")
+        assert result is None
+
+    def test_parse_single_citation_returns_none_when_too_short(self, auth_tokens):
+        """Test _parse_single_citation returns None when cite has len < 2 (line 617)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._parse_single_citation(["only_one"])
+        assert result is None
+
+    def test_parse_single_citation_returns_none_when_cite_inner_not_list(self, auth_tokens):
+        """Test _parse_single_citation returns None when cite[1] is not a list (line 621)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._parse_single_citation([["chunk-id"], "not_a_list"])
+        assert result is None
+
+    def test_parse_single_citation_returns_none_when_no_source_id(self, auth_tokens):
+        """Test _parse_single_citation returns None when no valid UUID found."""
+        client = NotebookLMClient(auth_tokens)
+        # cite_inner with 6 elements but source_id_data has no valid UUID
+        cite = [
+            ["chunk-001"],
+            [None, None, 0.9, [[None]], [], "not-a-uuid"],
+        ]
+        result = client.chat._parse_single_citation(cite)
+        assert result is None
+
+    def test_parse_single_citation_with_non_string_chunk_id(self, auth_tokens):
+        """Test _parse_single_citation with non-string first item in cite[0] (line 633)."""
+        client = NotebookLMClient(auth_tokens)
+        # cite[0][0] is not a string, so chunk_id stays None
+        valid_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        cite = [
+            [42],  # non-string first item
+            [
+                None,
+                None,
+                0.9,
+                [[None]],
+                [],
+                [[[[valid_uuid]]]],
+            ],
+        ]
+        result = client.chat._parse_single_citation(cite)
+        assert result is not None
+        assert result.source_id == valid_uuid
+        assert result.chunk_id is None
+
+    def test_parse_single_citation_with_empty_cite_0(self, auth_tokens):
+        """Test _parse_single_citation when cite[0] is empty list (line 631)."""
+        client = NotebookLMClient(auth_tokens)
+        valid_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        cite = [
+            [],  # empty list - cite[0] is list but empty
+            [
+                None,
+                None,
+                0.9,
+                [[None]],
+                [],
+                [[[[valid_uuid]]]],
+            ],
+        ]
+        result = client.chat._parse_single_citation(cite)
+        assert result is not None
+        assert result.chunk_id is None
+
+
+class TestExtractTextPassagesEdgeCases:
+    """Tests for _extract_text_passages edge cases (lines 631-682)."""
+
+    def test_extract_text_passages_returns_none_when_too_short(self, auth_tokens):
+        """Test _extract_text_passages returns (None, None, None) when cite_inner too short (line 661-662)."""
+        client = NotebookLMClient(auth_tokens)
+        cite_inner = [None, None, None, None]  # len == 4, no index 4
+        result = client.chat._extract_text_passages(cite_inner)
+        assert result == (None, None, None)
+
+    def test_extract_text_passages_returns_none_when_index4_not_list(self, auth_tokens):
+        """Test _extract_text_passages returns (None, None, None) when cite_inner[4] is not a list (line 661-662)."""
+        client = NotebookLMClient(auth_tokens)
+        cite_inner = [None, None, None, None, "not_a_list"]
+        result = client.chat._extract_text_passages(cite_inner)
+        assert result == (None, None, None)
+
+    def test_extract_text_passages_skips_non_list_passage_wrapper(self, auth_tokens):
+        """Test _extract_text_passages skips passage_wrapper that is not a list (line 669-670)."""
+        client = NotebookLMClient(auth_tokens)
+        # cite_inner[4] contains a non-list item
+        cite_inner = [None, None, None, None, ["not_a_list_wrapper"]]
+        result = client.chat._extract_text_passages(cite_inner)
+        assert result == (None, None, None)
+
+    def test_extract_text_passages_skips_short_passage_data(self, auth_tokens):
+        """Test _extract_text_passages skips passage_data with len < 3 (line 672-673)."""
+        client = NotebookLMClient(auth_tokens)
+        cite_inner = [None, None, None, None, [[[100, 200]]]]  # passage_data has len 2
+        result = client.chat._extract_text_passages(cite_inner)
+        assert result == (None, None, None)
+
+
+class TestCollectTextsFromNested:
+    """Tests for _collect_texts_from_nested (lines 698, 709)."""
+
+    def test_non_list_input_returns_immediately(self, auth_tokens):
+        """Test _collect_texts_from_nested returns immediately for non-list input (line 698)."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        client.chat._collect_texts_from_nested("not a list", texts)
+        assert texts == []
+
+    def test_non_list_input_none_returns_immediately(self, auth_tokens):
+        """Test _collect_texts_from_nested returns immediately for None input."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        client.chat._collect_texts_from_nested(None, texts)
+        assert texts == []
+
+    def test_nested_group_not_list_is_skipped(self, auth_tokens):
+        """Test _collect_texts_from_nested skips nested_group that is not a list."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # nested contains a non-list item
+        client.chat._collect_texts_from_nested(["not_a_list_group"], texts)
+        assert texts == []
+
+    def test_text_val_is_list_extracts_strings(self, auth_tokens):
+        """Test _collect_texts_from_nested extracts strings when text_val is a list (line 709)."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # Structure: nested=[nested_group], nested_group=[inner], inner=[start, end, text_val]
+        nested = [[[0, 100, ["part one", "  ", "part two"]]]]
+        client.chat._collect_texts_from_nested(nested, texts)
+        assert "part one" in texts
+        assert "part two" in texts
+
+    def test_text_val_list_skips_non_strings(self, auth_tokens):
+        """Test _collect_texts_from_nested skips non-string items in text_val list."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # text_val list contains a mix of string and non-string
+        nested = [[[0, 100, [42, "valid text", None]]]]
+        client.chat._collect_texts_from_nested(nested, texts)
+        assert texts == ["valid text"]
+
+    def test_inner_with_len_less_than_3_is_skipped(self, auth_tokens):
+        """Test _collect_texts_from_nested skips inner items with len < 3."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # inner has only 2 elements
+        nested = [[[0, 100]]]
+        client.chat._collect_texts_from_nested(nested, texts)
+        assert texts == []
+
+
+class TestExtractUuidFromNested:
+    """Tests for _extract_uuid_from_nested (lines 728-743)."""
+
+    def test_max_depth_zero_returns_none_with_warning(self, auth_tokens):
+        """Test _extract_uuid_from_nested returns None when max_depth=0 (lines 728-729)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._extract_uuid_from_nested("some-data", max_depth=0)
+        assert result is None
+
+    def test_none_data_returns_none(self, auth_tokens):
+        """Test _extract_uuid_from_nested returns None for None input (line 732)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._extract_uuid_from_nested(None)
+        assert result is None
+
+    def test_valid_uuid_string_is_returned(self, auth_tokens):
+        """Test _extract_uuid_from_nested returns UUID when given directly as string."""
+        client = NotebookLMClient(auth_tokens)
+        valid_uuid = "12345678-1234-1234-1234-123456789abc"
+        result = client.chat._extract_uuid_from_nested(valid_uuid)
+        assert result == valid_uuid
+
+    def test_non_uuid_string_returns_none(self, auth_tokens):
+        """Test _extract_uuid_from_nested returns None for non-UUID string."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._extract_uuid_from_nested("not-a-uuid")
+        assert result is None
+
+    def test_list_with_no_uuid_returns_none(self, auth_tokens):
+        """Test _extract_uuid_from_nested returns None when list contains no UUID (line 737-743)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._extract_uuid_from_nested(["no", "uuid", "here"])
+        assert result is None
+
+    def test_nested_list_finds_uuid(self, auth_tokens):
+        """Test _extract_uuid_from_nested finds UUID nested in lists."""
+        client = NotebookLMClient(auth_tokens)
+        valid_uuid = "abcdef12-abcd-abcd-abcd-abcdef123456"
+        result = client.chat._extract_uuid_from_nested([[[[valid_uuid]]]])
+        assert result == valid_uuid
+
+    def test_integer_data_returns_none(self, auth_tokens):
+        """Test _extract_uuid_from_nested returns None for integer input (line 743 fallthrough)."""
+        client = NotebookLMClient(auth_tokens)
+        result = client.chat._extract_uuid_from_nested(42)
+        assert result is None
+
+
+class TestGetConversationIdNullRaw:
+    """Tests for get_conversation_id when rpc_call returns None/falsy (line 231->230)."""
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_id_returns_none_when_raw_is_null(
+        self,
+        auth_tokens,
+    ):
+        """Test get_conversation_id returns None when rpc_call returns None (arc 231->230)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            # Patch rpc_call to return None directly (bypasses decode error)
+            with patch.object(
+                client._core,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                result = await client.chat.get_conversation_id("nb_123")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_id_returns_none_with_non_list_groups(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_conversation_id returns None when groups in raw are not lists (arc 231->230)."""
+        # Response has non-list items in the outer array (valid decode but no conv_id)
+        response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, ["not_a_list"])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_conversation_id("nb_123")
+
+        assert result is None
+
+
+class TestGetHistoryTurnsDataNotReversed:
+    """Test get_history when turns_data doesn't qualify for reversal (arc 272->279)."""
+
+    @pytest.mark.asyncio
+    async def test_get_history_skips_reversal_when_turns_data_empty(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_history returns [] when turns_data is empty (skips reversal, arc 272->279)."""
+        id_response = build_rpc_response(RPCMethod.GET_LAST_CONVERSATION_ID, [[["conv_001"]]])
+        # turns_data is an empty outer list, so turns_data[0] is falsy
+        turns_response = build_rpc_response(
+            RPCMethod.GET_CONVERSATION_TURNS,
+            [[]],
+        )
+        httpx_mock.add_response(content=id_response.encode())
+        httpx_mock.add_response(content=turns_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.chat.get_history("nb_123")
+
+        assert result == []
+
+
+class TestParseAskResponseNumericLengthPrefix:
+    """Tests for the numeric length-prefixed format in _parse_ask_response (lines 468-473)."""
+
+    def test_parse_response_with_length_prefix_at_end_of_lines(self, auth_tokens):
+        """Test response with numeric line at end has no following line (arc 468->470)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # Response ends with a numeric line (no content follows it)
+        inner_data = [["Valid answer.", None, [12345], None, [[], None, None, [], 1]]]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        # Append a dangling numeric line at the end with no content following
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n99\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        # The valid chunk should still be parsed
+        assert answer == "Valid answer."
+
+    def test_parse_response_with_direct_json_line_no_prefix(self, auth_tokens):
+        """Test response where JSON lines are direct (not length-prefixed) (lines 471-473)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # Response with direct JSON chunk (no length prefix)
+        inner_data = [["Direct JSON answer.", None, [12345], None, [[], None, None, [], 1]]]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        # No length prefix - just direct JSON
+        response_body = f")]}}'\n{chunk_json}\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        assert answer == "Direct JSON answer."
+
+
+class TestExtractAnswerEmptyInnerData:
+    """Tests for _extract_answer_and_refs_from_chunk when inner_data is empty (arc 544->532)."""
+
+    def test_empty_inner_data_returns_none(self, auth_tokens):
+        """Test that inner_data == [] (empty list) causes loop to find nothing (arc 544->532)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # inner_data is an empty list -> len(inner_data) == 0, skips the processing
+        inner_data: list = []
+        data = [["wrb.fr", "method_id", json.dumps(inner_data)]]
+        text, is_answer, refs = client.chat._extract_answer_and_refs_from_chunk(json.dumps(data))
+        assert text is None
+        assert is_answer is False
+
+
+class TestExtractTextPassagesMultiplePassages:
+    """Tests for _extract_text_passages with multiple passages (lines 676-682)."""
+
+    def test_extract_text_passages_multiple_passages_updates_end_char(self, auth_tokens):
+        """Test that end_char is updated for each valid passage (lines 678-682)."""
+        client = NotebookLMClient(auth_tokens)
+        # Two passage_wrappers: first sets start_char and end_char, second updates end_char
+        cite_inner = [
+            None,
+            None,
+            None,
+            None,
+            [
+                # First passage_wrapper
+                [[100, 200, [[[50, 150, "first text"]]]]],
+                # Second passage_wrapper - end_char should be updated to 400
+                [[300, 400, [[[250, 380, "second text"]]]]],
+            ],
+        ]
+        cited_text, start_char, end_char = client.chat._extract_text_passages(cite_inner)
+        assert start_char == 100  # from first passage
+        assert end_char == 400  # updated by second passage
+
+    def test_extract_text_passages_start_char_not_reset_on_second_passage(self, auth_tokens):
+        """Test start_char is only set once from the first valid passage (arc 676->678)."""
+        client = NotebookLMClient(auth_tokens)
+        cite_inner = [
+            None,
+            None,
+            None,
+            None,
+            [
+                # First passage: sets start_char=10
+                [[10, 100, [[[5, 50, "text one"]]]]],
+                # Second passage: start_char should NOT be reset to 200
+                [[200, 300, [[[150, 250, "text two"]]]]],
+            ],
+        ]
+        _, start_char, _ = client.chat._extract_text_passages(cite_inner)
+        assert start_char == 10  # only set from first passage
+
+
+class TestCollectTextsFromNestedEmptyTextVal:
+    """Test _collect_texts_from_nested when text_val list has no extractable strings (arc 709->703)."""
+
+    def test_text_val_list_all_empty_strings_adds_nothing(self, auth_tokens):
+        """Test that text_val list with only whitespace strings adds nothing (arc 709->703)."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # text_val is a list but all items are whitespace or empty
+        nested = [[[0, 100, ["  ", "", "   "]]]]
+        client.chat._collect_texts_from_nested(nested, texts)
+        assert texts == []
+
+    def test_text_val_list_with_non_string_items_adds_nothing(self, auth_tokens):
+        """Test that text_val list with only non-string items adds nothing."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # text_val is a list but all items are non-strings
+        nested = [[[0, 100, [None, 42, True]]]]
+        client.chat._collect_texts_from_nested(nested, texts)
+        assert texts == []
+
+    def test_text_val_neither_string_nor_list_does_nothing(self, auth_tokens):
+        """Test that text_val that is neither string nor list is skipped (arc 709->703)."""
+        client = NotebookLMClient(auth_tokens)
+        texts = []
+        # text_val is an integer - neither str nor list - skips both branches
+        nested = [[[0, 100, 42]]]
+        client.chat._collect_texts_from_nested(nested, texts)
+        assert texts == []
+
+
+class TestParseAskResponseBranchCoverage:
+    """Tests for remaining branch coverage in _parse_ask_response and citation assignment."""
+
+    def test_existing_marked_answer_not_overwritten_by_shorter(self, auth_tokens):
+        """Test process_chunk doesn't update best_marked_answer when text is shorter (arc 454->456)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # First chunk: longer marked answer becomes best_marked_answer
+        # Second chunk: shorter marked answer - should NOT overwrite (arc 454->456)
+        longer_inner = [
+            ["This is the longer marked answer text.", None, [12345], None, [[], None, None, [], 1]]
+        ]
+        shorter_inner = [["Short.", None, [12346], None, [[], None, None, [], 1]]]
+
+        longer_json = json.dumps(longer_inner)
+        shorter_json = json.dumps(shorter_inner)
+
+        def make_chunk(inner_json):
+            chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+            return f"{len(chunk_json)}\n{chunk_json}"
+
+        # Both chunks with marked answers
+        response_body = f")]}}'\n{make_chunk(longer_json)}\n{make_chunk(shorter_json)}\n"
+
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        # Longer marked answer wins
+        assert answer == "This is the longer marked answer text."
+
+    def test_citation_number_not_reassigned_when_already_set(self, auth_tokens):
+        """Test that citation_number already set is not overwritten (arc 496->495)."""
+        import json
+
+        client = NotebookLMClient(auth_tokens)
+        # Build a response where the reference has citation_number pre-assigned via chunk processing
+        # We need two chunks each returning the same reference so on second pass citation_number
+        # is already set. Actually simpler: provide a chunk where citation is parsed and assigned,
+        # then verify it's 1 (first assignment).
+        # The arc 496->495 fires when citation_number is not None - we test the final state
+        inner_data = [
+            [
+                "Answer with citation.",
+                None,
+                [12345],
+                None,
+                [
+                    [],
+                    None,
+                    None,
+                    [
+                        [
+                            ["chunk-001"],
+                            [
+                                None,
+                                None,
+                                0.9,
+                                [[None]],
+                                [[[100, 200, [[[50, 150, "cited text"]]]]]],
+                                [[[["eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"]]]],
+                                ["chunk-001"],
+                            ],
+                        ],
+                    ],
+                    1,
+                ],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        # Two identical chunks - second one produces a ref with citation_number already set
+        # But actually each call to _parse_ask_response creates fresh refs, so two chunks
+        # means two refs (same source), first gets 1, second gets 2 (both had citation_number=None)
+        # To trigger 496->495 we need ref.citation_number to already be set.
+        # This can happen if we manually set citation_number before the assignment loop.
+        # However, in the normal flow, refs from _parse_citations don't have citation_number set.
+        # The only way to get citation_number != None before the assignment loop is if
+        # somehow the code path sets it earlier - which it doesn't.
+        # So arc 496->495 requires citation_number to be not None from _parse_citations.
+        # Since _parse_citations creates ChatReference with citation_number=None by default,
+        # this arc may not be reachable in normal flow - it's a defensive check.
+        # Let's verify the assignment logic works correctly with multiple refs.
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+        answer, refs = client.chat._parse_ask_response_with_references(response_body)
+        assert len(refs) == 1
+        assert refs[0].citation_number == 1
+
+
+class TestExtractTextPassagesNonIntEndChar:
+    """Test _extract_text_passages when passage_data[1] is not an int (arc 678->682)."""
+
+    def test_non_int_end_char_does_not_update_end_char(self, auth_tokens):
+        """Test end_char is not updated when passage_data[1] is not an int (arc 678->682)."""
+        client = NotebookLMClient(auth_tokens)
+        # passage_data[1] is a string, not int
+        cite_inner = [
+            None,
+            None,
+            None,
+            None,
+            [
+                [[100, "not_an_int", [[[50, 150, "some text"]]]]],
+            ],
+        ]
+        cited_text, start_char, end_char = client.chat._extract_text_passages(cite_inner)
+        assert start_char == 100
+        assert end_char is None  # not set since passage_data[1] was not int

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -1,8 +1,22 @@
 """Integration tests for client initialization and core functionality."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 import pytest
 
 from notebooklm import NotebookLMClient
+from notebooklm._core import MAX_CONVERSATION_CACHE_SIZE, ClientCore, is_auth_error
+from notebooklm.rpc import (
+    AuthError,
+    ClientError,
+    NetworkError,
+    RateLimitError,
+    RPCError,
+    RPCMethod,
+    RPCTimeoutError,
+    ServerError,
+)
 
 
 class TestClientInitialization:
@@ -23,3 +37,412 @@ class TestClientInitialization:
         client = NotebookLMClient(auth_tokens)
         with pytest.raises(RuntimeError, match="not initialized"):
             await client.notebooks.list()
+
+
+class TestIsAuthError:
+    """Tests for the is_auth_error() helper function."""
+
+    def test_returns_true_for_auth_error(self):
+        assert is_auth_error(AuthError("invalid credentials")) is True
+
+    def test_returns_false_for_network_error(self):
+        assert is_auth_error(NetworkError("network down")) is False
+
+    def test_returns_false_for_rate_limit_error(self):
+        assert is_auth_error(RateLimitError("rate limited")) is False
+
+    def test_returns_false_for_server_error(self):
+        assert is_auth_error(ServerError("500 error")) is False
+
+    def test_returns_false_for_client_error(self):
+        assert is_auth_error(ClientError("400 bad request")) is False
+
+    def test_returns_false_for_rpc_timeout_error(self):
+        assert is_auth_error(RPCTimeoutError("timed out")) is False
+
+    def test_returns_true_for_401_http_status_error(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        error = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_response)
+        assert is_auth_error(error) is True
+
+    def test_returns_true_for_403_http_status_error(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        error = httpx.HTTPStatusError("403", request=MagicMock(), response=mock_response)
+        assert is_auth_error(error) is True
+
+    def test_returns_false_for_500_http_status_error(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        error = httpx.HTTPStatusError("500", request=MagicMock(), response=mock_response)
+        assert is_auth_error(error) is False
+
+    def test_returns_true_for_rpc_error_with_auth_message(self):
+        assert is_auth_error(RPCError("authentication expired")) is True
+
+    def test_returns_false_for_rpc_error_with_generic_message(self):
+        assert is_auth_error(RPCError("some generic error")) is False
+
+    def test_returns_false_for_plain_exception(self):
+        assert is_auth_error(ValueError("not an rpc error")) is False
+
+
+class TestRPCCallHTTPErrors:
+    """Tests for HTTP error handling in rpc_call()."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_with_retry_after_header(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            mock_response.headers = {"retry-after": "60"}
+            mock_response.reason_phrase = "Too Many Requests"
+            error = httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response)
+
+            with (
+                patch.object(core._http_client, "post", side_effect=error),
+                pytest.raises(RateLimitError) as exc_info,
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+            assert exc_info.value.retry_after == 60
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_without_retry_after_header(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            mock_response.headers = {}
+            mock_response.reason_phrase = "Too Many Requests"
+            error = httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response)
+
+            with (
+                patch.object(core._http_client, "post", side_effect=error),
+                pytest.raises(RateLimitError) as exc_info,
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+            assert exc_info.value.retry_after is None
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_with_invalid_retry_after_header(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            mock_response = MagicMock()
+            mock_response.status_code = 429
+            mock_response.headers = {"retry-after": "not-a-number"}
+            mock_response.reason_phrase = "Too Many Requests"
+            error = httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response)
+
+            with (
+                patch.object(core._http_client, "post", side_effect=error),
+                pytest.raises(RateLimitError) as exc_info,
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+            assert exc_info.value.retry_after is None
+
+    @pytest.mark.asyncio
+    async def test_client_error_400(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            mock_response = MagicMock()
+            mock_response.status_code = 400
+            mock_response.reason_phrase = "Bad Request"
+            error = httpx.HTTPStatusError("400", request=MagicMock(), response=mock_response)
+
+            with (
+                patch.object(core._http_client, "post", side_effect=error),
+                pytest.raises(ClientError),
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    @pytest.mark.asyncio
+    async def test_server_error_500(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_response.reason_phrase = "Internal Server Error"
+            error = httpx.HTTPStatusError("500", request=MagicMock(), response=mock_response)
+
+            with (
+                patch.object(core._http_client, "post", side_effect=error),
+                pytest.raises(ServerError),
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_raises_network_error(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with (
+                patch.object(
+                    core._http_client,
+                    "post",
+                    side_effect=httpx.ConnectTimeout("connect timeout"),
+                ),
+                pytest.raises(NetworkError),
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    @pytest.mark.asyncio
+    async def test_read_timeout_raises_rpc_timeout_error(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with (
+                patch.object(
+                    core._http_client,
+                    "post",
+                    side_effect=httpx.ReadTimeout("read timeout"),
+                ),
+                pytest.raises(RPCTimeoutError),
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    @pytest.mark.asyncio
+    async def test_connect_error_raises_network_error(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with (
+                patch.object(
+                    core._http_client,
+                    "post",
+                    side_effect=httpx.ConnectError("connection refused"),
+                ),
+                pytest.raises(NetworkError),
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    @pytest.mark.asyncio
+    async def test_generic_request_error_raises_network_error(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with (
+                patch.object(
+                    core._http_client,
+                    "post",
+                    side_effect=httpx.RequestError("something went wrong"),
+                ),
+                pytest.raises(NetworkError),
+            ):
+                await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+
+class TestRPCCallAuthRetry:
+    """Tests for auth retry path after decode_response raises RPCError."""
+
+    @pytest.mark.asyncio
+    async def test_auth_retry_on_decode_rpc_error(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            refresh_callback = AsyncMock()
+            core._refresh_callback = refresh_callback
+            import asyncio
+
+            core._refresh_lock = asyncio.Lock()
+
+            success_response = MagicMock()
+            success_response.status_code = 200
+            success_response.text = "some_valid_response"
+
+            with (
+                patch.object(core._http_client, "post", return_value=success_response),
+                patch(
+                    "notebooklm._core.decode_response",
+                    side_effect=[
+                        RPCError("authentication expired"),
+                        ["result_data"],
+                    ],
+                ),
+            ):
+                result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+            assert result == ["result_data"]
+            refresh_callback.assert_called_once()
+
+
+class TestGetHttpClient:
+    """Tests for get_http_client() RuntimeError when not initialized."""
+
+    def test_get_http_client_raises_when_not_initialized(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+        with pytest.raises(RuntimeError, match="not initialized"):
+            core.get_http_client()
+
+    @pytest.mark.asyncio
+    async def test_get_http_client_returns_client_when_initialized(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            http_client = client._core.get_http_client()
+            assert isinstance(http_client, httpx.AsyncClient)
+
+
+class TestConversationCacheFIFOEviction:
+    """Tests for FIFO eviction when conversation cache exceeds MAX_CONVERSATION_CACHE_SIZE."""
+
+    def test_fifo_eviction_when_cache_is_full(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+
+        # Fill the cache to capacity
+        for i in range(MAX_CONVERSATION_CACHE_SIZE):
+            core.cache_conversation_turn(f"conv_{i}", f"q{i}", f"a{i}", i)
+
+        assert len(core._conversation_cache) == MAX_CONVERSATION_CACHE_SIZE
+
+        # Adding one more should evict the oldest (conv_0)
+        core.cache_conversation_turn("conv_new", "q_new", "a_new", 0)
+
+        assert len(core._conversation_cache) == MAX_CONVERSATION_CACHE_SIZE
+        assert "conv_0" not in core._conversation_cache
+        assert "conv_new" in core._conversation_cache
+
+    def test_fifo_eviction_preserves_order(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+
+        # Fill cache to capacity
+        for i in range(MAX_CONVERSATION_CACHE_SIZE):
+            core.cache_conversation_turn(f"conv_{i}", f"q{i}", f"a{i}", i)
+
+        # Add two new conversations - should evict conv_0 then conv_1
+        core.cache_conversation_turn("conv_new_1", "q1", "a1", 0)
+        core.cache_conversation_turn("conv_new_2", "q2", "a2", 0)
+
+        assert "conv_0" not in core._conversation_cache
+        assert "conv_1" not in core._conversation_cache
+        assert "conv_new_1" in core._conversation_cache
+        assert "conv_new_2" in core._conversation_cache
+
+    def test_adding_turns_to_existing_conversation_does_not_evict(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+
+        # Fill cache to capacity
+        for i in range(MAX_CONVERSATION_CACHE_SIZE):
+            core.cache_conversation_turn(f"conv_{i}", f"q{i}", f"a{i}", i)
+
+        # Adding a second turn to an EXISTING conversation should NOT evict anything
+        core.cache_conversation_turn("conv_0", "q_extra", "a_extra", 1)
+
+        assert len(core._conversation_cache) == MAX_CONVERSATION_CACHE_SIZE
+        assert len(core._conversation_cache["conv_0"]) == 2
+
+
+class TestClearConversationCacheNotFound:
+    """Tests for clear_conversation_cache() returning False when ID not found."""
+
+    def test_clear_nonexistent_conversation_returns_false(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+        result = core.clear_conversation_cache("nonexistent_id")
+        assert result is False
+
+    def test_clear_existing_conversation_returns_true(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+        core.cache_conversation_turn("conv_abc", "question", "answer", 1)
+        result = core.clear_conversation_cache("conv_abc")
+        assert result is True
+        assert "conv_abc" not in core._conversation_cache
+
+    def test_clear_all_conversations_returns_true(self, auth_tokens):
+        core = ClientCore(auth_tokens)
+        core.cache_conversation_turn("conv_1", "q1", "a1", 1)
+        core.cache_conversation_turn("conv_2", "q2", "a2", 1)
+        result = core.clear_conversation_cache()
+        assert result is True
+        assert len(core._conversation_cache) == 0
+
+
+class TestGetSourceIds:
+    """Tests for get_source_ids() extracting source IDs from notebook data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_source_ids_from_nested_data(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            mock_notebook_data = [
+                [
+                    "notebook_title",
+                    [
+                        [["src_id_1", "extra"]],
+                        [["src_id_2", "extra"]],
+                    ],
+                ]
+            ]
+
+            with patch.object(
+                core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+            ):
+                ids = await core.get_source_ids("nb_123")
+
+            assert ids == ["src_id_1", "src_id_2"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_data_is_none(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=None):
+                ids = await core.get_source_ids("nb_123")
+
+            assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_data_is_empty_list(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=[]):
+                ids = await core.get_source_ids("nb_123")
+
+            assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_sources_list_is_empty(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            # Notebook with no sources
+            mock_notebook_data = [["notebook_title", []]]
+
+            with patch.object(
+                core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+            ):
+                ids = await core.get_source_ids("nb_123")
+
+            assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_data_is_not_list(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            with patch.object(
+                core, "rpc_call", new_callable=AsyncMock, return_value="unexpected_string"
+            ):
+                ids = await core.get_source_ids("nb_123")
+
+            assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_notebook_info_missing_sources(self, auth_tokens):
+        async with NotebookLMClient(auth_tokens) as client:
+            core = client._core
+
+            # notebook_data[0] exists but notebook_info[1] is missing
+            mock_notebook_data = [["notebook_title_only"]]
+
+            with patch.object(
+                core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
+            ):
+                ids = await core.get_source_ids("nb_123")
+
+            assert ids == []

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -562,3 +562,133 @@ class TestNotebookEdgeCases:
         # Should only include valid topics
         assert len(description.suggested_topics) == 1
         assert description.suggested_topics[0].question == "Valid question"
+
+
+class TestDescribeEdgeCases:
+    """Tests for get_description() branch edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_get_description_no_topics_key(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 171->188: result has only [0] (no result[1]) so topics stay empty."""
+        # result = [["A summary"]] — len is 1, so result[1] branch is never entered
+        response = build_rpc_response(
+            RPCMethod.SUMMARIZE,
+            [["A summary"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            description = await client.notebooks.get_description("nb_123")
+
+        assert description.summary == "A summary"
+        assert description.suggested_topics == []
+
+    @pytest.mark.asyncio
+    async def test_get_description_result_1_is_empty_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 173->177: result[1] exists but is an empty list, so inner block skipped."""
+        # result = [["A summary"], []] — result[1] has len 0, so the inner if is false
+        response = build_rpc_response(
+            RPCMethod.SUMMARIZE,
+            [["A summary"], []],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            description = await client.notebooks.get_description("nb_123")
+
+        assert description.summary == "A summary"
+        assert description.suggested_topics == []
+
+    @pytest.mark.asyncio
+    async def test_get_description_result_1_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 173->177: result[1] is present but not a list, inner block skipped."""
+        # result = [["A summary"], "not-a-list"]
+        response = build_rpc_response(
+            RPCMethod.SUMMARIZE,
+            [["A summary"], "not-a-list"],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            description = await client.notebooks.get_description("nb_123")
+
+        assert description.summary == "A summary"
+        assert description.suggested_topics == []
+
+
+class TestShareEdgeCases:
+    """Tests for share() and get_share_url() branch edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_share_with_artifact_id(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 260: share() public=True with artifact_id builds deep-link URL."""
+        response = build_rpc_response(RPCMethod.SHARE_ARTIFACT, None)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.notebooks.share("nb_123", public=True, artifact_id="art_456")
+
+        assert result["public"] is True
+        assert result["url"] == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
+        assert result["artifact_id"] == "art_456"
+
+    @pytest.mark.asyncio
+    async def test_share_public_false_returns_none_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 264: share() public=False sets url to None."""
+        response = build_rpc_response(RPCMethod.SHARE_ARTIFACT, None)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.notebooks.share("nb_123", public=False)
+
+        assert result["public"] is False
+        assert result["url"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_share_url_without_artifact(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Line 288: get_share_url() without artifact_id returns base URL."""
+        async with NotebookLMClient(auth_tokens) as client:
+            url = client.notebooks.get_share_url("nb_123")
+
+        assert url == "https://notebooklm.google.com/notebook/nb_123"
+
+    @pytest.mark.asyncio
+    async def test_get_share_url_with_artifact(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+    ):
+        """Lines 285-287: get_share_url() with artifact_id appends query param."""
+        async with NotebookLMClient(auth_tokens) as client:
+            url = client.notebooks.get_share_url("nb_123", artifact_id="art_789")
+
+        assert url == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_789"

--- a/tests/integration/test_research_api.py
+++ b/tests/integration/test_research_api.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
 
 
 class TestResearchAPI:
@@ -244,3 +245,454 @@ class TestResearchAPI:
             result = await client.research.import_sources("nb_123", "task_123", [])
 
         assert result == []
+
+
+class TestPollEdgeCases:
+    """Tests for poll() parsing branch edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_poll_unwrap_nested_result(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 132: result[0] is a list whose first element is also a list — unwrap one level."""
+        # Outer list wraps the inner task list: result[0][0] is a list → unwrap
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    [
+                        "task_wrap",
+                        [None, ["wrapped query"], None, [], 1],
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["task_id"] == "task_wrap"
+        assert result["query"] == "wrapped query"
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_non_list_task_data(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 137: task_data is not a list — continue, eventually return no_research."""
+        # Outer list contains a non-list item then a too-short list
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            ["not_a_list", ["only_one_elem"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "no_research"
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_non_string_task_id(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 143: task_id is not str — continue, eventually return no_research."""
+        # task_id is an integer (not str) and task_info is a list
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [[42, [None, ["query"], None, [], 1]]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "no_research"
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_non_list_task_info(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 143: task_info is not a list — continue, eventually return no_research."""
+        # task_id is str but task_info is a string, not list
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [["task_bad", "not_a_list"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "no_research"
+
+    @pytest.mark.asyncio
+    async def test_poll_sources_and_summary_has_only_sources_no_summary(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 157->160: sources_and_summary has len 1 (sources only, no summary string)."""
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    "task_nosummary",
+                    [
+                        None,
+                        ["no summary query"],
+                        None,
+                        [
+                            [
+                                ["https://example.com", "Title", "desc"],
+                            ]
+                            # No second element — summary is absent
+                        ],
+                        2,
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "completed"
+        assert result["summary"] == ""
+        assert len(result["sources"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_short_source_entry(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 163: a source entry in sources_data is too short (len < 2) — skipped."""
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    "task_shortsrc",
+                    [
+                        None,
+                        ["short src query"],
+                        None,
+                        [
+                            [
+                                ["only_one_element"],  # len < 2 → skipped
+                                ["https://valid.com", "Valid"],  # kept
+                            ],
+                            "Summary text",
+                        ],
+                        2,
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        # Only the valid source is returned
+        assert len(result["sources"]) == 1
+        assert result["sources"][0]["url"] == "https://valid.com"
+
+    @pytest.mark.asyncio
+    async def test_poll_deep_research_source_none_first_element(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Lines 171-172: deep research source where src[0] is None — title extracted, url=''."""
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    "task_deep",
+                    [
+                        None,
+                        ["deep query"],
+                        None,
+                        [
+                            [
+                                [None, "Deep Research Title", None, "web"],
+                            ],
+                            "Deep summary",
+                        ],
+                        2,
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "completed"
+        assert len(result["sources"]) == 1
+        assert result["sources"][0]["title"] == "Deep Research Title"
+        assert result["sources"][0]["url"] == ""
+
+    @pytest.mark.asyncio
+    async def test_poll_fast_research_source_with_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Lines 173-175: fast research source where src[0] is a str URL."""
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    "task_fast",
+                    [
+                        None,
+                        ["fast query"],
+                        None,
+                        [
+                            [
+                                ["https://fast.example.com", "Fast Title", "desc", "web"],
+                            ],
+                            "Fast summary",
+                        ],
+                        1,
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "in_progress"
+        assert result["sources"][0]["url"] == "https://fast.example.com"
+        assert result["sources"][0]["title"] == "Fast Title"
+
+    @pytest.mark.asyncio
+    async def test_poll_source_with_no_title_or_url_skipped(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 177->161: src has two elements but neither is title nor url — not appended."""
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [
+                [
+                    "task_empty_src",
+                    [
+                        None,
+                        ["empty src query"],
+                        None,
+                        [
+                            [
+                                # src[0] is not None and not str (e.g. integer), len < 3
+                                # so url="", title="" and nothing is appended
+                                [42, 99],
+                            ],
+                            "summary here",
+                        ],
+                        2,
+                    ],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "completed"
+        assert result["sources"] == []
+
+    @pytest.mark.asyncio
+    async def test_poll_all_tasks_invalid_returns_no_research(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 193: all items in the loop fail validation — final no_research is returned."""
+        # All task_data entries are short lists (len < 2) so every iteration hits `continue`
+        response = build_rpc_response(
+            RPCMethod.POLL_RESEARCH,
+            [["only_one"], ["also_one"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.poll("nb_123")
+
+        assert result["status"] == "no_research"
+
+
+class TestImportSourcesEdgeCases:
+    """Tests for import_sources() parsing branch edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_import_sources_skips_no_url_sources(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Lines 226, 228: sources without URLs are skipped; if ALL lack URLs, return []."""
+        # No HTTP call should be made when all sources lack URLs
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [{"title": "No URL source"}, {"title": "Also no URL"}],
+            )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_import_sources_filters_some_no_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 226: sources without URLs are filtered, valid ones are imported."""
+        # Double-wrap so the unwrap logic peels one layer: result[0][0] is a list
+        response = build_rpc_response(
+            RPCMethod.IMPORT_RESEARCH,
+            [
+                [
+                    [["src_good"], "Good Source"],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [
+                    {"url": "https://good.com", "title": "Good Source"},
+                    {"title": "No URL source"},  # filtered out
+                ],
+            )
+
+        assert len(result) == 1
+        assert result[0]["id"] == "src_good"
+
+    @pytest.mark.asyncio
+    async def test_import_sources_no_double_nesting(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 257->265: result[0][0] is not a list — no unwrap, loop runs on original result.
+
+        The unwrap condition requires result[0][0] to be a list. When result[0][0] is a
+        non-list value (e.g. None), the if-block is skipped and the for loop runs directly.
+        """
+        # result[0] = [None, "Flat Title"] so result[0][0] = None (not a list) → no unwrap
+        # The loop then processes each item in the original result directly.
+        # [None, "Flat Title"] has src_data[0]=None → src_id = None → skipped (covers 270->265)
+        # So we also include a valid entry to verify the loop ran:
+        # However, we need result[0][0] to NOT be a list to avoid unwrap.
+        # A valid entry looks like [["src_id"], "Title"] but result[0][0]=["src_id"] IS a list.
+        # The only way to avoid unwrap AND get results is if result[0] is a list but
+        # result[0][0] is not a list. Use result = ["not_a_list_entry", [["src_nw"], "Title"]].
+        # result[0] = "not_a_list_entry" → isinstance(result[0], list) is False → no unwrap.
+        response = build_rpc_response(
+            RPCMethod.IMPORT_RESEARCH,
+            # result[0] is a string, not a list → isinstance(result[0], list) is False
+            # condition fails → no unwrap → loop runs on the original result
+            ["string_not_list", [["src_nw"], "No-Wrap Title"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [{"url": "https://nowrap.example.com", "title": "No-Wrap Title"}],
+            )
+
+        # "string_not_list" is not a list → skipped; [["src_nw"], "No-Wrap Title"] is valid
+        assert len(result) == 1
+        assert result[0]["id"] == "src_nw"
+        assert result[0]["title"] == "No-Wrap Title"
+
+    @pytest.mark.asyncio
+    async def test_import_sources_src_data_too_short_skipped(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 266->265: src_data in result has len < 2 — skipped in loop."""
+        # First entry is too short (len 1), second is valid
+        response = build_rpc_response(
+            RPCMethod.IMPORT_RESEARCH,
+            [
+                ["short_only"],  # len 1 — skipped
+                [["src_valid"], "Valid"],  # len 2 — kept
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Valid"}],
+            )
+
+        assert len(result) == 1
+        assert result[0]["id"] == "src_valid"
+
+    @pytest.mark.asyncio
+    async def test_import_sources_src_id_none_skipped(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Line 270->265: src_data[0] is None (not a list) — src_id is None, entry skipped."""
+        # src_data[0] is None — not a list, so src_id = None → skipped
+        response = build_rpc_response(
+            RPCMethod.IMPORT_RESEARCH,
+            [
+                [None, "Title with no ID"],  # src_data[0] is None → skipped
+                [["src_real"], "Real Title"],  # valid
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.research.import_sources(
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "anything"}],
+            )
+
+        assert len(result) == 1
+        assert result[0]["id"] == "src_real"

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -2,12 +2,15 @@
 
 import re
 import urllib.parse
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient, Source, SourceType
+from notebooklm.exceptions import RPCError
 from notebooklm.rpc import RPCMethod
+from notebooklm.types import SourceAddError, SourceNotFoundError
 
 
 class TestAddSource:
@@ -742,3 +745,1568 @@ class TestGetFulltext:
         assert fulltext.title == "Empty Source"
         assert fulltext.content == ""
         assert fulltext.char_count == 0
+
+
+class TestListSourcesMalformedResponse:
+    """Tests for list() warning paths when API response is malformed (lines 71-95)."""
+
+    @pytest.mark.asyncio
+    async def test_list_sources_empty_response(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() returns [] when notebook response is empty (lines 71-76)."""
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert sources == []
+
+    @pytest.mark.asyncio
+    async def test_list_sources_non_list_notebook_entry(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() returns [] when nb_info is not a list (lines 80-85)."""
+        # notebook[0] is a string, not a list - fails isinstance(nb_info, list)
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, ["just_a_string"])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert sources == []
+
+    @pytest.mark.asyncio
+    async def test_list_sources_nb_info_missing_index_1(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() returns [] when nb_info list has no index 1 (lines 80-85)."""
+        # notebook[0] is a list with only 1 element - len(nb_info) <= 1
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [["just_a_title"]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert sources == []
+
+    @pytest.mark.asyncio
+    async def test_list_sources_sources_list_not_a_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() returns [] when sources_list is not a list (lines 89-95)."""
+        # nb_info[1] is a string - fails isinstance(sources_list, list)
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, [["Notebook Title", "not_a_list"]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert sources == []
+
+
+class TestListSourcesParsingEdgeCases:
+    """Tests for list() per-source parsing edge cases (lines 100-143)."""
+
+    @pytest.mark.asyncio
+    async def test_list_sources_src_id_not_nested(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() uses src[0] directly when src[0] is not a list (line 102)."""
+        # src[0] is a plain string (not a list), so src_id = src[0] directly
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [["plain_src_id", "Source Title", [None, 0], [None, 2]]],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].id == "plain_src_id"
+
+    @pytest.mark.asyncio
+    async def test_list_sources_url_list_empty(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() handles empty URL list at src[2][7] - url stays None (lines 109->113)."""
+        # src[2][7] is an empty list - URL should remain None
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        [
+                            ["src_001"],
+                            "Source Title",
+                            [None, 11, [1704067200, 0], None, 5, None, None, []],
+                            [None, 2],
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].url is None
+
+    @pytest.mark.asyncio
+    async def test_list_sources_timestamp_invalid(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() handles invalid timestamp gracefully (lines 119-120)."""
+        # timestamp_list[0] is None, causing TypeError in datetime.fromtimestamp
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        [
+                            ["src_001"],
+                            "Source Title",
+                            [None, 11, [None], None, 5],
+                            [None, 2],
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].created_at is None
+
+    @pytest.mark.asyncio
+    async def test_list_sources_invalid_status_code(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() uses default READY when status_code is unknown (lines 125->137, 127->137)."""
+        # status_code 999 is not in the SourceStatus enum values
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        [
+                            ["src_001"],
+                            "Source Title",
+                            [None, 11, [1704067200, 0], None, 5],
+                            [None, 999],
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        from notebooklm.rpc.types import SourceStatus
+
+        assert sources[0].status == SourceStatus.READY
+
+    @pytest.mark.asyncio
+    async def test_list_sources_type_code_not_int(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() skips type_code when src[2][4] is not an int (lines 140->143)."""
+        # src[2][4] is a string - type_code should stay None
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        [
+                            ["src_001"],
+                            "Source Title",
+                            [None, 11, [1704067200, 0], None, "not_an_int"],
+                            [None, 2],
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0]._type_code is None
+
+
+class TestWaitForSources:
+    """Tests for wait_for_sources() parallel waiting (lines 278-281, 455)."""
+
+    @pytest.mark.asyncio
+    async def test_wait_for_sources_parallel(
+        self,
+        auth_tokens,
+    ):
+        """Test wait_for_sources() calls wait_until_ready for each source in parallel."""
+        ready_source_1 = Source(id="src_1", title="Source 1")
+        ready_source_2 = Source(id="src_2", title="Source 2")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            call_count = 0
+
+            async def mock_wait(notebook_id, source_id, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if source_id == "src_1":
+                    return ready_source_1
+                return ready_source_2
+
+            with patch.object(client.sources, "wait_until_ready", side_effect=mock_wait):
+                results = await client.sources.wait_for_sources("nb_123", ["src_1", "src_2"])
+
+        assert len(results) == 2
+        assert call_count == 2
+        assert results[0].id == "src_1"
+        assert results[1].id == "src_2"
+
+
+class TestAddUrlErrorPaths:
+    """Tests for add_url() error paths (lines 320, 327-329, 332, 336)."""
+
+    @pytest.mark.asyncio
+    async def test_add_url_rpc_error_raises_source_add_error(
+        self,
+        auth_tokens,
+    ):
+        """Test add_url() wraps RPCError from _add_url_source in SourceAddError (lines 327-329)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "_add_url_source",
+                side_effect=RPCError("RPC call failed"),
+            ):
+                with pytest.raises(SourceAddError):
+                    await client.sources.add_url("nb_123", "https://example.com")
+
+    @pytest.mark.asyncio
+    async def test_add_url_youtube_rpc_error_raises_source_add_error(
+        self,
+        auth_tokens,
+    ):
+        """Test add_url() wraps RPCError from _add_youtube_source in SourceAddError (lines 327-329)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "_add_youtube_source",
+                side_effect=RPCError("YouTube RPC failed"),
+            ):
+                with pytest.raises(SourceAddError):
+                    await client.sources.add_url(
+                        "nb_123", "https://youtube.com/watch?v=dQw4w9WgXcQ"
+                    )
+
+    @pytest.mark.asyncio
+    async def test_add_url_none_result_raises_source_add_error(
+        self,
+        auth_tokens,
+    ):
+        """Test add_url() raises SourceAddError when API returns None (line 332)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "_add_url_source",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                with pytest.raises(SourceAddError, match="API returned no data"):
+                    await client.sources.add_url("nb_123", "https://example.com")
+
+    @pytest.mark.asyncio
+    async def test_add_url_wait_true(
+        self,
+        auth_tokens,
+    ):
+        """Test add_url() with wait=True calls wait_until_ready (lines 335-336)."""
+        source_data = [[[["src_wait_url"], "Example", [None, 11], [None, 2]]]]
+        ready_source = Source(id="src_wait_url", title="Example")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "_add_url_source",
+                new_callable=AsyncMock,
+                return_value=source_data,
+            ):
+                with patch.object(
+                    client.sources,
+                    "wait_until_ready",
+                    new_callable=AsyncMock,
+                    return_value=ready_source,
+                ) as mock_wait:
+                    result = await client.sources.add_url(
+                        "nb_123", "https://example.com", wait=True
+                    )
+
+        mock_wait.assert_called_once()
+        assert result.id == "src_wait_url"
+
+    @pytest.mark.asyncio
+    async def test_add_url_youtube_like_no_id_warning(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test add_url() warns when URL looks like YouTube but has no video ID (line 320)."""
+        response = build_rpc_response(
+            RPCMethod.ADD_SOURCE,
+            [[[["src_channel"], "YouTube Channel", [None, 11], [None, 2]]]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch("notebooklm._sources.is_youtube_url", return_value=True) as mock_is_yt:
+                with patch.object(
+                    client.sources,
+                    "_extract_youtube_video_id",
+                    return_value=None,
+                ):
+                    source = await client.sources.add_url(
+                        "nb_123", "https://youtube.com/channel/UCxxxxxxx"
+                    )
+
+        assert source is not None
+        mock_is_yt.assert_called_once()
+
+
+class TestAddTextErrorPaths:
+    """Tests for add_text() error paths (lines 374-375, 382, 387)."""
+
+    @pytest.mark.asyncio
+    async def test_add_text_rpc_error_raises_source_add_error(
+        self,
+        auth_tokens,
+    ):
+        """Test add_text() wraps RPCError in SourceAddError (lines 374-375)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources._core,
+                "rpc_call",
+                side_effect=RPCError("Text RPC failed"),
+            ):
+                with pytest.raises(SourceAddError, match="Failed to add text source"):
+                    await client.sources.add_text("nb_123", "My Title", "content")
+
+    @pytest.mark.asyncio
+    async def test_add_text_none_result_raises_source_add_error(
+        self,
+        auth_tokens,
+    ):
+        """Test add_text() raises SourceAddError when API returns None (line 382)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources._core,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value=None,
+            ):
+                with pytest.raises(SourceAddError, match="API returned no data"):
+                    await client.sources.add_text("nb_123", "My Title", "content")
+
+    @pytest.mark.asyncio
+    async def test_add_text_wait_true(
+        self,
+        auth_tokens,
+    ):
+        """Test add_text() with wait=True calls wait_until_ready (line 387)."""
+        source_data = [[[["src_wait_text"], "My Title", [None, 0], [None, 2]]]]
+        ready_source = Source(id="src_wait_text", title="My Title")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources._core,
+                "rpc_call",
+                new_callable=AsyncMock,
+                return_value=source_data,
+            ):
+                with patch.object(
+                    client.sources,
+                    "wait_until_ready",
+                    new_callable=AsyncMock,
+                    return_value=ready_source,
+                ) as mock_wait:
+                    result = await client.sources.add_text(
+                        "nb_123", "My Title", "content", wait=True
+                    )
+
+        mock_wait.assert_called_once()
+        assert result.id == "src_wait_text"
+
+
+class TestAddFileWait:
+    """Tests for add_file() with wait=True (lines 454-455)."""
+
+    @pytest.mark.asyncio
+    async def test_add_file_wait_true(
+        self,
+        auth_tokens,
+        tmp_path,
+    ):
+        """Test add_file() with wait=True calls wait_until_ready (lines 454-455)."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+
+        ready_source = Source(id="file_src_001", title="test.pdf")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "_register_file_source",
+                new_callable=AsyncMock,
+                return_value="file_src_001",
+            ):
+                with patch.object(
+                    client.sources,
+                    "_start_resumable_upload",
+                    new_callable=AsyncMock,
+                    return_value="https://upload.example.com/upload_id=abc",
+                ):
+                    with patch.object(
+                        client.sources,
+                        "_upload_file_streaming",
+                        new_callable=AsyncMock,
+                    ):
+                        with patch.object(
+                            client.sources,
+                            "wait_until_ready",
+                            new_callable=AsyncMock,
+                            return_value=ready_source,
+                        ) as mock_wait:
+                            result = await client.sources.add_file("nb_123", test_file, wait=True)
+
+        mock_wait.assert_called_once_with("nb_123", "file_src_001", timeout=120.0)
+        assert result.id == "file_src_001"
+
+
+class TestAddDriveWait:
+    """Tests for add_drive() with wait=True (line 526)."""
+
+    @pytest.mark.asyncio
+    async def test_add_drive_wait_true(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test add_drive() with wait=True calls wait_until_ready (line 526)."""
+        response = build_rpc_response(
+            RPCMethod.ADD_SOURCE,
+            [[[["drive_src_wait"], "My Drive Doc", [None, 0], [None, 2]]]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        ready_source = Source(id="drive_src_wait", title="My Drive Doc")
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "wait_until_ready",
+                new_callable=AsyncMock,
+                return_value=ready_source,
+            ) as mock_wait:
+                result = await client.sources.add_drive(
+                    "nb_123",
+                    file_id="drive_file_abc",
+                    title="My Drive Doc",
+                    wait=True,
+                )
+
+        mock_wait.assert_called_once()
+        assert result.id == "drive_src_wait"
+
+
+class TestCheckFreshnessEdgeCases:
+    """Tests for check_freshness() edge cases (lines 624, 657->667, 659->667)."""
+
+    @pytest.mark.asyncio
+    async def test_check_freshness_none_result_returns_false(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test check_freshness() returns False when result is None (line 624)."""
+        # None is not True, not False, not a list - falls through to return False
+        response = build_rpc_response(RPCMethod.CHECK_SOURCE_FRESHNESS, None)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
+
+        assert is_fresh is False
+
+    @pytest.mark.asyncio
+    async def test_check_freshness_list_first_element_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test check_freshness() returns False when result list's first item is not a list (line 624)."""
+        # result is ["some_string"] - first is a string, isinstance(first, list) is False
+        response = build_rpc_response(RPCMethod.CHECK_SOURCE_FRESHNESS, ["some_value"])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
+
+        assert is_fresh is False
+
+    @pytest.mark.asyncio
+    async def test_check_freshness_drive_nested_false_value(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test check_freshness() returns False when nested Drive structure has first[1] != True (lines 657->667, 659->667)."""
+        # result is [[None, False, ...]] - first[1] is False, not True
+        response = build_rpc_response(
+            RPCMethod.CHECK_SOURCE_FRESHNESS, [[None, False, ["src_001"]]]
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
+
+        assert is_fresh is False
+
+    @pytest.mark.asyncio
+    async def test_check_freshness_drive_nested_list_too_short(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test check_freshness() returns False when nested Drive list has only one element."""
+        # result is [[None]] - first has only 1 element, so len(first) > 1 check fails
+        response = build_rpc_response(RPCMethod.CHECK_SOURCE_FRESHNESS, [[None]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            is_fresh = await client.sources.check_freshness("nb_123", "src_001")
+
+        assert is_fresh is False
+
+
+class TestGetFulltextEdgeCases:
+    """Tests for get_fulltext() URL/type parsing and empty content (lines 700, 708->732, 764-765)."""
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_with_source_type_and_url(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() parses source_type and url from result[0][2] (lines 708-732)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                [
+                    "src_123",
+                    "Web Article",
+                    # result[0][2]: index 4=source_type(5), index 7=[url]
+                    [None, 0, None, None, 5, None, 1, ["https://example.com/article"]],
+                ],
+                None,
+                None,
+                [[["The main content of the article."]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_123")
+
+        assert fulltext.title == "Web Article"
+        assert fulltext.url == "https://example.com/article"
+        assert fulltext._type_code == 5
+        assert "main content" in fulltext.content
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_source_type_only_empty_url_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() parses type_code when result[0][2][7] is empty list (lines 714->725, 720->725)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                [
+                    "src_pdf",
+                    "PDF Document",
+                    # result[0][2]: index 4=3 (PDF), index 7=[] (empty url list)
+                    [None, 0, None, None, 3, None, None, []],
+                ],
+                None,
+                None,
+                [[["PDF text content here."]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_pdf")
+
+        assert fulltext._type_code == 3
+        assert fulltext.url is None
+        assert "PDF text content" in fulltext.content
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_no_content_logs_warning(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() logs warning when content is empty (lines 764-765 via 731-738)."""
+        # result[3][0] is an empty list -> texts = [] -> content = ""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                ["src_no_content", "No Content Source", [None, 0, None, None, 4]],
+                None,
+                None,
+                [[]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        import logging
+
+        with patch.object(
+            logging.getLogger("notebooklm._sources"),
+            "warning",
+        ) as mock_warn:
+            async with NotebookLMClient(auth_tokens) as client:
+                fulltext = await client.sources.get_fulltext("nb_123", "src_no_content")
+
+        assert fulltext.content == ""
+        assert fulltext.char_count == 0
+        mock_warn.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_result_not_list_raises_not_found(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() raises SourceNotFoundError when result is None (line 700)."""
+        response = build_rpc_response(RPCMethod.GET_SOURCE, None)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceNotFoundError):
+                await client.sources.get_fulltext("nb_123", "missing_src")
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_result_0_2_short_no_type(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() when result[0][2] has fewer than 5 elements - no type_code (lines 710->725, 714->725)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                # result[0][2] has only 3 elements - no index 4 for type_code
+                ["src_short", "Short Meta", [None, 0, None]],
+                None,
+                None,
+                [[["Some content."]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_short")
+
+        assert fulltext._type_code is None
+        assert fulltext.url is None
+        assert "Some content" in fulltext.content
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_result_0_2_has_type_no_url_field(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() when result[0][2] has type at [4] but no [7] (lines 719-720 branch)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                # result[0][2] has 6 elements - type at [4] but no [7]
+                ["src_no_url", "No URL Source", [None, 0, None, None, 9, None]],
+                None,
+                None,
+                [[["YouTube content here."]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_no_url")
+
+        assert fulltext._type_code == 9
+        assert fulltext.url is None
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_result3_missing(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() when result has fewer than 4 elements - no content (lines 727->732 branch not taken)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            # Only 2 elements - no result[3]
+            [
+                ["src_no_r3", "No Result3", [None, 0, None, None, 4]],
+                None,
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_no_r3")
+
+        assert fulltext.content == ""
+
+
+class TestExtractAllText:
+    """Tests for _extract_all_text() max_depth guard (lines 763-765)."""
+
+    @pytest.mark.asyncio
+    async def test_extract_all_text_max_depth_zero_returns_empty(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_all_text() returns [] when max_depth=0 (lines 763-765)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_all_text(["some", "text"], max_depth=0)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_extract_all_text_nested_lists(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_all_text() recursively extracts text from nested arrays."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_all_text([["hello", ["world"]], "foo", [[], "bar"]])
+
+        assert result == ["hello", "world", "foo", "bar"]
+
+
+class TestExtractYoutubeVideoId:
+    """Tests for _extract_youtube_video_id() edge cases (lines 810-819, 832-852)."""
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_youtu_be_no_path(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() returns None for youtu.be with empty path (line 836)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id("https://youtu.be/")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_non_youtube_domain(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() returns None for non-YouTube URL."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id("https://example.com/video")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_invalid_id_chars(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() returns None when video ID has invalid chars (line 812->815)."""
+        # URL with invalid video ID characters that fail _is_valid_video_id
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id(
+                "https://youtube.com/watch?v=invalid id!"
+            )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_parse_error(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() handles exceptions gracefully (lines 817-819)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            # Patching urlparse to raise ValueError covers the except block
+            with patch("notebooklm._sources.urlparse", side_effect=ValueError("parse error")):
+                result = client.sources._extract_youtube_video_id(
+                    "https://youtube.com/watch?v=abc123"
+                )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_watch_url(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() extracts ID from standard watch URL (lines 845-850)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id(
+                "https://youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+        assert result == "dQw4w9WgXcQ"
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_no_query_param(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() returns None for youtube.com URL without v param (line 852)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id(
+                "https://youtube.com/playlist?list=PLxxxxxxxx"
+            )
+
+        assert result is None
+
+
+class TestListSourcesSkippedEntries:
+    """Tests for list() skipping non-list source entries (line 100->99)."""
+
+    @pytest.mark.asyncio
+    async def test_list_sources_skips_non_list_entry(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() skips source entries that are not lists (line 100->99)."""
+        # Mix of valid and invalid source entries
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        # Valid source entry
+                        [["src_001"], "Valid Source", [None, 0], [None, 2]],
+                        # Non-list entry - should be skipped
+                        "not_a_list",
+                        # Another non-list - should be skipped
+                        None,
+                        # Valid source entry
+                        [["src_002"], "Also Valid", [None, 0], [None, 2]],
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 2
+        assert sources[0].id == "src_001"
+        assert sources[1].id == "src_002"
+
+    @pytest.mark.asyncio
+    async def test_list_sources_no_status_data(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() defaults to READY when src has no index 3 (line 125->137 false branch)."""
+        from notebooklm.rpc.types import SourceStatus
+
+        # Source with only 2 elements - no status data at index 3
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        [["src_001"], "No Status Source"],
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].status == SourceStatus.READY
+
+
+class TestWaitUntilReady:
+    """Tests for wait_until_ready() implementation (lines 214-244)."""
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_source_ready_immediately(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test wait_until_ready() returns immediately when source is already READY (line 231-232)."""
+        # Mock GET_NOTEBOOK to return a source with READY status (status_code=2)
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook",
+                    [
+                        [
+                            ["src_ready"],
+                            "Ready Source",
+                            [None, 0],
+                            [None, 2],  # status=READY
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            source = await client.sources.wait_until_ready("nb_123", "src_ready")
+
+        assert source.id == "src_ready"
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_source_not_found_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test wait_until_ready() raises SourceNotFoundError when source is None (line 226-227)."""
+        # Mock GET_NOTEBOOK to return no sources (so get() returns None)
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [["Notebook", [], "nb_123"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceNotFoundError):
+                await client.sources.wait_until_ready("nb_123", "src_missing")
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_timeout_raises(
+        self,
+        auth_tokens,
+    ):
+        """Test wait_until_ready() raises SourceTimeoutError when timeout=0 (line 221-222)."""
+        from notebooklm.types import SourceTimeoutError
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceTimeoutError):
+                await client.sources.wait_until_ready("nb_123", "src_timeout", timeout=0.0)
+
+
+class TestAddFileValidation:
+    """Tests for add_file() validation errors (line 429)."""
+
+    @pytest.mark.asyncio
+    async def test_add_file_directory_raises_validation_error(
+        self,
+        auth_tokens,
+        tmp_path,
+    ):
+        """Test add_file() raises ValidationError when path is a directory (line 429)."""
+        from notebooklm.exceptions import ValidationError
+
+        # tmp_path is a directory, not a file
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValidationError, match="Not a regular file"):
+                await client.sources.add_file("nb_123", tmp_path)
+
+
+class TestGetGuideEdgeCases:
+    """Tests for get_guide() inner parsing branches (lines 655->667, 657->667, 659->667)."""
+
+    @pytest.mark.asyncio
+    async def test_get_guide_outer_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_guide() returns empty when outer result[0] is not a list (line 657->667)."""
+        # result[0] is a string, not a list
+        response = build_rpc_response(RPCMethod.GET_SOURCE_GUIDE, ["not_a_list"])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            guide = await client.sources.get_guide("nb_123", "src_001")
+
+        assert guide["summary"] == ""
+        assert guide["keywords"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_guide_inner_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_guide() returns empty when inner outer[0] is not a list (line 659->667)."""
+        # outer is a list but outer[0] is a string, not a list
+        response = build_rpc_response(RPCMethod.GET_SOURCE_GUIDE, [["not_a_list"]])
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            guide = await client.sources.get_guide("nb_123", "src_001")
+
+        assert guide["summary"] == ""
+        assert guide["keywords"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_guide_result_false(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_guide() returns empty when result is falsy (line 655->667)."""
+        response = build_rpc_response(RPCMethod.GET_SOURCE_GUIDE, None)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            guide = await client.sources.get_guide("nb_123", "src_001")
+
+        assert guide["summary"] == ""
+        assert guide["keywords"] == []
+
+
+class TestGetFulltextResult0Branches:
+    """Tests for get_fulltext() result[0] parsing branches (lines 710->725, 714->725, 727->732)."""
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_result_0_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() when result[0] is not a list - title stays empty (line 710->725)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            # result[0] is a string, not a list
+            ["just_a_string"],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_no_list")
+
+        assert fulltext.title == ""
+        assert fulltext._type_code is None
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_result_0_2_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() when result[0][2] is not a list (line 714->725)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                # result[0][2] is a string, not a list
+                ["src_x", "My Title", "not_a_list"],
+                None,
+                None,
+                [[["Some text content."]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_x")
+
+        assert fulltext.title == "My Title"
+        assert fulltext._type_code is None
+        assert fulltext.url is None
+        assert "Some text content" in fulltext.content
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_content_blocks_not_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test get_fulltext() when content_blocks (result[3][0]) is not a list (line 727->732)."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                ["src_y", "Source Y", [None, 0, None, None, 4]],
+                None,
+                None,
+                # result[3][0] is a string, not a list
+                ["just_a_string"],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_y")
+
+        assert fulltext.content == ""
+
+
+class TestExtractVideoIdFromParsedUrl:
+    """Tests for _extract_video_id_from_parsed_url() branches (lines 835, 843, 846->852)."""
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_youtu_be_with_path(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() extracts ID from youtu.be short URL (line 835)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id("https://youtu.be/dQw4w9WgXcQ")
+
+        assert result == "dQw4w9WgXcQ"
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_shorts_url(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() extracts ID from YouTube Shorts URL (line 843)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id(
+                "https://youtube.com/shorts/dQw4w9WgXcQ"
+            )
+
+        assert result == "dQw4w9WgXcQ"
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_embed_url(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() extracts ID from embed URL (line 843)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id(
+                "https://youtube.com/embed/dQw4w9WgXcQ"
+            )
+
+        assert result == "dQw4w9WgXcQ"
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_watch_with_valid_id(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() via watch URL hits query param branch (lines 846->850)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            result = client.sources._extract_youtube_video_id(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s"
+            )
+
+        assert result == "dQw4w9WgXcQ"
+
+
+class TestAddYoutubeSourceDirect:
+    """Tests for _add_youtube_source() implementation (lines 870-876)."""
+
+    @pytest.mark.asyncio
+    async def test_add_url_youtube_video_success(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test add_url() with YouTube URL calls _add_youtube_source internally (lines 870-876)."""
+        response = build_rpc_response(
+            RPCMethod.ADD_SOURCE,
+            [
+                [
+                    [
+                        ["yt_src_001"],
+                        "Rick Astley - Never Gonna Give You Up",
+                        [
+                            None,
+                            11,
+                            None,
+                            None,
+                            9,
+                            None,
+                            1,
+                            ["https://youtube.com/watch?v=dQw4w9WgXcQ"],
+                        ],
+                        [None, 2],
+                    ]
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            source = await client.sources.add_url(
+                "nb_123", "https://youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+        assert source.id == "yt_src_001"
+        assert source.kind == "youtube"
+
+
+class TestRegisterFileSourceError:
+    """Tests for _register_file_source() error paths (lines 925, 931)."""
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_none_result_raises(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """Test _register_file_source() raises when result has no extractable ID (line 931)."""
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake")
+
+        # Return a response where extract_id returns None - nested empty list
+        rpc_response = build_rpc_response(
+            RPCMethod.ADD_SOURCE_FILE,
+            # Result is an empty list - extract_id([]) returns None
+            [],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*"),
+            content=rpc_response.encode(),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceAddError, match="Failed to get SOURCE_ID"):
+                await client.sources.add_file("nb_123", test_file)
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_nested_empty_list(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """Test _register_file_source() when extract_id hits base case None (line 925)."""
+        test_file = tmp_path / "empty_nested.pdf"
+        test_file.write_bytes(b"%PDF-1.4 content")
+
+        # Result is [[[]]] - extract_id([[]]) -> extract_id([]) -> returns None
+        rpc_response = build_rpc_response(
+            RPCMethod.ADD_SOURCE_FILE,
+            [[[]]],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*"),
+            content=rpc_response.encode(),
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceAddError):
+                await client.sources.add_file("nb_123", test_file)
+
+
+class TestStartResumableUploadError:
+    """Tests for _start_resumable_upload() missing upload URL (line 971)."""
+
+    @pytest.mark.asyncio
+    async def test_start_resumable_upload_missing_url_header(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        tmp_path,
+    ):
+        """Test _start_resumable_upload() raises when response has no upload URL header (line 971)."""
+        test_file = tmp_path / "no_url.pdf"
+        test_file.write_bytes(b"%PDF-1.4 content")
+
+        # Step 1: Successful RPC registration
+        rpc_response = build_rpc_response(
+            RPCMethod.ADD_SOURCE_FILE,
+            [[[["file_src_001"], "no_url.pdf", [None, None, None, None, 0]]]],
+        )
+        httpx_mock.add_response(
+            url=re.compile(r".*batchexecute.*"),
+            content=rpc_response.encode(),
+        )
+
+        # Step 2: Upload session response WITHOUT the required upload URL header
+        httpx_mock.add_response(
+            url=re.compile(r".*upload/_/\?authuser=0$"),
+            headers={},  # No x-goog-upload-url header
+            content=b"",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceAddError, match="Failed to get upload URL"):
+                await client.sources.add_file("nb_123", test_file)
+
+
+class TestWaitUntilReadyPolling:
+    """Tests for wait_until_ready() polling loop (lines 234-244)."""
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_polls_until_ready(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test wait_until_ready() polls and returns when source transitions to READY (lines 234-244)."""
+        # First response: source is PROCESSING (status=1)
+        processing_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook",
+                    [
+                        [
+                            ["src_polling"],
+                            "Processing Source",
+                            [None, 0],
+                            [None, 1],  # status=PROCESSING
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        # Second response: source is READY (status=2)
+        ready_response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook",
+                    [
+                        [
+                            ["src_polling"],
+                            "Processing Source",
+                            [None, 0],
+                            [None, 2],  # status=READY
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=processing_response.encode())
+        httpx_mock.add_response(content=ready_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            source = await client.sources.wait_until_ready(
+                "nb_123", "src_polling", initial_interval=0.01, timeout=30.0
+            )
+
+        assert source.id == "src_polling"
+
+
+class TestExtractVideoIdNoQuery:
+    """Tests for _extract_video_id_from_parsed_url() no-query branch (line 846->852)."""
+
+    @pytest.mark.asyncio
+    async def test_extract_youtube_video_id_no_query_string(
+        self,
+        auth_tokens,
+    ):
+        """Test _extract_youtube_video_id() returns None for youtube.com URL with no query at all (line 846->852)."""
+        async with NotebookLMClient(auth_tokens) as client:
+            # youtube.com URL with no path prefix and no query string
+            result = client.sources._extract_youtube_video_id("https://youtube.com/")
+
+        assert result is None
+
+
+class TestWaitUntilReadyErrorPaths:
+    """Tests for wait_until_ready() error state and mid-loop timeout (lines 234-244)."""
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_source_error_raises_processing_error(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test wait_until_ready() raises SourceProcessingError when source is in ERROR state (line 235)."""
+        from notebooklm.types import SourceProcessingError
+
+        # Source has ERROR status (status=3)
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook",
+                    [
+                        [
+                            ["src_error"],
+                            "Failed Source",
+                            [None, 0],
+                            [None, 3],  # status=ERROR
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(SourceProcessingError):
+                await client.sources.wait_until_ready("nb_123", "src_error")
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_timeout_mid_loop(
+        self,
+        auth_tokens,
+    ):
+        """Test wait_until_ready() raises SourceTimeoutError when timeout expires mid-loop (line 240)."""
+        from notebooklm.types import SourceTimeoutError
+
+        # A PROCESSING source that never becomes ready
+        processing_source = Source(id="src_slow", title="Slow Source", status=1)
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "get",
+                new_callable=AsyncMock,
+                return_value=processing_source,
+            ):
+                with pytest.raises(SourceTimeoutError):
+                    await client.sources.wait_until_ready(
+                        "nb_123",
+                        "src_slow",
+                        timeout=0.05,  # Very short timeout so polling loop hits elapsed > timeout
+                        initial_interval=0.001,
+                    )
+
+
+class TestWaitUntilReadyMidLoopTimeout:
+    """Test for the mid-loop timeout in wait_until_ready() (line 240)."""
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_remaining_zero_after_get(
+        self,
+        auth_tokens,
+    ):
+        """Test wait_until_ready() raises SourceTimeoutError at remaining<=0 check (line 240).
+
+        This covers the case where elapsed < timeout at the top of the loop,
+        but by the time we check remaining after get(), the timeout has expired.
+        """
+        from notebooklm.types import SourceTimeoutError
+
+        # A PROCESSING source
+        processing_source = Source(id="src_race", title="Race Source", status=1)
+        timeout_val = 1.0
+        # Simulate monotonic times: first call (start), second call (elapsed check in loop),
+        # third call (remaining check after get) - make third > timeout
+        # start=0.0, loop check: elapsed=0.5 < 1.0 (ok), remaining check: elapsed=1.5 > 1.0
+        monotonic_values = [0.0, 0.5, 1.5]
+        call_idx = 0
+
+        def fake_monotonic():
+            nonlocal call_idx
+            val = monotonic_values[min(call_idx, len(monotonic_values) - 1)]
+            call_idx += 1
+            return val
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with patch.object(
+                client.sources,
+                "get",
+                new_callable=AsyncMock,
+                return_value=processing_source,
+            ):
+                with patch("notebooklm._sources.monotonic", side_effect=fake_monotonic):
+                    with pytest.raises(SourceTimeoutError):
+                        await client.sources.wait_until_ready(
+                            "nb_123", "src_race", timeout=timeout_val
+                        )

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -893,3 +893,691 @@ class TestRateLimitDetection:
             data = json.loads(result.output)
             assert data["error"] is True
             assert data["code"] == "RATE_LIMITED"
+
+
+# =============================================================================
+# RESOLVE_LANGUAGE DIRECT TESTS
+# =============================================================================
+
+
+class TestResolveLanguageDirect:
+    """Direct tests for resolve_language() covering uncovered branches."""
+
+    def test_invalid_language_raises_bad_parameter(self):
+        """Line 111: language not in SUPPORTED_LANGUAGES raises click.BadParameter."""
+        import importlib
+
+        import click
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with pytest.raises(click.BadParameter) as exc_info:
+            generate_module.resolve_language("xx_INVALID")
+        assert "Unknown language code: xx_INVALID" in str(exc_info.value)
+        assert "notebooklm language list" in str(exc_info.value)
+
+    def test_none_language_with_config_returns_config(self):
+        """Line 118: language is None, config_lang is not None → returns config_lang."""
+        import importlib
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value="fr"):
+            result = generate_module.resolve_language(None)
+        assert result == "fr"
+
+    def test_none_language_no_config_returns_default(self):
+        """Line 139: language is None and config_lang is None → returns DEFAULT_LANGUAGE."""
+        import importlib
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value=None):
+            result = generate_module.resolve_language(None)
+        assert result == "en"
+
+
+# =============================================================================
+# _OUTPUT_GENERATION_STATUS DIRECT TESTS
+# =============================================================================
+
+
+class TestOutputGenerationStatusDirect:
+    """Direct tests for _output_generation_status() covering uncovered branches."""
+
+    def setup_method(self):
+        import importlib
+
+        self.generate_module = importlib.import_module("notebooklm.cli.generate")
+
+    def _make_status(
+        self, *, is_complete=False, is_failed=False, task_id=None, url=None, error=None
+    ):
+        status = MagicMock()
+        status.is_complete = is_complete
+        status.is_failed = is_failed
+        status.task_id = task_id
+        status.url = url
+        status.error = error
+        return status
+
+    def test_json_completed_with_url(self):
+        """Lines 200-201, 243: JSON output for completed status with URL."""
+        status = self._make_status(
+            is_complete=True, task_id="task_123", url="https://example.com/audio.mp3"
+        )
+        with patch.object(self.generate_module, "json_output_response") as mock_json:
+            self.generate_module._output_generation_status(status, "audio", json_output=True)
+        mock_json.assert_called_once_with(
+            {"task_id": "task_123", "status": "completed", "url": "https://example.com/audio.mp3"}
+        )
+
+    def test_json_failed(self):
+        """Line 251: JSON output for failed status."""
+        status = self._make_status(is_failed=True, error="Something went wrong")
+        with patch.object(self.generate_module, "json_error_response") as mock_err:
+            self.generate_module._output_generation_status(status, "audio", json_output=True)
+        mock_err.assert_called_once_with("GENERATION_FAILED", "Something went wrong")
+
+    def test_json_failed_no_error_message(self):
+        """Line 251: JSON failed output falls back to default message when error is None."""
+        status = self._make_status(is_failed=True, error=None)
+        with patch.object(self.generate_module, "json_error_response") as mock_err:
+            self.generate_module._output_generation_status(status, "audio", json_output=True)
+        mock_err.assert_called_once_with("GENERATION_FAILED", "Audio generation failed")
+
+    def test_json_pending_with_task_id(self):
+        """Lines 205-207, 257: JSON output for pending status extracts task_id from list."""
+        # Use a list result (lines 205-207: list path in handle_generation_result)
+        # and pending path in _output_generation_status (lines 255-257)
+        status = MagicMock()
+        status.is_complete = False
+        status.is_failed = False
+        status.task_id = "task_456"
+        with patch.object(self.generate_module, "json_output_response") as mock_json:
+            self.generate_module._output_generation_status(status, "audio", json_output=True)
+        mock_json.assert_called_once_with({"task_id": "task_456", "status": "pending"})
+
+    def test_text_completed_with_url(self):
+        """Line 262: Text output for completed status with URL."""
+        status = self._make_status(
+            is_complete=True, task_id="task_123", url="https://example.com/audio.mp3"
+        )
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_console.print.assert_called_once_with(
+            "[green]Audio ready:[/green] https://example.com/audio.mp3"
+        )
+
+    def test_text_completed_without_url(self):
+        """Line 264: Text output for completed status without URL."""
+        status = self._make_status(is_complete=True, task_id="task_123", url=None)
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_console.print.assert_called_once_with("[green]Audio ready[/green]")
+
+    def test_text_failed(self):
+        """Line 266: Text output for failed status."""
+        status = self._make_status(is_failed=True, error="Transcription error")
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_console.print.assert_called_once_with("[red]Failed:[/red] Transcription error")
+
+    def test_text_pending_with_task_id(self):
+        """Line 268: Text output for pending status shows task_id."""
+        status = self._make_status(task_id="task_789")
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_console.print.assert_called_once_with("[yellow]Started:[/yellow] task_789")
+
+    def test_text_pending_without_task_id_shows_status(self):
+        """Line 268: Text output for pending status shows status object when no task_id."""
+        status = MagicMock()
+        status.is_complete = False
+        status.is_failed = False
+        # Make _extract_task_id return None by having no task_id attr and not a dict/list
+        del status.task_id
+        with (
+            patch.object(self.generate_module, "_extract_task_id", return_value=None),
+            patch.object(self.generate_module, "console") as mock_console,
+        ):
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_console.print.assert_called_once()
+        call_args = mock_console.print.call_args[0][0]
+        assert "[yellow]Started:[/yellow]" in call_args
+
+
+class TestExtractTaskIdDirect:
+    """Direct tests for _extract_task_id() covering list path."""
+
+    def setup_method(self):
+        import importlib
+
+        self.generate_module = importlib.import_module("notebooklm.cli.generate")
+
+    def test_extract_from_list_first_string(self):
+        """Lines 231-232: list where first element is a string."""
+        result = self.generate_module._extract_task_id(["task_abc", "other"])
+        assert result == "task_abc"
+
+    def test_extract_from_list_first_not_string(self):
+        """Line 233: list where first element is not a string → returns None."""
+        result = self.generate_module._extract_task_id([123, "other"])
+        assert result is None
+
+    def test_extract_from_empty_list(self):
+        """Line 233: empty list → returns None."""
+        result = self.generate_module._extract_task_id([])
+        assert result is None
+
+    def test_extract_from_dict_task_id(self):
+        """Line 228: dict with task_id key."""
+        result = self.generate_module._extract_task_id({"task_id": "t1", "status": "pending"})
+        assert result == "t1"
+
+    def test_extract_from_dict_artifact_id(self):
+        """Line 228: dict with artifact_id key (no task_id)."""
+        result = self.generate_module._extract_task_id({"artifact_id": "a1"})
+        assert result == "a1"
+
+    def test_extract_from_object_with_task_id(self):
+        """Line 228: object with task_id attribute."""
+        status = MagicMock()
+        status.task_id = "task_obj"
+        result = self.generate_module._extract_task_id(status)
+        assert result == "task_obj"
+
+
+# =============================================================================
+# _OUTPUT_MIND_MAP_RESULT DIRECT TESTS
+# =============================================================================
+
+
+class TestOutputMindMapResultDirect:
+    """Direct tests for _output_mind_map_result() covering uncovered branches."""
+
+    def setup_method(self):
+        import importlib
+
+        self.generate_module = importlib.import_module("notebooklm.cli.generate")
+
+    def test_falsy_result_json_calls_error(self):
+        """Lines 624-626: falsy result with json_output → json_error_response."""
+        with patch.object(self.generate_module, "json_error_response") as mock_err:
+            self.generate_module._output_mind_map_result(None, json_output=True)
+        mock_err.assert_called_once_with("GENERATION_FAILED", "Mind map generation failed")
+
+    def test_falsy_result_no_json_prints_message(self):
+        """Lines 627-628: falsy result without json_output → console.print yellow."""
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_mind_map_result(None, json_output=False)
+        mock_console.print.assert_called_with("[yellow]No result[/yellow]")
+
+    def test_truthy_result_json_calls_output(self):
+        """Line 631: truthy result with json_output → json_output_response."""
+        result_data = {"note_id": "n1", "mind_map": {"name": "Root", "children": []}}
+        with patch.object(self.generate_module, "json_output_response") as mock_json:
+            self.generate_module._output_mind_map_result(result_data, json_output=True)
+        mock_json.assert_called_once_with(result_data)
+
+    def test_truthy_result_dict_text_output(self):
+        """Lines 633-635: truthy result dict with text output prints note_id and children count."""
+        result_data = {
+            "note_id": "n1",
+            "mind_map": {"name": "Root", "children": [{"label": "Child1"}, {"label": "Child2"}]},
+        }
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_mind_map_result(result_data, json_output=False)
+        printed_args = [call[0][0] for call in mock_console.print.call_args_list]
+        assert any("n1" in arg for arg in printed_args)
+        assert any("Root" in arg for arg in printed_args)
+        assert any("2" in arg for arg in printed_args)
+
+    def test_truthy_result_non_dict_text_output(self):
+        """Non-dict truthy result with text output → console.print(result)."""
+        result_data = "some-string-result"
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_mind_map_result(result_data, json_output=False)
+        # Should print the result directly
+        printed_args = [call[0][0] for call in mock_console.print.call_args_list]
+        assert any("some-string-result" in str(arg) for arg in printed_args)
+
+
+# =============================================================================
+# GENERATE REVISE-SLIDE CLI TESTS
+# =============================================================================
+
+
+class TestGenerateReviseSlide:
+    """Tests for the 'generate revise-slide' CLI command (lines 971-989)."""
+
+    def test_revise_slide_basic(self, runner, mock_auth):
+        """Lines 971-975: revise-slide command invokes client.artifacts.revise_slide."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.revise_slide = AsyncMock(
+                return_value={"artifact_id": "art_rev_1", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "revise-slide",
+                        "Make the title bigger",
+                        "--artifact",
+                        "art_1",
+                        "--slide",
+                        "0",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        mock_client.artifacts.revise_slide.assert_called_once()
+
+    def test_revise_slide_passes_correct_args(self, runner, mock_auth):
+        """Lines 985-989: verify artifact_id, slide_index, and prompt are forwarded."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.revise_slide = AsyncMock(
+                return_value={"artifact_id": "art_rev_2", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "revise-slide",
+                        "Remove taxonomy",
+                        "--artifact",
+                        "art_1",
+                        "--slide",
+                        "3",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_client.artifacts.revise_slide.call_args
+        assert call_kwargs is not None, "revise_slide was not called"
+        assert call_kwargs.kwargs.get("artifact_id") == "art_1"
+        assert call_kwargs.kwargs.get("slide_index") == 3
+        assert call_kwargs.kwargs.get("prompt") == "Remove taxonomy"
+
+    def test_revise_slide_missing_artifact_fails(self, runner, mock_auth):
+        """revise-slide requires --artifact option."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "revise-slide",
+                        "Make bigger",
+                        "--slide",
+                        "0",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code != 0
+
+    def test_revise_slide_missing_slide_fails(self, runner, mock_auth):
+        """revise-slide requires --slide option."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "revise-slide",
+                        "Make bigger",
+                        "--artifact",
+                        "art_1",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code != 0
+
+    def test_revise_slide_json_output(self, runner, mock_auth):
+        """revise-slide with --json flag produces JSON output."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.revise_slide = AsyncMock(
+                return_value={"artifact_id": "art_rev_3", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "revise-slide",
+                        "Bold the title",
+                        "--artifact",
+                        "art_1",
+                        "--slide",
+                        "1",
+                        "-n",
+                        "nb_123",
+                        "--json",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "task_id" in data or "artifact_id" in data or "status" in data
+
+
+# =============================================================================
+# GENERATE REPORT WITH DESCRIPTION (LINE 1057)
+# =============================================================================
+
+
+class TestGenerateReportWithNonBriefingFormat:
+    """Test generate report when description is provided with non-briefing-doc format.
+
+    Line 1057: the else-branch that sets custom_prompt = description when
+    report_format != 'briefing-doc' and description is provided.
+    """
+
+    def test_report_description_with_study_guide_format(self, runner, mock_auth):
+        """Line 1057: description + non-default format → custom_prompt = description."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_report = AsyncMock(
+                return_value={"artifact_id": "report_xyz", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "report",
+                        "Focus on beginners",
+                        "--format",
+                        "study-guide",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        mock_client.artifacts.generate_report.assert_called_once()
+        call_kwargs = mock_client.artifacts.generate_report.call_args.kwargs
+        # custom_prompt should be the description argument
+        assert call_kwargs.get("custom_prompt") == "Focus on beginners"
+
+    def test_report_description_with_blog_post_format(self, runner, mock_auth):
+        """Line 1057: description + blog-post format → custom_prompt set."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_report = AsyncMock(
+                return_value={"artifact_id": "report_abc", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "report",
+                        "Write in casual tone",
+                        "--format",
+                        "blog-post",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        mock_client.artifacts.generate_report.assert_called_once()
+        call_kwargs = mock_client.artifacts.generate_report.call_args.kwargs
+        assert call_kwargs.get("custom_prompt") == "Write in casual tone"
+
+
+# =============================================================================
+# HANDLE_GENERATION_RESULT PATHS (GenerationStatus and list result formats)
+# =============================================================================
+
+
+class TestHandleGenerationResultPaths:
+    """Test handle_generation_result branches: GenerationStatus input and list input."""
+
+    def test_generation_result_with_generation_status_object(self, runner, mock_auth):
+        """Lines 200-201: result is a GenerationStatus → task_id = result.task_id."""
+        from notebooklm.types import GenerationStatus
+
+        status = GenerationStatus(
+            task_id="task_gen_1", status="pending", error=None, error_code=None
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=status)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
+
+        assert result.exit_code == 0
+        assert "task_gen_1" in result.output or "Started" in result.output
+
+    def test_generation_result_with_list_input(self, runner, mock_auth):
+        """Lines 205-207: result is a list → task_id from first element."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=["task_list_1", "extra"])
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
+
+        assert result.exit_code == 0
+        assert "task_list_1" in result.output or "Started" in result.output
+
+    def test_generation_result_falsy_shows_failed_message(self, runner, mock_auth):
+        """Line 173: falsy result → text error message."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
+
+        assert result.exit_code == 0
+        assert "generation failed" in result.output.lower()
+
+    def test_generation_result_falsy_json_shows_error(self, runner, mock_auth):
+        """Line 173: falsy result with --json → json_error_response (exits with code 1)."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
+
+        # json_error_response calls sys.exit(1), so exit_code is 1
+        data = json.loads(result.output)
+        assert data["error"] is True
+        assert data["code"] == "GENERATION_FAILED"
+
+    def test_generation_with_wait_and_generation_status(self, runner, mock_auth):
+        """Line 213: wait=True with GenerationStatus triggers wait_for_completion."""
+        from notebooklm.types import GenerationStatus
+
+        initial_status = GenerationStatus(
+            task_id="task_wait_1", status="pending", error=None, error_code=None
+        )
+        completed_status = GenerationStatus(
+            task_id="task_wait_1",
+            status="completed",
+            error=None,
+            error_code=None,
+            url="https://example.com/result.mp3",
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=initial_status)
+            mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
+
+        assert result.exit_code == 0
+        mock_client.artifacts.wait_for_completion.assert_called_once()
+
+
+# =============================================================================
+# ADDITIONAL TARGETED COVERAGE TESTS
+# =============================================================================
+
+
+class TestGenerateWithRetryConsoleOutput:
+    """Test generate_with_retry console output branch (line 111)."""
+
+    @pytest.mark.asyncio
+    async def test_retry_shows_console_message_when_not_json(self):
+        """Line 111: console.print shown during retry when json_output=False."""
+        import importlib
+
+        from notebooklm.types import GenerationStatus
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+
+        rate_limited = GenerationStatus(
+            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
+        )
+        success_result = GenerationStatus(
+            task_id="task_123", status="pending", error=None, error_code=None
+        )
+        generate_fn = AsyncMock(side_effect=[rate_limited, success_result])
+
+        with (
+            patch.object(generate_module, "console") as mock_console,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await generate_module.generate_with_retry(
+                generate_fn, max_retries=1, artifact_type="audio", json_output=False
+            )
+
+        assert result == success_result
+        # Console should have been called with the retry message
+        mock_console.print.assert_called_once()
+        call_text = mock_console.print.call_args[0][0]
+        assert "rate limited" in call_text.lower() or "Retrying" in call_text
+
+
+class TestHandleGenerationResultListPathAndWait:
+    """Test handle_generation_result: list path and wait with console message."""
+
+    def test_wait_with_task_id_shows_generating_message(self, runner, mock_auth):
+        """Line 211->213: wait=True, task_id present, not json → console.print generating."""
+        from notebooklm.types import GenerationStatus
+
+        initial_status = GenerationStatus(
+            task_id="task_console_1", status="pending", error=None, error_code=None
+        )
+        completed_status = GenerationStatus(
+            task_id="task_console_1",
+            status="completed",
+            error=None,
+            error_code=None,
+            url="https://example.com/audio.mp3",
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=initial_status)
+            mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
+
+        assert result.exit_code == 0
+        # The console message "Generating audio... Task: task_console_1" should appear
+        assert "task_console_1" in result.output or "Generating" in result.output
+        mock_client.artifacts.wait_for_completion.assert_called_once()
+
+    def test_list_result_extracts_task_id_for_wait(self, runner, mock_auth):
+        """Lines 205->210, 213: list result + wait=True → task_id from list[0]."""
+        from notebooklm.types import GenerationStatus
+
+        completed_status = GenerationStatus(
+            task_id="task_list_wait",
+            status="completed",
+            error=None,
+            error_code=None,
+            url="https://example.com/audio.mp3",
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(
+                return_value=["task_list_wait", "extra"]
+            )
+            mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
+
+        assert result.exit_code == 0
+        mock_client.artifacts.wait_for_completion.assert_called_once()
+
+
+class TestOutputMindMapNonDictMindMap:
+    """Test _output_mind_map_result when mind_map value is not a dict (line 985->else)."""
+
+    def setup_method(self):
+        import importlib
+
+        self.generate_module = importlib.import_module("notebooklm.cli.generate")
+
+    def test_mind_map_non_dict_value_prints_directly(self):
+        """Line 985->else (988-989): mind_map is not a dict → console.print(result)."""
+        result_data = {
+            "note_id": "n1",
+            "mind_map": ["node1", "node2"],  # list, not dict → else branch
+        }
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_mind_map_result(result_data, json_output=False)
+        printed_calls = [call[0][0] for call in mock_console.print.call_args_list]
+        # Should print the header and Note ID, then the raw result
+        assert any("n1" in str(arg) for arg in printed_calls)

--- a/tests/unit/cli/test_language.py
+++ b/tests/unit/cli/test_language.py
@@ -2,7 +2,7 @@
 
 import importlib
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -180,3 +180,233 @@ class TestGenerateUsesConfigLanguage:
         assert result.exit_code == 0
         assert "--language" in result.output
         assert "from config" in result.output.lower() or "default" in result.output.lower()
+
+
+# =============================================================================
+# GET_CONFIG ERROR PATHS (lines 116-121)
+# =============================================================================
+
+
+class TestGetConfigErrorPaths:
+    def test_get_config_json_decode_error(self, tmp_path):
+        """Test get_config() returns {} when config file has invalid JSON."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text("this is not valid json{{{")
+
+        with patch.object(language_module, "get_config_path", return_value=config_file):
+            result = language_module.get_config()
+
+        assert result == {}
+
+    def test_get_config_oserror(self, tmp_path):
+        """Test get_config() returns {} when config file can't be read (OSError)."""
+        config_file = tmp_path / "config.json"
+        # Create the file so exists() returns True, then mock read_text to raise OSError
+        config_file.write_text('{"language": "en"}')
+
+        with (
+            patch.object(language_module, "get_config_path", return_value=config_file),
+            patch.object(
+                config_file.__class__, "read_text", side_effect=OSError("permission denied")
+            ),
+        ):
+            result = language_module.get_config()
+
+        assert result == {}
+
+
+# =============================================================================
+# _SYNC_LANGUAGE_TO_SERVER AND _GET_LANGUAGE_FROM_SERVER (lines 162-164, 176-186)
+# =============================================================================
+
+
+class TestSyncLanguageToServer:
+    def test_sync_language_to_server_success(self):
+        """Test _sync_language_to_server returns run_async result on success."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"auth": {"SID": "test", "HSID": "test", "SSID": "test"}}
+
+        with (
+            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
+            patch.object(language_module, "run_async", return_value="en") as mock_run,
+        ):
+            result = language_module._sync_language_to_server("en", mock_ctx)
+
+        assert result == "en"
+        mock_run.assert_called_once()
+
+    def test_sync_language_to_server_exception_returns_none(self):
+        """Test _sync_language_to_server returns None when exception occurs."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+
+        with patch.object(language_module, "get_auth_tokens", side_effect=Exception("no auth")):
+            result = language_module._sync_language_to_server("en", mock_ctx)
+
+        assert result is None
+
+    def test_sync_language_to_server_run_async_exception(self):
+        """Test _sync_language_to_server returns None when run_async raises."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+
+        with (
+            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
+            patch.object(language_module, "run_async", side_effect=Exception("connection error")),
+        ):
+            result = language_module._sync_language_to_server("en", mock_ctx)
+
+        assert result is None
+
+
+class TestGetLanguageFromServer:
+    def test_get_language_from_server_success(self):
+        """Test _get_language_from_server returns the server language on success."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"auth": {"SID": "test"}}
+
+        with (
+            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
+            patch.object(language_module, "run_async", return_value="fr") as mock_run,
+        ):
+            result = language_module._get_language_from_server(mock_ctx)
+
+        assert result == "fr"
+        mock_run.assert_called_once()
+
+    def test_get_language_from_server_exception_returns_none(self):
+        """Test _get_language_from_server returns None when exception occurs."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+
+        with patch.object(language_module, "get_auth_tokens", side_effect=Exception("no auth")):
+            result = language_module._get_language_from_server(mock_ctx)
+
+        assert result is None
+
+    def test_get_language_from_server_run_async_exception(self):
+        """Test _get_language_from_server returns None when run_async raises."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+
+        with (
+            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
+            patch.object(language_module, "run_async", side_effect=Exception("rpc error")),
+        ):
+            result = language_module._get_language_from_server(mock_ctx)
+
+        assert result is None
+
+
+# =============================================================================
+# LANGUAGE GET SERVER SYNC PATHS (lines 244-250, 270)
+# =============================================================================
+
+
+class TestLanguageGetServerSyncPaths:
+    def test_language_get_server_has_different_value_updates_local(self, runner, mock_config_file):
+        """Test 'language get' updates local config when server has a different value."""
+        # Local is "en", server returns "fr" → local should be updated to "fr"
+        mock_config_file.write_text(json.dumps({"language": "en"}))
+
+        with patch.object(language_module, "_get_language_from_server", return_value="fr"):
+            result = runner.invoke(cli, ["language", "get"])
+
+        assert result.exit_code == 0
+        # Local config should be updated to "fr"
+        config = json.loads(mock_config_file.read_text())
+        assert config["language"] == "fr"
+        # Output should show "fr" (the server value)
+        assert "fr" in result.output
+
+    def test_language_get_server_different_shows_synced(self, runner, mock_config_file):
+        """Test 'language get' shows synced message when server differs from local."""
+        mock_config_file.write_text(json.dumps({"language": "en"}))
+
+        with patch.object(language_module, "_get_language_from_server", return_value="ja"):
+            result = runner.invoke(cli, ["language", "get"])
+
+        assert result.exit_code == 0
+        assert "synced" in result.output.lower()
+
+    def test_language_get_server_same_value_no_update(self, runner, mock_config_file):
+        """Test 'language get' does not update local when server value matches."""
+        mock_config_file.write_text(json.dumps({"language": "en"}))
+
+        with (
+            patch.object(language_module, "_get_language_from_server", return_value="en"),
+            patch.object(language_module, "set_language") as mock_set,
+        ):
+            result = runner.invoke(cli, ["language", "get"])
+
+        assert result.exit_code == 0
+        mock_set.assert_not_called()
+
+    def test_language_get_no_language_shows_not_set(self, runner, mock_config_file):
+        """Test 'language get' shows 'not set' when no language is configured and server returns None."""
+        # No language configured locally
+        with patch.object(language_module, "_get_language_from_server", return_value=None):
+            result = runner.invoke(cli, ["language", "get"])
+
+        assert result.exit_code == 0
+        assert "not set" in result.output
+
+    def test_language_get_server_sync_json_output(self, runner, mock_config_file):
+        """Test 'language get --json' reflects synced_from_server when values differ."""
+        mock_config_file.write_text(json.dumps({"language": "en"}))
+
+        with patch.object(language_module, "_get_language_from_server", return_value="de"):
+            result = runner.invoke(cli, ["language", "get", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["language"] == "de"
+        assert data["synced_from_server"] is True
+
+
+# =============================================================================
+# LANGUAGE SET SYNC FAILED AND JSON PATHS (lines 316-320, 335-336)
+# =============================================================================
+
+
+class TestLanguageSetSyncFailedAndJsonPaths:
+    def test_language_set_sync_failed_shows_local_only_message(self, runner, mock_config_file):
+        """Test 'language set' shows local-only message when server sync fails."""
+        with patch.object(language_module, "_sync_language_to_server", return_value=None):
+            result = runner.invoke(cli, ["language", "set", "en"])
+
+        assert result.exit_code == 0
+        assert "saved locally" in result.output or "server sync failed" in result.output
+
+    def test_language_set_sync_success_shows_synced_message(self, runner, mock_config_file):
+        """Test 'language set' shows synced message when server sync succeeds."""
+        with patch.object(language_module, "_sync_language_to_server", return_value="en"):
+            result = runner.invoke(cli, ["language", "set", "en"])
+
+        assert result.exit_code == 0
+        assert "synced" in result.output.lower()
+        # Should NOT show "server sync failed"
+        assert "server sync failed" not in result.output
+
+    def test_language_set_json_output_with_server_sync(self, runner, mock_config_file):
+        """Test 'language set --json' includes synced_to_server field."""
+        with patch.object(language_module, "_sync_language_to_server", return_value="fr"):
+            result = runner.invoke(cli, ["language", "set", "fr", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["language"] == "fr"
+        assert data["name"] == "Français"
+        assert "synced_to_server" in data
+        assert data["synced_to_server"] is True
+
+    def test_language_set_json_output_sync_failed(self, runner, mock_config_file):
+        """Test 'language set --json' shows synced_to_server=False when sync fails."""
+        with patch.object(language_module, "_sync_language_to_server", return_value=None):
+            result = runner.invoke(cli, ["language", "set", "ko", "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["language"] == "ko"
+        assert "synced_to_server" in data
+        assert data["synced_to_server"] is False

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -8,7 +8,13 @@ import pytest
 from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
-from notebooklm.types import Source
+from notebooklm.types import (
+    Source,
+    SourceFulltext,
+    SourceNotFoundError,
+    SourceProcessingError,
+    SourceTimeoutError,
+)
 
 from .conftest import create_mock_client, patch_client_for_module
 
@@ -630,3 +636,428 @@ class TestSourceCommandsExist:
         assert result.exit_code == 0
         assert "SOURCE_ID" in result.output
         assert "exit code" in result.output.lower()
+
+
+# =============================================================================
+# SOURCE ADD AUTO-DETECT TESTS
+# =============================================================================
+
+
+class TestSourceAddAutoDetect:
+    def test_source_add_autodetect_file(self, runner, mock_auth, tmp_path):
+        """Pass a real file path without --type; should auto-detect as 'file'."""
+        test_file = tmp_path / "notes.txt"
+        test_file.write_text("Some file content")
+
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_file = AsyncMock(
+                return_value=Source(id="src_file", title="notes.txt")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["source", "add", str(test_file), "-n", "nb_123"],
+                )
+
+            assert result.exit_code == 0
+            mock_client.sources.add_file.assert_called_once()
+
+    def test_source_add_autodetect_plain_text(self, runner, mock_auth):
+        """Pass plain text (not URL, not existing path) without --type.
+
+        Should auto-detect as 'text' with default title 'Pasted Text'.
+        """
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_text = AsyncMock(
+                return_value=Source(id="src_text", title="Pasted Text")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["source", "add", "This is just some plain text content", "-n", "nb_123"],
+                )
+
+            assert result.exit_code == 0
+            # Verify add_text was called with the default "Pasted Text" title
+            mock_client.sources.add_text.assert_called_once()
+            call_args = mock_client.sources.add_text.call_args
+            assert call_args[0][1] == "Pasted Text"  # title arg
+
+    def test_source_add_autodetect_text_with_custom_title(self, runner, mock_auth):
+        """Pass plain text without --type but with --title.
+
+        Title should be the custom title, not 'Pasted Text'.
+        """
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_text = AsyncMock(
+                return_value=Source(id="src_text", title="Custom Title")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add",
+                        "This is just some plain text content",
+                        "--title",
+                        "Custom Title",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            mock_client.sources.add_text.assert_called_once()
+            call_args = mock_client.sources.add_text.call_args
+            assert call_args[0][1] == "Custom Title"  # title arg
+
+
+# =============================================================================
+# SOURCE FULLTEXT TESTS
+# =============================================================================
+
+
+class TestSourceFulltext:
+    def test_source_fulltext_console_output(self, runner, mock_auth):
+        """Short content (<= 2000 chars) is displayed in full."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="Test Source",
+                    content="This is the full text content.",
+                    char_count=30,
+                    url=None,
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "fulltext", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 0
+            assert "src_123" in result.output
+            assert "Test Source" in result.output
+            assert "This is the full text content." in result.output
+            # Should NOT show truncation message for short content
+            assert "more chars" not in result.output
+
+    def test_source_fulltext_truncated_output(self, runner, mock_auth):
+        """Long content (> 2000 chars) is truncated with a 'more chars' message."""
+        long_content = "A" * 3000
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="Long Source",
+                    content=long_content,
+                    char_count=3000,
+                    url=None,
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "fulltext", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 0
+            assert "more chars" in result.output
+
+    def test_source_fulltext_save_to_file(self, runner, mock_auth, tmp_path):
+        """-o flag saves content to file."""
+        output_file = tmp_path / "output.txt"
+        content = "Full text content to save."
+
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="Test Source",
+                    content=content,
+                    char_count=len(content),
+                    url=None,
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["source", "fulltext", "src_123", "-n", "nb_123", "-o", str(output_file)],
+                )
+
+            assert result.exit_code == 0
+            assert "Saved" in result.output
+            assert output_file.read_text(encoding="utf-8") == content
+
+    def test_source_fulltext_json_output(self, runner, mock_auth):
+        """--json outputs JSON with fulltext fields."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="Test Source",
+                    content="Some content",
+                    char_count=12,
+                    url=None,
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["source", "fulltext", "src_123", "-n", "nb_123", "--json"]
+                )
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["source_id"] == "src_123"
+            assert data["title"] == "Test Source"
+            assert data["content"] == "Some content"
+            assert data["char_count"] == 12
+
+    def test_source_fulltext_with_url(self, runner, mock_auth):
+        """Shows URL field when present in fulltext."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Web Source")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="Web Source",
+                    content="Web page content.",
+                    char_count=17,
+                    url="https://example.com/page",
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "fulltext", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 0
+            assert "https://example.com/page" in result.output
+
+
+# =============================================================================
+# SOURCE WAIT TESTS
+# =============================================================================
+
+
+class TestSourceWait:
+    def test_source_wait_success(self, runner, mock_auth):
+        """wait_until_ready returns a Source → prints 'ready'."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                return_value=Source(id="src_123", title="Test Source", status=2)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 0
+            assert "ready" in result.output.lower()
+
+    def test_source_wait_success_with_title(self, runner, mock_auth):
+        """Source has a title → prints the title after 'ready' message."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="My Source Title")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                return_value=Source(id="src_123", title="My Source Title", status=2)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 0
+            assert "My Source Title" in result.output
+
+    def test_source_wait_success_json(self, runner, mock_auth):
+        """--json output on successful wait."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                return_value=Source(id="src_123", title="Test Source", status=2)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["source_id"] == "src_123"
+            assert data["status"] == "ready"
+
+    def test_source_wait_not_found(self, runner, mock_auth):
+        """Raises SourceNotFoundError → exit code 1."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceNotFoundError("src_123")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 1
+            assert "not found" in result.output.lower()
+
+    def test_source_wait_not_found_json(self, runner, mock_auth):
+        """--json on SourceNotFoundError → JSON with status 'not_found', exit 1."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceNotFoundError("src_123")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["status"] == "not_found"
+            assert data["source_id"] == "src_123"
+
+    def test_source_wait_processing_error(self, runner, mock_auth):
+        """Raises SourceProcessingError → exit code 1."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceProcessingError("src_123", status=3)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 1
+            assert "processing failed" in result.output.lower()
+
+    def test_source_wait_processing_error_json(self, runner, mock_auth):
+        """--json on SourceProcessingError → JSON with status 'error', exit 1."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceProcessingError("src_123", status=3)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["status"] == "error"
+            assert data["source_id"] == "src_123"
+            assert data["status_code"] == 3
+
+    def test_source_wait_timeout(self, runner, mock_auth):
+        """Raises SourceTimeoutError → exit code 2."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceTimeoutError("src_123", timeout=30.0, last_status=1)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
+
+            assert result.exit_code == 2
+            assert "timeout" in result.output.lower()
+
+    def test_source_wait_timeout_json(self, runner, mock_auth):
+        """--json on SourceTimeoutError → JSON with status 'timeout', exit 2."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Test Source")]
+            )
+            mock_client.sources.wait_until_ready = AsyncMock(
+                side_effect=SourceTimeoutError("src_123", timeout=30.0, last_status=1)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 2
+            data = json.loads(result.output)
+            assert data["status"] == "timeout"
+            assert data["source_id"] == "src_123"
+            assert data["timeout_seconds"] == 30
+            assert data["last_status_code"] == 1


### PR DESCRIPTION
## Summary

- Adds ~6,400 lines of new tests across 9 test files, raising total branch coverage from **88% to 93.61%**
- Raises the CI coverage threshold from 70% to **90%** (`fail_under` in `pyproject.toml`)
- All 1,809 tests pass; ruff, mypy, and pytest all clean

### New test coverage by module

| Module | Before | After |
|--------|--------|-------|
| `_core.py` | ~70% | ~95% |
| `_chat.py` | 85% | 99% |
| `_sources.py` | 86% | 99% |
| `_artifacts.py` | ~82% | ~94% |
| `cli/generate.py` | ~80% | 99% |
| `cli/language.py` | ~75% | 97% |
| `cli/source.py` | ~80% | 94% |

### Key areas covered

- **`_core.py`**: HTTP error codes (400/429/500), rate-limit `retry-after` header parsing, auth retry on `RPCError`, FIFO conversation cache eviction semantics, `get_source_ids` helper
- **`_chat.py`**: `ask()` error handling, `get_conversation_id()` edge cases, `get_history()` error paths, full citation/reference extraction chain (74 new tests)
- **`_sources.py`**: `wait_until_ready()`, `add_url/text/file()` with `wait=True`, drive source wait, freshness checks, `get_fulltext()` content parsing, YouTube ID extraction (64 new tests)
- **`_artifacts.py`**: `ArtifactParseError` paths, mind map JSON parsing, `revise_slide()`, download error paths, poll status variants, deprecated `wait_for_completion()` API
- **`_notebooks.py`**: `describe()` and `share()` edge cases including `get_notebook()` failure paths from Issue #114
- **`_research.py`**: Poll response boundary conditions, import source edge cases
- **`cli/generate.py`**: `resolve_language()`, output helpers, `revise-slide` command
- **`cli/language.py`**: Config read errors, server sync/get paths, JSON output variants
- **`cli/source.py`**: Auto-detect (file/URL/plain text), `fulltext`, `wait` commands

## Test plan

- [x] `ruff format src/ tests/` — 2 files reformatted, all clean
- [x] `ruff check src/ tests/` — all checks passed
- [x] `mypy src/notebooklm --ignore-missing-imports` — no issues
- [x] `pytest --cov` — 1809 passed, 9 skipped, coverage 93.61% ≥ 90% threshold

Generated with [Claude Code](https://claude.com/claude-code)