### PR TITLE
cli: add --timeout to source add-research

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -42,6 +42,9 @@ logger = logging.getLogger(__name__)
 CONTEXT_FILE = get_context_path()
 BROWSER_PROFILE_DIR = get_browser_profile_dir()
 
+# Default timeout for import_with_retry (seconds)
+DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS = 1800
+
 # CLI artifact type name aliases
 _CLI_ARTIFACT_ALIASES = {
     "flashcard": "flashcards",  # CLI uses singular, enum uses plural
@@ -88,7 +91,7 @@ async def import_with_retry(
     task_id: str,
     sources: list[dict],
     *,
-    max_elapsed: float = 1800,
+    max_elapsed: float = DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS,
     initial_delay: float = 5,
     backoff_factor: float = 2,
     max_delay: float = 60,

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -26,6 +26,7 @@ from .._url_utils import is_youtube_url
 from ..client import NotebookLMClient
 from ..types import source_status_to_str
 from .helpers import (
+    DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS,
     console,
     display_report,
     display_research_sources,
@@ -542,9 +543,9 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 @click.option("--import-all", is_flag=True, help="Import all found sources")
 @click.option(
     "--timeout",
-    default=1800,
+    default=DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS,
     type=int,
-    help="Maximum seconds for import retries (default: 1800)",
+    help=f"Maximum seconds for import retries (default: {DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS})",
 )
 @click.option(
     "--no-wait",

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -541,13 +541,19 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources")
 @click.option(
+    "--timeout",
+    default=1800,
+    type=int,
+    help="Maximum seconds for import retries (default: 1800)",
+)
+@click.option(
     "--no-wait",
     is_flag=True,
     help="Start research and return immediately (use 'research status/wait' to monitor)",
 )
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, no_wait, client_auth
+    ctx, query, notebook_id, search_source, mode, import_all, timeout, no_wait, client_auth
 ):
     """Search web or drive and add sources from results.
 
@@ -606,6 +612,7 @@ def source_add_research(
                         nb_id_resolved,
                         task_id,
                         sources,
+                        max_elapsed=timeout,
                     )
                     console.print(f"[green]Imported {len(imported)} sources[/green]")
             else:

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from notebooklm.cli.helpers import DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import (
     Source,
@@ -666,7 +667,7 @@ class TestSourceAddResearch:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
-            max_elapsed=1800,
+            max_elapsed=DEFAULT_IMPORT_RETRY_TIMEOUT_SECONDS,
         )
 
     def test_add_research_timeout_passed_to_import(self, runner, mock_auth):

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -666,6 +666,50 @@ class TestSourceAddResearch:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=1800,
+        )
+
+    def test_add_research_timeout_passed_to_import(self, runner, mock_auth):
+        with (
+            patch_client_for_module("source") as mock_client_cls,
+            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_456"})
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_456",
+                    "sources": [{"title": "Source 1", "url": "http://example.com"}],
+                    "report": "",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add-research",
+                        "AI papers",
+                        "--import-all",
+                        "--timeout",
+                        "600",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_456",
+            [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=600,
         )
 
 


### PR DESCRIPTION
Fixes #194.

`source add-research --import-all` had no way to control the import retry budget — it always used `import_with_retry()`'s hardcoded 1800s default.

This adds `--timeout` (default 1800) and passes it through as `max_elapsed`, which is exactly how `research wait --import-all` already works.

**Changes:**
- `source add-research`: add `--timeout INT` option
- Pass `max_elapsed=timeout` to `import_with_retry()` when `--import-all` is set
- Update existing test assertion to include `max_elapsed=1800`
- Add test verifying a custom `--timeout 600` is forwarded correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --timeout option for source import operations to control how long import retry cycles may run (default: 1800 seconds).

* **Chores**
  * Centralized the default retry timeout into a named constant.

* **Tests**
  * Added/updated tests to verify the timeout value is propagated to the import retry logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->