### PR TITLE
test(cli): avoid CodeQL URL substring assertion

### DIFF
--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -772,4 +772,5 @@ class TestNotebookMetadata:
                 result = runner.invoke(cli, ["metadata"])
 
             assert result.exit_code == 0
-            assert "https://example.com" in result.output
+            output_lines = result.output.splitlines()
+            assert "     https://example.com/article" in output_lines


### PR DESCRIPTION
## Summary
- replace the metadata CLI URL substring assertion with an exact line assertion
- keep the test behavior the same while avoiding the CodeQL incomplete URL substring sanitization rule

## Verification
- ============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0 -- /opt/homebrew/opt/python@3.14/bin/python3.14
cachedir: .pytest_cache
rootdir: /Users/blackmyth/src/notebooklm-py
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 33 items / 32 deselected / 1 selected

tests/unit/cli/test_notebook.py::TestNotebookMetadata::test_metadata_with_url_source PASSED [100%]

=============================== warnings summary ===============================
../../../../opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1428
  /opt/homebrew/lib/python3.14/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: timeout
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 1 passed, 32 deselected, 1 warning in 0.02s ==================

Follow-up to merged PR #174.