### PR TITLE
docs: update README tagline to highlight agentic skill and AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img src="https://raw.githubusercontent.com/teng-lin/notebooklm-py/main/notebooklm-py.png" alt="notebooklm-py logo" width="128">
 </p>
 
-**Unofficial Python API and agentic skill for Google NotebookLM.** Full programmatic access to NotebookLM's features—including capabilities the web UI doesn't expose—via Python, CLI, and AI agents like Claude Code, Codex, and OpenClaw etc.
+**Unofficial Python API and agentic skill for Google NotebookLM.** Full programmatic access to NotebookLM's features—including capabilities the web UI doesn't expose—via Python, CLI, and AI agents like Claude Code, Codex, and OpenClaw.
 
 [![PyPI version](https://img.shields.io/pypi/v/notebooklm-py.svg)](https://pypi.org/project/notebooklm-py/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/notebooklm-py/)


### PR DESCRIPTION
## Summary

- Updates the README hero tagline from generic "Comprehensive Python API" to emphasize the agentic skill positioning
- Highlights compatibility with AI agents (Claude Code, Codex, OpenClaw) alongside Python and CLI
- Improves SEO by surfacing keywords: agentic skill, AI agents, Claude Code, Codex, OpenClaw

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm tagline is visible above the fold