### PR TITLE
fix: migration overwrites stale profile cookies with fresh login data

### DIFF
--- a/src/notebooklm/migration.py
+++ b/src/notebooklm/migration.py
@@ -79,12 +79,12 @@ def migrate_to_profiles() -> bool:
 
     logger.info("Migrating legacy layout to profiles/default/")
 
-    # Copy files (skip if destination already exists and is newer — avoids
-    # overwriting profile data that was updated after a partial migration)
+    # Copy files — overwrite if source is newer (e.g., login wrote fresh
+    # cookies to the legacy root path after a previous migration).
     for src in legacy_files:
         dst = default_dir / src.name
-        if dst.exists():
-            logger.debug("Skipping %s (already exists in profile)", src.name)
+        if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
+            logger.debug("Skipping %s (profile copy is same age or newer)", src.name)
         else:
             shutil.copy2(src, dst)
             if sys.platform != "win32":

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -137,6 +137,49 @@ class TestMigrateToProfiles:
         # Original removed
         assert not (tmp_path / "storage_state.json").exists()
 
+    def test_overwrites_stale_profile_when_legacy_is_newer(self, tmp_path):
+        """Fresh login data at legacy root overwrites a stale profile copy.
+
+        Regression for the scenario where a previous migration left a profile
+        copy in place, and a subsequent `login` wrote fresh cookies to the
+        legacy root path. The migration must prefer the newer source.
+        """
+        default_dir = tmp_path / "profiles" / "default"
+        default_dir.mkdir(parents=True)
+        stale_profile = default_dir / "storage_state.json"
+        stale_profile.write_text('{"cookies":["stale"]}')
+        os.utime(stale_profile, (1000, 1000))
+
+        fresh_legacy = tmp_path / "storage_state.json"
+        fresh_legacy.write_text('{"cookies":["fresh"]}')
+        os.utime(fresh_legacy, (2000, 2000))
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+            migrate_to_profiles()
+
+        # Profile copy now holds the fresh data, legacy file is gone
+        assert json.loads(stale_profile.read_text()) == {"cookies": ["fresh"]}
+        assert not fresh_legacy.exists()
+
+    def test_keeps_newer_profile_when_legacy_is_older(self, tmp_path):
+        """An up-to-date profile copy is preserved over an older legacy file."""
+        default_dir = tmp_path / "profiles" / "default"
+        default_dir.mkdir(parents=True)
+        fresh_profile = default_dir / "storage_state.json"
+        fresh_profile.write_text('{"cookies":["fresh"]}')
+        os.utime(fresh_profile, (2000, 2000))
+
+        stale_legacy = tmp_path / "storage_state.json"
+        stale_legacy.write_text('{"cookies":["stale"]}')
+        os.utime(stale_legacy, (1000, 1000))
+
+        with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+            migrate_to_profiles()
+
+        # Profile copy is preserved, legacy file is cleaned up
+        assert json.loads(fresh_profile.read_text()) == {"cookies": ["fresh"]}
+        assert not stale_legacy.exists()
+
 
 class TestEnsureProfilesDir:
     def test_creates_on_first_run(self, tmp_path):


### PR DESCRIPTION
## Summary
- Migration from legacy flat layout to `profiles/default/` skipped copying `storage_state.json` when the destination already existed — regardless of whether the source was newer
- This caused a recurring auth failure cycle: `login` writes fresh cookies to the legacy root path, migration deletes the fresh file but keeps the stale profile copy, auth fails
- Fix: compare `st_mtime` before skipping — if the legacy root file is newer, overwrite the profile copy

## Root Cause

`_legacy_fallback()` in `paths.py` resolves `get_storage_path()` to the root `~/.notebooklm/storage_state.json` when it exists (for backwards compat). So `login` writes there. But `ensure_profiles_dir()` runs on every CLI invocation and triggers `migrate_to_profiles()` whenever legacy files exist at root. The migration copied root → profile on first run, but on subsequent runs it saw the profile copy already existed and skipped the copy — then deleted the (newer) root file anyway.

The original comment even said "skip if destination already exists **and is newer**" but the `and is newer` part was never implemented in the condition.

## Test plan
- [ ] Verify `ruff format`, `ruff check`, `mypy` pass (confirmed locally)
- [ ] Scenario: fresh `login` → next CLI command → auth still works (fresh cookies preserved in profile)
- [ ] Scenario: profile copy is already up-to-date → migration skips correctly (no unnecessary overwrites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Profile migration now compares file modification times and only replaces profile data when the source is newer, avoiding unintended overwrites.
* **Tests**
  * Added regression tests to verify timestamp-based precedence during migration (overwrite when legacy is newer; keep when profile is newer).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/247)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->