### PR TITLE
fix: preserve auth cookies across Google redirects

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -141,8 +141,8 @@ class ClientCore:
             self._http_client = httpx.AsyncClient(
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-                    "Cookie": self.auth.cookie_header,
                 },
+                cookies=self.auth.cookies,
                 timeout=timeout,
             )
 
@@ -171,7 +171,8 @@ class ClientCore:
         """
         if not self._http_client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
-        self._http_client.headers["Cookie"] = self.auth.cookie_header
+        self._http_client.cookies.clear()
+        self._http_client.cookies.update(self.auth.cookies)
 
     def _build_url(self, rpc_method: RPCMethod, source_path: str = "/") -> str:
         """Build the batchexecute URL for an RPC call.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -49,6 +49,7 @@ MINIMUM_REQUIRED_COOKIES = {"SID"}
 # Includes googleusercontent.com for authenticated media downloads
 ALLOWED_COOKIE_DOMAINS = {
     ".google.com",
+    "accounts.google.com",
     "notebooklm.google.com",
     ".googleusercontent.com",
 }
@@ -659,15 +660,9 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
         ValueError: If tokens cannot be extracted from response
     """
     logger.debug("Fetching CSRF and session tokens from NotebookLM")
-    cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            "https://notebooklm.google.com/",
-            headers={"Cookie": cookie_header},
-            follow_redirects=True,
-            timeout=30.0,
-        )
+    async with httpx.AsyncClient(cookies=cookies, follow_redirects=True, timeout=30.0) as client:
+        response = await client.get("https://notebooklm.google.com/")
         response.raise_for_status()
 
         final_url = str(response.url)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -68,6 +68,11 @@ class TestExtractCookies:
                     "value": "osid_value",
                     "domain": "notebooklm.google.com",
                 },
+                {
+                    "name": "ACCOUNT_CHOOSER",
+                    "value": "chooser_value",
+                    "domain": "accounts.google.com",
+                },
                 {"name": "OTHER", "value": "other_value", "domain": "other.com"},
             ]
         }
@@ -78,6 +83,7 @@ class TestExtractCookies:
         assert cookies["HSID"] == "hsid_value"
         assert cookies["__Secure-1PSID"] == "secure_value"
         assert cookies["OSID"] == "osid_value"
+        assert cookies["ACCOUNT_CHOOSER"] == "chooser_value"
         assert "OTHER" not in cookies
 
     def test_raises_if_missing_sid(self):
@@ -541,8 +547,8 @@ class TestFetchTokens:
             await fetch_tokens(cookies)
 
     @pytest.mark.asyncio
-    async def test_fetch_tokens_includes_cookie_header(self, httpx_mock: HTTPXMock):
-        """Test that fetch_tokens includes cookie header."""
+    async def test_fetch_tokens_includes_cookie_jar_cookies(self, httpx_mock: HTTPXMock):
+        """Test that fetch_tokens sends cookies via the client cookie jar."""
         html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
         httpx_mock.add_response(content=html.encode())
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -53,6 +53,45 @@ class TestNotebookLMClientInit:
 # =============================================================================
 
 
+class TestClientCoreCookies:
+    @pytest.mark.asyncio
+    async def test_open_uses_cookie_jar(self, mock_auth):
+        """Test ClientCore initializes httpx with auth cookies in the cookie jar."""
+        core = ClientCore(mock_auth)
+
+        await core.open()
+        try:
+            assert core._http_client is not None
+            assert core._http_client.headers.get("Cookie") is None
+            assert core._http_client.cookies.get("SID") == "test_sid"
+            assert core._http_client.cookies.get("HSID") == "test_hsid"
+        finally:
+            await core.close()
+
+    @pytest.mark.asyncio
+    async def test_update_auth_headers_refreshes_cookie_jar(self, mock_auth):
+        """Test auth refresh updates the cookie jar, not a raw Cookie header."""
+        core = ClientCore(mock_auth)
+
+        await core.open()
+        try:
+            core.auth = AuthTokens(
+                cookies={"SID": "new_sid", "SAPISID": "new_sapisid"},
+                csrf_token="new_csrf",
+                session_id="new_session",
+            )
+
+            core.update_auth_headers()
+
+            assert core._http_client is not None
+            assert core._http_client.headers.get("Cookie") is None
+            assert core._http_client.cookies.get("SID") == "new_sid"
+            assert core._http_client.cookies.get("SAPISID") == "new_sapisid"
+            assert core._http_client.cookies.get("HSID") is None
+        finally:
+            await core.close()
+
+
 class TestClientContextManager:
     @pytest.mark.asyncio
     async def test_context_manager_opens_and_closes(self, mock_auth):


### PR DESCRIPTION
## Summary
- switch auth bootstrap and core client setup from raw `Cookie` headers to httpx cookie jars
- keep `accounts.google.com` cookies when loading storage state so Google auth redirects stay authenticated
- add regression coverage for the new cookie handling paths

## Testing
- python3 -m pytest tests/unit/test_auth.py tests/unit/test_client.py -q
- python3 -m pytest tests/unit/cli/test_session.py -q

Closes #273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refactored HTTP cookie handling to use proper cookie jar management instead of manual header injection during authentication requests.
  * Extended supported authentication domains to include accounts.google.com for cookie extraction.

* **Tests**
  * Added comprehensive test coverage validating cookie jar initialization and authentication header updates in the client core.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->