### PR TITLE
fix(research): add report_id parameter to import_sources()

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ playwright install chromium
 uv pip install -e ".[all]"
 ```
 
+### Alternative: Conda/Mamba Installation
+
+[Conda](https://docs.conda.io/) or [Mamba](https://mamba.readthedocs.io/) can be used for environment management:
+
+```bash
+# Using conda
+conda install -c conda-forge notebooklm-py
+
+# Using mamba (faster)
+mamba install -c conda-forge notebooklm-py
+```
+
 ### Development Installation
 
 For contributors or testing unreleased features:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,25 @@ pip install "notebooklm-py[browser]"
 playwright install chromium
 ```
 
+### Alternative: uv Installation
+
+[uv](https://github.com/astral-sh/uv) is a fast Python package installer and resolver written in Rust:
+
+```bash
+# Install uv if you don't have it
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Basic installation with uv
+uv pip install notebooklm-py
+
+# With browser login support
+uv pip install "notebooklm-py[browser]"
+playwright install chromium
+
+# Development installation
+uv pip install -e ".[all]"
+```
+
 ### Development Installation
 
 For contributors or testing unreleased features:

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -22,15 +22,18 @@ class ResearchAPI:
 
     Usage:
         async with NotebookLMClient.from_storage() as client:
-            # Start research
-            task = await client.research.start(notebook_id, "quantum computing")
+            # Start research (deep mode for comprehensive results)
+            task = await client.research.start(notebook_id, "quantum computing", mode="deep")
 
             # Poll for results
             result = await client.research.poll(notebook_id)
             if result["status"] == "completed":
-                # Import selected sources
+                # Import selected sources AND preserve the deep research report
                 imported = await client.research.import_sources(
-                    notebook_id, task["task_id"], result["sources"][:5]
+                    notebook_id,
+                    task["task_id"],
+                    result["sources"][:5],
+                    report_id=task["report_id"],  # Preserve deep research report
                 )
     """
 
@@ -198,6 +201,7 @@ class ResearchAPI:
         task_id: str,
         sources: list[dict[str, str]],
         allow_title_only: bool = False,
+        report_id: str | None = None,
     ) -> list[dict[str, str]]:
         """Import selected research sources into the notebook.
 
@@ -207,6 +211,9 @@ class ResearchAPI:
             sources: List of sources to import, each with 'url' and 'title'.
             allow_title_only: If True, allow importing sources without URLs
                 (e.g., deep research sources that only have titles).
+            report_id: Optional report ID from deep research to preserve the
+                research report in the notebook. If provided, the deep research
+                report will be preserved after importing sources.
 
         Returns:
             List of imported sources with 'id' and 'title'.
@@ -270,7 +277,9 @@ class ResearchAPI:
                     2,
                 ])
 
-        params = [None, [1], task_id, notebook_id, source_array]
+        # Build params: [report_id, [1], task_id, notebook_id, source_array]
+        # report_id is at position 0 to preserve deep research reports
+        params = [report_id, [1], task_id, notebook_id, source_array]
 
         result = await self._core.rpc_call(
             RPCMethod.IMPORT_RESEARCH,

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -197,6 +197,7 @@ class ResearchAPI:
         notebook_id: str,
         task_id: str,
         sources: list[dict[str, str]],
+        allow_title_only: bool = False,
     ) -> list[dict[str, str]]:
         """Import selected research sources into the notebook.
 
@@ -204,6 +205,8 @@ class ResearchAPI:
             notebook_id: The notebook ID.
             task_id: The research task ID.
             sources: List of sources to import, each with 'url' and 'title'.
+            allow_title_only: If True, allow importing sources without URLs
+                (e.g., deep research sources that only have titles).
 
         Returns:
             List of imported sources with 'id' and 'title'.
@@ -220,29 +223,52 @@ class ResearchAPI:
             return []
 
         # Filter out sources without URLs - these cause the entire batch to fail
-        valid_sources = [s for s in sources if s.get("url")]
-        skipped_count = len(sources) - len(valid_sources)
-        if skipped_count > 0:
-            logger.warning("Skipping %d source(s) without URLs (cannot be imported)", skipped_count)
+        # However, deep research sources often only have titles without URLs
+        if allow_title_only:
+            valid_sources = sources
+        else:
+            valid_sources = [s for s in sources if s.get("url")]
+            skipped_count = len(sources) - len(valid_sources)
+            if skipped_count > 0:
+                logger.warning("Skipping %d source(s) without URLs (cannot be imported)", skipped_count)
         if not valid_sources:
             return []
 
-        source_array = [
-            [
-                None,
-                None,
-                [src["url"], src.get("title", "Untitled")],
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                2,
-            ]
-            for src in valid_sources
-        ]
+        source_array = []
+        for src in valid_sources:
+            url = src.get("url")
+            title = src.get("title", "Untitled")
+            if url:
+                # Standard source with URL
+                source_array.append([
+                    None,
+                    None,
+                    [url, title],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    2,
+                ])
+            else:
+                # Title-only source (e.g., deep research results)
+                # Format: [None, title, None, type, ...]
+                source_array.append([
+                    None,
+                    title,
+                    None,
+                    1,  # source type
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    2,
+                ])
 
         params = [None, [1], task_id, notebook_id, source_array]
 

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -221,6 +221,17 @@ def register_session_commands(cli):
 
             input("[Press ENTER when logged in] ")
 
+            # Navigate to accounts.google.com to ensure .google.com cookies are set
+            # (fixes UK/regional users whose cookies land on .google.co.uk)
+            # See: https://github.com/teng-lin/notebooklm-py/issues/146
+            try:
+                page.goto("https://accounts.google.com/", wait_until="networkidle", timeout=10000)
+                page.goto("https://myaccount.google.com/", wait_until="networkidle", timeout=10000)
+                # Return to NotebookLM to capture its specific cookies too
+                page.goto("https://notebooklm.google.com/", wait_until="networkidle", timeout=10000)
+            except Exception as e:
+                logger.debug(f"Cross-domain cookie navigation failed: {e}")
+
             current_url = page.url
             if "notebooklm.google.com" not in current_url:
                 console.print(f"[yellow]Warning: Current URL is {current_url}[/yellow]")

--- a/src/notebooklm/data/SKILL.md
+++ b/src/notebooklm/data/SKILL.md
@@ -559,3 +559,43 @@ notebooklm language --help     # Language settings
 **Re-authenticate:** `notebooklm login`
 **Check version:** `notebooklm --version`
 **Update skill:** `notebooklm skill install`
+
+## OpenClaw Integration
+
+This skill also works with **OpenClaw** (openclaw.ai). OpenClaw is an AI assistant platform that supports CLI tools.
+
+### Installation for OpenClaw
+
+1. Install the package:
+```bash
+pip install notebooklm-py
+```
+
+2. Authenticate:
+```bash
+notebooklm login
+```
+
+3. Verify:
+```bash
+notebooklm status
+```
+
+### OpenClaw-Specific Notes
+
+- OpenClaw uses the same CLI interface as Claude Code
+- All commands and workflows documented above apply
+- For OpenClaw skill installation, the skill file is automatically available after pip install
+- Use explicit notebook IDs (`-n <id>`) in parallel workflows to avoid context conflicts
+- JSON output (`--json`) is recommended for programmatic integration
+
+### Example OpenClaw Workflow
+
+```
+User: Create a podcast about machine learning
+Agent: 1. notebooklm create "ML Research"
+       2. notebooklm source add "https://en.wikipedia.org/wiki/Machine_learning"
+       3. notebooklm source wait <source_id>
+       4. notebooklm generate audio "Explain key ML concepts"
+       5. notebooklm download audio ./ml-podcast.mp3
+```


### PR DESCRIPTION
## Summary

Add optional `report_id` parameter to `import_sources()` to preserve deep research reports when importing sources.

## Changes

- Add optional `report_id: str | None = None` parameter to `import_sources()`
- Update docstring with parameter description
- Modify RPC params to include report_id at position 0
- Update usage example to show deep research workflow

## Fixes

- Fixes issue #180: Deep research report disappears after `import_sources()`
- Closes #185

## Usage

```python
# Start deep research
task = await client.research.start(notebook_id, "quantum computing", mode="deep")

# Poll for results
result = await client.research.poll(notebook_id)
if result["status"] == "completed":
    # Import selected sources AND preserve the deep research report
    imported = await client.research.import_sources(
        notebook_id,
        task["task_id"],
        result["sources"][:5],
        report_id=task["report_id"]
    )
```