### PR TITLE
feat(cli): add Gemini CLI skill support

### DIFF
--- a/src/notebooklm/cli/agent.py
+++ b/src/notebooklm/cli/agent.py
@@ -13,7 +13,7 @@ def agent():
 
 
 @agent.command("show")
-@click.argument("target", type=click.Choice(["codex", "claude"], case_sensitive=False))
+@click.argument("target", type=click.Choice(["codex", "claude", "gemini"], case_sensitive=False))
 def show_agent(target: str):
     """Display instructions for Codex or Claude Code."""
     content = get_agent_source_content(target)

--- a/src/notebooklm/cli/agent_templates.py
+++ b/src/notebooklm/cli/agent_templates.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 AGENT_TEMPLATE_FILES = {
     "claude": "SKILL.md",
+    "gemini": "SKILL.md",
     "codex": "CODEX.md",
 }
 
@@ -31,7 +32,7 @@ def get_agent_source_content(target: str) -> str | None:
 
     # Prefer the repo-root skill when running from a source checkout so both
     # GitHub discovery and local CLI installs use the same source of truth.
-    if normalized == "claude" and REPO_ROOT_CLAUDE_SKILL.exists():
+    if normalized in ("claude", "gemini") and REPO_ROOT_CLAUDE_SKILL.exists():
         return REPO_ROOT_CLAUDE_SKILL.read_text(encoding="utf-8")
 
     filename = AGENT_TEMPLATE_FILES.get(normalized)

--- a/src/notebooklm/cli/skill.py
+++ b/src/notebooklm/cli/skill.py
@@ -20,6 +20,7 @@ class SkillTarget:
 
 TARGETS = {
     "claude": SkillTarget("Claude Code", Path(".claude") / "skills" / "notebooklm" / "SKILL.md"),
+    "gemini": SkillTarget("Gemini CLI", Path(".gemini") / "skills" / "notebooklm" / "SKILL.md"),
     "agents": SkillTarget("Agent Skills", Path(".agents") / "skills" / "notebooklm" / "SKILL.md"),
 }
 SCOPES = ("user", "project")

--- a/tests/unit/cli/test_agent.py
+++ b/tests/unit/cli/test_agent.py
@@ -39,6 +39,14 @@ class TestAgentShow:
         assert result.exit_code == 0
         assert "Claude Skill" in result.output
 
+    def test_agent_show_gemini_displays_content(self, runner):
+        """Test that agent show gemini displays the bundled instructions."""
+        with patch.object(agent_module, "get_agent_source_content", return_value="# Gemini Skill"):
+            result = runner.invoke(cli, ["agent", "show", "gemini"])
+
+        assert result.exit_code == 0
+        assert "Gemini Skill" in result.output
+
     def test_agent_show_missing_content_returns_error(self, runner):
         """Test error when bundled agent instructions are missing."""
         with patch.object(agent_module, "get_agent_source_content", return_value=None):
@@ -69,6 +77,13 @@ class TestAgentTemplates:
     def test_claude_template_reads_package_data(self):
         """Test that claude content reads from packaged skill data."""
         content = agent_templates_module.get_agent_source_content("claude")
+
+        assert content is not None
+        assert "NotebookLM Automation" in content
+
+    def test_gemini_template_reads_same_skill_as_claude(self):
+        """Test that gemini content reads from the same SKILL.md as claude."""
+        content = agent_templates_module.get_agent_source_content("gemini")
 
         assert content is not None
         assert "NotebookLM Automation" in content

--- a/tests/unit/cli/test_skill.py
+++ b/tests/unit/cli/test_skill.py
@@ -37,6 +37,7 @@ class TestSkillInstall:
         assert result.exit_code == 0
         assert "installed" in result.output.lower()
         assert (home / ".claude" / "skills" / "notebooklm" / "SKILL.md").exists()
+        assert (home / ".gemini" / "skills" / "notebooklm" / "SKILL.md").exists()
         assert (home / ".agents" / "skills" / "notebooklm" / "SKILL.md").exists()
 
     def test_skill_install_project_agents_target_only(self, runner, tmp_path):
@@ -75,6 +76,7 @@ class TestSkillInstall:
 
         assert result.exit_code == 0
         assert (project / ".claude" / "skills" / "notebooklm" / "SKILL.md").exists()
+        assert (project / ".gemini" / "skills" / "notebooklm" / "SKILL.md").exists()
         assert (project / ".agents" / "skills" / "notebooklm" / "SKILL.md").exists()
 
     def test_skill_install_source_not_found(self, runner, tmp_path):
@@ -122,6 +124,7 @@ class TestSkillStatus:
         assert result.exit_code == 0
         assert "not installed" in result.output.lower()
         assert "claude code" in result.output.lower()
+        assert "gemini cli" in result.output.lower()
         assert "agent skills" in result.output.lower()
 
     def test_skill_status_installed_version_mismatch(self, runner, tmp_path):
@@ -145,7 +148,11 @@ class TestSkillStatus:
         """Test status when both targets are installed with the current version."""
         home = tmp_path / "home"
         version = "1.2.3"
-        for subdir in [".claude/skills/notebooklm", ".agents/skills/notebooklm"]:
+        for subdir in [
+            ".claude/skills/notebooklm",
+            ".gemini/skills/notebooklm",
+            ".agents/skills/notebooklm",
+        ]:
             dest = home / subdir / "SKILL.md"
             dest.parent.mkdir(parents=True)
             dest.write_text(f"<!-- notebooklm-py v{version} -->\n# Test")
@@ -184,7 +191,11 @@ class TestSkillUninstall:
     def test_skill_uninstall_all_targets_removes_both(self, runner, tmp_path):
         """Test that uninstall --target all removes both targets and cleans empty dirs."""
         home = tmp_path / "home"
-        for subdir in [".claude/skills/notebooklm", ".agents/skills/notebooklm"]:
+        for subdir in [
+            ".claude/skills/notebooklm",
+            ".gemini/skills/notebooklm",
+            ".agents/skills/notebooklm",
+        ]:
             dest = home / subdir / "SKILL.md"
             dest.parent.mkdir(parents=True)
             dest.write_text("# Test")
@@ -194,9 +205,11 @@ class TestSkillUninstall:
 
         assert result.exit_code == 0
         assert not (home / ".claude" / "skills" / "notebooklm" / "SKILL.md").exists()
+        assert not (home / ".gemini" / "skills" / "notebooklm" / "SKILL.md").exists()
         assert not (home / ".agents" / "skills" / "notebooklm" / "SKILL.md").exists()
         # Empty intermediate directories should be cleaned up
         assert not (home / ".claude" / "skills" / "notebooklm").exists()
+        assert not (home / ".gemini" / "skills" / "notebooklm").exists()
         assert not (home / ".agents" / "skills" / "notebooklm").exists()
 
     def test_skill_uninstall_not_installed(self, runner, tmp_path):


### PR DESCRIPTION
## Summary

- Add `gemini` as a supported skill install target alongside `claude` and `agents`
- Gemini CLI uses the same `SKILL.md` format (YAML frontmatter with `name`/`description`), so the existing file is reused — no new file needed
- Install path: `~/.gemini/skills/notebooklm/SKILL.md` (user scope) or `.gemini/skills/notebooklm/SKILL.md` (project scope)

## Changes

- `cli/skill.py`: Added `"gemini"` entry to `TARGETS` dict
- `cli/agent_templates.py`: Added `"gemini"` to `AGENT_TEMPLATE_FILES` (maps to `SKILL.md`) and repo-root fallback
- `cli/agent.py`: Added `"gemini"` to `agent show` command choices
- Tests updated to cover the new gemini target in install/status/uninstall/show flows

## Test plan

- [x] `ruff format` — clean
- [x] `ruff check` — no issues
- [x] `mypy` — no issues
- [x] `pytest tests/unit/cli/test_skill.py tests/unit/cli/test_agent.py` — 33/33 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini as a supported target across agent and skill CLI commands (show, install, status, uninstall).
  * Gemini uses the same skill/template layout as Claude.

* **Tests**
  * Added unit tests to cover Gemini in agent display and skill install/status/uninstall flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/221)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->