### PR TITLE
feat(cli): add timeout flag to source add-research

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -411,6 +411,7 @@ notebooklm source add-research <query> [OPTIONS]
 - `--mode [fast|deep]` - Research depth (default: fast)
 - `--from [web|drive]` - Search source (default: web)
 - `--import-all` - Automatically import all found sources (works with blocking mode)
+- `--timeout SECONDS` - Maximum seconds to keep retrying imports when `--import-all` is used (default: 1800)
 - `--no-wait` - Start research and return immediately (non-blocking)
 
 **Examples:**
@@ -423,6 +424,9 @@ notebooklm source add-research "Project Alpha" --from drive --mode deep
 
 # Non-blocking deep research for agent workflows
 notebooklm source add-research "AI safety papers" --mode deep --no-wait
+
+# Keep retrying imports for up to 10 minutes
+notebooklm source add-research "AI safety papers" --import-all --timeout 600
 ```
 
 ### Research: `status`

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -421,13 +421,19 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources")
 @click.option(
+    "--timeout",
+    default=1800,
+    type=int,
+    help="Maximum seconds to keep retrying imports when --import-all is used (default: 1800)",
+)
+@click.option(
     "--no-wait",
     is_flag=True,
     help="Start research and return immediately (use 'research status/wait' to monitor)",
 )
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, no_wait, client_auth
+    ctx, query, notebook_id, search_source, mode, import_all, timeout, no_wait, client_auth
 ):
     """Search web or drive and add sources from results.
 
@@ -486,6 +492,7 @@ def source_add_research(
                         nb_id_resolved,
                         task_id,
                         sources,
+                        max_elapsed=float(timeout),
                     )
                     console.print(f"[green]Imported {len(imported)} sources[/green]")
             else:

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -489,6 +489,49 @@ class TestSourceAddResearch:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=1800.0,
+        )
+
+    def test_add_research_with_import_all_passes_custom_timeout(self, runner, mock_auth):
+        with (
+            patch_client_for_module("source") as mock_client_cls,
+            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "sources": [{"title": "Source 1", "url": "http://example.com"}],
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add-research",
+                        "AI papers",
+                        "--import-all",
+                        "--timeout",
+                        "45",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=45.0,
         )
 
 


### PR DESCRIPTION
## Summary
- add a `--timeout` option to `notebooklm source add-research`
- pass that value through to `import_with_retry()` when `--import-all` is used
- document the new CLI flag and cover default/custom timeout behavior in unit tests

## Testing
- `python -m pytest tests/unit/cli/test_source.py tests/unit/cli/test_notebook.py tests/unit/cli/test_research.py -q`
- `python -m ruff check src/notebooklm/cli/source.py tests/unit/cli/test_source.py`

Closes #194.
