### PR TITLE
feat: support language and instructions for mind maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,11 @@ async def main():
         await client.artifacts.download_quiz(nb.id, "quiz.json", output_format="json")
 
         # Generate mind map and export
-        result = await client.artifacts.generate_mind_map(nb.id)
+        result = await client.artifacts.generate_mind_map(
+            nb.id,
+            language="ja",
+            instructions="Focus on chronology and causal links",
+        )
         await client.artifacts.download_mind_map(nb.id, "mindmap.json")
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -200,7 +200,11 @@ async def main():
             language="ja",
             instructions="Focus on chronology and causal links",
         )
-        await client.artifacts.download_mind_map(nb.id, "mindmap.json")
+        await client.artifacts.download_mind_map(
+            nb.id,
+            "mindmap.json",
+            artifact_id=result["note_id"],
+        )
 
 asyncio.run(main())
 ```

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -725,7 +725,7 @@ params = [
     None,                                         # 2
     None,                                         # 3
     None,                                         # 4
-    ["interactive_mindmap", [["[CONTEXT]", ""]], ""],  # 5: Mind map command
+    ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],  # 5: Mind map command
     None,                                         # 6
     [2, None, [1]],                               # 7: Fixed config
 ]

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -988,6 +988,8 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
+        language: str = "en",
+        instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map.
 
@@ -997,6 +999,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
+            language: Language code (default: "en").
+            instructions: Extra context or constraints for the generated mind map.
 
         Returns:
             Dictionary with 'mind_map' (JSON data) and 'note_id'.
@@ -1014,7 +1018,7 @@ class ArtifactsAPI:
             None,
             None,
             None,
-            ["interactive_mindmap", [["[CONTEXT]", ""]], ""],
+            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
             None,
             [2, None, [1]],
         ]

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -1003,7 +1003,9 @@ def generate_data_table(
 )
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, language, instructions, json_output, client_auth):
+def generate_mind_map(
+    ctx, notebook_id, source_ids, language, instructions, json_output, client_auth
+):
     """Generate mind map.
 
     \b
@@ -1024,9 +1026,7 @@ def generate_mind_map(ctx, notebook_id, source_ids, language, instructions, json
             }
 
             if json_output:
-                result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, **generate_kwargs
-                )
+                result = await client.artifacts.generate_mind_map(nb_id_resolved, **generate_kwargs)
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -995,9 +995,15 @@ def generate_data_table(
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
+@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--instructions",
+    default=None,
+    help="Extra instructions to guide the generated mind map.",
+)
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
+def generate_mind_map(ctx, notebook_id, source_ids, language, instructions, json_output, client_auth):
     """Generate mind map.
 
     \b
@@ -1011,14 +1017,20 @@ def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
             sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
 
             # Show status spinner only for console output
+            generate_kwargs = {
+                "source_ids": sources,
+                "language": resolve_language(language),
+                "instructions": instructions,
+            }
+
             if json_output:
                 result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, source_ids=sources
+                    nb_id_resolved, **generate_kwargs
                 )
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(
-                        nb_id_resolved, source_ids=sources
+                        nb_id_resolved, **generate_kwargs
                     )
 
             _output_mind_map_result(result, json_output)

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -431,6 +431,40 @@ class TestGenerateMindMap:
                 result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
 
             assert result.exit_code == 0
+            mock_client.artifacts.generate_mind_map.assert_awaited_once()
+            kwargs = mock_client.artifacts.generate_mind_map.await_args.kwargs
+            assert kwargs["language"] == "en"
+            assert kwargs["instructions"] is None
+
+    def test_generate_mind_map_with_language_and_instructions(self, runner, mock_auth):
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_mind_map = AsyncMock(
+                return_value={"mind_map": {"name": "Root", "children": []}, "note_id": "n1"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "mind-map",
+                        "-n",
+                        "nb_123",
+                        "--language",
+                        "ja",
+                        "--instructions",
+                        "Focus on chronology",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            mock_client.artifacts.generate_mind_map.assert_awaited_once()
+            kwargs = mock_client.artifacts.generate_mind_map.await_args.kwargs
+            assert kwargs["language"] == "ja"
+            assert kwargs["instructions"] == "Focus on chronology"
 
 
 # =============================================================================

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -419,6 +419,10 @@ class TestGenerateDataTable:
 
 class TestGenerateMindMap:
     def test_generate_mind_map(self, runner, mock_auth):
+        import importlib
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+
         with patch_client_for_module("generate") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.generate_mind_map = AsyncMock(
@@ -427,7 +431,7 @@ class TestGenerateMindMap:
             mock_client_cls.return_value = mock_client
 
             with (
-                patch("notebooklm.cli.generate.get_language", return_value=None),
+                patch.object(generate_module, "get_language", return_value=None),
                 patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
             ):
                 mock_fetch.return_value = ("csrf", "session")

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -426,12 +426,12 @@ class TestGenerateMindMap:
             )
             mock_client_cls.return_value = mock_client
 
-            with patch("notebooklm.cli.generate.get_language", return_value=None):
-                with patch(
-                    "notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock
-                ) as mock_fetch:
-                    mock_fetch.return_value = ("csrf", "session")
-                    result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
+            with (
+                patch("notebooklm.cli.generate.get_language", return_value=None),
+                patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
+            ):
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
 
             assert result.exit_code == 0
             mock_client.artifacts.generate_mind_map.assert_awaited_once()

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -426,9 +426,12 @@ class TestGenerateMindMap:
             )
             mock_client_cls.return_value = mock_client
 
-            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
-                result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
+            with patch("notebooklm.cli.generate.get_language", return_value=None):
+                with patch(
+                    "notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock
+                ) as mock_fetch:
+                    mock_fetch.return_value = ("csrf", "session")
+                    result = runner.invoke(cli, ["generate", "mind-map", "-n", "nb_123"])
 
             assert result.exit_code == 0
             mock_client.artifacts.generate_mind_map.assert_awaited_once()

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -431,7 +431,7 @@ class TestGenerateMindMap:
             mock_client_cls.return_value = mock_client
 
             with (
-                patch.object(generate_module, "get_language", return_value=None),
+                patch.object(generate_module, "get_language", return_value="en"),
                 patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch,
             ):
                 mock_fetch.return_value = ("csrf", "session")

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -510,6 +510,29 @@ class TestArtifactsSourceSelection:
         assert source_ids_nested == [[["src_mm_1"]], [["src_mm_2"]]]
 
     @pytest.mark.asyncio
+    async def test_generate_mind_map_language_and_instructions_encoding(
+        self, mock_core, mock_notes_api
+    ):
+        """Test generate_mind_map forwards language and instructions into the RPC payload."""
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
+
+        await api.generate_mind_map(
+            notebook_id="nb_123",
+            source_ids=["src_mm_1"],
+            language="ja",
+            instructions="Focus on chronology",
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        assert params[5] == [
+            "interactive_mindmap",
+            [["[CONTEXT]", "Focus on chronology"]],
+            "ja",
+        ]
+
+    @pytest.mark.asyncio
     async def test_suggest_reports_uses_get_suggested_reports(self, mock_core, mock_notes_api):
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -533,6 +533,25 @@ class TestArtifactsSourceSelection:
         ]
 
     @pytest.mark.asyncio
+    async def test_generate_mind_map_omits_context_when_instructions_none(
+        self, mock_core, mock_notes_api
+    ):
+        """Test generate_mind_map preserves the empty-context fallback when instructions are omitted."""
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
+
+        await api.generate_mind_map(
+            notebook_id="nb_123",
+            source_ids=["src_mm_1"],
+            language="en",
+            instructions=None,
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        assert params[5] == ["interactive_mindmap", [["[CONTEXT]", ""]], "en"]
+
+    @pytest.mark.asyncio
     async def test_suggest_reports_uses_get_suggested_reports(self, mock_core, mock_notes_api):
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod


### PR DESCRIPTION
## Summary
- add `language` and `instructions` support to `generate_mind_map()` and encode both into the RPC payload
- expose `--language` and `--instructions` on `notebooklm generate mind-map`
- add unit coverage for both API payload encoding and CLI forwarding

## Testing
- `python3 -m pytest tests/unit/cli/test_generate.py -k 'mind_map' tests/unit/test_source_selection.py -k 'mind_map'`\n\nCloses #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mind map generation accepts a configurable language (default: English) and optional instructions via the Python API and CLI (--language, --instructions).

* **Documentation**
  * README and RPC reference updated to show language/instructions usage; README example now passes the returned artifact_id when downloading.

* **Tests**
  * Added/updated unit tests verifying language and instructions are forwarded end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->