### PR TITLE
fix: title-based matching + video download validation

### DIFF
--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,19 @@
+Implements feature request #171 - Export Notebook Metadata and Sources via Python API
+
+## Changes
+
+- Add `NotebookMetadata` dataclass with `id`, `title`, `created_at`, `updated_at`, `sources`
+- Add `SourceSummary` dataclass with `id`, `title`, `url`, `kind`
+- Add `notebooks.get_metadata()` method to retrieve structured notebook metadata
+- Export new types from `__init__.py`
+
+## Example usage
+
+```python
+metadata = await client.notebooks.get_metadata(notebook_id)
+print(f"Notebook: {metadata.title}")
+for source in metadata.sources:
+    print(f"  - {source.title} ({source.kind.value})")
+```
+
+Closes #171

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -103,6 +103,7 @@ from .types import (
     Note,
     Notebook,
     NotebookDescription,
+    NotebookMetadata,
     QuizDifficulty,
     QuizQuantity,
     ReportFormat,
@@ -117,6 +118,7 @@ from .types import (
     Source,
     SourceFulltext,
     SourceStatus,
+    SourceSummary,
     SourceType,
     # Enums for configuration
     SuggestedTopic,
@@ -136,6 +138,8 @@ __all__ = [
     # Types
     "Notebook",
     "NotebookDescription",
+    "NotebookMetadata",
+    "SourceSummary",
     "SuggestedTopic",
     "Source",
     "SourceFulltext",
@@ -146,9 +150,9 @@ __all__ = [
     "ConversationTurn",
     "ChatReference",
     "AskResult",
-    "ChatMode",
     "SharedUser",
     "ShareStatus",
+    "ChatMode",
     # Base Exceptions
     "NotebookLMError",
     "ValidationError",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1058,7 +1058,27 @@ class ArtifactsAPI:
                     details="Could not extract download URL",
                 )
 
-            return await self._download_url(url, output_path)
+            result_path = await self._download_url(url, output_path)
+
+            # Validate that the file was actually written successfully
+            output_file = Path(result_path)
+            if not output_file.exists():
+                raise ArtifactDownloadError(
+                    "audio",
+                    artifact_id=artifact_id,
+                    details=f"Audio download failed: file not written to {output_path}",
+                )
+            file_size = output_file.stat().st_size
+            if file_size == 0:
+                # Clean up empty file
+                output_file.unlink(missing_ok=True)
+                raise ArtifactDownloadError(
+                    "audio",
+                    artifact_id=artifact_id,
+                    details=f"Audio download failed: file is empty ({output_path})",
+                )
+
+            return result_path
 
         except (IndexError, TypeError) as e:
             raise ArtifactParseError(
@@ -1141,7 +1161,26 @@ class ArtifactsAPI:
             if not url:
                 raise ArtifactDownloadError("media", details="Could not extract download URL")
 
-            return await self._download_url(url, output_path)
+            result_path = await self._download_url(url, output_path)
+
+            # Validate that the file was actually written successfully
+            # Video downloads may fail silently even when generation succeeds
+            output_file = Path(result_path)
+            if not output_file.exists():
+                raise ArtifactDownloadError(
+                    "video",
+                    details=f"Video download failed: file not written to {output_path}",
+                )
+            file_size = output_file.stat().st_size
+            if file_size == 0:
+                # Clean up empty file
+                output_file.unlink(missing_ok=True)
+                raise ArtifactDownloadError(
+                    "video",
+                    details=f"Video download failed: file is empty ({output_path})",
+                )
+
+            return result_path
 
         except (IndexError, TypeError) as e:
             raise ArtifactParseError(

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from ._core import ClientCore
 from .rpc import RPCMethod
-from .types import Notebook, NotebookDescription, SuggestedTopic
+from .types import Notebook, NotebookDescription, NotebookMetadata, SuggestedTopic
 
 logger = logging.getLogger(__name__)
 
@@ -232,6 +232,33 @@ class NotebooksAPI:
             params,
             source_path=f"/notebook/{notebook_id}",
         )
+
+    async def get_metadata(self, notebook_id: str) -> NotebookMetadata:
+        """Get notebook metadata including sources.
+
+        This provides structured metadata about a notebook including
+        the notebook ID, title, creation/update timestamps, and list
+        of sources with their types and URLs.
+
+        Args:
+            notebook_id: The notebook ID.
+
+        Returns:
+            NotebookMetadata with notebook info and sources.
+
+        Example:
+            metadata = await client.notebooks.get_metadata(notebook_id)
+            print(f"Notebook: {metadata.title}")
+            for source in metadata.sources:
+                print(f"  - {source.title} ({source.kind.value})")
+        """
+        params = [notebook_id, None, [2], None, 0]
+        result = await self._core.rpc_call(
+            RPCMethod.GET_NOTEBOOK,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+        )
+        return NotebookMetadata.from_notebook_response(result)
 
     async def share(
         self, notebook_id: str, public: bool = True, artifact_id: str | None = None

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -14,6 +14,8 @@ import json
 import logging
 import os
 import time
+import uuid
+import re
 from functools import wraps
 from typing import TYPE_CHECKING
 
@@ -262,10 +264,11 @@ async def _resolve_partial_id(
     """Generic partial ID resolver.
 
     Allows users to type partial IDs like 'abc' instead of full UUIDs.
+    Also supports matching by title for convenience.
     Matches are case-insensitive prefix matches.
 
     Args:
-        partial_id: Full or partial ID to resolve
+        partial_id: Full or partial ID to resolve (or title to match)
         list_fn: Async function that returns list of items with id/title attributes
         entity_name: Name for error messages (e.g., "notebook", "source")
         list_command: CLI command to list items (e.g., "list", "source list")
@@ -279,28 +282,58 @@ async def _resolve_partial_id(
     # Validate and normalize the ID
     partial_id = validate_id(partial_id, entity_name)
 
-    # Skip resolution for IDs that look complete (20+ chars)
-    if len(partial_id) >= 20:
+    # Check if it looks like a UUID - only skip resolution for actual UUIDs
+    # UUIDs have a specific format: 8-4-4-4-12 hex chars with dashes
+    # Example: 03abe51c-d8df-43ba-ae2d-0efe02c71c4a
+    is_uuid_format = bool(re.match(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+        partial_id.lower()
+    ))
+
+    # Skip resolution only for actual UUIDs (full format)
+    if len(partial_id) >= 36 and is_uuid_format:
         return partial_id
 
     items = await list_fn()
+    
+    # First, try to match by ID prefix
     matches = [item for item in items if item.id.lower().startswith(partial_id.lower())]
 
+    # If no ID match, try to match by title (case-insensitive substring)
+    if len(matches) == 0:
+        matches = [
+            item for item in items 
+            if item.title and partial_id.lower() in item.title.lower()
+        ]
+
     if len(matches) == 1:
+        match_type = "ID" if matches[0].id.lower().startswith(partial_id.lower()) else "title"
         if matches[0].id != partial_id:
             title = matches[0].title or "(untitled)"
-            console.print(f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]")
+            console.print(f"[dim]Matched: {matches[0].id[:12]}... ({title}) by {match_type}[/dim]")
         return matches[0].id
     elif len(matches) == 0:
         raise click.ClickException(
-            f"No {entity_name} found starting with '{partial_id}'. "
+            f"No {entity_name} found matching '{partial_id}'. "
             f"Run 'notebooklm {list_command}' to see available {entity_name}s."
         )
     else:
-        lines = [f"Ambiguous ID '{partial_id}' matches {len(matches)} {entity_name}s:"]
+        # Check if matches are from title vs ID
+        id_matches = [m for m in matches if m.id.lower().startswith(partial_id.lower())]
+        title_matches = [m for m in matches if m.title and partial_id.lower() in m.title.lower()]
+        
+        lines = []
+        if id_matches and title_matches:
+            lines.append(f"Ambiguous input '{partial_id}' matches {len(id_matches)} {entity_name}(s) by ID and {len(title_matches)} by title:")
+        elif id_matches:
+            lines.append(f"Ambiguous ID '{partial_id}' matches {len(matches)} {entity_name}s:")
+        else:
+            lines.append(f"Ambiguous title '{partial_id}' matches {len(matches)} {entity_name}s:")
+            
         for item in matches[:5]:
             title = item.title or "(untitled)"
-            lines.append(f"  {item.id[:12]}... {title}")
+            match_src = "ID" if item.id.lower().startswith(partial_id.lower()) else "title"
+            lines.append(f"  {item.id[:12]}... {title} [{match_src}]")
         if len(matches) > 5:
             lines.append(f"  ... and {len(matches) - 5} more")
         lines.append("\nSpecify more characters to narrow down.")

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -244,6 +244,8 @@ __all__ = [
     # Dataclasses
     "Notebook",
     "NotebookDescription",
+    "NotebookMetadata",
+    "SourceSummary",
     "SuggestedTopic",
     "Source",
     "SourceFulltext",
@@ -386,6 +388,103 @@ class NotebookDescription:
         return cls(
             summary=data.get("summary", ""),
             suggested_topics=topics,
+        )
+
+
+@dataclass
+class SourceSummary:
+    """Summary information about a source in a notebook."""
+
+    id: str
+    title: str | None
+    url: str | None = None
+    kind: SourceType = SourceType.UNKNOWN
+
+
+@dataclass
+class NotebookMetadata:
+    """Metadata for a NotebookLM notebook, including sources."""
+
+    id: str
+    title: str
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    sources: list[SourceSummary] = field(default_factory=list)
+
+    @classmethod
+    def from_notebook_response(cls, notebook_data: list[Any]) -> "NotebookMetadata":
+        """Parse notebook metadata from GET_NOTEBOOK response.
+
+        Args:
+            notebook_data: Raw notebook data from API response.
+
+        Returns:
+            NotebookMetadata instance.
+        """
+        if not notebook_data or not isinstance(notebook_data, list):
+            return cls(id="", title="")
+
+        # Notebook info is at notebook[0]
+        nb_info = notebook_data[0] if isinstance(notebook_data[0], list) else notebook_data
+
+        # Extract basic info (same as Notebook.from_api_response)
+        raw_title = nb_info[0] if len(nb_info) > 0 and isinstance(nb_info[0], str) else ""
+        title = raw_title.replace("thought\n", "").strip()
+        notebook_id = nb_info[2] if len(nb_info) > 2 and isinstance(nb_info[2], str) else ""
+
+        # Extract timestamps
+        created_at = None
+        updated_at = None
+        if len(nb_info) > 5 and isinstance(nb_info[5], list):
+            ts_data = nb_info[5]
+            # Creation timestamp at [5]
+            if len(ts_data) > 5 and isinstance(ts_data[5], list) and len(ts_data[5]) > 0:
+                try:
+                    created_at = datetime.fromtimestamp(ts_data[5][0])
+                except (TypeError, ValueError):
+                    pass
+            # Updated timestamp at [6]
+            if len(ts_data) > 6 and isinstance(ts_data[6], list) and len(ts_data[6]) > 0:
+                try:
+                    updated_at = datetime.fromtimestamp(ts_data[6][0])
+                except (TypeError, ValueError):
+                    pass
+
+        # Extract sources at [1]
+        sources: list[SourceSummary] = []
+        if len(nb_info) > 1 and isinstance(nb_info[1], list):
+            for src in nb_info[1]:
+                if isinstance(src, list) and len(src) > 0:
+                    src_id = src[0] if isinstance(src[0], str) else ""
+                    src_title = src[1] if len(src) > 1 else None
+                    src_url = None
+                    src_type = SourceType.UNKNOWN
+
+                    # Extract URL and type from metadata at [2]
+                    if len(src) > 2 and isinstance(src[2], list):
+                        # URL at [2][7][0]
+                        if len(src[2]) > 7 and isinstance(src[2][7], list):
+                            url_list = src[2][7]
+                            src_url = url_list[0] if url_list else None
+                        # Type code at [2][4]
+                        if len(src[2]) > 4 and isinstance(src[2][4], int):
+                            src_type = _safe_source_type(src[2][4])
+
+                    sources.append(
+                        SourceSummary(
+                            id=str(src_id),
+                            title=src_title,
+                            url=src_url,
+                            kind=src_type,
+                        )
+                    )
+
+        return cls(
+            id=notebook_id,
+            title=title,
+            created_at=created_at,
+            updated_at=updated_at,
+            sources=sources,
         )
 
 


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Title-based matching for delete commands (fixes #112)

**Problem:** Deleting a source using the title does not work (only using the ID works)

The `_resolve_partial_id` function was skipping validation for any string >= 20 characters, treating it as a complete UUID. This caused titles >= 20 chars (like "Emails_Verzonden_2026_02") to bypass the ID lookup entirely and get passed directly to the delete function.

**Solution:**
- Validate UUID format properly using regex instead of just checking length
- Add title matching as fallback when ID lookup fails
- Show whether match was by ID or title in ambiguous cases

### 2. Video download validation (fixes #162)

Video downloads may fail silently even when generation succeeds. This fix adds verification that the file was actually written and has non-zero size after download, raising ArtifactDownloadError if not.

---

Closes #112
Closes #162