### PR TITLE
Add caching, living docs, bulk operations, and notebook health checks

### DIFF
--- a/docs/auth-architecture.md
+++ b/docs/auth-architecture.md
@@ -1,0 +1,301 @@
+# Authentication Architecture
+
+**Status:** Active
+**Last Updated:** 2026-03-11
+
+This document explains how authentication works across all notebooklm-py surfaces (Python library, CLI, MCP worker) and how to bridge between them.
+
+## Overview
+
+NotebookLM uses Google's cookie-based authentication. Every API call requires:
+
+1. **Session cookies** (~25 cookies from `.google.com` and related domains)
+2. **CSRF token** (`SNlM0e`) — extracted from the NotebookLM homepage HTML
+3. **Session ID** (`FdrFJe`) — extracted from the NotebookLM homepage HTML
+4. **Build label** (`cfb2h`) — optional but keeps the `bl` parameter current
+
+Cookies are long-lived (days to weeks). CSRF tokens and session IDs are short-lived and auto-refreshed by the client.
+
+## Auth Surfaces
+
+### 1. Python Library (`NotebookLMClient`)
+
+The library uses `AuthTokens` — a dataclass holding cookies + CSRF + session ID + build label.
+
+```python
+# AuthTokens.from_storage() does everything:
+# 1. Loads cookies from storage_state.json or NOTEBOOKLM_AUTH_JSON
+# 2. Fetches notebooklm.google.com to extract CSRF, session ID, build label
+# 3. Returns a ready-to-use AuthTokens instance
+
+auth = await AuthTokens.from_storage()
+async with NotebookLMClient(auth) as client:
+    notebooks = await client.notebooks.list()
+```
+
+**Auto-refresh:** When an API call fails with an auth error, `client.refresh_auth()` re-fetches the homepage to get fresh CSRF/session tokens. This is automatic — the `ClientCore` calls the refresh callback on auth failures.
+
+### 2. CLI (`notebooklm` command)
+
+The CLI uses the `@with_client` decorator which calls `get_auth_tokens(ctx)` → `AuthTokens.from_storage()`. Same auth pipeline as the library.
+
+```bash
+# Interactive login — opens browser, saves cookies
+notebooklm login
+
+# All subsequent commands load from storage automatically
+notebooklm list
+notebooklm ask "What is this about?"
+```
+
+### 3. MCP Worker (`notebooklm-worker`)
+
+The MCP worker is a Cloudflare Worker that stores auth in **R2 object storage** and **KV**. It has its own cookie store that is NOT shared with the local CLI/library.
+
+**Key difference:** The MCP worker's auth is isolated. There is no MCP tool that exports raw cookies.
+
+| MCP Tool | What It Does | Exports Cookies? |
+|----------|-------------|-----------------|
+| `nlm_auth_status` | Returns `authenticated`, `cookie_count`, `has_csrf` | No — status only |
+| `refresh_auth` | Re-fetches CSRF/session tokens from homepage | No — returns `has_csrf`, `build_label` |
+| `save_auth_tokens` | Saves cookies TO the worker's R2 store | No — input only, not output |
+
+## Auth Loading Precedence
+
+When the library or CLI loads auth, it checks these sources in order:
+
+```
+1. --storage CLI flag          (explicit path to storage_state.json)
+      ↓ (if not provided)
+2. NOTEBOOKLM_AUTH_JSON        (env var with inline JSON — for CI/CD)
+      ↓ (if not set)
+3. $NOTEBOOKLM_HOME/storage_state.json   (custom home dir)
+      ↓ (if NOTEBOOKLM_HOME not set)
+4. ~/.notebooklm/storage_state.json      (default location)
+```
+
+**First match wins.** If none found, raises `FileNotFoundError`.
+
+### Source: `auth.py:_load_storage_state()`
+
+```python
+def _load_storage_state(path: Path | None = None) -> dict[str, Any]:
+    # 1. Explicit path (--storage flag)
+    if path:
+        return json.loads(path.read_text())
+
+    # 2. NOTEBOOKLM_AUTH_JSON env var
+    if "NOTEBOOKLM_AUTH_JSON" in os.environ:
+        return json.loads(os.environ["NOTEBOOKLM_AUTH_JSON"])
+
+    # 3. File at configured home dir
+    storage_path = get_storage_path()  # respects NOTEBOOKLM_HOME
+    return json.loads(storage_path.read_text())
+```
+
+## Storage State Format
+
+The `storage_state.json` file uses Playwright's format:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "SID",
+      "value": "g.a000abc...",
+      "domain": ".google.com",
+      "path": "/",
+      "expires": 1742000000,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "__Secure-1PSID",
+      "value": "g.a000xyz...",
+      "domain": ".google.com",
+      "path": "/",
+      "expires": 1742000000,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "None"
+    }
+  ],
+  "origins": []
+}
+```
+
+**Minimum required cookie:** `SID` (checked by `extract_cookies_from_storage()`).
+
+**Commonly present cookies (~25):**
+`SID`, `HSID`, `SSID`, `APISID`, `SAPISID`, `__Secure-1PSID`, `__Secure-3PSID`, `__Secure-1PSIDTS`, `__Secure-3PSIDTS`, `__Secure-1PAPISID`, `__Secure-3PAPISID`, `NID`, `AEC`, `SOCS`, plus others.
+
+## Cookie Domain Handling
+
+Google sets cookies on multiple domains depending on the user's region:
+
+| Domain Pattern | Example | Priority |
+|---------------|---------|----------|
+| `.google.com` | Base domain | Highest — always preferred |
+| `.google.com.XX` | `.google.com.sg` (Singapore) | Fallback |
+| `.google.co.XX` | `.google.co.uk` (UK) | Fallback |
+| `.google.XX` | `.google.de` (Germany) | Fallback |
+
+When the same cookie name exists on multiple domains (e.g., `SID` on both `.google.com` and `.google.com.sg`), the `.google.com` value always wins. This prevents non-deterministic behavior.
+
+**Supported regional domains:** See `GOOGLE_REGIONAL_CCTLDS` in `auth.py` for the full list (~50 countries).
+
+## Token Lifecycle
+
+```
+notebooklm login (browser)
+    │
+    ├── Saves cookies to storage_state.json
+    │   (long-lived: days to weeks)
+    │
+    ▼
+AuthTokens.from_storage()
+    │
+    ├── Loads cookies from storage
+    ├── GET https://notebooklm.google.com/
+    ├── Extracts SNlM0e (CSRF token)
+    ├── Extracts FdrFJe (session ID)
+    └── Extracts cfb2h (build label)
+        (short-lived: hours)
+    │
+    ▼
+API calls using cookies + CSRF + session ID
+    │
+    ├── On auth error → client.refresh_auth()
+    │   └── Re-fetches homepage for fresh CSRF/session
+    │       (cookies stay the same)
+    │
+    └── On persistent auth error → cookies expired
+        └── Must re-run: notebooklm login
+```
+
+## Bridging MCP Worker ↔ Local CLI
+
+**Problem:** The MCP worker and local CLI maintain separate auth stores. You cannot directly export cookies from the MCP worker to use locally.
+
+### How to Share Auth
+
+#### Option A: Browser Login (Recommended)
+
+Both the MCP worker and local CLI authenticate against the same Google account. Log in once locally and the cookies work everywhere:
+
+```bash
+# 1. Login locally
+notebooklm login
+
+# 2. Verify it works
+notebooklm list
+
+# 3. If MCP worker needs the same cookies, export and save:
+cat ~/.notebooklm/storage_state.json
+# → Use save_auth_tokens MCP tool to push cookies to the worker
+```
+
+#### Option B: Export from Browser DevTools
+
+If `notebooklm login` isn't available (headless server), extract cookies manually:
+
+1. Open https://notebooklm.google.com in Chrome
+2. Open DevTools → Application → Cookies
+3. Copy all `.google.com` cookies
+4. Format as Playwright storage state JSON
+5. Save to `~/.notebooklm/storage_state.json` or set `NOTEBOOKLM_AUTH_JSON`
+
+#### Option C: CI/CD with Env Var
+
+```bash
+# Set inline auth (no file writes)
+export NOTEBOOKLM_AUTH_JSON='{"cookies":[{"name":"SID","value":"...","domain":".google.com",...}]}'
+
+# CLI and library both pick this up automatically
+notebooklm list
+python -c "
+import asyncio
+from notebooklm import NotebookLMClient
+async def main():
+    async with await NotebookLMClient.from_storage() as client:
+        print(await client.notebooks.list())
+asyncio.run(main())
+"
+```
+
+#### Option D: Share Between Machines
+
+```bash
+# Copy auth to remote machine
+scp ~/.notebooklm/storage_state.json user@server:~/.notebooklm/
+
+# Or use a shared path
+export NOTEBOOKLM_HOME=/shared/mount/.notebooklm
+```
+
+### What Does NOT Work
+
+| Approach | Why It Fails |
+|----------|-------------|
+| `nlm_auth_status` MCP tool | Returns flags (`authenticated: true`), not cookie values |
+| `refresh_auth` MCP tool | Returns `has_csrf`/`build_label`, not cookies |
+| `save_auth_tokens` MCP tool | Saves cookies TO the worker, doesn't export FROM it |
+| Reading MCP worker's R2/KV | No tool exposes raw cookie data from storage |
+
+## Troubleshooting
+
+### "Storage file not found"
+
+```
+FileNotFoundError: Storage file not found: ~/.notebooklm/storage_state.json
+Run 'notebooklm login' to authenticate first.
+```
+
+**Fix:** Run `notebooklm login` or set `NOTEBOOKLM_AUTH_JSON`.
+
+### "Missing required cookies: {'SID'}"
+
+The storage state file exists but doesn't contain Google auth cookies.
+
+**Fix:** Re-run `notebooklm login`. The existing `storage_state.json` may be from a failed login.
+
+### "Authentication expired or invalid"
+
+CSRF token extraction failed — Google redirected to login page.
+
+**Fix:**
+1. Try `notebooklm login` to get fresh cookies
+2. If cookies are less than a day old, it may be a transient issue — retry
+
+### "Session Expired" errors during API calls
+
+The CSRF token or session ID expired but cookies are still valid.
+
+**Fix:** This should auto-recover. The `refresh_auth()` callback re-fetches tokens automatically. If it persists, cookies have expired → re-login.
+
+### MCP Worker authenticated but CLI is not
+
+The MCP worker and CLI use independent auth stores.
+
+**Fix:** Run `notebooklm login` locally. The MCP worker's cookies cannot be exported to the CLI.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/notebooklm/auth.py` | `AuthTokens`, cookie extraction, token fetching |
+| `src/notebooklm/_core.py` | `ClientCore` with auto-refresh on auth failure |
+| `src/notebooklm/client.py` | `refresh_auth()` method on `NotebookLMClient` |
+| `src/notebooklm/cli/helpers.py` | `get_auth_tokens()`, `@with_client` decorator |
+| `src/notebooklm/paths.py` | `get_storage_path()`, `get_home_dir()` |
+| `~/.notebooklm/storage_state.json` | Default cookie storage location |
+
+## Security Notes
+
+- `storage_state.json` contains sensitive session cookies — treat as a credential file
+- Set permissions to `600` (`chmod 600 storage_state.json`)
+- Never commit to git or share publicly
+- `NOTEBOOKLM_AUTH_JSON` stays in memory only (no file written)
+- Cookie domains are validated against a whitelist to prevent injection
+- Regional domain handling prevents `.google.com` suffix attacks (e.g., `evil-google.com` is rejected)

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -894,7 +894,7 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
 
     print("Fetching auth tokens...")
     try:
-        csrf_token, session_id = await fetch_tokens(cookies)
+        csrf_token, session_id, _build_label = await fetch_tokens(cookies)
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(2)

--- a/scripts/diagnose_get_notebook.py
+++ b/scripts/diagnose_get_notebook.py
@@ -139,7 +139,7 @@ async def run_diagnosis(notebook_id: str | None = None) -> None:
 
     print("Fetching auth tokens...")
     try:
-        csrf_token, session_id = await fetch_tokens(cookies)
+        csrf_token, session_id, _build_label = await fetch_tokens(cookies)
     except (ValueError, httpx.HTTPError) as e:
         print(f"ERROR: Failed to fetch auth tokens: {e}")
         print("Try running: notebooklm login")

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -43,6 +43,9 @@ except PackageNotFoundError:
 # Public API: Cache
 from ._cache import CacheConfig, CacheMiddleware
 
+# Public API: Living Docs
+from ._living_docs import LivingDoc, LivingDocsAPI, StaleCheckResult, SyncResult
+
 # Public API: Authentication
 from .auth import DEFAULT_STORAGE_PATH, AuthTokens
 
@@ -138,6 +141,11 @@ __all__ = [
     # Cache
     "CacheConfig",
     "CacheMiddleware",
+    # Living Docs
+    "LivingDocsAPI",
+    "LivingDoc",
+    "StaleCheckResult",
+    "SyncResult",
     # Auth
     "AuthTokens",
     "DEFAULT_STORAGE_PATH",

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -103,6 +103,7 @@ from .types import (
     Note,
     Notebook,
     NotebookDescription,
+    NotebookHealth,
     QuizDifficulty,
     QuizQuantity,
     ReportFormat,
@@ -136,6 +137,7 @@ __all__ = [
     # Types
     "Notebook",
     "NotebookDescription",
+    "NotebookHealth",
     "SuggestedTopic",
     "Source",
     "SourceFulltext",

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -40,6 +40,9 @@ except PackageNotFoundError:
         __version__,
     )
 
+# Public API: Cache
+from ._cache import CacheConfig, CacheMiddleware
+
 # Public API: Authentication
 from .auth import DEFAULT_STORAGE_PATH, AuthTokens
 
@@ -131,6 +134,9 @@ __all__ = [
     "__version__",
     # Client (main entry point)
     "NotebookLMClient",
+    # Cache
+    "CacheConfig",
+    "CacheMiddleware",
     # Auth
     "AuthTokens",
     "DEFAULT_STORAGE_PATH",

--- a/src/notebooklm/_cache.py
+++ b/src/notebooklm/_cache.py
@@ -1,0 +1,498 @@
+"""Cache middleware for NotebookLM API client.
+
+Provides an optional caching layer that intercepts API calls to reduce
+rate limiting and store query/response pairs for dataset building.
+
+Supports two backends:
+- LocalSQLiteBackend: Local SQLite database (default, no external deps)
+- NullBackend: No-op backend (caching disabled)
+
+The cache is opt-in and does not affect behavior when not configured.
+"""
+
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheConfig:
+    """Configuration for the cache middleware.
+
+    Attributes:
+        enabled: Whether caching is enabled.
+        db_path: Path to the SQLite database file. If None, uses
+            ~/.notebooklm/cache.db.
+        default_ttl: Default TTL in seconds for cached entries (300 = 5 min).
+        query_ttl: TTL for chat query/response cache (86400 = 24 hours).
+        notebook_ttl: TTL for notebook metadata cache (300 = 5 min).
+        source_ttl: TTL for source content cache (3600 = 1 hour).
+        log_queries: Whether to log all queries for dataset building.
+    """
+
+    enabled: bool = True
+    db_path: Path | None = None
+    default_ttl: int = 300
+    query_ttl: int = 86400
+    notebook_ttl: int = 300
+    source_ttl: int = 3600
+    log_queries: bool = True
+
+
+@dataclass
+class CacheEntry:
+    """A cached value with metadata."""
+
+    key: str
+    value: Any
+    created_at: float
+    ttl: int
+    hit_count: int = 0
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the cache entry has expired."""
+        if self.ttl <= 0:
+            return False  # TTL 0 = never expires
+        return (time.time() - self.created_at) > self.ttl
+
+
+class CacheBackend:
+    """Abstract cache backend interface."""
+
+    def get(self, key: str) -> CacheEntry | None:
+        """Get a cached entry by key."""
+        raise NotImplementedError
+
+    def set(self, key: str, value: Any, ttl: int = 300) -> None:
+        """Store a value in the cache."""
+        raise NotImplementedError
+
+    def delete(self, key: str) -> bool:
+        """Delete a cached entry."""
+        raise NotImplementedError
+
+    def invalidate_prefix(self, prefix: str) -> int:
+        """Delete all entries matching a key prefix."""
+        raise NotImplementedError
+
+    def store_query(
+        self,
+        notebook_id: str,
+        query_text: str,
+        response_text: str,
+        *,
+        citations: str | None = None,
+        conversation_id: str | None = None,
+        turn_number: int = 1,
+        source_ids: list[str] | None = None,
+        latency_ms: int | None = None,
+    ) -> None:
+        """Store a query/response pair for dataset building."""
+        raise NotImplementedError
+
+    def log_query(
+        self,
+        notebook_id: str,
+        query_text: str,
+        *,
+        response_length: int = 0,
+        citation_count: int = 0,
+        source_count: int = 0,
+        latency_ms: int = 0,
+        cache_hit: bool = False,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Log a query for analytics (append-only)."""
+        raise NotImplementedError
+
+    def close(self) -> None:
+        """Close the backend."""
+        pass
+
+
+class NullBackend(CacheBackend):
+    """No-op backend when caching is disabled."""
+
+    def get(self, key: str) -> CacheEntry | None:
+        return None
+
+    def set(self, key: str, value: Any, ttl: int = 300) -> None:
+        pass
+
+    def delete(self, key: str) -> bool:
+        return False
+
+    def invalidate_prefix(self, prefix: str) -> int:
+        return 0
+
+    def store_query(
+        self, notebook_id: str, query_text: str, response_text: str, **kwargs: Any
+    ) -> None:
+        pass
+
+    def log_query(self, notebook_id: str, query_text: str, **kwargs: Any) -> None:
+        pass
+
+
+class LocalSQLiteBackend(CacheBackend):
+    """SQLite-based cache backend for local use.
+
+    Creates tables matching the D1 schema so data can be migrated
+    to Cloudflare D1 when running via the worker.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.row_factory = sqlite3.Row
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        """Create cache tables if they don't exist."""
+        self._conn.executescript("""
+            CREATE TABLE IF NOT EXISTS nlm_cache (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                ttl INTEGER NOT NULL DEFAULT 300,
+                hit_count INTEGER DEFAULT 0
+            );
+
+            CREATE TABLE IF NOT EXISTS nlm_query_cache (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                notebook_id TEXT NOT NULL,
+                query_hash TEXT NOT NULL,
+                query_text TEXT NOT NULL,
+                response_text TEXT NOT NULL,
+                response_citations TEXT,
+                conversation_id TEXT,
+                turn_number INTEGER DEFAULT 1,
+                source_ids TEXT,
+                model_context TEXT,
+                latency_ms INTEGER,
+                created_at REAL NOT NULL,
+                expires_at REAL,
+                hit_count INTEGER DEFAULT 0,
+                UNIQUE(notebook_id, query_hash)
+            );
+
+            CREATE TABLE IF NOT EXISTS nlm_query_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                notebook_id TEXT NOT NULL,
+                query_text TEXT NOT NULL,
+                response_length INTEGER,
+                citation_count INTEGER,
+                source_count INTEGER,
+                latency_ms INTEGER,
+                cache_hit INTEGER DEFAULT 0,
+                agent_id TEXT,
+                session_id TEXT,
+                created_at REAL NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_cache_key ON nlm_cache(key);
+            CREATE INDEX IF NOT EXISTS idx_qc_notebook ON nlm_query_cache(notebook_id);
+            CREATE INDEX IF NOT EXISTS idx_qc_hash ON nlm_query_cache(query_hash);
+        """)
+
+    def get(self, key: str) -> CacheEntry | None:
+        """Get a cached entry by key."""
+        row = self._conn.execute(
+            "SELECT key, value, created_at, ttl, hit_count FROM nlm_cache WHERE key = ?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return None
+
+        entry = CacheEntry(
+            key=row["key"],
+            value=json.loads(row["value"]),
+            created_at=row["created_at"],
+            ttl=row["ttl"],
+            hit_count=row["hit_count"],
+        )
+
+        if entry.is_expired:
+            self.delete(key)
+            return None
+
+        # Increment hit count
+        self._conn.execute(
+            "UPDATE nlm_cache SET hit_count = hit_count + 1 WHERE key = ?",
+            (key,),
+        )
+        self._conn.commit()
+        return entry
+
+    def set(self, key: str, value: Any, ttl: int = 300) -> None:
+        """Store a value in the cache."""
+        self._conn.execute(
+            """INSERT OR REPLACE INTO nlm_cache (key, value, created_at, ttl, hit_count)
+               VALUES (?, ?, ?, ?, 0)""",
+            (key, json.dumps(value), time.time(), ttl),
+        )
+        self._conn.commit()
+
+    def delete(self, key: str) -> bool:
+        """Delete a cached entry."""
+        cursor = self._conn.execute("DELETE FROM nlm_cache WHERE key = ?", (key,))
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def invalidate_prefix(self, prefix: str) -> int:
+        """Delete all entries matching a key prefix."""
+        cursor = self._conn.execute(
+            "DELETE FROM nlm_cache WHERE key LIKE ?",
+            (f"{prefix}%",),
+        )
+        self._conn.commit()
+        return cursor.rowcount
+
+    def store_query(
+        self,
+        notebook_id: str,
+        query_text: str,
+        response_text: str,
+        *,
+        citations: str | None = None,
+        conversation_id: str | None = None,
+        turn_number: int = 1,
+        source_ids: list[str] | None = None,
+        latency_ms: int | None = None,
+    ) -> None:
+        """Store a query/response pair."""
+        query_hash = _normalize_and_hash(query_text)
+        source_ids_json = json.dumps(source_ids) if source_ids else None
+
+        self._conn.execute(
+            """INSERT OR REPLACE INTO nlm_query_cache
+               (notebook_id, query_hash, query_text, response_text,
+                response_citations, conversation_id, turn_number,
+                source_ids, latency_ms, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                notebook_id,
+                query_hash,
+                query_text,
+                response_text,
+                citations,
+                conversation_id,
+                turn_number,
+                source_ids_json,
+                latency_ms,
+                time.time(),
+            ),
+        )
+        self._conn.commit()
+
+    def get_cached_query(self, notebook_id: str, query_text: str) -> str | None:
+        """Look up a cached query response."""
+        query_hash = _normalize_and_hash(query_text)
+        row = self._conn.execute(
+            """SELECT response_text, created_at FROM nlm_query_cache
+               WHERE notebook_id = ? AND query_hash = ?""",
+            (notebook_id, query_hash),
+        ).fetchone()
+
+        if row is None:
+            return None
+
+        # Update hit count
+        self._conn.execute(
+            """UPDATE nlm_query_cache SET hit_count = hit_count + 1
+               WHERE notebook_id = ? AND query_hash = ?""",
+            (notebook_id, query_hash),
+        )
+        self._conn.commit()
+        return row["response_text"]
+
+    def log_query(
+        self,
+        notebook_id: str,
+        query_text: str,
+        *,
+        response_length: int = 0,
+        citation_count: int = 0,
+        source_count: int = 0,
+        latency_ms: int = 0,
+        cache_hit: bool = False,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Log a query for analytics."""
+        self._conn.execute(
+            """INSERT INTO nlm_query_log
+               (notebook_id, query_text, response_length, citation_count,
+                source_count, latency_ms, cache_hit, agent_id, session_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                notebook_id,
+                query_text,
+                response_length,
+                citation_count,
+                source_count,
+                latency_ms,
+                1 if cache_hit else 0,
+                agent_id,
+                session_id,
+                time.time(),
+            ),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+        if self._conn:
+            self._conn.close()
+
+
+class CacheMiddleware:
+    """Optional cache layer that wraps API calls.
+
+    Usage:
+        config = CacheConfig(enabled=True)
+        cache = CacheMiddleware(config)
+
+        # Wrap a fetch operation
+        result = cache.get_or_fetch(
+            cache_key="nlm:notebooks:list",
+            ttl=300,
+            fetch_fn=lambda: client.notebooks.list()
+        )
+
+        # Store a query/response pair
+        cache.store_query(notebook_id, question, answer)
+    """
+
+    def __init__(self, config: CacheConfig | None = None) -> None:
+        if config is None or not config.enabled:
+            self._backend: CacheBackend = NullBackend()
+            self._config = config or CacheConfig(enabled=False)
+        else:
+            self._config = config
+            db_path = config.db_path
+            if db_path is None:
+                from .paths import get_home_dir
+
+                db_path = get_home_dir(create=True) / "cache.db"
+            self._backend = LocalSQLiteBackend(db_path)
+
+    @property
+    def config(self) -> CacheConfig:
+        """Get the cache configuration."""
+        return self._config
+
+    @property
+    def backend(self) -> CacheBackend:
+        """Get the cache backend."""
+        return self._backend
+
+    def get_or_fetch_sync(
+        self,
+        cache_key: str,
+        ttl: int,
+        fetch_fn: Any,
+    ) -> Any:
+        """Check cache synchronously, return if hit.
+
+        For async fetch operations, use this to check cache first,
+        then call fetch_fn only on miss.
+
+        Returns:
+            Tuple of (cached_value_or_None, was_cache_hit).
+        """
+        entry = self._backend.get(cache_key)
+        if entry is not None:
+            logger.debug("Cache HIT: %s", cache_key)
+            return entry.value, True
+        return None, False
+
+    def store(self, cache_key: str, value: Any, ttl: int) -> None:
+        """Store a value in the cache."""
+        self._backend.set(cache_key, value, ttl=ttl)
+        logger.debug("Cache STORE: %s (ttl=%ds)", cache_key, ttl)
+
+    def invalidate(self, cache_key: str) -> None:
+        """Invalidate a specific cache key."""
+        self._backend.delete(cache_key)
+        logger.debug("Cache INVALIDATE: %s", cache_key)
+
+    def invalidate_notebook(self, notebook_id: str) -> None:
+        """Invalidate all cache entries for a notebook."""
+        count = self._backend.invalidate_prefix(f"nlm:notebook:{notebook_id}")
+        self._backend.delete("nlm:notebooks:list")
+        logger.debug("Cache INVALIDATE notebook %s (%d entries)", notebook_id, count + 1)
+
+    def store_query(
+        self,
+        notebook_id: str,
+        query_text: str,
+        response_text: str,
+        *,
+        citations: str | None = None,
+        conversation_id: str | None = None,
+        turn_number: int = 1,
+        source_ids: list[str] | None = None,
+        latency_ms: int | None = None,
+    ) -> None:
+        """Store a query/response pair for caching and dataset building."""
+        self._backend.store_query(
+            notebook_id,
+            query_text,
+            response_text,
+            citations=citations,
+            conversation_id=conversation_id,
+            turn_number=turn_number,
+            source_ids=source_ids,
+            latency_ms=latency_ms,
+        )
+
+    def log_query(
+        self,
+        notebook_id: str,
+        query_text: str,
+        *,
+        response_length: int = 0,
+        citation_count: int = 0,
+        source_count: int = 0,
+        latency_ms: int = 0,
+        cache_hit: bool = False,
+        agent_id: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Log a query for analytics (append-only)."""
+        if self._config.log_queries:
+            self._backend.log_query(
+                notebook_id,
+                query_text,
+                response_length=response_length,
+                citation_count=citation_count,
+                source_count=source_count,
+                latency_ms=latency_ms,
+                cache_hit=cache_hit,
+                agent_id=agent_id,
+                session_id=session_id,
+            )
+
+    def close(self) -> None:
+        """Close the cache backend."""
+        self._backend.close()
+
+
+def _normalize_and_hash(query: str) -> str:
+    """Normalize a query string and return its SHA256 hash.
+
+    Normalization: lowercase, strip whitespace, collapse multiple spaces.
+    """
+    normalized = " ".join(query.lower().strip().split())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -4,6 +4,7 @@ Provides operations for asking questions, managing conversations, and
 retrieving conversation history.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -451,6 +452,49 @@ class ChatAPI:
 
         goal, length, prompt = mode_configs[mode]
         await self.configure(notebook_id, goal, length, prompt)
+
+    async def multi_ask(
+        self,
+        queries: list[tuple[str, str]],
+    ) -> list[AskResult]:
+        """Ask questions across multiple notebooks in parallel.
+
+        Fires all queries concurrently using asyncio.gather, reducing total
+        latency compared to sequential calls.
+
+        Args:
+            queries: List of (notebook_id, question) tuples.
+
+        Returns:
+            List of AskResult objects in the same order as queries.
+            Failed queries return an AskResult with an error message as the answer.
+
+        Example:
+            results = await client.chat.multi_ask([
+                ("nb-1", "What is the main thesis?"),
+                ("nb-2", "Summarize the key findings"),
+                ("nb-3", "List all citations"),
+            ])
+            for result in results:
+                print(result.answer[:200])
+        """
+
+        async def _safe_ask(notebook_id: str, question: str) -> AskResult:
+            try:
+                return await self.ask(notebook_id, question)
+            except Exception as e:
+                logger.warning("multi_ask failed for notebook %s: %s", notebook_id, e)
+                return AskResult(
+                    answer=f"Error: {e}",
+                    conversation_id="",
+                    turn_number=0,
+                    is_follow_up=False,
+                    references=[],
+                    raw_response="",
+                )
+
+        tasks = [_safe_ask(nb_id, q) for nb_id, q in queries]
+        return list(await asyncio.gather(*tasks))
 
     # =========================================================================
     # Private Helpers

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from typing import Any
 from urllib.parse import quote, urlencode
@@ -87,6 +88,7 @@ class ChatAPI:
                 conversation_id=result.conversation_id
             )
         """
+        _ask_start = time.perf_counter()
         logger.debug(
             "Asking question in notebook %s (conversation=%s)",
             notebook_id,
@@ -174,6 +176,39 @@ class ChatAPI:
             self._core.cache_conversation_turn(conversation_id, question, answer_text, turn_number)
         else:
             turn_number = len(turns)
+
+        # Store query/response in persistent cache for dataset building
+        if self._core._cache and answer_text:
+            try:
+                elapsed_ms = int((time.perf_counter() - _ask_start) * 1000) if _ask_start else None
+                citations_json = (
+                    json.dumps(
+                        [{"source_id": r.source_id, "text": r.cited_text} for r in references]
+                    )
+                    if references
+                    else None
+                )
+                self._core._cache.store_query(
+                    notebook_id,
+                    question,
+                    answer_text,
+                    citations=citations_json,
+                    conversation_id=conversation_id,
+                    turn_number=turn_number,
+                    source_ids=source_ids,
+                    latency_ms=elapsed_ms,
+                )
+                self._core._cache.log_query(
+                    notebook_id,
+                    question,
+                    response_length=len(answer_text),
+                    citation_count=len(references),
+                    source_count=len(source_ids) if source_ids else 0,
+                    latency_ms=elapsed_ms or 0,
+                    cache_hit=False,
+                )
+            except Exception:
+                logger.debug("Failed to store query in cache", exc_info=True)
 
         return AskResult(
             answer=answer_text,

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -135,7 +135,10 @@ class ChatAPI:
 
         self._core._reqid_counter += 100000
         url_params = {
-            "bl": os.environ.get("NOTEBOOKLM_BL", _DEFAULT_BL),
+            "bl": os.environ.get(
+                "NOTEBOOKLM_BL",
+                self._core.auth.build_label or _DEFAULT_BL,
+            ),
             "hl": "en",
             "_reqid": str(self._core._reqid_counter),
             "rt": "c",

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -1,14 +1,19 @@
 """Core infrastructure for NotebookLM API client."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode
 
 import httpx
+
+if TYPE_CHECKING:
+    from ._cache import CacheMiddleware
 
 from .auth import AuthTokens
 from .rpc import (
@@ -95,6 +100,7 @@ class ClientCore:
         connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
         refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = None,
         refresh_retry_delay: float = 0.2,
+        cache: CacheMiddleware | None = None,
     ):
         """Initialize the core client.
 
@@ -107,6 +113,8 @@ class ClientCore:
             refresh_callback: Optional async callback to refresh auth tokens on failure.
                 If provided, rpc_call will automatically retry once after refreshing.
             refresh_retry_delay: Delay in seconds before retrying after refresh.
+            cache: Optional cache middleware for reducing API calls and storing
+                query/response pairs. If None, no caching is performed.
         """
         self.auth = auth
         self._timeout = timeout
@@ -116,6 +124,7 @@ class ClientCore:
         self._refresh_lock: asyncio.Lock | None = asyncio.Lock() if refresh_callback else None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
+        self._cache = cache
         # Request ID counter for chat API (must be unique per request)
         self._reqid_counter: int = 100000
         # OrderedDict for FIFO eviction when cache exceeds MAX_CONVERSATION_CACHE_SIZE

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -40,6 +40,12 @@ MAX_CONVERSATION_CACHE_SIZE = 100
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_CONNECT_TIMEOUT = 10.0  # Connection establishment timeout
 
+# Retry configuration for transient server errors (429, 500, 502, 503, 504)
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+DEFAULT_MAX_RETRIES = 3  # 4 total attempts (initial + 3 retries)
+DEFAULT_RETRY_BASE_DELAY = 1.0  # seconds
+DEFAULT_RETRY_MAX_DELAY = 16.0  # seconds
+
 # Auth error detection patterns (case-insensitive)
 AUTH_ERROR_PATTERNS = (
     "authentication",
@@ -204,18 +210,23 @@ class ClientCore:
         source_path: str = "/",
         allow_null: bool = False,
         _is_retry: bool = False,
+        _server_retry: int = 0,
     ) -> Any:
         """Make an RPC call to the NotebookLM API.
 
         Automatically refreshes authentication tokens and retries once if an
         auth failure is detected and a refresh_callback was provided.
 
+        Retries automatically with exponential backoff on transient server
+        errors (429, 500, 502, 503, 504) up to DEFAULT_MAX_RETRIES times.
+
         Args:
             method: The RPC method to call.
             params: Parameters for the RPC call (nested list structure).
             source_path: The source path parameter (usually /notebook/{id}).
             allow_null: If True, don't raise error when response is null.
-            _is_retry: Internal flag to prevent infinite retries.
+            _is_retry: Internal flag to prevent infinite auth retries.
+            _server_retry: Internal counter for server error retries.
 
         Returns:
             Decoded response data.
@@ -248,6 +259,41 @@ class ClientCore:
                 )
                 if refreshed is not None:
                     return refreshed
+
+            # Retry on transient server errors with exponential backoff
+            if (
+                isinstance(e, httpx.HTTPStatusError)
+                and e.response.status_code in RETRYABLE_STATUS_CODES
+                and _server_retry < DEFAULT_MAX_RETRIES
+            ):
+                delay = min(
+                    DEFAULT_RETRY_BASE_DELAY * (2**_server_retry),
+                    DEFAULT_RETRY_MAX_DELAY,
+                )
+                # Use retry-after header if available (for 429s)
+                retry_after_header = e.response.headers.get("retry-after")
+                if retry_after_header:
+                    try:
+                        delay = max(delay, float(retry_after_header))
+                    except ValueError:
+                        pass
+                logger.warning(
+                    "RPC %s got HTTP %s, retrying in %.1fs (attempt %d/%d)",
+                    method.name,
+                    e.response.status_code,
+                    delay,
+                    _server_retry + 1,
+                    DEFAULT_MAX_RETRIES,
+                )
+                await asyncio.sleep(delay)
+                return await self.rpc_call(
+                    method,
+                    params,
+                    source_path,
+                    allow_null,
+                    _is_retry=_is_retry,
+                    _server_retry=_server_retry + 1,
+                )
 
             if isinstance(e, httpx.HTTPStatusError):
                 status = e.response.status_code

--- a/src/notebooklm/_living_docs.py
+++ b/src/notebooklm/_living_docs.py
@@ -1,0 +1,373 @@
+"""Living Documents API - auto-syncing Drive files linked to notebooks.
+
+Living documents are Google Drive files registered to notebooks that can be
+monitored for staleness and synced automatically. The registry is stored
+locally at ~/.notebooklm/living_docs.json.
+
+Usage:
+    async with NotebookLMClient.from_storage() as client:
+        # Register a Drive doc linked to a notebook
+        doc = await client.living_docs.register(
+            drive_file_id="1abc...",
+            notebook_id="nb_123",
+            title="Master Timeline",
+        )
+
+        # Check which docs are stale
+        stale = await client.living_docs.check_stale()
+
+        # Sync all stale docs
+        results = await client.living_docs.sync_all()
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ._core import ClientCore
+from ._sources import SourcesAPI
+from .paths import get_home_dir
+from .rpc import DriveMimeType
+
+logger = logging.getLogger(__name__)
+
+# Templates matching the MCP worker's living doc templates
+LIVING_DOC_TEMPLATES: dict[str, dict] = {
+    "violations-master": {
+        "title": "Master Violations Register",
+        "description": "All legal/regulatory violations with statutes, evidence, and severity",
+        "suggested_notebooks": ["violations", "evidence"],
+    },
+    "chain-of-title": {
+        "title": "Chain of Title Analysis",
+        "description": "Complete assignment chain, defects, and standing analysis",
+        "suggested_notebooks": ["chain of title"],
+    },
+    "timeline-master": {
+        "title": "Master Case Timeline",
+        "description": "Chronological events from loan origination to present",
+        "suggested_notebooks": ["timeline"],
+    },
+    "damages-calculations": {
+        "title": "Damages & Exposure Calculations",
+        "description": "Constitutional forfeiture, statutory damages, actual damages",
+        "suggested_notebooks": ["damages", "constitutional"],
+    },
+    "discovery-tracker": {
+        "title": "Discovery Requests & Responses",
+        "description": "Interrogatories, RFPs, depositions, and compliance tracking",
+        "suggested_notebooks": ["discovery"],
+    },
+    "evidence-index": {
+        "title": "Evidence Index & Exhibit List",
+        "description": "All exhibits with descriptions, sources, and authentication status",
+        "suggested_notebooks": ["evidence"],
+    },
+    "defendant-profiles": {
+        "title": "Defendant Profiles & Liability",
+        "description": "Each defendant's role, actions, and individual liability",
+        "suggested_notebooks": ["servicing"],
+    },
+    "filing-strategy": {
+        "title": "Filing Strategy & Court Deadlines",
+        "description": "Upcoming deadlines, motion strategy, and filing calendar",
+        "suggested_notebooks": ["filing"],
+    },
+}
+
+
+@dataclass
+class LivingDoc:
+    """A registered living document."""
+
+    drive_file_id: str
+    notebook_id: str
+    source_id: str | None = None
+    title: str | None = None
+    mime_type: str = DriveMimeType.GOOGLE_DOC.value
+    template: str | None = None
+    registered_at: str = ""
+    last_synced_at: str | None = None
+
+    def __post_init__(self):
+        if not self.registered_at:
+            self.registered_at = datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class StaleCheckResult:
+    """Result of checking living docs for staleness."""
+
+    stale: list[LivingDoc] = field(default_factory=list)
+    fresh: list[LivingDoc] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
+
+    @property
+    def stale_count(self) -> int:
+        return len(self.stale)
+
+    @property
+    def fresh_count(self) -> int:
+        return len(self.fresh)
+
+    @property
+    def total_documents(self) -> int:
+        return len(self.stale) + len(self.fresh) + len(self.errors)
+
+
+@dataclass
+class SyncResult:
+    """Result of syncing living documents."""
+
+    synced: list[LivingDoc] = field(default_factory=list)
+    skipped: list[LivingDoc] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
+
+    @property
+    def synced_count(self) -> int:
+        return len(self.synced)
+
+
+def _get_registry_path() -> Path:
+    """Get the living docs registry file path."""
+    return get_home_dir() / "living_docs.json"
+
+
+def _load_registry() -> list[dict]:
+    """Load the living docs registry from disk."""
+    path = _get_registry_path()
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("documents", [])
+    except (json.JSONDecodeError, KeyError):
+        logger.warning("Corrupt living_docs.json, starting fresh")
+        return []
+
+
+def _save_registry(docs: list[dict]) -> None:
+    """Save the living docs registry to disk."""
+    path = _get_registry_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    data = {"documents": docs, "updated_at": datetime.now(timezone.utc).isoformat()}
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _doc_from_dict(d: dict) -> LivingDoc:
+    """Create a LivingDoc from a dict."""
+    return LivingDoc(
+        drive_file_id=d["drive_file_id"],
+        notebook_id=d["notebook_id"],
+        source_id=d.get("source_id"),
+        title=d.get("title"),
+        mime_type=d.get("mime_type", DriveMimeType.GOOGLE_DOC.value),
+        template=d.get("template"),
+        registered_at=d.get("registered_at", ""),
+        last_synced_at=d.get("last_synced_at"),
+    )
+
+
+class LivingDocsAPI:
+    """Living Documents API for auto-syncing Drive files with notebooks.
+
+    Living documents are Drive files that you update externally and want
+    to keep in sync with NotebookLM notebooks. Register a doc once, then
+    use check_stale() and sync_all() to keep everything current.
+    """
+
+    def __init__(self, core: ClientCore, sources_api: SourcesAPI) -> None:
+        self._core = core
+        self._sources = sources_api
+
+    def list(self) -> list[LivingDoc]:
+        """List all registered living documents.
+
+        Returns:
+            List of registered LivingDoc entries.
+        """
+        entries = _load_registry()
+        return [_doc_from_dict(d) for d in entries]
+
+    def templates(self) -> dict[str, dict]:
+        """Get available living document templates.
+
+        Returns:
+            Dict mapping template IDs to their metadata.
+        """
+        return LIVING_DOC_TEMPLATES
+
+    async def register(
+        self,
+        drive_file_id: str,
+        notebook_id: str,
+        title: str | None = None,
+        mime_type: str = DriveMimeType.GOOGLE_DOC.value,
+        template: str | None = None,
+        add_to_notebook: bool = True,
+    ) -> LivingDoc:
+        """Register a Drive file as a living document linked to a notebook.
+
+        Args:
+            drive_file_id: Google Drive file ID.
+            notebook_id: Notebook to link the document to.
+            title: Display title (defaults to Drive filename).
+            mime_type: Drive MIME type (default: Google Doc).
+            template: Optional template ID for categorization.
+            add_to_notebook: If True, also add as a source to the notebook.
+
+        Returns:
+            The registered LivingDoc.
+        """
+        doc = LivingDoc(
+            drive_file_id=drive_file_id,
+            notebook_id=notebook_id,
+            title=title or drive_file_id,
+            mime_type=mime_type,
+            template=template,
+        )
+
+        # Add to notebook as a Drive source
+        if add_to_notebook:
+            source = await self._sources.add_drive(
+                notebook_id,
+                drive_file_id,
+                doc.title or drive_file_id,
+                mime_type,
+            )
+            doc.source_id = source.id
+            doc.last_synced_at = datetime.now(timezone.utc).isoformat()
+
+        # Save to registry
+        entries = _load_registry()
+        # Remove existing entry for same drive_file_id + notebook_id
+        entries = [
+            e
+            for e in entries
+            if not (e["drive_file_id"] == drive_file_id and e["notebook_id"] == notebook_id)
+        ]
+        entries.append(asdict(doc))
+        _save_registry(entries)
+
+        return doc
+
+    async def add_to_notebook(
+        self,
+        drive_file_id: str,
+        notebook_id: str,
+    ) -> LivingDoc:
+        """Add a Drive file to a notebook and register as a living document.
+
+        Convenience method that combines register + add_to_notebook.
+
+        Args:
+            drive_file_id: Google Drive file ID.
+            notebook_id: Target notebook ID.
+
+        Returns:
+            The registered LivingDoc.
+        """
+        return await self.register(
+            drive_file_id=drive_file_id,
+            notebook_id=notebook_id,
+            add_to_notebook=True,
+        )
+
+    def remove(self, drive_file_id: str) -> bool:
+        """Remove a living document from the registry.
+
+        This only removes the tracking entry — it does NOT delete the
+        source from NotebookLM or the file from Drive.
+
+        Args:
+            drive_file_id: The Drive file ID to unregister.
+
+        Returns:
+            True if a document was removed.
+        """
+        entries = _load_registry()
+        original_count = len(entries)
+        entries = [e for e in entries if e["drive_file_id"] != drive_file_id]
+        if len(entries) < original_count:
+            _save_registry(entries)
+            return True
+        return False
+
+    async def check_stale(self) -> StaleCheckResult:
+        """Check which living documents need syncing.
+
+        Uses the source freshness API to determine if each
+        registered document has been updated since last sync.
+
+        Returns:
+            StaleCheckResult with stale, fresh, and error lists.
+        """
+        result = StaleCheckResult()
+        entries = _load_registry()
+
+        for entry in entries:
+            doc = _doc_from_dict(entry)
+            if not doc.source_id:
+                result.errors.append(
+                    {"drive_file_id": doc.drive_file_id, "error": "No source_id registered"}
+                )
+                continue
+
+            try:
+                is_fresh = await self._sources.check_freshness(doc.notebook_id, doc.source_id)
+                if is_fresh:
+                    result.fresh.append(doc)
+                else:
+                    result.stale.append(doc)
+            except Exception as e:
+                logger.warning("Failed to check freshness for %s: %s", doc.drive_file_id, e)
+                result.errors.append({"drive_file_id": doc.drive_file_id, "error": str(e)})
+
+        return result
+
+    async def sync_all(self) -> SyncResult:
+        """Sync all stale living documents by refreshing their sources.
+
+        Returns:
+            SyncResult with synced, skipped, and error lists.
+        """
+        result = SyncResult()
+        stale_check = await self.check_stale()
+
+        # Skip fresh docs
+        result.skipped = stale_check.fresh
+
+        # Sync stale docs
+        for doc in stale_check.stale:
+            if not doc.source_id:
+                result.errors.append({"drive_file_id": doc.drive_file_id, "error": "No source_id"})
+                continue
+
+            try:
+                await self._sources.refresh(doc.notebook_id, doc.source_id)
+                doc.last_synced_at = datetime.now(timezone.utc).isoformat()
+                result.synced.append(doc)
+
+                # Update registry with new sync time
+                self._update_sync_time(doc.drive_file_id, doc.notebook_id, doc.last_synced_at)
+            except Exception as e:
+                logger.warning("Failed to sync %s: %s", doc.drive_file_id, e)
+                result.errors.append({"drive_file_id": doc.drive_file_id, "error": str(e)})
+
+        # Include errors from stale check
+        result.errors.extend(stale_check.errors)
+
+        return result
+
+    def _update_sync_time(self, drive_file_id: str, notebook_id: str, synced_at: str) -> None:
+        """Update the last_synced_at for a document in the registry."""
+        entries = _load_registry()
+        for entry in entries:
+            if entry["drive_file_id"] == drive_file_id and entry["notebook_id"] == notebook_id:
+                entry["last_synced_at"] = synced_at
+                break
+        _save_registry(entries)

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -379,6 +379,85 @@ class NotebooksAPI:
             status=status,
         )
 
+    async def merge(
+        self,
+        source_notebook_id: str,
+        target_notebook_id: str,
+        *,
+        skip_duplicates: bool = True,
+    ) -> builtins.list[Any]:
+        """Copy all sources from one notebook to another.
+
+        Reads sources from the source notebook, fetches their full text content,
+        and adds each as a text source to the target notebook. URL sources are
+        re-added by URL; text-only sources are copied as text.
+
+        Args:
+            source_notebook_id: The notebook to copy sources from.
+            target_notebook_id: The notebook to copy sources into.
+            skip_duplicates: If True, skip sources whose title already exists
+                in the target notebook (default: True).
+
+        Returns:
+            List of newly created Source objects in the target notebook.
+
+        Raises:
+            RuntimeError: If no sources API was provided to the notebooks API.
+
+        Example:
+            merged = await client.notebooks.merge(src_id, dst_id)
+            print(f"Copied {len(merged)} sources")
+        """
+        if self._sources is None:
+            raise RuntimeError(
+                "No sources API available. Use NotebookLMClient which wires "
+                "the sources API automatically."
+            )
+
+        src_sources = await self._sources.list(source_notebook_id)
+        if not src_sources:
+            return []
+
+        # Get existing titles in target for dedup
+        existing_titles: set[str] = set()
+        existing_urls: set[str] = set()
+        if skip_duplicates:
+            target_sources = await self._sources.list(target_notebook_id)
+            existing_titles = {s.title for s in target_sources if s.title}
+            existing_urls = {s.url for s in target_sources if s.url}
+
+        added: builtins.list[Any] = []
+        for src in src_sources:
+            # Skip duplicates by title or URL
+            if skip_duplicates:
+                if src.title and src.title in existing_titles:
+                    logger.debug("Skipping duplicate (title): %s", src.title)
+                    continue
+                if src.url and src.url in existing_urls:
+                    logger.debug("Skipping duplicate (URL): %s", src.url)
+                    continue
+
+            try:
+                if src.url:
+                    new_source = await self._sources.add_url(
+                        target_notebook_id, src.url, skip_dedup=True
+                    )
+                else:
+                    # For text-only sources, fetch content and re-add
+                    fulltext = await self._sources.get_fulltext(source_notebook_id, src.id)
+                    new_source = await self._sources.add_text(
+                        target_notebook_id,
+                        src.title or "Untitled",
+                        fulltext.content or "",
+                        skip_dedup=True,
+                    )
+                added.append(new_source)
+                logger.debug("Merged source: %s", src.title)
+            except Exception:
+                logger.warning("Failed to merge source %s (%s)", src.id, src.title, exc_info=True)
+
+        return added
+
     async def health_all(self) -> builtins.list[NotebookHealth]:
         """Run health checks on all notebooks in parallel.
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -1,11 +1,19 @@
 """Notebook operations API."""
 
+from __future__ import annotations
+
+import asyncio
+import builtins
 import logging
-from typing import Any
+from collections import Counter
+from typing import TYPE_CHECKING, Any
 
 from ._core import ClientCore
 from .rpc import RPCMethod
-from .types import Notebook, NotebookDescription, SuggestedTopic
+from .types import Notebook, NotebookDescription, NotebookHealth, SuggestedTopic
+
+if TYPE_CHECKING:
+    from ._sources import SourcesAPI
 
 logger = logging.getLogger(__name__)
 
@@ -23,13 +31,15 @@ class NotebooksAPI:
             await client.notebooks.rename(new_nb.id, "Better Title")
     """
 
-    def __init__(self, core: ClientCore):
+    def __init__(self, core: ClientCore, sources_api: SourcesAPI | None = None):
         """Initialize the notebooks API.
 
         Args:
             core: The core client infrastructure.
+            sources_api: Optional sources API for health checks.
         """
         self._core = core
+        self._sources: SourcesAPI | None = sources_api
 
     async def list(self) -> list[Notebook]:
         """List all notebooks.
@@ -286,3 +296,108 @@ class NotebooksAPI:
         if artifact_id:
             return f"{base_url}?artifactId={artifact_id}"
         return base_url
+
+    async def health(self, notebook_id: str) -> NotebookHealth:
+        """Audit notebook health - check for empty, stale sources, duplicates.
+
+        Inspects the notebook's sources and reports:
+        - Whether the notebook has any sources at all.
+        - Which sources are stale (need refresh), checked via
+          ``client.sources.check_freshness()`` when a sources API is available.
+        - Which URLs appear more than once across sources.
+
+        Args:
+            notebook_id: The notebook ID to audit.
+
+        Returns:
+            NotebookHealth report with status, stale sources, and duplicate URLs.
+
+        Raises:
+            RuntimeError: If no sources API was provided to the notebooks API.
+
+        Example:
+            report = await client.notebooks.health(notebook_id)
+            if report.status == "needs_attention":
+                print(f"Stale sources: {report.stale_sources}")
+                print(f"Duplicate URLs: {report.duplicate_urls}")
+        """
+        if self._sources is None:
+            raise RuntimeError(
+                "No sources API available. Use NotebookLMClient which wires "
+                "the sources API automatically."
+            )
+
+        # Get notebook info and sources in parallel
+        notebook, sources = await asyncio.gather(
+            self.get(notebook_id),
+            self._sources.list(notebook_id),
+        )
+
+        source_count = len(sources)
+        has_sources = source_count > 0
+
+        if not has_sources:
+            return NotebookHealth(
+                notebook_id=notebook_id,
+                title=notebook.title,
+                source_count=0,
+                has_sources=False,
+                stale_sources=[],
+                duplicate_urls=[],
+                status="empty",
+            )
+
+        # Check freshness for all sources in parallel
+        freshness_tasks = [self._sources.check_freshness(notebook_id, src.id) for src in sources]
+        freshness_results = await asyncio.gather(*freshness_tasks, return_exceptions=True)
+
+        stale_sources: list[str] = []
+        for src, result in zip(sources, freshness_results, strict=False):
+            if isinstance(result, Exception):
+                # If freshness check fails, flag as stale to be safe
+                stale_sources.append(src.id)
+            elif result is False:
+                stale_sources.append(src.id)
+
+        # Find duplicate URLs
+        url_counts: Counter[str] = Counter()
+        for src in sources:
+            if src.url:
+                url_counts[src.url] += 1
+        duplicate_urls = [url for url, count in url_counts.items() if count > 1]
+
+        # Determine status
+        status = "needs_attention" if stale_sources or duplicate_urls else "healthy"
+
+        return NotebookHealth(
+            notebook_id=notebook_id,
+            title=notebook.title,
+            source_count=source_count,
+            has_sources=True,
+            stale_sources=stale_sources,
+            duplicate_urls=duplicate_urls,
+            status=status,
+        )
+
+    async def health_all(self) -> builtins.list[NotebookHealth]:
+        """Run health checks on all notebooks in parallel.
+
+        Lists all notebooks and then runs ``health()`` on each one concurrently.
+
+        Returns:
+            List of NotebookHealth reports, one per notebook.
+
+        Raises:
+            RuntimeError: If no sources API was provided to the notebooks API.
+
+        Example:
+            reports = await client.notebooks.health_all()
+            for report in reports:
+                print(f"{report.title}: {report.status}")
+        """
+        notebooks = await self.list()
+        if not notebooks:
+            return []
+
+        tasks = [self.health(nb.id) for nb in notebooks]
+        return list(await asyncio.gather(*tasks))

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -50,6 +50,37 @@ class SourcesAPI:
         """
         self._core = core
 
+    async def _check_duplicate(
+        self,
+        notebook_id: str,
+        *,
+        url: str | None = None,
+        title: str | None = None,
+    ) -> Source | None:
+        """Check if a source with the same URL or title already exists.
+
+        Args:
+            notebook_id: The notebook ID.
+            url: URL to check for duplicates (used for URL/YouTube sources).
+            title: Title to check for duplicates (used for text sources).
+
+        Returns:
+            The existing Source if a duplicate is found, None otherwise.
+        """
+        existing_sources = await self.list(notebook_id)
+
+        if url is not None:
+            for source in existing_sources:
+                if source.url and source.url == url:
+                    return source
+
+        if title is not None:
+            for source in existing_sources:
+                if source.title and source.title == title:
+                    return source
+
+        return None
+
     async def list(self, notebook_id: str) -> list[Source]:
         """List all sources in a notebook.
 
@@ -286,6 +317,7 @@ class SourcesAPI:
         url: str,
         wait: bool = False,
         wait_timeout: float = 120.0,
+        skip_dedup: bool = True,
     ) -> Source:
         """Add a URL source to a notebook.
 
@@ -296,9 +328,14 @@ class SourcesAPI:
             url: The URL to add.
             wait: If True, wait for source to be ready before returning.
             wait_timeout: Maximum seconds to wait if wait=True (default: 120).
+            skip_dedup: If True, skip duplicate checking (default: True).
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.
+
+        Raises:
+            ValueError: If a source with the same URL already exists and
+                skip_dedup is False.
 
         Example:
             # Add and wait for processing
@@ -309,6 +346,15 @@ class SourcesAPI:
             # ... add more sources ...
             await client.sources.wait_for_sources(nb_id, [s.id for s in sources])
         """
+        if not skip_dedup:
+            existing = await self._check_duplicate(notebook_id, url=url)
+            if existing:
+                raise ValueError(
+                    f"Duplicate source: a source with URL '{url}' already exists "
+                    f"in notebook {notebook_id} (source_id={existing.id}, "
+                    f"title='{existing.title}'). Use skip_dedup=True to add anyway."
+                )
+
         logger.debug("Adding URL source to notebook %s: %s", notebook_id, url[:80])
         video_id = self._extract_youtube_video_id(url)
         try:
@@ -344,6 +390,7 @@ class SourcesAPI:
         content: str,
         wait: bool = False,
         wait_timeout: float = 120.0,
+        skip_dedup: bool = True,
     ) -> Source:
         """Add a text source (copied text) to a notebook.
 
@@ -353,10 +400,24 @@ class SourcesAPI:
             content: Text content.
             wait: If True, wait for source to be ready before returning.
             wait_timeout: Maximum seconds to wait if wait=True (default: 120).
+            skip_dedup: If True, skip duplicate checking (default: True).
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.
+
+        Raises:
+            ValueError: If a source with the same title already exists and
+                skip_dedup is False.
         """
+        if not skip_dedup:
+            existing = await self._check_duplicate(notebook_id, title=title)
+            if existing:
+                raise ValueError(
+                    f"Duplicate source: a source with title '{title}' already exists "
+                    f"in notebook {notebook_id} (source_id={existing.id}). "
+                    f"Use skip_dedup=True to add anyway."
+                )
+
         logger.debug("Adding text source to notebook %s: %s", notebook_id, title)
         params = [
             [[None, [title, content], None, None, None, None, None, None]],
@@ -745,6 +806,142 @@ class SourcesAPI:
             url=url,
             char_count=len(content),
         )
+
+    # =========================================================================
+    # Bulk operations
+    # =========================================================================
+
+    async def add_urls(
+        self,
+        notebook_id: str,
+        urls: builtins.list[str],
+        *,
+        skip_failures: bool = False,
+    ) -> builtins.list[Source]:
+        """Add multiple URL sources in parallel.
+
+        Uses asyncio.gather() to add all URLs concurrently.
+
+        Args:
+            notebook_id: The notebook ID.
+            urls: List of URLs to add.
+            skip_failures: If True, catch per-URL exceptions and continue.
+                If False (default), raise the first exception encountered.
+
+        Returns:
+            List of successfully added Source objects.
+
+        Raises:
+            SourceAddError: If any URL fails and skip_failures is False.
+
+        Example:
+            sources = await client.sources.add_urls(
+                nb_id,
+                ["https://example.com/a", "https://example.com/b"],
+                skip_failures=True,
+            )
+        """
+        if not urls:
+            return []
+
+        results = await asyncio.gather(
+            *(self.add_url(notebook_id, url) for url in urls),
+            return_exceptions=True,
+        )
+
+        sources: builtins.list[Source] = []
+        for i, result in enumerate(results):
+            if isinstance(result, BaseException):
+                if skip_failures:
+                    logger.warning("Failed to add URL %s: %s", urls[i], result)
+                else:
+                    raise result
+            else:
+                sources.append(result)
+
+        return sources
+
+    async def delete_bulk(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str],
+    ) -> builtins.list[str]:
+        """Delete multiple sources in parallel.
+
+        Uses asyncio.gather() to delete all sources concurrently.
+
+        Args:
+            notebook_id: The notebook ID.
+            source_ids: List of source IDs to delete.
+
+        Returns:
+            List of successfully deleted source IDs.
+
+        Example:
+            deleted = await client.sources.delete_bulk(nb_id, ["id1", "id2"])
+        """
+        if not source_ids:
+            return []
+
+        results = await asyncio.gather(
+            *(self.delete(notebook_id, sid) for sid in source_ids),
+            return_exceptions=True,
+        )
+
+        deleted: builtins.list[str] = []
+        for i, result in enumerate(results):
+            if isinstance(result, BaseException):
+                logger.warning("Failed to delete source %s: %s", source_ids[i], result)
+            else:
+                deleted.append(source_ids[i])
+
+        return deleted
+
+    async def refresh_bulk(
+        self,
+        notebook_id: str,
+        source_ids: builtins.list[str] | None = None,
+    ) -> builtins.list[Source]:
+        """Refresh multiple sources in parallel.
+
+        Uses asyncio.gather() to refresh all sources concurrently. If
+        source_ids is None, refreshes all sources in the notebook.
+
+        Args:
+            notebook_id: The notebook ID.
+            source_ids: List of source IDs to refresh. If None, refreshes
+                all sources in the notebook.
+
+        Returns:
+            List of Source objects for successfully refreshed sources.
+
+        Example:
+            # Refresh specific sources
+            refreshed = await client.sources.refresh_bulk(nb_id, ["id1", "id2"])
+
+            # Refresh all sources
+            refreshed = await client.sources.refresh_bulk(nb_id)
+        """
+        if source_ids is None:
+            all_sources = await self.list(notebook_id)
+            source_ids = [s.id for s in all_sources]
+
+        if not source_ids:
+            return []
+
+        results = await asyncio.gather(
+            *(self.refresh(notebook_id, sid) for sid in source_ids),
+            return_exceptions=True,
+        )
+
+        refreshed: builtins.list[Source] = []
+        for i, result in enumerate(results):
+            if isinstance(result, BaseException):
+                logger.warning("Failed to refresh source %s: %s", source_ids[i], result)
+            else:
+                refreshed.append(Source(id=source_ids[i], title=None))
+
+        return refreshed
 
     # =========================================================================
     # Private helper methods

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -158,6 +158,7 @@ class AuthTokens:
     cookies: dict[str, str]
     csrf_token: str
     session_id: str
+    build_label: str = ""
 
     @property
     def cookie_header(self) -> str:
@@ -193,8 +194,13 @@ class AuthTokens:
                 notebooks = await client.list_notebooks()
         """
         cookies = load_auth_from_storage(path)
-        csrf_token, session_id = await fetch_tokens(cookies)
-        return cls(cookies=cookies, csrf_token=csrf_token, session_id=session_id)
+        csrf_token, session_id, build_label = await fetch_tokens(cookies)
+        return cls(
+            cookies=cookies,
+            csrf_token=csrf_token,
+            session_id=session_id,
+            build_label=build_label,
+        )
 
 
 def _is_google_domain(domain: str) -> bool:
@@ -585,8 +591,8 @@ def load_httpx_cookies(path: Path | None = None) -> "httpx.Cookies":
     return cookies
 
 
-async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
-    """Fetch CSRF token and session ID from NotebookLM homepage.
+async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str, str]:
+    """Fetch CSRF token, session ID, and build label from NotebookLM homepage.
 
     Makes an authenticated request to NotebookLM and extracts the required
     tokens from the page HTML.
@@ -595,7 +601,8 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
         cookies: Dict of Google auth cookies
 
     Returns:
-        Tuple of (csrf_token, session_id)
+        Tuple of (csrf_token, session_id, build_label). build_label may be
+        empty string if not found in the page.
 
     Raises:
         httpx.HTTPError: If request fails
@@ -626,5 +633,12 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
         csrf = extract_csrf_from_html(response.text, final_url)
         session_id = extract_session_id_from_html(response.text, final_url)
 
+        # Extract build label (cfb2h) to keep bl parameter current
+        build_label = ""
+        bl_match = re.search(r'"cfb2h":"([^"]+)"', response.text)
+        if bl_match:
+            build_label = bl_match.group(1)
+            logger.debug("Extracted build label: %s", build_label)
+
         logger.debug("Authentication tokens obtained successfully")
-        return csrf, session_id
+        return csrf, session_id, build_label

--- a/src/notebooklm/cli/__init__.py
+++ b/src/notebooklm/cli/__init__.py
@@ -54,6 +54,7 @@ from .helpers import (
     with_client,
 )
 from .language import get_language, language
+from .living_doc import living_doc
 from .note import note
 from .notebook import register_notebook_commands
 from .options import (
@@ -84,6 +85,7 @@ __all__ = [
     "download",
     "note",
     "share",
+    "living_doc",
     "skill",
     "research",
     "language",

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -198,6 +198,60 @@ def register_chat_commands(cli):
 
         return _run()
 
+    @cli.command("multi-ask")
+    @click.argument("question")
+    @click.option(
+        "-n",
+        "--notebooks",
+        "notebook_ids",
+        multiple=True,
+        required=True,
+        help="Notebook IDs to query (can be repeated)",
+    )
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+    @with_client
+    def multi_ask_cmd(ctx, question, notebook_ids, json_output, client_auth):
+        """Ask a question across multiple notebooks simultaneously.
+
+        Sends the same question to multiple notebooks in parallel and
+        displays results grouped by notebook.
+
+        \b
+        Example:
+          notebooklm multi-ask "what are the key themes?" -n nb1 -n nb2 -n nb3
+          notebooklm multi-ask "summarize" -n nb1 -n nb2 --json
+        """
+
+        async def _run():
+            async with NotebookLMClient(client_auth) as client:
+                resolved_ids = []
+                for nb_id in notebook_ids:
+                    resolved_ids.append(await resolve_notebook_id(client, nb_id))
+
+                queries = [(nb_id, question) for nb_id in resolved_ids]
+                results = await client.chat.multi_ask(queries)
+
+                if json_output:
+                    from dataclasses import asdict
+
+                    data = {
+                        "question": question,
+                        "results": [],
+                    }
+                    for (nb_id, _), result in zip(queries, results, strict=True):
+                        entry = asdict(result)
+                        del entry["raw_response"]
+                        entry["notebook_id"] = nb_id
+                        data["results"].append(entry)
+                    json_output_response(data)
+                    return
+
+                for (nb_id, _), result in zip(queries, results, strict=True):
+                    console.print(f"\n[bold cyan]Notebook {nb_id[:12]}...:[/bold cyan]")
+                    console.print(result.answer)
+
+        return _run()
+
     @cli.command("configure")
     @click.option(
         "-n",

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -165,8 +165,10 @@ async def _download_artifacts_generic(
     nb_id = require_notebook(notebook)
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     cookies = load_auth_from_storage(storage_path)
-    csrf, session_id = await fetch_tokens(cookies)
-    auth = AuthTokens(cookies=cookies, csrf_token=csrf, session_id=session_id)
+    csrf, session_id, build_label = await fetch_tokens(cookies)
+    auth = AuthTokens(
+        cookies=cookies, csrf_token=csrf, session_id=session_id, build_label=build_label
+    )
 
     # Adjust extension for PPTX format (must be outside _download() to avoid UnboundLocalError)
     if artifact_type_name == "slide-deck" and slide_format == "pptx":
@@ -789,8 +791,10 @@ async def _download_interactive(
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     cookies = load_auth_from_storage(storage_path)
 
-    csrf, session_id = await fetch_tokens(cookies)
-    auth = AuthTokens(cookies=cookies, csrf_token=csrf, session_id=session_id)
+    csrf, session_id, build_label = await fetch_tokens(cookies)
+    auth = AuthTokens(
+        cookies=cookies, csrf_token=csrf, session_id=session_id, build_label=build_label
+    )
 
     async with NotebookLMClient(auth) as client:
         nb_id_resolved = await resolve_notebook_id(client, nb_id)

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -100,7 +100,7 @@ def get_client(ctx) -> tuple[dict, str, str]:
     """
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     cookies = load_auth_from_storage(storage_path)
-    csrf, session_id = run_async(fetch_tokens(cookies))
+    csrf, session_id, _build_label = run_async(fetch_tokens(cookies))
     return cookies, csrf, session_id
 
 
@@ -113,8 +113,12 @@ def get_auth_tokens(ctx) -> AuthTokens:
     Returns:
         AuthTokens ready for client construction
     """
-    cookies, csrf, session_id = get_client(ctx)
-    return AuthTokens(cookies=cookies, csrf_token=csrf, session_id=session_id)
+    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
+    cookies = load_auth_from_storage(storage_path)
+    csrf, session_id, build_label = run_async(fetch_tokens(cookies))
+    return AuthTokens(
+        cookies=cookies, csrf_token=csrf, session_id=session_id, build_label=build_label
+    )
 
 
 # =============================================================================

--- a/src/notebooklm/cli/living_doc.py
+++ b/src/notebooklm/cli/living_doc.py
@@ -1,0 +1,314 @@
+"""Living document management CLI commands.
+
+Commands:
+    list         List all registered living documents
+    register     Register a Drive file as a living document
+    remove       Unregister a living document
+    check-stale  Check which documents need syncing
+    sync         Sync all stale documents
+    templates    List available document templates
+"""
+
+import click
+from rich.table import Table
+
+from ..client import NotebookLMClient
+from .helpers import (
+    console,
+    json_output_response,
+    require_notebook,
+    resolve_notebook_id,
+    with_client,
+)
+
+
+@click.group("living-doc")
+def living_doc():
+    """Living document management commands.
+
+    \b
+    Living documents are Google Drive files that auto-sync with notebooks.
+    Register a doc once, then use check-stale and sync to keep it current.
+
+    \b
+    Commands:
+      list         List registered living documents
+      register     Register a Drive file linked to a notebook
+      remove       Unregister a living document
+      check-stale  Check which documents need syncing
+      sync         Sync all stale documents
+      templates    List available templates
+    """
+    pass
+
+
+@living_doc.command("list")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def living_doc_list(ctx, json_output, client_auth):
+    """List all registered living documents."""
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            docs = client.living_docs.list()
+
+            if json_output:
+                from dataclasses import asdict
+
+                data = {
+                    "documents": [asdict(d) for d in docs],
+                    "count": len(docs),
+                }
+                json_output_response(data)
+                return
+
+            if not docs:
+                console.print("[yellow]No living documents registered[/yellow]")
+                console.print("[dim]Use 'living-doc register' to add one[/dim]")
+                return
+
+            table = Table(title="Living Documents")
+            table.add_column("Drive File ID", style="cyan")
+            table.add_column("Title", style="green")
+            table.add_column("Notebook", style="dim")
+            table.add_column("Source ID", style="dim")
+            table.add_column("Last Synced", style="yellow")
+
+            for doc in docs:
+                table.add_row(
+                    doc.drive_file_id[:16] + "...",
+                    doc.title or "-",
+                    doc.notebook_id[:12] + "...",
+                    (doc.source_id[:12] + "...") if doc.source_id else "-",
+                    doc.last_synced_at or "never",
+                )
+
+            console.print(table)
+
+    return _run()
+
+
+@living_doc.command("register")
+@click.argument("drive_file_id")
+@click.option(
+    "-n",
+    "--notebook",
+    "notebook_id",
+    default=None,
+    help="Notebook ID (uses current if not set)",
+)
+@click.option("--title", default=None, help="Display title for the document")
+@click.option(
+    "--mime-type",
+    type=click.Choice(["google-doc", "google-slides", "google-sheets", "pdf"]),
+    default="google-doc",
+    help="Document type (default: google-doc)",
+)
+@click.option("--template", default=None, help="Template ID for categorization")
+@click.option(
+    "--no-add",
+    is_flag=True,
+    help="Register only, don't add as notebook source",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def living_doc_register(
+    ctx, drive_file_id, notebook_id, title, mime_type, template, no_add, json_output, client_auth
+):
+    """Register a Drive file as a living document.
+
+    Links a Google Drive file to a notebook so it can be monitored
+    for changes and synced automatically.
+
+    \b
+    Examples:
+      living-doc register 1abc123 --title "Master Timeline"
+      living-doc register 1abc123 -n nb_456 --template timeline-master
+      living-doc register 1abc123 --mime-type google-sheets --no-add
+    """
+    from ..rpc import DriveMimeType
+
+    nb_id = require_notebook(notebook_id)
+
+    mime_map = {
+        "google-doc": DriveMimeType.GOOGLE_DOC.value,
+        "google-slides": DriveMimeType.GOOGLE_SLIDES.value,
+        "google-sheets": DriveMimeType.GOOGLE_SHEETS.value,
+        "pdf": DriveMimeType.PDF.value,
+    }
+    mime = mime_map[mime_type]
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+
+            with console.status("Registering living document..."):
+                doc = await client.living_docs.register(
+                    drive_file_id=drive_file_id,
+                    notebook_id=nb_id_resolved,
+                    title=title,
+                    mime_type=mime,
+                    template=template,
+                    add_to_notebook=not no_add,
+                )
+
+            if json_output:
+                from dataclasses import asdict
+
+                json_output_response(asdict(doc))
+                return
+
+            console.print(f"[green]Registered living document:[/green] {doc.drive_file_id}")
+            if doc.title:
+                console.print(f"[bold]Title:[/bold] {doc.title}")
+            if doc.source_id:
+                console.print(f"[bold]Source ID:[/bold] {doc.source_id}")
+            if doc.template:
+                console.print(f"[bold]Template:[/bold] {doc.template}")
+
+    return _run()
+
+
+@living_doc.command("remove")
+@click.argument("drive_file_id")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@with_client
+def living_doc_remove(ctx, drive_file_id, yes, client_auth):
+    """Remove a living document from the registry.
+
+    This only removes the tracking entry. It does NOT delete the source
+    from NotebookLM or the file from Google Drive.
+    """
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            if not yes and not click.confirm(f"Unregister living document {drive_file_id}?"):
+                return
+
+            removed = client.living_docs.remove(drive_file_id)
+            if removed:
+                console.print(f"[green]Removed living document:[/green] {drive_file_id}")
+            else:
+                console.print("[yellow]Document not found in registry[/yellow]")
+
+    return _run()
+
+
+@living_doc.command("check-stale")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def living_doc_check_stale(ctx, json_output, client_auth):
+    """Check which living documents need syncing."""
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            with console.status("Checking document freshness..."):
+                result = await client.living_docs.check_stale()
+
+            if json_output:
+                from dataclasses import asdict
+
+                data = {
+                    "stale": [asdict(d) for d in result.stale],
+                    "stale_count": result.stale_count,
+                    "fresh": [asdict(d) for d in result.fresh],
+                    "fresh_count": result.fresh_count,
+                    "errors": result.errors,
+                    "total_documents": result.total_documents,
+                }
+                json_output_response(data)
+                return
+
+            if result.total_documents == 0:
+                console.print("[yellow]No living documents registered[/yellow]")
+                return
+
+            if result.stale:
+                console.print(f"[yellow]Stale documents ({result.stale_count}):[/yellow]")
+                for doc in result.stale:
+                    console.print(f"  - {doc.title or doc.drive_file_id}")
+                console.print("\n[dim]Run 'living-doc sync' to refresh[/dim]")
+            else:
+                console.print(f"[green]All {result.fresh_count} documents are fresh[/green]")
+
+            if result.errors:
+                console.print(f"\n[red]Errors ({len(result.errors)}):[/red]")
+                for err in result.errors:
+                    console.print(f"  - {err['drive_file_id']}: {err['error']}")
+
+    return _run()
+
+
+@living_doc.command("sync")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def living_doc_sync(ctx, json_output, client_auth):
+    """Sync all stale living documents by refreshing their sources."""
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            with console.status("Syncing living documents..."):
+                result = await client.living_docs.sync_all()
+
+            if json_output:
+                from dataclasses import asdict
+
+                data = {
+                    "synced": [asdict(d) for d in result.synced],
+                    "synced_count": result.synced_count,
+                    "skipped": [asdict(d) for d in result.skipped],
+                    "errors": result.errors,
+                }
+                json_output_response(data)
+                return
+
+            if result.synced:
+                console.print(f"[green]Synced {result.synced_count} document(s):[/green]")
+                for doc in result.synced:
+                    console.print(f"  - {doc.title or doc.drive_file_id}")
+
+            if result.skipped:
+                console.print(f"[dim]Skipped {len(result.skipped)} fresh document(s)[/dim]")
+
+            if result.errors:
+                console.print(f"\n[red]Errors ({len(result.errors)}):[/red]")
+                for err in result.errors:
+                    console.print(f"  - {err['drive_file_id']}: {err['error']}")
+
+            if not result.synced and not result.errors:
+                console.print("[green]All documents are already up to date[/green]")
+
+    return _run()
+
+
+@living_doc.command("templates")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def living_doc_templates(ctx, json_output, client_auth):
+    """List available living document templates."""
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            templates = client.living_docs.templates()
+
+            if json_output:
+                json_output_response({"templates": templates})
+                return
+
+            table = Table(title="Living Document Templates")
+            table.add_column("Template ID", style="cyan")
+            table.add_column("Title", style="green")
+            table.add_column("Description")
+            table.add_column("Suggested Notebooks", style="dim")
+
+            for tid, tmpl in templates.items():
+                table.add_row(
+                    tid,
+                    tmpl["title"],
+                    tmpl["description"],
+                    ", ".join(tmpl["suggested_notebooks"]),
+                )
+
+            console.print(table)
+
+    return _run()

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -160,6 +160,241 @@ def register_notebook_commands(cli):
 
         return _run()
 
+    @cli.command("get")
+    @click.argument("notebook_id", required=False, default=None)
+    @click.option(
+        "-n",
+        "--notebook",
+        "notebook_opt",
+        default=None,
+        help="Notebook ID (uses current if not set). Supports partial IDs.",
+    )
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+    @with_client
+    def get_cmd(ctx, notebook_id, notebook_opt, json_output, client_auth):
+        """Get notebook details.
+
+        NOTEBOOK_ID supports partial matching (e.g., 'abc' matches 'abc123...').
+        """
+        notebook_id = require_notebook(notebook_id or notebook_opt)
+
+        async def _run():
+            async with NotebookLMClient(client_auth) as client:
+                resolved_id = await resolve_notebook_id(client, notebook_id)
+                nb = await client.notebooks.get(resolved_id)
+
+                if json_output:
+                    data = {
+                        "notebook": {
+                            "id": nb.id,
+                            "title": nb.title,
+                            "is_owner": nb.is_owner,
+                            "sources_count": nb.sources_count,
+                            "created_at": nb.created_at.isoformat() if nb.created_at else None,
+                        }
+                    }
+                    json_output_response(data)
+                    return
+
+                console.print(f"[bold cyan]Notebook:[/bold cyan] {nb.title}")
+                console.print(f"[bold]ID:[/bold] {nb.id}")
+                console.print(f"[bold]Owner:[/bold] {'Yes' if nb.is_owner else 'No'}")
+                console.print(f"[bold]Sources:[/bold] {nb.sources_count}")
+                if nb.created_at:
+                    console.print(
+                        f"[bold]Created:[/bold] {nb.created_at.strftime('%Y-%m-%d %H:%M')}"
+                    )
+
+        return _run()
+
+    @cli.command("health")
+    @click.option(
+        "-n",
+        "--notebook",
+        "notebook_id",
+        default=None,
+        help="Notebook ID (uses current if not set). Supports partial IDs.",
+    )
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+    @with_client
+    def health_cmd(ctx, notebook_id, json_output, client_auth):
+        """Audit notebook health - check for empty, stale sources, duplicates.
+
+        NOTEBOOK_ID supports partial matching (e.g., 'abc' matches 'abc123...').
+        """
+        notebook_id = require_notebook(notebook_id)
+
+        async def _run():
+            async with NotebookLMClient(client_auth) as client:
+                resolved_id = await resolve_notebook_id(client, notebook_id)
+                report = await client.notebooks.health(resolved_id)
+
+                if json_output:
+                    data = {
+                        "notebook_id": report.notebook_id,
+                        "title": report.title,
+                        "source_count": report.source_count,
+                        "has_sources": report.has_sources,
+                        "stale_sources": report.stale_sources,
+                        "duplicate_urls": report.duplicate_urls,
+                        "status": report.status,
+                    }
+                    json_output_response(data)
+                    return
+
+                status_color = {
+                    "healthy": "green",
+                    "needs_attention": "yellow",
+                    "empty": "red",
+                }.get(report.status, "white")
+
+                console.print(f"[bold cyan]Health Report:[/bold cyan] {report.title}")
+                console.print(
+                    f"[bold]Status:[/bold] [{status_color}]{report.status}[/{status_color}]"
+                )
+                console.print(f"[bold]Sources:[/bold] {report.source_count}")
+
+                if report.stale_sources:
+                    console.print(
+                        f"\n[yellow]Stale sources ({len(report.stale_sources)}):[/yellow]"
+                    )
+                    for sid in report.stale_sources:
+                        console.print(f"  - {sid}")
+
+                if report.duplicate_urls:
+                    console.print(
+                        f"\n[yellow]Duplicate URLs ({len(report.duplicate_urls)}):[/yellow]"
+                    )
+                    for url in report.duplicate_urls:
+                        console.print(f"  - {url}")
+
+        return _run()
+
+    @cli.command("health-all")
+    @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+    @with_client
+    def health_all_cmd(ctx, json_output, client_auth):
+        """Audit health of ALL notebooks."""
+
+        async def _run():
+            async with NotebookLMClient(client_auth) as client:
+                reports = await client.notebooks.health_all()
+
+                if json_output:
+                    data = {
+                        "reports": [
+                            {
+                                "notebook_id": r.notebook_id,
+                                "title": r.title,
+                                "source_count": r.source_count,
+                                "has_sources": r.has_sources,
+                                "stale_sources": r.stale_sources,
+                                "duplicate_urls": r.duplicate_urls,
+                                "status": r.status,
+                            }
+                            for r in reports
+                        ],
+                        "count": len(reports),
+                    }
+                    json_output_response(data)
+                    return
+
+                if not reports:
+                    console.print("[yellow]No notebooks found[/yellow]")
+                    return
+
+                table = Table(title="Notebook Health")
+                table.add_column("Title", style="cyan")
+                table.add_column("Status")
+                table.add_column("Sources", justify="right")
+                table.add_column("Stale", justify="right")
+                table.add_column("Duplicates", justify="right")
+
+                for r in reports:
+                    status_color = {
+                        "healthy": "green",
+                        "needs_attention": "yellow",
+                        "empty": "red",
+                    }.get(r.status, "white")
+                    table.add_row(
+                        r.title,
+                        f"[{status_color}]{r.status}[/{status_color}]",
+                        str(r.source_count),
+                        str(len(r.stale_sources)),
+                        str(len(r.duplicate_urls)),
+                    )
+
+                console.print(table)
+
+        return _run()
+
+    @cli.command("merge")
+    @click.argument("target_notebook_id")
+    @click.option(
+        "-n",
+        "--notebook",
+        "notebook_id",
+        default=None,
+        help="Source notebook ID (uses current if not set). Supports partial IDs.",
+    )
+    @click.option(
+        "--skip-duplicates/--no-skip-duplicates",
+        default=True,
+        help="Skip sources that already exist in target (default: True)",
+    )
+    @click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+    @with_client
+    def merge_cmd(ctx, target_notebook_id, notebook_id, skip_duplicates, yes, client_auth):
+        """Merge sources from current notebook into target notebook.
+
+        Copies all sources from the source notebook into TARGET_NOTEBOOK_ID.
+        URL sources are re-added by URL; text sources are copied as text.
+
+        TARGET_NOTEBOOK_ID supports partial matching.
+        """
+        notebook_id = require_notebook(notebook_id)
+
+        async def _run():
+            async with NotebookLMClient(client_auth) as client:
+                source_id = await resolve_notebook_id(client, notebook_id)
+                target_id = await resolve_notebook_id(client, target_notebook_id)
+
+                if not yes and not click.confirm(
+                    f"Merge sources from {source_id} into {target_id}?"
+                ):
+                    return
+
+                added = await client.notebooks.merge(
+                    source_id, target_id, skip_duplicates=skip_duplicates
+                )
+                console.print(f"[green]Merged {len(added)} source(s)[/green] into {target_id}")
+
+        return _run()
+
+    @cli.command("archive")
+    @click.option(
+        "-n",
+        "--notebook",
+        "notebook_id",
+        default=None,
+        help="Notebook ID (uses current if not set). Supports partial IDs.",
+    )
+    @with_client
+    def archive_cmd(ctx, notebook_id, client_auth):
+        """Remove notebook from recently viewed list.
+
+        NOTEBOOK_ID supports partial matching (e.g., 'abc' matches 'abc123...').
+        """
+        notebook_id = require_notebook(notebook_id)
+
+        async def _run():
+            async with NotebookLMClient(client_auth) as client:
+                resolved_id = await resolve_notebook_id(client, notebook_id)
+                await client.notebooks.remove_from_recent(resolved_id)
+                console.print(f"[green]Archived notebook:[/green] {resolved_id}")
+
+        return _run()
+
     @cli.command("summary")
     @click.option(
         "-n",

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -531,7 +531,7 @@ def register_session_commands(cli):
         # Check 4: Token fetch (optional)
         if test_fetch:
             try:
-                csrf, session_id = run_async(fetch_tokens(cookies))
+                csrf, session_id, _build_label = run_async(fetch_tokens(cookies))
                 checks["token_fetch"] = True
                 details["csrf_length"] = len(csrf)
                 details["session_id_length"] = len(session_id)

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -1,17 +1,21 @@
 """Source management CLI commands.
 
 Commands:
-    list         List sources in a notebook
-    add          Add a source (url, text, file, youtube)
-    get          Get source details
-    fulltext     Get full indexed text content of a source
-    guide        Get AI-generated source summary and keywords
-    stale        Check if a URL/Drive source needs refresh
-    delete       Delete a source
-    rename       Rename a source
-    refresh      Refresh a URL/Drive source
-    add-drive    Add a Google Drive document
-    add-research Search web/drive and add sources from results
+    list           List sources in a notebook
+    add            Add a source (url, text, file, youtube)
+    add-bulk       Add multiple URLs at once
+    get            Get source details
+    fulltext       Get full indexed text content of a source
+    guide          Get AI-generated source summary and keywords
+    stale          Check if a URL/Drive source needs refresh
+    delete         Delete a source
+    delete-bulk    Delete multiple sources at once
+    rename         Rename a source
+    refresh        Refresh a URL/Drive source
+    refresh-bulk   Refresh multiple sources at once
+    wait-all       Wait for all specified sources to finish processing
+    add-drive      Add a Google Drive document
+    add-research   Search web/drive and add sources from results
 """
 
 import asyncio
@@ -31,6 +35,7 @@ from .helpers import (
     require_notebook,
     resolve_notebook_id,
     resolve_source_id,
+    resolve_source_ids,
     with_client,
 )
 
@@ -41,15 +46,19 @@ def source():
 
     \b
     Commands:
-      list         List sources in a notebook
-      add          Add a source (url, text, file, youtube)
-      get          Get source details
-      fulltext     Get full indexed text content
-      guide        Get AI-generated source summary and keywords
-      stale        Check if source needs refresh
-      delete       Delete a source
-      rename       Rename a source
-      refresh      Refresh a URL/Drive source
+      list           List sources in a notebook
+      add            Add a source (url, text, file, youtube)
+      add-bulk       Add multiple URLs at once
+      get            Get source details
+      fulltext       Get full indexed text content
+      guide          Get AI-generated source summary and keywords
+      stale          Check if source needs refresh
+      delete         Delete a source
+      delete-bulk    Delete multiple sources at once
+      rename         Rename a source
+      refresh        Refresh a URL/Drive source
+      refresh-bulk   Refresh multiple sources at once
+      wait-all       Wait for all sources to finish processing
 
     \b
     Partial ID Support:
@@ -769,6 +778,252 @@ def source_wait(ctx, source_id, notebook_id, timeout, json_output, client_auth):
                     json_output_response(data)
                 else:
                     console.print(f"[yellow]⚠ Timeout waiting for source:[/yellow] {e.source_id}")
+                    console.print(f"[dim]Last status: {e.last_status}[/dim]")
+                raise SystemExit(2) from None
+
+    return _run()
+
+
+@source.command("add-bulk")
+@click.argument("urls", nargs=-1, required=True)
+@click.option(
+    "-n",
+    "--notebook",
+    "notebook_id",
+    default=None,
+    help="Notebook ID (uses current if not set)",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def source_add_bulk(ctx, urls, notebook_id, json_output, client_auth):
+    """Add multiple URLs as sources at once.
+
+    \b
+    Examples:
+      source add-bulk https://example.com/a https://example.com/b
+      source add-bulk https://a.com https://b.com --json
+    """
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            sources = await client.sources.add_urls(nb_id_resolved, list(urls))
+
+            if json_output:
+                data = {
+                    "sources": [
+                        {
+                            "id": src.id,
+                            "title": src.title,
+                            "type": str(src.kind),
+                            "url": src.url,
+                        }
+                        for src in sources
+                    ],
+                    "count": len(sources),
+                }
+                json_output_response(data)
+                return
+
+            console.print(f"[green]Added {len(sources)} sources:[/green]")
+            for src in sources:
+                console.print(f"  {src.id}")
+
+    if not json_output:
+        with console.status(f"Adding {len(urls)} URL sources..."):
+            return _run()
+    return _run()
+
+
+@source.command("delete-bulk")
+@click.argument("source_ids", nargs=-1, required=True)
+@click.option(
+    "-n",
+    "--notebook",
+    "notebook_id",
+    default=None,
+    help="Notebook ID (uses current if not set)",
+)
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@with_client
+def source_delete_bulk(ctx, source_ids, notebook_id, yes, client_auth):
+    """Delete multiple sources at once.
+
+    SOURCE_ID arguments can be full UUIDs or partial prefixes.
+
+    \b
+    Examples:
+      source delete-bulk abc123 def456
+      source delete-bulk abc123 def456 -y    # Skip confirmation
+    """
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            resolved_ids = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            assert resolved_ids is not None  # guaranteed by required=True
+
+            if not yes and not click.confirm(f"Delete {len(resolved_ids)} sources?"):
+                return
+
+            deleted = await client.sources.delete_bulk(nb_id_resolved, resolved_ids)
+            console.print(f"[green]Deleted {len(deleted)} sources:[/green]")
+            for sid in deleted:
+                console.print(f"  {sid}")
+
+    return _run()
+
+
+@source.command("refresh-bulk")
+@click.argument("source_ids", nargs=-1, required=True)
+@click.option(
+    "-n",
+    "--notebook",
+    "notebook_id",
+    default=None,
+    help="Notebook ID (uses current if not set)",
+)
+@with_client
+def source_refresh_bulk(ctx, source_ids, notebook_id, client_auth):
+    """Refresh multiple URL/Drive sources at once.
+
+    SOURCE_ID arguments can be full UUIDs or partial prefixes.
+
+    \b
+    Examples:
+      source refresh-bulk abc123 def456
+    """
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            resolved_ids = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            assert resolved_ids is not None  # guaranteed by required=True
+
+            with console.status(f"Refreshing {len(resolved_ids)} sources..."):
+                refreshed = await client.sources.refresh_bulk(nb_id_resolved, resolved_ids)
+
+            console.print(f"[green]Refreshed {len(refreshed)} sources:[/green]")
+            for src in refreshed:
+                console.print(f"  {src.id}")
+
+    return _run()
+
+
+@source.command("wait-all")
+@click.argument("source_ids", nargs=-1, required=True)
+@click.option(
+    "-n",
+    "--notebook",
+    "notebook_id",
+    default=None,
+    help="Notebook ID (uses current if not set)",
+)
+@click.option(
+    "--timeout",
+    default=120,
+    type=int,
+    help="Maximum seconds to wait per source (default: 120)",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
+@with_client
+def source_wait_all(ctx, source_ids, notebook_id, timeout, json_output, client_auth):
+    """Wait for multiple sources to finish processing.
+
+    SOURCE_ID arguments can be full UUIDs or partial prefixes.
+
+    \b
+    Exit codes:
+      0 - All sources are ready
+      1 - A source was not found or processing failed
+      2 - Timeout reached
+
+    \b
+    Examples:
+      source wait-all abc123 def456                    # Wait for sources
+      source wait-all abc123 def456 --timeout 300      # Wait up to 5 minutes
+      source wait-all abc123 def456 --json             # Output as JSON
+    """
+    from ..types import SourceNotFoundError, SourceProcessingError, SourceTimeoutError
+
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            resolved_ids = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            assert resolved_ids is not None  # guaranteed by required=True
+
+            if not json_output:
+                console.print(f"[dim]Waiting for {len(resolved_ids)} sources...[/dim]")
+
+            try:
+                sources = await client.sources.wait_for_sources(
+                    nb_id_resolved,
+                    resolved_ids,
+                    timeout=float(timeout),
+                )
+
+                if json_output:
+                    data = {
+                        "sources": [
+                            {
+                                "source_id": src.id,
+                                "title": src.title,
+                                "status": "ready",
+                                "status_code": src.status,
+                            }
+                            for src in sources
+                        ],
+                        "count": len(sources),
+                    }
+                    json_output_response(data)
+                else:
+                    console.print(f"[green]All {len(sources)} sources ready:[/green]")
+                    for src in sources:
+                        title = f" ({src.title})" if src.title else ""
+                        console.print(f"  {src.id}{title}")
+
+            except SourceNotFoundError as e:
+                if json_output:
+                    data = {
+                        "source_id": e.source_id,
+                        "status": "not_found",
+                        "error": str(e),
+                    }
+                    json_output_response(data)
+                else:
+                    console.print(f"[red]Source not found:[/red] {e.source_id}")
+                raise SystemExit(1) from None
+
+            except SourceProcessingError as e:
+                if json_output:
+                    data = {
+                        "source_id": e.source_id,
+                        "status": "error",
+                        "status_code": e.status,
+                        "error": str(e),
+                    }
+                    json_output_response(data)
+                else:
+                    console.print(f"[red]Source processing failed:[/red] {e.source_id}")
+                raise SystemExit(1) from None
+
+            except SourceTimeoutError as e:
+                if json_output:
+                    data = {
+                        "source_id": e.source_id,
+                        "status": "timeout",
+                        "last_status_code": e.last_status,
+                        "timeout_seconds": int(e.timeout),
+                        "error": str(e),
+                    }
+                    json_output_response(data)
+                else:
+                    console.print(f"[yellow]Timeout waiting for source:[/yellow] {e.source_id}")
                     console.print(f"[dim]Last status: {e.last_status}[/dim]")
                 raise SystemExit(2) from None
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -86,8 +86,9 @@ class NotebookLMClient:
 
         # Initialize sub-client APIs
         # Note: notes must be initialized before artifacts (artifacts uses notes API)
-        self.notebooks = NotebooksAPI(self._core)
+        # Note: sources must be initialized before notebooks (notebooks uses sources for health checks)
         self.sources = SourcesAPI(self._core)
+        self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
         self.notes = NotesAPI(self._core)
         self.artifacts = ArtifactsAPI(self._core, notes_api=self.notes)
         self.chat = ChatAPI(self._core)

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -24,6 +24,7 @@ import re
 from pathlib import Path
 
 from ._artifacts import ArtifactsAPI
+from ._cache import CacheConfig, CacheMiddleware
 from ._chat import ChatAPI
 from ._core import DEFAULT_TIMEOUT, ClientCore
 from ._notebooks import NotebooksAPI
@@ -73,16 +74,29 @@ class NotebookLMClient:
         auth: The AuthTokens used for authentication
     """
 
-    def __init__(self, auth: AuthTokens, timeout: float = DEFAULT_TIMEOUT):
+    def __init__(
+        self,
+        auth: AuthTokens,
+        timeout: float = DEFAULT_TIMEOUT,
+        cache_config: CacheConfig | None = None,
+    ):
         """Initialize the NotebookLM client.
 
         Args:
             auth: Authentication tokens from browser login.
             timeout: HTTP request timeout in seconds. Defaults to 30 seconds.
+            cache_config: Optional cache configuration. If provided and enabled,
+                API responses will be cached locally and query/response pairs
+                will be stored for dataset building.
         """
+        # Initialize cache middleware if configured
+        self._cache = CacheMiddleware(cache_config) if cache_config else None
+
         # Pass refresh_auth as callback for automatic retry on auth failures
         # Note: refresh_auth calls update_auth_headers internally
-        self._core = ClientCore(auth, timeout=timeout, refresh_callback=self.refresh_auth)
+        self._core = ClientCore(
+            auth, timeout=timeout, refresh_callback=self.refresh_auth, cache=self._cache
+        )
 
         # Initialize sub-client APIs
         # Note: notes must be initialized before artifacts (artifacts uses notes API)
@@ -110,6 +124,8 @@ class NotebookLMClient:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Close the client connection."""
         logger.debug("Closing NotebookLM client")
+        if self._cache:
+            self._cache.close()
         await self._core.close()
 
     @property
@@ -119,7 +135,10 @@ class NotebookLMClient:
 
     @classmethod
     async def from_storage(
-        cls, path: str | None = None, timeout: float = DEFAULT_TIMEOUT
+        cls,
+        path: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        cache_config: CacheConfig | None = None,
     ) -> "NotebookLMClient":
         """Create a client from Playwright storage state file.
 
@@ -130,6 +149,8 @@ class NotebookLMClient:
             path: Path to storage_state.json. If None, uses default location
                   (~/.notebooklm/storage_state.json).
             timeout: HTTP request timeout in seconds. Defaults to 30 seconds.
+            cache_config: Optional cache configuration for response caching
+                and query/response dataset building.
 
         Returns:
             NotebookLMClient instance (not yet connected).
@@ -137,10 +158,15 @@ class NotebookLMClient:
         Example:
             async with await NotebookLMClient.from_storage() as client:
                 notebooks = await client.notebooks.list()
+
+            # With caching enabled:
+            config = CacheConfig(enabled=True, log_queries=True)
+            async with await NotebookLMClient.from_storage(cache_config=config) as client:
+                notebooks = await client.notebooks.list()
         """
         storage_path = Path(path) if path else None
         auth = await AuthTokens.from_storage(storage_path)
-        return cls(auth, timeout=timeout)
+        return cls(auth, timeout=timeout, cache_config=cache_config)
 
     async def refresh_auth(self) -> AuthTokens:
         """Refresh authentication tokens by fetching the NotebookLM homepage.

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -27,6 +27,7 @@ from ._artifacts import ArtifactsAPI
 from ._cache import CacheConfig, CacheMiddleware
 from ._chat import ChatAPI
 from ._core import DEFAULT_TIMEOUT, ClientCore
+from ._living_docs import LivingDocsAPI
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
@@ -51,6 +52,7 @@ class NotebookLMClient:
     - notes: Create and manage user notes
     - settings: Manage user settings (output language, etc.)
     - sharing: Manage notebook sharing and permissions
+    - living_docs: Auto-syncing Drive files linked to notebooks
 
     Usage:
         # Create from saved authentication
@@ -109,6 +111,7 @@ class NotebookLMClient:
         self.research = ResearchAPI(self._core)
         self.settings = SettingsAPI(self._core)
         self.sharing = SharingAPI(self._core)
+        self.living_docs = LivingDocsAPI(self._core, sources_api=self.sources)
 
     @property
     def auth(self) -> AuthTokens:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -207,6 +207,13 @@ class NotebookLMClient:
             )
         self._core.auth.session_id = sid_match.group(1)
 
+        # Extract cfb2h (build label / bl parameter) - keeps API requests current
+        # Without this, the hardcoded bl value goes stale every few weeks
+        bl_match = re.search(r'"cfb2h":"([^"]+)"', response.text)
+        if bl_match:
+            self._core.auth.build_label = bl_match.group(1)
+            logger.debug("Extracted build label: %s", self._core.auth.build_label)
+
         # CRITICAL: Update the HTTP client headers with new auth tokens
         # Without this, the client continues using stale credentials
         self._core.update_auth_headers()

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -65,6 +65,7 @@ from .cli import (
     download,
     generate,
     language,
+    living_doc,
     note,
     register_chat_commands,
     register_notebook_commands,
@@ -142,6 +143,7 @@ cli.add_command(share)
 cli.add_command(skill)
 cli.add_command(research)
 cli.add_command(language)
+cli.add_command(living_doc)
 
 
 # =============================================================================

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -244,6 +244,7 @@ __all__ = [
     # Dataclasses
     "Notebook",
     "NotebookDescription",
+    "NotebookHealth",
     "SuggestedTopic",
     "Source",
     "SourceFulltext",
@@ -387,6 +388,35 @@ class NotebookDescription:
             summary=data.get("summary", ""),
             suggested_topics=topics,
         )
+
+
+@dataclass
+class NotebookHealth:
+    """Health audit report for a notebook.
+
+    Returned by ``client.notebooks.health()`` and ``client.notebooks.health_all()``.
+    Checks for empty notebooks, stale sources, and duplicate URLs.
+
+    Attributes:
+        notebook_id: The notebook ID.
+        title: The notebook title.
+        source_count: Total number of sources in the notebook.
+        has_sources: Whether the notebook has any sources.
+        stale_sources: Source IDs that need refresh.
+        duplicate_urls: URLs that appear more than once across sources.
+        status: Overall health status -
+            ``"healthy"`` if no issues,
+            ``"needs_attention"`` if stale sources or duplicates exist,
+            ``"empty"`` if the notebook has no sources.
+    """
+
+    notebook_id: str
+    title: str
+    source_count: int
+    has_sources: bool
+    stale_sources: list[str] = field(default_factory=list)
+    duplicate_urls: list[str] = field(default_factory=list)
+    status: str = "healthy"
 
 
 # =============================================================================

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -67,7 +67,7 @@ def mock_auth_for_vcr():
         patch("notebooklm.cli.helpers.load_auth_from_storage", return_value=mock_cookies),
         patch(
             "notebooklm.cli.helpers.fetch_tokens",
-            return_value=("vcr_mock_csrf", "vcr_mock_session"),
+            return_value=("vcr_mock_csrf", "vcr_mock_session", "vcr_mock_bl"),
         ),
     ):
         yield

--- a/tests/integration/test_living_docs_mcp.py
+++ b/tests/integration/test_living_docs_mcp.py
@@ -1,0 +1,258 @@
+"""Integration test: verify local LivingDocsAPI matches MCP server behavior.
+
+This test uses a mock sources API to simulate the same flow the MCP worker
+performs, validating that our local registry produces identical outputs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._living_docs import (
+    LivingDocsAPI,
+)
+from notebooklm.types import Source
+
+# --- Fixtures matching real MCP server data ---
+
+REAL_NOTEBOOK_ID = "8b4e18ab-a101-4be7-b55b-35b6cd995af4"
+REAL_GOOGLE_DOC_SOURCES = [
+    {
+        "source_id": "0d81ddc2-4995-490f-becc-23efeff25177",
+        "title": "CASE STRATEGY MASTER: Nguyen v",
+        "type": "google_docs",
+        "is_fresh": True,
+    },
+    {
+        "source_id": "c673fbc2-145e-4828-8df4-0595d6d6059b",
+        "title": "Discovery Master Timeline - Nguyen v. Fay 2007-2026 (Court Ready)",
+        "type": "google_docs",
+        "is_fresh": True,
+    },
+    {
+        "source_id": "a488081a-b7e5-4370-bc74-5b255f9d28a6",
+        "title": "Complete Nguyen v. Fay Litigation Log & Strategy Analysis",
+        "type": "google_docs",
+        "is_fresh": True,
+    },
+]
+
+MCP_TEMPLATES = [
+    "violations-master",
+    "chain-of-title",
+    "timeline-master",
+    "damages-calculations",
+    "discovery-tracker",
+    "evidence-index",
+    "defendant-profiles",
+    "filing-strategy",
+]
+
+
+@pytest.fixture(autouse=True)
+def temp_registry(tmp_path, monkeypatch):
+    """Use a temporary registry file."""
+    registry_path = tmp_path / "living_docs.json"
+    monkeypatch.setattr(
+        "notebooklm._living_docs._get_registry_path",
+        lambda: registry_path,
+    )
+    return registry_path
+
+
+@pytest.fixture
+def mock_sources_api():
+    """Mock SourcesAPI that simulates real Google Docs source behavior."""
+    api = AsyncMock()
+
+    def make_source(drive_file_id):
+        # Simulate add_drive returning a Source object
+        for src in REAL_GOOGLE_DOC_SOURCES:
+            if src["source_id"] == drive_file_id:
+                return Source(id=src["source_id"], title=src["title"])
+        return Source(id=drive_file_id, title="Unknown")
+
+    api.add_drive = AsyncMock(side_effect=lambda nb_id, fid, title, mime: make_source(fid))
+    api.refresh = AsyncMock(return_value=True)
+    api.check_freshness = AsyncMock(return_value=True)  # default: fresh
+    return api
+
+
+@pytest.fixture
+def api(mock_sources_api):
+    core = MagicMock()
+    return LivingDocsAPI(core, sources_api=mock_sources_api)
+
+
+class TestMCPParity:
+    """Verify our local living docs match MCP server behavior."""
+
+    def test_templates_match_mcp(self, api):
+        """Our templates should match the MCP worker's template list."""
+        templates = api.templates()
+        assert sorted(templates.keys()) == sorted(MCP_TEMPLATES)
+
+    def test_list_empty_matches_mcp(self, api):
+        """Empty list should match MCP's empty response."""
+        docs = api.list()
+        assert len(docs) == 0
+        # MCP returns: {"documents": [], "count": 0, "templates": [...]}
+
+    @pytest.mark.asyncio
+    async def test_register_matches_mcp(self, api):
+        """Register should create a doc entry like MCP's register."""
+        doc = await api.register(
+            drive_file_id="drive_file_abc123",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Case Strategy Master",
+        )
+
+        # MCP returns: {"success": true, "drive_file_id": "...", "title": "...", ...}
+        assert doc.drive_file_id == "drive_file_abc123"
+        assert doc.notebook_id == REAL_NOTEBOOK_ID
+        assert doc.title == "Case Strategy Master"
+        assert doc.source_id is not None  # Should have been added to notebook
+
+    @pytest.mark.asyncio
+    async def test_register_list_roundtrip(self, api):
+        """Register then list should return the same doc."""
+        await api.register(
+            drive_file_id="file_1",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Timeline",
+            template="timeline-master",
+        )
+        await api.register(
+            drive_file_id="file_2",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Evidence",
+            template="evidence-index",
+        )
+
+        docs = api.list()
+        assert len(docs) == 2
+        # MCP returns: {"documents": [...], "count": 2, "templates": [...]}
+        assert docs[0].drive_file_id == "file_1"
+        assert docs[0].template == "timeline-master"
+        assert docs[1].drive_file_id == "file_2"
+        assert docs[1].template == "evidence-index"
+
+    @pytest.mark.asyncio
+    async def test_check_stale_all_fresh(self, api, mock_sources_api):
+        """All fresh docs should match MCP's stale_count=0 response."""
+        mock_sources_api.check_freshness = AsyncMock(return_value=True)
+
+        await api.register(
+            drive_file_id="file_1",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Doc 1",
+        )
+
+        result = await api.check_stale()
+        # MCP returns: {"stale": [], "stale_count": 0, "fresh": [...], "fresh_count": 1, ...}
+        assert result.stale_count == 0
+        assert result.fresh_count == 1
+        assert result.total_documents == 1
+
+    @pytest.mark.asyncio
+    async def test_check_stale_mixed(self, api, mock_sources_api):
+        """Mixed stale/fresh should report correctly."""
+        await api.register(
+            drive_file_id="fresh_doc",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Fresh",
+        )
+        await api.register(
+            drive_file_id="stale_doc",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Stale",
+        )
+
+        # Make check_freshness return False for stale_doc's source_id
+        docs = api.list()
+        stale_source_id = docs[1].source_id
+
+        async def freshness_check(nb_id, source_id):
+            return source_id != stale_source_id
+
+        mock_sources_api.check_freshness = AsyncMock(side_effect=freshness_check)
+
+        result = await api.check_stale()
+        assert result.stale_count == 1
+        assert result.fresh_count == 1
+        assert result.stale[0].title == "Stale"
+
+    @pytest.mark.asyncio
+    async def test_sync_refreshes_stale(self, api, mock_sources_api):
+        """Sync should refresh stale docs and skip fresh ones."""
+        await api.register(
+            drive_file_id="stale_doc",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Stale Doc",
+        )
+
+        mock_sources_api.check_freshness = AsyncMock(return_value=False)
+
+        result = await api.sync_all()
+        assert result.synced_count == 1
+        assert result.synced[0].title == "Stale Doc"
+        assert result.synced[0].last_synced_at is not None
+        mock_sources_api.refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_remove_matches_mcp(self, api):
+        """Remove should match MCP's remove behavior."""
+        await api.register(
+            drive_file_id="file_1",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="To Remove",
+        )
+
+        # MCP returns: {"success": true, "removed": true, "remaining": 0}
+        removed = api.remove("file_1")
+        assert removed is True
+
+        docs = api.list()
+        assert len(docs) == 0
+
+    @pytest.mark.asyncio
+    async def test_remove_nonexistent_matches_mcp(self, api):
+        """Remove nonexistent should return false."""
+        removed = api.remove("nonexistent")
+        assert removed is False
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self, api, mock_sources_api):
+        """Full lifecycle: register -> list -> check -> sync -> remove."""
+        # 1. Register
+        doc = await api.register(
+            drive_file_id="lifecycle_doc",
+            notebook_id=REAL_NOTEBOOK_ID,
+            title="Lifecycle Test",
+            template="timeline-master",
+        )
+        assert doc.source_id is not None
+
+        # 2. List
+        docs = api.list()
+        assert len(docs) == 1
+
+        # 3. Check (fresh)
+        mock_sources_api.check_freshness = AsyncMock(return_value=True)
+        result = await api.check_stale()
+        assert result.fresh_count == 1
+        assert result.stale_count == 0
+
+        # 4. Make stale and sync
+        mock_sources_api.check_freshness = AsyncMock(return_value=False)
+        sync_result = await api.sync_all()
+        assert sync_result.synced_count == 1
+
+        # 5. Verify sync updated timestamp
+        docs = api.list()
+        assert docs[0].last_synced_at is not None
+
+        # 6. Remove
+        removed = api.remove("lifecycle_doc")
+        assert removed is True
+        assert len(api.list()) == 0

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -38,7 +38,7 @@ def mock_fetch_tokens():
     Uses AsyncMock since fetch_tokens is an async function.
     """
     with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock:
-        mock.return_value = ("csrf_token", "session_id")
+        mock.return_value = ("csrf_token", "session_id", "bl_label")
         yield mock
 
 

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -51,7 +51,7 @@ class TestArtifactList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -70,7 +70,7 @@ class TestArtifactList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -89,7 +89,7 @@ class TestArtifactList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "list", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 0
@@ -125,7 +125,7 @@ class TestArtifactGet:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "get", "art_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -141,7 +141,7 @@ class TestArtifactGet:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "get", "nonexistent", "-n", "nb_123"])
 
             # Now exits with error from resolve_artifact_id (no match)
@@ -169,7 +169,7 @@ class TestArtifactRename:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "rename", "art_123", "New Title", "-n", "nb_123"]
                 )
@@ -192,7 +192,7 @@ class TestArtifactRename:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "rename", "mm_123", "New Title", "-n", "nb_123"]
                 )
@@ -221,7 +221,7 @@ class TestArtifactDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "delete", "art_123", "-n", "nb_123", "-y"])
 
             assert result.exit_code == 0
@@ -245,7 +245,7 @@ class TestArtifactDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "delete", "mm_456", "-n", "nb_123", "-y"])
 
             assert result.exit_code == 0
@@ -272,7 +272,7 @@ class TestArtifactExport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "export", "art_123", "--title", "My Export", "-n", "nb_123"]
                 )
@@ -301,7 +301,7 @@ class TestArtifactExport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -339,7 +339,7 @@ class TestArtifactExport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "export", "art_123", "--title", "Fail", "-n", "nb_123"]
                 )
@@ -363,7 +363,7 @@ class TestArtifactPoll:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "poll", "task_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -392,7 +392,7 @@ class TestArtifactWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "wait", "art_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -413,7 +413,7 @@ class TestArtifactWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "wait", "art_123", "-n", "nb_123"])
 
             assert result.exit_code == 1
@@ -432,7 +432,7 @@ class TestArtifactWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "wait", "art_123", "-n", "nb_123", "--timeout", "5"]
                 )
@@ -455,7 +455,7 @@ class TestArtifactWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "wait", "art_123", "-n", "nb_123", "--json"]
                 )
@@ -478,7 +478,7 @@ class TestArtifactWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["artifact", "wait", "art_123", "-n", "nb_123", "--json", "--timeout", "5"]
                 )
@@ -506,7 +506,7 @@ class TestArtifactSuggestions:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "suggestions", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -519,7 +519,7 @@ class TestArtifactSuggestions:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "suggestions", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -536,7 +536,7 @@ class TestArtifactSuggestions:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["artifact", "suggestions", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 0

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -63,7 +63,7 @@ class TestAskSaveAsNote:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["ask", "What is 42?", "--save-as-note", "-n", "nb_123"]
                 )
@@ -83,7 +83,7 @@ class TestAskSaveAsNote:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -111,7 +111,7 @@ class TestAskSaveAsNote:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["ask", "What is 42?", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -127,7 +127,7 @@ class TestHistoryCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -143,7 +143,7 @@ class TestHistoryCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "--save", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -157,7 +157,7 @@ class TestHistoryCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -171,7 +171,7 @@ class TestHistoryCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "--json", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -194,7 +194,7 @@ class TestHistoryCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "--json", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -216,7 +216,7 @@ class TestHistoryCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "--show-all", "-n", "nb_123"])
 
             assert result.exit_code == 0, result.output
@@ -254,7 +254,7 @@ class TestAskServerResumed:
                 patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
             ):
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "question"])
 
         assert result.exit_code == 0, result.output
@@ -284,7 +284,7 @@ class TestAskServerResumed:
                 patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
             ):
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "follow-up question"])
 
         assert result.exit_code == 0, result.output

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -59,7 +59,7 @@ def mock_fetch_tokens():
         patch.object(download_module, "load_auth_from_storage") as mock_load,
     ):
         mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-        mock_fetch.return_value = ("csrf", "session")
+        mock_fetch.return_value = ("csrf", "session", "bl_label")
         yield mock_fetch
 
 
@@ -91,7 +91,7 @@ class TestDownloadAudio:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["download", "audio", str(output_file), "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -110,7 +110,7 @@ class TestDownloadAudio:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["download", "audio", "--dry-run", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -127,7 +127,7 @@ class TestDownloadAudio:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["download", "audio", "-n", "nb_123"])
 
             assert "No completed audio artifacts found" in result.output or result.exit_code != 0
@@ -161,7 +161,7 @@ class TestDownloadVideo:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["download", "video", str(output_file), "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -196,7 +196,7 @@ class TestDownloadInfographic:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["download", "infographic", str(output_file), "-n", "nb_123"]
                 )
@@ -234,7 +234,7 @@ class TestDownloadSlideDeck:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test", "HSID": "test", "SSID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["download", "slide-deck", str(output_dir), "-n", "nb_123"]
                 )
@@ -278,7 +278,7 @@ class TestDownloadFlags:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["download", "audio", str(output_file), "--latest", "-n", "nb_123"]
                 )
@@ -315,7 +315,7 @@ class TestDownloadFlags:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["download", "audio", str(output_file), "--earliest", "-n", "nb_123"]
                 )
@@ -346,7 +346,7 @@ class TestDownloadFlags:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["download", "audio", str(output_file), "--force", "-n", "nb_123"]
                 )
@@ -372,7 +372,7 @@ class TestDownloadFlags:
                 patch.object(download_module, "load_auth_from_storage") as mock_load,
             ):
                 mock_load.return_value = {"SID": "test"}
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 runner.invoke(
                     cli, ["download", "audio", str(output_file), "--no-clobber", "-n", "nb_123"]
                 )

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -45,7 +45,7 @@ class TestGenerateAudio:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -60,7 +60,7 @@ class TestGenerateAudio:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "audio", "--format", "debate", "-n", "nb_123"]
                 )
@@ -77,7 +77,7 @@ class TestGenerateAudio:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "audio", "--length", "long", "-n", "nb_123"]
                 )
@@ -99,7 +99,7 @@ class TestGenerateAudio:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "--wait", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -112,7 +112,7 @@ class TestGenerateAudio:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -134,7 +134,7 @@ class TestGenerateVideo:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "video", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -148,7 +148,7 @@ class TestGenerateVideo:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "video", "--style", "kawaii", "-n", "nb_123"]
                 )
@@ -171,7 +171,7 @@ class TestGenerateQuiz:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "quiz", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -185,7 +185,7 @@ class TestGenerateQuiz:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -218,7 +218,7 @@ class TestGenerateFlashcards:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "flashcards", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -239,7 +239,7 @@ class TestGenerateSlideDeck:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "slide-deck", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -253,7 +253,7 @@ class TestGenerateSlideDeck:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -286,7 +286,7 @@ class TestGenerateInfographic:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "infographic", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -300,7 +300,7 @@ class TestGenerateInfographic:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -333,7 +333,7 @@ class TestGenerateDataTable:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "data-table", "Compare key concepts", "-n", "nb_123"]
                 )
@@ -356,7 +356,7 @@ class TestGenerateMindMap:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -377,7 +377,7 @@ class TestGenerateReport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "report", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -391,7 +391,7 @@ class TestGenerateReport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "report", "--format", "study-guide", "-n", "nb_123"]
                 )
@@ -407,7 +407,7 @@ class TestGenerateReport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "report", "Create a white paper", "-n", "nb_123"]
                 )
@@ -434,7 +434,7 @@ class TestGenerateReport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -465,7 +465,7 @@ class TestGenerateReport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -496,7 +496,7 @@ class TestGenerateReport:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["generate", "report", "My custom prompt", "--append", "extra", "-n", "nb_123"],
@@ -541,7 +541,7 @@ class TestGenerateJsonOutput:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", cmd, "--json", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -558,7 +558,7 @@ class TestGenerateJsonOutput:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "data-table", "Compare concepts", "--json", "-n", "nb_123"]
                 )
@@ -577,7 +577,7 @@ class TestGenerateJsonOutput:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "mind-map", "--json", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -632,7 +632,7 @@ class TestGenerateLanguageValidation:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["generate", "audio", "-n", "nb_123", "--language", "invalid_code"],
@@ -652,7 +652,7 @@ class TestGenerateLanguageValidation:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["generate", "audio", "-n", "nb_123", "--language", "ja"]
                 )
@@ -867,7 +867,7 @@ class TestRateLimitDetection:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
             assert "rate limited by Google" in result.output
@@ -887,7 +887,7 @@ class TestRateLimitDetection:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
 
             data = json.loads(result.output)
@@ -1158,7 +1158,7 @@ class TestGenerateReviseSlide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1187,7 +1187,7 @@ class TestGenerateReviseSlide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1217,7 +1217,7 @@ class TestGenerateReviseSlide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1240,7 +1240,7 @@ class TestGenerateReviseSlide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1266,7 +1266,7 @@ class TestGenerateReviseSlide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1310,7 +1310,7 @@ class TestGenerateReportWithNonBriefingFormat:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1340,7 +1340,7 @@ class TestGenerateReportWithNonBriefingFormat:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -1382,7 +1382,7 @@ class TestHandleGenerationResultPaths:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
         assert result.exit_code == 0
@@ -1396,7 +1396,7 @@ class TestHandleGenerationResultPaths:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
         assert result.exit_code == 0
@@ -1410,7 +1410,7 @@ class TestHandleGenerationResultPaths:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
         assert result.exit_code == 0
@@ -1424,7 +1424,7 @@ class TestHandleGenerationResultPaths:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
 
         # json_error_response calls sys.exit(1), so exit_code is 1
@@ -1454,7 +1454,7 @@ class TestHandleGenerationResultPaths:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
 
         assert result.exit_code == 0
@@ -1526,7 +1526,7 @@ class TestHandleGenerationResultListPathAndWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
 
         assert result.exit_code == 0
@@ -1555,7 +1555,7 @@ class TestHandleGenerationResultListPathAndWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
 
         assert result.exit_code == 0

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -420,7 +420,7 @@ class TestWithClientDecorator:
         with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load:
             mock_load.return_value = {"SID": "test"}
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(test_cmd)
 
         assert result.exit_code == 0
@@ -464,7 +464,7 @@ class TestWithClientDecorator:
         with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load:
             mock_load.return_value = {"SID": "test"}
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(test_cmd)
 
         assert result.exit_code == 1
@@ -488,7 +488,7 @@ class TestWithClientDecorator:
         with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load:
             mock_load.return_value = {"SID": "test"}
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(test_cmd, ["--json"])
 
         assert result.exit_code == 1
@@ -510,7 +510,7 @@ class TestGetClient:
         with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load:
             mock_load.return_value = {"SID": "test_sid"}
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf_token", "session_id")
+                mock_fetch.return_value = ("csrf_token", "session_id", "bl_label")
 
                 cookies, csrf, session = get_client(ctx)
 
@@ -525,7 +525,7 @@ class TestGetClient:
         with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load:
             mock_load.return_value = {"SID": "test"}
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
 
                 get_client(ctx)
 
@@ -540,7 +540,7 @@ class TestGetAuthTokens:
         with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load:
             mock_load.return_value = {"SID": "test_sid"}
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf_token", "session_id")
+                mock_fetch.return_value = ("csrf_token", "session_id", "bl_label")
 
                 auth = get_auth_tokens(ctx)
 

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -57,7 +57,7 @@ class TestNoteList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -69,7 +69,7 @@ class TestNoteList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -91,7 +91,7 @@ class TestNoteCreate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["note", "create", "Hello world", "--title", "My Note", "-n", "nb_123"],
@@ -109,7 +109,7 @@ class TestNoteCreate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "create", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -121,7 +121,7 @@ class TestNoteCreate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "create", "Test", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -147,7 +147,7 @@ class TestNoteGet:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "get", "note_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -163,7 +163,7 @@ class TestNoteGet:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "get", "nonexistent", "-n", "nb_123"])
 
             # resolve_note_id will raise ClickException for no match
@@ -188,7 +188,7 @@ class TestNoteSave:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["note", "save", "note_123", "--content", "New content", "-n", "nb_123"]
                 )
@@ -207,7 +207,7 @@ class TestNoteSave:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["note", "save", "note_123", "--title", "New Title", "-n", "nb_123"]
                 )
@@ -222,7 +222,7 @@ class TestNoteSave:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "save", "note_123", "-n", "nb_123"])
 
         assert "Provide --title and/or --content" in result.output
@@ -248,7 +248,7 @@ class TestNoteRename:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["note", "rename", "note_123", "New Title", "-n", "nb_123"]
                 )
@@ -265,7 +265,7 @@ class TestNoteRename:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["note", "rename", "nonexistent", "New Title", "-n", "nb_123"]
                 )
@@ -292,7 +292,7 @@ class TestNoteDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["note", "delete", "note_123", "-n", "nb_123", "-y"])
 
             assert result.exit_code == 0

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -45,7 +45,7 @@ class TestNotebookList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["list"])
 
             assert result.exit_code == 0
@@ -73,7 +73,7 @@ class TestNotebookList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["list"])
 
             assert result.exit_code == 0
@@ -96,7 +96,7 @@ class TestNotebookList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["list", "--json"])
 
             assert result.exit_code == 0
@@ -123,7 +123,7 @@ class TestNotebookCreate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["create", "Test Notebook"])
 
             assert result.exit_code == 0
@@ -140,7 +140,7 @@ class TestNotebookCreate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["create", "Test Notebook", "--json"])
 
             assert result.exit_code == 0
@@ -172,7 +172,7 @@ class TestNotebookDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["delete", "-n", "nb_to_delete", "-y"])
 
             assert result.exit_code == 0
@@ -205,7 +205,7 @@ class TestNotebookDelete:
                 patch("notebooklm.cli.notebook.clear_context"),
                 patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
             ):
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["delete", "-n", "nb_to_delete", "-y"])
 
             assert result.exit_code == 0
@@ -229,7 +229,7 @@ class TestNotebookDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["delete", "-n", "nb_123", "-y"])
 
             assert result.exit_code == 0
@@ -260,7 +260,7 @@ class TestNotebookRename:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["rename", "New Title", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -303,7 +303,7 @@ class TestNotebookSummary:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["summary", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -333,7 +333,7 @@ class TestNotebookSummary:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["summary", "-n", "nb_123", "--topics"])
 
             assert result.exit_code == 0
@@ -358,7 +358,7 @@ class TestNotebookSummary:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["summary", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -379,7 +379,7 @@ class TestNotebookHistory:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -393,7 +393,7 @@ class TestNotebookHistory:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -406,7 +406,7 @@ class TestNotebookHistory:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["history", "--clear"])
 
             assert result.exit_code == 0
@@ -440,7 +440,7 @@ class TestNotebookAsk:
                 ),
                 patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
             ):
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "What is this?"])
 
             assert result.exit_code == 0
@@ -460,7 +460,7 @@ class TestNotebookAsk:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "-c", "conv_123", "Follow-up"])
 
             assert result.exit_code == 0
@@ -480,7 +480,7 @@ class TestNotebookConfigure:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["configure", "-n", "nb_123", "--mode", "learning-guide"]
                 )
@@ -495,7 +495,7 @@ class TestNotebookConfigure:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["configure", "-n", "nb_123", "--persona", "Act as a tutor"]
                 )
@@ -511,7 +511,7 @@ class TestNotebookConfigure:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["configure", "-n", "nb_123", "--response-length", "longer"]
                 )
@@ -536,7 +536,7 @@ class TestSourceAddResearch:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add-research", "AI research", "-n", "nb_123"]
                 )
@@ -551,7 +551,7 @@ class TestSourceAddResearch:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add-research", "AI research", "-n", "nb_123"]
                 )
@@ -570,7 +570,7 @@ class TestSourceAddResearch:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add-research", "AI research", "-n", "nb_123", "--import-all"]
                 )

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -105,7 +105,7 @@ class TestUseCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
 
                 # Patch in session module where it's imported
                 with patch(
@@ -133,7 +133,7 @@ class TestUseCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
 
                 # Patch in session module where it's imported
                 with patch(
@@ -174,7 +174,7 @@ class TestUseCommand:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
 
                 # Patch in session module where it's imported
                 with patch(
@@ -533,7 +533,7 @@ class TestAuthCheckCommand:
         mock_storage_path.write_text(json.dumps(storage_data))
 
         with patch("notebooklm.auth.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-            mock_fetch.return_value = ("csrf_12345", "sess_67890")
+            mock_fetch.return_value = ("csrf_12345", "sess_67890", "bl_test")
 
             result = runner.invoke(cli, ["auth", "check", "--test", "--json"])
 
@@ -724,7 +724,7 @@ class TestSessionEdgeCases:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
 
                 # Patch in session module where it's imported
                 with patch(
@@ -761,7 +761,7 @@ class TestSessionEdgeCases:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
 
                 # Patch resolve_notebook_id to raise ClickException (e.g., ambiguous ID)
                 with patch(

--- a/tests/unit/cli/test_share.py
+++ b/tests/unit/cli/test_share.py
@@ -52,7 +52,7 @@ class TestShareStatus:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "status", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -73,7 +73,7 @@ class TestShareStatus:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "status", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -101,7 +101,7 @@ class TestSharePublic:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "public", "-n", "nb_123", "--enable"])
 
             assert result.exit_code == 0
@@ -123,7 +123,7 @@ class TestSharePublic:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "public", "-n", "nb_123", "--disable"])
 
             assert result.exit_code == 0
@@ -149,7 +149,7 @@ class TestShareAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "add", "user@example.com", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -175,7 +175,7 @@ class TestShareAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["share", "add", "user@example.com", "-n", "nb_123", "-p", "editor"],
@@ -210,7 +210,7 @@ class TestShareRemove:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["share", "remove", "user@example.com", "-n", "nb_123", "-y"]
                 )
@@ -231,7 +231,7 @@ class TestShareRemove:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["share", "remove", "user@example.com", "-n", "nb_123", "--json"]
                 )
@@ -267,7 +267,7 @@ class TestShareViewLevel:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "view-level", "full", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -297,7 +297,7 @@ class TestShareViewLevel:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "view-level", "chat", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -327,7 +327,7 @@ class TestShareViewLevel:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["share", "view-level", "full", "-n", "nb_123", "--json"]
                 )
@@ -354,7 +354,7 @@ class TestShareUpdate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["share", "update", "user@example.com", "-n", "nb_123", "-p", "editor"],
@@ -379,7 +379,7 @@ class TestShareUpdate:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -419,7 +419,7 @@ class TestShareJsonOutput:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "status", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 0
@@ -440,7 +440,7 @@ class TestShareJsonOutput:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "public", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 0
@@ -459,7 +459,7 @@ class TestShareJsonOutput:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["share", "add", "user@example.com", "-n", "nb_123", "--json"]
                 )
@@ -501,7 +501,7 @@ class TestShareStatusWithUsers:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["share", "status", "-n", "nb_123"])
 
             assert result.exit_code == 0

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -54,7 +54,7 @@ class TestSourceList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "list", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -76,7 +76,7 @@ class TestSourceList:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "list", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 0
@@ -105,7 +105,7 @@ class TestSourceAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add", "https://example.com", "-n", "nb_123"]
                 )
@@ -125,7 +125,7 @@ class TestSourceAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add", "https://youtube.com/watch?v=abc123", "-n", "nb_123"]
                 )
@@ -142,7 +142,7 @@ class TestSourceAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["source", "add", "Some text content", "--type", "text", "-n", "nb_123"],
@@ -159,7 +159,7 @@ class TestSourceAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -190,7 +190,7 @@ class TestSourceAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["source", "add", str(test_file), "--type", "file", "-n", "nb_123"],
@@ -211,7 +211,7 @@ class TestSourceAdd:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add", "https://example.com", "-n", "nb_123", "--json"]
                 )
@@ -245,7 +245,7 @@ class TestSourceGet:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "get", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -261,7 +261,7 @@ class TestSourceGet:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "get", "nonexistent", "-n", "nb_123"])
 
             # Now exits with error from resolve_source_id (no match)
@@ -286,7 +286,7 @@ class TestSourceDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "delete", "src_123", "-n", "nb_123", "-y"])
 
             assert result.exit_code == 0
@@ -304,7 +304,7 @@ class TestSourceDelete:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "delete", "src_123", "-n", "nb_123", "-y"])
 
             assert result.exit_code == 0
@@ -330,7 +330,7 @@ class TestSourceRename:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "rename", "src_123", "New Title", "-n", "nb_123"]
                 )
@@ -359,7 +359,7 @@ class TestSourceRefresh:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "refresh", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -376,7 +376,7 @@ class TestSourceRefresh:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "refresh", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -401,7 +401,7 @@ class TestSourceAddDrive:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "add-drive", "drive_file_id", "My Google Doc", "-n", "nb_123"]
                 )
@@ -421,7 +421,7 @@ class TestSourceAddDrive:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -465,7 +465,7 @@ class TestSourceGuide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "guide", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -484,7 +484,7 @@ class TestSourceGuide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "guide", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -502,7 +502,7 @@ class TestSourceGuide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "guide", "src_123", "-n", "nb_123", "--json"]
                 )
@@ -526,7 +526,7 @@ class TestSourceGuide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "guide", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -547,7 +547,7 @@ class TestSourceGuide:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "guide", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -573,7 +573,7 @@ class TestSourceStale:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "stale", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0  # 0 = stale (condition is true)
@@ -591,7 +591,7 @@ class TestSourceStale:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "stale", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 1  # 1 = not stale (condition is false)
@@ -657,7 +657,7 @@ class TestSourceAddAutoDetect:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["source", "add", str(test_file), "-n", "nb_123"],
@@ -679,7 +679,7 @@ class TestSourceAddAutoDetect:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["source", "add", "This is just some plain text content", "-n", "nb_123"],
@@ -704,7 +704,7 @@ class TestSourceAddAutoDetect:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     [
@@ -749,7 +749,7 @@ class TestSourceFulltext:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "fulltext", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -779,7 +779,7 @@ class TestSourceFulltext:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "fulltext", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -807,7 +807,7 @@ class TestSourceFulltext:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli,
                     ["source", "fulltext", "src_123", "-n", "nb_123", "-o", str(output_file)],
@@ -836,7 +836,7 @@ class TestSourceFulltext:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(
                     cli, ["source", "fulltext", "src_123", "-n", "nb_123", "--json"]
                 )
@@ -867,7 +867,7 @@ class TestSourceFulltext:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "fulltext", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -893,7 +893,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -912,7 +912,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 0
@@ -931,7 +931,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 0
@@ -952,7 +952,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 1
@@ -971,7 +971,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 1
@@ -992,7 +992,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 1
@@ -1011,7 +1011,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 1
@@ -1033,7 +1033,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123"])
 
             assert result.exit_code == 2
@@ -1052,7 +1052,7 @@ class TestSourceWait:
             mock_client_cls.return_value = mock_client
 
             with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
+                mock_fetch.return_value = ("csrf", "session", "bl_label")
                 result = runner.invoke(cli, ["source", "wait", "src_123", "-n", "nb_123", "--json"])
 
             assert result.exit_code == 2

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -517,10 +517,11 @@ class TestFetchTokens:
         )
 
         cookies = {"SID": "test_sid"}
-        csrf, session_id = await fetch_tokens(cookies)
+        csrf, session_id, build_label = await fetch_tokens(cookies)
 
         assert csrf == "AF1_QpN-csrf_token_123"
         assert session_id == "session_id_456"
+        assert build_label == ""  # No cfb2h in test HTML
 
     @pytest.mark.asyncio
     async def test_fetch_tokens_redirect_to_login(self, httpx_mock: HTTPXMock):

--- a/tests/unit/test_bulk_operations.py
+++ b/tests/unit/test_bulk_operations.py
@@ -1,0 +1,187 @@
+"""Unit tests for SourcesAPI bulk operations."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._sources import SourcesAPI
+from notebooklm.types import Source, SourceAddError
+
+
+@pytest.fixture
+def sources_api():
+    """Create a SourcesAPI with a mocked core."""
+    core = MagicMock()
+    return SourcesAPI(core)
+
+
+# =========================================================================
+# add_urls
+# =========================================================================
+
+
+class TestAddUrls:
+    """Tests for SourcesAPI.add_urls()."""
+
+    @pytest.mark.asyncio
+    async def test_add_urls_success(self, sources_api):
+        """All URLs added successfully."""
+        src_a = Source(id="a", title="A")
+        src_b = Source(id="b", title="B")
+
+        sources_api.add_url = AsyncMock(side_effect=[src_a, src_b])
+
+        result = await sources_api.add_urls("nb1", ["http://a.com", "http://b.com"])
+
+        assert result == [src_a, src_b]
+        assert sources_api.add_url.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_add_urls_empty_list(self, sources_api):
+        """Empty URL list returns empty result."""
+        sources_api.add_url = AsyncMock()
+
+        result = await sources_api.add_urls("nb1", [])
+
+        assert result == []
+        sources_api.add_url.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_urls_failure_raises(self, sources_api):
+        """Without skip_failures, first error is raised."""
+        sources_api.add_url = AsyncMock(
+            side_effect=[Source(id="a", title="A"), SourceAddError("http://b.com")]
+        )
+
+        with pytest.raises(SourceAddError):
+            await sources_api.add_urls("nb1", ["http://a.com", "http://b.com"])
+
+    @pytest.mark.asyncio
+    async def test_add_urls_skip_failures(self, sources_api):
+        """With skip_failures=True, errors are skipped."""
+        src_a = Source(id="a", title="A")
+        sources_api.add_url = AsyncMock(side_effect=[src_a, SourceAddError("http://b.com")])
+
+        result = await sources_api.add_urls(
+            "nb1", ["http://a.com", "http://b.com"], skip_failures=True
+        )
+
+        assert result == [src_a]
+
+    @pytest.mark.asyncio
+    async def test_add_urls_all_fail_skip(self, sources_api):
+        """With skip_failures=True and all failing, returns empty list."""
+        sources_api.add_url = AsyncMock(
+            side_effect=[SourceAddError("http://a.com"), SourceAddError("http://b.com")]
+        )
+
+        result = await sources_api.add_urls(
+            "nb1", ["http://a.com", "http://b.com"], skip_failures=True
+        )
+
+        assert result == []
+
+
+# =========================================================================
+# delete_bulk
+# =========================================================================
+
+
+class TestDeleteBulk:
+    """Tests for SourcesAPI.delete_bulk()."""
+
+    @pytest.mark.asyncio
+    async def test_delete_bulk_success(self, sources_api):
+        """All deletions succeed."""
+        sources_api.delete = AsyncMock(return_value=True)
+
+        result = await sources_api.delete_bulk("nb1", ["s1", "s2", "s3"])
+
+        assert result == ["s1", "s2", "s3"]
+        assert sources_api.delete.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_delete_bulk_empty_list(self, sources_api):
+        """Empty list returns empty result."""
+        sources_api.delete = AsyncMock()
+
+        result = await sources_api.delete_bulk("nb1", [])
+
+        assert result == []
+        sources_api.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_bulk_partial_failure(self, sources_api):
+        """Partial failures are skipped, successful IDs returned."""
+        sources_api.delete = AsyncMock(side_effect=[True, RuntimeError("fail"), True])
+
+        result = await sources_api.delete_bulk("nb1", ["s1", "s2", "s3"])
+
+        assert result == ["s1", "s3"]
+
+
+# =========================================================================
+# refresh_bulk
+# =========================================================================
+
+
+class TestRefreshBulk:
+    """Tests for SourcesAPI.refresh_bulk()."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_bulk_with_ids(self, sources_api):
+        """Refresh specific source IDs."""
+        sources_api.refresh = AsyncMock(return_value=True)
+
+        result = await sources_api.refresh_bulk("nb1", ["s1", "s2"])
+
+        assert len(result) == 2
+        assert result[0].id == "s1"
+        assert result[1].id == "s2"
+        assert sources_api.refresh.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_refresh_bulk_none_lists_all(self, sources_api):
+        """With source_ids=None, lists all sources first."""
+        sources_api.list = AsyncMock(
+            return_value=[Source(id="x1", title="X1"), Source(id="x2", title="X2")]
+        )
+        sources_api.refresh = AsyncMock(return_value=True)
+
+        result = await sources_api.refresh_bulk("nb1")
+
+        sources_api.list.assert_called_once_with("nb1")
+        assert len(result) == 2
+        assert result[0].id == "x1"
+        assert result[1].id == "x2"
+
+    @pytest.mark.asyncio
+    async def test_refresh_bulk_empty_list(self, sources_api):
+        """Empty list returns empty result."""
+        sources_api.refresh = AsyncMock()
+
+        result = await sources_api.refresh_bulk("nb1", [])
+
+        assert result == []
+        sources_api.refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_bulk_none_empty_notebook(self, sources_api):
+        """With source_ids=None and empty notebook, returns empty."""
+        sources_api.list = AsyncMock(return_value=[])
+        sources_api.refresh = AsyncMock()
+
+        result = await sources_api.refresh_bulk("nb1")
+
+        assert result == []
+        sources_api.refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_bulk_partial_failure(self, sources_api):
+        """Partial failures are skipped."""
+        sources_api.refresh = AsyncMock(side_effect=[True, RuntimeError("fail")])
+
+        result = await sources_api.refresh_bulk("nb1", ["s1", "s2"])
+
+        assert len(result) == 1
+        assert result[0].id == "s1"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -594,8 +594,8 @@ class TestRpcCallAutoRetry:
         assert call_count[0] == 2, "Should only retry once"
 
     @pytest.mark.asyncio
-    async def test_no_retry_on_non_auth_error(self):
-        """rpc_call should NOT retry on non-auth errors (HTTP 500)."""
+    async def test_no_retry_on_non_retryable_client_error(self):
+        """rpc_call should NOT retry on non-retryable client errors (HTTP 400)."""
         auth = AuthTokens(
             cookies={"SID": "test"},
             csrf_token="csrf",
@@ -615,17 +615,48 @@ class TestRpcCallAutoRetry:
         async def mock_post(*args, **kwargs):
             call_count[0] += 1
             request = httpx.Request("POST", args[0])
+            response = httpx.Response(400, request=request)
+            raise httpx.HTTPStatusError("Bad Request", request=request, response=response)
+
+        core._http_client = MagicMock()
+        core._http_client.post = mock_post
+
+        with pytest.raises(RPCError, match="Client error 400"):
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+        assert len(refresh_called) == 0, "Should not refresh on non-auth error"
+        assert call_count[0] == 1, "Should not retry on non-retryable error"
+
+    @pytest.mark.asyncio
+    async def test_retries_on_server_error(self):
+        """rpc_call should retry with backoff on 500/502/503/504 errors."""
+        from unittest.mock import patch as mock_patch
+
+        auth = AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="csrf",
+            session_id="sid",
+        )
+        core = ClientCore(auth, refresh_retry_delay=0)
+
+        call_count = [0]
+
+        async def mock_post(*args, **kwargs):
+            call_count[0] += 1
+            request = httpx.Request("POST", args[0])
             response = httpx.Response(500, request=request)
             raise httpx.HTTPStatusError("Server Error", request=request, response=response)
 
         core._http_client = MagicMock()
         core._http_client.post = mock_post
 
-        with pytest.raises(RPCError, match="Server error 500"):
+        with (
+            mock_patch("notebooklm._core.asyncio.sleep", return_value=None),
+            pytest.raises(RPCError, match="Server error 500"),
+        ):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
-        assert len(refresh_called) == 0, "Should not refresh on non-auth error"
-        assert call_count[0] == 1, "Should not retry on non-auth error"
+        assert call_count[0] == 4, "Should retry 3 times (4 total attempts)"
 
     @pytest.mark.asyncio
     async def test_refresh_failure_raises_original_error(self):

--- a/tests/unit/test_living_docs.py
+++ b/tests/unit/test_living_docs.py
@@ -1,0 +1,242 @@
+"""Unit tests for the Living Documents API."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from notebooklm._living_docs import (
+    LIVING_DOC_TEMPLATES,
+    LivingDoc,
+    LivingDocsAPI,
+    StaleCheckResult,
+    SyncResult,
+    _get_registry_path,
+    _load_registry,
+    _save_registry,
+)
+from notebooklm.rpc import DriveMimeType
+from notebooklm.types import Source
+
+
+@pytest.fixture
+def mock_source():
+    """Create a mock Source object."""
+    return Source(id="src_001", title="Test Doc")
+
+
+@pytest.fixture
+def mock_sources_api(mock_source):
+    """Create a mock SourcesAPI."""
+    api = AsyncMock()
+    api.add_drive = AsyncMock(return_value=mock_source)
+    api.refresh = AsyncMock(return_value=True)
+    api.check_freshness = AsyncMock(return_value=True)
+    return api
+
+
+@pytest.fixture
+def living_docs_api(mock_sources_api):
+    """Create a LivingDocsAPI with mocked dependencies."""
+    core = MagicMock()
+    return LivingDocsAPI(core, sources_api=mock_sources_api)
+
+
+@pytest.fixture(autouse=True)
+def temp_registry(tmp_path, monkeypatch):
+    """Use a temporary registry file for all tests."""
+    registry_path = tmp_path / "living_docs.json"
+    monkeypatch.setattr(
+        "notebooklm._living_docs._get_registry_path",
+        lambda: registry_path,
+    )
+    return registry_path
+
+
+class TestLivingDocDataclass:
+    def test_defaults(self):
+        doc = LivingDoc(drive_file_id="abc", notebook_id="nb_1")
+        assert doc.drive_file_id == "abc"
+        assert doc.notebook_id == "nb_1"
+        assert doc.source_id is None
+        assert doc.mime_type == DriveMimeType.GOOGLE_DOC.value
+        assert doc.registered_at  # Should be auto-set
+
+    def test_custom_values(self):
+        doc = LivingDoc(
+            drive_file_id="abc",
+            notebook_id="nb_1",
+            title="My Doc",
+            template="timeline-master",
+        )
+        assert doc.title == "My Doc"
+        assert doc.template == "timeline-master"
+
+
+class TestStaleCheckResult:
+    def test_counts(self):
+        result = StaleCheckResult(
+            stale=[LivingDoc(drive_file_id="a", notebook_id="nb1")],
+            fresh=[
+                LivingDoc(drive_file_id="b", notebook_id="nb2"),
+                LivingDoc(drive_file_id="c", notebook_id="nb3"),
+            ],
+            errors=[{"drive_file_id": "d", "error": "fail"}],
+        )
+        assert result.stale_count == 1
+        assert result.fresh_count == 2
+        assert result.total_documents == 4
+
+    def test_empty(self):
+        result = StaleCheckResult()
+        assert result.stale_count == 0
+        assert result.fresh_count == 0
+        assert result.total_documents == 0
+
+
+class TestSyncResult:
+    def test_synced_count(self):
+        result = SyncResult(
+            synced=[LivingDoc(drive_file_id="a", notebook_id="nb1")],
+        )
+        assert result.synced_count == 1
+
+
+class TestRegistry:
+    def test_load_empty(self, temp_registry):
+        assert _load_registry() == []
+
+    def test_save_and_load(self, temp_registry):
+        docs = [{"drive_file_id": "abc", "notebook_id": "nb_1"}]
+        _save_registry(docs)
+        loaded = _load_registry()
+        assert len(loaded) == 1
+        assert loaded[0]["drive_file_id"] == "abc"
+
+    def test_load_corrupt(self, temp_registry):
+        temp_registry.write_text("not json")
+        assert _load_registry() == []
+
+
+class TestLivingDocsAPI:
+    def test_list_empty(self, living_docs_api):
+        assert living_docs_api.list() == []
+
+    def test_templates(self, living_docs_api):
+        templates = living_docs_api.templates()
+        assert "timeline-master" in templates
+        assert "violations-master" in templates
+        assert len(templates) == len(LIVING_DOC_TEMPLATES)
+
+    @pytest.mark.asyncio
+    async def test_register(self, living_docs_api, mock_sources_api):
+        doc = await living_docs_api.register(
+            drive_file_id="file_123",
+            notebook_id="nb_456",
+            title="My Timeline",
+        )
+        assert doc.drive_file_id == "file_123"
+        assert doc.notebook_id == "nb_456"
+        assert doc.title == "My Timeline"
+        assert doc.source_id == "src_001"
+        assert doc.last_synced_at is not None
+
+        mock_sources_api.add_drive.assert_called_once()
+
+        # Verify persisted
+        docs = living_docs_api.list()
+        assert len(docs) == 1
+        assert docs[0].drive_file_id == "file_123"
+
+    @pytest.mark.asyncio
+    async def test_register_no_add(self, living_docs_api, mock_sources_api):
+        doc = await living_docs_api.register(
+            drive_file_id="file_123",
+            notebook_id="nb_456",
+            add_to_notebook=False,
+        )
+        assert doc.source_id is None
+        mock_sources_api.add_drive.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_register_dedup(self, living_docs_api):
+        await living_docs_api.register(
+            drive_file_id="file_123",
+            notebook_id="nb_456",
+            title="v1",
+        )
+        await living_docs_api.register(
+            drive_file_id="file_123",
+            notebook_id="nb_456",
+            title="v2",
+        )
+        docs = living_docs_api.list()
+        assert len(docs) == 1
+        assert docs[0].title == "v2"
+
+    def test_remove(self, living_docs_api, temp_registry):
+        _save_registry([{"drive_file_id": "abc", "notebook_id": "nb_1"}])
+        assert living_docs_api.remove("abc") is True
+        assert living_docs_api.list() == []
+
+    def test_remove_not_found(self, living_docs_api):
+        assert living_docs_api.remove("nonexistent") is False
+
+    @pytest.mark.asyncio
+    async def test_check_stale_fresh(self, living_docs_api, mock_sources_api):
+        _save_registry(
+            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
+        )
+        mock_sources_api.check_freshness = AsyncMock(return_value=True)
+
+        result = await living_docs_api.check_stale()
+        assert result.fresh_count == 1
+        assert result.stale_count == 0
+
+    @pytest.mark.asyncio
+    async def test_check_stale_stale(self, living_docs_api, mock_sources_api):
+        _save_registry(
+            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
+        )
+        mock_sources_api.check_freshness = AsyncMock(return_value=False)
+
+        result = await living_docs_api.check_stale()
+        assert result.stale_count == 1
+        assert result.fresh_count == 0
+
+    @pytest.mark.asyncio
+    async def test_check_stale_no_source_id(self, living_docs_api):
+        _save_registry([{"drive_file_id": "abc", "notebook_id": "nb_1"}])
+
+        result = await living_docs_api.check_stale()
+        assert len(result.errors) == 1
+        assert "No source_id" in result.errors[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_sync_all(self, living_docs_api, mock_sources_api):
+        _save_registry(
+            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
+        )
+        mock_sources_api.check_freshness = AsyncMock(return_value=False)
+
+        result = await living_docs_api.sync_all()
+        assert result.synced_count == 1
+        mock_sources_api.refresh.assert_called_once_with("nb_1", "src_1")
+
+    @pytest.mark.asyncio
+    async def test_sync_all_skips_fresh(self, living_docs_api, mock_sources_api):
+        _save_registry(
+            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
+        )
+        mock_sources_api.check_freshness = AsyncMock(return_value=True)
+
+        result = await living_docs_api.sync_all()
+        assert result.synced_count == 0
+        assert len(result.skipped) == 1
+        mock_sources_api.refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_to_notebook(self, living_docs_api, mock_sources_api):
+        doc = await living_docs_api.add_to_notebook("file_123", "nb_456")
+        assert doc.source_id == "src_001"
+        mock_sources_api.add_drive.assert_called_once()

--- a/tests/unit/test_living_docs.py
+++ b/tests/unit/test_living_docs.py
@@ -1,7 +1,6 @@
 """Unit tests for the Living Documents API."""
 
-import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -11,7 +10,6 @@ from notebooklm._living_docs import (
     LivingDocsAPI,
     StaleCheckResult,
     SyncResult,
-    _get_registry_path,
     _load_registry,
     _save_registry,
 )
@@ -184,9 +182,7 @@ class TestLivingDocsAPI:
 
     @pytest.mark.asyncio
     async def test_check_stale_fresh(self, living_docs_api, mock_sources_api):
-        _save_registry(
-            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
-        )
+        _save_registry([{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}])
         mock_sources_api.check_freshness = AsyncMock(return_value=True)
 
         result = await living_docs_api.check_stale()
@@ -195,9 +191,7 @@ class TestLivingDocsAPI:
 
     @pytest.mark.asyncio
     async def test_check_stale_stale(self, living_docs_api, mock_sources_api):
-        _save_registry(
-            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
-        )
+        _save_registry([{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}])
         mock_sources_api.check_freshness = AsyncMock(return_value=False)
 
         result = await living_docs_api.check_stale()
@@ -214,9 +208,7 @@ class TestLivingDocsAPI:
 
     @pytest.mark.asyncio
     async def test_sync_all(self, living_docs_api, mock_sources_api):
-        _save_registry(
-            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
-        )
+        _save_registry([{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}])
         mock_sources_api.check_freshness = AsyncMock(return_value=False)
 
         result = await living_docs_api.sync_all()
@@ -225,9 +217,7 @@ class TestLivingDocsAPI:
 
     @pytest.mark.asyncio
     async def test_sync_all_skips_fresh(self, living_docs_api, mock_sources_api):
-        _save_registry(
-            [{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}]
-        )
+        _save_registry([{"drive_file_id": "abc", "notebook_id": "nb_1", "source_id": "src_1"}])
         mock_sources_api.check_freshness = AsyncMock(return_value=True)
 
         result = await living_docs_api.sync_all()

--- a/tests/unit/test_notebook_health.py
+++ b/tests/unit/test_notebook_health.py
@@ -1,0 +1,289 @@
+"""Tests for NotebooksAPI.health() and health_all() methods."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._notebooks import NotebooksAPI
+from notebooklm.types import Notebook, NotebookHealth, Source
+
+
+@pytest.fixture
+def mock_core():
+    """Create a mock ClientCore."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_sources():
+    """Create a mock SourcesAPI."""
+    sources = AsyncMock()
+    return sources
+
+
+@pytest.fixture
+def notebooks_api(mock_core, mock_sources):
+    """Create a NotebooksAPI with mocked dependencies."""
+    return NotebooksAPI(mock_core, sources_api=mock_sources)
+
+
+@pytest.fixture
+def notebooks_api_no_sources(mock_core):
+    """Create a NotebooksAPI without a sources API."""
+    return NotebooksAPI(mock_core)
+
+
+# =============================================================================
+# NotebookHealth DATACLASS TESTS
+# =============================================================================
+
+
+class TestNotebookHealthDataclass:
+    def test_default_values(self):
+        """Test NotebookHealth has correct defaults."""
+        health = NotebookHealth(
+            notebook_id="nb-1",
+            title="Test",
+            source_count=0,
+            has_sources=False,
+        )
+        assert health.stale_sources == []
+        assert health.duplicate_urls == []
+        assert health.status == "healthy"
+
+    def test_all_fields(self):
+        """Test NotebookHealth with all fields set."""
+        health = NotebookHealth(
+            notebook_id="nb-1",
+            title="Test",
+            source_count=3,
+            has_sources=True,
+            stale_sources=["src-1", "src-2"],
+            duplicate_urls=["https://example.com"],
+            status="needs_attention",
+        )
+        assert health.notebook_id == "nb-1"
+        assert health.title == "Test"
+        assert health.source_count == 3
+        assert health.has_sources is True
+        assert len(health.stale_sources) == 2
+        assert len(health.duplicate_urls) == 1
+        assert health.status == "needs_attention"
+
+
+# =============================================================================
+# health() METHOD TESTS
+# =============================================================================
+
+
+class TestNotebookHealth:
+    @pytest.mark.asyncio
+    async def test_health_no_sources_api_raises(self, notebooks_api_no_sources):
+        """Test health() raises RuntimeError when no sources API is available."""
+        with pytest.raises(RuntimeError, match="No sources API available"):
+            await notebooks_api_no_sources.health("nb-1")
+
+    @pytest.mark.asyncio
+    async def test_health_empty_notebook(self, notebooks_api, mock_sources):
+        """Test health() returns 'empty' status for notebook with no sources."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Empty Notebook"))
+        mock_sources.list.return_value = []
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.notebook_id == "nb-1"
+        assert result.title == "Empty Notebook"
+        assert result.source_count == 0
+        assert result.has_sources is False
+        assert result.stale_sources == []
+        assert result.duplicate_urls == []
+        assert result.status == "empty"
+
+    @pytest.mark.asyncio
+    async def test_health_healthy_notebook(self, notebooks_api, mock_sources):
+        """Test health() returns 'healthy' for a good notebook."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Good Notebook"))
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Source 1", url="https://example.com"),
+            Source(id="src-2", title="Source 2", url="https://other.com"),
+        ]
+        # All sources are fresh
+        mock_sources.check_freshness.return_value = True
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.status == "healthy"
+        assert result.source_count == 2
+        assert result.has_sources is True
+        assert result.stale_sources == []
+        assert result.duplicate_urls == []
+
+    @pytest.mark.asyncio
+    async def test_health_stale_sources(self, notebooks_api, mock_sources):
+        """Test health() detects stale sources."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Stale Notebook"))
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Fresh Source"),
+            Source(id="src-2", title="Stale Source"),
+        ]
+        # First source fresh, second stale
+        mock_sources.check_freshness.side_effect = [True, False]
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.status == "needs_attention"
+        assert result.stale_sources == ["src-2"]
+
+    @pytest.mark.asyncio
+    async def test_health_freshness_check_exception(self, notebooks_api, mock_sources):
+        """Test health() flags sources as stale when freshness check fails."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Error Notebook"))
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Error Source"),
+        ]
+        # Freshness check throws an exception
+        mock_sources.check_freshness.side_effect = Exception("API error")
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.status == "needs_attention"
+        assert result.stale_sources == ["src-1"]
+
+    @pytest.mark.asyncio
+    async def test_health_duplicate_urls(self, notebooks_api, mock_sources):
+        """Test health() detects duplicate URLs."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Dupes Notebook"))
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Source 1", url="https://example.com"),
+            Source(id="src-2", title="Source 2", url="https://example.com"),
+            Source(id="src-3", title="Source 3", url="https://unique.com"),
+        ]
+        mock_sources.check_freshness.return_value = True
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.status == "needs_attention"
+        assert result.duplicate_urls == ["https://example.com"]
+        assert result.stale_sources == []
+
+    @pytest.mark.asyncio
+    async def test_health_sources_without_urls_no_duplicates(self, notebooks_api, mock_sources):
+        """Test health() ignores sources without URLs for duplicate check."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Text Notebook"))
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Text Source 1", url=None),
+            Source(id="src-2", title="Text Source 2", url=None),
+        ]
+        mock_sources.check_freshness.return_value = True
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.status == "healthy"
+        assert result.duplicate_urls == []
+
+    @pytest.mark.asyncio
+    async def test_health_stale_and_duplicates(self, notebooks_api, mock_sources):
+        """Test health() reports needs_attention when both issues exist."""
+        notebooks_api.get = AsyncMock(return_value=Notebook(id="nb-1", title="Bad Notebook"))
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Source 1", url="https://example.com"),
+            Source(id="src-2", title="Source 2", url="https://example.com"),
+        ]
+        # First fresh, second stale
+        mock_sources.check_freshness.side_effect = [True, False]
+
+        result = await notebooks_api.health("nb-1")
+
+        assert result.status == "needs_attention"
+        assert result.stale_sources == ["src-2"]
+        assert result.duplicate_urls == ["https://example.com"]
+
+
+# =============================================================================
+# health_all() METHOD TESTS
+# =============================================================================
+
+
+class TestNotebookHealthAll:
+    @pytest.mark.asyncio
+    async def test_health_all_empty(self, notebooks_api):
+        """Test health_all() returns empty list when no notebooks exist."""
+        notebooks_api.list = AsyncMock(return_value=[])
+
+        result = await notebooks_api.health_all()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_health_all_multiple_notebooks(self, notebooks_api, mock_sources):
+        """Test health_all() runs health on all notebooks."""
+        notebooks_api.list = AsyncMock(
+            return_value=[
+                Notebook(id="nb-1", title="Notebook 1"),
+                Notebook(id="nb-2", title="Notebook 2"),
+            ]
+        )
+        notebooks_api.get = AsyncMock(
+            side_effect=lambda nid: Notebook(id=nid, title=f"Notebook {nid[-1]}")
+        )
+        mock_sources.list.return_value = [
+            Source(id="src-1", title="Source 1"),
+        ]
+        mock_sources.check_freshness.return_value = True
+
+        result = await notebooks_api.health_all()
+
+        assert len(result) == 2
+        assert result[0].notebook_id == "nb-1"
+        assert result[1].notebook_id == "nb-2"
+
+    @pytest.mark.asyncio
+    async def test_health_all_mixed_statuses(self, notebooks_api, mock_sources):
+        """Test health_all() with notebooks in different states."""
+        notebooks_api.list = AsyncMock(
+            return_value=[
+                Notebook(id="nb-empty", title="Empty"),
+                Notebook(id="nb-good", title="Good"),
+            ]
+        )
+
+        async def mock_get(nid):
+            if nid == "nb-empty":
+                return Notebook(id="nb-empty", title="Empty")
+            return Notebook(id="nb-good", title="Good")
+
+        notebooks_api.get = AsyncMock(side_effect=mock_get)
+
+        async def mock_list_sources(nid):
+            if nid == "nb-empty":
+                return []
+            return [Source(id="src-1", title="Source 1")]
+
+        mock_sources.list.side_effect = mock_list_sources
+        mock_sources.check_freshness.return_value = True
+
+        result = await notebooks_api.health_all()
+
+        assert len(result) == 2
+        statuses = {r.notebook_id: r.status for r in result}
+        assert statuses["nb-empty"] == "empty"
+        assert statuses["nb-good"] == "healthy"
+
+
+# =============================================================================
+# EXPORT TESTS
+# =============================================================================
+
+
+class TestNotebookHealthExport:
+    def test_importable_from_notebooklm(self):
+        """Test NotebookHealth is importable from the top-level package."""
+        from notebooklm import NotebookHealth
+
+        assert NotebookHealth is not None
+
+    def test_importable_from_types(self):
+        """Test NotebookHealth is importable from types module."""
+        from notebooklm.types import NotebookHealth
+
+        assert NotebookHealth is not None

--- a/tests/unit/test_source_dedup.py
+++ b/tests/unit/test_source_dedup.py
@@ -1,0 +1,197 @@
+"""Unit tests for source deduplication logic."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._sources import SourcesAPI
+from notebooklm.types import Source
+
+
+@pytest.fixture
+def sources_api():
+    """Create a SourcesAPI with a mocked core."""
+    core = MagicMock()
+    api = SourcesAPI(core)
+    return api
+
+
+class TestCheckDuplicate:
+    """Tests for the _check_duplicate helper method."""
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_url(self, sources_api):
+        """Returns None when no source has a matching URL."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="s1", title="Page A", url="https://example.com/a"),
+                Source(id="s2", title="Page B", url="https://example.com/b"),
+            ]
+        )
+        result = await sources_api._check_duplicate("nb1", url="https://example.com/c")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_duplicate_url_found(self, sources_api):
+        """Returns the existing source when URL matches."""
+        existing = Source(id="s1", title="Page A", url="https://example.com/a")
+        sources_api.list = AsyncMock(return_value=[existing])
+        result = await sources_api._check_duplicate("nb1", url="https://example.com/a")
+        assert result is existing
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_title(self, sources_api):
+        """Returns None when no source has a matching title."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="s1", title="Notes A"),
+                Source(id="s2", title="Notes B"),
+            ]
+        )
+        result = await sources_api._check_duplicate("nb1", title="Notes C")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_duplicate_title_found(self, sources_api):
+        """Returns the existing source when title matches."""
+        existing = Source(id="s2", title="My Notes")
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="s1", title="Other"),
+                existing,
+            ]
+        )
+        result = await sources_api._check_duplicate("nb1", title="My Notes")
+        assert result is existing
+
+    @pytest.mark.asyncio
+    async def test_empty_notebook(self, sources_api):
+        """Returns None when the notebook has no sources."""
+        sources_api.list = AsyncMock(return_value=[])
+        result = await sources_api._check_duplicate("nb1", url="https://example.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_source_with_none_url_not_matched(self, sources_api):
+        """Sources with url=None should not match any URL check."""
+        sources_api.list = AsyncMock(return_value=[Source(id="s1", title="Text source", url=None)])
+        result = await sources_api._check_duplicate("nb1", url="https://example.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_source_with_none_title_not_matched(self, sources_api):
+        """Sources with title=None should not match any title check."""
+        sources_api.list = AsyncMock(
+            return_value=[Source(id="s1", title=None, url="https://example.com")]
+        )
+        result = await sources_api._check_duplicate("nb1", title="Some Title")
+        assert result is None
+
+
+class TestAddUrlDedup:
+    """Tests for deduplication in add_url."""
+
+    @pytest.mark.asyncio
+    async def test_add_url_raises_on_duplicate(self, sources_api):
+        """add_url raises ValueError when a duplicate URL exists."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="s1", title="Existing Page", url="https://example.com/page"),
+            ]
+        )
+        with pytest.raises(ValueError, match="Duplicate source.*https://example.com/page"):
+            await sources_api.add_url("nb1", "https://example.com/page", skip_dedup=False)
+
+    @pytest.mark.asyncio
+    async def test_add_url_skip_dedup(self, sources_api):
+        """add_url proceeds when skip_dedup=True even if duplicate exists."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="s1", title="Existing Page", url="https://example.com/page"),
+            ]
+        )
+        # Mock the internal methods to avoid actual RPC calls
+        sources_api._add_url_source = AsyncMock(
+            return_value=[[["new_id"], "Existing Page", [None, None, None, None, None]]]
+        )
+        sources_api._extract_youtube_video_id = MagicMock(return_value=None)
+
+        result = await sources_api.add_url("nb1", "https://example.com/page", skip_dedup=True)
+        assert result.id == "new_id"
+        # list should not have been called since we skip dedup
+        # (list was set up but _check_duplicate should not be called)
+
+    @pytest.mark.asyncio
+    async def test_add_url_no_duplicate_proceeds(self, sources_api):
+        """add_url proceeds normally when no duplicate found."""
+        sources_api.list = AsyncMock(return_value=[])
+        sources_api._add_url_source = AsyncMock(
+            return_value=[[["new_id"], "New Page", [None, None, None, None, None]]]
+        )
+        sources_api._extract_youtube_video_id = MagicMock(return_value=None)
+
+        result = await sources_api.add_url("nb1", "https://example.com/new", skip_dedup=False)
+        assert result.id == "new_id"
+
+    @pytest.mark.asyncio
+    async def test_add_url_error_message_includes_source_info(self, sources_api):
+        """ValueError message includes existing source ID and title."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="src-abc-123", title="My Article", url="https://example.com"),
+            ]
+        )
+        with pytest.raises(ValueError, match="source_id=src-abc-123") as exc_info:
+            await sources_api.add_url("nb1", "https://example.com", skip_dedup=False)
+        assert "My Article" in str(exc_info.value)
+        assert "skip_dedup=True" in str(exc_info.value)
+
+
+class TestAddTextDedup:
+    """Tests for deduplication in add_text."""
+
+    @pytest.mark.asyncio
+    async def test_add_text_raises_on_duplicate_title(self, sources_api):
+        """add_text raises ValueError when a source with the same title exists."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="s1", title="My Notes"),
+            ]
+        )
+        with pytest.raises(ValueError, match="Duplicate source.*My Notes"):
+            await sources_api.add_text("nb1", "My Notes", "some content", skip_dedup=False)
+
+    @pytest.mark.asyncio
+    async def test_add_text_skip_dedup(self, sources_api):
+        """add_text proceeds when skip_dedup=True even if duplicate exists."""
+        sources_api.list = AsyncMock(return_value=[Source(id="s1", title="My Notes")])
+        # Mock the core rpc_call to return a valid source response
+        sources_api._core.rpc_call = AsyncMock(
+            return_value=[[["new_id"], "My Notes", [None, None, None, None, None]]]
+        )
+
+        result = await sources_api.add_text("nb1", "My Notes", "new content", skip_dedup=True)
+        assert result.id == "new_id"
+
+    @pytest.mark.asyncio
+    async def test_add_text_no_duplicate_proceeds(self, sources_api):
+        """add_text proceeds normally when no duplicate title found."""
+        sources_api.list = AsyncMock(return_value=[])
+        sources_api._core.rpc_call = AsyncMock(
+            return_value=[[["new_id"], "Fresh Notes", [None, None, None, None, None]]]
+        )
+
+        result = await sources_api.add_text("nb1", "Fresh Notes", "content", skip_dedup=False)
+        assert result.id == "new_id"
+
+    @pytest.mark.asyncio
+    async def test_add_text_error_message_includes_source_info(self, sources_api):
+        """ValueError message includes existing source ID."""
+        sources_api.list = AsyncMock(
+            return_value=[
+                Source(id="src-xyz-789", title="Research Notes"),
+            ]
+        )
+        with pytest.raises(ValueError, match="source_id=src-xyz-789") as exc_info:
+            await sources_api.add_text("nb1", "Research Notes", "content", skip_dedup=False)
+        assert "skip_dedup=True" in str(exc_info.value)


### PR DESCRIPTION
## Summary

This PR adds four major features to the NotebookLM client:

1. **Optional caching layer** with SQLite backend to reduce API rate limiting
2. **Living Documents API** for managing auto-syncing Google Drive files linked to notebooks
3. **Bulk source operations** (add/delete/refresh multiple sources at once)
4. **Notebook health auditing** to detect empty notebooks, stale sources, and duplicate URLs

## Key Changes

### Cache Middleware (`src/notebooklm/_cache.py`)
- New `CacheConfig` dataclass for configurable cache behavior (TTLs, database path, query logging)
- Abstract `CacheBackend` interface with two implementations:
  - `LocalSQLiteBackend`: Stores cache in local SQLite database with D1-compatible schema
  - `NullBackend`: No-op backend when caching is disabled
- Supports separate TTLs for different cache types (queries, notebooks, sources)
- Query/response logging for dataset building with metadata (citations, latency, source IDs)
- Integrated into `ClientCore` via `CacheMiddleware` wrapper

### Living Documents API (`src/notebooklm/_living_docs.py`)
- `LivingDoc` dataclass for registering Google Drive files to notebooks
- `LivingDocsAPI` for managing living document registry (stored at `~/.notebooklm/living_docs.json`)
- `StaleCheckResult` and `SyncResult` dataclasses for tracking document freshness and sync operations
- Pre-defined templates matching MCP worker templates (violations, timeline, damages, discovery, etc.)
- Methods: `register()`, `list()`, `remove()`, `check_stale()`, `sync_all()`, `get_template()`
- CLI commands in `src/notebooklm/cli/living_doc.py` for full management

### Bulk Source Operations (`src/notebooklm/_sources.py`)
- `add_urls()`: Add multiple URLs in parallel with optional failure handling
- `delete_sources()`: Delete multiple sources by ID
- `refresh_sources()`: Refresh multiple sources in parallel
- `wait_all()`: Wait for multiple sources to finish processing
- `_check_duplicate()`: Helper to detect duplicate URLs/titles before adding
- `skip_dedup` parameter on `add_url()` to optionally skip duplicate checking

### Notebook Health Checks (`src/notebooklm/_notebooks.py`)
- `NotebookHealth` dataclass in `types.py` with fields: `notebook_id`, `title`, `source_count`, `has_sources`, `stale_sources`, `duplicate_urls`, `status`
- `health()` method on `NotebooksAPI` to audit notebook:
  - Detects empty notebooks
  - Identifies stale sources via `check_freshness()`
  - Finds duplicate URLs across sources
  - Returns overall health status
- `health_all()` method to audit all notebooks in parallel
- CLI command `notebook health` for interactive auditing

### Authentication & Build Label
- Added `build_label` field to `AuthTokens` dataclass
- `fetch_tokens()` now returns 3-tuple: `(csrf, session_id, build_label)`
- Build label automatically used in API calls via `self._core.auth.build_label`
- Updated all test mocks to return 3-tuple

### CLI Enhancements
- New `living-doc` command group with subcommands: list, register, remove, check-stale, sync, templates
- New `source` subcommands: `add-bulk`, `delete-bulk`, `refresh-bulk`, `wait-all`
- New `notebook` subcommands: `get`, `health`
- New `chat` subcommand: `multi-ask` (ask question across multiple notebooks)
- Updated help text and command documentation

### Tests
- `tests/unit/test_notebook_health.py`: Tests for health check dataclass and methods
- `tests/unit/test_living_docs.py`: Unit tests for living docs API
- `tests/unit/test_source_dedup.py`: Tests for duplicate detection
- `

https://claude.ai/code/session_01T9JgzhLLjrsoJb9SsEg9c8