### PR TITLE
feat(cli): add timeout options for source imports

### DIFF
--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -17,8 +17,8 @@ Commands:
 
 import asyncio
 import re
-from pathlib import Path
 from collections.abc import Awaitable
+from pathlib import Path
 from typing import Literal
 
 import click

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -18,6 +18,7 @@ Commands:
 import asyncio
 import re
 from pathlib import Path
+from collections.abc import Awaitable
 from typing import Literal
 
 import click
@@ -251,7 +252,7 @@ def source_add(
     timeout: int,
     json_output: bool,
     client_auth: AuthTokens,
-) -> None:
+) -> Awaitable[None]:
     """Add a source to a notebook.
 
     \b
@@ -564,7 +565,7 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
     default=1800,
     type=click.IntRange(min=1),
     show_default=True,
-    help="Maximum seconds to wait for research and source import to complete",
+    help="Maximum seconds for --import-all source import retries after research completes",
 )
 @click.option(
     "--no-wait",
@@ -582,7 +583,7 @@ def source_add_research(
     timeout: int,
     no_wait: bool,
     client_auth: AuthTokens,
-) -> None:
+) -> Awaitable[None]:
     """Search web or drive and add sources from results.
 
     \b

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -18,11 +18,13 @@ Commands:
 import asyncio
 import re
 from pathlib import Path
+from typing import Literal
 
 import click
 from rich.table import Table
 
 from .._url_utils import is_youtube_url
+from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import source_status_to_str
 from .helpers import (
@@ -233,15 +235,23 @@ def source_list(ctx, notebook_id, json_output, client_auth):
 @click.option(
     "--timeout",
     default=30,
-    type=int,
+    type=click.IntRange(min=1),
     show_default=True,
     help="HTTP request timeout in seconds for adding the source",
 )
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
 def source_add(
-    ctx, content, notebook_id, source_type, title, mime_type, timeout, json_output, client_auth
-):
+    ctx: click.Context,
+    content: str,
+    notebook_id: str | None,
+    source_type: Literal["url", "text", "file", "youtube"] | None,
+    title: str | None,
+    mime_type: str | None,
+    timeout: int,
+    json_output: bool,
+    client_auth: AuthTokens,
+) -> None:
     """Add a source to a notebook.
 
     \b
@@ -552,9 +562,9 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 @click.option(
     "--timeout",
     default=1800,
-    type=int,
+    type=click.IntRange(min=1),
     show_default=True,
-    help="Maximum seconds to keep retrying source import when --import-all is used",
+    help="Maximum seconds to wait for research and source import to complete",
 )
 @click.option(
     "--no-wait",
@@ -563,8 +573,16 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 )
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, timeout, no_wait, client_auth
-):
+    ctx: click.Context,
+    query: str,
+    notebook_id: str | None,
+    search_source: Literal["web", "drive"],
+    mode: Literal["fast", "deep"],
+    import_all: bool,
+    timeout: int,
+    no_wait: bool,
+    client_auth: AuthTokens,
+) -> None:
     """Search web or drive and add sources from results.
 
     \b

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -230,9 +230,18 @@ def source_list(ctx, notebook_id, json_output, client_auth):
 )
 @click.option("--title", help="Title for text sources")
 @click.option("--mime-type", help="MIME type for file sources")
+@click.option(
+    "--timeout",
+    default=30,
+    type=int,
+    show_default=True,
+    help="HTTP request timeout in seconds for adding the source",
+)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
-def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_output, client_auth):
+def source_add(
+    ctx, content, notebook_id, source_type, title, mime_type, timeout, json_output, client_auth
+):
     """Add a source to a notebook.
 
     \b
@@ -272,7 +281,7 @@ def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_ou
             file_title = title or "Pasted Text"
 
     async def _run():
-        async with NotebookLMClient(client_auth) as client:
+        async with NotebookLMClient(client_auth, timeout=float(timeout)) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             if detected_type == "url" or detected_type == "youtube":
                 src = await client.sources.add_url(nb_id_resolved, content)
@@ -541,13 +550,20 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources")
 @click.option(
+    "--timeout",
+    default=1800,
+    type=int,
+    show_default=True,
+    help="Maximum seconds to keep retrying source import when --import-all is used",
+)
+@click.option(
     "--no-wait",
     is_flag=True,
     help="Start research and return immediately (use 'research status/wait' to monitor)",
 )
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, no_wait, client_auth
+    ctx, query, notebook_id, search_source, mode, import_all, timeout, no_wait, client_auth
 ):
     """Search web or drive and add sources from results.
 
@@ -606,6 +622,7 @@ def source_add_research(
                         nb_id_resolved,
                         task_id,
                         sources,
+                        max_elapsed=float(timeout),
                     )
                     console.print(f"[green]Imported {len(imported)} sources[/green]")
             else:

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -223,6 +223,28 @@ class TestSourceAdd:
             data = json.loads(result.output)
             assert data["source"]["id"] == "src_new"
 
+    def test_source_add_passes_timeout_to_client(self, runner, mock_auth):
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_url = AsyncMock(
+                return_value=Source(
+                    id="src_new",
+                    title="Example",
+                    url="https://example.com",
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["source", "add", "https://example.com", "-n", "nb_123", "--timeout", "90"],
+                )
+
+            assert result.exit_code == 0
+            assert mock_client_cls.call_args.kwargs["timeout"] == 90.0
+
 
 # =============================================================================
 # SOURCE GET TESTS
@@ -666,6 +688,52 @@ class TestSourceAddResearch:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=1800.0,
+        )
+
+    def test_add_research_with_import_all_passes_timeout_budget(self, runner, mock_auth):
+        with (
+            patch_client_for_module("source") as mock_client_cls,
+            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "sources": [{"title": "Source 1", "url": "http://example.com"}],
+                    "report": "# Report",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add-research",
+                        "AI papers",
+                        "--mode",
+                        "deep",
+                        "--import-all",
+                        "--timeout",
+                        "90",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=90.0,
         )
 
 

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -245,6 +245,12 @@ class TestSourceAdd:
             assert result.exit_code == 0
             assert mock_client_cls.call_args.kwargs["timeout"] == 90.0
 
+    def test_source_add_rejects_non_positive_timeout(self, runner, mock_auth):
+        result = runner.invoke(cli, ["source", "add", "https://example.com", "--timeout", "0"])
+
+        assert result.exit_code == 2
+        assert "x>=1" in result.output
+
 
 # =============================================================================
 # SOURCE GET TESTS
@@ -735,6 +741,12 @@ class TestSourceAddResearch:
             [{"title": "Source 1", "url": "http://example.com"}],
             max_elapsed=90.0,
         )
+
+    def test_add_research_rejects_non_positive_timeout(self, runner, mock_auth):
+        result = runner.invoke(cli, ["source", "add-research", "AI papers", "--timeout", "0"])
+
+        assert result.exit_code == 2
+        assert "x>=1" in result.output
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add `--timeout` to `notebooklm source add` so slow remote URL imports can override the default 30s RPC timeout
- add `--timeout` to `notebooklm source add-research --import-all` so import retry budget matches the caller instead of being fixed at the helper default
- add CLI regression tests for both timeout paths

## Why
Two open issues point at the same ergonomics gap around source import timeouts:
- `source add <https_url>` can time out on slower pages with no CLI override (#192)
- `source add-research --import-all` cannot tune its retry budget, unlike `research wait --import-all` (#194)

This patch keeps the existing defaults, but exposes the knobs where users actually need them.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/unit/cli/test_source.py tests/unit/cli/test_notebook.py -k 'source_add_research or source_add'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --timeout option to the source add command (default 30s, min 1s) to limit operation duration.
  * Added a --timeout option to the source add-research command (default 1800s, min 1s) to cap import/retry elapsed time when importing all.

* **Tests**
  * Added unit tests validating timeout propagation and enforcement (>=1s) and related error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->