### PR TITLE
fix: preserve YouTube source URLs from NotebookLM metadata

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -24,6 +24,7 @@ from .types import (
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
+    _extract_source_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -102,12 +103,8 @@ class SourcesAPI:
                 src_id = src[0][0] if isinstance(src[0], list) else src[0]
                 title = src[1] if len(src) > 1 else None
 
-                # Extract URL if present (at src[2][7])
-                url = None
-                if len(src) > 2 and isinstance(src[2], list) and len(src[2]) > 7:
-                    url_list = src[2][7]
-                    if isinstance(url_list, list) and len(url_list) > 0:
-                        url = url_list[0]
+                # Extract URL if present
+                url = _extract_source_url(src[2] if len(src) > 2 else None)
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]
                 created_at = None
@@ -716,10 +713,7 @@ class SourcesAPI:
                     if len(result[0][2]) > 4:
                         source_type = result[0][2][4]
 
-                    # URL at result[0][2][7][0]
-                    if len(result[0][2]) > 7 and isinstance(result[0][2][7], list):
-                        if len(result[0][2][7]) > 0:
-                            url = result[0][2][7][0]
+                    url = _extract_source_url(result[0][2])
 
             # Content blocks at result[3][0]
             # Each block may be nested arrays with text strings

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -369,7 +369,7 @@ def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
 
     removed: list[Path] = []
     for path in paths_to_remove:
-        if not path.exists():
+        if not path.exists() and not path.is_symlink():
             continue
         if path.is_symlink() or path.is_file():
             path.unlink()

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -1063,6 +1063,8 @@ def register_session_commands(cli):
             raise SystemExit(1) from e
 
         if removed:
-            console.print("[green]Logged out. Removed saved browser session and auth state.[/green]")
+            console.print(
+                "[green]Logged out. Removed saved browser session and auth state.[/green]"
+            )
         else:
             console.print("[yellow]No saved auth state found for the active profile.[/yellow]")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -33,6 +34,7 @@ from ..auth import (
 )
 from ..client import NotebookLMClient
 from ..paths import (
+    get_home_dir,
     get_browser_profile_dir,
     get_context_path,
     get_path_info,
@@ -340,6 +342,43 @@ def _ensure_chromium_installed() -> None:
         )
 
 
+def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
+    """Delete auth files/directories for the active profile.
+
+    Also checks legacy default-profile paths when the resolved paths are profile-based.
+    Returns the paths that were actually removed.
+    """
+    paths_to_remove = [storage_path, browser_profile]
+
+    legacy_storage = get_home_dir() / "storage_state.json"
+    legacy_browser = get_home_dir() / "browser_profile"
+    for legacy_path in (legacy_storage, legacy_browser):
+        if legacy_path not in paths_to_remove:
+            paths_to_remove.append(legacy_path)
+
+    removed: list[Path] = []
+    for path in paths_to_remove:
+        if not path.exists():
+            continue
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+        removed.append(path)
+
+    return removed
+
+
+def _get_recovered_page(context: Any, current_page: Any):
+    """Recover a live page when the original Playwright page was closed."""
+    pages = [page for page in context.pages if not getattr(page, "is_closed", lambda: False)()]
+    if pages:
+        return pages[0]
+    if current_page and not getattr(current_page, "is_closed", lambda: False)():
+        return current_page
+    return context.new_page()
+
+
 def register_session_commands(cli):
     """Register session commands on the main CLI group."""
 
@@ -368,7 +407,12 @@ def register_session_commands(cli):
             "Requires: pip install 'notebooklm[cookies]'"
         ),
     )
-    def login(storage, browser, browser_cookies):
+    @click.option(
+        "--fresh",
+        is_flag=True,
+        help="Delete saved browser session before login so you can choose a different account.",
+    )
+    def login(storage, browser, browser_cookies, fresh):
         """Log in to NotebookLM via browser.
 
         Opens a browser window for Google login. After logging in,
@@ -399,6 +443,20 @@ def register_session_commands(cli):
 
         storage_path = Path(storage) if storage else get_storage_path()
         browser_profile = get_browser_profile_dir()
+
+        if fresh:
+            try:
+                removed = _clear_auth_files(storage_path, browser_profile)
+            except PermissionError as e:
+                console.print(
+                    "[red]Could not clear the saved browser session.[/red]\n"
+                    "Close any running NotebookLM/Chromium windows and try again.\n"
+                    f"Details: {e}"
+                )
+                raise SystemExit(1) from e
+            if removed:
+                console.print("[yellow]Cleared saved browser session for a fresh login.[/yellow]")
+
         if sys.platform == "win32":
             # On Windows < Python 3.13, mode= is ignored by mkdir(). On
             # Python 3.13+, mode= applies Windows ACLs that can be overly
@@ -463,12 +521,31 @@ def register_session_commands(cli):
                         break
                     except PlaywrightError as exc:
                         error_str = str(exc)
+                        is_target_closed = (
+                            "target page, context or browser has been closed" in error_str.lower()
+                        )
                         is_retryable = any(
                             code in error_str for code in RETRYABLE_CONNECTION_ERRORS
                         )
 
                         # Check if we should retry
-                        if is_retryable and attempt < LOGIN_MAX_RETRIES:
+                        if is_target_closed and attempt < LOGIN_MAX_RETRIES:
+                            page = _get_recovered_page(context, page)
+                            backoff_seconds = attempt
+                            console.print(
+                                f"[yellow]Browser page was replaced during login "
+                                f"(attempt {attempt}/{LOGIN_MAX_RETRIES}). "
+                                f"Retrying in {backoff_seconds}s...[/yellow]"
+                            )
+                            time.sleep(backoff_seconds)
+                        elif is_target_closed:
+                            logger.error("Login page kept closing during account switch")
+                            console.print(
+                                "[red]The login page kept closing while switching accounts.[/red]\n"
+                                "Retry with 'notebooklm login --fresh' to start from a clean browser session."
+                            )
+                            raise SystemExit(1) from None
+                        elif is_retryable and attempt < LOGIN_MAX_RETRIES:
                             # Retryable error with attempts remaining: retry
                             backoff_seconds = attempt  # Linear backoff: 1s, 2s
                             logger.debug(
@@ -948,3 +1025,24 @@ def register_session_commands(cli):
             console.print(
                 "\n[yellow]Cookies may be expired. Run 'notebooklm login' to refresh.[/yellow]"
             )
+
+    @auth_group.command("logout")
+    def auth_logout():
+        """Clear saved authentication state for the active profile."""
+        storage_path = get_storage_path()
+        browser_profile = get_browser_profile_dir()
+
+        try:
+            removed = _clear_auth_files(storage_path, browser_profile)
+        except PermissionError as e:
+            console.print(
+                "[red]Could not remove saved auth files.[/red]\n"
+                "Close any running browser windows for this profile and try again.\n"
+                f"Details: {e}"
+            )
+            raise SystemExit(1) from e
+
+        if removed:
+            console.print("[green]Logged out. Removed saved browser session and auth state.[/green]")
+        else:
+            console.print("[yellow]No saved auth state found for the active profile.[/yellow]")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -34,9 +34,9 @@ from ..auth import (
 )
 from ..client import NotebookLMClient
 from ..paths import (
-    get_home_dir,
     get_browser_profile_dir,
     get_context_path,
+    get_home_dir,
     get_path_info,
     get_storage_path,
 )
@@ -345,22 +345,35 @@ def _ensure_chromium_installed() -> None:
 def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
     """Delete auth files/directories for the active profile.
 
-    Also checks legacy default-profile paths when the resolved paths are profile-based.
+    Clears the active profile's storage, context, and browser profile paths.
+    Home-root legacy paths are only removed when the active profile resolves to
+    the default profile's legacy-compatible locations.
     Returns the paths that were actually removed.
     """
-    paths_to_remove = [storage_path, browser_profile]
+    context_path = get_context_path()
+    paths_to_remove = [storage_path, context_path, browser_profile]
 
-    legacy_storage = get_home_dir() / "storage_state.json"
-    legacy_browser = get_home_dir() / "browser_profile"
-    for legacy_path in (legacy_storage, legacy_browser):
-        if legacy_path not in paths_to_remove:
-            paths_to_remove.append(legacy_path)
+    default_storage = get_storage_path("default")
+    default_context = get_context_path("default")
+    default_browser = get_browser_profile_dir("default")
+    if (
+        storage_path == default_storage
+        and context_path == default_context
+        and browser_profile == default_browser
+    ):
+        legacy_storage = get_home_dir() / "storage_state.json"
+        legacy_browser = get_home_dir() / "browser_profile"
+        for legacy_path in (legacy_storage, legacy_browser):
+            if legacy_path not in paths_to_remove:
+                paths_to_remove.append(legacy_path)
 
     removed: list[Path] = []
     for path in paths_to_remove:
         if not path.exists():
             continue
-        if path.is_dir():
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        elif path.is_dir():
             shutil.rmtree(path)
         else:
             path.unlink()
@@ -1029,6 +1042,13 @@ def register_session_commands(cli):
     @auth_group.command("logout")
     def auth_logout():
         """Clear saved authentication state for the active profile."""
+        if os.environ.get("NOTEBOOKLM_AUTH_JSON"):
+            console.print(
+                "[red]Cannot run 'auth logout' when NOTEBOOKLM_AUTH_JSON is set.[/red]\n"
+                "Unset NOTEBOOKLM_AUTH_JSON to disable inline authentication."
+            )
+            raise SystemExit(1)
+
         storage_path = get_storage_path()
         browser_profile = get_browser_profile_dir()
 

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -382,7 +382,7 @@ def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
     return removed
 
 
-def _get_recovered_page(context: Any, current_page: Any):
+def _get_recovered_page(context: Any, current_page: Any) -> Any:
     """Recover a live page when the original Playwright page was closed."""
     pages = [page for page in context.pages if not getattr(page, "is_closed", lambda: False)()]
     if pages:
@@ -398,7 +398,7 @@ def register_session_commands(cli):
     @cli.command("login")
     @click.option(
         "--storage",
-        type=click.Path(),
+        type=click.Path(dir_okay=False),
         default=None,
         help="Where to save storage_state.json (default: profile-specific location)",
     )

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -371,12 +371,17 @@ def _clear_auth_files(storage_path: Path, browser_profile: Path) -> list[Path]:
     for path in paths_to_remove:
         if not path.exists() and not path.is_symlink():
             continue
-        if path.is_symlink() or path.is_file():
-            path.unlink()
-        elif path.is_dir():
-            shutil.rmtree(path)
-        else:
-            path.unlink()
+        try:
+            if path.is_symlink() or path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+        except FileNotFoundError:
+            # Another process may clear the auth artifact between our existence
+            # check and the delete call. That race is benign for logout/fresh-login.
+            continue
         removed.append(path)
 
     return removed

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -175,6 +175,33 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 }
 
 
+def _extract_source_url(metadata: list[Any] | None) -> str | None:
+    """Extract a source URL from NotebookLM source metadata.
+
+    NotebookLM stores URLs in different slots depending on source type:
+    - metadata[7][0] for web pages and PDFs
+    - metadata[5][0] for YouTube sources
+    - metadata[0] as a legacy/fallback flat URL
+    """
+    if not isinstance(metadata, list):
+        return None
+
+    if len(metadata) > 7 and isinstance(metadata[7], list) and metadata[7]:
+        first = metadata[7][0]
+        if isinstance(first, str) and first:
+            return first
+
+    if len(metadata) > 5 and isinstance(metadata[5], list) and metadata[5]:
+        first = metadata[5][0]
+        if isinstance(first, str) and first:
+            return first
+
+    if len(metadata) > 0 and isinstance(metadata[0], str) and metadata[0].startswith("http"):
+        return metadata[0]
+
+    return None
+
+
 def _safe_source_type(type_code: int | None) -> SourceType:
     """Convert internal type code to user-facing SourceType enum.
 
@@ -583,10 +610,7 @@ class Source:
                     title = entry[1] if len(entry) > 1 else None
 
                     # Try to extract URL if present
-                    url = None
-                    if len(entry) > 2 and isinstance(entry[2], list):
-                        if len(entry[2]) > 7 and isinstance(entry[2][7], list):
-                            url = entry[2][7][0] if entry[2][7] else None
+                    url = _extract_source_url(entry[2] if len(entry) > 2 else None)
 
                     return cls(id=str(source_id), title=title, url=url, _type_code=None)
 
@@ -594,13 +618,7 @@ class Source:
                 url = None
                 type_code = None
                 if len(entry) > 2 and isinstance(entry[2], list):
-                    if len(entry[2]) > 7:
-                        url_list = entry[2][7]
-                        if isinstance(url_list, list) and len(url_list) > 0:
-                            url = url_list[0]
-                    if not url and len(entry[2]) > 0:
-                        if isinstance(entry[2][0], str) and entry[2][0].startswith("http"):
-                            url = entry[2][0]
+                    url = _extract_source_url(entry[2])
                     # Extract type code at entry[2][4] if available
                     if len(entry[2]) > 4 and isinstance(entry[2][4], int):
                         type_code = entry[2][4]

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -601,7 +601,7 @@ class Source:
                     title = entry[1] if len(entry) > 1 else None
                 else:
                     # Medium nested: [[['id'], 'title', ...]]
-                    entry = data[0]
+                    entry = data[0][0]
                     source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
                     title = entry[1] if len(entry) > 1 else None
 

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -178,22 +178,18 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 def _extract_source_url(metadata: list[Any] | None) -> str | None:
     """Extract a source URL from NotebookLM source metadata.
 
-    NotebookLM stores URLs in different slots depending on source type:
-    - metadata[7][0] for web pages and PDFs
-    - metadata[5][0] for YouTube sources
-    - metadata[0] as a legacy/fallback flat URL
+    NotebookLM stores URLs in different slots depending on source type, so we
+    check the known nested slots first and only accept values that look like
+    actual URLs before falling back to the legacy flat field.
     """
     if not isinstance(metadata, list):
         return None
 
-    if len(metadata) > 7 and isinstance(metadata[7], list) and metadata[7]:
-        first = metadata[7][0]
-        if isinstance(first, str) and first:
-            return first
-
-    if len(metadata) > 5 and isinstance(metadata[5], list) and metadata[5]:
-        first = metadata[5][0]
-        if isinstance(first, str) and first:
+    for index in (7, 5):
+        if len(metadata) <= index or not isinstance(metadata[index], list) or not metadata[index]:
+            continue
+        first = metadata[index][0]
+        if isinstance(first, str) and first.startswith("http"):
             return first
 
     if len(metadata) > 0 and isinstance(metadata[0], str) and metadata[0].startswith("http"):

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -590,7 +590,7 @@ class Source:
         if not data or not isinstance(data, list):
             raise ValueError(f"Invalid source data: {data}")
 
-        # Try deeply nested format: [[[[id], title, metadata, ...]]]
+        # Try nested formats: [[[id], title, metadata, ...]] or [[[[id], ...]]]
         if isinstance(data[0], list) and len(data[0]) > 0:
             if isinstance(data[0][0], list) and len(data[0][0]) > 0:
                 # Check if deeply nested vs medium nested
@@ -600,8 +600,8 @@ class Source:
                     source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
                     title = entry[1] if len(entry) > 1 else None
                 else:
-                    # Medium nested: [[['id'], 'title', ...]]
-                    entry = data[0][0]
+                    # Medium nested: [[[id], 'title', ...]]
+                    entry = data[0]
                     source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
                     title = entry[1] if len(entry) > 1 else None
 

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -10,6 +10,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+import notebooklm.cli.session as session_module
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Notebook
 
@@ -234,6 +235,39 @@ class TestLoginCommand:
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
 
+    def test_login_fresh_clears_saved_auth_state(self, runner, tmp_path):
+        """Test login --fresh removes both storage and browser profile before launch."""
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text("{}")
+        browser_profile = tmp_path / "browser_profile"
+        browser_profile.mkdir()
+        (browser_profile / "Cookies").write_text("cookie-db")
+
+        with (
+            patch("notebooklm.cli.session._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch("builtins.input", return_value=""),
+        ):
+            mock_context = MagicMock()
+            mock_page = MagicMock()
+            mock_page.url = "https://notebooklm.google.com/"
+            mock_context.pages = [mock_page]
+            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login", "--fresh"])
+
+        assert result.exit_code == 0
+        assert storage_file.exists()
+        assert "Cleared saved browser session" in result.output
+        assert mock_launch.call_args.kwargs["user_data_dir"] == str(browser_profile)
+
     def test_login_reraises_non_navigation_playwright_errors(
         self, runner, mock_login_browser_with_storage
     ):
@@ -267,6 +301,56 @@ class TestLoginCommand:
         assert len(goto_calls) == 3
         assert goto_calls[1].kwargs.get("wait_until") == "commit"
         assert goto_calls[2].kwargs.get("wait_until") == "commit"
+
+    def test_login_recovers_from_target_closed_error(self, runner, tmp_path):
+        """Test login retries with a fresh page when account switching closes the page."""
+        from playwright.sync_api import Error as PlaywrightError
+
+        storage_file = tmp_path / "storage.json"
+        browser_profile = tmp_path / "browser_profile"
+
+        with (
+            patch("notebooklm.cli.session._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch("builtins.input", return_value=""),
+            patch("notebooklm.cli.session.time.sleep"),
+        ):
+            mock_context = MagicMock()
+            first_page = MagicMock()
+            first_page.url = "https://notebooklm.google.com/"
+            replacement_page = MagicMock()
+            replacement_page.url = "https://notebooklm.google.com/"
+            replacement_page.is_closed.return_value = False
+            mock_context.pages = [replacement_page]
+            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+
+            call_count = 0
+
+            def goto_side_effect(url, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    first_page.is_closed.return_value = True
+                    raise PlaywrightError(
+                        "Page.goto: Target page, context or browser has been closed"
+                    )
+
+            first_page.goto.side_effect = goto_side_effect
+            mock_context.new_page.return_value = replacement_page
+            mock_context.pages = [first_page]
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0
+        assert replacement_page.goto.called
+        assert "Authentication saved" in result.output
 
     def test_login_retries_on_connection_closed_error(
         self, runner, mock_login_browser_with_storage
@@ -559,10 +643,49 @@ class TestStatusCommand:
         result = runner.invoke(cli, ["status", "--json"])
 
         assert result.exit_code == 0
-        # Should be valid JSON
         output_data = json.loads(result.output)
         assert output_data["has_context"] is True
         assert output_data["notebook"]["id"] == "nb_json_test"
+
+
+# =============================================================================
+# AUTH COMMAND TESTS
+# =============================================================================
+
+
+class TestAuthCommands:
+    def test_auth_logout_removes_profile_auth_files(self, runner, tmp_path):
+        """Test auth logout deletes saved storage state and browser profile."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text("{}")
+        browser_profile = tmp_path / "browser_profile"
+        browser_profile.mkdir()
+        (browser_profile / "Cookies").write_text("cookie-db")
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(session_module, "_clear_auth_files", return_value=[storage_file, browser_profile]),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "Logged out" in result.output
+
+    def test_auth_logout_is_noop_when_nothing_saved(self, runner, tmp_path):
+        """Test auth logout reports cleanly when there is nothing to remove."""
+        storage_file = tmp_path / "missing-storage.json"
+        browser_profile = tmp_path / "missing-browser-profile"
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
+            patch.object(session_module, "_clear_auth_files", return_value=[]),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "No saved auth state found" in result.output
 
     def test_status_json_output_no_context(self, runner, mock_context_file):
         """Test status --json outputs valid JSON when no context."""

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -665,7 +665,9 @@ class TestAuthCommands:
         with (
             patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
             patch("notebooklm.cli.session.get_browser_profile_dir", return_value=browser_profile),
-            patch.object(session_module, "_clear_auth_files", return_value=[storage_file, browser_profile]),
+            patch.object(
+                session_module, "_clear_auth_files", return_value=[storage_file, browser_profile]
+            ),
         ):
             result = runner.invoke(cli, ["auth", "logout"])
 

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -654,6 +654,30 @@ class TestStatusCommand:
 
 
 class TestAuthCommands:
+    def test_clear_auth_files_ignores_concurrent_file_removal(self, tmp_path):
+        """_clear_auth_files should tolerate a benign delete race."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text("{}")
+        browser_profile = tmp_path / "browser_profile"
+        browser_profile.mkdir()
+
+        original_unlink = Path.unlink
+        call_count = 0
+
+        def flaky_unlink(self, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if self == storage_file and call_count == 1:
+                original_unlink(storage_file, missing_ok=True)
+                raise FileNotFoundError
+            return original_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", new=flaky_unlink):
+            removed = session_module._clear_auth_files(storage_file, browser_profile)
+
+        assert removed == [browser_profile]
+        assert not browser_profile.exists()
+
     def test_auth_logout_removes_profile_auth_files(self, runner, tmp_path):
         """Test auth logout deletes saved storage state and browser profile."""
         storage_file = tmp_path / "storage_state.json"

--- a/tests/unit/test_source_status.py
+++ b/tests/unit/test_source_status.py
@@ -218,8 +218,57 @@ class TestWaitUntilReady:
         # Check that intervals increase exponentially
         assert len(sleep_intervals) >= 2
         # With initial_interval=0.05 and backoff_factor=2.0:
-        # First sleep: 0.05, Second sleep: 0.10, Third sleep: 0.20
-        assert sleep_intervals[1] >= sleep_intervals[0] * 1.5
+
+
+class TestSourceUrlExtraction:
+    """Tests for URL extraction across source response shapes."""
+
+    @pytest.fixture
+    def sources_api(self):
+        core = MagicMock()
+        core.rpc_call = AsyncMock()
+        return SourcesAPI(core)
+
+    @pytest.mark.asyncio
+    async def test_list_extracts_youtube_url_from_metadata_slot_5(self, sources_api):
+        sources_api._core.rpc_call.return_value = [
+            [
+                None,
+                [
+                    [
+                        ["src_yt"],
+                        "YouTube Video",
+                        [None, None, [1710000000, 0], None, 9, ["https://youtube.com/watch?v=list-slot5", "vid", "channel"]],
+                        [None, SourceStatus.READY],
+                    ]
+                ]
+            ],
+        ]
+
+        sources = await sources_api.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].url == "https://youtube.com/watch?v=list-slot5"
+        assert sources[0].kind == "youtube"
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_extracts_youtube_url_from_metadata_slot_5(self, sources_api):
+        sources_api._core.rpc_call.return_value = [
+            [
+                ["src_yt"],
+                "YouTube Video",
+                [None, None, None, None, 9, ["https://youtube.com/watch?v=get-slot5", "vid", "channel"]],
+            ],
+            None,
+            None,
+            [["Transcript line 1", ["Transcript line 2"]]],
+        ]
+
+        source = await sources_api.get_fulltext("nb_123", "src_yt")
+
+        assert source.url == "https://youtube.com/watch?v=get-slot5"
+        assert source.kind == "youtube"
+        assert "Transcript line 1" in source.content
 
 
 class TestWaitForSources:

--- a/tests/unit/test_source_status.py
+++ b/tests/unit/test_source_status.py
@@ -238,10 +238,17 @@ class TestSourceUrlExtraction:
                     [
                         ["src_yt"],
                         "YouTube Video",
-                        [None, None, [1710000000, 0], None, 9, ["https://youtube.com/watch?v=list-slot5", "vid", "channel"]],
+                        [
+                            None,
+                            None,
+                            [1710000000, 0],
+                            None,
+                            9,
+                            ["https://youtube.com/watch?v=list-slot5", "vid", "channel"],
+                        ],
                         [None, SourceStatus.READY],
                     ]
-                ]
+                ],
             ],
         ]
 
@@ -257,7 +264,14 @@ class TestSourceUrlExtraction:
             [
                 ["src_yt"],
                 "YouTube Video",
-                [None, None, None, None, 9, ["https://youtube.com/watch?v=get-slot5", "vid", "channel"]],
+                [
+                    None,
+                    None,
+                    None,
+                    None,
+                    9,
+                    ["https://youtube.com/watch?v=get-slot5", "vid", "channel"],
+                ],
             ],
             None,
             None,

--- a/tests/unit/test_source_status.py
+++ b/tests/unit/test_source_status.py
@@ -215,8 +215,10 @@ class TestWaitUntilReady:
                 max_interval=1.0,
             )
 
-        # Check that intervals increase exponentially
-        assert len(sleep_intervals) >= 2
+        # Check that intervals grow with backoff
+        assert len(sleep_intervals) >= 3
+        assert sleep_intervals[1] > sleep_intervals[0]
+        assert sleep_intervals[2] > sleep_intervals[1]
         # With initial_interval=0.05 and backoff_factor=2.0:
 
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -160,6 +160,24 @@ class TestSource:
 
         assert source.kind == SourceType.YOUTUBE
         assert source.kind == "youtube"  # str enum comparison
+        assert source.url == "https://youtube.com/watch?v=abc"
+
+    def test_from_api_response_youtube_source_uses_youtube_metadata_slot(self):
+        """Test that YouTube sources can read the URL from metadata[5][0]."""
+        data = [
+            [
+                [
+                    ["src_yt"],
+                    "YouTube Video",
+                    [None, None, None, None, 9, ["https://youtube.com/watch?v=slot5", "slot5", "Channel"]],
+                ]
+            ]
+        ]
+
+        source = Source.from_api_response(data)
+
+        assert source.kind == SourceType.YOUTUBE
+        assert source.url == "https://youtube.com/watch?v=slot5"
 
     def test_from_api_response_web_page_source(self):
         """Test that web page sources are parsed with type code 5."""

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -169,7 +169,14 @@ class TestSource:
                 [
                     ["src_yt"],
                     "YouTube Video",
-                    [None, None, None, None, 9, ["https://youtube.com/watch?v=slot5", "slot5", "Channel"]],
+                    [
+                        None,
+                        None,
+                        None,
+                        None,
+                        9,
+                        ["https://youtube.com/watch?v=slot5", "slot5", "Channel"],
+                    ],
                 ]
             ]
         ]


### PR DESCRIPTION
## Summary
- fix source URL extraction to also read YouTube URLs from metadata slot `5`
- reuse the same extraction logic in `Source.from_api_response()`, `sources.list()`, and `sources.get_fulltext()`
- add regression tests covering YouTube URL parsing across nested source shapes and fulltext/list responses

## Testing
- `PYTHONPATH=src python3 -m pytest tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_sources_upload.py tests/unit/cli/test_source.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--fresh` flag to login to clear saved authentication state before starting
  * Added `auth logout` command to remove saved authentication/session files

* **Bug Fixes**
  * Improved login recovery/retry when the browser or page closes unexpectedly; suggests `login --fresh` on persistent failures
  * Maps permission errors during auth-file removal to user-facing messages; disallows logout when external auth env is set
  * Tightened storage argument validation for login

* **Refactor**
  * Centralized source URL extraction for more consistent parsing

* **Tests**
  * Expanded tests for URL extraction, login/logout flows, and retry/backoff behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->