### PR TITLE
fix: use sys.executable for Playwright subprocess calls

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -326,7 +326,7 @@ def _ensure_chromium_installed() -> None:
         if install_result.returncode != 0:
             console.print(
                 "[red]Failed to install Chromium browser.[/red]\n"
-                "Run manually: playwright install chromium"
+                "Run manually: python -m playwright install chromium"
             )
             raise SystemExit(1)
         console.print("[green]Chromium installed successfully.[/green]\n")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -308,7 +308,7 @@ def _ensure_chromium_installed() -> None:
     """
     try:
         result = subprocess.run(
-            ["playwright", "install", "--dry-run", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "--dry-run", "chromium"],
             capture_output=True,
             text=True,
         )
@@ -319,7 +319,7 @@ def _ensure_chromium_installed() -> None:
 
         console.print("[yellow]Chromium browser not installed. Installing now...[/yellow]")
         install_result = subprocess.run(
-            ["playwright", "install", "chromium"],
+            [sys.executable, "-m", "playwright", "install", "chromium"],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
## Summary
- Fixes #278: Playwright pre-flight check fails when CLI is not on PATH (virtualenv/pipx)
- Replaces bare `playwright` with `sys.executable -m playwright` in both subprocess calls
- Standard Python pattern for invoking package CLI tools, consistent with pip/pytest

## Test plan
- [x] Lint, format, type check all pass
- [x] Full test suite: 2013 passed, 9 skipped
- [ ] Manual: run `notebooklm login` via `.venv/bin/notebooklm` without activating venv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Chromium installation in the CLI by invoking Playwright via the current Python interpreter.
  * Updated the manual installation hint to recommend `python -m playwright install chromium` for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->