### PR TITLE
fix: replace assert with runtime checks for -O safety

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -100,7 +100,8 @@ class ChatAPI:
             conversation_id = str(uuid.uuid4())
             conversation_history = None
         else:
-            assert conversation_id is not None  # Type narrowing for mypy
+            if conversation_id is None:  # Defensive check (was assert, stripped by -O)
+                raise RuntimeError("conversation_id unexpectedly None in continuation mode")
             conversation_history = self._build_conversation_history(conversation_id)
 
         sources_array = [[[sid]] for sid in source_ids] if source_ids else []

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -384,12 +384,14 @@ class ClientCore:
         )
 
         # This function is only called when _refresh_callback is set
-        assert self._refresh_callback is not None
+        if self._refresh_callback is None:
+            raise RuntimeError("_refresh_callback is None; token refresh cannot proceed")
 
         # Use lock to coordinate refresh task creation
         # Note: refresh_callback is expected to update auth headers internally
         # Lock is always created when callback is set (see __init__)
-        assert self._refresh_lock is not None
+        if self._refresh_lock is None:
+            raise RuntimeError("_refresh_lock is None; cannot coordinate token refresh")
 
         # Determine which task to await (existing or new)
         async with self._refresh_lock:


### PR DESCRIPTION
## Summary

Three `assert` statements in production code (`_chat.py`, `_core.py`) are silently stripped when Python runs with the `-O` (optimize) flag, removing critical guards:

- **`_chat.py:103`** — `conversation_id` nullability check in continuation mode; if stripped, `None` propagates silently into conversation history lookup
- **`_core.py:387`** — `_refresh_callback` guard before token refresh; if stripped under `-O`, a `None` callback causes an undiagnosable `TypeError`
- **`_core.py:392`** — `_refresh_lock` guard for coordinating concurrent refreshes; same silent failure pattern

Each `assert` is replaced with an explicit `if ... is None: raise RuntimeError(...)` that persists regardless of optimization level.

## Changes

| File | Change |
|------|--------|
| `src/notebooklm/_chat.py` | `assert conversation_id is not None` → `if conversation_id is None: raise RuntimeError(...)` |
| `src/notebooklm/_core.py` | `assert self._refresh_callback is not None` → `if ... is None: raise RuntimeError(...)` |
| `src/notebooklm/_core.py` | `assert self._refresh_lock is not None` → `if ... is None: raise RuntimeError(...)` |

## Why This Matters

Production deployments commonly use `python -O` or `PYTHONOPTIMIZE=1` for performance. These three assertions guard auth token refresh and conversation state — exactly the kind of invariants that must hold in production. The replacement `RuntimeError` exceptions provide clear diagnostic messages and survive all optimization levels.

---

*Audited by [UNA](https://tombudd.com) (Unified Nexus Architecture) — an autonomous AI agent designed and built by Tom Budd.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal error handling in chat and authentication workflows to ensure more predictable behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->