### PR TITLE
fix: resolve source/notebook IDs by title when prefix match fails

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -29,6 +29,9 @@ from ..auth import (
 from ..paths import get_browser_profile_dir, get_context_path
 from ..types import ArtifactType
 
+# Valid characters in a UUID (hex digits + dashes)
+_UUID_CHARS = frozenset("0123456789abcdef-")
+
 if TYPE_CHECKING:
     from ..types import Artifact
 
@@ -280,7 +283,7 @@ async def _resolve_partial_id(
     partial_id = validate_id(partial_id, entity_name)
 
     # Skip resolution for IDs that look like complete UUIDs (hex + dashes only, 20+ chars)
-    if len(partial_id) >= 20 and all(c in "0123456789abcdef-" for c in partial_id.lower()):
+    if len(partial_id) >= 20 and all(c in _UUID_CHARS for c in partial_id.lower()):
         return partial_id
 
     items = await list_fn()
@@ -292,7 +295,7 @@ async def _resolve_partial_id(
             console.print(f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]")
         return matches[0].id
     elif len(matches) == 0:
-        # Fall back to title matching (case-insensitive, exact then substring)
+        # Fall back to title matching (case-insensitive, exact)
         title_exact = [
             item for item in items if item.title and item.title.lower() == partial_id.lower()
         ]

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -279,8 +279,8 @@ async def _resolve_partial_id(
     # Validate and normalize the ID
     partial_id = validate_id(partial_id, entity_name)
 
-    # Skip resolution for IDs that look complete (20+ chars)
-    if len(partial_id) >= 20:
+    # Skip resolution for IDs that look like complete UUIDs (hex + dashes only, 20+ chars)
+    if len(partial_id) >= 20 and all(c in "0123456789abcdef-" for c in partial_id.lower()):
         return partial_id
 
     items = await list_fn()
@@ -292,8 +292,26 @@ async def _resolve_partial_id(
             console.print(f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]")
         return matches[0].id
     elif len(matches) == 0:
+        # Fall back to title matching (case-insensitive, exact then substring)
+        title_exact = [
+            item for item in items if item.title and item.title.lower() == partial_id.lower()
+        ]
+        if len(title_exact) == 1:
+            console.print(
+                f"[dim]Matched by title: {title_exact[0].id[:12]}... ({title_exact[0].title})[/dim]"
+            )
+            return title_exact[0].id
+        if len(title_exact) > 1:
+            lines = [
+                f"Title '{partial_id}' matches {len(title_exact)} {entity_name}s "
+                f"(use ID to disambiguate):"
+            ]
+            for item in title_exact[:5]:
+                lines.append(f"  {item.id[:12]}... {item.title}")
+            raise click.ClickException("\n".join(lines))
+
         raise click.ClickException(
-            f"No {entity_name} found starting with '{partial_id}'. "
+            f"No {entity_name} found matching '{partial_id}' (checked ID prefix and title). "
             f"Run 'notebooklm {list_command}' to see available {entity_name}s."
         )
     else:

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -586,3 +586,114 @@ class TestRunAsync:
 
         result = run_async(sample_coro())
         assert result == "result"
+
+
+# =============================================================================
+# RESOLVE PARTIAL ID TESTS
+# =============================================================================
+
+
+class TestResolvePartialId:
+    """Tests for _resolve_partial_id title matching and UUID detection."""
+
+    def _make_item(self, item_id: str, title: str | None = None):
+        """Create a mock item with id and title attributes."""
+        item = MagicMock()
+        item.id = item_id
+        item.title = title
+        return item
+
+    def test_title_match_when_id_prefix_fails(self):
+        """Titles should resolve to the correct ID when no ID prefix matches."""
+        from notebooklm.cli.helpers import _resolve_partial_id
+
+        items = [
+            self._make_item("03abe51c-d8df-43ba-ae2d-0efe02c71c4a", "My Document.txt"),
+            self._make_item("6486682a-cf2d-48f0-8c2b-165841a7cede", "Other File.txt"),
+        ]
+
+        async def _run():
+            result = await _resolve_partial_id(
+                "My Document.txt",
+                list_fn=AsyncMock(return_value=items),
+                entity_name="source",
+                list_command="source list",
+            )
+            assert result == "03abe51c-d8df-43ba-ae2d-0efe02c71c4a"
+
+        run_async(_run())
+
+    def test_title_match_case_insensitive(self):
+        """Title matching should be case-insensitive."""
+        from notebooklm.cli.helpers import _resolve_partial_id
+
+        items = [
+            self._make_item("abc123", "README.md"),
+        ]
+
+        async def _run():
+            result = await _resolve_partial_id(
+                "readme.md",
+                list_fn=AsyncMock(return_value=items),
+                entity_name="source",
+                list_command="source list",
+            )
+            assert result == "abc123"
+
+        run_async(_run())
+
+    def test_long_title_not_treated_as_uuid(self):
+        """Long non-UUID strings (like filenames) should not bypass resolution."""
+        from notebooklm.cli.helpers import _resolve_partial_id
+
+        items = [
+            self._make_item("abc-def-123", "Emails_Verzonden_2025-Q1.txt"),
+        ]
+
+        async def _run():
+            result = await _resolve_partial_id(
+                "Emails_Verzonden_2025-Q1.txt",
+                list_fn=AsyncMock(return_value=items),
+                entity_name="source",
+                list_command="source list",
+            )
+            assert result == "abc-def-123"
+
+        run_async(_run())
+
+    def test_actual_uuid_still_skips_resolution(self):
+        """Real UUIDs (20+ hex chars) should still skip resolution for performance."""
+        from notebooklm.cli.helpers import _resolve_partial_id
+
+        async def _run():
+            result = await _resolve_partial_id(
+                "03abe51c-d8df-43ba-ae2d-0efe02c71c4a",
+                list_fn=AsyncMock(),  # Should not be called
+                entity_name="source",
+                list_command="source list",
+            )
+            assert result == "03abe51c-d8df-43ba-ae2d-0efe02c71c4a"
+
+        run_async(_run())
+
+    def test_ambiguous_title_raises_error(self):
+        """Multiple sources with the same title should raise an error."""
+        import click
+
+        from notebooklm.cli.helpers import _resolve_partial_id
+
+        items = [
+            self._make_item("id-1", "duplicate.txt"),
+            self._make_item("id-2", "duplicate.txt"),
+        ]
+
+        async def _run():
+            with pytest.raises(click.ClickException, match="matches 2"):
+                await _resolve_partial_id(
+                    "duplicate.txt",
+                    list_fn=AsyncMock(return_value=items),
+                    entity_name="source",
+                    list_command="source list",
+                )
+
+        run_async(_run())


### PR DESCRIPTION
## Summary
- Fixes `source delete` (and other commands) silently failing when passed a title instead of an ID
- The `_resolve_partial_id` helper treated any input 20+ chars as a complete UUID, bypassing resolution — titles like `Emails_Verzonden_2025-Q1.txt` were passed as-is to the API which silently ignored them
- Now only skips resolution for inputs that look like actual UUIDs (hex + dashes)
- Falls back to case-insensitive exact title matching when no ID prefix match is found
- Ambiguous titles (multiple sources with same name) raise a clear error

Fixes #112

## Test plan
- [x] Added 5 unit tests covering: title match, case-insensitive match, long non-UUID title, actual UUID bypass, ambiguous title error
- [x] All 1291 existing unit tests pass
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)