### PR TITLE
feat: add markdown output format for source fulltext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Source fulltext markdown format** - Retrieve source content as structured Markdown with headings, tables, links, and emphasis preserved
+  - New `format` parameter on `client.sources.get_fulltext()` (`"text"` default, `"markdown"`)
+  - New `-f`/`--format` CLI option on `source fulltext` command
+  - Requires optional `markdownify` dependency (`pip install notebooklm-py[markdown]`)
+
 ## [0.3.4] - 2026-03-12
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -97,7 +97,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
 | `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
-| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` |
+| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` (`-f markdown` requires the `markdown` extra: `pip install notebooklm-py[markdown]`) |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
 | `rename <id> <title>` | Source ID, new title | - | `source rename src123 "New Name"` |
 | `refresh <id>` | Source ID | - | `source refresh src123` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -97,7 +97,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
 | `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
-| `fulltext <id>` | Source ID | `--json`, `-o FILE` | `source fulltext src123 -o content.txt` |
+| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
 | `rename <id> <title>` | Source ID, new title | - | `source rename src123 "New Name"` |
 | `refresh <id>` | Source ID | - | `source refresh src123` |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -233,7 +233,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id)` | `str, str` | `SourceFulltext` | Get full indexed text content |
+| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -233,7 +233,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
+| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, *, format: str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -233,7 +233,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, *, format: str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
+| `get_fulltext(notebook_id, source_id, *, output_format)` | `str, str, *, output_format: str` | `SourceFulltext` | Get full content (output_format: `"text"` or `"markdown"`) |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "ruff>=0.4.0",
     "vcrpy>=6.0.0",
 ]
-all = ["notebooklm-py[browser,dev]"]
+all = ["notebooklm-py[browser,dev,markdown]"]
 
 [project.scripts]
 notebooklm = "notebooklm.notebooklm_cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Documentation = "https://github.com/teng-lin/notebooklm-py#readme"
 Issues = "https://github.com/teng-lin/notebooklm-py/issues"
 
 [project.optional-dependencies]
+markdown = ["markdownify>=0.14.1"]
 browser = ["playwright>=1.40.0"]
 dev = [
     "pytest>=8.0.0",

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -666,15 +666,19 @@ class SourcesAPI:
 
         return {"summary": summary, "keywords": keywords}
 
-    async def get_fulltext(self, notebook_id: str, source_id: str) -> SourceFulltext:
-        """Get the full indexed text content of a source.
-
-        Returns the raw text content that was extracted and indexed from the source,
-        along with metadata. This is what NotebookLM uses for chat and artifact generation.
+    async def get_fulltext(
+        self, notebook_id: str, source_id: str, *, format: str = "text"
+    ) -> SourceFulltext:
+        """Get the full content of a source.
 
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to get fulltext for.
+            format: Content format - ``"text"`` (default) returns flattened
+                plaintext, ``"markdown"`` returns the source with headings,
+                tables, links, and emphasis preserved.  The markdown path
+                requires the ``markdownify`` package (``pip install
+                markdownify``).
 
         Returns:
             SourceFulltext object with content, title, source_type, url, and char_count.
@@ -685,9 +689,14 @@ class SourcesAPI:
         Note:
             Source type codes: 1=google_docs, 2=google_other, 3=pdf, 4=pasted_text,
             5=web_page, 8=generated_text, 9=youtube
+
+            The ``"markdown"`` format works by requesting the HTML rendition
+            from the API (params ``[3],[3]`` instead of ``[2],[2]``) and
+            converting it via *markdownify*.
         """
-        # GET_SOURCE RPC with params: [[source_id], [2], [2]]
-        params = [[source_id], [2], [2]]
+        # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
+        params = [[source_id], [3], [3]] if format == "markdown" else [[source_id], [2], [2]]
+
         result = await self._core.rpc_call(
             RPCMethod.GET_SOURCE,
             params,
@@ -720,13 +729,22 @@ class SourcesAPI:
                         if len(result[0][2][7]) > 0:
                             url = result[0][2][7][0]
 
-            # Content blocks at result[3][0]
-            # Each block may be nested arrays with text strings
-            if len(result) > 3 and isinstance(result[3], list) and len(result[3]) > 0:
-                content_blocks = result[3][0]
-                if isinstance(content_blocks, list):
-                    texts = self._extract_all_text(content_blocks)
-                    content = "\n".join(texts)
+            if format == "markdown":
+                # HTML content at result[4][1]
+                if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
+                    html_content = result[4][1]
+                    if isinstance(html_content, str):
+                        from markdownify import markdownify as md
+
+                        content = md(html_content, heading_style="ATX")
+            else:
+                # Plaintext content blocks at result[3][0]
+                # Each block may be nested arrays with text strings
+                if len(result) > 3 and isinstance(result[3], list) and len(result[3]) > 0:
+                    content_blocks = result[3][0]
+                    if isinstance(content_blocks, list):
+                        texts = self._extract_all_text(content_blocks)
+                        content = "\n".join(texts)
 
         # Log warning if content is empty but source exists
         if not content:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -676,9 +676,9 @@ class SourcesAPI:
             source_id: The source ID to get fulltext for.
             format: Content format - ``"text"`` (default) returns flattened
                 plaintext, ``"markdown"`` returns the source with headings,
-                tables, links, and emphasis preserved.  The markdown path
+                tables, links, and emphasis preserved. The markdown format
                 requires the ``markdownify`` package (``pip install
-                markdownify``).
+                'notebooklm-py[markdown]'``).
 
         Returns:
             SourceFulltext object with content, title, source_type, url, and char_count.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -734,7 +734,13 @@ class SourcesAPI:
                 if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
                     html_content = result[4][1]
                     if isinstance(html_content, str):
-                        from markdownify import markdownify as md
+                        try:
+                            from markdownify import markdownify as md
+                        except ImportError:
+                            raise ImportError(
+                                "The 'markdown' format requires the 'markdownify' package. "
+                                "Please install it with: pip install 'notebooklm-py[markdown]'"
+                            ) from None
 
                         content = md(html_content, heading_style="ATX")
             else:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -694,6 +694,9 @@ class SourcesAPI:
             from the API (params ``[3],[3]`` instead of ``[2],[2]``) and
             converting it via *markdownify*.
         """
+        if format not in ("text", "markdown"):
+            raise ValueError(f"Invalid format: '{format}'. Must be 'text' or 'markdown'.")
+
         # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
         params = [[source_id], [3], [3]] if format == "markdown" else [[source_id], [2], [2]]
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -7,7 +7,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from time import monotonic
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -667,14 +667,18 @@ class SourcesAPI:
         return {"summary": summary, "keywords": keywords}
 
     async def get_fulltext(
-        self, notebook_id: str, source_id: str, *, format: str = "text"
+        self,
+        notebook_id: str,
+        source_id: str,
+        *,
+        output_format: Literal["text", "markdown"] = "text",
     ) -> SourceFulltext:
         """Get the full content of a source.
 
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to get fulltext for.
-            format: Content format - ``"text"`` (default) returns flattened
+            output_format: Content format - ``"text"`` (default) returns flattened
                 plaintext, ``"markdown"`` returns the source with headings,
                 tables, links, and emphasis preserved. The markdown format
                 requires the ``markdownify`` package (``pip install
@@ -694,11 +698,11 @@ class SourcesAPI:
             from the API (params ``[3],[3]`` instead of ``[2],[2]``) and
             converting it via *markdownify*.
         """
-        if format not in ("text", "markdown"):
-            raise ValueError(f"Invalid format: '{format}'. Must be 'text' or 'markdown'.")
+        if output_format not in ("text", "markdown"):
+            raise ValueError(f"Invalid format: '{output_format}'. Must be 'text' or 'markdown'.")
 
         # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
-        params = [[source_id], [3], [3]] if format == "markdown" else [[source_id], [2], [2]]
+        params = [[source_id], [3], [3]] if output_format == "markdown" else [[source_id], [2], [2]]
 
         result = await self._core.rpc_call(
             RPCMethod.GET_SOURCE,
@@ -732,7 +736,7 @@ class SourcesAPI:
                         if len(result[0][2][7]) > 0:
                             url = result[0][2][7][0]
 
-            if format == "markdown":
+            if output_format == "markdown":
                 # HTML content at result[4][1]
                 if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
                     html_content = result[4][1]

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -657,7 +657,7 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_fo
 
             with console.status("Fetching fulltext content..."):
                 fulltext = await client.sources.get_fulltext(
-                    nb_id_resolved, resolved_id, format=content_format
+                    nb_id_resolved, resolved_id, output_format=content_format
                 )
 
             if json_output:

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -625,20 +625,28 @@ def source_add_research(
 )
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.option("--output", "-o", type=click.Path(), help="Write content to file")
+@click.option(
+    "--format",
+    "-f",
+    "content_format",
+    type=click.Choice(["text", "markdown"]),
+    default="text",
+    help="Content format: text (default) or markdown",
+)
 @with_client
-def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_auth):
-    """Get full indexed text content of a source.
+def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_format, client_auth):
+    """Get full content of a source.
 
-    Retrieves the complete text content as indexed by NotebookLM. This is the
-    actual text that NotebookLM uses when answering questions about this source.
+    Retrieves the complete content from NotebookLM. Use --format markdown to get
+    a rich version with headings, tables, links, and emphasis preserved.
 
     SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
 
     \b
     Examples:
-      source fulltext abc123                    # Show fulltext in terminal
-      source fulltext abc123 --json             # Output as JSON
-      source fulltext abc123 -o content.txt     # Save to file
+      source fulltext abc123                        # Show plaintext in terminal
+      source fulltext abc123 -f markdown -o out.md  # Save markdown to file
+      source fulltext abc123 --json                 # Output as JSON
     """
     nb_id = require_notebook(notebook_id)
 
@@ -648,7 +656,9 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_aut
             resolved_id = await resolve_source_id(client, nb_id_resolved, source_id)
 
             with console.status("Fetching fulltext content..."):
-                fulltext = await client.sources.get_fulltext(nb_id_resolved, resolved_id)
+                fulltext = await client.sources.get_fulltext(
+                    nb_id_resolved, resolved_id, format=content_format
+                )
 
             if json_output:
                 from dataclasses import asdict


### PR DESCRIPTION
Adds a `format` parameter to `get_fulltext()` that lets users retrieve source
content as structured Markdown instead of flattened plaintext.

## What

- New `format` kwarg on `client.sources.get_fulltext()` — `"text"` (default) or `"markdown"`
- New `-f`/`--format` CLI option on `source fulltext`
- Markdown format preserves headings, tables, links, and emphasis from the source
- Uses the API's HTML rendition (params `[3],[3]`) converted via `markdownify`

## Why

The existing plaintext output strips all structure — headings, tables, links,
emphasis are lost. For downstream use cases (LLM context, note-taking, research
pipelines), preserving that structure matters. resolves https://github.com/teng-lin/notebooklm-py/issues/222

## Details

- Default behavior unchanged — `"text"` is the default for both CLI and Python API
- `markdownify` is an optional dependency (`pip install notebooklm-py[markdown]`)
- Added `markdown` extra to `pyproject.toml`
- Updated cli-reference, python-api docs, and changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fulltext output now supports markdown in addition to plain text via a new format option.
  * CLI command adds a -f/--format flag to choose text or markdown output.
  * Optional markdown support available via an extra dependency.

* **Documentation**
  * CLI reference and Python API docs updated to document the new format option and example usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->