### PR TITLE
fix: extract YouTube source URLs from index [2][5]

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -102,12 +102,25 @@ class SourcesAPI:
                 src_id = src[0][0] if isinstance(src[0], list) else src[0]
                 title = src[1] if len(src) > 1 else None
 
-                # Extract URL if present (at src[2][7])
+                # Extract URL if present
+                # Web/PDF sources store URL at src[2][7]
+                # YouTube sources store URL at src[2][5][0]
+                # Some sources store URL at src[2][0]
                 url = None
-                if len(src) > 2 and isinstance(src[2], list) and len(src[2]) > 7:
-                    url_list = src[2][7]
-                    if isinstance(url_list, list) and len(url_list) > 0:
-                        url = url_list[0]
+                if len(src) > 2 and isinstance(src[2], list):
+                    if len(src[2]) > 7 and isinstance(src[2][7], list) and len(src[2][7]) > 0:
+                        url = src[2][7][0]
+                    if not url and len(src[2]) > 5:
+                        yt_data = src[2][5]
+                        if (
+                            isinstance(yt_data, list)
+                            and len(yt_data) > 0
+                            and isinstance(yt_data[0], str)
+                        ):
+                            url = yt_data[0]
+                    if not url and len(src[2]) > 0:
+                        if isinstance(src[2][0], str) and src[2][0].startswith("http"):
+                            url = src[2][0]
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]
                 created_at = None

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -583,10 +583,22 @@ class Source:
                     title = entry[1] if len(entry) > 1 else None
 
                     # Try to extract URL if present
+                    # Web/PDF at [2][7], YouTube at [2][5][0], fallback at [2][0]
                     url = None
                     if len(entry) > 2 and isinstance(entry[2], list):
                         if len(entry[2]) > 7 and isinstance(entry[2][7], list):
                             url = entry[2][7][0] if entry[2][7] else None
+                        if not url and len(entry[2]) > 5:
+                            yt_data = entry[2][5]
+                            if (
+                                isinstance(yt_data, list)
+                                and len(yt_data) > 0
+                                and isinstance(yt_data[0], str)
+                            ):
+                                url = yt_data[0]
+                        if not url and len(entry[2]) > 0:
+                            if isinstance(entry[2][0], str) and entry[2][0].startswith("http"):
+                                url = entry[2][0]
 
                     return cls(id=str(source_id), title=title, url=url, _type_code=None)
 
@@ -598,6 +610,14 @@ class Source:
                         url_list = entry[2][7]
                         if isinstance(url_list, list) and len(url_list) > 0:
                             url = url_list[0]
+                    if not url and len(entry[2]) > 5:
+                        yt_data = entry[2][5]
+                        if (
+                            isinstance(yt_data, list)
+                            and len(yt_data) > 0
+                            and isinstance(yt_data[0], str)
+                        ):
+                            url = yt_data[0]
                     if not url and len(entry[2]) > 0:
                         if isinstance(entry[2][0], str) and entry[2][0].startswith("http"):
                             url = entry[2][0]

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -951,6 +951,52 @@ class TestListSourcesParsingEdgeCases:
         assert sources[0].url is None
 
     @pytest.mark.asyncio
+    async def test_list_sources_youtube_url_at_index5(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Test list() extracts YouTube URL from src[2][5][0].
+
+        YouTube sources store URL data at src[2][5] as [url, video_id, channel]
+        and src[2][7] is null. Fixes #265.
+        """
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Notebook Title",
+                    [
+                        [
+                            ["src_yt"],
+                            "YouTube Video",
+                            [
+                                None,
+                                11,
+                                [1704067200, 0],
+                                None,
+                                9,
+                                ["https://www.youtube.com/watch?v=abc123", "abc123", "channel"],
+                                None,
+                                None,
+                            ],
+                            [None, 2],
+                        ]
+                    ],
+                    "nb_123",
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].url == "https://www.youtube.com/watch?v=abc123"
+
+    @pytest.mark.asyncio
     async def test_list_sources_timestamp_invalid(
         self,
         auth_tokens,

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -161,6 +161,41 @@ class TestSource:
         assert source.kind == SourceType.YOUTUBE
         assert source.kind == "youtube"  # str enum comparison
 
+    def test_from_api_response_youtube_source_url_at_index5(self):
+        """Test YouTube URL extraction from index [2][5] (real API structure).
+
+        In the real API, YouTube sources store URL data at src[2][5] as
+        [url, video_id, channel_name] and src[2][7] is null.
+        Fixes https://github.com/teng-lin/notebooklm-py/issues/265
+        """
+        data = [
+            [
+                [
+                    ["src_yt2"],
+                    "YouTube Video Real",
+                    [
+                        None,
+                        None,
+                        None,
+                        None,
+                        9,
+                        [
+                            "https://www.youtube.com/watch?v=dcWU-qD8ISQ",
+                            "dcWU-qD8ISQ",
+                            "john newquist",
+                        ],
+                        None,
+                        None,
+                    ],
+                ]
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.id == "src_yt2"
+        assert source.url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
+        assert source.kind == SourceType.YOUTUBE
+
     def test_from_api_response_web_page_source(self):
         """Test that web page sources are parsed with type code 5."""
         data = [


### PR DESCRIPTION
## Summary
- Fixes #265: `Source.url` is always `None` for YouTube sources
- YouTube sources store URL data at `src[2][5]` as `[url, video_id, channel_name]` while `src[2][7]` is `null`
- Adds YouTube URL fallback (`[2][5]`) in all three extraction paths: `SourcesAPI.list()`, and both nested formats in `Source.from_api_response()`

## Test plan
- [x] New unit test: `test_from_api_response_youtube_source_url_at_index5` — verifies deeply nested YouTube URL extraction
- [x] New integration test: `test_list_sources_youtube_url_at_index5` — verifies `list()` extracts YouTube URL from `src[2][5]`
- [x] Existing YouTube tests still pass (URL at `[7]` path unchanged)
- [x] Full test suite: 2015 passed, 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source URL extraction to reliably detect and parse URLs from YouTube, web, PDF, and other source types
  * Enhanced handling of multiple API response data structures with intelligent fallback mechanisms for consistent URL retrieval
  * Strengthened URL detection logic to support various source format variations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->