### PR TITLE
fix(cli): replace union-with-None hints in CLI modules

### DIFF
--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -16,7 +16,7 @@ import json
 from collections.abc import Awaitable, Callable
 from functools import partial
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, Optional, Tuple, TypedDict
 
 import click
 
@@ -113,13 +113,13 @@ async def _download_artifacts_generic(
     artifact_kind: ArtifactType,
     file_extension: str,
     default_output_dir: str,
-    output_path: str | None,
-    notebook: str | None,
+    output_path: Optional[str],
+    notebook: Optional[str],
     latest: bool,
     earliest: bool,
     download_all: bool,
-    name: str | None,
-    artifact_id: str | None,
+    name: Optional[str],
+    artifact_id: Optional[str],
     json_output: bool,
     dry_run: bool,
     force: bool,
@@ -192,7 +192,7 @@ async def _download_artifacts_generic(
                 "mind-map": client.artifacts.download_mind_map,
                 "data-table": client.artifacts.download_data_table,
             }
-            download_fn: _DownloadFn | None = download_methods.get(artifact_type_name)
+            download_fn: Optional[_DownloadFn] = download_methods.get(artifact_type_name)
             if not download_fn:
                 raise ValueError(f"Unknown artifact type: {artifact_type_name}")
 
@@ -212,7 +212,7 @@ async def _download_artifacts_generic(
                 }
 
             # Helper for file conflict resolution
-            def _resolve_conflict(path: Path) -> tuple[Path | None, dict | None]:
+            def _resolve_conflict(path: Path) -> Tuple[Optional[Path], Optional[dict]]:
                 if not path.exists():
                     return path, None
 
@@ -782,10 +782,10 @@ def download_data_table(ctx, **kwargs):
 async def _download_interactive(
     ctx,
     artifact_type: str,
-    output_path: str | None,
-    notebook: str | None,
+    output_path: Optional[str],
+    notebook: Optional[str],
     output_format: str,
-    artifact_id: str | None,
+    artifact_id: Optional[str],
 ) -> str:
     """Download quiz or flashcard artifact.
 

--- a/src/notebooklm/cli/download_helpers.py
+++ b/src/notebooklm/cli/download_helpers.py
@@ -1,7 +1,7 @@
 """Helper functions for download commands."""
 
 import re
-from typing import TypedDict
+from typing import Optional, TypedDict
 
 # Reserve space for " (999)" suffix when handling duplicate filenames
 DUPLICATE_SUFFIX_RESERVE = 7
@@ -48,8 +48,8 @@ def select_artifact(
     artifacts: list[ArtifactDict],
     latest: bool = True,
     earliest: bool = False,
-    name: str | None = None,
-    artifact_id: str | None = None,
+    name: Optional[str] = None,
+    artifact_id: Optional[str] = None,
 ) -> tuple[ArtifactDict, str]:
     """
     Select an artifact from a list based on criteria.

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -15,7 +15,7 @@ Commands:
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, Optional
 
 import click
 
@@ -91,11 +91,11 @@ def calculate_backoff_delay(
 
 
 async def generate_with_retry(
-    generate_fn: Callable[[], Awaitable[GenerationStatus | None]],
+    generate_fn: Callable[[], Awaitable[Optional[GenerationStatus]]],
     max_retries: int,
     artifact_type: str,
     json_output: bool = False,
-) -> GenerationStatus | None:
+) -> Optional[GenerationStatus]:
     """Generate artifact with retry on rate limit.
 
     Retries the generation call with exponential backoff when rate limited.
@@ -134,7 +134,7 @@ async def generate_with_retry(
     return None
 
 
-def resolve_language(language: str | None) -> str:
+def resolve_language(language: Optional[str]) -> str:
     """Resolve language from CLI flag, config, or default.
 
     Priority: CLI flag > config file > "en" default.
@@ -163,7 +163,7 @@ async def handle_generation_result(
     wait: bool = False,
     json_output: bool = False,
     timeout: float = 300.0,
-) -> GenerationStatus | None:
+) -> Optional[GenerationStatus]:
     """Handle generation result with optional waiting and output formatting.
 
     Consolidates common pattern across all generate commands:
@@ -210,7 +210,7 @@ async def handle_generation_result(
         return result
 
     # Extract task_id from various result formats
-    task_id: str | None = None
+    task_id: Optional[str] = None
     status: Any = result
     if isinstance(result, GenerationStatus):
         task_id = result.task_id
@@ -234,7 +234,7 @@ async def handle_generation_result(
     return status if isinstance(status, GenerationStatus) else None
 
 
-def _extract_task_id(status: Any) -> str | None:
+def _extract_task_id(status: Any) -> Optional[str]:
     """Extract task ID from various status formats.
 
     Handles GenerationStatus objects, dicts with task_id/artifact_id keys,

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -15,7 +15,7 @@ import logging
 import os
 import time
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import click
 from rich.console import Console
@@ -42,7 +42,7 @@ _CLI_ARTIFACT_ALIASES = {
 }
 
 
-def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
+def cli_name_to_artifact_type(name: str) -> Optional[ArtifactType]:
     """Convert CLI artifact type name to ArtifactType enum.
 
     Args:
@@ -165,7 +165,7 @@ def get_auth_tokens(ctx) -> AuthTokens:
 # =============================================================================
 
 
-def _get_context_value(key: str) -> str | None:
+def _get_context_value(key: str) -> Optional[str]:
     """Read a single value from context.json."""
     context_file = get_context_path()
     if not context_file.exists():
@@ -185,7 +185,7 @@ def _get_context_value(key: str) -> str | None:
         return None
 
 
-def _set_context_value(key: str, value: str | None) -> None:
+def _set_context_value(key: str, value: Optional[str]) -> None:
     """Set or clear a single value in context.json."""
     context_file = get_context_path()
     if not context_file.exists():
@@ -207,16 +207,16 @@ def _set_context_value(key: str, value: str | None) -> None:
         logger.warning("Failed to write context file %s for key '%s': %s", context_file, key, e)
 
 
-def get_current_notebook() -> str | None:
+def get_current_notebook() -> Optional[str]:
     """Get the current notebook ID from context."""
     return _get_context_value("notebook_id")
 
 
 def set_current_notebook(
     notebook_id: str,
-    title: str | None = None,
-    is_owner: bool | None = None,
-    created_at: str | None = None,
+    title: Optional[str] = None,
+    is_owner: Optional[bool] = None,
+    created_at: Optional[str] = None,
 ):
     """Set the current notebook context.
 
@@ -226,7 +226,7 @@ def set_current_notebook(
     context_file = get_context_path()
     context_file.parent.mkdir(parents=True, exist_ok=True)
 
-    data: dict[str, str | bool] = {"notebook_id": notebook_id}
+    data: dict[str, Union[str, bool]] = {"notebook_id": notebook_id}
     if title:
         data["title"] = title
     if is_owner is not None:
@@ -244,12 +244,12 @@ def clear_context():
         context_file.unlink()
 
 
-def get_current_conversation() -> str | None:
+def get_current_conversation() -> Optional[str]:
     """Get the current conversation ID from context."""
     return _get_context_value("conversation_id")
 
 
-def set_current_conversation(conversation_id: str | None):
+def set_current_conversation(conversation_id: Optional[str]):
     """Set or clear the current conversation ID in context."""
     _set_context_value("conversation_id", conversation_id)
 
@@ -272,7 +272,7 @@ def validate_id(entity_id: str, entity_name: str = "ID") -> str:
     return entity_id.strip()
 
 
-def require_notebook(notebook_id: str | None) -> str:
+def require_notebook(notebook_id: Optional[str]) -> str:
     """Get notebook ID from argument or context, raise if neither.
 
     Args:
@@ -392,7 +392,7 @@ async def resolve_note_id(client, notebook_id: str, partial_id: str) -> str:
 
 async def resolve_source_ids(
     client, notebook_id: str, source_ids: tuple[str, ...]
-) -> list[str] | None:
+) -> Optional[list[str]]:
     """Resolve multiple partial source IDs to full IDs.
 
     Args:
@@ -542,7 +542,7 @@ def json_output_response(data: dict) -> None:
     click.echo(json.dumps(data, indent=2, default=str))
 
 
-def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
+def json_error_response(code: str, message: str, extra: Optional[dict] = None) -> None:
     """Print JSON error and exit (no colors for machine parsing).
 
     Args:
@@ -588,7 +588,7 @@ def display_research_sources(sources: list[dict], max_display: int = 10) -> None
         for src in sources[:max_display]:
             row = [src.get("title", "Untitled")[:50]]
             if has_types:
-                rt: int | None = src.get("result_type")
+                rt: Optional[int] = src.get("result_type")
                 label = (
                     _RESULT_TYPE_LABELS.get(rt, str(rt) if rt is not None else "")
                     if rt is not None

--- a/src/notebooklm/cli/skill.py
+++ b/src/notebooklm/cli/skill.py
@@ -3,6 +3,7 @@
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 import click
 
@@ -25,7 +26,7 @@ TARGETS = {
 SCOPES = ("user", "project")
 
 
-def get_skill_source_content() -> str | None:
+def get_skill_source_content() -> Optional[str]:
     """Read the skill source file from package data."""
     return get_agent_source_content("claude")
 
@@ -40,7 +41,7 @@ def get_package_version() -> str:
         return "unknown"
 
 
-def get_skill_version(skill_path: Path) -> str | None:
+def get_skill_version(skill_path: Path) -> Optional[str]:
     """Extract version from skill file header comment."""
     if not skill_path.exists():
         return None
@@ -91,7 +92,7 @@ def remove_empty_parents(skill_path: Path, scope: str) -> None:
         current = current.parent
 
 
-def get_installed_content(target: str, scope: str) -> str | None:
+def get_installed_content(target: str, scope: str) -> Optional[str]:
     """Read an installed skill file."""
     skill_path = get_skill_path(target, scope)
     if not skill_path.exists():


### PR DESCRIPTION
## Summary
- replace `X | None` annotations in CLI modules with `Optional[X]`
- update related annotations to `Tuple[...]` / `Union[...]` forms in the same paths
- keep behavior unchanged while making type-hint syntax compatible with older Python interpreters

## Files
- `src/notebooklm/cli/helpers.py`
- `src/notebooklm/cli/download.py`
- `src/notebooklm/cli/download_helpers.py`
- `src/notebooklm/cli/skill.py`
- `src/notebooklm/cli/generate.py`

Co-Authored-By: Oz <oz-agent@warp.dev>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type annotations across CLI modules to use consistent typing conventions, ensuring better code maintainability without any changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->