### PR TITLE
fix: add __main__.py to support python -m notebooklm

### DIFF
--- a/src/notebooklm/__main__.py
+++ b/src/notebooklm/__main__.py
@@ -2,4 +2,5 @@
 
 from notebooklm.notebooklm_cli import main
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`python -m notebooklm` fails with `No module named notebooklm.__main__`. The CLI works fine via the installed entry point, but the module invocation path is missing.

Adds `src/notebooklm/__main__.py` that imports and calls the existing CLI `main()`.

Fixes #159