### PR TITLE
feat(auth): add fresh login and logout flow

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -578,6 +578,7 @@ def register_session_commands(cli):
                 console.print("3. Press [bold]ENTER[/bold] here to save and close\n")
 
                 input("[Press ENTER when logged in] ")
+                page = _get_recovered_page(context, page)
 
                 # Force .google.com cookies for regional users (e.g. UK lands on
                 # .google.co.uk). Use "commit" to resolve once response headers
@@ -587,7 +588,11 @@ def register_session_commands(cli):
                     try:
                         page.goto(url, wait_until="commit")
                     except PlaywrightError as exc:
-                        if "Navigation interrupted" not in str(exc):
+                        error_str = str(exc).lower()
+                        if "target page, context or browser has been closed" in error_str:
+                            page = _get_recovered_page(context, page)
+                            page.goto(url, wait_until="commit")
+                        elif "navigation interrupted" not in error_str:
                             raise
 
                 current_url = page.url
@@ -1031,6 +1036,7 @@ def register_session_commands(cli):
     @auth_group.command("logout")
     def auth_logout():
         """Clear saved authentication state for the active profile."""
+        has_inline_auth = bool(os.environ.get("NOTEBOOKLM_AUTH_JSON"))
         storage_path = get_storage_path()
         browser_profile = get_browser_profile_dir()
 
@@ -1050,3 +1056,9 @@ def register_session_commands(cli):
             )
         else:
             console.print("[yellow]No saved auth state found for the active profile.[/yellow]")
+
+        if has_inline_auth:
+            console.print(
+                "[yellow]NOTEBOOKLM_AUTH_JSON is still set, so inline auth remains active.[/yellow]\n"
+                "Unset NOTEBOOKLM_AUTH_JSON (or restart your shell) to fully log out."
+            )

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -34,9 +34,9 @@ from ..auth import (
 )
 from ..client import NotebookLMClient
 from ..paths import (
-    get_home_dir,
     get_browser_profile_dir,
     get_context_path,
+    get_home_dir,
     get_path_info,
     get_storage_path,
 )
@@ -360,21 +360,23 @@ def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
     for path in paths_to_remove:
         if not path.exists():
             continue
-        if path.is_dir():
+        if path.is_symlink():
+            path.unlink()
+        elif path.is_dir():
             shutil.rmtree(path)
         else:
-            path.unlink()
+            path.unlink(missing_ok=True)
         removed.append(path)
 
     return removed
 
 
-def _get_recovered_page(context: Any, current_page: Any):
+def _get_recovered_page(context: Any, current_page: Any) -> Any:
     """Recover a live page when the original Playwright page was closed."""
-    pages = [page for page in context.pages if not getattr(page, "is_closed", lambda: False)()]
+    pages = [page for page in context.pages if not page.is_closed()]
     if pages:
         return pages[0]
-    if current_page and not getattr(current_page, "is_closed", lambda: False)():
+    if current_page and not current_page.is_closed():
         return current_page
     return context.new_page()
 
@@ -447,7 +449,7 @@ def register_session_commands(cli):
         if fresh:
             try:
                 removed = _clear_auth_files(storage_path, browser_profile)
-            except PermissionError as e:
+            except OSError as e:
                 console.print(
                     "[red]Could not clear the saved browser session.[/red]\n"
                     "Close any running NotebookLM/Chromium windows and try again.\n"
@@ -1034,7 +1036,7 @@ def register_session_commands(cli):
 
         try:
             removed = _clear_auth_files(storage_path, browser_profile)
-        except PermissionError as e:
+        except OSError as e:
             console.print(
                 "[red]Could not remove saved auth files.[/red]\n"
                 "Close any running browser windows for this profile and try again.\n"
@@ -1043,6 +1045,8 @@ def register_session_commands(cli):
             raise SystemExit(1) from e
 
         if removed:
-            console.print("[green]Logged out. Removed saved browser session and auth state.[/green]")
+            console.print(
+                "[green]Logged out. Removed saved browser session and auth state.[/green]"
+            )
         else:
             console.print("[yellow]No saved auth state found for the active profile.[/yellow]")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -33,6 +34,7 @@ from ..auth import (
 )
 from ..client import NotebookLMClient
 from ..paths import (
+    get_home_dir,
     get_browser_profile_dir,
     get_context_path,
     get_path_info,
@@ -340,6 +342,43 @@ def _ensure_chromium_installed() -> None:
         )
 
 
+def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
+    """Delete auth files/directories for the active profile.
+
+    Also checks legacy default-profile paths when the resolved paths are profile-based.
+    Returns the paths that were actually removed.
+    """
+    paths_to_remove = [storage_path, browser_profile]
+
+    legacy_storage = get_home_dir() / "storage_state.json"
+    legacy_browser = get_home_dir() / "browser_profile"
+    for legacy_path in (legacy_storage, legacy_browser):
+        if legacy_path not in paths_to_remove:
+            paths_to_remove.append(legacy_path)
+
+    removed: list[Path] = []
+    for path in paths_to_remove:
+        if not path.exists():
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+        removed.append(path)
+
+    return removed
+
+
+def _get_recovered_page(context: Any, current_page: Any):
+    """Recover a live page when the original Playwright page was closed."""
+    pages = [page for page in context.pages if not getattr(page, "is_closed", lambda: False)()]
+    if pages:
+        return pages[0]
+    if current_page and not getattr(current_page, "is_closed", lambda: False)():
+        return current_page
+    return context.new_page()
+
+
 def register_session_commands(cli):
     """Register session commands on the main CLI group."""
 
@@ -368,7 +407,12 @@ def register_session_commands(cli):
             "Requires: pip install 'notebooklm[cookies]'"
         ),
     )
-    def login(storage, browser, browser_cookies):
+    @click.option(
+        "--fresh",
+        is_flag=True,
+        help="Delete saved browser session before login so you can choose a different account.",
+    )
+    def login(storage, browser, browser_cookies, fresh):
         """Log in to NotebookLM via browser.
 
         Opens a browser window for Google login. After logging in,
@@ -399,6 +443,20 @@ def register_session_commands(cli):
 
         storage_path = Path(storage) if storage else get_storage_path()
         browser_profile = get_browser_profile_dir()
+
+        if fresh:
+            try:
+                removed = _clear_auth_files(storage_path, browser_profile)
+            except PermissionError as e:
+                console.print(
+                    "[red]Could not clear the saved browser session.[/red]\n"
+                    "Close any running NotebookLM/Chromium windows and try again.\n"
+                    f"Details: {e}"
+                )
+                raise SystemExit(1) from e
+            if removed:
+                console.print("[yellow]Cleared saved browser session for a fresh login.[/yellow]")
+
         if sys.platform == "win32":
             # On Windows < Python 3.13, mode= is ignored by mkdir(). On
             # Python 3.13+, mode= applies Windows ACLs that can be overly
@@ -463,12 +521,31 @@ def register_session_commands(cli):
                         break
                     except PlaywrightError as exc:
                         error_str = str(exc)
+                        is_target_closed = (
+                            "target page, context or browser has been closed" in error_str.lower()
+                        )
                         is_retryable = any(
                             code in error_str for code in RETRYABLE_CONNECTION_ERRORS
                         )
 
                         # Check if we should retry
-                        if is_retryable and attempt < LOGIN_MAX_RETRIES:
+                        if is_target_closed and attempt < LOGIN_MAX_RETRIES:
+                            page = _get_recovered_page(context, page)
+                            backoff_seconds = attempt
+                            console.print(
+                                f"[yellow]Browser page was replaced during login "
+                                f"(attempt {attempt}/{LOGIN_MAX_RETRIES}). "
+                                f"Retrying in {backoff_seconds}s...[/yellow]"
+                            )
+                            time.sleep(backoff_seconds)
+                        elif is_target_closed:
+                            logger.error("Login page kept closing during account switch")
+                            console.print(
+                                "[red]The login page kept closing while switching accounts.[/red]\n"
+                                "Retry with 'notebooklm login --fresh' to start from a clean browser session."
+                            )
+                            raise SystemExit(1) from None
+                        elif is_retryable and attempt < LOGIN_MAX_RETRIES:
                             # Retryable error with attempts remaining: retry
                             backoff_seconds = attempt  # Linear backoff: 1s, 2s
                             logger.debug(
@@ -948,3 +1025,24 @@ def register_session_commands(cli):
             console.print(
                 "\n[yellow]Cookies may be expired. Run 'notebooklm login' to refresh.[/yellow]"
             )
+
+    @auth_group.command("logout")
+    def auth_logout():
+        """Clear saved authentication state for the active profile."""
+        storage_path = get_storage_path()
+        browser_profile = get_browser_profile_dir()
+
+        try:
+            removed = _clear_auth_files(storage_path, browser_profile)
+        except PermissionError as e:
+            console.print(
+                "[red]Could not remove saved auth files.[/red]\n"
+                "Close any running browser windows for this profile and try again.\n"
+                f"Details: {e}"
+            )
+            raise SystemExit(1) from e
+
+        if removed:
+            console.print("[green]Logged out. Removed saved browser session and auth state.[/green]")
+        else:
+            console.print("[yellow]No saved auth state found for the active profile.[/yellow]")

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -10,6 +10,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+import notebooklm.cli.session as session_module
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Notebook
 
@@ -234,6 +235,39 @@ class TestLoginCommand:
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
 
+    def test_login_fresh_clears_saved_auth_state(self, runner, tmp_path):
+        """Test login --fresh removes both storage and browser profile before launch."""
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text("{}")
+        browser_profile = tmp_path / "browser_profile"
+        browser_profile.mkdir()
+        (browser_profile / "Cookies").write_text("cookie-db")
+
+        with (
+            patch("notebooklm.cli.session._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch("builtins.input", return_value=""),
+        ):
+            mock_context = MagicMock()
+            mock_page = MagicMock()
+            mock_page.url = "https://notebooklm.google.com/"
+            mock_context.pages = [mock_page]
+            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login", "--fresh"])
+
+        assert result.exit_code == 0
+        assert storage_file.exists()
+        assert "Cleared saved browser session" in result.output
+        assert mock_launch.call_args.kwargs["user_data_dir"] == str(browser_profile)
+
     def test_login_reraises_non_navigation_playwright_errors(
         self, runner, mock_login_browser_with_storage
     ):
@@ -267,6 +301,56 @@ class TestLoginCommand:
         assert len(goto_calls) == 3
         assert goto_calls[1].kwargs.get("wait_until") == "commit"
         assert goto_calls[2].kwargs.get("wait_until") == "commit"
+
+    def test_login_recovers_from_target_closed_error(self, runner, tmp_path):
+        """Test login retries with a fresh page when account switching closes the page."""
+        from playwright.sync_api import Error as PlaywrightError
+
+        storage_file = tmp_path / "storage.json"
+        browser_profile = tmp_path / "browser_profile"
+
+        with (
+            patch("notebooklm.cli.session._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch("builtins.input", return_value=""),
+            patch("notebooklm.cli.session.time.sleep"),
+        ):
+            mock_context = MagicMock()
+            first_page = MagicMock()
+            first_page.url = "https://notebooklm.google.com/"
+            replacement_page = MagicMock()
+            replacement_page.url = "https://notebooklm.google.com/"
+            replacement_page.is_closed.return_value = False
+            mock_context.pages = [replacement_page]
+            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+
+            call_count = 0
+
+            def goto_side_effect(url, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    first_page.is_closed.return_value = True
+                    raise PlaywrightError(
+                        "Page.goto: Target page, context or browser has been closed"
+                    )
+
+            first_page.goto.side_effect = goto_side_effect
+            mock_context.new_page.return_value = replacement_page
+            mock_context.pages = [first_page]
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0
+        assert replacement_page.goto.called
+        assert "Authentication saved" in result.output
 
     def test_login_retries_on_connection_closed_error(
         self, runner, mock_login_browser_with_storage
@@ -559,10 +643,49 @@ class TestStatusCommand:
         result = runner.invoke(cli, ["status", "--json"])
 
         assert result.exit_code == 0
-        # Should be valid JSON
         output_data = json.loads(result.output)
         assert output_data["has_context"] is True
         assert output_data["notebook"]["id"] == "nb_json_test"
+
+
+# =============================================================================
+# AUTH COMMAND TESTS
+# =============================================================================
+
+
+class TestAuthCommands:
+    def test_auth_logout_removes_profile_auth_files(self, runner, tmp_path):
+        """Test auth logout deletes saved storage state and browser profile."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text("{}")
+        browser_profile = tmp_path / "browser_profile"
+        browser_profile.mkdir()
+        (browser_profile / "Cookies").write_text("cookie-db")
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(session_module, "_clear_auth_files", return_value=[storage_file, browser_profile]),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "Logged out" in result.output
+
+    def test_auth_logout_is_noop_when_nothing_saved(self, runner, tmp_path):
+        """Test auth logout reports cleanly when there is nothing to remove."""
+        storage_file = tmp_path / "missing-storage.json"
+        browser_profile = tmp_path / "missing-browser-profile"
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(session_module, "_clear_auth_files", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "No saved auth state found" in result.output
 
     def test_status_json_output_no_context(self, runner, mock_context_file):
         """Test status --json outputs valid JSON when no context."""

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -199,6 +199,7 @@ class TestLoginCommand:
             mock_context = MagicMock()
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
+            mock_page.is_closed.return_value = False
             mock_context.pages = [mock_page]
             # Make storage_state create the file so chmod succeeds
             mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
@@ -254,6 +255,7 @@ class TestLoginCommand:
             mock_context = MagicMock()
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
+            mock_page.is_closed.return_value = False
             mock_context.pages = [mock_page]
             mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
             mock_launch = (
@@ -321,6 +323,7 @@ class TestLoginCommand:
             mock_context = MagicMock()
             first_page = MagicMock()
             first_page.url = "https://notebooklm.google.com/"
+            first_page.is_closed.return_value = False
             replacement_page = MagicMock()
             replacement_page.url = "https://notebooklm.google.com/"
             replacement_page.is_closed.return_value = False
@@ -350,6 +353,56 @@ class TestLoginCommand:
 
         assert result.exit_code == 0
         assert replacement_page.goto.called
+        assert "Authentication saved" in result.output
+
+    def test_login_recovers_page_after_enter_and_cookie_loop(self, runner, tmp_path):
+        """Test login refreshes the page after ENTER and retries cookie sync on page closure."""
+        from playwright.sync_api import Error as PlaywrightError
+
+        storage_file = tmp_path / "storage.json"
+        browser_profile = tmp_path / "browser_profile"
+
+        with (
+            patch("notebooklm.cli.session._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch("builtins.input", return_value=""),
+        ):
+            mock_context = MagicMock()
+            initial_page = MagicMock()
+            initial_page.url = "https://notebooklm.google.com/"
+            initial_page.is_closed.return_value = True
+            recovered_page = MagicMock()
+            recovered_page.url = "https://notebooklm.google.com/"
+            recovered_page.is_closed.return_value = False
+            mock_context.pages = [recovered_page]
+            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+
+            cookie_retry = {"raised": False}
+
+            def recovered_goto(url, **kwargs):
+                if (
+                    url == "https://accounts.google.com/"
+                    and kwargs.get("wait_until") == "commit"
+                    and not cookie_retry["raised"]
+                ):
+                    cookie_retry["raised"] = True
+                    raise PlaywrightError(
+                        "Page.goto: Target page, context or browser has been closed"
+                    )
+
+            recovered_page.goto.side_effect = recovered_goto
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0
+        assert recovered_page.goto.call_count >= 3
         assert "Authentication saved" in result.output
 
     def test_login_retries_on_connection_closed_error(
@@ -710,6 +763,22 @@ class TestAuthCommands:
 
         assert result.exit_code == 0
         assert "No saved auth state found" in result.output
+
+    def test_auth_logout_warns_when_inline_auth_is_set(self, runner, tmp_path, monkeypatch):
+        """Test auth logout warns when NOTEBOOKLM_AUTH_JSON still keeps inline auth active."""
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", '{"cookies":[]}')
+        storage_file = tmp_path / "storage_state.json"
+        browser_profile = tmp_path / "browser_profile"
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(session_module, "_clear_auth_files", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "NOTEBOOKLM_AUTH_JSON is still set" in result.output
 
 
 # =============================================================================

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -647,46 +647,6 @@ class TestStatusCommand:
         assert output_data["has_context"] is True
         assert output_data["notebook"]["id"] == "nb_json_test"
 
-
-# =============================================================================
-# AUTH COMMAND TESTS
-# =============================================================================
-
-
-class TestAuthCommands:
-    def test_auth_logout_removes_profile_auth_files(self, runner, tmp_path):
-        """Test auth logout deletes saved storage state and browser profile."""
-        storage_file = tmp_path / "storage_state.json"
-        storage_file.write_text("{}")
-        browser_profile = tmp_path / "browser_profile"
-        browser_profile.mkdir()
-        (browser_profile / "Cookies").write_text("cookie-db")
-
-        with (
-            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
-            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
-            patch.object(session_module, "_clear_auth_files", return_value=[storage_file, browser_profile]),
-        ):
-            result = runner.invoke(cli, ["auth", "logout"])
-
-        assert result.exit_code == 0
-        assert "Logged out" in result.output
-
-    def test_auth_logout_is_noop_when_nothing_saved(self, runner, tmp_path):
-        """Test auth logout reports cleanly when there is nothing to remove."""
-        storage_file = tmp_path / "missing-storage.json"
-        browser_profile = tmp_path / "missing-browser-profile"
-
-        with (
-            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
-            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
-            patch.object(session_module, "_clear_auth_files", return_value=[]),
-        ):
-            result = runner.invoke(cli, ["auth", "logout"])
-
-        assert result.exit_code == 0
-        assert "No saved auth state found" in result.output
-
     def test_status_json_output_no_context(self, runner, mock_context_file):
         """Test status --json outputs valid JSON when no context."""
         if mock_context_file.exists():
@@ -708,6 +668,48 @@ class TestAuthCommands:
 
         # Should not crash, should show minimal info or no context
         assert result.exit_code == 0
+
+
+# =============================================================================
+# AUTH COMMAND TESTS
+# =============================================================================
+
+
+class TestAuthCommands:
+    def test_auth_logout_removes_profile_auth_files(self, runner, tmp_path):
+        """Test auth logout deletes saved storage state and browser profile."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text("{}")
+        browser_profile = tmp_path / "browser_profile"
+        browser_profile.mkdir()
+        (browser_profile / "Cookies").write_text("cookie-db")
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(
+                session_module, "_clear_auth_files", return_value=[storage_file, browser_profile]
+            ),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "Logged out" in result.output
+
+    def test_auth_logout_is_noop_when_nothing_saved(self, runner, tmp_path):
+        """Test auth logout reports cleanly when there is nothing to remove."""
+        storage_file = tmp_path / "missing-storage.json"
+        browser_profile = tmp_path / "missing-browser-profile"
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(session_module, "_clear_auth_files", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "No saved auth state found" in result.output
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add `notebooklm login --fresh` to clear saved browser/session state before launching Playwright
- add `notebooklm auth logout` to remove saved auth files for the active profile, with legacy default-profile cleanup too
- recover from account-switch flows that replace the Playwright page, and cover the new auth flows with unit tests

## Testing
- `PYTHONPATH=src python3 -m pytest tests/unit/cli/test_session.py -q`

Fixes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--fresh` flag to login to clear saved authentication state before signing in.
  * Added `auth logout` command to remove saved authentication/session data with clear success or "nothing to remove" feedback and a warning if inline auth remains set.

* **Bug Fixes**
  * Login now recovers from unexpected browser/page closures, retrying navigation and prompting to rerun with `--fresh` if account switching repeatedly fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->