### PR TITLE
feat(generate): add language and instructions to mind maps

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -988,6 +988,8 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
+        language: str = "en",
+        instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map.
 
@@ -997,6 +999,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
+            language: Output language code.
+            instructions: Optional generation instructions.
 
         Returns:
             Dictionary with 'mind_map' (JSON data) and 'note_id'.
@@ -1014,7 +1018,7 @@ class ArtifactsAPI:
             None,
             None,
             None,
-            ["interactive_mindmap", [["[CONTEXT]", ""]], ""],
+            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
             None,
             [2, None, [1]],
         ]

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -999,7 +999,9 @@ def generate_data_table(
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @json_option
 @with_client
-def generate_mind_map(ctx, description, notebook_id, language, source_ids, json_output, client_auth):
+def generate_mind_map(
+    ctx, description, notebook_id, language, source_ids, json_output, client_auth
+):
     """Generate mind map.
 
     \b
@@ -1015,22 +1017,24 @@ def generate_mind_map(ctx, description, notebook_id, language, source_ids, json_
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            resolved_language = resolve_language(language)
+            instructions = description or None
 
             # Show status spinner only for console output
             if json_output:
                 result = await client.artifacts.generate_mind_map(
                     nb_id_resolved,
                     source_ids=sources,
-                    language=resolve_language(language),
-                    instructions=description or None,
+                    language=resolved_language,
+                    instructions=instructions,
                 )
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(
                         nb_id_resolved,
                         source_ids=sources,
-                        language=resolve_language(language),
-                        instructions=description or None,
+                        language=resolved_language,
+                        instructions=instructions,
                     )
 
             _output_mind_map_result(result, json_output)

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -987,6 +987,7 @@ def generate_data_table(
 
 
 @generate.command("mind-map")
+@click.argument("description", default="", required=False)
 @click.option(
     "-n",
     "--notebook",
@@ -994,14 +995,19 @@ def generate_data_table(
     default=None,
     help="Notebook ID (uses current if not set)",
 )
+@click.option("--language", default=None, help="Output language (default: from config or 'en')")
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
+def generate_mind_map(ctx, description, notebook_id, language, source_ids, json_output, client_auth):
     """Generate mind map.
 
     \b
     Use --json for machine-readable output.
+
+    \b
+    Example:
+      notebooklm generate mind-map "focus on chronology" --language zh_Hans
     """
     nb_id = require_notebook(notebook_id)
 
@@ -1013,12 +1019,18 @@ def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
             # Show status spinner only for console output
             if json_output:
                 result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, source_ids=sources
+                    nb_id_resolved,
+                    source_ids=sources,
+                    language=resolve_language(language),
+                    instructions=description or None,
                 )
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(
-                        nb_id_resolved, source_ids=sources
+                        nb_id_resolved,
+                        source_ids=sources,
+                        language=resolve_language(language),
+                        instructions=description or None,
                     )
 
             _output_mind_map_result(result, json_output)

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -432,6 +432,36 @@ class TestGenerateMindMap:
 
             assert result.exit_code == 0
 
+    def test_generate_mind_map_with_language(self, runner, mock_auth):
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_mind_map = AsyncMock(
+                return_value={"mind_map": {"name": "Root", "children": []}, "note_id": "n1"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "mind-map",
+                        "--language",
+                        "zh_Hans",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            mock_client.artifacts.generate_mind_map.assert_awaited_once_with(
+                "nb_123",
+                source_ids=None,
+                language="zh_Hans",
+                instructions=None,
+            )
+
 
 # =============================================================================
 # GENERATE REPORT TESTS

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -527,7 +527,11 @@ class TestArtifactsSourceSelection:
 
         params = mock_core.rpc_call.call_args.args[1]
 
-        assert params[5] == ["interactive_mindmap", [["[CONTEXT]", "Focus on chronology"]], "zh_Hans"]
+        assert params[5] == [
+            "interactive_mindmap",
+            [["[CONTEXT]", "Focus on chronology"]],
+            "zh_Hans",
+        ]
 
     @pytest.mark.asyncio
     async def test_suggest_reports_uses_get_suggested_reports(self, mock_core, mock_notes_api):

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -510,6 +510,26 @@ class TestArtifactsSourceSelection:
         assert source_ids_nested == [[["src_mm_1"]], [["src_mm_2"]]]
 
     @pytest.mark.asyncio
+    async def test_generate_mind_map_includes_language_and_instructions(
+        self, mock_core, mock_notes_api
+    ):
+        """Test generate_mind_map encodes language and instructions in config."""
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
+
+        await api.generate_mind_map(
+            notebook_id="nb_123",
+            source_ids=["src_mm_1"],
+            language="zh_Hans",
+            instructions="Focus on chronology",
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+
+        assert params[5] == ["interactive_mindmap", [["[CONTEXT]", "Focus on chronology"]], "zh_Hans"]
+
+    @pytest.mark.asyncio
     async def test_suggest_reports_uses_get_suggested_reports(self, mock_core, mock_notes_api):
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod


### PR DESCRIPTION
## Summary
- add `language` and `instructions` support to `ArtifactsAPI.generate_mind_map()`
- expose `generate mind-map [DESCRIPTION] --language ...` in the CLI
- cover the new payload and CLI behavior with unit tests

Closes #250

## Testing
- uv run pytest tests/unit/cli/test_generate.py -k mind_map
- uv run pytest tests/unit/test_source_selection.py -k mind_map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mind map generation supports language selection (default: English).
  * Custom instructions/descriptions can be supplied when generating mind maps.
  * CLI `generate mind-map` adds an optional `description` argument and a `--language` option.

* **Tests**
  * Added unit tests for the CLI and API paths to verify language and instructions are passed in requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->