### PR TITLE
fix(login): use sys.executable for Playwright subprocess calls

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -308,7 +308,7 @@ def _ensure_chromium_installed() -> None:
     """
     try:
         result = subprocess.run(
-            ["playwright", "install", "--dry-run", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "--dry-run", "chromium"],
             capture_output=True,
             text=True,
         )
@@ -319,14 +319,14 @@ def _ensure_chromium_installed() -> None:
 
         console.print("[yellow]Chromium browser not installed. Installing now...[/yellow]")
         install_result = subprocess.run(
-            ["playwright", "install", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "chromium"],
             capture_output=True,
             text=True,
         )
         if install_result.returncode != 0:
             console.print(
                 "[red]Failed to install Chromium browser.[/red]\n"
-                "Run manually: playwright install chromium"
+                f"Run manually: {sys.executable} -m playwright install chromium"
             )
             raise SystemExit(1)
         console.print("[green]Chromium installed successfully.[/green]\n")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -326,7 +326,7 @@ def _ensure_chromium_installed() -> None:
         if install_result.returncode != 0:
             console.print(
                 "[red]Failed to install Chromium browser.[/red]\n"
-                f"Run manually: {sys.executable} -m playwright install chromium"
+                f'Run manually: "{sys.executable}" -m playwright install chromium'
             )
             raise SystemExit(1)
         console.print("[green]Chromium installed successfully.[/green]\n")


### PR DESCRIPTION
## Summary

Replace bare `playwright` command in `_ensure_chromium_installed()` with `sys.executable -m playwright` to ensure the correct Python environment's Playwright is invoked.

Fixes #278

## Changes

- Use `[sys.executable, "-m", "playwright", ...]` for the dry-run Chromium check
- Use `[sys.executable, "-m", "playwright", ...]` for the auto-install command
- Update the manual install instruction in the error message to match

## Why

When notebooklm-py is installed in a virtualenv or via pipx, the `playwright` CLI entry point may not be on `$PATH`. The current code calls `subprocess.run(["playwright", ...])`, which raises `FileNotFoundError` — caught silently, but avoidable.

Using `sys.executable -m playwright` is the standard Python pattern (used by pip, pytest, etc.) and guarantees the subprocess uses the same Python interpreter that's running the package.

## Related Issue

#278

## Test Plan

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [ ] `mypy` (running locally)
- [ ] `pytest` (running locally)

### Manual test

Verified on macOS 15.3, Python 3.12 in a virtualenv where `playwright` is not on PATH:
- Before: `Warning: Chromium pre-flight check failed: [Errno 2] No such file or directory: 'playwright'`
- After: Pre-flight check completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chromium pre-install now runs via the app's Python runtime to improve installation reliability.
  * Installation failure messages now display the exact python -m playwright install chromium command for clearer manual recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->