### PR TITLE
fix(auth): handle Navigation interrupted on already-authenticated sessions

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -255,8 +255,16 @@ def register_session_commands(cli):
 
             # Force .google.com cookies for regional users (e.g. UK lands on
             # .google.co.uk). Use "load" not "networkidle" to avoid analytics hangs.
-            page.goto(GOOGLE_ACCOUNTS_URL, wait_until="load")
-            page.goto(NOTEBOOKLM_URL, wait_until="load")
+            # Wrap in try-except: already-authenticated sessions may redirect
+            # and cause "Navigation interrupted" (see GitHub issue #214).
+            try:
+                page.goto(GOOGLE_ACCOUNTS_URL, wait_until="load")
+            except Exception:
+                pass  # redirect race is harmless — cookies already set
+            try:
+                page.goto(NOTEBOOKLM_URL, wait_until="load")
+            except Exception:
+                pass  # same: redirect means we're already on NotebookLM
 
             current_url = page.url
             if NOTEBOOKLM_HOST not in current_url:


### PR DESCRIPTION
## Summary

- Wrap cookie-forcing `page.goto()` calls in try-except to handle redirect race condition
- When a user already has an active Google session, Playwright throws `Navigation interrupted` because Google immediately redirects — this is safe to ignore since cookies are already set

## Problem

`notebooklm login` crashes with `Page.goto: Navigation interrupted` when the user already has an active Google session in the browser. This is the most common scenario — most users keep Google signed in on Chrome.

**Reproduction steps:**
1. Be signed into Google in your default browser
2. Run `notebooklm login`
3. Complete login, press ENTER
4. Crash at the cookie-forcing navigation (line 258-259)

## Fix

The two `page.goto()` calls for regional cookie forcing (`accounts.google.com` → `notebooklm.google.com`) are wrapped in try-except. When the redirect race occurs, the exception is silently caught — the cookies are already set in an authenticated session, so skipping is safe.

## Test plan

- [x] Tested on Windows 11 with Google session already active — login completes successfully
- [ ] Verify regional users (UK, CN) still get correct cookies

Fixes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced login resilience to handle navigation interruptions and race conditions that previously caused authentication to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->