### PR TITLE
feat: add language and instructions support for mind maps

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -988,6 +988,8 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
+        language: str = "en",
+        instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map.
 
@@ -997,6 +999,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
+            language: Language code (default: "en").
+            instructions: Custom instructions for mind map generation.
 
         Returns:
             Dictionary with 'mind_map' (JSON data) and 'note_id'.
@@ -1014,7 +1018,7 @@ class ArtifactsAPI:
             None,
             None,
             None,
-            ["interactive_mindmap", [["[CONTEXT]", ""]], ""],
+            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
             None,
             [2, None, [1]],
         ]

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -995,13 +995,19 @@ def generate_data_table(
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
+@click.option("--language", "-l", default="en", help="Language code (default: en)")
+@click.option("--instructions", "-i", default=None, help="Custom instructions for mind map")
 @json_option
 @with_client
-def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
+def generate_mind_map(
+    ctx, notebook_id, source_ids, language, instructions, json_output, client_auth
+):
     """Generate mind map.
 
     \b
     Use --json for machine-readable output.
+    Use --language to set the output language (default: en).
+    Use --instructions to provide custom instructions.
     """
     nb_id = require_notebook(notebook_id)
 
@@ -1013,12 +1019,18 @@ def generate_mind_map(ctx, notebook_id, source_ids, json_output, client_auth):
             # Show status spinner only for console output
             if json_output:
                 result = await client.artifacts.generate_mind_map(
-                    nb_id_resolved, source_ids=sources
+                    nb_id_resolved,
+                    source_ids=sources,
+                    language=language,
+                    instructions=instructions,
                 )
             else:
                 with console.status("Generating mind map..."):
                     result = await client.artifacts.generate_mind_map(
-                        nb_id_resolved, source_ids=sources
+                        nb_id_resolved,
+                        source_ids=sources,
+                        language=language,
+                        instructions=instructions,
                     )
 
             _output_mind_map_result(result, json_output)

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -995,7 +995,9 @@ def generate_data_table(
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
-@click.option("--language", "-l", default="en", help="Language code (default: en)")
+@click.option(
+    "--language", "-l", default=None, help="Output language (default: from config or 'en')"
+)
 @click.option("--instructions", "-i", default=None, help="Custom instructions for mind map")
 @json_option
 @with_client
@@ -1006,7 +1008,7 @@ def generate_mind_map(
 
     \b
     Use --json for machine-readable output.
-    Use --language to set the output language (default: en).
+    Use --language to set the output language (default: from config or 'en').
     Use --instructions to provide custom instructions.
     """
     nb_id = require_notebook(notebook_id)
@@ -1015,13 +1017,14 @@ def generate_mind_map(
         async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            resolved_language = resolve_language(language)
 
             # Show status spinner only for console output
             if json_output:
                 result = await client.artifacts.generate_mind_map(
                     nb_id_resolved,
                     source_ids=sources,
-                    language=language,
+                    language=resolved_language,
                     instructions=instructions,
                 )
             else:
@@ -1029,7 +1032,7 @@ def generate_mind_map(
                     result = await client.artifacts.generate_mind_map(
                         nb_id_resolved,
                         source_ids=sources,
-                        language=language,
+                        language=resolved_language,
                         instructions=instructions,
                     )
 


### PR DESCRIPTION
## Summary
- Fixes #250: `generate_mind_map()` now accepts `language` and `instructions` parameters
- Passes `language` at `params[5][2]` and `instructions` at `params[5][1][0][1]` in the RPC payload, consistent with other generation methods
- CLI `generate mind-map` now exposes `--language`/`-l` and `--instructions`/`-i` flags

## Test plan
- [x] Lint, format, type check all pass
- [x] Full test suite: 2013 passed, 9 skipped
- [ ] Manual: `notebooklm generate mind-map --language ja --instructions "Focus on key concepts"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mind-map generation now supports language selection (English default).
  * Users can provide custom instructions to tailor mind-map generation.
  * Command-line generation includes new options to set language and pass instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->