### PR TITLE
fix(sources): resolve YouTube source add returning 'API returned no data'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **YouTube source add "API returned no data"** — `_add_youtube_source` used `allow_null=True` which silently swallowed null API responses and bypassed retry/auth-recovery. Now uses `allow_null=False` (matching `_add_url_source`) so stale sessions trigger automatic token refresh.
+- **YouTube URL extraction from metadata** — `Source.from_api_response` now tries metadata index 5 (YouTube) in addition to index 7 (web pages), reflecting a Google-side response structure change.
+
 ## [0.3.4] - 2026-03-12
 
 ### Added

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -866,7 +866,13 @@ class SourcesAPI:
         return bool(video_id and re.match(r"^[a-zA-Z0-9_-]+$", video_id))
 
     async def _add_youtube_source(self, notebook_id: str, url: str) -> Any:
-        """Add a YouTube video as a source."""
+        """Add a YouTube video as a source.
+
+        Note: allow_null is intentionally False (default) so that null API
+        responses trigger the retry/auth-recovery path in rpc_call, matching
+        the behaviour of _add_url_source.  Previously allow_null=True silently
+        swallowed null responses, preventing automatic retry on stale tokens.
+        """
         params = [
             [[None, None, None, None, None, None, None, [url], None, None, 1]],
             notebook_id,
@@ -877,7 +883,6 @@ class SourcesAPI:
             RPCMethod.ADD_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
         )
 
     async def _add_url_source(self, notebook_id: str, url: str) -> Any:

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -580,10 +580,15 @@ class Source:
                     title = entry[1] if len(entry) > 1 else None
 
                     # Try to extract URL if present
+                    # YouTube sources may store URL at index 5 (changed by Google),
+                    # while web pages use index 7.  Try both positions.
                     url = None
                     if len(entry) > 2 and isinstance(entry[2], list):
-                        if len(entry[2]) > 7 and isinstance(entry[2][7], list):
-                            url = entry[2][7][0] if entry[2][7] else None
+                        for idx in (7, 5):
+                            if len(entry[2]) > idx and isinstance(entry[2][idx], list):
+                                url = entry[2][idx][0] if entry[2][idx] else None
+                                if url:
+                                    break
 
                     return cls(id=str(source_id), title=title, url=url, _type_code=None)
 
@@ -591,10 +596,13 @@ class Source:
                 url = None
                 type_code = None
                 if len(entry) > 2 and isinstance(entry[2], list):
-                    if len(entry[2]) > 7:
-                        url_list = entry[2][7]
-                        if isinstance(url_list, list) and len(url_list) > 0:
-                            url = url_list[0]
+                    # Try index 7 first (web pages), then index 5 (YouTube)
+                    for idx in (7, 5):
+                        if len(entry[2]) > idx:
+                            url_list = entry[2][idx]
+                            if isinstance(url_list, list) and len(url_list) > 0:
+                                url = url_list[0]
+                                break
                     if not url and len(entry[2]) > 0:
                         if isinstance(entry[2][0], str) and entry[2][0].startswith("http"):
                             url = entry[2][0]


### PR DESCRIPTION
## Summary

- Remove `allow_null=True` from `_add_youtube_source()` so null API responses trigger the retry/auth-recovery path in `rpc_call`, matching `_add_url_source()` behaviour
- Update `Source.from_api_response()` to try metadata index 5 (YouTube) in addition to index 7 (web pages), reflecting a Google-side response structure change

## Root Cause

When adding a YouTube source, `_add_youtube_source()` called `rpc_call()` with `allow_null=True`. If the API returned null (e.g. due to stale session cookies), this bypassed the automatic retry/auth-recovery mechanism. The caller then saw `result is None` and raised `SourceAddError("API returned no data")`.

In contrast, `_add_url_source()` uses the default `allow_null=False`, which means null responses raise `RPCError` and trigger token refresh + retry — and URL sources work fine.

Additionally, Google moved YouTube source URLs from metadata index 7 to index 5 in the API response structure. The URL extraction in `Source.from_api_response()` now tries both positions.

## Test plan

- [ ] Verify YouTube URL source add succeeds (e.g. `notebooklm source add --url "https://www.youtube.com/watch?v=VIDEO_ID" NOTEBOOK_ID`)
- [ ] Verify regular URL source add still works
- [ ] Verify `notebooklm list --json` correctly extracts YouTube source URLs

Related: #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for YouTube sources: null API responses now trigger retry and authentication recovery flows instead of being silently processed
  * Enhanced source URL extraction to check multiple metadata locations, improving compatibility with API response structure variations

* **Documentation**
  * Updated changelog to document YouTube error handling refinements and URL extraction improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->