### PR TITLE
feat(artifacts): add language and instructions to generate_mind_map

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -988,6 +988,8 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
+        language: str = "en",
+        instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map.
 
@@ -997,6 +999,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
+            language: Language code (default: "en").
+            instructions: Custom instructions for the mind map.
 
         Returns:
             Dictionary with 'mind_map' (JSON data) and 'note_id'.
@@ -1014,7 +1018,7 @@ class ArtifactsAPI:
             None,
             None,
             None,
-            ["interactive_mindmap", [["[CONTEXT]", ""]], ""],
+            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
             None,
             [2, None, [1]],
         ]

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -995,9 +995,13 @@ def generate_data_table(
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
+@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option("--instructions", default=None, help="Custom instructions for the mind map")
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
+def generate_mind_map(
+    ctx, notebook_id, source_ids, language, instructions, json_output, client_auth
+):
     """Generate mind map.
 
     \b
@@ -1010,16 +1014,19 @@ def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
 
-            # Show status spinner only for console output
-            if json_output:
-                result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, source_ids=sources
+            async def _generate():
+                return await client.artifacts.generate_mind_map(
+                    nb_id_resolved,
+                    source_ids=sources,
+                    language=resolve_language(language),
+                    instructions=instructions,
                 )
+
+            if json_output:
+                result = await _generate()
             else:
                 with console.status("Generating mind map..."):
-                    result = await client.artifacts.generate_mind_map(
-                        nb_id_resolved, source_ids=sources
-                    )
+                    result = await _generate()
 
             _output_mind_map_result(result, json_output)
 

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -510,6 +510,31 @@ class TestArtifactsSourceSelection:
         assert source_ids_nested == [[["src_mm_1"]], [["src_mm_2"]]]
 
     @pytest.mark.asyncio
+    async def test_generate_mind_map_passes_language_and_instructions(
+        self, mock_core, mock_notes_api
+    ):
+        """Test generate_mind_map passes language and instructions to RPC payload."""
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        mock_core.get_source_ids.return_value = ["src_1"]
+        mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
+
+        await api.generate_mind_map(
+            notebook_id="nb_123",
+            source_ids=["src_1"],
+            language="ja",
+            instructions="Focus on key themes",
+        )
+
+        call_args = mock_core.rpc_call.call_args
+        params = call_args.args[1]
+
+        # params[5] should contain the mind map config with language and instructions
+        mind_map_config = params[5]
+        assert mind_map_config[1][0][1] == "Focus on key themes"
+        assert mind_map_config[2] == "ja"
+
+    @pytest.mark.asyncio
     async def test_suggest_reports_uses_get_suggested_reports(self, mock_core, mock_notes_api):
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod


### PR DESCRIPTION
## Summary
- Add `language` and `instructions` parameters to `generate_mind_map()` API method, consistent with all other artifact generation methods
- Add `--language` and `--instructions` CLI options to `generate mind-map` command
- Refactor CLI to use `_generate()` closure pattern to deduplicate the json/non-json branches

Closes #250

## Test plan
- [x] Added unit test verifying language and instructions are placed correctly in RPC payload
- [x] All 1967 existing tests pass
- [x] Linting (`ruff format`, `ruff check`), type checking (`mypy`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `--language` option to the mind-map generation command, allowing you to specify the output language for your generated mind maps
* Added `--instructions` option to the mind-map generation command, allowing you to provide custom instructions to guide and customize the mind-map generation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->