### PR TITLE
fix: add language and instructions parameters to generate_mind_map()

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -988,6 +988,8 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
+        language: str = "en",
+        instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map.
 
@@ -997,6 +999,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
+            language: Language code (default: "en").
+            instructions: Custom instructions for mind map generation.
 
         Returns:
             Dictionary with 'mind_map' (JSON data) and 'note_id'.
@@ -1014,7 +1018,7 @@ class ArtifactsAPI:
             None,
             None,
             None,
-            ["interactive_mindmap", [["[CONTEXT]", ""]], ""],
+            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
             None,
             [2, None, [1]],
         ]

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -995,15 +995,18 @@ def generate_data_table(
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
+@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option("--instructions", default=None, help="Custom instructions for mind map generation")
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
+def generate_mind_map(ctx, notebook_id, source_ids, language, instructions, json_output, client_auth):
     """Generate mind map.
 
     \b
     Use --json for machine-readable output.
     """
     nb_id = require_notebook(notebook_id)
+    resolved_language = resolve_language(language)
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
@@ -1013,12 +1016,12 @@ def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
             # Show status spinner only for console output
             if json_output:
                 result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, source_ids=sources
+                    nb_id_resolved, source_ids=sources, language=resolved_language, instructions=instructions
                 )
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(
-                        nb_id_resolved, source_ids=sources
+                        nb_id_resolved, source_ids=sources, language=resolved_language, instructions=instructions
                     )
 
             _output_mind_map_result(result, json_output)

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -999,7 +999,9 @@ def generate_data_table(
 @click.option("--instructions", default=None, help="Custom instructions for mind map generation")
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, language, instructions, json_output, client_auth):
+def generate_mind_map(
+    ctx, notebook_id, source_ids, language, instructions, json_output, client_auth
+):
     """Generate mind map.
 
     \b
@@ -1016,12 +1018,18 @@ def generate_mind_map(ctx, notebook_id, source_ids, language, instructions, json
             # Show status spinner only for console output
             if json_output:
                 result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, source_ids=sources, language=resolved_language, instructions=instructions
+                    nb_id_resolved,
+                    source_ids=sources,
+                    language=resolved_language,
+                    instructions=instructions,
                 )
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(
-                        nb_id_resolved, source_ids=sources, language=resolved_language, instructions=instructions
+                        nb_id_resolved,
+                        source_ids=sources,
+                        language=resolved_language,
+                        instructions=instructions,
                     )
 
             _output_mind_map_result(result, json_output)

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -1531,6 +1531,39 @@ class TestGenerateMindMapParsing:
         assert result["note_id"] == "note_dict_001"
 
     @pytest.mark.asyncio
+    async def test_generate_mind_map_language_and_instructions(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """generate_mind_map passes language and instructions to the RPC payload."""
+        captured_params = []
+
+        async with NotebookLMClient(auth_tokens) as client:
+            async def capturing_rpc_call(method, params, **kwargs):
+                if method == RPCMethod.GENERATE_MIND_MAP:
+                    captured_params.append(params)
+                return None
+
+            with patch.object(
+                client.artifacts._core,
+                "rpc_call",
+                side_effect=capturing_rpc_call,
+            ):
+                await client.artifacts.generate_mind_map(
+                    "nb_123",
+                    source_ids=["src_001"],
+                    language="ja",
+                    instructions="Focus on key relationships",
+                )
+
+        assert len(captured_params) == 1
+        mind_map_config = captured_params[0][5]
+        assert mind_map_config[2] == "ja"
+        assert mind_map_config[1][0][1] == "Focus on key relationships"
+
+    @pytest.mark.asyncio
     async def test_generate_mind_map_with_source_ids_none_fetches_sources(
         self,
         auth_tokens,

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -1541,6 +1541,7 @@ class TestGenerateMindMapParsing:
         captured_params = []
 
         async with NotebookLMClient(auth_tokens) as client:
+
             async def capturing_rpc_call(method, params, **kwargs):
                 if method == RPCMethod.GENERATE_MIND_MAP:
                     captured_params.append(params)


### PR DESCRIPTION
Fixes #250

## Problem

`generate_mind_map()` does not accept `language` or `instructions` parameters, unlike every other artifact generation method (audio, video, report, slides, infographic, etc.). The payload contained hardcoded static values:

```python
["interactive_mindmap", [["[CONTEXT]", ""]], ""]
```

This means mind maps were always generated in English with no custom instructions, ignoring the configured language or any user-provided instructions.

## Solution

Added `language` and `instructions` parameters to `generate_mind_map()` in `_artifacts.py`, matching the signature of other generation methods:

- `language: str = "en"` — passed to `params[5][2]`
- `instructions: str | None = None` — passed to `params[5][1][0][1]`

Updated the CLI `generate mind-map` command in `cli/generate.py` to expose `--language` and `--instructions` flags, using the same `resolve_language()` helper as other generate commands.

## Testing

- Added integration test in `tests/integration/test_artifacts.py`: `test_generate_mind_map_language_and_instructions` — verifies that the `language` and `instructions` values are correctly placed in the RPC payload
- All existing tests continue to pass (2016 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mind map generation supports language selection (default: English) and an optional instructions text to guide output.

* **CLI**
  * Added --language and --instructions flags to mind-map generation commands.

* **Tests**
  * Added integration tests validating language and instructions are passed to mind map generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->