### PR TITLE
feat(chat): add --timeout option to ask command

### DIFF
--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -102,6 +102,13 @@ def register_chat_commands(cli):
     )
     @click.option("--save-as-note", is_flag=True, help="Save response as a note")
     @click.option("--note-title", default=None, help="Note title (use with --save-as-note)")
+    @click.option(
+        "--timeout",
+        default=120,
+        type=int,
+        show_default=True,
+        help="Request timeout in seconds. Increase for long prompts (default: 120).",
+    )
     @with_client
     def ask_cmd(
         ctx,
@@ -112,6 +119,7 @@ def register_chat_commands(cli):
         json_output,
         save_as_note,
         note_title,
+        timeout,
         client_auth,
     ):
         """Ask a notebook a question.
@@ -131,7 +139,7 @@ def register_chat_commands(cli):
         nb_id = require_notebook(notebook_id)
 
         async def _run():
-            async with NotebookLMClient(client_auth) as client:
+            async with NotebookLMClient(client_auth, timeout=float(timeout)) as client:
                 nb_id_resolved = await resolve_notebook_id(client, nb_id)
                 effective_conv_id = _determine_conversation_id(
                     explicit_conversation_id=conversation_id,

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -139,7 +139,7 @@ def register_chat_commands(cli):
         nb_id = require_notebook(notebook_id)
 
         async def _run():
-            async with NotebookLMClient(client_auth, timeout=(10.0, float(timeout))) as client:
+            async with NotebookLMClient(client_auth, timeout=float(timeout)) as client:
                 nb_id_resolved = await resolve_notebook_id(client, nb_id)
                 effective_conv_id = _determine_conversation_id(
                     explicit_conversation_id=conversation_id,

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -105,9 +105,9 @@ def register_chat_commands(cli):
     @click.option(
         "--timeout",
         default=120,
-        type=int,
+        type=click.IntRange(min=1),
         show_default=True,
-        help="Request timeout in seconds. Increase for long prompts (default: 120).",
+        help="Request timeout in seconds. Increase for long prompts.",
     )
     @with_client
     def ask_cmd(
@@ -139,7 +139,7 @@ def register_chat_commands(cli):
         nb_id = require_notebook(notebook_id)
 
         async def _run():
-            async with NotebookLMClient(client_auth, timeout=float(timeout)) as client:
+            async with NotebookLMClient(client_auth, timeout=(10.0, float(timeout))) as client:
                 nb_id_resolved = await resolve_notebook_id(client, nb_id)
                 effective_conv_id = _determine_conversation_id(
                     explicit_conversation_id=conversation_id,


### PR DESCRIPTION
## Summary

Long or complex prompts can exceed the default HTTP timeout, causing `notebooklm ask` to fail silently with a connection error. There is currently no way to increase this without changing client-wide settings in code.

This PR adds a `--timeout` option (default: 120s) to the `ask` command, letting users increase it for slower responses.

**Usage:**
```
$ notebooklm ask "summarize everything across all 50 sources" --timeout 300
```

## Changes

- `cli/chat.py`: add `--timeout` (int, default 120, `show_default=True`) to `ask`
  - Passed as `timeout=float(timeout)` to `NotebookLMClient()`
  - Scoped to the `ask` invocation only — no effect on other commands

## Test plan

- [ ] `notebooklm ask --help` shows `--timeout INTEGER` with default `[default: 120]`
- [ ] `notebooklm ask "question" --timeout 300` uses the extended timeout
- [ ] Default behavior (no flag) is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI ask command now accepts a --timeout option (integer, min 1, default 120). Users can set a per-invocation request timeout to control how long the command waits for a response, improving handling of long-running or slow interactions and preventing reliance on built-in default timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->