### PR TITLE
fix(auth): use domain-preserving cookie jar for token fetch

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -175,6 +175,10 @@ class AuthTokens:
         This is the recommended way to create AuthTokens for programmatic use.
         It loads cookies from storage and fetches CSRF/session tokens automatically.
 
+        Uses a domain-preserving httpx.Cookies jar for token fetching so that
+        redirects across Google domains (e.g., notebooklm.google.com to
+        accounts.google.com) retain proper cookie scoping.
+
         Args:
             path: Path to storage_state.json. If None, uses default location
                   (~/.notebooklm/storage_state.json).
@@ -193,7 +197,10 @@ class AuthTokens:
                 notebooks = await client.list_notebooks()
         """
         cookies = load_auth_from_storage(path)
-        csrf_token, session_id = await fetch_tokens(cookies)
+        # Use domain-preserving cookie jar for token fetch to handle
+        # cross-domain redirects correctly (see issue #114)
+        cookie_jar = load_httpx_cookies(path)
+        csrf_token, session_id = await fetch_tokens(cookies, cookie_jar=cookie_jar)
         return cls(cookies=cookies, csrf_token=csrf_token, session_id=session_id)
 
 
@@ -585,14 +592,29 @@ def load_httpx_cookies(path: Path | None = None) -> "httpx.Cookies":
     return cookies
 
 
-async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
+async def fetch_tokens(
+    cookies: dict[str, str],
+    cookie_jar: "httpx.Cookies | None" = None,
+) -> tuple[str, str]:
     """Fetch CSRF token and session ID from NotebookLM homepage.
 
     Makes an authenticated request to NotebookLM and extracts the required
     tokens from the page HTML.
 
+    When a cookie_jar is provided, it is used instead of flattening cookies
+    into a single Cookie header. This preserves domain scoping so that
+    redirects across Google domains (e.g., notebooklm.google.com to
+    accounts.google.com) send only the cookies that belong to each domain.
+    Without this, the flat header sends all cookies to every domain in the
+    redirect chain, which can cause Google to reject the request or redirect
+    to the account chooser/login page.
+
     Args:
-        cookies: Dict of Google auth cookies
+        cookies: Dict of Google auth cookies (used as fallback when
+            cookie_jar is not provided).
+        cookie_jar: Optional httpx.Cookies jar with domain-scoped cookies.
+            When provided, takes precedence over the flat cookies dict for
+            the HTTP request.
 
     Returns:
         Tuple of (csrf_token, session_id)
@@ -602,29 +624,40 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
         ValueError: If tokens cannot be extracted from response
     """
     logger.debug("Fetching CSRF and session tokens from NotebookLM")
-    cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            "https://notebooklm.google.com/",
-            headers={"Cookie": cookie_header},
-            follow_redirects=True,
-            timeout=30.0,
-        )
-        response.raise_for_status()
-
-        final_url = str(response.url)
-
-        # Check if we were redirected to login
-        if is_google_auth_redirect(final_url):
-            raise ValueError(
-                "Authentication expired or invalid. "
-                "Redirected to: " + final_url + "\n"
-                "Run 'notebooklm login' to re-authenticate."
+    if cookie_jar is not None:
+        logger.debug("Using domain-preserving cookie jar for token fetch")
+        async with httpx.AsyncClient(cookies=cookie_jar) as client:
+            response = await client.get(
+                "https://notebooklm.google.com/",
+                follow_redirects=True,
+                timeout=30.0,
+            )
+    else:
+        logger.debug("Using flat cookie header for token fetch (legacy path)")
+        cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://notebooklm.google.com/",
+                headers={"Cookie": cookie_header},
+                follow_redirects=True,
+                timeout=30.0,
             )
 
-        csrf = extract_csrf_from_html(response.text, final_url)
-        session_id = extract_session_id_from_html(response.text, final_url)
+    response.raise_for_status()
 
-        logger.debug("Authentication tokens obtained successfully")
-        return csrf, session_id
+    final_url = str(response.url)
+
+    # Check if we were redirected to login
+    if is_google_auth_redirect(final_url):
+        raise ValueError(
+            "Authentication expired or invalid. "
+            "Redirected to: " + final_url + "\n"
+            "Run 'notebooklm login' to re-authenticate."
+        )
+
+    csrf = extract_csrf_from_html(response.text, final_url)
+    session_id = extract_session_id_from_html(response.text, final_url)
+
+    logger.debug("Authentication tokens obtained successfully")
+    return csrf, session_id

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -20,7 +20,7 @@ from typing import Any, TypedDict
 
 import click
 
-from ..auth import AuthTokens, fetch_tokens, load_auth_from_storage
+from ..auth import AuthTokens, fetch_tokens, load_auth_from_storage, load_httpx_cookies
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
 from .download_helpers import (
@@ -165,7 +165,8 @@ async def _download_artifacts_generic(
     nb_id = require_notebook(notebook)
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     cookies = load_auth_from_storage(storage_path)
-    csrf, session_id = await fetch_tokens(cookies)
+    cookie_jar = load_httpx_cookies(storage_path)
+    csrf, session_id = await fetch_tokens(cookies, cookie_jar=cookie_jar)
     auth = AuthTokens(cookies=cookies, csrf_token=csrf, session_id=session_id)
 
     # Adjust extension for PPTX format (must be outside _download() to avoid UnboundLocalError)
@@ -803,8 +804,9 @@ async def _download_interactive(
     nb_id = require_notebook(notebook)
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     cookies = load_auth_from_storage(storage_path)
+    cookie_jar = load_httpx_cookies(storage_path)
 
-    csrf, session_id = await fetch_tokens(cookies)
+    csrf, session_id = await fetch_tokens(cookies, cookie_jar=cookie_jar)
     auth = AuthTokens(cookies=cookies, csrf_token=csrf, session_id=session_id)
 
     async with NotebookLMClient(auth) as client:

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -25,6 +25,7 @@ from ..auth import (
     AuthTokens,
     fetch_tokens,
     load_auth_from_storage,
+    load_httpx_cookies,
 )
 from ..exceptions import RPCTimeoutError
 from ..paths import get_browser_profile_dir, get_context_path
@@ -149,7 +150,8 @@ def get_client(ctx) -> tuple[dict, str, str]:
     """
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     cookies = load_auth_from_storage(storage_path)
-    csrf, session_id = run_async(fetch_tokens(cookies))
+    cookie_jar = load_httpx_cookies(storage_path)
+    csrf, session_id = run_async(fetch_tokens(cookies, cookie_jar=cookie_jar))
     return cookies, csrf, session_id
 
 

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -490,6 +490,7 @@ def register_session_commands(cli):
         from ..auth import (
             extract_cookies_from_storage,
             fetch_tokens,
+            load_httpx_cookies,
         )
 
         storage_path = get_storage_path()
@@ -568,7 +569,10 @@ def register_session_commands(cli):
         # Check 4: Token fetch (optional)
         if test_fetch:
             try:
-                csrf, session_id = run_async(fetch_tokens(cookies))
+                cookie_jar = load_httpx_cookies()
+                csrf, session_id = run_async(
+                    fetch_tokens(cookies, cookie_jar=cookie_jar)
+                )
                 checks["token_fetch"] = True
                 details["csrf_length"] = len(csrf)
                 details["session_id_length"] = len(session_id)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -554,6 +554,96 @@ class TestFetchTokens:
         assert "HSID=hsid_value" in cookie_header
 
 
+class TestFetchTokensWithCookieJar:
+    """Test fetch_tokens with domain-preserving httpx.Cookies jar (issue #114)."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_tokens_with_cookie_jar(self, httpx_mock: HTTPXMock):
+        """Test successful token fetch using cookie jar."""
+        import httpx
+
+        html = """
+        <html>
+        <script>
+            window.WIZ_global_data = {
+                "SNlM0e": "AF1_QpN-csrf_jar",
+                "FdrFJe": "session_jar_789"
+            };
+        </script>
+        </html>
+        """
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            content=html.encode(),
+        )
+
+        cookies = {"SID": "test_sid"}
+        jar = httpx.Cookies()
+        jar.set("SID", "test_sid", domain=".google.com")
+        jar.set("OSID", "test_osid", domain="notebooklm.google.com")
+
+        csrf, session_id = await fetch_tokens(cookies, cookie_jar=jar)
+
+        assert csrf == "AF1_QpN-csrf_jar"
+        assert session_id == "session_jar_789"
+
+    @pytest.mark.asyncio
+    async def test_cookie_jar_does_not_use_flat_header(self, httpx_mock: HTTPXMock):
+        """Test that cookie jar path does not set a flat Cookie header."""
+        import httpx
+
+        html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
+        httpx_mock.add_response(content=html.encode())
+
+        cookies = {"SID": "flat_sid"}
+        jar = httpx.Cookies()
+        jar.set("SID", "jar_sid", domain=".google.com")
+
+        await fetch_tokens(cookies, cookie_jar=jar)
+
+        request = httpx_mock.get_request()
+        # When using the cookie jar path, the flat "SID=flat_sid" header
+        # should not appear; httpx manages cookies via the jar instead.
+        raw_cookie = request.headers.get("cookie", "")
+        assert "flat_sid" not in raw_cookie
+
+    @pytest.mark.asyncio
+    async def test_legacy_path_without_cookie_jar(self, httpx_mock: HTTPXMock):
+        """Test that omitting cookie_jar falls back to flat Cookie header."""
+        html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
+        httpx_mock.add_response(content=html.encode())
+
+        cookies = {"SID": "sid_value", "HSID": "hsid_value"}
+        await fetch_tokens(cookies)
+
+        request = httpx_mock.get_request()
+        cookie_header = request.headers.get("cookie", "")
+        assert "SID=sid_value" in cookie_header
+        assert "HSID=hsid_value" in cookie_header
+
+    @pytest.mark.asyncio
+    async def test_cookie_jar_redirect_to_login(self, httpx_mock: HTTPXMock):
+        """Test raises error when redirected to login with cookie jar."""
+        import httpx
+
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/signin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/signin",
+            content=b"<html>Login</html>",
+        )
+
+        cookies = {"SID": "expired_sid"}
+        jar = httpx.Cookies()
+        jar.set("SID", "expired_sid", domain=".google.com")
+
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await fetch_tokens(cookies, cookie_jar=jar)
+
+
 class TestAuthTokensFromStorage:
     """Test AuthTokens.from_storage class method."""
 


### PR DESCRIPTION
## Summary

Fixes #114. The token-fetch path in `fetch_tokens()` flattened all browser cookies into a single `Cookie` header string. When `httpx` followed redirects across Google domains (e.g., `notebooklm.google.com` -> `accounts.google.com`), every cookie was sent to every domain regardless of its original scope. This caused Google to reject the request or redirect to the account chooser/login page, resulting in `RPC rLM1Ne returned null result data` errors for `GET_NOTEBOOK`.

### What changed

- `fetch_tokens()` now accepts an optional `cookie_jar` parameter (`httpx.Cookies`). When provided, cookies are passed via `httpx.AsyncClient(cookies=...)` instead of a flat `Cookie` header. This preserves per-domain cookie scoping across redirects.
- All call sites now load a domain-preserving cookie jar via `load_httpx_cookies()` (which already existed for download auth) and pass it to `fetch_tokens()`.
- The flat-header fallback is retained for backward compatibility when `cookie_jar` is not provided.

### Files changed

- `src/notebooklm/auth.py` - Updated `fetch_tokens()` signature and `AuthTokens.from_storage()`
- `src/notebooklm/cli/helpers.py` - Updated `get_client()` to pass cookie jar
- `src/notebooklm/cli/session.py` - Updated `auth check --test` to pass cookie jar
- `src/notebooklm/cli/download.py` - Updated both download entry points to pass cookie jar
- `tests/unit/test_auth.py` - Added `TestFetchTokensWithCookieJar` test class

### Root cause (from issue diagnosis by @mouseroser)

Cookies from Playwright storage were flattened into a plain `Cookie` header for the token-fetch request. When redirects crossed into `accounts.google.com`, cookie domain scope was lost. A domain-preserving `httpx.Cookies` jar keeps the right cookies attached to each domain in the redirect chain.

## Test plan

- [ ] Existing `TestFetchTokens` tests continue to pass (legacy flat-header path)
- [ ] New `TestFetchTokensWithCookieJar` tests verify cookie jar path works correctly
- [ ] New test verifies cookie jar path does not inject flat cookie header values
- [ ] New test verifies redirect-to-login detection works with cookie jar
- [ ] CI passes