### PR TITLE
feat(pipeline): add modular research pipeline framework

### DIFF
--- a/src/notebooklm/cli/__init__.py
+++ b/src/notebooklm/cli/__init__.py
@@ -68,6 +68,7 @@ from .options import (
     standard_options,
     wait_option,
 )
+from .pipeline import pipeline
 from .research import research
 
 # Register functions (top-level command style)
@@ -87,6 +88,7 @@ __all__ = [
     "skill",
     "research",
     "language",
+    "pipeline",
     # Language config
     "get_language",
     # Register functions (top-level command style)

--- a/src/notebooklm/cli/pipeline.py
+++ b/src/notebooklm/cli/pipeline.py
@@ -1,0 +1,440 @@
+"""Pipeline CLI commands.
+
+Provides CLI commands for running and managing research pipelines:
+- notebooklm pipeline run <config.yaml> - Run a pipeline
+- notebooklm pipeline list - List available templates
+- notebooklm pipeline validate <config.yaml> - Validate configuration
+- notebooklm pipeline create <name.yaml> - Create from template
+- notebooklm pipeline status - Show pipeline execution status
+"""
+
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from ..client import NotebookLMClient
+from ..pipeline import (
+    PipelineConfigError,
+    PipelineContext,
+    PipelineEngine,
+    load_pipeline_config,
+    validate_pipeline_file,
+)
+from .helpers import (
+    get_auth_tokens,
+    handle_auth_error,
+    handle_error,
+    json_error_response,
+    json_output_response,
+    run_async,
+)
+from .options import json_option
+
+console = Console()
+
+
+def _get_templates_dir() -> Path:
+    """Get the built-in templates directory."""
+    return Path(__file__).parent.parent / "data" / "templates"
+
+
+def _list_template_files() -> list[Path]:
+    """List all template YAML files."""
+    templates_dir = _get_templates_dir()
+    if not templates_dir.exists():
+        return []
+    return sorted(templates_dir.glob("*.yaml"))
+
+
+@click.group(name="pipeline")
+def pipeline():
+    """Research pipeline commands.
+
+    \b
+    Run complex research workflows defined in YAML:
+      notebooklm pipeline run research.yaml --var topic="AI safety"
+      notebooklm pipeline list
+      notebooklm pipeline validate my-pipeline.yaml
+    """
+    pass
+
+
+@pipeline.command("run")
+@click.argument("config_file", type=click.Path(exists=True))
+@click.option(
+    "--var",
+    "-v",
+    "variables",
+    multiple=True,
+    help="Set variable (name=value). Can be used multiple times.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    help="Output directory for results.",
+)
+@json_option
+@click.pass_context
+def run_pipeline(ctx, config_file: str, variables: tuple, output: str | None, json_output: bool):
+    """Run a research pipeline from configuration file.
+
+    \b
+    Examples:
+      notebooklm pipeline run research-to-podcast.yaml
+      notebooklm pipeline run research.yaml --var topic="quantum computing"
+      notebooklm pipeline run analysis.yaml -v topic="AI" -v depth="deep"
+    """
+    try:
+        auth = get_auth_tokens(ctx)
+    except FileNotFoundError:
+        handle_auth_error(json_output)
+        return
+
+    # Parse variables
+    var_dict: dict[str, Any] = {}
+    for var in variables:
+        if "=" in var:
+            key, value = var.split("=", 1)
+            var_dict[key.strip()] = value.strip()
+        else:
+            console.print(
+                f"[yellow]Warning: Invalid variable format '{var}' (expected name=value)[/yellow]"
+            )
+
+    if output:
+        var_dict["output_dir"] = output
+
+    async def _run():
+        async with NotebookLMClient(auth) as client:
+            # Create engine with progress callback
+            def progress_callback(step: str, status: str, current: int, total: int):
+                if not json_output:
+                    console.print(f"  [{current}/{total}] {step}: {status}")
+
+            engine = PipelineEngine(progress_callback=progress_callback)
+
+            if not json_output:
+                console.print(f"[bold]Running pipeline:[/bold] {config_file}")
+                console.print(f"[dim]Variables: {var_dict or 'none'}[/dim]\n")
+
+            try:
+                result = await engine.run(
+                    config_file,
+                    client=client,
+                    variables=var_dict,
+                )
+
+                if json_output:
+                    json_output_response(result.to_dict())
+                else:
+                    _display_pipeline_result(result)
+
+            except PipelineConfigError as e:
+                if json_output:
+                    json_error_response("CONFIG_ERROR", str(e))
+                else:
+                    console.print(f"[red]Configuration error:[/red] {e}")
+                    raise SystemExit(1) from None
+
+    try:
+        run_async(_run())
+    except Exception as e:
+        if json_output:
+            json_error_response("PIPELINE_ERROR", str(e))
+        else:
+            handle_error(e)
+
+
+def _display_pipeline_result(ctx: PipelineContext):
+    """Display pipeline execution results."""
+    # Status panel
+    status_color = "green" if ctx.is_completed else "red" if ctx.is_failed else "yellow"
+    status_text = ctx.status.value.upper()
+
+    console.print()
+    console.print(
+        Panel(
+            f"[{status_color}]{status_text}[/{status_color}]",
+            title=f"Pipeline: {ctx.pipeline_name}",
+            expand=False,
+        )
+    )
+
+    # Notebook info
+    if ctx.notebook_id:
+        console.print("\n[bold]Notebook:[/bold]")
+        console.print(f"  ID: {ctx.notebook_id}")
+        if ctx.notebook_title:
+            console.print(f"  Title: {ctx.notebook_title}")
+        if ctx.notebook_url:
+            console.print(f"  URL: [link={ctx.notebook_url}]{ctx.notebook_url}[/link]")
+
+    # Sources and artifacts
+    console.print("\n[bold]Results:[/bold]")
+    console.print(f"  Sources added: {len(ctx.source_ids)}")
+    console.print(f"  Artifacts created: {len(ctx.artifact_ids)}")
+    console.print(f"  Questions answered: {len(ctx.qa_results)}")
+
+    # Step results
+    if ctx.results:
+        console.print("\n[bold]Steps:[/bold]")
+        for name, result in ctx.results.items():
+            icon = "[green]✓[/green]" if result.success else "[red]✗[/red]"
+            duration = f" ({result.duration_seconds:.1f}s)" if result.duration_seconds else ""
+            console.print(f"  {icon} {name}{duration}")
+            if result.error:
+                console.print(f"      [dim red]{result.error}[/dim red]")
+
+    # Errors
+    if ctx.errors:
+        console.print("\n[bold red]Errors:[/bold red]")
+        for error in ctx.errors:
+            console.print(f"  • [{error.get('step')}] {error.get('error')}")
+
+    # Duration
+    if ctx.duration_seconds:
+        console.print(f"\n[dim]Total time: {ctx.duration_seconds:.1f}s[/dim]")
+
+
+@pipeline.command("list")
+@json_option
+def list_templates(json_output: bool):
+    """List available pipeline templates.
+
+    Shows built-in templates that can be used as starting points.
+    """
+    templates = _list_template_files()
+
+    if json_output:
+        template_data = []
+        for t in templates:
+            try:
+                config = load_pipeline_config(t)
+                template_data.append(
+                    {
+                        "name": t.stem,
+                        "file": t.name,
+                        "description": config.description,
+                        "steps": len(config.steps),
+                    }
+                )
+            except Exception:
+                template_data.append(
+                    {
+                        "name": t.stem,
+                        "file": t.name,
+                        "description": "Error loading template",
+                        "steps": 0,
+                    }
+                )
+        json_output_response({"templates": template_data})
+        return
+
+    if not templates:
+        console.print("[yellow]No templates found.[/yellow]")
+        console.print("[dim]Templates should be in: {_get_templates_dir()}[/dim]")
+        return
+
+    table = Table(title="Available Pipeline Templates")
+    table.add_column("Name", style="cyan")
+    table.add_column("Description")
+    table.add_column("Steps", justify="right")
+
+    for template_path in templates:
+        try:
+            config = load_pipeline_config(template_path)
+            table.add_row(
+                template_path.stem,
+                config.description[:50] + "..."
+                if len(config.description) > 50
+                else config.description,
+                str(len(config.steps)),
+            )
+        except Exception as e:
+            table.add_row(template_path.stem, f"[red]Error: {e}[/red]", "-")
+
+    console.print(table)
+    console.print(
+        "\n[dim]Use 'notebooklm pipeline create --template <name> <output.yaml>' to copy a template[/dim]"
+    )
+
+
+@pipeline.command("validate")
+@click.argument("config_file", type=click.Path(exists=True))
+@json_option
+def validate_config(config_file: str, json_output: bool):
+    """Validate a pipeline configuration file.
+
+    Checks YAML syntax and pipeline structure without running.
+    """
+    is_valid, errors = validate_pipeline_file(config_file)
+
+    if json_output:
+        json_output_response(
+            {
+                "valid": is_valid,
+                "file": config_file,
+                "errors": errors,
+            }
+        )
+        return
+
+    if is_valid:
+        console.print(f"[green]✓[/green] {config_file} is valid")
+
+        # Show summary
+        try:
+            config = load_pipeline_config(config_file)
+            console.print(f"\n[bold]Pipeline:[/bold] {config.name}")
+            if config.description:
+                console.print(f"[dim]{config.description}[/dim]")
+            console.print(f"\n[bold]Steps ({len(config.steps)}):[/bold]")
+            for step in config.steps:
+                console.print(f"  • {step.name} ({step.type})")
+            if config.variables:
+                console.print("\n[bold]Variables:[/bold]")
+                for key, value in config.variables.items():
+                    display_value = value if value is not None else "[required]"
+                    console.print(f"  • {key}: {display_value}")
+        except Exception:
+            pass
+    else:
+        console.print(f"[red]✗[/red] {config_file} has errors:")
+        for error in errors:
+            console.print(f"  • {error}")
+        raise SystemExit(1)
+
+
+@pipeline.command("create")
+@click.argument("output_file", type=click.Path())
+@click.option(
+    "--template",
+    "-t",
+    "template_name",
+    help="Template to copy from (use 'list' to see available).",
+)
+def create_pipeline(output_file: str, template_name: str | None):
+    """Create a new pipeline configuration file.
+
+    \b
+    Examples:
+      notebooklm pipeline create my-research.yaml
+      notebooklm pipeline create my-pipeline.yaml --template research-to-podcast
+    """
+    output_path = Path(output_file)
+
+    if output_path.exists():
+        console.print(f"[red]Error:[/red] {output_file} already exists")
+        raise SystemExit(1)
+
+    if template_name:
+        # Copy from template
+        template_path = _get_templates_dir() / f"{template_name}.yaml"
+        if not template_path.exists():
+            console.print(f"[red]Error:[/red] Template '{template_name}' not found")
+            console.print("[dim]Use 'notebooklm pipeline list' to see available templates[/dim]")
+            raise SystemExit(1)
+
+        content = template_path.read_text(encoding="utf-8")
+        output_path.write_text(content, encoding="utf-8")
+        console.print(f"[green]✓[/green] Created {output_file} from template '{template_name}'")
+    else:
+        # Create minimal template
+        minimal_template = """# Pipeline configuration
+pipeline:
+  name: "my-pipeline"
+  description: "My research pipeline"
+
+variables:
+  topic: null  # Required at runtime
+
+steps:
+  - name: create_notebook
+    type: builtin:create_notebook
+    config:
+      title: "Research: {{ topic }}"
+
+  - name: add_sources
+    type: builtin:ingest
+    config:
+      sources:
+        - plugin: source:url
+          url: "https://example.com"
+
+  - name: wait_for_processing
+    type: builtin:wait_sources
+    config:
+      timeout: 300
+
+  - name: generate_content
+    type: builtin:synthesize
+    config:
+      artifacts:
+        - type: report
+          format: study-guide
+      questions:
+        - "What are the key points about {{ topic }}?"
+"""
+        output_path.write_text(minimal_template, encoding="utf-8")
+        console.print(f"[green]✓[/green] Created {output_file}")
+
+    console.print("\n[dim]Edit the file, then run:[/dim]")
+    console.print(f"  notebooklm pipeline validate {output_file}")
+    console.print(f'  notebooklm pipeline run {output_file} --var topic="your topic"')
+
+
+@pipeline.command("status")
+@json_option
+def pipeline_status(json_output: bool):
+    """Show information about available pipeline steps and plugins.
+
+    Lists all built-in steps and registered plugins.
+    """
+    from ..pipeline import BUILTIN_STEPS, create_default_registry
+
+    registry = create_default_registry()
+
+    if json_output:
+        json_output_response(
+            {
+                "builtin_steps": list(BUILTIN_STEPS.keys()),
+                "plugins": registry.list_plugins(),
+            }
+        )
+        return
+
+    # Built-in steps
+    console.print("[bold]Built-in Steps:[/bold]")
+    step_descriptions = {
+        "create_notebook": "Create a new NotebookLM notebook",
+        "ingest": "Add sources to the notebook",
+        "wait_sources": "Wait for sources to finish processing",
+        "synthesize": "Generate artifacts (audio, reports, etc.)",
+        "wait_artifacts": "Wait for artifacts to complete",
+        "ask": "Ask questions to the notebook",
+        "export": "Export artifacts to files",
+    }
+    for name in BUILTIN_STEPS:
+        desc = step_descriptions.get(name, "")
+        console.print(f"  • [cyan]builtin:{name}[/cyan] - {desc}")
+
+    # Plugins
+    console.print("\n[bold]Source Plugins:[/bold]")
+    for plugin in registry.list_plugins():
+        if plugin.startswith("source:"):
+            console.print(f"  • [cyan]{plugin}[/cyan]")
+
+    console.print("\n[bold]Tool Plugins:[/bold]")
+    for plugin in registry.list_plugins():
+        if plugin.startswith("tool:"):
+            console.print(f"  • [cyan]{plugin}[/cyan]")
+
+    console.print("\n[bold]Exporter Plugins:[/bold]")
+    for plugin in registry.list_plugins():
+        if plugin.startswith("exporter:"):
+            console.print(f"  • [cyan]{plugin}[/cyan]")

--- a/src/notebooklm/data/templates/document-analysis.yaml
+++ b/src/notebooklm/data/templates/document-analysis.yaml
@@ -1,0 +1,66 @@
+# Document Analysis Pipeline
+# Analyze documents from URLs and generate study materials
+
+pipeline:
+  name: "document-analysis"
+  description: "Analyze documents and generate comprehensive study materials"
+
+variables:
+  name: "Document Analysis"  # Name for the notebook
+  urls: []  # List of document URLs to analyze
+  output_dir: "./output"
+
+steps:
+  - name: create_notebook
+    type: builtin:create_notebook
+    config:
+      title: "{{ name }}"
+
+  - name: add_documents
+    type: builtin:ingest
+    config:
+      sources:
+        - plugin: source:urls
+          urls: "{{ urls }}"
+
+  - name: wait_for_processing
+    type: builtin:wait_sources
+    config:
+      timeout: 600
+      poll_interval: 5
+
+  - name: generate_study_materials
+    type: builtin:synthesize
+    config:
+      artifacts:
+        - type: report
+          format: study-guide
+        - type: report
+          format: briefing-doc
+        - type: quiz
+          difficulty: medium
+          quantity: standard
+        - type: flashcards
+          difficulty: medium
+          quantity: standard
+        - type: mind_map
+      questions:
+        - "Summarize the main themes across all documents."
+        - "What are the key takeaways?"
+        - "What questions remain unanswered?"
+
+  - name: wait_for_artifacts
+    type: builtin:wait_artifacts
+    config:
+      timeout: 600
+
+  - name: export_results
+    type: builtin:export
+    config:
+      formats:
+        - plugin: exporter:markdown
+          output: "{{ output_dir }}/{{ name | slugify }}-summary.md"
+          include_qa: true
+          include_summary: true
+        - plugin: exporter:json
+          output: "{{ output_dir }}/{{ name | slugify }}-results.json"

--- a/src/notebooklm/data/templates/research-to-podcast.yaml
+++ b/src/notebooklm/data/templates/research-to-podcast.yaml
@@ -1,0 +1,62 @@
+# Research to Podcast Pipeline
+# Research a topic and generate an audio overview (podcast)
+
+pipeline:
+  name: "research-to-podcast"
+  description: "Research a topic using NotebookLM and create a podcast-style audio overview"
+
+variables:
+  topic: null  # Required: The topic to research
+  notebook_name: "Research: {{ topic }}"
+  output_dir: "./output"
+
+steps:
+  - name: create_notebook
+    type: builtin:create_notebook
+    config:
+      title: "{{ notebook_name }}"
+
+  - name: research_topic
+    type: builtin:ingest
+    config:
+      sources:
+        - plugin: source:research
+          query: "{{ topic }}"
+
+  - name: wait_for_sources
+    type: builtin:wait_sources
+    config:
+      timeout: 600
+      poll_interval: 5
+
+  - name: generate_content
+    type: builtin:synthesize
+    config:
+      artifacts:
+        - type: audio
+          format: deep-dive
+          length: medium
+        - type: report
+          format: study-guide
+      questions:
+        - "What are the key insights about {{ topic }}?"
+        - "What are the main controversies or debates in this field?"
+        - "What are the practical applications?"
+
+  - name: wait_for_artifacts
+    type: builtin:wait_artifacts
+    config:
+      timeout: 600
+      poll_interval: 10
+
+  - name: export_audio
+    type: builtin:export
+    config:
+      formats:
+        - plugin: exporter:audio
+          output: "{{ output_dir }}/{{ topic | slugify }}.mp3"
+        - plugin: exporter:markdown
+          output: "{{ output_dir }}/{{ topic | slugify }}-guide.md"
+          include_qa: true
+        - plugin: exporter:json
+          output: "{{ output_dir }}/{{ topic | slugify }}-results.json"

--- a/src/notebooklm/data/templates/youtube-knowledge.yaml
+++ b/src/notebooklm/data/templates/youtube-knowledge.yaml
@@ -1,0 +1,66 @@
+# YouTube Knowledge Extraction Pipeline
+# Extract knowledge from YouTube videos or playlists
+
+pipeline:
+  name: "youtube-knowledge"
+  description: "Extract knowledge from YouTube videos and create study materials"
+
+variables:
+  name: "YouTube Knowledge Base"  # Notebook name
+  videos: []  # List of YouTube video URLs
+  playlist: null  # Optional: YouTube playlist URL
+  output_dir: "./output"
+
+steps:
+  - name: create_notebook
+    type: builtin:create_notebook
+    config:
+      title: "{{ name }}"
+
+  - name: add_videos
+    type: builtin:ingest
+    config:
+      sources:
+        - plugin: source:youtube
+          urls: "{{ videos }}"
+        - plugin: source:youtube
+          playlist: "{{ playlist }}"
+    when: "videos or playlist"
+
+  - name: wait_for_transcription
+    type: builtin:wait_sources
+    config:
+      timeout: 900  # YouTube processing can take longer
+      poll_interval: 10
+
+  - name: generate_knowledge_products
+    type: builtin:synthesize
+    config:
+      artifacts:
+        - type: audio
+          format: conversational
+          length: medium
+        - type: report
+          format: study-guide
+        - type: mind_map
+      questions:
+        - "What are the main topics covered in these videos?"
+        - "What are the key lessons or insights?"
+        - "Create a timeline of concepts presented."
+
+  - name: wait_for_generation
+    type: builtin:wait_artifacts
+    config:
+      timeout: 600
+
+  - name: export_knowledge
+    type: builtin:export
+    config:
+      formats:
+        - plugin: exporter:audio
+          output: "{{ output_dir }}/{{ name | slugify }}-podcast.mp3"
+        - plugin: exporter:markdown
+          output: "{{ output_dir }}/{{ name | slugify }}-notes.md"
+          include_qa: true
+        - plugin: exporter:json
+          output: "{{ output_dir }}/{{ name | slugify }}.json"

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -66,6 +66,7 @@ from .cli import (
     generate,
     language,
     note,
+    pipeline,
     register_chat_commands,
     register_notebook_commands,
     # Register functions for top-level commands
@@ -142,6 +143,7 @@ cli.add_command(share)
 cli.add_command(skill)
 cli.add_command(research)
 cli.add_command(language)
+cli.add_command(pipeline)
 
 
 # =============================================================================

--- a/src/notebooklm/pipeline/__init__.py
+++ b/src/notebooklm/pipeline/__init__.py
@@ -1,0 +1,120 @@
+"""NotebookLM Pipeline Framework.
+
+A modular framework for building research pipelines with NotebookLM.
+
+Key Components:
+- PipelineEngine: Orchestrates pipeline execution
+- PipelineContext: Shared state across steps
+- PipelineConfig: YAML-based configuration
+- Steps: Built-in and custom pipeline steps
+- Plugins: Source, tool, and exporter plugins
+
+Example:
+    from notebooklm import NotebookLMClient
+    from notebooklm.pipeline import PipelineEngine
+
+    async with await NotebookLMClient.from_storage() as client:
+        engine = PipelineEngine()
+        result = await engine.run(
+            "research-to-podcast.yaml",
+            client=client,
+            variables={"topic": "quantum computing"}
+        )
+        print(f"Notebook: {result.notebook_url}")
+        print(f"Audio: {result.artifact_outputs}")
+"""
+
+from .config import (
+    PipelineConfig,
+    PipelineConfigError,
+    PipelineValidationError,
+    StepConfig,
+    load_pipeline_config,
+    slugify,
+    substitute_variables,
+    validate_pipeline_file,
+)
+from .context import (
+    PipelineContext,
+    PipelineStatus,
+    StepResult,
+)
+from .engine import (
+    PipelineEngine,
+    PipelineError,
+    ProgressCallback,
+    StepError,
+)
+from .registry import (
+    BaseExporterPlugin,
+    BasePlugin,
+    BaseSourcePlugin,
+    BaseToolPlugin,
+    ExporterPlugin,
+    Plugin,
+    PluginRegistry,
+    PluginType,
+    SourcePlugin,
+    ToolPlugin,
+    create_default_registry,
+)
+from .steps import (
+    BUILTIN_STEPS,
+    AskStep,
+    BaseStep,
+    CreateNotebookStep,
+    ExportStep,
+    IngestStep,
+    PipelineStep,
+    SynthesizeStep,
+    WaitArtifactsStep,
+    WaitSourcesStep,
+    get_builtin_step,
+)
+
+__all__ = [
+    # Engine
+    "PipelineEngine",
+    "PipelineError",
+    "StepError",
+    "ProgressCallback",
+    # Context
+    "PipelineContext",
+    "PipelineStatus",
+    "StepResult",
+    # Config
+    "PipelineConfig",
+    "StepConfig",
+    "PipelineConfigError",
+    "PipelineValidationError",
+    "load_pipeline_config",
+    "validate_pipeline_file",
+    "substitute_variables",
+    "slugify",
+    # Steps
+    "PipelineStep",
+    "BaseStep",
+    "BUILTIN_STEPS",
+    "get_builtin_step",
+    "CreateNotebookStep",
+    "IngestStep",
+    "WaitSourcesStep",
+    "SynthesizeStep",
+    "WaitArtifactsStep",
+    "AskStep",
+    "ExportStep",
+    # Registry
+    "PluginRegistry",
+    "PluginType",
+    "create_default_registry",
+    # Plugin Protocols
+    "Plugin",
+    "SourcePlugin",
+    "ToolPlugin",
+    "ExporterPlugin",
+    # Plugin Base Classes
+    "BasePlugin",
+    "BaseSourcePlugin",
+    "BaseToolPlugin",
+    "BaseExporterPlugin",
+]

--- a/src/notebooklm/pipeline/config.py
+++ b/src/notebooklm/pipeline/config.py
@@ -1,0 +1,265 @@
+"""Pipeline configuration loading and validation.
+
+Supports YAML pipeline definitions with Jinja2 variable substitution.
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Jinja2 is optional - use simple substitution if not available
+try:
+    from jinja2 import BaseLoader, Environment, TemplateError
+
+    JINJA2_AVAILABLE = True
+except ImportError:
+    JINJA2_AVAILABLE = False
+    Environment = None
+    BaseLoader = None
+    TemplateError = Exception
+
+
+class PipelineConfigError(Exception):
+    """Error in pipeline configuration."""
+
+    pass
+
+
+class PipelineValidationError(PipelineConfigError):
+    """Validation error in pipeline configuration."""
+
+    pass
+
+
+@dataclass
+class StepConfig:
+    """Configuration for a single pipeline step."""
+
+    name: str
+    type: str  # e.g., "builtin:create_notebook", "source:youtube", "tool:notebooklm"
+    config: dict[str, Any] = field(default_factory=dict)
+    when: str | None = None  # Optional condition expression
+    timeout: int | None = None  # Optional timeout in seconds
+
+    @property
+    def step_type(self) -> str:
+        """Get the step type (builtin, source, tool, exporter)."""
+        if ":" in self.type:
+            return self.type.split(":")[0]
+        return "builtin"
+
+    @property
+    def step_handler(self) -> str:
+        """Get the step handler name."""
+        if ":" in self.type:
+            return self.type.split(":", 1)[1]
+        return self.type
+
+
+@dataclass
+class PipelineConfig:
+    """Complete pipeline configuration."""
+
+    name: str
+    description: str = ""
+    variables: dict[str, Any] = field(default_factory=dict)
+    steps: list[StepConfig] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PipelineConfig":
+        """Create PipelineConfig from dictionary."""
+        pipeline_data = data.get("pipeline", {})
+        name = pipeline_data.get("name", "unnamed")
+        description = pipeline_data.get("description", "")
+
+        # Parse variables
+        variables = data.get("variables", {})
+
+        # Parse steps
+        steps = []
+        for step_data in data.get("steps", []):
+            steps.append(
+                StepConfig(
+                    name=step_data.get("name", ""),
+                    type=step_data.get("type", ""),
+                    config=step_data.get("config", {}),
+                    when=step_data.get("when"),
+                    timeout=step_data.get("timeout"),
+                )
+            )
+
+        return cls(
+            name=name,
+            description=description,
+            variables=variables,
+            steps=steps,
+            metadata=data.get("metadata", {}),
+        )
+
+    def validate(self) -> list[str]:
+        """Validate the pipeline configuration.
+
+        Returns:
+            List of validation error messages (empty if valid).
+        """
+        errors = []
+
+        if not self.name:
+            errors.append("Pipeline name is required")
+
+        if not self.steps:
+            errors.append("Pipeline must have at least one step")
+
+        step_names = set()
+        for i, step in enumerate(self.steps):
+            if not step.name:
+                errors.append(f"Step {i + 1} is missing a name")
+            elif step.name in step_names:
+                errors.append(f"Duplicate step name: {step.name}")
+            else:
+                step_names.add(step.name)
+
+            if not step.type:
+                errors.append(f"Step '{step.name or i + 1}' is missing a type")
+
+        return errors
+
+
+def slugify(text: str) -> str:
+    """Convert text to URL-friendly slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[-\s]+", "-", text)
+    return text
+
+
+def _create_jinja_env() -> Any:
+    """Create Jinja2 environment with custom filters."""
+    if not JINJA2_AVAILABLE:
+        return None
+
+    env = Environment(loader=BaseLoader())
+    env.filters["slugify"] = slugify
+    return env
+
+
+def _simple_substitute(template: str, variables: dict[str, Any]) -> str:
+    """Simple variable substitution without Jinja2.
+
+    Supports {{ variable }} syntax but not filters or complex expressions.
+    """
+    result = template
+    for key, value in variables.items():
+        pattern = r"\{\{\s*" + re.escape(key) + r"\s*\}\}"
+        result = re.sub(pattern, str(value) if value is not None else "", result)
+    return result
+
+
+def substitute_variables(value: Any, variables: dict[str, Any]) -> Any:
+    """Recursively substitute variables in a value.
+
+    Supports Jinja2 templates ({{ variable }}, {{ var | filter }}) if available,
+    falls back to simple substitution otherwise.
+
+    Args:
+        value: Value to process (string, dict, list, or other)
+        variables: Variable name -> value mapping
+
+    Returns:
+        Value with variables substituted
+    """
+    if isinstance(value, str):
+        if "{{" not in value:
+            return value
+
+        if JINJA2_AVAILABLE:
+            try:
+                env = _create_jinja_env()
+                template = env.from_string(value)
+                return template.render(**variables)
+            except TemplateError:
+                # Fall back to simple substitution on Jinja errors
+                return _simple_substitute(value, variables)
+        else:
+            return _simple_substitute(value, variables)
+
+    elif isinstance(value, dict):
+        return {k: substitute_variables(v, variables) for k, v in value.items()}
+
+    elif isinstance(value, list):
+        return [substitute_variables(item, variables) for item in value]
+
+    else:
+        return value
+
+
+def load_pipeline_config(
+    path: Path | str,
+    variables: dict[str, Any] | None = None,
+) -> PipelineConfig:
+    """Load pipeline configuration from YAML file.
+
+    Args:
+        path: Path to YAML configuration file
+        variables: Runtime variables to merge with config variables
+
+    Returns:
+        PipelineConfig object
+
+    Raises:
+        PipelineConfigError: If file cannot be loaded
+        PipelineValidationError: If configuration is invalid
+    """
+    path = Path(path)
+
+    if not path.exists():
+        raise PipelineConfigError(f"Pipeline config not found: {path}")
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            raw_data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        raise PipelineConfigError(f"Invalid YAML in {path}: {e}") from e
+
+    if not isinstance(raw_data, dict):
+        raise PipelineConfigError(f"Pipeline config must be a YAML mapping: {path}")
+
+    # Merge runtime variables with config variables
+    all_variables = {**raw_data.get("variables", {}), **(variables or {})}
+
+    # Substitute variables in the entire config
+    substituted_data = substitute_variables(raw_data, all_variables)
+    substituted_data["variables"] = all_variables
+
+    # Parse into PipelineConfig
+    config = PipelineConfig.from_dict(substituted_data)
+
+    # Validate
+    errors = config.validate()
+    if errors:
+        raise PipelineValidationError(
+            "Pipeline config validation failed:\n" + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    return config
+
+
+def validate_pipeline_file(path: Path | str) -> tuple[bool, list[str]]:
+    """Validate a pipeline configuration file.
+
+    Args:
+        path: Path to YAML configuration file
+
+    Returns:
+        Tuple of (is_valid, error_messages)
+    """
+    try:
+        config = load_pipeline_config(path)
+        errors = config.validate()
+        return len(errors) == 0, errors
+    except PipelineConfigError as e:
+        return False, [str(e)]

--- a/src/notebooklm/pipeline/context.py
+++ b/src/notebooklm/pipeline/context.py
@@ -1,0 +1,173 @@
+"""Pipeline context - shared state across pipeline steps.
+
+The PipelineContext holds all state that needs to be passed between steps,
+including notebook IDs, source IDs, artifact IDs, and step results.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+
+class PipelineStatus(str, Enum):
+    """Pipeline execution status."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class StepResult:
+    """Result of a single step execution."""
+
+    step_name: str
+    success: bool
+    output: Any = None
+    error: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    @property
+    def duration_seconds(self) -> float | None:
+        """Get step duration in seconds."""
+        if self.started_at and self.completed_at:
+            return (self.completed_at - self.started_at).total_seconds()
+        return None
+
+
+@dataclass
+class PipelineContext:
+    """Shared context passed between pipeline steps.
+
+    This dataclass holds all state that accumulates during pipeline execution:
+    - Identifiers (pipeline, notebook, sources, artifacts)
+    - Results from each step
+    - Errors encountered
+    - Variables for template substitution
+
+    Example:
+        ctx = PipelineContext(
+            pipeline_name="research-to-podcast",
+            variables={"topic": "quantum computing"}
+        )
+        # After create_notebook step:
+        ctx.notebook_id = "abc123"
+        # After ingest step:
+        ctx.source_ids.extend(["src1", "src2"])
+        # After synthesize step:
+        ctx.artifact_ids.extend(["art1"])
+    """
+
+    # Pipeline identity
+    pipeline_id: str = field(default_factory=lambda: str(uuid4()))
+    pipeline_name: str = ""
+
+    # NotebookLM state
+    notebook_id: str | None = None
+    notebook_title: str | None = None
+    notebook_url: str | None = None
+    source_ids: list[str] = field(default_factory=list)
+    artifact_ids: list[str] = field(default_factory=list)
+
+    # Step results (step_name -> StepResult)
+    results: dict[str, StepResult] = field(default_factory=dict)
+
+    # Errors encountered during execution
+    errors: list[dict[str, Any]] = field(default_factory=list)
+
+    # Variables for template substitution
+    variables: dict[str, Any] = field(default_factory=dict)
+
+    # Execution state
+    status: PipelineStatus = PipelineStatus.PENDING
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    current_step: str | None = None
+
+    # Artifact outputs (for exporters)
+    # Maps artifact_id -> downloaded content/path
+    artifact_outputs: dict[str, Any] = field(default_factory=dict)
+
+    # Chat/Q&A results
+    qa_results: list[dict[str, str]] = field(default_factory=list)
+
+    def add_result(self, step_name: str, result: StepResult) -> None:
+        """Record a step result."""
+        self.results[step_name] = result
+
+    def add_error(self, step_name: str, error: str, exception: Exception | None = None) -> None:
+        """Record an error."""
+        self.errors.append(
+            {
+                "step": step_name,
+                "error": error,
+                "exception_type": type(exception).__name__ if exception else None,
+                "timestamp": datetime.now().isoformat(),
+            }
+        )
+
+    def get_result(self, step_name: str) -> StepResult | None:
+        """Get result from a previous step."""
+        return self.results.get(step_name)
+
+    def get_variable(self, name: str, default: Any = None) -> Any:
+        """Get a variable value for template substitution."""
+        return self.variables.get(name, default)
+
+    def set_variable(self, name: str, value: Any) -> None:
+        """Set a variable for template substitution."""
+        self.variables[name] = value
+
+    @property
+    def is_running(self) -> bool:
+        """Check if pipeline is currently running."""
+        return self.status == PipelineStatus.RUNNING
+
+    @property
+    def is_completed(self) -> bool:
+        """Check if pipeline completed successfully."""
+        return self.status == PipelineStatus.COMPLETED
+
+    @property
+    def is_failed(self) -> bool:
+        """Check if pipeline failed."""
+        return self.status == PipelineStatus.FAILED
+
+    @property
+    def duration_seconds(self) -> float | None:
+        """Get total pipeline duration in seconds."""
+        if self.started_at and self.completed_at:
+            return (self.completed_at - self.started_at).total_seconds()
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert context to dictionary for serialization."""
+        return {
+            "pipeline_id": self.pipeline_id,
+            "pipeline_name": self.pipeline_name,
+            "notebook_id": self.notebook_id,
+            "notebook_title": self.notebook_title,
+            "notebook_url": self.notebook_url,
+            "source_ids": self.source_ids,
+            "artifact_ids": self.artifact_ids,
+            "status": self.status.value,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "duration_seconds": self.duration_seconds,
+            "variables": self.variables,
+            "errors": self.errors,
+            "qa_results": self.qa_results,
+            "results": {
+                name: {
+                    "success": r.success,
+                    "error": r.error,
+                    "duration_seconds": r.duration_seconds,
+                }
+                for name, r in self.results.items()
+            },
+        }

--- a/src/notebooklm/pipeline/engine.py
+++ b/src/notebooklm/pipeline/engine.py
@@ -1,0 +1,393 @@
+"""Pipeline engine - orchestrates pipeline execution.
+
+The PipelineEngine is the main entry point for running pipelines:
+- Loads and validates configuration
+- Manages execution context
+- Runs steps in sequence
+- Handles errors and progress reporting
+"""
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .config import PipelineConfig, StepConfig, load_pipeline_config
+from .context import PipelineContext, PipelineStatus, StepResult
+from .registry import PluginRegistry, PluginType, create_default_registry
+from .steps import BUILTIN_STEPS, get_builtin_step
+
+if TYPE_CHECKING:
+    from ..client import NotebookLMClient
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineError(Exception):
+    """Error during pipeline execution."""
+
+    pass
+
+
+class StepError(PipelineError):
+    """Error during step execution."""
+
+    def __init__(self, step_name: str, message: str, cause: Exception | None = None):
+        self.step_name = step_name
+        self.cause = cause
+        super().__init__(f"Step '{step_name}' failed: {message}")
+
+
+# Type for progress callback
+ProgressCallback = Callable[[str, str, int, int], None]
+
+
+class PipelineEngine:
+    """Engine for executing research pipelines.
+
+    The engine handles:
+    - Loading pipeline configuration from YAML
+    - Managing pipeline context (shared state)
+    - Executing steps in sequence
+    - Plugin resolution and execution
+    - Error handling and progress reporting
+
+    Example:
+        engine = PipelineEngine()
+        async with await NotebookLMClient.from_storage() as client:
+            result = await engine.run(
+                "research-to-podcast.yaml",
+                client=client,
+                variables={"topic": "quantum computing"}
+            )
+            print(f"Pipeline completed: {result.notebook_url}")
+    """
+
+    def __init__(
+        self,
+        registry: PluginRegistry | None = None,
+        progress_callback: ProgressCallback | None = None,
+    ):
+        """Initialize the pipeline engine.
+
+        Args:
+            registry: Plugin registry (uses default if not provided)
+            progress_callback: Optional callback for progress updates
+                Signature: (step_name, status, current_step, total_steps) -> None
+        """
+        self.registry = registry or create_default_registry()
+        self.progress_callback = progress_callback
+
+    def _report_progress(self, step_name: str, status: str, current: int, total: int) -> None:
+        """Report progress to callback if set."""
+        if self.progress_callback:
+            self.progress_callback(step_name, status, current, total)
+        logger.info("Pipeline progress: [%d/%d] %s - %s", current, total, step_name, status)
+
+    async def run(
+        self,
+        config_path: Path | str,
+        client: "NotebookLMClient",
+        variables: dict[str, Any] | None = None,
+    ) -> PipelineContext:
+        """Run a pipeline from configuration file.
+
+        Args:
+            config_path: Path to pipeline YAML configuration
+            client: NotebookLM client for API calls
+            variables: Runtime variables for template substitution
+
+        Returns:
+            PipelineContext with results
+
+        Raises:
+            PipelineError: If pipeline fails
+        """
+        # Load and validate configuration
+        config = load_pipeline_config(config_path, variables)
+
+        # Create context
+        ctx = PipelineContext(
+            pipeline_name=config.name,
+            variables=config.variables,
+        )
+
+        return await self.run_config(config, client, ctx)
+
+    async def run_config(
+        self,
+        config: PipelineConfig,
+        client: "NotebookLMClient",
+        ctx: PipelineContext | None = None,
+    ) -> PipelineContext:
+        """Run a pipeline from configuration object.
+
+        Args:
+            config: Pipeline configuration
+            client: NotebookLM client for API calls
+            ctx: Optional existing context (creates new if not provided)
+
+        Returns:
+            PipelineContext with results
+        """
+        if ctx is None:
+            ctx = PipelineContext(
+                pipeline_name=config.name,
+                variables=config.variables,
+            )
+
+        ctx.status = PipelineStatus.RUNNING
+        ctx.started_at = datetime.now()
+
+        total_steps = len(config.steps)
+        logger.info("Starting pipeline '%s' with %d steps", config.name, total_steps)
+
+        try:
+            for i, step_config in enumerate(config.steps, 1):
+                ctx.current_step = step_config.name
+                self._report_progress(step_config.name, "starting", i, total_steps)
+
+                # Check conditional execution
+                if step_config.when and not self._evaluate_condition(step_config.when, ctx):
+                    logger.info("Skipping step '%s' (condition not met)", step_config.name)
+                    self._report_progress(step_config.name, "skipped", i, total_steps)
+                    continue
+
+                # Execute the step
+                result = await self.run_step(step_config, client, ctx)
+
+                # Record result
+                ctx.add_result(step_config.name, result)
+
+                if result.success:
+                    self._report_progress(step_config.name, "completed", i, total_steps)
+                else:
+                    self._report_progress(step_config.name, "failed", i, total_steps)
+                    # Log error but continue if it's a soft failure
+                    logger.warning("Step '%s' failed: %s", step_config.name, result.error)
+
+            ctx.status = PipelineStatus.COMPLETED
+            logger.info("Pipeline '%s' completed successfully", config.name)
+
+        except Exception as e:
+            ctx.status = PipelineStatus.FAILED
+            ctx.add_error(ctx.current_step or "unknown", str(e), e)
+            logger.error("Pipeline '%s' failed: %s", config.name, e)
+            raise PipelineError(f"Pipeline failed: {e}") from e
+
+        finally:
+            ctx.completed_at = datetime.now()
+            ctx.current_step = None
+
+        return ctx
+
+    async def run_step(
+        self,
+        step_config: StepConfig,
+        client: "NotebookLMClient",
+        ctx: PipelineContext,
+    ) -> StepResult:
+        """Run a single pipeline step.
+
+        Args:
+            step_config: Step configuration
+            client: NotebookLM client
+            ctx: Pipeline context
+
+        Returns:
+            StepResult with outcome
+        """
+        step_type = step_config.step_type
+        step_handler = step_config.step_handler
+
+        logger.debug(
+            "Running step '%s' (type=%s, handler=%s)",
+            step_config.name,
+            step_type,
+            step_handler,
+        )
+
+        try:
+            if step_type == "builtin":
+                return await self._run_builtin_step(step_handler, client, ctx, step_config.config)
+
+            elif step_type == "source":
+                return await self._run_source_plugin(step_handler, client, ctx, step_config.config)
+
+            elif step_type == "tool":
+                return await self._run_tool_plugin(step_handler, client, ctx, step_config.config)
+
+            elif step_type == "exporter":
+                return await self._run_exporter_plugin(
+                    step_handler, client, ctx, step_config.config
+                )
+
+            else:
+                raise StepError(step_config.name, f"Unknown step type: {step_type}")
+
+        except Exception as e:
+            logger.error("Step '%s' raised exception: %s", step_config.name, e)
+            return StepResult(
+                step_name=step_config.name,
+                success=False,
+                error=str(e),
+                started_at=datetime.now(),
+                completed_at=datetime.now(),
+            )
+
+    async def _run_builtin_step(
+        self,
+        handler: str,
+        client: "NotebookLMClient",
+        ctx: PipelineContext,
+        config: dict[str, Any],
+    ) -> StepResult:
+        """Run a built-in step."""
+        step = get_builtin_step(handler)
+        if not step:
+            raise StepError(handler, f"Unknown built-in step: {handler}")
+
+        return await step.execute(ctx, client, config)
+
+    async def _run_source_plugin(
+        self,
+        handler: str,
+        client: "NotebookLMClient",
+        ctx: PipelineContext,
+        config: dict[str, Any],
+    ) -> StepResult:
+        """Run a source plugin."""
+        plugin = self.registry.get_source(handler)
+        if not plugin:
+            raise StepError(handler, f"Unknown source plugin: {handler}")
+
+        started = datetime.now()
+        try:
+            source_ids = await plugin.add_sources(ctx, client, config)
+            ctx.source_ids.extend(source_ids)
+            return StepResult(
+                step_name=handler,
+                success=True,
+                output={"source_ids": source_ids},
+                started_at=started,
+                completed_at=datetime.now(),
+            )
+        except Exception as e:
+            return StepResult(
+                step_name=handler,
+                success=False,
+                error=str(e),
+                started_at=started,
+                completed_at=datetime.now(),
+            )
+
+    async def _run_tool_plugin(
+        self,
+        handler: str,
+        client: "NotebookLMClient",
+        ctx: PipelineContext,
+        config: dict[str, Any],
+    ) -> StepResult:
+        """Run a tool plugin."""
+        plugin = self.registry.get_tool(handler)
+        if not plugin:
+            raise StepError(handler, f"Unknown tool plugin: {handler}")
+
+        started = datetime.now()
+        try:
+            result = await plugin.execute(ctx, client, config)
+            return StepResult(
+                step_name=handler,
+                success=True,
+                output=result,
+                started_at=started,
+                completed_at=datetime.now(),
+            )
+        except Exception as e:
+            return StepResult(
+                step_name=handler,
+                success=False,
+                error=str(e),
+                started_at=started,
+                completed_at=datetime.now(),
+            )
+
+    async def _run_exporter_plugin(
+        self,
+        handler: str,
+        client: "NotebookLMClient",
+        ctx: PipelineContext,
+        config: dict[str, Any],
+    ) -> StepResult:
+        """Run an exporter plugin."""
+        plugin = self.registry.get_exporter(handler)
+        if not plugin:
+            raise StepError(handler, f"Unknown exporter plugin: {handler}")
+
+        started = datetime.now()
+        try:
+            paths = await plugin.export(ctx, client, config)
+            return StepResult(
+                step_name=handler,
+                success=True,
+                output={"paths": paths},
+                started_at=started,
+                completed_at=datetime.now(),
+            )
+        except Exception as e:
+            return StepResult(
+                step_name=handler,
+                success=False,
+                error=str(e),
+                started_at=started,
+                completed_at=datetime.now(),
+            )
+
+    def _evaluate_condition(self, condition: str, ctx: PipelineContext) -> bool:
+        """Evaluate a step condition.
+
+        Simple evaluation of conditions like:
+        - "notebook_id"  -> ctx.notebook_id is not None
+        - "source_ids"   -> len(ctx.source_ids) > 0
+        - "variable:foo" -> ctx.get_variable("foo") is truthy
+
+        Args:
+            condition: Condition string
+            ctx: Pipeline context
+
+        Returns:
+            True if condition is met
+        """
+        if condition.startswith("variable:"):
+            var_name = condition.split(":", 1)[1]
+            return bool(ctx.get_variable(var_name))
+
+        if condition == "notebook_id":
+            return ctx.notebook_id is not None
+
+        if condition == "source_ids":
+            return len(ctx.source_ids) > 0
+
+        if condition == "artifact_ids":
+            return len(ctx.artifact_ids) > 0
+
+        # Default: evaluate as boolean
+        return bool(condition)
+
+    def list_available_steps(self) -> dict[str, list[str]]:
+        """List all available step types.
+
+        Returns:
+            Dictionary with builtin, source, tool, and exporter step names
+        """
+        return {
+            "builtin": list(BUILTIN_STEPS.keys()),
+            "source": [
+                name.split(":", 1)[1] for name in self.registry.list_plugins(PluginType.SOURCE)
+            ],
+            "tool": [name.split(":", 1)[1] for name in self.registry.list_plugins(PluginType.TOOL)],
+            "exporter": [
+                name.split(":", 1)[1] for name in self.registry.list_plugins(PluginType.EXPORTER)
+            ],
+        }

--- a/src/notebooklm/pipeline/plugins/__init__.py
+++ b/src/notebooklm/pipeline/plugins/__init__.py
@@ -1,0 +1,25 @@
+"""Pipeline plugins package.
+
+Contains built-in plugins for sources, tools, and exporters.
+"""
+
+from .exporters.audio import AudioExporterPlugin
+from .exporters.json_export import JsonExporterPlugin
+from .exporters.markdown import MarkdownExporterPlugin
+from .sources.research import ResearchSourcePlugin
+from .sources.web_url import WebUrlSourcePlugin
+from .sources.youtube import YouTubeSourcePlugin
+from .tools.notebooklm import NotebookLMToolPlugin
+
+__all__ = [
+    # Sources
+    "YouTubeSourcePlugin",
+    "WebUrlSourcePlugin",
+    "ResearchSourcePlugin",
+    # Tools
+    "NotebookLMToolPlugin",
+    # Exporters
+    "MarkdownExporterPlugin",
+    "JsonExporterPlugin",
+    "AudioExporterPlugin",
+]

--- a/src/notebooklm/pipeline/plugins/exporters/__init__.py
+++ b/src/notebooklm/pipeline/plugins/exporters/__init__.py
@@ -1,0 +1,11 @@
+"""Exporter plugins for pipeline output."""
+
+from .audio import AudioExporterPlugin
+from .json_export import JsonExporterPlugin
+from .markdown import MarkdownExporterPlugin
+
+__all__ = [
+    "MarkdownExporterPlugin",
+    "JsonExporterPlugin",
+    "AudioExporterPlugin",
+]

--- a/src/notebooklm/pipeline/plugins/exporters/audio.py
+++ b/src/notebooklm/pipeline/plugins/exporters/audio.py
@@ -1,0 +1,106 @@
+"""Audio exporter plugin.
+
+Downloads audio artifacts to files.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseExporterPlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class AudioExporterPlugin(BaseExporterPlugin):
+    """Plugin for downloading audio artifacts.
+
+    Downloads completed audio artifacts (podcasts) to files.
+
+    Config:
+        output: Output file path (supports variable substitution)
+        artifact_id: Specific artifact ID to download (optional, downloads all audio if not specified)
+
+    Example:
+        plugin: exporter:audio
+        output: "./output/{{ topic | slugify }}.mp3"
+    """
+
+    name = "audio"
+    plugin_type = PluginType.EXPORTER
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "output": {
+                    "type": "string",
+                    "description": "Output file path",
+                },
+                "artifact_id": {
+                    "type": "string",
+                    "description": "Specific artifact ID to download",
+                },
+            },
+            "required": ["output"],
+        }
+
+    async def export(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Download audio artifacts to files.
+
+        Args:
+            ctx: Pipeline context
+            client: NotebookLM client
+            config: Plugin configuration
+
+        Returns:
+            List of exported file paths
+        """
+        from ....types import ArtifactType
+
+        if not ctx.notebook_id:
+            raise ValueError("No notebook ID in context")
+
+        output_path = config.get("output", "output.mp3")
+        artifact_id = config.get("artifact_id")
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        exported_paths = []
+
+        if artifact_id:
+            # Download specific artifact
+            await client.artifacts.download_audio(ctx.notebook_id, artifact_id, str(path))
+            ctx.artifact_outputs[artifact_id] = str(path)
+            exported_paths.append(str(path))
+        else:
+            # Download all completed audio artifacts
+            artifacts = await client.artifacts.list(ctx.notebook_id)
+            audio_artifacts = [
+                a for a in artifacts if a.kind == ArtifactType.AUDIO and a.is_completed
+            ]
+
+            for i, artifact in enumerate(audio_artifacts):
+                if len(audio_artifacts) > 1:
+                    # Add index to filename for multiple artifacts
+                    stem = path.stem
+                    suffix = path.suffix
+                    artifact_path = path.parent / f"{stem}_{i + 1}{suffix}"
+                else:
+                    artifact_path = path
+
+                await client.artifacts.download_audio(
+                    ctx.notebook_id, artifact.id, str(artifact_path)
+                )
+                ctx.artifact_outputs[artifact.id] = str(artifact_path)
+                exported_paths.append(str(artifact_path))
+
+        return exported_paths

--- a/src/notebooklm/pipeline/plugins/exporters/json_export.py
+++ b/src/notebooklm/pipeline/plugins/exporters/json_export.py
@@ -1,0 +1,100 @@
+"""JSON exporter plugin.
+
+Exports pipeline results to JSON files.
+"""
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseExporterPlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class JsonExporterPlugin(BaseExporterPlugin):
+    """Plugin for exporting pipeline results to JSON.
+
+    Exports the complete pipeline context including:
+    - Pipeline metadata
+    - Notebook information
+    - Source and artifact IDs
+    - Q&A results
+    - Step results and errors
+
+    Config:
+        output: Output file path (supports variable substitution)
+        indent: JSON indentation (default: 2)
+        include_results: Whether to include step results (default: true)
+
+    Example:
+        plugin: exporter:json
+        output: "./output/{{ topic | slugify }}-results.json"
+        indent: 2
+    """
+
+    name = "json"
+    plugin_type = PluginType.EXPORTER
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "output": {
+                    "type": "string",
+                    "description": "Output file path",
+                },
+                "indent": {
+                    "type": "integer",
+                    "description": "JSON indentation",
+                    "default": 2,
+                },
+                "include_results": {
+                    "type": "boolean",
+                    "description": "Include step results",
+                    "default": True,
+                },
+            },
+            "required": ["output"],
+        }
+
+    async def export(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Export pipeline results to JSON file.
+
+        Args:
+            ctx: Pipeline context
+            client: NotebookLM client (unused but required by protocol)
+            config: Plugin configuration
+
+        Returns:
+            List of exported file paths
+        """
+        output_path = config.get("output", "output.json")
+        indent = config.get("indent", 2)
+        include_results = config.get("include_results", True)
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Build export data
+        data = ctx.to_dict()
+
+        # Optionally remove detailed results
+        if not include_results:
+            data.pop("results", None)
+
+        # Write JSON file
+        path.write_text(
+            json.dumps(data, indent=indent, default=str, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        return [str(path)]

--- a/src/notebooklm/pipeline/plugins/exporters/markdown.py
+++ b/src/notebooklm/pipeline/plugins/exporters/markdown.py
@@ -1,0 +1,145 @@
+"""Markdown exporter plugin.
+
+Exports reports and Q&A results to markdown files.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseExporterPlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class MarkdownExporterPlugin(BaseExporterPlugin):
+    """Plugin for exporting content to markdown files.
+
+    Exports:
+    - Report artifacts as markdown
+    - Q&A results as markdown
+    - Pipeline summary as markdown
+
+    Config:
+        output: Output file path (supports variable substitution)
+        include_qa: Whether to include Q&A results (default: true)
+        include_summary: Whether to include pipeline summary (default: false)
+
+    Example:
+        plugin: exporter:markdown
+        output: "./output/{{ topic | slugify }}-guide.md"
+        include_qa: true
+    """
+
+    name = "markdown"
+    plugin_type = PluginType.EXPORTER
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "output": {
+                    "type": "string",
+                    "description": "Output file path",
+                },
+                "include_qa": {
+                    "type": "boolean",
+                    "description": "Include Q&A results",
+                    "default": True,
+                },
+                "include_summary": {
+                    "type": "boolean",
+                    "description": "Include pipeline summary",
+                    "default": False,
+                },
+            },
+            "required": ["output"],
+        }
+
+    async def export(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Export content to markdown file.
+
+        Args:
+            ctx: Pipeline context
+            client: NotebookLM client
+            config: Plugin configuration
+
+        Returns:
+            List of exported file paths
+        """
+        from ....types import ArtifactType
+
+        output_path = config.get("output", "output.md")
+        include_qa = config.get("include_qa", True)
+        include_summary = config.get("include_summary", False)
+
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        content_parts = []
+
+        # Add title
+        title = ctx.notebook_title or ctx.pipeline_name or "Pipeline Output"
+        content_parts.append(f"# {title}\n")
+
+        # Add pipeline info if summary requested
+        if include_summary:
+            content_parts.append("## Pipeline Summary\n")
+            content_parts.append(f"- **Pipeline**: {ctx.pipeline_name}")
+            content_parts.append(f"- **Notebook ID**: {ctx.notebook_id}")
+            if ctx.notebook_url:
+                content_parts.append(f"- **Notebook URL**: {ctx.notebook_url}")
+            content_parts.append(f"- **Sources**: {len(ctx.source_ids)}")
+            content_parts.append(f"- **Artifacts**: {len(ctx.artifact_ids)}")
+            content_parts.append("")
+
+        # Export report artifacts
+        if ctx.notebook_id:
+            try:
+                import tempfile
+
+                artifacts = await client.artifacts.list(ctx.notebook_id)
+                report_artifacts = [
+                    a for a in artifacts if a.kind == ArtifactType.REPORT and a.is_completed
+                ]
+
+                for artifact in report_artifacts:
+                    try:
+                        # download_report writes to a file
+                        with tempfile.NamedTemporaryFile(
+                            mode="w", suffix=".md", delete=False
+                        ) as tmp:
+                            tmp_path = tmp.name
+                        await client.artifacts.download_report(
+                            ctx.notebook_id, tmp_path, artifact_id=artifact.id
+                        )
+                        report_content = Path(tmp_path).read_text(encoding="utf-8")
+                        Path(tmp_path).unlink()  # Clean up temp file
+                        content_parts.append(f"## {artifact.title}\n")
+                        content_parts.append(report_content)
+                        content_parts.append("")
+                    except Exception:
+                        pass  # Skip artifacts that can't be read
+            except Exception:
+                pass  # Skip if artifacts can't be listed
+
+        # Add Q&A results
+        if include_qa and ctx.qa_results:
+            content_parts.append("## Questions & Answers\n")
+            for qa in ctx.qa_results:
+                content_parts.append(f"### Q: {qa['question']}\n")
+                content_parts.append(qa["answer"])
+                content_parts.append("")
+
+        # Write file
+        content = "\n".join(content_parts)
+        path.write_text(content, encoding="utf-8")
+
+        return [str(path)]

--- a/src/notebooklm/pipeline/plugins/sources/__init__.py
+++ b/src/notebooklm/pipeline/plugins/sources/__init__.py
@@ -1,0 +1,11 @@
+"""Source plugins for pipeline ingestion."""
+
+from .research import ResearchSourcePlugin
+from .web_url import WebUrlSourcePlugin
+from .youtube import YouTubeSourcePlugin
+
+__all__ = [
+    "YouTubeSourcePlugin",
+    "WebUrlSourcePlugin",
+    "ResearchSourcePlugin",
+]

--- a/src/notebooklm/pipeline/plugins/sources/research.py
+++ b/src/notebooklm/pipeline/plugins/sources/research.py
@@ -1,0 +1,107 @@
+"""Research source plugin.
+
+Uses NotebookLM's research feature to discover and add sources.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseSourcePlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class ResearchSourcePlugin(BaseSourcePlugin):
+    """Plugin for using NotebookLM's research feature.
+
+    The research feature searches the web for relevant sources
+    based on a query and allows importing them into a notebook.
+
+    Config:
+        query: Search query for research
+        max_sources: Maximum number of sources to import (default: all)
+        auto_import: Whether to auto-import found sources (default: true)
+
+    Example:
+        - plugin: source:research
+          query: "latest developments in quantum computing 2024"
+          max_sources: 10
+    """
+
+    name = "research"
+    plugin_type = PluginType.SOURCE
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Research query",
+                },
+                "max_sources": {
+                    "type": "integer",
+                    "description": "Maximum sources to import",
+                    "minimum": 1,
+                },
+                "auto_import": {
+                    "type": "boolean",
+                    "description": "Auto-import found sources",
+                    "default": True,
+                },
+            },
+            "required": ["query"],
+        }
+
+    async def add_sources(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Research and add sources.
+
+        Args:
+            ctx: Pipeline context with notebook_id
+            client: NotebookLM client
+            config: Plugin configuration
+
+        Returns:
+            List of added source IDs
+        """
+        if not ctx.notebook_id:
+            raise ValueError("No notebook ID in context")
+
+        query = config.get("query", "")
+        if not query:
+            raise ValueError("Research query is required")
+
+        max_sources = config.get("max_sources")
+        auto_import = config.get("auto_import", True)
+
+        # Start research - requires notebook_id
+        research_result = await client.research.start(ctx.notebook_id, query)
+        if not research_result:
+            return []
+
+        # Poll for results
+        poll_result = await client.research.poll(ctx.notebook_id)
+        sources = poll_result.get("sources", [])
+        if not sources:
+            return []
+
+        # Limit sources if specified
+        if max_sources and len(sources) > max_sources:
+            sources = sources[:max_sources]
+
+        # Import sources if auto_import is enabled
+        if auto_import:
+            task_id = research_result.get("task_id", "")
+            # import_sources returns list of dicts with 'id' and 'title'
+            imported = await client.research.import_sources(ctx.notebook_id, task_id, sources)
+            # Extract just the IDs
+            return [s.get("id", "") for s in imported if s.get("id")]
+
+        return []

--- a/src/notebooklm/pipeline/plugins/sources/web_url.py
+++ b/src/notebooklm/pipeline/plugins/sources/web_url.py
@@ -1,0 +1,85 @@
+"""Web URL source plugin.
+
+Adds web pages as sources to a notebook.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseSourcePlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class WebUrlSourcePlugin(BaseSourcePlugin):
+    """Plugin for adding web pages as sources.
+
+    Config:
+        url: Single web page URL
+        urls: List of web page URLs
+
+    Example:
+        - plugin: source:web_url
+          url: "https://example.com/article"
+
+        - plugin: source:web_url
+          urls:
+            - "https://example.com/page1"
+            - "https://example.com/page2"
+    """
+
+    name = "web_url"
+    plugin_type = PluginType.SOURCE
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Single web page URL",
+                },
+                "urls": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of web page URLs",
+                },
+            },
+        }
+
+    async def add_sources(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Add web pages as sources.
+
+        Args:
+            ctx: Pipeline context with notebook_id
+            client: NotebookLM client
+            config: Plugin configuration
+
+        Returns:
+            List of added source IDs
+        """
+        if not ctx.notebook_id:
+            raise ValueError("No notebook ID in context")
+
+        source_ids: list[str] = []
+
+        # Handle single URL
+        url = config.get("url")
+        if url:
+            source = await client.sources.add_url(ctx.notebook_id, url)
+            source_ids.append(source.id)
+
+        # Handle multiple URLs
+        urls = config.get("urls", [])
+        for web_url in urls:
+            source = await client.sources.add_url(ctx.notebook_id, web_url)
+            source_ids.append(source.id)
+
+        return source_ids

--- a/src/notebooklm/pipeline/plugins/sources/youtube.py
+++ b/src/notebooklm/pipeline/plugins/sources/youtube.py
@@ -1,0 +1,98 @@
+"""YouTube source plugin.
+
+Adds YouTube videos as sources to a notebook.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseSourcePlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class YouTubeSourcePlugin(BaseSourcePlugin):
+    """Plugin for adding YouTube videos as sources.
+
+    Config:
+        url: Single YouTube video URL
+        urls: List of YouTube video URLs
+        playlist: YouTube playlist URL (adds all videos)
+
+    Example:
+        - plugin: source:youtube
+          url: "https://www.youtube.com/watch?v=abc123"
+
+        - plugin: source:youtube
+          urls:
+            - "https://www.youtube.com/watch?v=abc123"
+            - "https://www.youtube.com/watch?v=def456"
+    """
+
+    name = "youtube"
+    plugin_type = PluginType.SOURCE
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Single YouTube video URL",
+                },
+                "urls": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "List of YouTube video URLs",
+                },
+                "playlist": {
+                    "type": "string",
+                    "description": "YouTube playlist URL",
+                },
+            },
+        }
+
+    async def add_sources(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Add YouTube videos as sources.
+
+        Args:
+            ctx: Pipeline context with notebook_id
+            client: NotebookLM client
+            config: Plugin configuration
+
+        Returns:
+            List of added source IDs
+        """
+        if not ctx.notebook_id:
+            raise ValueError("No notebook ID in context")
+
+        source_ids: list[str] = []
+
+        # Handle single URL
+        url = config.get("url")
+        if url:
+            source = await client.sources.add_url(ctx.notebook_id, url)
+            source_ids.append(source.id)
+
+        # Handle multiple URLs
+        urls = config.get("urls", [])
+        for video_url in urls:
+            source = await client.sources.add_url(ctx.notebook_id, video_url)
+            source_ids.append(source.id)
+
+        # Handle playlist
+        playlist_url = config.get("playlist")
+        if playlist_url:
+            # Note: NotebookLM handles playlist URLs directly
+            # It will expand the playlist into individual video sources
+            source = await client.sources.add_url(ctx.notebook_id, playlist_url)
+            source_ids.append(source.id)
+
+        return source_ids

--- a/src/notebooklm/pipeline/plugins/tools/__init__.py
+++ b/src/notebooklm/pipeline/plugins/tools/__init__.py
@@ -1,0 +1,7 @@
+"""Tool plugins for pipeline processing."""
+
+from .notebooklm import NotebookLMToolPlugin
+
+__all__ = [
+    "NotebookLMToolPlugin",
+]

--- a/src/notebooklm/pipeline/plugins/tools/notebooklm.py
+++ b/src/notebooklm/pipeline/plugins/tools/notebooklm.py
@@ -1,0 +1,268 @@
+"""NotebookLM tool plugin.
+
+Wraps NotebookLM's artifact generation capabilities.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from ...registry import BaseToolPlugin, PluginType
+
+if TYPE_CHECKING:
+    from ....client import NotebookLMClient
+    from ...context import PipelineContext
+
+
+class NotebookLMToolPlugin(BaseToolPlugin):
+    """Plugin for NotebookLM artifact generation.
+
+    Generates various artifacts from notebook sources:
+    - Audio overviews (podcasts)
+    - Video overviews
+    - Reports (study guides, briefing docs, blog posts)
+    - Quizzes and flashcards
+    - Mind maps
+    - Infographics
+    - Slide decks
+
+    Config:
+        artifacts: List of artifact configurations
+        questions: Optional questions to ask
+        wait_for_completion: Whether to wait for artifacts (default: false)
+
+    Example:
+        type: tool:notebooklm
+        config:
+          artifacts:
+            - type: audio
+              format: deep-dive
+              length: medium
+            - type: report
+              format: study-guide
+          questions:
+            - "What are the key insights?"
+    """
+
+    name = "notebooklm"
+    plugin_type = PluginType.TOOL
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {
+            "type": "object",
+            "properties": {
+                "artifacts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "audio",
+                                    "video",
+                                    "report",
+                                    "quiz",
+                                    "flashcards",
+                                    "mind_map",
+                                    "infographic",
+                                    "slide_deck",
+                                ],
+                            },
+                            "format": {"type": "string"},
+                            "length": {"type": "string"},
+                            "difficulty": {"type": "string"},
+                            "quantity": {"type": "string"},
+                        },
+                        "required": ["type"],
+                    },
+                },
+                "questions": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "wait_for_completion": {
+                    "type": "boolean",
+                    "default": False,
+                },
+            },
+        }
+
+    async def execute(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Generate artifacts and optionally ask questions.
+
+        Args:
+            ctx: Pipeline context with notebook_id and source_ids
+            client: NotebookLM client
+            config: Plugin configuration
+
+        Returns:
+            Dictionary with generated artifact IDs and Q&A results
+        """
+        from ....types import (
+            AudioFormat,
+            AudioLength,
+            QuizDifficulty,
+            QuizQuantity,
+            ReportFormat,
+        )
+
+        if not ctx.notebook_id:
+            raise ValueError("No notebook ID in context")
+
+        artifacts_config = config.get("artifacts", [])
+        questions = config.get("questions", [])
+        wait = config.get("wait_for_completion", False)
+
+        generated = []
+        qa_results = []
+        source_ids = ctx.source_ids if ctx.source_ids else None
+
+        # Generate each artifact
+        for art_cfg in artifacts_config:
+            art_type = art_cfg.get("type", "")
+
+            if art_type == "audio":
+                fmt = art_cfg.get("format", "deep-dive")
+                # AudioFormat: DEEP_DIVE=1, BRIEF=2, CRITIQUE=3, DEBATE=4
+                format_map = {
+                    "deep-dive": AudioFormat.DEEP_DIVE,
+                    "brief": AudioFormat.BRIEF,
+                    "critique": AudioFormat.CRITIQUE,
+                    "debate": AudioFormat.DEBATE,
+                }
+                audio_format = format_map.get(fmt, AudioFormat.DEEP_DIVE)
+                length_map = {
+                    "short": AudioLength.SHORT,
+                    "medium": AudioLength.DEFAULT,
+                    "long": AudioLength.LONG,
+                }
+                audio_length = length_map.get(art_cfg.get("length", "medium"), AudioLength.DEFAULT)
+
+                status = await client.artifacts.generate_audio(
+                    ctx.notebook_id,
+                    source_ids=source_ids,
+                    audio_format=audio_format,
+                    audio_length=audio_length,
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "audio", "task_id": status.task_id})
+
+            elif art_type == "video":
+                status = await client.artifacts.generate_video(
+                    ctx.notebook_id, source_ids=source_ids
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "video", "task_id": status.task_id})
+
+            elif art_type == "report":
+                fmt = art_cfg.get("format", "study-guide")
+                report_format_map: dict[str, ReportFormat] = {
+                    "study-guide": ReportFormat.STUDY_GUIDE,
+                    "briefing-doc": ReportFormat.BRIEFING_DOC,
+                    "blog-post": ReportFormat.BLOG_POST,
+                }
+                report_format = report_format_map.get(fmt, ReportFormat.STUDY_GUIDE)
+
+                status = await client.artifacts.generate_report(
+                    ctx.notebook_id,
+                    report_format=report_format,
+                    source_ids=source_ids,
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "report", "format": fmt, "task_id": status.task_id})
+
+            elif art_type == "quiz":
+                difficulty_map = {
+                    "easy": QuizDifficulty.EASY,
+                    "medium": QuizDifficulty.MEDIUM,
+                    "hard": QuizDifficulty.HARD,
+                }
+                quantity_map = {
+                    "fewer": QuizQuantity.FEWER,
+                    "standard": QuizQuantity.STANDARD,
+                }
+
+                status = await client.artifacts.generate_quiz(
+                    ctx.notebook_id,
+                    source_ids=source_ids,
+                    difficulty=difficulty_map.get(
+                        art_cfg.get("difficulty", "medium"), QuizDifficulty.MEDIUM
+                    ),
+                    quantity=quantity_map.get(
+                        art_cfg.get("quantity", "standard"), QuizQuantity.STANDARD
+                    ),
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "quiz", "task_id": status.task_id})
+
+            elif art_type == "flashcards":
+                difficulty_map = {
+                    "easy": QuizDifficulty.EASY,
+                    "medium": QuizDifficulty.MEDIUM,
+                    "hard": QuizDifficulty.HARD,
+                }
+                quantity_map = {
+                    "fewer": QuizQuantity.FEWER,
+                    "standard": QuizQuantity.STANDARD,
+                }
+
+                status = await client.artifacts.generate_flashcards(
+                    ctx.notebook_id,
+                    source_ids=source_ids,
+                    difficulty=difficulty_map.get(
+                        art_cfg.get("difficulty", "medium"), QuizDifficulty.MEDIUM
+                    ),
+                    quantity=quantity_map.get(
+                        art_cfg.get("quantity", "standard"), QuizQuantity.STANDARD
+                    ),
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "flashcards", "task_id": status.task_id})
+
+            elif art_type == "mind_map":
+                # generate_mind_map returns dict, not GenerationStatus
+                mind_map_result = await client.artifacts.generate_mind_map(
+                    ctx.notebook_id, source_ids=source_ids
+                )
+                if isinstance(mind_map_result, dict) and mind_map_result.get("mind_map_id"):
+                    ctx.artifact_ids.append(mind_map_result["mind_map_id"])
+                    generated.append({"type": "mind_map", "id": mind_map_result["mind_map_id"]})
+
+            elif art_type == "infographic":
+                status = await client.artifacts.generate_infographic(
+                    ctx.notebook_id, source_ids=source_ids
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "infographic", "task_id": status.task_id})
+
+            elif art_type == "slide_deck":
+                status = await client.artifacts.generate_slide_deck(
+                    ctx.notebook_id, source_ids=source_ids
+                )
+                ctx.artifact_ids.append(status.task_id)
+                generated.append({"type": "slide_deck", "task_id": status.task_id})
+
+        # Wait for completion if requested
+        if wait and ctx.artifact_ids:
+            for artifact_id in ctx.artifact_ids:
+                await client.artifacts.wait_for_completion(
+                    ctx.notebook_id, artifact_id, timeout=600.0
+                )
+
+        # Ask questions
+        for question in questions:
+            result = await client.chat.ask(ctx.notebook_id, question)
+            qa_results.append({"question": question, "answer": result.answer})
+            ctx.qa_results.append({"question": question, "answer": result.answer})
+
+        return {
+            "artifacts_generated": len(generated),
+            "artifacts": generated,
+            "questions_answered": len(qa_results),
+            "qa_results": qa_results,
+        }

--- a/src/notebooklm/pipeline/registry.py
+++ b/src/notebooklm/pipeline/registry.py
@@ -1,0 +1,296 @@
+"""Plugin registry for pipeline extensibility.
+
+Manages registration and discovery of:
+- Source plugins (YouTube, URL, research, etc.)
+- Tool plugins (NotebookLM, Perplexity, etc.)
+- Exporter plugins (markdown, JSON, audio, etc.)
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from ..client import NotebookLMClient
+    from .context import PipelineContext
+
+
+class PluginType(str, Enum):
+    """Types of plugins."""
+
+    SOURCE = "source"
+    TOOL = "tool"
+    EXPORTER = "exporter"
+
+
+@runtime_checkable
+class Plugin(Protocol):
+    """Protocol for all plugins.
+
+    Plugins extend pipeline capabilities:
+    - Source plugins add new ways to ingest content
+    - Tool plugins wrap external services
+    - Exporter plugins handle output formats
+    """
+
+    name: str
+    plugin_type: PluginType
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        ...
+
+
+@runtime_checkable
+class SourcePlugin(Protocol):
+    """Protocol for source plugins.
+
+    Source plugins add content to notebooks from various sources.
+    """
+
+    name: str
+    plugin_type: PluginType
+
+    async def add_sources(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Add sources and return list of source IDs."""
+        ...
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        ...
+
+
+@runtime_checkable
+class ToolPlugin(Protocol):
+    """Protocol for tool plugins.
+
+    Tool plugins wrap external services for content generation.
+    """
+
+    name: str
+    plugin_type: PluginType
+
+    async def execute(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Execute the tool and return results."""
+        ...
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        ...
+
+
+@runtime_checkable
+class ExporterPlugin(Protocol):
+    """Protocol for exporter plugins.
+
+    Exporter plugins handle output formats and file writing.
+    """
+
+    name: str
+    plugin_type: PluginType
+
+    async def export(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Export content and return list of output paths."""
+        ...
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        ...
+
+
+class BasePlugin:
+    """Base class for plugin implementations."""
+
+    name: str = "base"
+    plugin_type: PluginType = PluginType.SOURCE
+
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return JSON schema for plugin configuration."""
+        return {"type": "object", "properties": {}}
+
+
+class BaseSourcePlugin(BasePlugin, ABC):
+    """Base class for source plugins."""
+
+    plugin_type = PluginType.SOURCE
+
+    @abstractmethod
+    async def add_sources(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Add sources and return list of source IDs."""
+        pass
+
+
+class BaseToolPlugin(BasePlugin, ABC):
+    """Base class for tool plugins."""
+
+    plugin_type = PluginType.TOOL
+
+    @abstractmethod
+    async def execute(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Execute the tool and return results."""
+        pass
+
+
+class BaseExporterPlugin(BasePlugin, ABC):
+    """Base class for exporter plugins."""
+
+    plugin_type = PluginType.EXPORTER
+
+    @abstractmethod
+    async def export(
+        self,
+        ctx: "PipelineContext",
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> list[str]:
+        """Export content and return list of output paths."""
+        pass
+
+
+@dataclass
+class PluginRegistry:
+    """Registry for pipeline plugins.
+
+    Manages plugin registration and lookup by type and name.
+    Plugins are registered with namespaced names like:
+    - source:youtube
+    - tool:notebooklm
+    - exporter:markdown
+
+    Example:
+        registry = PluginRegistry()
+        registry.register(YouTubeSourcePlugin())
+        plugin = registry.get("source:youtube")
+    """
+
+    _sources: dict[str, BaseSourcePlugin] = field(default_factory=dict)
+    _tools: dict[str, BaseToolPlugin] = field(default_factory=dict)
+    _exporters: dict[str, BaseExporterPlugin] = field(default_factory=dict)
+
+    def register(self, plugin: BasePlugin) -> None:
+        """Register a plugin.
+
+        Args:
+            plugin: Plugin instance to register
+        """
+        if plugin.plugin_type == PluginType.SOURCE:
+            self._sources[plugin.name] = plugin  # type: ignore
+        elif plugin.plugin_type == PluginType.TOOL:
+            self._tools[plugin.name] = plugin  # type: ignore
+        elif plugin.plugin_type == PluginType.EXPORTER:
+            self._exporters[plugin.name] = plugin  # type: ignore
+
+    def get(self, full_name: str) -> BasePlugin | None:
+        """Get a plugin by full name (e.g., "source:youtube").
+
+        Args:
+            full_name: Full plugin name with type prefix
+
+        Returns:
+            Plugin instance or None if not found
+        """
+        if ":" not in full_name:
+            return None
+
+        plugin_type, name = full_name.split(":", 1)
+
+        if plugin_type == "source":
+            return self._sources.get(name)
+        elif plugin_type == "tool":
+            return self._tools.get(name)
+        elif plugin_type == "exporter":
+            return self._exporters.get(name)
+
+        return None
+
+    def get_source(self, name: str) -> BaseSourcePlugin | None:
+        """Get a source plugin by name."""
+        return self._sources.get(name)
+
+    def get_tool(self, name: str) -> BaseToolPlugin | None:
+        """Get a tool plugin by name."""
+        return self._tools.get(name)
+
+    def get_exporter(self, name: str) -> BaseExporterPlugin | None:
+        """Get an exporter plugin by name."""
+        return self._exporters.get(name)
+
+    def list_plugins(self, plugin_type: PluginType | None = None) -> list[str]:
+        """List all registered plugin names.
+
+        Args:
+            plugin_type: Optional filter by plugin type
+
+        Returns:
+            List of full plugin names (e.g., "source:youtube")
+        """
+        plugins: list[str] = []
+
+        if plugin_type is None or plugin_type == PluginType.SOURCE:
+            plugins.extend(f"source:{name}" for name in self._sources)
+
+        if plugin_type is None or plugin_type == PluginType.TOOL:
+            plugins.extend(f"tool:{name}" for name in self._tools)
+
+        if plugin_type is None or plugin_type == PluginType.EXPORTER:
+            plugins.extend(f"exporter:{name}" for name in self._exporters)
+
+        return sorted(plugins)
+
+
+def create_default_registry() -> PluginRegistry:
+    """Create a registry with default built-in plugins.
+
+    Returns:
+        PluginRegistry with standard plugins registered
+    """
+    from .plugins.exporters.audio import AudioExporterPlugin
+    from .plugins.exporters.json_export import JsonExporterPlugin
+    from .plugins.exporters.markdown import MarkdownExporterPlugin
+    from .plugins.sources.research import ResearchSourcePlugin
+    from .plugins.sources.web_url import WebUrlSourcePlugin
+    from .plugins.sources.youtube import YouTubeSourcePlugin
+    from .plugins.tools.notebooklm import NotebookLMToolPlugin
+
+    registry = PluginRegistry()
+
+    # Register source plugins
+    registry.register(YouTubeSourcePlugin())
+    registry.register(WebUrlSourcePlugin())
+    registry.register(ResearchSourcePlugin())
+
+    # Register tool plugins
+    registry.register(NotebookLMToolPlugin())
+
+    # Register exporter plugins
+    registry.register(MarkdownExporterPlugin())
+    registry.register(JsonExporterPlugin())
+    registry.register(AudioExporterPlugin())
+
+    return registry

--- a/src/notebooklm/pipeline/steps.py
+++ b/src/notebooklm/pipeline/steps.py
@@ -1,0 +1,710 @@
+"""Built-in pipeline steps.
+
+These steps handle common operations in research pipelines:
+- create_notebook: Create a new NotebookLM notebook
+- ingest: Add sources to a notebook
+- wait_sources: Wait for sources to finish processing
+- synthesize: Generate artifacts (audio, reports, etc.)
+- wait_artifacts: Wait for artifacts to complete
+- ask: Ask questions to the notebook
+- export: Export artifacts to files
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from .context import PipelineContext, StepResult
+
+if TYPE_CHECKING:
+    from ..client import NotebookLMClient
+
+
+@runtime_checkable
+class PipelineStep(Protocol):
+    """Protocol for pipeline steps.
+
+    Steps are the building blocks of pipelines. Each step:
+    - Has a unique name
+    - Receives context and client
+    - Returns a StepResult
+    """
+
+    name: str
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        """Execute the step.
+
+        Args:
+            ctx: Pipeline context with shared state
+            client: NotebookLM client for API calls
+            config: Step-specific configuration
+
+        Returns:
+            StepResult with success/failure and output
+        """
+        ...
+
+
+class BaseStep(ABC):
+    """Base class for built-in steps."""
+
+    name: str = "base"
+
+    @abstractmethod
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        """Execute the step."""
+        pass
+
+    def _start_result(self, step_name: str) -> StepResult:
+        """Create a StepResult with start time."""
+        return StepResult(
+            step_name=step_name,
+            success=False,
+            started_at=datetime.now(),
+        )
+
+    def _complete_result(
+        self,
+        result: StepResult,
+        success: bool,
+        output: Any = None,
+        error: str | None = None,
+    ) -> StepResult:
+        """Complete a StepResult."""
+        result.success = success
+        result.output = output
+        result.error = error
+        result.completed_at = datetime.now()
+        return result
+
+
+class CreateNotebookStep(BaseStep):
+    """Create a new NotebookLM notebook.
+
+    Config:
+        title: Notebook title (supports variable substitution)
+    """
+
+    name = "create_notebook"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        result = self._start_result(self.name)
+
+        title = config.get("title", ctx.pipeline_name or "Pipeline Notebook")
+
+        try:
+            notebook = await client.notebooks.create(title)
+            ctx.notebook_id = notebook.id
+            ctx.notebook_title = notebook.title
+            ctx.notebook_url = f"https://notebooklm.google.com/notebook/{notebook.id}"
+
+            return self._complete_result(
+                result,
+                success=True,
+                output={
+                    "notebook_id": notebook.id,
+                    "title": notebook.title,
+                    "url": ctx.notebook_url,
+                },
+            )
+        except Exception as e:
+            ctx.add_error(self.name, str(e), e)
+            return self._complete_result(result, success=False, error=str(e))
+
+
+class IngestStep(BaseStep):
+    """Add sources to a notebook.
+
+    Config:
+        sources: List of source configurations, each with:
+            - plugin: Source plugin name (e.g., "source:youtube", "source:url")
+            - Plus plugin-specific config (url, query, etc.)
+    """
+
+    name = "ingest"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        result = self._start_result(self.name)
+
+        if not ctx.notebook_id:
+            return self._complete_result(result, success=False, error="No notebook ID in context")
+
+        sources_config = config.get("sources", [])
+        added_sources = []
+        errors = []
+
+        for source_cfg in sources_config:
+            plugin_type = source_cfg.get("plugin", "")
+
+            try:
+                # Handle different source types
+                if plugin_type in ("source:url", "source:web_url"):
+                    url = source_cfg.get("url")
+                    if url:
+                        source = await client.sources.add_url(ctx.notebook_id, url)
+                        ctx.source_ids.append(source.id)
+                        added_sources.append({"id": source.id, "type": "url", "url": url})
+
+                elif plugin_type == "source:youtube":
+                    url = source_cfg.get("url")
+                    if url:
+                        source = await client.sources.add_url(ctx.notebook_id, url)
+                        ctx.source_ids.append(source.id)
+                        added_sources.append({"id": source.id, "type": "youtube", "url": url})
+
+                elif plugin_type == "source:text":
+                    text = source_cfg.get("text", "")
+                    title = source_cfg.get("title", "Pasted Text")
+                    if text:
+                        # add_text signature: (notebook_id, title, content)
+                        source = await client.sources.add_text(ctx.notebook_id, title, text)
+                        ctx.source_ids.append(source.id)
+                        added_sources.append({"id": source.id, "type": "text", "title": title})
+
+                elif plugin_type == "source:research":
+                    query = source_cfg.get("query")
+                    if query:
+                        # Use research API - requires notebook_id
+                        research_result = await client.research.start(ctx.notebook_id, query)
+                        # Poll for results and import sources
+                        if research_result:
+                            poll_result = await client.research.poll(ctx.notebook_id)
+                            sources = poll_result.get("sources", [])
+                            if sources:
+                                task_id = research_result.get("task_id", "")
+                                imported = await client.research.import_sources(
+                                    ctx.notebook_id,
+                                    task_id,
+                                    sources,
+                                )
+                                # imported is list of dicts with 'id' and 'title'
+                                imported_ids = [s.get("id", "") for s in imported if s.get("id")]
+                                ctx.source_ids.extend(imported_ids)
+                                added_sources.append(
+                                    {
+                                        "type": "research",
+                                        "query": query,
+                                        "imported_count": len(imported_ids),
+                                    }
+                                )
+
+                elif plugin_type == "source:urls":
+                    # Batch add multiple URLs
+                    urls = source_cfg.get("urls", [])
+                    for url in urls:
+                        try:
+                            source = await client.sources.add_url(ctx.notebook_id, url)
+                            ctx.source_ids.append(source.id)
+                            added_sources.append({"id": source.id, "type": "url", "url": url})
+                        except Exception as e:
+                            errors.append(f"Failed to add {url}: {e}")
+
+                else:
+                    errors.append(f"Unknown source plugin: {plugin_type}")
+
+            except Exception as e:
+                errors.append(f"Error with {plugin_type}: {e}")
+                ctx.add_error(self.name, str(e), e)
+
+        output = {
+            "sources_added": len(added_sources),
+            "sources": added_sources,
+        }
+        if errors:
+            output["errors"] = errors
+
+        return self._complete_result(
+            result,
+            success=len(added_sources) > 0,
+            output=output,
+            error="; ".join(errors) if errors and not added_sources else None,
+        )
+
+
+class WaitSourcesStep(BaseStep):
+    """Wait for sources to finish processing.
+
+    Config:
+        timeout: Maximum wait time in seconds (default: 600)
+        poll_interval: Time between status checks (default: 5)
+    """
+
+    name = "wait_sources"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        result = self._start_result(self.name)
+
+        if not ctx.notebook_id:
+            return self._complete_result(result, success=False, error="No notebook ID in context")
+
+        if not ctx.source_ids:
+            return self._complete_result(
+                result, success=True, output={"message": "No sources to wait for"}
+            )
+
+        timeout = config.get("timeout", 600)
+        poll_interval = config.get("poll_interval", 5.0)
+
+        try:
+            await client.sources.wait_for_sources(
+                ctx.notebook_id,
+                ctx.source_ids,
+                timeout=float(timeout),
+                poll_interval=float(poll_interval),
+            )
+            return self._complete_result(
+                result,
+                success=True,
+                output={"sources_ready": len(ctx.source_ids)},
+            )
+        except Exception as e:
+            ctx.add_error(self.name, str(e), e)
+            return self._complete_result(result, success=False, error=str(e))
+
+
+class SynthesizeStep(BaseStep):
+    """Generate artifacts from notebook sources.
+
+    Config:
+        artifacts: List of artifact configurations, each with:
+            - type: audio, video, report, quiz, flashcards, mind_map, etc.
+            - Plus type-specific config (format, length, etc.)
+        questions: Optional list of questions to ask
+    """
+
+    name = "synthesize"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        from ..types import (
+            AudioFormat,
+            AudioLength,
+            QuizDifficulty,
+            QuizQuantity,
+            ReportFormat,
+        )
+
+        result = self._start_result(self.name)
+
+        if not ctx.notebook_id:
+            return self._complete_result(result, success=False, error="No notebook ID in context")
+
+        artifacts_config = config.get("artifacts", [])
+        questions = config.get("questions", [])
+        generated = []
+        errors = []
+
+        # Generate each artifact
+        for art_cfg in artifacts_config:
+            art_type = art_cfg.get("type", "")
+            source_ids = ctx.source_ids if ctx.source_ids else None
+
+            try:
+                if art_type == "audio":
+                    fmt = art_cfg.get("format", "conversational")
+                    # AudioFormat: DEEP_DIVE=1, BRIEF=2, CRITIQUE=3, DEBATE=4
+                    format_map = {
+                        "deep-dive": AudioFormat.DEEP_DIVE,
+                        "brief": AudioFormat.BRIEF,
+                        "critique": AudioFormat.CRITIQUE,
+                        "debate": AudioFormat.DEBATE,
+                    }
+                    audio_format = format_map.get(fmt, AudioFormat.DEEP_DIVE)
+                    length_map = {
+                        "short": AudioLength.SHORT,
+                        "medium": AudioLength.DEFAULT,
+                        "long": AudioLength.LONG,
+                    }
+                    audio_length = length_map.get(
+                        art_cfg.get("length", "medium"), AudioLength.DEFAULT
+                    )
+
+                    status = await client.artifacts.generate_audio(
+                        ctx.notebook_id,
+                        source_ids=source_ids,
+                        audio_format=audio_format,
+                        audio_length=audio_length,
+                    )
+                    ctx.artifact_ids.append(status.task_id)
+                    generated.append({"type": "audio", "task_id": status.task_id})
+
+                elif art_type == "video":
+                    status = await client.artifacts.generate_video(
+                        ctx.notebook_id, source_ids=source_ids
+                    )
+                    ctx.artifact_ids.append(status.task_id)
+                    generated.append({"type": "video", "task_id": status.task_id})
+
+                elif art_type == "report":
+                    fmt = art_cfg.get("format", "study-guide")
+                    report_format_map: dict[str, ReportFormat] = {
+                        "study-guide": ReportFormat.STUDY_GUIDE,
+                        "briefing-doc": ReportFormat.BRIEFING_DOC,
+                        "briefing_doc": ReportFormat.BRIEFING_DOC,
+                        "blog-post": ReportFormat.BLOG_POST,
+                    }
+                    report_format = report_format_map.get(fmt, ReportFormat.STUDY_GUIDE)
+
+                    status = await client.artifacts.generate_report(
+                        ctx.notebook_id,
+                        report_format=report_format,
+                        source_ids=source_ids,
+                    )
+                    ctx.artifact_ids.append(status.task_id)
+                    generated.append({"type": "report", "format": fmt, "task_id": status.task_id})
+
+                elif art_type == "quiz":
+                    difficulty_map = {
+                        "easy": QuizDifficulty.EASY,
+                        "medium": QuizDifficulty.MEDIUM,
+                        "hard": QuizDifficulty.HARD,
+                    }
+                    quantity_map = {
+                        "fewer": QuizQuantity.FEWER,
+                        "standard": QuizQuantity.STANDARD,
+                    }
+
+                    # generate_quiz uses 'quantity' not 'num_questions'
+                    status = await client.artifacts.generate_quiz(
+                        ctx.notebook_id,
+                        source_ids=source_ids,
+                        difficulty=difficulty_map.get(
+                            art_cfg.get("difficulty", "medium"), QuizDifficulty.MEDIUM
+                        ),
+                        quantity=quantity_map.get(
+                            art_cfg.get("quantity", "standard"), QuizQuantity.STANDARD
+                        ),
+                    )
+                    ctx.artifact_ids.append(status.task_id)
+                    generated.append({"type": "quiz", "task_id": status.task_id})
+
+                elif art_type == "flashcards":
+                    difficulty_map = {
+                        "easy": QuizDifficulty.EASY,
+                        "medium": QuizDifficulty.MEDIUM,
+                        "hard": QuizDifficulty.HARD,
+                    }
+                    quantity_map = {
+                        "fewer": QuizQuantity.FEWER,
+                        "standard": QuizQuantity.STANDARD,
+                    }
+
+                    # generate_flashcards uses 'quantity' not 'num_cards'
+                    status = await client.artifacts.generate_flashcards(
+                        ctx.notebook_id,
+                        source_ids=source_ids,
+                        difficulty=difficulty_map.get(
+                            art_cfg.get("difficulty", "medium"), QuizDifficulty.MEDIUM
+                        ),
+                        quantity=quantity_map.get(
+                            art_cfg.get("quantity", "standard"), QuizQuantity.STANDARD
+                        ),
+                    )
+                    ctx.artifact_ids.append(status.task_id)
+                    generated.append({"type": "flashcards", "task_id": status.task_id})
+
+                elif art_type == "mind_map":
+                    # generate_mind_map returns dict, not GenerationStatus
+                    mind_map_result = await client.artifacts.generate_mind_map(
+                        ctx.notebook_id, source_ids=source_ids
+                    )
+                    # Mind map returns dict with 'mind_map_id'
+                    if isinstance(mind_map_result, dict) and mind_map_result.get("mind_map_id"):
+                        ctx.artifact_ids.append(mind_map_result["mind_map_id"])
+                        generated.append({"type": "mind_map", "id": mind_map_result["mind_map_id"]})
+
+                else:
+                    errors.append(f"Unknown artifact type: {art_type}")
+
+            except Exception as e:
+                errors.append(f"Error generating {art_type}: {e}")
+                ctx.add_error(self.name, str(e), e)
+
+        # Ask questions if provided
+        for question in questions:
+            try:
+                ask_result = await client.chat.ask(ctx.notebook_id, question)
+                ctx.qa_results.append({"question": question, "answer": ask_result.answer})
+            except Exception as e:
+                errors.append(f"Error asking '{question[:30]}...': {e}")
+                ctx.add_error(self.name, str(e), e)
+
+        output = {
+            "artifacts_generated": len(generated),
+            "artifacts": generated,
+            "questions_answered": len(ctx.qa_results),
+        }
+        if errors:
+            output["errors"] = errors
+
+        return self._complete_result(
+            result,
+            success=len(generated) > 0 or len(ctx.qa_results) > 0,
+            output=output,
+            error="; ".join(errors) if errors and not generated else None,
+        )
+
+
+class WaitArtifactsStep(BaseStep):
+    """Wait for artifacts to finish generating.
+
+    Config:
+        timeout: Maximum wait time in seconds (default: 600)
+        poll_interval: Time between status checks (default: 10)
+    """
+
+    name = "wait_artifacts"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        result = self._start_result(self.name)
+
+        if not ctx.notebook_id:
+            return self._complete_result(result, success=False, error="No notebook ID in context")
+
+        if not ctx.artifact_ids:
+            return self._complete_result(
+                result, success=True, output={"message": "No artifacts to wait for"}
+            )
+
+        timeout = config.get("timeout", 600)
+        poll_interval = config.get("poll_interval", 10.0)
+
+        completed = []
+        failed = []
+
+        for artifact_id in ctx.artifact_ids:
+            try:
+                status = await client.artifacts.wait_for_completion(
+                    ctx.notebook_id,
+                    artifact_id,
+                    timeout=float(timeout),
+                    poll_interval=float(poll_interval),
+                )
+                if status.is_complete:
+                    completed.append(artifact_id)
+                else:
+                    failed.append({"id": artifact_id, "error": status.error})
+            except Exception as e:
+                failed.append({"id": artifact_id, "error": str(e)})
+                ctx.add_error(self.name, str(e), e)
+
+        return self._complete_result(
+            result,
+            success=len(completed) > 0,
+            output={
+                "completed": len(completed),
+                "failed": len(failed),
+                "completed_ids": completed,
+                "failed_ids": failed,
+            },
+            error=f"{len(failed)} artifacts failed" if failed else None,
+        )
+
+
+class AskStep(BaseStep):
+    """Ask questions to the notebook.
+
+    Config:
+        questions: List of questions to ask
+    """
+
+    name = "ask"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        result = self._start_result(self.name)
+
+        if not ctx.notebook_id:
+            return self._complete_result(result, success=False, error="No notebook ID in context")
+
+        questions = config.get("questions", [])
+        if not questions:
+            return self._complete_result(
+                result, success=True, output={"message": "No questions to ask"}
+            )
+
+        answers = []
+        errors = []
+
+        for question in questions:
+            try:
+                ask_result = await client.chat.ask(ctx.notebook_id, question)
+                answers.append({"question": question, "answer": ask_result.answer})
+                ctx.qa_results.append({"question": question, "answer": ask_result.answer})
+            except Exception as e:
+                errors.append(f"Error asking '{question[:30]}...': {e}")
+                ctx.add_error(self.name, str(e), e)
+
+        return self._complete_result(
+            result,
+            success=len(answers) > 0,
+            output={
+                "questions_answered": len(answers),
+                "answers": answers,
+            },
+            error="; ".join(errors) if errors and not answers else None,
+        )
+
+
+class ExportStep(BaseStep):
+    """Export artifacts to files.
+
+    Config:
+        formats: List of export configurations, each with:
+            - plugin: Exporter plugin name (e.g., "exporter:markdown", "exporter:audio")
+            - output: Output path (supports variable substitution)
+            - Plus exporter-specific config
+    """
+
+    name = "export"
+
+    async def execute(
+        self,
+        ctx: PipelineContext,
+        client: "NotebookLMClient",
+        config: dict[str, Any],
+    ) -> StepResult:
+        from pathlib import Path
+
+        result = self._start_result(self.name)
+
+        if not ctx.notebook_id:
+            return self._complete_result(result, success=False, error="No notebook ID in context")
+
+        formats_config = config.get("formats", [])
+        exported = []
+        errors = []
+
+        for fmt_cfg in formats_config:
+            plugin_type = fmt_cfg.get("plugin", "")
+            output_path = fmt_cfg.get("output", "")
+
+            try:
+                if plugin_type == "exporter:audio":
+                    # Download audio artifacts
+                    artifacts = await client.artifacts.list(ctx.notebook_id)
+                    audio_artifacts = [
+                        a for a in artifacts if a.kind.value == "audio" and a.is_completed
+                    ]
+
+                    for artifact in audio_artifacts:
+                        path = Path(output_path)
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        await client.artifacts.download_audio(
+                            ctx.notebook_id, artifact.id, str(path)
+                        )
+                        exported.append({"type": "audio", "path": str(path)})
+                        ctx.artifact_outputs[artifact.id] = str(path)
+
+                elif plugin_type == "exporter:markdown":
+                    # Export reports as markdown using download_report
+
+                    artifacts = await client.artifacts.list(ctx.notebook_id)
+                    report_artifacts = [
+                        a for a in artifacts if a.kind.value == "report" and a.is_completed
+                    ]
+
+                    for artifact in report_artifacts:
+                        path = Path(output_path)
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        # download_report writes to a file, returns the path
+                        await client.artifacts.download_report(
+                            ctx.notebook_id, str(path), artifact_id=artifact.id
+                        )
+                        exported.append({"type": "markdown", "path": str(path)})
+                        ctx.artifact_outputs[artifact.id] = str(path)
+
+                elif plugin_type == "exporter:json":
+                    # Export pipeline results as JSON
+                    import json
+
+                    path = Path(output_path)
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_text(
+                        json.dumps(ctx.to_dict(), indent=2, default=str),
+                        encoding="utf-8",
+                    )
+                    exported.append({"type": "json", "path": str(path)})
+
+                else:
+                    errors.append(f"Unknown exporter plugin: {plugin_type}")
+
+            except Exception as e:
+                errors.append(f"Error with {plugin_type}: {e}")
+                ctx.add_error(self.name, str(e), e)
+
+        return self._complete_result(
+            result,
+            success=len(exported) > 0,
+            output={
+                "exports": len(exported),
+                "files": exported,
+            },
+            error="; ".join(errors) if errors and not exported else None,
+        )
+
+
+# Registry of built-in steps
+BUILTIN_STEPS: dict[str, type[BaseStep]] = {
+    "create_notebook": CreateNotebookStep,
+    "ingest": IngestStep,
+    "wait_sources": WaitSourcesStep,
+    "synthesize": SynthesizeStep,
+    "wait_artifacts": WaitArtifactsStep,
+    "ask": AskStep,
+    "export": ExportStep,
+}
+
+
+def get_builtin_step(name: str) -> BaseStep | None:
+    """Get a built-in step by name.
+
+    Args:
+        name: Step name (e.g., "create_notebook", "ingest")
+
+    Returns:
+        Step instance or None if not found
+    """
+    step_class = BUILTIN_STEPS.get(name)
+    if step_class:
+        return step_class()
+    return None


### PR DESCRIPTION
## Summary

Add a new modular pipeline framework for chainable, YAML-driven workflows:

- **PipelineEngine** for orchestrating multi-step workflows
- **Plugin system** with source, tool, and exporter plugins
- **Built-in steps**: create_notebook, ingest, wait_sources, synthesize, wait_artifacts, ask, export
- **Source plugins**: youtube, web_url, research
- **Tool plugin**: notebooklm (wraps client for artifact generation)
- **Exporter plugins**: markdown, json, audio
- **CLI commands**: `pipeline run/list/validate/create/status`
- **Built-in templates**: research-to-podcast, document-analysis, youtube-knowledge

## Usage

```bash
# Run a pipeline with variables
notebooklm pipeline run research-to-podcast.yaml --var topic="quantum computing"

# List available templates
notebooklm pipeline list

# Validate a pipeline config
notebooklm pipeline validate my-pipeline.yaml

# Create from template
notebooklm pipeline create --template research-to-podcast my-research.yaml

# Check available steps and plugins
notebooklm pipeline status
```

## Example Pipeline YAML

```yaml
pipeline:
  name: "research-to-podcast"
  description: "Research a topic and create a podcast"

variables:
  topic: null  # Required at runtime

steps:
  - name: create_notebook
    type: builtin:create_notebook
    config:
      title: "Research: {{ topic }}"

  - name: research_sources
    type: source:research
    config:
      query: "{{ topic }}"
      max_sources: 10

  - name: generate_podcast
    type: tool:notebooklm
    config:
      artifacts:
        - type: audio
          format: deep-dive
          length: medium

  - name: export_audio
    type: exporter:audio
    config:
      output: "./output/{{ topic | slugify }}.mp3"
```

## Test plan

- [x] All 1282 unit tests pass
- [x] Ruff format/lint checks pass
- [x] mypy type checking passes
- [x] CLI commands verified working (`pipeline --help`, `status`, `list`, `validate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)