### PR TITLE
feat(source): add ‘source clean’ command

### DIFF
--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -900,3 +900,88 @@ def source_wait(ctx, source_id, notebook_id, timeout, json_output, client_auth):
                 raise SystemExit(2) from None
 
     return _run()
+
+
+@source.command("clean")
+@click.option(
+    "-n",
+    "--notebook",
+    "notebook_id",
+    default=None,
+    help="Notebook ID (uses current if not set)",
+)
+@click.option("--dry-run", is_flag=True, help="Show what would be deleted without actually deleting")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
+@with_client
+def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
+    """Automatically remove duplicate, error, and access-blocked sources."""
+    from urllib.parse import urlparse, urlunparse
+    nb_id = require_notebook(notebook_id)
+
+    async def _run():
+        async with NotebookLMClient(client_auth) as client:
+            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            with console.status("Fetching sources for cleanup..."):
+                sources = await client.sources.list(nb_id_resolved)
+
+            to_delete = set()
+
+            GATEWAY_PATTERNS = re.compile(
+                r'^\s*(access denied|403|404|forbidden|not found|502|just a moment|attention required|security check|captcha)',
+                re.IGNORECASE
+            )
+
+            # Process oldest first so we keep the oldest copy of each URL
+            sorted_sources = sorted(sources, key=lambda s: s.created_at.timestamp() if s.created_at else 0)
+            seen_urls: set[str] = set()
+
+            for s in sorted_sources:
+                title = (s.title or "").strip()
+                status = str(s.status).lower() if s.status else "unknown"
+
+                # Remove sources in error or unknown state
+                if status in ["error", "unknown"]:
+                    to_delete.add(s.id)
+                    continue
+
+                # Remove sources blocked by gateways or anti-bot pages
+                if GATEWAY_PATTERNS.match(title) or title.startswith(("http://", "https://")):
+                    to_delete.add(s.id)
+                    continue
+
+                # Deduplicate by normalized URL (strip query string and fragment)
+                url = s.url or ""
+                if url:
+                    parsed = urlparse(url)
+                    normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+                    if normalized in seen_urls:
+                        to_delete.add(s.id)
+                        continue
+                    seen_urls.add(normalized)
+
+            if not to_delete:
+                console.print("[green]Notebook is already clean. No junk sources found.[/green]")
+                return
+
+            if dry_run:
+                console.print(f"[yellow]Would delete {len(to_delete)} junk source(s) (dry run).[/yellow]")
+                return
+
+            if not yes and not click.confirm(f"Delete {len(to_delete)} junk source(s)?"):
+                return
+
+            console.print(f"[dim]Cleaning {len(to_delete)} source(s) (in chunks of 10)...[/dim]")
+
+            # Chunk deletions to avoid rate limiting
+            delete_list = list(to_delete)
+            chunk_size = 10
+            for i in range(0, len(delete_list), chunk_size):
+                chunk = delete_list[i:i + chunk_size]
+                delete_tasks = [client.sources.delete(nb_id_resolved, sid) for sid in chunk]
+                await asyncio.gather(*delete_tasks, return_exceptions=True)
+                if i + chunk_size < len(delete_list):
+                    await asyncio.sleep(0.5)
+
+            console.print(f"[green]Successfully cleaned {len(to_delete)} source(s).[/green]")
+
+    return _run()

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -997,7 +997,9 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
                     await asyncio.sleep(0.5)
 
             if failed:
-                console.print(f"[yellow]Cleaned {deleted} source(s). {failed} deletion(s) failed.[/yellow]")
+                console.print(
+                    f"[yellow]Cleaned {deleted} source(s). {failed} deletion(s) failed.[/yellow]"
+                )
             else:
                 console.print(f"[green]Successfully cleaned {deleted} source(s).[/green]")
 

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -942,7 +942,7 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
 
             for s in sorted_sources:
                 title = (s.title or "").strip()
-                status = str(s.status).lower() if s.status else "unknown"
+                status = source_status_to_str(s.status) if s.status else "unknown"
 
                 # Remove sources in error or unknown state
                 if status in ["error", "unknown"]:
@@ -982,13 +982,23 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
             # Chunk deletions to avoid rate limiting
             delete_list = list(to_delete)
             chunk_size = 10
+            deleted = 0
+            failed = 0
             for i in range(0, len(delete_list), chunk_size):
                 chunk = delete_list[i : i + chunk_size]
                 delete_tasks = [client.sources.delete(nb_id_resolved, sid) for sid in chunk]
-                await asyncio.gather(*delete_tasks, return_exceptions=True)
+                results = await asyncio.gather(*delete_tasks, return_exceptions=True)
+                for r in results:
+                    if isinstance(r, Exception):
+                        failed += 1
+                    else:
+                        deleted += 1
                 if i + chunk_size < len(delete_list):
                     await asyncio.sleep(0.5)
 
-            console.print(f"[green]Successfully cleaned {len(to_delete)} source(s).[/green]")
+            if failed:
+                console.print(f"[yellow]Cleaned {deleted} source(s). {failed} deletion(s) failed.[/yellow]")
+            else:
+                console.print(f"[green]Successfully cleaned {deleted} source(s).[/green]")
 
     return _run()

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -910,12 +910,15 @@ def source_wait(ctx, source_id, notebook_id, timeout, json_output, client_auth):
     default=None,
     help="Notebook ID (uses current if not set)",
 )
-@click.option("--dry-run", is_flag=True, help="Show what would be deleted without actually deleting")
+@click.option(
+    "--dry-run", is_flag=True, help="Show what would be deleted without actually deleting"
+)
 @click.option("--yes", "-y", is_flag=True, help="Skip confirmation")
 @with_client
 def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
     """Automatically remove duplicate, error, and access-blocked sources."""
     from urllib.parse import urlparse, urlunparse
+
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -927,12 +930,14 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
             to_delete = set()
 
             GATEWAY_PATTERNS = re.compile(
-                r'^\s*(access denied|403|404|forbidden|not found|502|just a moment|attention required|security check|captcha)',
-                re.IGNORECASE
+                r"^\s*(access denied|403|404|forbidden|not found|502|just a moment|attention required|security check|captcha)",
+                re.IGNORECASE,
             )
 
             # Process oldest first so we keep the oldest copy of each URL
-            sorted_sources = sorted(sources, key=lambda s: s.created_at.timestamp() if s.created_at else 0)
+            sorted_sources = sorted(
+                sources, key=lambda s: s.created_at.timestamp() if s.created_at else 0
+            )
             seen_urls: set[str] = set()
 
             for s in sorted_sources:
@@ -964,7 +969,9 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
                 return
 
             if dry_run:
-                console.print(f"[yellow]Would delete {len(to_delete)} junk source(s) (dry run).[/yellow]")
+                console.print(
+                    f"[yellow]Would delete {len(to_delete)} junk source(s) (dry run).[/yellow]"
+                )
                 return
 
             if not yes and not click.confirm(f"Delete {len(to_delete)} junk source(s)?"):
@@ -976,7 +983,7 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
             delete_list = list(to_delete)
             chunk_size = 10
             for i in range(0, len(delete_list), chunk_size):
-                chunk = delete_list[i:i + chunk_size]
+                chunk = delete_list[i : i + chunk_size]
                 delete_tasks = [client.sources.delete(nb_id_resolved, sid) for sid in chunk]
                 await asyncio.gather(*delete_tasks, return_exceptions=True)
                 if i + chunk_size < len(delete_list):

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -58,12 +58,24 @@ _JUNK_STATUSES = frozenset({"error"})
 def _normalize_url_for_dedup(url: str) -> str:
     """Return a URL with only the fragment stripped, for dedup comparison.
 
-    Query strings are preserved because they often disambiguate distinct
-    resources (e.g. YouTube ``?v=ID``, Google Docs ``?id=ID``, arXiv versions),
-    so collapsing them would falsely flag legitimate sources as duplicates.
+    Scheme and host are lowercased per RFC 3986 (both are case-insensitive),
+    so ``https://Example.com/a`` and ``https://example.com/a`` are recognised
+    as the same resource. Query strings are preserved because they often
+    disambiguate distinct resources (e.g. YouTube ``?v=ID``, Google Docs
+    ``?id=ID``, arXiv versions), so collapsing them would falsely flag
+    legitimate sources as duplicates.
     """
     parsed = urlparse(url)
-    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, parsed.query, ""))
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path,
+            parsed.params,
+            parsed.query,
+            "",
+        )
+    )
 
 
 # Sort key sentinel: sources with no created_at go to the END so a real,

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -18,6 +18,7 @@ Commands:
 import asyncio
 import re
 from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 import click
 from rich.table import Table
@@ -38,6 +39,89 @@ from .helpers import (
     validate_id,
     with_client,
 )
+
+# Titles matching this pattern indicate the source was blocked by an anti-bot
+# gateway, CAPTCHA, or returned an HTTP error page instead of real content.
+_GATEWAY_TITLE_PATTERN = re.compile(
+    r"^\s*(access denied|403|404|forbidden|not found|502"
+    r"|just a moment|attention required|security check|captcha)",
+    re.IGNORECASE,
+)
+
+# Only sources with explicit "error" status are auto-cleaned. "unknown" is
+# excluded on purpose: it covers status codes we don't recognize yet (future
+# NotebookLM states) and missing-status responses, which must not be silently
+# deleted.
+_JUNK_STATUSES = frozenset({"error"})
+
+
+def _normalize_url_for_dedup(url: str) -> str:
+    """Return a URL with only the fragment stripped, for dedup comparison.
+
+    Query strings are preserved because they often disambiguate distinct
+    resources (e.g. YouTube ``?v=ID``, Google Docs ``?id=ID``, arXiv versions),
+    so collapsing them would falsely flag legitimate sources as duplicates.
+    """
+    parsed = urlparse(url)
+    return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, parsed.query, ""))
+
+
+# Sort key sentinel: sources with no created_at go to the END so a real,
+# dated copy is preferred as the "oldest" anchor during dedup.
+_UNDATED_SORT_KEY = float("inf")
+
+
+def _classify_junk_sources(sources: list) -> list[tuple[str, str, str, str]]:
+    """Identify junk sources for cleanup.
+
+    Returns a deterministically ordered list of ``(id, title, status, reason)``
+    tuples for every source that should be deleted. ``reason`` is one of
+    ``"error_status"``, ``"gateway_title"``, or ``"duplicate_of:<short-id>"``.
+    The oldest non-junk copy of each URL is kept; later duplicates are flagged.
+    """
+    sorted_sources = sorted(
+        sources,
+        key=lambda s: s.created_at.timestamp() if s.created_at else _UNDATED_SORT_KEY,
+    )
+
+    candidates: list[tuple[str, str, str, str]] = []
+    seen_urls: dict[str, str] = {}
+
+    for s in sorted_sources:
+        title = (s.title or "").strip()
+        status = source_status_to_str(s.status) if s.status else "unknown"
+
+        if status in _JUNK_STATUSES:
+            candidates.append((s.id, title, status, "error_status"))
+            continue
+
+        if _GATEWAY_TITLE_PATTERN.match(title):
+            candidates.append((s.id, title, status, "gateway_title"))
+            continue
+
+        url = s.url or ""
+        if url:
+            normalized = _normalize_url_for_dedup(url)
+            kept = seen_urls.get(normalized)
+            if kept is not None:
+                candidates.append((s.id, title, status, f"duplicate_of:{kept[:8]}"))
+                continue
+            seen_urls[normalized] = s.id
+
+    return candidates
+
+
+def _print_clean_candidates(candidates: list[tuple[str, str, str, str]]) -> None:
+    """Print a Rich table summarizing sources that will (or would) be deleted."""
+    table = Table(title=f"{len(candidates)} source(s) flagged for cleanup")
+    table.add_column("ID", style="dim", overflow="fold")
+    table.add_column("Title", overflow="fold")
+    table.add_column("Status")
+    table.add_column("Reason")
+    for sid, title, status, reason in candidates:
+        display_title = title if title else "[dim](no title)[/dim]"
+        table.add_row(sid[:8], display_title, status, reason)
+    console.print(table)
 
 
 @click.group()
@@ -961,8 +1045,6 @@ def source_wait(ctx, source_id, notebook_id, timeout, json_output, client_auth):
 @with_client
 def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
     """Automatically remove duplicate, error, and access-blocked sources."""
-    from urllib.parse import urlparse, urlunparse
-
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -971,79 +1053,50 @@ def source_clean(ctx, notebook_id, dry_run, yes, client_auth):
             with console.status("Fetching sources for cleanup..."):
                 sources = await client.sources.list(nb_id_resolved)
 
-            to_delete = set()
+            candidates = _classify_junk_sources(sources)
 
-            GATEWAY_PATTERNS = re.compile(
-                r"^\s*(access denied|403|404|forbidden|not found|502|just a moment|attention required|security check|captcha)",
-                re.IGNORECASE,
-            )
-
-            # Process oldest first so we keep the oldest copy of each URL
-            sorted_sources = sorted(
-                sources, key=lambda s: s.created_at.timestamp() if s.created_at else 0
-            )
-            seen_urls: set[str] = set()
-
-            for s in sorted_sources:
-                title = (s.title or "").strip()
-                status = source_status_to_str(s.status) if s.status else "unknown"
-
-                # Remove sources in error or unknown state
-                if status in ["error", "unknown"]:
-                    to_delete.add(s.id)
-                    continue
-
-                # Remove sources blocked by gateways or anti-bot pages
-                if GATEWAY_PATTERNS.match(title) or title.startswith(("http://", "https://")):
-                    to_delete.add(s.id)
-                    continue
-
-                # Deduplicate by normalized URL (strip query string and fragment)
-                url = s.url or ""
-                if url:
-                    parsed = urlparse(url)
-                    normalized = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
-                    if normalized in seen_urls:
-                        to_delete.add(s.id)
-                        continue
-                    seen_urls.add(normalized)
-
-            if not to_delete:
+            if not candidates:
                 console.print("[green]Notebook is already clean. No junk sources found.[/green]")
                 return
 
+            _print_clean_candidates(candidates)
+
             if dry_run:
                 console.print(
-                    f"[yellow]Would delete {len(to_delete)} junk source(s) (dry run).[/yellow]"
+                    f"[yellow]Dry run: would delete {len(candidates)} source(s).[/yellow]"
                 )
                 return
 
-            if not yes and not click.confirm(f"Delete {len(to_delete)} junk source(s)?"):
+            if not yes and not click.confirm(f"Delete {len(candidates)} source(s)?"):
                 return
 
-            console.print(f"[dim]Cleaning {len(to_delete)} source(s) (in chunks of 10)...[/dim]")
+            console.print(f"[dim]Cleaning {len(candidates)} source(s) (in chunks of 10)...[/dim]")
 
-            # Chunk deletions to avoid rate limiting
-            delete_list = list(to_delete)
+            delete_list = [c[0] for c in candidates]
             chunk_size = 10
             deleted = 0
-            failed = 0
+            failures: list[tuple[str, str]] = []
             for i in range(0, len(delete_list), chunk_size):
                 chunk = delete_list[i : i + chunk_size]
                 delete_tasks = [client.sources.delete(nb_id_resolved, sid) for sid in chunk]
                 results = await asyncio.gather(*delete_tasks, return_exceptions=True)
-                for r in results:
+                for sid, r in zip(chunk, results, strict=True):
                     if isinstance(r, Exception):
-                        failed += 1
+                        failures.append((sid, str(r)))
                     else:
                         deleted += 1
                 if i + chunk_size < len(delete_list):
                     await asyncio.sleep(0.5)
 
-            if failed:
+            if failures:
                 console.print(
-                    f"[yellow]Cleaned {deleted} source(s). {failed} deletion(s) failed.[/yellow]"
+                    f"[yellow]Cleaned {deleted} source(s). "
+                    f"{len(failures)} deletion(s) failed.[/yellow]"
                 )
+                for sid, err in failures[:5]:
+                    console.print(f"  [red]{sid}:[/red] {err}")
+                if len(failures) > 5:
+                    console.print(f"  [dim]...and {len(failures) - 5} more[/dim]")
             else:
                 console.print(f"[green]Successfully cleaned {deleted} source(s).[/green]")
 

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -14,6 +14,7 @@ from notebooklm.types import (
     SourceFulltext,
     SourceNotFoundError,
     SourceProcessingError,
+    SourceStatus,
     SourceTimeoutError,
 )
 
@@ -1584,3 +1585,242 @@ class TestSourceWait:
             assert data["source_id"] == "src_123"
             assert data["timeout_seconds"] == 30
             assert data["last_status_code"] == 1
+
+
+# =============================================================================
+# SOURCE CLEAN TESTS
+# =============================================================================
+
+
+def _src(
+    sid: str,
+    *,
+    title: str | None = None,
+    url: str | None = None,
+    status: int = SourceStatus.READY,
+    created_at: datetime | None = None,
+) -> Source:
+    """Build a Source fixture with sensible defaults for clean tests."""
+    return Source(id=sid, title=title, url=url, status=status, created_at=created_at)
+
+
+class TestSourceCleanClassify:
+    """Unit tests for the pure-function ``_classify_junk_sources`` helper.
+
+    These are independent of Click/CLI invocation so they're fast and exercise
+    every branch of the classification logic without mocking the client.
+    """
+
+    def test_empty_notebook_returns_nothing(self):
+        assert source_module._classify_junk_sources([]) == []
+
+    def test_error_status_is_flagged(self):
+        s = _src("src_e", status=SourceStatus.ERROR, url="https://ex.com/a")
+        out = source_module._classify_junk_sources([s])
+        assert [(c[0], c[3]) for c in out] == [("src_e", "error_status")]
+
+    def test_unknown_status_is_not_flagged(self):
+        # Unrecognized status codes must NOT be auto-deleted; they may
+        # represent future NotebookLM states or missing-status payloads.
+        s = _src("src_u", status=99, url="https://ex.com/a")
+        assert source_module._classify_junk_sources([s]) == []
+
+    def test_zero_status_is_not_flagged(self):
+        # status=0 maps to "unknown" via the truthy fallback. Must NOT delete.
+        s = _src("src_z", status=0, url="https://ex.com/a")
+        assert source_module._classify_junk_sources([s]) == []
+
+    def test_processing_status_is_not_flagged(self):
+        s = _src("src_p", status=SourceStatus.PROCESSING, url="https://ex.com/a")
+        assert source_module._classify_junk_sources([s]) == []
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Access Denied",
+            "403 Forbidden",
+            "404 Not Found",
+            "Just a Moment...",
+            "Attention Required! | Cloudflare",
+            "Security check",
+            "CAPTCHA verification",
+            "  403  ",
+        ],
+    )
+    def test_gateway_titles_are_flagged(self, title):
+        s = _src("src_g", title=title, url="https://ex.com/a")
+        out = source_module._classify_junk_sources([s])
+        assert [(c[0], c[3]) for c in out] == [("src_g", "gateway_title")]
+
+    def test_legitimate_titles_starting_with_digits_are_not_flagged(self):
+        # "404 Not Found" is a gateway title, but "100 Ways to ..." is not.
+        s = _src("src_ok", title="100 Ways to Cook Pasta", url="https://ex.com/a")
+        assert source_module._classify_junk_sources([s]) == []
+
+    def test_url_title_on_ready_source_is_not_deleted(self):
+        # Regression: PR review caught that URL-as-title was being treated as
+        # junk, which deletes legitimate in-flight sources (Source.title is
+        # documented to "may be URL if not yet processed").
+        s = _src(
+            "src_url",
+            title="https://example.com/article",
+            url="https://example.com/article",
+        )
+        assert source_module._classify_junk_sources([s]) == []
+
+    def test_dedup_keeps_oldest_and_flags_later_copies(self):
+        # Oldest at t=0; two later duplicates.
+        sources = [
+            _src("src_3", url="https://ex.com/a", created_at=datetime(2024, 3, 1)),
+            _src("src_1", url="https://ex.com/a", created_at=datetime(2024, 1, 1)),
+            _src("src_2", url="https://ex.com/a", created_at=datetime(2024, 2, 1)),
+        ]
+        out = source_module._classify_junk_sources(sources)
+        deleted_ids = sorted(c[0] for c in out)
+        assert deleted_ids == ["src_2", "src_3"]
+        assert all(c[3].startswith("duplicate_of:src_1"[:21]) for c in out)
+
+    def test_dedup_when_oldest_is_error(self):
+        # First copy (oldest) is error → flagged as error_status, NOT recorded
+        # in seen_urls. Second copy becomes the kept anchor; third copy
+        # deduped against it. Both deletions report their own reason.
+        sources = [
+            _src(
+                "src_e",
+                url="https://ex.com/a",
+                status=SourceStatus.ERROR,
+                created_at=datetime(2024, 1, 1),
+            ),
+            _src("src_ok", url="https://ex.com/a", created_at=datetime(2024, 2, 1)),
+            _src("src_dup", url="https://ex.com/a", created_at=datetime(2024, 3, 1)),
+        ]
+        out = source_module._classify_junk_sources(sources)
+        by_id = {c[0]: c[3] for c in out}
+        assert set(by_id) == {"src_e", "src_dup"}
+        assert by_id["src_e"] == "error_status"
+        assert by_id["src_dup"].startswith("duplicate_of:")
+
+    def test_dedup_preserves_query_string(self):
+        # Different YouTube video IDs (via ?v=) must NOT be collapsed.
+        sources = [
+            _src("yt_a", url="https://youtube.com/watch?v=AAA"),
+            _src("yt_b", url="https://youtube.com/watch?v=BBB"),
+        ]
+        assert source_module._classify_junk_sources(sources) == []
+
+    def test_dedup_strips_fragment(self):
+        sources = [
+            _src("src_1", url="https://ex.com/a#top", created_at=datetime(2024, 1, 1)),
+            _src("src_2", url="https://ex.com/a#bottom", created_at=datetime(2024, 2, 1)),
+        ]
+        out = source_module._classify_junk_sources(sources)
+        assert [c[0] for c in out] == ["src_2"]
+
+    def test_undated_sources_go_to_end_of_sort(self):
+        # If src_undated were placed at position 0 (epoch sentinel), it would
+        # be kept and src_dated deleted as a duplicate. With float('inf') the
+        # dated one wins.
+        sources = [
+            _src("src_undated", url="https://ex.com/a", created_at=None),
+            _src("src_dated", url="https://ex.com/a", created_at=datetime(2024, 1, 1)),
+        ]
+        out = source_module._classify_junk_sources(sources)
+        assert [c[0] for c in out] == ["src_undated"]
+
+    def test_source_with_no_url_is_not_deduped(self):
+        # Text-only sources have url=None — they must never be deduped together.
+        sources = [
+            _src("src_1", title="Note A"),
+            _src("src_2", title="Note B"),
+        ]
+        assert source_module._classify_junk_sources(sources) == []
+
+
+class TestSourceCleanCommand:
+    """End-to-end Click invocation tests for the ``source clean`` command."""
+
+    def _patch_clean(self, sources):
+        """Return a context manager that wires up a mock client returning sources."""
+        return _CleanPatch(sources)
+
+    def test_already_clean_short_circuits(self, runner, mock_auth):
+        with self._patch_clean([_src("src_1", title="Page", url="https://ex.com/a")]) as mc:
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123", "-y"])
+            assert result.exit_code == 0
+            assert "already clean" in result.output.lower()
+            mc.sources.delete.assert_not_called()
+
+    def test_dry_run_shows_table_and_skips_delete(self, runner, mock_auth):
+        sources = [
+            _src("src_err", title="oops", status=SourceStatus.ERROR),
+            _src("src_block", title="Just a Moment...", url="https://ex.com/x"),
+        ]
+        with self._patch_clean(sources) as mc:
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123", "--dry-run"])
+            assert result.exit_code == 0
+            assert "Dry run" in result.output
+            assert "error_status" in result.output
+            assert "gateway_title" in result.output
+            mc.sources.delete.assert_not_called()
+
+    def test_yes_skips_confirmation_and_deletes(self, runner, mock_auth):
+        sources = [_src("src_err", status=SourceStatus.ERROR)]
+        with self._patch_clean(sources) as mc:
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123", "-y"])
+            assert result.exit_code == 0
+            mc.sources.delete.assert_awaited_once_with("nb_123", "src_err")
+            assert "Successfully cleaned" in result.output
+
+    def test_user_declines_confirmation_aborts(self, runner, mock_auth):
+        sources = [_src("src_err", status=SourceStatus.ERROR)]
+        with self._patch_clean(sources) as mc:
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123"], input="n\n")
+            assert result.exit_code == 0
+            mc.sources.delete.assert_not_called()
+
+    def test_partial_failure_reports_failing_ids(self, runner, mock_auth):
+        sources = [
+            _src("src_a", status=SourceStatus.ERROR),
+            _src("src_b", status=SourceStatus.ERROR),
+        ]
+
+        async def fake_delete(nb, sid):
+            if sid == "src_b":
+                raise RuntimeError("boom")
+
+        with self._patch_clean(sources) as mc:
+            mc.sources.delete = AsyncMock(side_effect=fake_delete)
+            result = runner.invoke(cli, ["source", "clean", "-n", "nb_123", "-y"])
+            assert result.exit_code == 0
+            assert "1 deletion(s) failed" in result.output
+            assert "src_b" in result.output
+            assert "boom" in result.output
+
+
+class _CleanPatch:
+    """Context manager that patches the NotebookLMClient for source-clean tests."""
+
+    def __init__(self, sources):
+        self._sources = sources
+        self._stack: list = []
+
+    def __enter__(self):
+        mock_client_cls_ctx = patch_client_for_module("source")
+        mock_client_cls = mock_client_cls_ctx.__enter__()
+        self._stack.append(mock_client_cls_ctx)
+
+        mock_client = create_mock_client()
+        mock_client.sources.list = AsyncMock(return_value=self._sources)
+        mock_client.sources.delete = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+        self.sources = mock_client.sources
+
+        fetch_ctx = patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock)
+        fetch_mock = fetch_ctx.__enter__()
+        fetch_mock.return_value = ("csrf", "session")
+        self._stack.append(fetch_ctx)
+        return self
+
+    def __exit__(self, *exc):
+        for ctx in reversed(self._stack):
+            ctx.__exit__(*exc)

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -1,5 +1,6 @@
 """Tests for source CLI commands."""
 
+import contextlib
 import importlib
 import json
 from datetime import datetime
@@ -1716,6 +1717,16 @@ class TestSourceCleanClassify:
         out = source_module._classify_junk_sources(sources)
         assert [c[0] for c in out] == ["src_2"]
 
+    def test_dedup_is_case_insensitive_on_scheme_and_host(self):
+        # Per RFC 3986, scheme and host are case-insensitive, so mixed-case
+        # copies of the same URL must be recognised as duplicates.
+        sources = [
+            _src("src_1", url="https://Example.COM/a", created_at=datetime(2024, 1, 1)),
+            _src("src_2", url="HTTPS://example.com/a", created_at=datetime(2024, 2, 1)),
+        ]
+        out = source_module._classify_junk_sources(sources)
+        assert [c[0] for c in out] == ["src_2"]
+
     def test_undated_sources_go_to_end_of_sort(self):
         # If src_undated were placed at position 0 (epoch sentinel), it would
         # be kept and src_dated deleted as a duplicate. With float('inf') the
@@ -1798,16 +1809,18 @@ class TestSourceCleanCommand:
 
 
 class _CleanPatch:
-    """Context manager that patches the NotebookLMClient for source-clean tests."""
+    """Context manager that patches the NotebookLMClient for source-clean tests.
+
+    Uses ``ExitStack`` so any patch that raises mid-setup correctly unwinds the
+    patches that already entered, instead of leaking them into the next test.
+    """
 
     def __init__(self, sources):
         self._sources = sources
-        self._stack: list = []
+        self._exit_stack = contextlib.ExitStack()
 
     def __enter__(self):
-        mock_client_cls_ctx = patch_client_for_module("source")
-        mock_client_cls = mock_client_cls_ctx.__enter__()
-        self._stack.append(mock_client_cls_ctx)
+        mock_client_cls = self._exit_stack.enter_context(patch_client_for_module("source"))
 
         mock_client = create_mock_client()
         mock_client.sources.list = AsyncMock(return_value=self._sources)
@@ -1815,12 +1828,11 @@ class _CleanPatch:
         mock_client_cls.return_value = mock_client
         self.sources = mock_client.sources
 
-        fetch_ctx = patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock)
-        fetch_mock = fetch_ctx.__enter__()
+        fetch_mock = self._exit_stack.enter_context(
+            patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock)
+        )
         fetch_mock.return_value = ("csrf", "session")
-        self._stack.append(fetch_ctx)
         return self
 
     def __exit__(self, *exc):
-        for ctx in reversed(self._stack):
-            ctx.__exit__(*exc)
+        return self._exit_stack.__exit__(*exc)


### PR DESCRIPTION
## Summary

After failed deep-research runs, bulk imports, or bot-blocked crawls, notebooks can accumulate junk sources: errored ones, gateway/anti-bot pages (Cloudflare, 403, 404), and duplicates. There is currently no way to clean these up in bulk — users must delete them one by one.

This PR adds `notebooklm source clean`, which automatically identifies and removes junk sources in one command.

## What it removes

| Category | Criteria |
|----------|----------|
| **Error/unknown** | `status` is `error` or `unknown` |
| **Gateway / anti-bot** | Title matches patterns: `403`, `404`, `Forbidden`, `Access Denied`, `Just a Moment`, `Attention Required`, `Security Check`, `CAPTCHA` |
| **Duplicates** | Same URL already seen (normalized: scheme+host+path, no query/fragment); keeps the oldest copy |

## Flags

```
notebooklm source clean             # interactive confirmation
notebooklm source clean --dry-run   # preview without deleting
notebooklm source clean -y          # skip confirmation
notebooklm source clean -n <id>     # target specific notebook
```

## Implementation notes

- Sources are sorted oldest-first before deduplication so the earliest copy is always kept
- Deletions are chunked in batches of 10 with a 0.5s inter-chunk delay to avoid rate limiting on large notebooks
- Uses existing `asyncio.gather` pattern consistent with other bulk operations in the codebase

## Test plan

- [ ] `--dry-run` prints count and exits without deleting
- [ ] Sources with `status=error` are removed
- [ ] Duplicate URLs: only the newest copy is deleted
- [ ] Gateway-titled sources (e.g. title `"403 Forbidden"`) are removed
- [ ] Clean notebook prints `"Notebook is already clean"`
- [ ] `-y` skips confirmation prompt
- [ ] Deletions are batched (no 429 on 50+ junk sources)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `notebooklm source clean` CLI to find and optionally remove junk sources (status errors, gateway/security blocks, duplicate URLs). Keeps oldest copy per URL, preserves query strings, strips fragments, and prints a summary table. Supports `--dry-run` (preview) and `--yes` (skip confirmation); performs batched deletions with brief pauses and reports successes or top failures.

* **Tests**
  * Added unit and end-to-end tests for classification, dedupe rules, dry-run, confirmation flow, and deletion error reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/261)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->