### PR TITLE
fix: auto-set context to newly created notebook

### DIFF
--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -22,6 +22,7 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
+    set_current_notebook,
     with_client,
 )
 
@@ -82,6 +83,10 @@ def register_notebook_commands(cli):
             async with NotebookLMClient(client_auth) as client:
                 nb = await client.notebooks.create(title)
 
+                # Auto-switch context to the newly created notebook
+                created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
+                set_current_notebook(nb.id, nb.title, nb.is_owner, created_str)
+
                 if json_output:
                     data = {
                         "notebook": {
@@ -94,6 +99,7 @@ def register_notebook_commands(cli):
                     return
 
                 console.print(f"[green]Created notebook:[/green] {nb.id} - {nb.title}")
+                console.print(f"[dim]Context set to new notebook[/dim]")
 
         return _run()
 

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -83,7 +83,6 @@ def register_notebook_commands(cli):
             async with NotebookLMClient(client_auth) as client:
                 nb = await client.notebooks.create(title)
 
-                # Auto-switch context to the newly created notebook
                 created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
                 set_current_notebook(nb.id, nb.title, nb.is_owner, created_str)
 
@@ -99,7 +98,7 @@ def register_notebook_commands(cli):
                     return
 
                 console.print(f"[green]Created notebook:[/green] {nb.id} - {nb.title}")
-                console.print(f"[dim]Context set to new notebook[/dim]")
+                console.print("[dim]Context set to new notebook[/dim]")
 
         return _run()
 

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -120,7 +120,7 @@ class TestNotebookList:
 
 
 class TestNotebookCreate:
-    def test_notebook_create(self, runner, mock_auth):
+    def test_notebook_create(self, runner, mock_auth, mock_context_file):
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.create = AsyncMock(
@@ -138,8 +138,12 @@ class TestNotebookCreate:
 
             assert result.exit_code == 0
             assert "Created notebook" in result.output
+            assert "Context set to new notebook" in result.output
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "new_nb_id"
+            assert context["title"] == "Test Notebook"
 
-    def test_notebook_create_json_output(self, runner, mock_auth):
+    def test_notebook_create_json_output(self, runner, mock_auth, mock_context_file):
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.create = AsyncMock(
@@ -158,6 +162,54 @@ class TestNotebookCreate:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["notebook"]["id"] == "new_nb_id"
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "new_nb_id"
+
+    def test_notebook_create_replaces_existing_context(self, runner, mock_auth, mock_context_file):
+        """Reproduces #220: create must overwrite a previously active context."""
+        mock_context_file.write_text(
+            json.dumps({"notebook_id": "old_nb", "title": "Previously Active"})
+        )
+
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(
+                return_value=Notebook(
+                    id="brand_new", title="Fresh", created_at=datetime(2024, 1, 1)
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Fresh"])
+
+            assert result.exit_code == 0
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "brand_new"
+            assert context["title"] == "Fresh"
+
+    def test_notebook_create_without_created_at(self, runner, mock_auth, mock_context_file):
+        """Guard the `if nb.created_at else None` branch so a future refactor can't regress it."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(
+                return_value=Notebook(id="nb_no_date", title="Undated", created_at=None)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Undated"])
+
+            assert result.exit_code == 0
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "nb_no_date"
+            assert "created_at" not in context
 
     def test_notebook_create_json_quota_error(self, runner, mock_auth):
         """Create emits structured JSON when notebook quota is detected."""


### PR DESCRIPTION
## Summary

- `notebooklm create` now automatically sets the CLI context to the newly created notebook
- Previously, after `create`, subsequent commands like `source add` would target the **previously active** notebook — not the one just created
- Added `set_current_notebook()` call after notebook creation, matching the behavior of the `use` command

## Problem

```bash
notebooklm create "My Research"    # Creates notebook, but context stays on old one
notebooklm source add "https://..."  # ❌ Added to the PREVIOUS notebook!
```

## Fix

```bash
notebooklm create "My Research"    # Creates notebook AND sets context
notebooklm source add "https://..."  # ✅ Added to "My Research"
```

## Changes

- `src/notebooklm/cli/notebook.py`: Import `set_current_notebook` and call it after `client.notebooks.create()` in `create_cmd()`

## Test plan

- [ ] `notebooklm create "Test" --json` → verify context switches (check with `notebooklm status`)
- [ ] `notebooklm create "Test"` (non-JSON) → verify "Context set to new notebook" message
- [ ] `notebooklm source add <url>` after create → verify source lands in new notebook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebooks created through the CLI are now automatically set as the current notebook, with a confirmation message displayed to confirm the context switch.

* **Tests**
  * Added and updated unit tests to verify the active-context file is written, overwritten when appropriate, and handles missing creation timestamps correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->