### PR TITLE
feat(cli): add --prompt-file option to read prompts from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ notebooklm source add "./paper.pdf"
 
 # 3. Chat with your sources
 notebooklm ask "What are the key themes?"
+notebooklm ask --prompt-file ./long_question.txt  # Read question from file
 
-# 4. Generate content
+# 4. Generate content (use --prompt-file for long prompts)
 notebooklm generate audio "make it engaging" --wait
 notebooklm generate video --style whiteboard --wait
 notebooklm generate cinematic-video "documentary-style summary" --wait
@@ -201,6 +202,8 @@ notebooklm skill status              # Check local agent skill installation
 notebooklm profile list              # List all Google account profiles
 notebooklm profile switch work       # Switch active account profile
 ```
+
+Use `--prompt-file PATH` with `ask`, prompt-based `generate` commands, and `source add-research` when the text is too long for the shell command line. This reads prompt/query text from a file and is separate from `source add ./file.pdf`, which still uploads that file as a NotebookLM source.
 
 ### Python API
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -147,9 +147,11 @@ Before starting workflows, verify the CLI is ready:
 | Wait for source processing | `notebooklm source wait <source_id>` |
 | Web research (fast) | `notebooklm source add-research "query"` |
 | Web research (deep) | `notebooklm source add-research "query" --mode deep --no-wait` |
+| Web research (query from file) | `notebooklm source add-research --prompt-file research_query.txt --mode deep` |
 | Check research status | `notebooklm research status` |
 | Wait for research | `notebooklm research wait --import-all` |
 | Chat | `notebooklm ask "question"` |
+| Chat (long prompt from file) | `notebooklm ask --prompt-file question.txt` |
 | Chat (specific sources) | `notebooklm ask "question" -s src_id1 -s src_id2` |
 | Chat (with references) | `notebooklm ask "question" --json` |
 | Chat (save answer as note) | `notebooklm ask "question" --save-as-note` |
@@ -161,6 +163,7 @@ Before starting workflows, verify the CLI is ready:
 | Get source fulltext | `notebooklm source fulltext <source_id>` |
 | Get source guide | `notebooklm source guide <source_id>` |
 | Generate podcast | `notebooklm generate audio "instructions"` |
+| Generate (long prompt from file) | `notebooklm generate audio --prompt-file instructions.txt` |
 | Generate podcast (JSON) | `notebooklm generate audio --json` |
 | Generate podcast (specific sources) | `notebooklm generate audio -s src_id1 -s src_id2` |
 | Generate video | `notebooklm generate video "instructions"` |
@@ -256,6 +259,7 @@ All generate commands support:
 - `--language` to set output language (defaults to configured language or 'en')
 - `--json` for machine-readable output (returns `task_id` and `status`)
 - `--retry N` to automatically retry on rate limits with exponential backoff
+- `--prompt-file PATH` to read description/query from a file (mutually exclusive with positional argument; use for long prompts)
 
 | Type | Command | Options | Download |
 |------|---------|---------|----------|
@@ -490,6 +494,20 @@ All commands use consistent exit codes:
 - `source wait` returns 1 if source not found or processing failed
 - `artifact wait` returns 2 if timeout reached before completion
 - `generate` returns 1 if rate limited (check stderr for details)
+
+## Long Prompts
+
+When a prompt or query exceeds shell command-line length limits, use `--prompt-file` to read it from a file:
+
+```bash
+notebooklm ask --prompt-file ./long_question.txt
+notebooklm generate report --prompt-file ./custom_report_prompt.txt
+notebooklm source add-research --prompt-file ./research_query.txt --mode deep
+```
+
+`--prompt-file` is mutually exclusive with the positional text argument. The file is read as UTF-8 with trailing whitespace stripped. Supported on: `ask`, all `generate` subcommands (except `mind-map`), and `source add-research`.
+
+> **Note:** `--prompt-file` reads a *prompt/query text file*, not a source document. To upload a file as a notebook source, use `source add ./file.pdf`.
 
 ## Known Limitations
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -152,7 +152,7 @@ Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`,
 | `video [description]` | `--format [explainer\|brief\|cinematic]`, `--style [auto\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--prompt-file PATH`, `--wait` | `generate video "Explainer for kids"` |
 | `cinematic-video [description]` | Alias for `video --format cinematic`; supports the same options | `generate cinematic-video "Documentary about quantum physics"` |
 | `slide-deck [description]` | `--format [detailed\|presenter]`, `--length [default\|short]`, `--prompt-file PATH`, `--wait` | `generate slide-deck` |
-| `revise-slide <description>` | `-a/--artifact <id>` (required), `--slide N` (required), `--prompt-file PATH`, `--wait` | `generate revise-slide "Move title up" --artifact <id> --slide 0` |
+| `revise-slide [description]` | `-a/--artifact <id>` (required), `--slide N` (required), `--prompt-file PATH`, `--wait` | `generate revise-slide "Move title up" --artifact <id> --slide 0` |
 | `quiz [description]` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]`, `--prompt-file PATH`, `--wait` | `generate quiz --difficulty hard` |
 | `flashcards [description]` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]`, `--prompt-file PATH`, `--wait` | `generate flashcards` |
 | `infographic [description]` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]`, `--prompt-file PATH`, `--wait` | `generate infographic` |
@@ -692,8 +692,9 @@ notebooklm generate video [description] [OPTIONS]
 ```
 
 **Options:**
-- `--format [explainer|brief]` - Video format
-- `--style [auto|classic|whiteboard|kawaii|anime|watercolor|retro|heritage|paper-craft]` - Visual style
+- `--format [explainer|brief|cinematic]` - Video format
+- `--style [auto|custom|classic|whiteboard|kawaii|anime|watercolor|retro-print|heritage|paper-craft]` - Visual style
+- `--style-prompt TEXT` - Custom visual style prompt (required when `--style custom`; rejected with `--format cinematic`)
 - `--language LANG` - Language code
 - `-s, --source ID` - Use specific source(s) (repeatable, uses all if not specified)
 - `--wait` - Wait for generation to complete

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -93,6 +93,7 @@ See [Configuration](configuration.md) for details on environment variables and C
 | Command | Description | Example |
 |---------|-------------|---------|
 | `ask <question>` | Ask a question | `notebooklm ask "What is this about?"` |
+| `ask --prompt-file` | Ask with question from file | `notebooklm ask --prompt-file q.txt` |
 | `ask -s <id>` | Ask using specific sources | `notebooklm ask "Summarize" -s src1 -s src2` |
 | `ask --json` | Get answer with source references | `notebooklm ask "Explain X" --json` |
 | `ask --save-as-note` | Save response as a note | `notebooklm ask "Explain X" --save-as-note` |
@@ -113,7 +114,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `list` | - | - | `source list` |
 | `add <content>` | URL/file/text | `--title`, `--type`, `--mime-type`, `--timeout`, `--json` | `source add "https://..." --timeout 90` |
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
-| `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait`, `--timeout` | `source add-research "AI" --mode deep --no-wait` |
+| `add-research [query]` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait`, `--timeout`, `--prompt-file PATH` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
 | `fulltext <id>` | Source ID | `--json`, `-o FILE` | `source fulltext src123 -o content.txt` |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
@@ -138,6 +139,7 @@ All generate commands support:
 - `--source/-s` to select specific sources (repeatable)
 - `--json` for machine-readable output (returns `task_id` and `status`)
 - `--retry N` to automatically retry on rate limits with exponential backoff
+- `--prompt-file PATH` to read the description/query from a file instead of the command line (mutually exclusive with the positional argument; useful for long prompts that exceed shell length limits)
 
 Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`, `infographic`, `slide-deck`, `data-table`, `mind-map`) also support:
 - `--language` to override output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)
@@ -146,17 +148,17 @@ Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`,
 
 | Command | Options | Example |
 |---------|---------|---------|
-| `audio [description]` | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]`, `--wait` | `generate audio "Focus on history"` |
-| `video [description]` | `--format [explainer\|brief\|cinematic]`, `--style [auto\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--wait` | `generate video "Explainer for kids"` |
+| `audio [description]` | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]`, `--prompt-file PATH`, `--wait` | `generate audio "Focus on history"` |
+| `video [description]` | `--format [explainer\|brief\|cinematic]`, `--style [auto\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]`, `--prompt-file PATH`, `--wait` | `generate video "Explainer for kids"` |
 | `cinematic-video [description]` | Alias for `video --format cinematic`; supports the same options | `generate cinematic-video "Documentary about quantum physics"` |
-| `slide-deck [description]` | `--format [detailed\|presenter]`, `--length [default\|short]`, `--wait` | `generate slide-deck` |
-| `revise-slide <description>` | `-a/--artifact <id>` (required), `--slide N` (required), `--wait` | `generate revise-slide "Move title up" --artifact <id> --slide 0` |
-| `quiz [description]` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]`, `--wait` | `generate quiz --difficulty hard` |
-| `flashcards [description]` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]`, `--wait` | `generate flashcards` |
-| `infographic [description]` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]`, `--wait` | `generate infographic` |
-| `data-table <description>` | `--wait` | `generate data-table "compare concepts"` |
+| `slide-deck [description]` | `--format [detailed\|presenter]`, `--length [default\|short]`, `--prompt-file PATH`, `--wait` | `generate slide-deck` |
+| `revise-slide <description>` | `-a/--artifact <id>` (required), `--slide N` (required), `--prompt-file PATH`, `--wait` | `generate revise-slide "Move title up" --artifact <id> --slide 0` |
+| `quiz [description]` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]`, `--prompt-file PATH`, `--wait` | `generate quiz --difficulty hard` |
+| `flashcards [description]` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]`, `--prompt-file PATH`, `--wait` | `generate flashcards` |
+| `infographic [description]` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]`, `--prompt-file PATH`, `--wait` | `generate infographic` |
+| `data-table [description]` | `--prompt-file PATH`, `--wait` | `generate data-table "compare concepts"` |
 | `mind-map` | *(sync, no wait needed)* | `generate mind-map` |
-| `report [description]` | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append "extra instructions"`, `--wait` | `generate report --format study-guide` |
+| `report [description]` | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append "extra instructions"`, `--prompt-file PATH`, `--wait` | `generate report --format study-guide` |
 
 ### Artifact Commands (`notebooklm artifact <cmd>`)
 
@@ -555,7 +557,7 @@ See [Troubleshooting](troubleshooting.md) for full per-OS scheduler recipes (lau
 Perform AI-powered research and add discovered sources to the notebook.
 
 ```bash
-notebooklm source add-research <query> [OPTIONS]
+notebooklm source add-research [query] [OPTIONS]
 ```
 
 **Options:**
@@ -564,6 +566,7 @@ notebooklm source add-research <query> [OPTIONS]
 - `--import-all` - Automatically import all found sources (works with blocking mode)
 - `--no-wait` - Start research and return immediately (non-blocking)
 - `--timeout SECONDS` - Retry budget for `--import-all` when the IMPORT_RESEARCH RPC times out (default: 1800). Mirrors `research wait --timeout`. Has no effect without `--import-all`.
+- `--prompt-file PATH` - Read query from a file instead of the positional argument
 
 **Examples:**
 ```bash
@@ -578,6 +581,9 @@ notebooklm source add-research "AI safety papers" --mode deep --no-wait
 
 # Bounded import-retry budget for large result sets
 notebooklm source add-research "AI papers" --mode deep --import-all --timeout 3600
+
+# Read long query from file
+notebooklm source add-research --prompt-file research_query.txt --mode deep
 ```
 
 ### Research: `status`
@@ -653,6 +659,7 @@ notebooklm generate audio [description] [OPTIONS]
 - `-s, --source ID` - Use specific source(s) (repeatable, uses all if not specified)
 - `--wait` - Wait for generation to complete
 - `--json` - Output as JSON (returns `task_id` and `status`)
+- `--prompt-file PATH` - Read description from a file (mutually exclusive with positional argument)
 
 **Examples:**
 ```bash
@@ -671,6 +678,9 @@ notebooklm generate audio -s src_abc -s src_def
 # JSON output for scripting/automation
 notebooklm generate audio --json
 # Output: {"task_id": "abc123...", "status": "pending"}
+
+# Read long instructions from a file
+notebooklm generate audio --prompt-file instructions.txt --format debate
 ```
 
 ### Generate: `video`
@@ -709,7 +719,7 @@ notebooklm generate video --json
 Revise an individual slide in an existing slide deck using a natural-language prompt.
 
 ```bash
-notebooklm generate revise-slide <description> --artifact <id> --slide N [OPTIONS]
+notebooklm generate revise-slide [description] --artifact <id> --slide N [OPTIONS]
 ```
 
 **Required Options:**
@@ -719,6 +729,7 @@ notebooklm generate revise-slide <description> --artifact <id> --slide N [OPTION
 **Optional:**
 - `--wait` - Wait for revision to complete
 - `--json` - Machine-readable output
+- `--prompt-file PATH` - Read description from a file (mutually exclusive with positional argument)
 
 **Examples:**
 ```bash
@@ -747,6 +758,7 @@ notebooklm generate report [description] [OPTIONS]
 - `-s, --source ID` - Use specific source(s) (repeatable, uses all if not specified)
 - `--wait` - Wait for generation to complete
 - `--json` - Output as JSON
+- `--prompt-file PATH` - Read description from a file (mutually exclusive with positional argument)
 
 **Examples:**
 ```bash
@@ -762,6 +774,9 @@ notebooklm generate report "Create a white paper analyzing the key trends"
 # Append instructions to a built-in format
 notebooklm generate report --format study-guide --append "Target audience: beginners"
 notebooklm generate report --format briefing-doc --append "Focus on AI trends, keep it under 2 pages"
+
+# Read a long custom prompt from file (auto-selects custom format)
+notebooklm generate report --prompt-file custom_report.txt
 ```
 
 ### Download: `audio`, `video`, `slide-deck`, `infographic`, `report`, `mind-map`, `data-table`

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -20,10 +20,12 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
+    resolve_prompt,
     resolve_source_ids,
     set_current_conversation,
     with_client,
 )
+from .options import prompt_file_option
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +83,8 @@ def register_chat_commands(cli):
     """Register chat commands on the main CLI group."""
 
     @cli.command("ask")
-    @click.argument("question")
+    @click.argument("question", default="", required=False)
+    @prompt_file_option
     @click.option(
         "-n",
         "--notebook",
@@ -106,6 +109,7 @@ def register_chat_commands(cli):
     def ask_cmd(
         ctx,
         question,
+        prompt_file,
         notebook_id,
         conversation_id,
         source_ids,
@@ -128,6 +132,7 @@ def register_chat_commands(cli):
           notebooklm ask "explain X" --json             # Get answer with source references
           notebooklm ask "explain X" --save-as-note     # Save response as a note
         """
+        question = resolve_prompt(question, prompt_file, "question", required=True)
         nb_id = require_notebook(notebook_id)
 
         async def _run():

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -42,11 +42,12 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
+    resolve_prompt,
     resolve_source_ids,
     with_client,
 )
 from .language import SUPPORTED_LANGUAGES, get_language
-from .options import json_option, retry_option
+from .options import json_option, prompt_file_option, retry_option
 
 DEFAULT_LANGUAGE = "en"
 
@@ -332,6 +333,7 @@ def generate():
 
 @generate.command("audio")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -364,6 +366,7 @@ def generate():
 def generate_audio(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     audio_format,
     audio_length,
@@ -385,6 +388,7 @@ def generate_audio(
       notebooklm generate audio "make it funny and casual" --format debate
       notebooklm generate audio -s src_001 -s src_002 "from specific sources"
     """
+    description = resolve_prompt(description, prompt_file, "description")
     nb_id = require_notebook(notebook_id)
     format_map = {
         "deep-dive": AudioFormat.DEEP_DIVE,
@@ -423,6 +427,7 @@ def generate_audio(
 
 @generate.command("video")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -468,6 +473,7 @@ def generate_audio(
 def generate_video(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     video_format,
     style,
@@ -495,6 +501,7 @@ def generate_video(
       notebooklm generate video --format cinematic "documentary overview"
       notebooklm generate video -s src_001 "from specific source"
     """
+    description = resolve_prompt(description, prompt_file, "description")
     # Auto-select cinematic format when invoked as 'generate cinematic-video'
     if ctx.info_name == "cinematic-video":
         video_format = "cinematic"
@@ -577,6 +584,7 @@ generate.add_command(_cinematic_video_gen_cmd)
 
 @generate.command("slide-deck")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -609,6 +617,7 @@ generate.add_command(_cinematic_video_gen_cmd)
 def generate_slide_deck(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     deck_format,
     deck_length,
@@ -629,6 +638,7 @@ def generate_slide_deck(
       notebooklm generate slide-deck "include speaker notes"
       notebooklm generate slide-deck "executive summary" --format presenter --length short
     """
+    description = resolve_prompt(description, prompt_file, "description")
     nb_id = require_notebook(notebook_id)
     format_map = {
         "detailed": SlideDeckFormat.DETAILED_DECK,
@@ -663,7 +673,8 @@ def generate_slide_deck(
 
 
 @generate.command("revise-slide")
-@click.argument("description")
+@click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -692,6 +703,7 @@ def generate_slide_deck(
 def generate_revise_slide(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     artifact_id,
     slide_index,
@@ -710,6 +722,7 @@ def generate_revise_slide(
       notebooklm generate revise-slide "Move the title up" --artifact <id> --slide 0
       notebooklm generate revise-slide "Remove taxonomy" --artifact <id> --slide 3 --wait
     """
+    description = resolve_prompt(description, prompt_file, "description", required=True)
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -736,6 +749,7 @@ def generate_revise_slide(
 
 @generate.command("quiz")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -753,6 +767,7 @@ def generate_revise_slide(
 def generate_quiz(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     quantity,
     difficulty,
@@ -772,6 +787,7 @@ def generate_quiz(
       notebooklm generate quiz "focus on vocabulary terms"
       notebooklm generate quiz "test key concepts" --difficulty hard --quantity more
     """
+    description = resolve_prompt(description, prompt_file, "description")
     nb_id = require_notebook(notebook_id)
     quantity_map = {
         "fewer": QuizQuantity.FEWER,
@@ -808,6 +824,7 @@ def generate_quiz(
 
 @generate.command("flashcards")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -825,6 +842,7 @@ def generate_quiz(
 def generate_flashcards(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     quantity,
     difficulty,
@@ -844,6 +862,7 @@ def generate_flashcards(
       notebooklm generate flashcards "vocabulary terms only"
       notebooklm generate flashcards --quantity more --difficulty easy
     """
+    description = resolve_prompt(description, prompt_file, "description")
     nb_id = require_notebook(notebook_id)
     quantity_map = {
         "fewer": QuizQuantity.FEWER,
@@ -880,6 +899,7 @@ def generate_flashcards(
 
 @generate.command("infographic")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -915,6 +935,7 @@ def generate_flashcards(
 def generate_infographic(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     orientation,
     detail,
@@ -936,6 +957,7 @@ def generate_infographic(
       notebooklm generate infographic "include statistics and key findings"
       notebooklm generate infographic --orientation portrait --detail detailed
     """
+    description = resolve_prompt(description, prompt_file, "description")
     nb_id = require_notebook(notebook_id)
     orientation_map = {
         "landscape": InfographicOrientation.LANDSCAPE,
@@ -973,7 +995,8 @@ def generate_infographic(
 
 
 @generate.command("data-table")
-@click.argument("description")
+@click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -994,6 +1017,7 @@ def generate_infographic(
 def generate_data_table(
     ctx,
     description,
+    prompt_file,
     notebook_id,
     language,
     source_ids,
@@ -1012,6 +1036,7 @@ def generate_data_table(
       notebooklm generate data-table "comparison of key concepts"
       notebooklm generate data-table -s src_001 "timeline of events"
     """
+    description = resolve_prompt(description, prompt_file, "description", required=True)
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -1112,6 +1137,7 @@ def _output_mind_map_result(result: Any, json_output: bool) -> None:
 
 @generate.command("report")
 @click.argument("description", default="", required=False)
+@prompt_file_option
 @click.option(
     "--format",
     "report_format",
@@ -1145,6 +1171,7 @@ def _output_mind_map_result(result: Any, json_output: bool) -> None:
 def generate_report_cmd(
     ctx,
     description,
+    prompt_file,
     report_format,
     notebook_id,
     source_ids,
@@ -1169,6 +1196,7 @@ def generate_report_cmd(
       notebooklm generate report --format briefing-doc --append "Focus on AI trends"
       notebooklm generate report --format study-guide --append "Target audience: beginners"
     """
+    description = resolve_prompt(description, prompt_file, "description")
     nb_id = require_notebook(notebook_id)
 
     # Smart detection: if description provided without explicit format change, treat as custom

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -16,6 +16,7 @@ import os
 import time
 from dataclasses import dataclass
 from functools import wraps
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -767,6 +768,54 @@ async def resolve_source_ids(
     for sid in source_ids:
         resolved.append(await resolve_source_id(client, notebook_id, sid))
     return resolved
+
+
+def resolve_prompt(
+    argument_value: str | None,
+    prompt_file: str | None,
+    param_name: str = "prompt",
+    *,
+    required: bool = False,
+) -> str:
+    """Resolve prompt text from a positional argument or ``--prompt-file``.
+
+    Exactly one source may be provided. The file is read as UTF-8 with surrounding
+    whitespace stripped. When ``required`` is True and neither source yields
+    text, a ``UsageError`` is raised; otherwise an empty string is returned.
+
+    Args:
+        argument_value: Value of the positional CLI argument (may be empty).
+        prompt_file: Path passed via ``--prompt-file`` (may be ``None``).
+        param_name: Name of the positional argument, used in error messages.
+        required: When True, raise ``UsageError`` if both sources are empty.
+
+    Raises:
+        click.UsageError: Both sources provided, or ``required`` and both empty.
+        click.ClickException: Prompt file unreadable or not valid UTF-8.
+    """
+    if argument_value and prompt_file:
+        raise click.UsageError(
+            f"Cannot use both the {param_name} argument and --prompt-file. Choose one."
+        )
+
+    if prompt_file:
+        path = Path(prompt_file)
+        if not path.is_file():
+            raise click.ClickException(f"Prompt file '{prompt_file}' is not a regular file.")
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            raise click.ClickException(f"Failed to read prompt file '{prompt_file}': {e}") from e
+        except UnicodeDecodeError as e:
+            raise click.ClickException(
+                f"Prompt file '{prompt_file}' is not valid UTF-8: {e}"
+            ) from e
+    else:
+        text = argument_value or ""
+
+    if required and not text:
+        raise click.UsageError(f"Provide a {param_name} argument or --prompt-file.")
+    return text
 
 
 # =============================================================================

--- a/src/notebooklm/cli/options.py
+++ b/src/notebooklm/cli/options.py
@@ -80,6 +80,17 @@ def output_option(f):
     )(f)
 
 
+def prompt_file_option(f):
+    """Add --prompt-file option for reading prompt/query text from a file."""
+    return click.option(
+        "--prompt-file",
+        "prompt_file",
+        type=click.Path(exists=True, dir_okay=False),
+        default=None,
+        help="Read prompt/query text from a file instead of the positional argument",
+    )(f)
+
+
 def retry_option(f):
     """Add --retry option for rate limit retry with exponential backoff."""
     return click.option(

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -34,10 +34,12 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
+    resolve_prompt,
     resolve_source_id,
     validate_id,
     with_client,
 )
+from .options import prompt_file_option
 
 
 @click.group()
@@ -535,7 +537,8 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 
 
 @source.command("add-research")
-@click.argument("query")
+@click.argument("query", default="", required=False)
+@prompt_file_option
 @click.option(
     "-n",
     "--notebook",
@@ -577,6 +580,7 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 def source_add_research(
     ctx,
     query,
+    prompt_file,
     notebook_id,
     search_source,
     mode,
@@ -596,7 +600,9 @@ def source_add_research(
       source add-research "tutorials" --import-all        # Auto-import all results
       source add-research "topic" --import-all --cited-only
       source add-research "topic" --mode deep --no-wait   # Non-blocking deep search
+      source add-research --prompt-file query.txt --mode deep   # Read query from file
     """
+    query = resolve_prompt(query, prompt_file, "query", required=True)
     if cited_only and not import_all:
         raise click.UsageError("--cited-only requires --import-all")
 

--- a/tests/unit/cli/test_prompt_file.py
+++ b/tests/unit/cli/test_prompt_file.py
@@ -1,0 +1,186 @@
+"""Tests for the --prompt-file option across prompt-based CLI commands."""
+
+from unittest.mock import AsyncMock
+
+import click
+import pytest
+
+from notebooklm.cli.helpers import resolve_prompt
+from notebooklm.notebooklm_cli import cli
+from notebooklm.rpc.types import ReportFormat
+from notebooklm.types import AskResult
+
+from .conftest import create_mock_client, patch_client_for_module
+
+
+def make_ask_result(answer: str = "The answer is 42.") -> AskResult:
+    return AskResult(
+        answer=answer,
+        conversation_id="a1b2c3d4-0000-0000-0000-000000000001",
+        turn_number=1,
+        is_follow_up=False,
+        references=[],
+        raw_response="",
+    )
+
+
+class TestResolvePrompt:
+    def test_uses_argument_when_prompt_file_missing(self):
+        assert resolve_prompt("hello", None, "question") == "hello"
+
+    def test_reads_prompt_file_and_strips_whitespace(self, tmp_path):
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("hello from file\n\n", encoding="utf-8")
+
+        assert resolve_prompt("", str(prompt_file), "question") == "hello from file"
+
+    def test_rejects_argument_and_prompt_file_together(self, tmp_path):
+        prompt_file = tmp_path / "prompt.txt"
+        prompt_file.write_text("hello from file", encoding="utf-8")
+
+        with pytest.raises(click.UsageError, match="question argument and --prompt-file"):
+            resolve_prompt("hello", str(prompt_file), "question")
+
+    def test_empty_file_with_required_raises(self, tmp_path):
+        prompt_file = tmp_path / "empty.txt"
+        prompt_file.write_text("", encoding="utf-8")
+
+        with pytest.raises(click.UsageError, match="Provide a question argument"):
+            resolve_prompt("", str(prompt_file), "question", required=True)
+
+    def test_whitespace_only_file_with_required_raises(self, tmp_path):
+        prompt_file = tmp_path / "blank.txt"
+        prompt_file.write_text("   \n\t  \n", encoding="utf-8")
+
+        with pytest.raises(click.UsageError, match="Provide a question argument"):
+            resolve_prompt("", str(prompt_file), "question", required=True)
+
+    def test_empty_file_without_required_returns_empty_string(self, tmp_path):
+        prompt_file = tmp_path / "empty.txt"
+        prompt_file.write_text("", encoding="utf-8")
+
+        assert resolve_prompt("", str(prompt_file), "description") == ""
+
+    def test_non_utf8_file_raises_click_exception(self, tmp_path):
+        prompt_file = tmp_path / "binary.bin"
+        prompt_file.write_bytes(b"\xff\xfe\x00binary garbage")
+
+        with pytest.raises(click.ClickException, match="not valid UTF-8"):
+            resolve_prompt("", str(prompt_file), "question")
+
+    def test_strips_leading_and_trailing_whitespace(self, tmp_path):
+        prompt_file = tmp_path / "padded.txt"
+        prompt_file.write_text("  \n hello world \n  ", encoding="utf-8")
+
+        assert resolve_prompt("", str(prompt_file), "question") == "hello world"
+
+    def test_rejects_non_regular_file(self, tmp_path):
+        # FIFO is not a regular file. Use os.mkfifo to create one cross-platform-ish
+        # (skipped on Windows where mkfifo is unavailable).
+        import os
+
+        fifo = tmp_path / "pipe"
+        try:
+            os.mkfifo(str(fifo))
+        except (AttributeError, OSError):
+            pytest.skip("mkfifo not available on this platform")
+
+        with pytest.raises(click.ClickException, match="is not a regular file"):
+            resolve_prompt("", str(fifo), "question")
+
+
+class TestAskPromptFile:
+    def test_ask_accepts_prompt_file(self, runner, mock_auth, mock_fetch_tokens, tmp_path):
+        prompt_file = tmp_path / "question.txt"
+        prompt_file.write_text("What is 42?", encoding="utf-8")
+
+        with patch_client_for_module("chat") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=make_ask_result())
+            mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["ask", "--prompt-file", str(prompt_file), "-n", "nb_123"])
+
+        assert result.exit_code == 0, result.output
+        call_args = mock_client.chat.ask.await_args
+        assert call_args.args[1] == "What is 42?"
+
+    def test_ask_requires_argument_or_prompt_file(self, runner, mock_auth, mock_fetch_tokens):
+        result = runner.invoke(cli, ["ask", "-n", "nb_123"])
+
+        assert result.exit_code != 0
+        assert "Provide a question argument or --prompt-file." in result.output
+
+
+class TestGeneratePromptFile:
+    def test_generate_report_prompt_file_infers_custom(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        prompt_file = tmp_path / "report.txt"
+        prompt_file.write_text("Create a white paper about AI trends", encoding="utf-8")
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_report = AsyncMock(
+                return_value={"artifact_id": "report_123", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli, ["generate", "report", "--prompt-file", str(prompt_file), "-n", "nb_123"]
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.artifacts.generate_report.call_args.kwargs
+        assert call_kwargs["report_format"] == ReportFormat.CUSTOM
+        assert call_kwargs["custom_prompt"] == "Create a white paper about AI trends"
+
+    def test_generate_data_table_accepts_prompt_file(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        prompt_file = tmp_path / "table.txt"
+        prompt_file.write_text("Compare key concepts", encoding="utf-8")
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_data_table = AsyncMock(
+                return_value={"artifact_id": "table_123", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                ["generate", "data-table", "--prompt-file", str(prompt_file), "-n", "nb_123"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.artifacts.generate_data_table.call_args.kwargs
+        assert call_kwargs["instructions"] == "Compare key concepts"
+
+
+class TestSourceAddResearchPromptFile:
+    def test_add_research_accepts_prompt_file(self, runner, mock_auth, mock_fetch_tokens, tmp_path):
+        prompt_file = tmp_path / "research.txt"
+        prompt_file.write_text("AI papers", encoding="utf-8")
+
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "add-research",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--no-wait",
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client.research.start.assert_awaited_once_with("nb_123", "AI papers", "web", "fast")


### PR DESCRIPTION
## Summary

Add `--prompt-file` option to support reading long prompts from a file, available in `ask`, `generate`, `source add-research`, and `chat` commands.

## Changes

- Add `resolve_prompt()` helper in `helpers.py` to read prompt from file or positional argument, with mutual exclusivity enforcement
- Add `prompt_file_option` in `options.py` to expose `--prompt-file` across commands
- Integrate into `chat.py`, `generate.py`, and `source.py`
- Add unit tests for the new option
- Update README, SKILL.md and CLI reference docs

## Commands run locally

```
uv run ruff check src/ tests/ --fix
uv run ruff format src/ tests/
uv run pytest
```

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--prompt-file` to CLI flows (ask, generate subcommands, source add-research) to read long prompts/queries from a file; some generate commands now accept optional positional prompts.
  * Extended video generation options with a `cinematic` format, `custom` style, and a `--style-prompt` input.

* **Documentation**
  * Updated CLI docs, quick start, and examples with `--prompt-file` usage and a new "Long Prompts" guidance.

* **Tests**
  * Added unit and CLI tests covering `--prompt-file` behavior and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/218)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->