### PR TITLE
fix: run playwright preflight via current python

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -301,14 +301,16 @@ def _windows_playwright_event_loop() -> Iterator[None]:
 def _ensure_chromium_installed() -> None:
     """Check if Chromium is installed and install if needed.
 
-    This pre-flight check runs `playwright install --dry-run chromium` to detect
-    if the browser needs installation, then auto-installs if necessary.
+    This pre-flight check runs `python -m playwright install --dry-run chromium`
+    to detect if the browser needs installation, then auto-installs if necessary.
 
     Silently proceeds on any errors - Playwright will handle them during launch.
     """
+    playwright_cmd = [sys.executable, "-m", "playwright"]
+
     try:
         result = subprocess.run(
-            ["playwright", "install", "--dry-run", "chromium"],
+            [*playwright_cmd, "install", "--dry-run", "chromium"],
             capture_output=True,
             text=True,
         )
@@ -319,22 +321,21 @@ def _ensure_chromium_installed() -> None:
 
         console.print("[yellow]Chromium browser not installed. Installing now...[/yellow]")
         install_result = subprocess.run(
-            ["playwright", "install", "chromium"],
+            [*playwright_cmd, "install", "chromium"],
             capture_output=True,
             text=True,
         )
         if install_result.returncode != 0:
             console.print(
                 "[red]Failed to install Chromium browser.[/red]\n"
-                "Run manually: playwright install chromium"
+                f"Run manually: {sys.executable} -m playwright install chromium"
             )
             raise SystemExit(1)
         console.print("[green]Chromium installed successfully.[/green]\n")
     except SystemExit:
         raise
     except Exception as e:
-        # FileNotFoundError: playwright CLI not found but sync_playwright imported
-        # Other exceptions: dry-run check failed - let Playwright handle it during launch
+        # Other exceptions: dry-run check failed - let Playwright handle them during launch
         console.print(
             f"[dim]Warning: Chromium pre-flight check failed: {e}. Proceeding anyway.[/dim]"
         )

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1,6 +1,7 @@
 """Tests for session CLI commands (login, use, status, clear)."""
 
 import json
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -48,6 +49,54 @@ def mock_context_file(tmp_path):
 # =============================================================================
 # LOGIN COMMAND TESTS
 # =============================================================================
+
+
+class TestChromiumPreflight:
+    def test_ensure_chromium_installed_uses_current_python(self):
+        """Use the current Python env so venv/pipx installs work without PATH hacks."""
+        from notebooklm.cli.session import _ensure_chromium_installed
+
+        dry_run = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch("notebooklm.cli.session.subprocess.run", return_value=dry_run) as mock_run:
+            _ensure_chromium_installed()
+
+        mock_run.assert_called_once_with(
+            [sys.executable, "-m", "playwright", "install", "--dry-run", "chromium"],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_ensure_chromium_installed_uses_current_python_for_install(self):
+        """Auto-install should reuse the same interpreter as the running CLI."""
+        from notebooklm.cli.session import _ensure_chromium_installed
+
+        dry_run = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="chromium will download if not already installed",
+            stderr="",
+        )
+        install = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with patch(
+            "notebooklm.cli.session.subprocess.run", side_effect=[dry_run, install]
+        ) as mock_run:
+            _ensure_chromium_installed()
+
+        assert mock_run.call_args_list[0].args[0] == [
+            sys.executable,
+            "-m",
+            "playwright",
+            "install",
+            "--dry-run",
+            "chromium",
+        ]
+        assert mock_run.call_args_list[1].args[0] == [
+            sys.executable,
+            "-m",
+            "playwright",
+            "install",
+            "chromium",
+        ]
 
 
 class TestLoginCommand:


### PR DESCRIPTION
## Summary
- run Chromium pre-flight checks via  instead of a bare  binary
- keep the auto-install path on the same interpreter and update the manual fallback hint
- add regression coverage for both dry-run and install commands

## Testing
- ....................................................................     [100%]
68 passed in 0.38s

Closes #278.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chromium installation process to use the current Python interpreter for better compatibility and reliability.
  * Enhanced error messages to provide clearer guidance when installation issues occur.

* **Tests**
  * Added comprehensive test coverage for the Chromium installation preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->