### PR TITLE
fix: add timeout override for source add

### DIFF
--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -23,7 +23,7 @@ import click
 from rich.table import Table
 
 from .._url_utils import is_youtube_url
-from ..client import NotebookLMClient
+from ..client import DEFAULT_TIMEOUT, NotebookLMClient
 from ..types import source_status_to_str
 from .helpers import (
     console,
@@ -230,9 +230,25 @@ def source_list(ctx, notebook_id, json_output, client_auth):
 )
 @click.option("--title", help="Title for text sources")
 @click.option("--mime-type", help="MIME type for file sources")
+@click.option(
+    "--timeout",
+    default=int(DEFAULT_TIMEOUT),
+    type=int,
+    help="HTTP request timeout in seconds for the add operation (default: 30)",
+)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
-def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_output, client_auth):
+def source_add(
+    ctx,
+    content,
+    notebook_id,
+    source_type,
+    title,
+    mime_type,
+    timeout,
+    json_output,
+    client_auth,
+):
     """Add a source to a notebook.
 
     \b
@@ -249,6 +265,7 @@ def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_ou
       source add https://youtube.com/...          # YouTube video
       source add "My notes here"                  # Inline text
       source add "My notes" --title "Research"   # Text with custom title
+      source add https://example.com --timeout 45 # Allow slower ADD_SOURCE requests
     """
     nb_id = require_notebook(notebook_id)
 
@@ -272,7 +289,7 @@ def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_ou
             file_title = title or "Pasted Text"
 
     async def _run():
-        async with NotebookLMClient(client_auth) as client:
+        async with NotebookLMClient(client_auth, timeout=float(timeout)) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             if detected_type == "url" or detected_type == "youtube":
                 src = await client.sources.add_url(nb_id_resolved, content)

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -115,6 +115,37 @@ class TestSourceAdd:
 
             assert result.exit_code == 0
 
+    def test_source_add_url_with_custom_timeout(self, runner, mock_auth):
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_url = AsyncMock(
+                return_value=Source(
+                    id="src_new",
+                    title="Example",
+                    url="https://example.com",
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add",
+                        "https://example.com",
+                        "--timeout",
+                        "45",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            assert mock_client_cls.call_count == 1
+            assert mock_client_cls.call_args.kwargs["timeout"] == 45.0
+
     def test_source_add_youtube_url(self, runner, mock_auth):
         with patch_client_for_module("source") as mock_client_cls:
             mock_client = create_mock_client()


### PR DESCRIPTION
## Summary
- add a `--timeout` option to `notebooklm source add`
- pass the selected timeout through to `NotebookLMClient(...)` so slow `ADD_SOURCE` RPCs can override the default 30s HTTP timeout
- cover the new CLI behavior with a focused unit test

## Testing
- `PYTHONPATH=$PWD/src /Users/frank-mac-mini/.openclaw/workspace/repos/notebooklm-py/.venv/bin/python -m pytest tests/unit/cli/test_source.py -q`
- `/Users/frank-mac-mini/.openclaw/workspace/repos/notebooklm-py/.venv/bin/ruff format --check src/notebooklm/cli/source.py tests/unit/cli/test_source.py`
- `/Users/frank-mac-mini/.openclaw/workspace/repos/notebooklm-py/.venv/bin/ruff check src/notebooklm/cli/source.py tests/unit/cli/test_source.py`

Closes #192
