### PR TITLE
fix: deduplicate research sources before import

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -76,6 +76,60 @@ def run_async(coro):
     return asyncio.run(coro)
 
 
+async def deduplicate_research_sources(
+    client,
+    notebook_id: str,
+    sources: list[dict],
+    *,
+    json_output: bool = False,
+) -> list[dict]:
+    """Filter out research sources that already exist in the notebook.
+
+    Compares research source URLs against existing notebook sources to prevent
+    duplicate imports. Report entries (result_type=5) are always kept since
+    they have no URL to deduplicate against.
+
+    This is intentionally CLI-only policy. Library consumers calling
+    `client.research.import_sources()` directly still get one-shot behavior.
+
+    Args:
+        client: NotebookLM client instance.
+        notebook_id: The notebook ID.
+        sources: Research sources to filter.
+        json_output: If True, suppress console output.
+
+    Returns:
+        Filtered list of sources not already present in the notebook.
+    """
+    existing_sources = await client.sources.list(notebook_id)
+    existing_urls = {getattr(s, "url", None) for s in existing_sources}
+    existing_urls.discard(None)
+
+    new_sources = []
+    skipped = 0
+    for src in sources:
+        # Always keep report entries (no URL to deduplicate)
+        if src.get("result_type") == 5:
+            new_sources.append(src)
+            continue
+        url = src.get("url")
+        if url and url in existing_urls:
+            skipped += 1
+        else:
+            new_sources.append(src)
+
+    if skipped > 0:
+        logger.info(
+            "Deduplicated %d source(s) already present in notebook %s",
+            skipped,
+            notebook_id,
+        )
+        if not json_output:
+            console.print(f"[dim]Skipped {skipped} source(s) already in notebook[/dim]")
+
+    return new_sources
+
+
 async def import_with_retry(
     client,
     notebook_id: str,
@@ -106,18 +160,36 @@ async def import_with_retry(
             if remaining <= 0:
                 raise
 
+            # Before retrying, remove sources that were already imported
+            # (the timed-out call may have partially succeeded server-side)
+            sources = await deduplicate_research_sources(
+                client,
+                notebook_id,
+                sources,
+                json_output=json_output,
+            )
+            if not sources:
+                logger.info(
+                    "All sources already imported after timeout; skipping retry for notebook %s",
+                    notebook_id,
+                )
+                if not json_output:
+                    console.print("[green]All sources already imported[/green]")
+                return []
+
             sleep_for = min(delay, max_delay, remaining)
             logger.warning(
-                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs (attempt %d, %.1fs elapsed)",
+                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs (attempt %d, %.1fs elapsed, %d sources remaining)",
                 notebook_id,
                 sleep_for,
                 attempt + 1,
                 elapsed,
+                len(sources),
             )
             if not json_output:
                 console.print(
                     f"[yellow]Import timed out; retrying in {sleep_for:.0f}s "
-                    f"(attempt {attempt + 1})[/yellow]"
+                    f"(attempt {attempt + 1}, {len(sources)} sources remaining)[/yellow]"
                 )
             await asyncio.sleep(sleep_for)
             delay = min(delay * backoff_factor, max_delay)

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -12,6 +12,7 @@ import click
 from ..client import NotebookLMClient
 from .helpers import (
     console,
+    deduplicate_research_sources,
     display_report,
     display_research_sources,
     import_with_retry,
@@ -188,16 +189,27 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
                     "report": report,
                 }
                 if import_all and sources and task_id:
-                    imported = await import_with_retry(
+                    sources = await deduplicate_research_sources(
                         client,
                         nb_id_resolved,
-                        task_id,
                         sources,
-                        max_elapsed=timeout,
                         json_output=True,
                     )
-                    result["imported"] = len(imported)
-                    result["imported_sources"] = imported
+                    if sources:
+                        imported = await import_with_retry(
+                            client,
+                            nb_id_resolved,
+                            task_id,
+                            sources,
+                            max_elapsed=timeout,
+                            json_output=True,
+                        )
+                        result["imported"] = len(imported)
+                        result["imported_sources"] = imported
+                    else:
+                        result["imported"] = 0
+                        result["imported_sources"] = []
+                        result["deduplicated"] = True
                 json_output_response(result)
             else:
                 console.print(f"[green]✓ Research completed:[/green] {query}")
@@ -206,14 +218,22 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
                 display_report(report)
 
                 if import_all and sources and task_id:
-                    with console.status("Importing sources..."):
-                        imported = await import_with_retry(
-                            client,
-                            nb_id_resolved,
-                            task_id,
-                            sources,
-                            max_elapsed=timeout,
-                        )
-                    console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    sources = await deduplicate_research_sources(
+                        client,
+                        nb_id_resolved,
+                        sources,
+                    )
+                    if sources:
+                        with console.status("Importing sources..."):
+                            imported = await import_with_retry(
+                                client,
+                                nb_id_resolved,
+                                task_id,
+                                sources,
+                                max_elapsed=timeout,
+                            )
+                        console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    else:
+                        console.print("[green]All sources already in notebook[/green]")
 
     return _run()

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -27,6 +27,7 @@ from ..client import NotebookLMClient
 from ..types import source_status_to_str
 from .helpers import (
     console,
+    deduplicate_research_sources,
     display_report,
     display_research_sources,
     get_source_type_display,
@@ -601,13 +602,21 @@ def source_add_research(
                 display_report(status.get("report", ""), json_hint=False)
 
                 if import_all and sources and task_id:
-                    imported = await import_with_retry(
+                    sources = await deduplicate_research_sources(
                         client,
                         nb_id_resolved,
-                        task_id,
                         sources,
                     )
-                    console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    if sources:
+                        imported = await import_with_retry(
+                            client,
+                            nb_id_resolved,
+                            task_id,
+                            sources,
+                        )
+                        console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    else:
+                        console.print("[green]All sources already in notebook[/green]")
             else:
                 console.print(f"[yellow]Status: {status.get('status', 'unknown')}[/yellow]")
 

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -9,6 +9,7 @@ from notebooklm import Artifact
 from notebooklm.cli.helpers import (
     clear_context,
     cli_name_to_artifact_type,
+    deduplicate_research_sources,
     display_report,
     display_research_sources,
     get_artifact_type_display,
@@ -651,10 +652,12 @@ class TestImportWithRetry:
                 [{"id": "src_1", "title": "Source 1"}],
             ]
         )
+        # Dedup check on retry finds no existing sources
+        client.sources.list = AsyncMock(return_value=[])
 
         with (
             patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch("notebooklm.cli.helpers.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -668,7 +671,6 @@ class TestImportWithRetry:
         assert imported == [{"id": "src_1", "title": "Source 1"}]
         assert client.research.import_sources.await_count == 2
         mock_sleep.assert_awaited_once_with(5)
-        mock_console.print.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_retries_silently_for_json_output(self):
@@ -679,6 +681,8 @@ class TestImportWithRetry:
                 [],
             ]
         )
+        # Dedup check on retry finds no existing sources
+        client.sources.list = AsyncMock(return_value=[])
 
         with (
             patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
@@ -699,6 +703,8 @@ class TestImportWithRetry:
         client = MagicMock()
         error = RPCTimeoutError("Timed out", timeout_seconds=30.0)
         client.research.import_sources = AsyncMock(side_effect=error)
+        # Dedup check still needed even though budget is exhausted
+        client.sources.list = AsyncMock(return_value=[])
 
         with (
             patch("notebooklm.cli.helpers.time.monotonic", side_effect=[0.0, 1801.0]),
@@ -731,5 +737,158 @@ class TestImportWithRetry:
                 [{"url": "https://example.com", "title": "Source 1"}],
             )
 
+        assert client.research.import_sources.await_count == 1
+        mock_sleep.assert_not_awaited()
+
+
+# =============================================================================
+# DEDUPLICATE RESEARCH SOURCES TESTS
+# =============================================================================
+
+
+class TestDeduplicateResearchSources:
+    @pytest.mark.asyncio
+    async def test_filters_out_existing_urls(self):
+        client = MagicMock()
+        existing = MagicMock()
+        existing.url = "https://example.com/already-there"
+        client.sources.list = AsyncMock(return_value=[existing])
+
+        sources = [
+            {"url": "https://example.com/already-there", "title": "Existing"},
+            {"url": "https://example.com/new-one", "title": "New"},
+        ]
+
+        with patch("notebooklm.cli.helpers.console"):
+            result = await deduplicate_research_sources(client, "nb_123", sources)
+
+        assert len(result) == 1
+        assert result[0]["url"] == "https://example.com/new-one"
+
+    @pytest.mark.asyncio
+    async def test_keeps_report_entries(self):
+        client = MagicMock()
+        existing = MagicMock()
+        existing.url = "https://example.com/existing"
+        client.sources.list = AsyncMock(return_value=[existing])
+
+        sources = [
+            {"url": "https://example.com/existing", "title": "Existing"},
+            {"result_type": 5, "title": "Report", "report_markdown": "# Report"},
+        ]
+
+        with patch("notebooklm.cli.helpers.console"):
+            result = await deduplicate_research_sources(client, "nb_123", sources)
+
+        assert len(result) == 1
+        assert result[0]["result_type"] == 5
+
+    @pytest.mark.asyncio
+    async def test_returns_all_when_no_duplicates(self):
+        client = MagicMock()
+        client.sources.list = AsyncMock(return_value=[])
+
+        sources = [
+            {"url": "https://example.com/a", "title": "A"},
+            {"url": "https://example.com/b", "title": "B"},
+        ]
+
+        with patch("notebooklm.cli.helpers.console"):
+            result = await deduplicate_research_sources(client, "nb_123", sources)
+
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_all_duplicates(self):
+        client = MagicMock()
+        existing_a = MagicMock()
+        existing_a.url = "https://example.com/a"
+        existing_b = MagicMock()
+        existing_b.url = "https://example.com/b"
+        client.sources.list = AsyncMock(return_value=[existing_a, existing_b])
+
+        sources = [
+            {"url": "https://example.com/a", "title": "A"},
+            {"url": "https://example.com/b", "title": "B"},
+        ]
+
+        with patch("notebooklm.cli.helpers.console"):
+            result = await deduplicate_research_sources(client, "nb_123", sources)
+
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_sources_without_url_attr(self):
+        """Existing sources without url attribute should not cause errors."""
+        client = MagicMock()
+        # Source without url attribute (e.g., text/pasted sources)
+        existing = MagicMock(spec=["id", "title"])
+        client.sources.list = AsyncMock(return_value=[existing])
+
+        sources = [{"url": "https://example.com/new", "title": "New"}]
+
+        with patch("notebooklm.cli.helpers.console"):
+            result = await deduplicate_research_sources(client, "nb_123", sources)
+
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_import_with_retry_deduplicates_between_retries(self):
+        """After a timeout, sources that were partially imported should be excluded from retry."""
+        client = MagicMock()
+
+        # First call times out, second succeeds with the remaining source
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_2", "title": "Source 2"}],
+            ]
+        )
+
+        # After timeout, dedup check finds Source 1 was already imported
+        existing = MagicMock()
+        existing.url = "https://example.com/1"
+        client.sources.list = AsyncMock(return_value=[existing])
+
+        sources = [
+            {"url": "https://example.com/1", "title": "Source 1"},
+            {"url": "https://example.com/2", "title": "Source 2"},
+        ]
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(client, "nb_123", "task_123", sources)
+
+        assert imported == [{"id": "src_2", "title": "Source 2"}]
+        # Second import call should only have Source 2
+        retry_sources = client.research.import_sources.call_args_list[1][0][2]
+        assert len(retry_sources) == 1
+        assert retry_sources[0]["url"] == "https://example.com/2"
+
+    @pytest.mark.asyncio
+    async def test_import_with_retry_skips_retry_when_all_imported(self):
+        """If all sources were imported despite timeout, skip retry entirely."""
+        client = MagicMock()
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        # After timeout, dedup finds all sources already imported
+        existing = MagicMock()
+        existing.url = "https://example.com/1"
+        client.sources.list = AsyncMock(return_value=[existing])
+
+        sources = [{"url": "https://example.com/1", "title": "Source 1"}]
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(client, "nb_123", "task_123", sources)
+
+        assert imported == []
+        # Should not have retried — only the initial failed attempt
         assert client.research.import_sources.await_count == 1
         mock_sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Adds `deduplicate_research_sources()` helper that checks existing notebook sources by URL before importing research results
- Prevents duplicate source creation when `--import-all` retries on RPC timeouts (the primary cause of 4-5x duplicates after deep research)
- Applied at three levels: `source add-research`, `research wait`, and between retries in `import_with_retry()`
- Report entries (result_type=5) are always preserved since they have no URL to deduplicate against

## Problem

Deep research with `--import-all` had no deduplication at any level. When an RPC call timed out and retried, the full source list was re-sent — and Google's server created new source entries each time. With default exponential backoff, this produced 4-5 copies of every source.

Additionally, running both `source add-research --import-all` and later `research wait --import-all` would double-import everything since neither checked what was already in the notebook.

## Changes

| File | Change |
|------|--------|
| `cli/helpers.py` | New `deduplicate_research_sources()` + dedup between retries in `import_with_retry()` |
| `cli/source.py` | Dedup before import in `source add-research --import-all` |
| `cli/research.py` | Dedup before import in `research wait --import-all` (both JSON and console paths) |
| `tests/unit/cli/test_helpers.py` | 7 new tests for dedup logic + updated existing retry tests |

## Design decisions

- **CLI-only policy**: Dedup is in the CLI layer, not the library API. `client.research.import_sources()` retains one-shot behavior for library consumers who may want explicit control.
- **URL-based matching**: Compares against `source.url` from existing sources. Sources without URLs (text, pasted) are ignored. Report entries are always kept.
- **`getattr` for URL access**: Handles source objects that may not have a `url` attribute (e.g., text sources) without raising `AttributeError`.

## Test plan

- [x] All 1431 existing unit tests pass
- [x] 7 new tests covering: URL filtering, report preservation, no-duplicate passthrough, all-duplicate detection, missing URL attribute handling, dedup between retries, skip-retry-when-all-imported
- [x] `ruff check`, `ruff format`, `mypy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the source import workflow to detect and prevent duplicate research sources from being added to notebooks. The system now checks for existing sources before importing new ones, automatically skipping items that are already present.

* **Tests**
  * Added comprehensive test coverage for source deduplication functionality, validating edge cases and retry behavior scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->