### PR TITLE
feat(note): add --json flag to note list command

### DIFF
--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -16,6 +16,7 @@ from ..client import NotebookLMClient
 from ..types import Note
 from .helpers import (
     console,
+    json_output_response,
     require_notebook,
     resolve_note_id,
     resolve_notebook_id,
@@ -62,21 +63,25 @@ def note_list(ctx, notebook_id, json_output, client_auth):
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             notes = await client.notes.list(nb_id_resolved)
 
-            if not notes:
-                if json_output:
-                    from ..cli.helpers import json_output_response
-                    json_output_response([])
-                else:
-                    console.print("[yellow]No notes found[/yellow]")
+            if json_output:
+                data = {
+                    "notebook_id": nb_id_resolved,
+                    "notes": [
+                        {
+                            "id": n.id,
+                            "title": n.title or "Untitled",
+                            "preview": (n.content or "")[:100],
+                        }
+                        for n in notes
+                        if isinstance(n, Note)
+                    ],
+                    "count": len(notes),
+                }
+                json_output_response(data)
                 return
 
-            if json_output:
-                from ..cli.helpers import json_output_response
-                json_output_response([
-                    {"id": n.id, "title": n.title or "", "preview": (n.content or "")[:100]}
-                    for n in notes
-                    if isinstance(n, Note)
-                ])
+            if not notes:
+                console.print("[yellow]No notes found[/yellow]")
                 return
 
             table = Table(title=f"Notes in {nb_id_resolved}")

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -64,20 +64,22 @@ def note_list(ctx, notebook_id, json_output, client_auth):
             notes = await client.notes.list(nb_id_resolved)
 
             if json_output:
-                data = {
-                    "notebook_id": nb_id_resolved,
-                    "notes": [
-                        {
-                            "id": n.id,
-                            "title": n.title or "Untitled",
-                            "preview": (n.content or "")[:100],
-                        }
-                        for n in notes
-                        if isinstance(n, Note)
-                    ],
-                    "count": len(notes),
-                }
-                json_output_response(data)
+                serialized = [
+                    {
+                        "id": n.id,
+                        "title": n.title or "Untitled",
+                        "preview": (n.content or "")[:100],
+                    }
+                    for n in notes
+                    if isinstance(n, Note)
+                ]
+                json_output_response(
+                    {
+                        "notebook_id": nb_id_resolved,
+                        "notes": serialized,
+                        "count": len(serialized),
+                    }
+                )
                 return
 
             if not notes:

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -51,8 +51,9 @@ def note():
     default=None,
     help="Notebook ID (uses current if not set)",
 )
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
-def note_list(ctx, notebook_id, client_auth):
+def note_list(ctx, notebook_id, json_output, client_auth):
     """List all notes in a notebook."""
     nb_id = require_notebook(notebook_id)
 
@@ -62,11 +63,24 @@ def note_list(ctx, notebook_id, client_auth):
             notes = await client.notes.list(nb_id_resolved)
 
             if not notes:
-                console.print("[yellow]No notes found[/yellow]")
+                if json_output:
+                    from ..cli.helpers import json_output_response
+                    json_output_response([])
+                else:
+                    console.print("[yellow]No notes found[/yellow]")
+                return
+
+            if json_output:
+                from ..cli.helpers import json_output_response
+                json_output_response([
+                    {"id": n.id, "title": n.title or "", "preview": (n.content or "")[:100]}
+                    for n in notes
+                    if isinstance(n, Note)
+                ])
                 return
 
             table = Table(title=f"Notes in {nb_id_resolved}")
-            table.add_column("ID", style="cyan")
+            table.add_column("ID", style="cyan", no_wrap=True)
             table.add_column("Title", style="green")
             table.add_column("Preview", style="dim", max_width=50)
 

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -23,11 +23,13 @@ def make_note(id: str, title: str, content: str, notebook_id: str = "nb_123") ->
 
 @pytest.fixture
 def runner():
+    """Provide a Click test runner."""
     return CliRunner()
 
 
 @pytest.fixture
 def mock_auth():
+    """Patch auth storage to return test credentials."""
     with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
         mock.return_value = {
             "SID": "test",
@@ -45,7 +47,10 @@ def mock_auth():
 
 
 class TestNoteList:
+    """Tests for the note list command."""
+
     def test_note_list(self, runner, mock_auth):
+        """Renders a table when notes exist."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(
@@ -63,6 +68,7 @@ class TestNoteList:
             assert result.exit_code == 0
 
     def test_note_list_empty(self, runner, mock_auth):
+        """Shows 'No notes found' when the notebook has no notes."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[])
@@ -75,6 +81,73 @@ class TestNoteList:
             assert result.exit_code == 0
             assert "No notes found" in result.output
 
+    def test_note_list_json(self, runner, mock_auth):
+        """Outputs valid JSON with notebook_id, notes array, and count."""
+        import json
+
+        with patch_client_for_module("note") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notes.list = AsyncMock(
+                return_value=[
+                    make_note("note_1", "Note Title", "Content 1"),
+                    make_note("note_2", "Another Note", "Content 2"),
+                ]
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["note", "list", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["notebook_id"] == "nb_123"
+            assert len(data["notes"]) == 2
+            assert data["count"] == 2
+            assert data["notes"][0]["id"] == "note_1"
+
+    def test_note_list_json_empty(self, runner, mock_auth):
+        """JSON output has empty notes array and count of zero when no notes exist."""
+        import json
+
+        with patch_client_for_module("note") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notes.list = AsyncMock(return_value=[])
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["note", "list", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["notes"] == []
+            assert data["count"] == 0
+
+    def test_note_list_json_count_matches_serialized_notes(self, runner, mock_auth):
+        """count reflects only Note instances, not total items in the raw list."""
+        import json
+
+        with patch_client_for_module("note") as mock_client_cls:
+            mock_client = create_mock_client()
+            # Include a non-Note item to verify count only counts Note instances
+            mock_client.notes.list = AsyncMock(
+                return_value=[
+                    make_note("note_1", "Title", "Content"),
+                    "unexpected_string_item",  # non-Note item
+                ]
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["note", "list", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data["notes"]) == 1
+            assert data["count"] == 1  # must match notes array length, not raw list length
+
 
 # =============================================================================
 # NOTE CREATE TESTS
@@ -82,7 +155,10 @@ class TestNoteList:
 
 
 class TestNoteCreate:
+    """Tests for the note create command."""
+
     def test_note_create(self, runner, mock_auth):
+        """Creates a note and confirms success message."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.create = AsyncMock(
@@ -101,6 +177,7 @@ class TestNoteCreate:
             assert "Note created" in result.output
 
     def test_note_create_empty(self, runner, mock_auth):
+        """Creates an empty note with the default title."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.create = AsyncMock(
@@ -115,6 +192,7 @@ class TestNoteCreate:
             assert result.exit_code == 0
 
     def test_note_create_failure(self, runner, mock_auth):
+        """Shows a warning when the API returns None."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.create = AsyncMock(return_value=None)
@@ -134,7 +212,10 @@ class TestNoteCreate:
 
 
 class TestNoteGet:
+    """Tests for the note get command."""
+
     def test_note_get(self, runner, mock_auth):
+        """Displays note ID, title, and content."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list for resolve_note_id
@@ -155,6 +236,7 @@ class TestNoteGet:
             assert "This is the content" in result.output
 
     def test_note_get_not_found(self, runner, mock_auth):
+        """Exits with error code 1 when no matching note exists."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list to return empty (no match for resolve_note_id)
@@ -177,7 +259,10 @@ class TestNoteGet:
 
 
 class TestNoteSave:
+    """Tests for the note save command."""
+
     def test_note_save_content(self, runner, mock_auth):
+        """Updates note content and prints confirmation."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list for resolve_note_id
@@ -197,6 +282,7 @@ class TestNoteSave:
             assert "Note updated" in result.output
 
     def test_note_save_title(self, runner, mock_auth):
+        """Updates note title and prints confirmation."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list for resolve_note_id
@@ -234,7 +320,10 @@ class TestNoteSave:
 
 
 class TestNoteRename:
+    """Tests for the note rename command."""
+
     def test_note_rename(self, runner, mock_auth):
+        """Renames a note and prints the new title."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list for resolve_note_id
@@ -257,6 +346,7 @@ class TestNoteRename:
             assert "Note renamed" in result.output
 
     def test_note_rename_not_found(self, runner, mock_auth):
+        """Exits with error code 1 when the note cannot be resolved."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list to return empty (no match for resolve_note_id)
@@ -281,7 +371,10 @@ class TestNoteRename:
 
 
 class TestNoteDelete:
+    """Tests for the note delete command."""
+
     def test_note_delete(self, runner, mock_auth):
+        """Deletes a note and prints the deleted note ID."""
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             # Mock notes.list for resolve_note_id
@@ -305,7 +398,10 @@ class TestNoteDelete:
 
 
 class TestNoteCommandsExist:
+    """Smoke tests that verify all note subcommands are registered."""
+
     def test_note_group_exists(self, runner):
+        """Note group help lists all expected subcommands."""
         result = runner.invoke(cli, ["note", "--help"])
         assert result.exit_code == 0
         assert "list" in result.output
@@ -314,7 +410,14 @@ class TestNoteCommandsExist:
         assert "delete" in result.output
 
     def test_note_create_command_exists(self, runner):
+        """note create --help exposes --title and CONTENT argument."""
         result = runner.invoke(cli, ["note", "create", "--help"])
         assert result.exit_code == 0
         assert "--title" in result.output
         assert "[CONTENT]" in result.output
+
+    def test_note_list_json_flag_exists(self, runner):
+        """note list --help exposes the --json flag."""
+        result = runner.invoke(cli, ["note", "list", "--help"])
+        assert result.exit_code == 0
+        assert "--json" in result.output


### PR DESCRIPTION
## Summary

`notebooklm note list` was the only list command in the CLI without a `--json` flag, making it impossible to parse notes programmatically.

This PR adds `--json` to `note list`, consistent with `source list`, `artifact list`, `notebook list`, and every other list command.

**Output format:**
```
$ notebooklm note list --json
[{"id": "...", "title": "...", "preview": "first 100 chars of content"}]
```

## Changes

- `cli/note.py`: add `--json` / `json_output` flag to `note list`
  - Returns `[]` as JSON when no notes exist
  - Returns `[{id, title, preview}]` array for each note
  - Sets `no_wrap=True` on the ID column in table view (UUIDs wrap badly in narrow terminals)

## Test plan

- [ ] `notebooklm note list --json` returns valid JSON array
- [ ] `notebooklm note list --json` on empty notebook returns `[]`
- [ ] `notebooklm note list` (no flag) still renders the rich table unchanged
- [ ] ID column no longer wraps in narrow terminals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--json` flag to `note list` to return JSON (includes notebook_id, notes array with id, title defaulting to "Untitled", preview of first 100 chars, and count).
  * When the flag is used and no notes are found, an empty JSON list is returned.

* **Bug Fixes / Style**
  * Improved ID column readability in the default table output to prevent wrapping.

* **Tests**
  * Added tests covering JSON output, empty lists, count behavior, and `--help` exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->