### PR TITLE
fix: deduplicate sources on research import retry

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -119,9 +119,9 @@ async def import_with_retry(
                     if not json_output:
                         console.print("[green]All sources already imported.[/green]")
                     return []
-            except Exception:
+            except Exception as exc:
                 # If listing fails, retry with current pending list
-                pass
+                logger.debug("Failed to list existing sources for deduplication: %s", exc)
 
             sleep_for = min(delay, max_delay, remaining)
             logger.warning(

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -90,34 +90,53 @@ async def import_with_retry(
 ) -> list[dict[str, str]]:
     """Retry research import on RPC timeouts with exponential backoff.
 
+    On retry, already-imported sources are filtered out to prevent duplicates.
+
     This is intentionally CLI-only policy. Library consumers calling
     `client.research.import_sources()` directly still get one-shot behavior.
     """
     started_at = time.monotonic()
     delay = initial_delay
     attempt = 1
+    pending_sources = list(sources)
 
     while True:
         try:
-            return await client.research.import_sources(notebook_id, task_id, sources)
+            return await client.research.import_sources(notebook_id, task_id, pending_sources)
         except RPCTimeoutError:
             elapsed = time.monotonic() - started_at
             remaining = max_elapsed - elapsed
             if remaining <= 0:
                 raise
 
+            # Filter out already-imported sources to prevent duplicates
+            try:
+                existing = await client.sources.list(notebook_id)
+                existing_urls = {s.url for s in existing if s.url}
+                pending_sources = [s for s in pending_sources if s.get("url") not in existing_urls]
+                if not pending_sources:
+                    logger.info("All sources already imported; no retry needed")
+                    if not json_output:
+                        console.print("[green]All sources already imported.[/green]")
+                    return []
+            except Exception:
+                # If listing fails, retry with current pending list
+                pass
+
             sleep_for = min(delay, max_delay, remaining)
             logger.warning(
-                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs (attempt %d, %.1fs elapsed)",
+                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs "
+                "(attempt %d, %.1fs elapsed, %d sources remaining)",
                 notebook_id,
                 sleep_for,
                 attempt + 1,
                 elapsed,
+                len(pending_sources),
             )
             if not json_output:
                 console.print(
                     f"[yellow]Import timed out; retrying in {sleep_for:.0f}s "
-                    f"(attempt {attempt + 1})[/yellow]"
+                    f"(attempt {attempt + 1}, {len(pending_sources)} remaining)[/yellow]"
                 )
             await asyncio.sleep(sleep_for)
             delay = min(delay * backoff_factor, max_delay)


### PR DESCRIPTION
## Summary
- Fixes #241: `research wait --import-all` imports duplicate sources on timeout retry
- Before each retry, fetches existing notebook sources and filters out already-imported URLs
- If all sources are already imported, skips retry entirely and returns early
- Gracefully falls back to retrying with the current list if source listing fails

## Test plan
- [x] Lint, format, type check all pass
- [x] Full test suite: 2013 passed, 9 skipped
- [ ] Manual: trigger timeout during large import and verify no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source import resilience: retries now skip sources already imported to prevent duplicates.
  * Better timeout recovery: if checking existing imports fails, import retries continue without blocking.
  * Enhanced status feedback: CLI/log messages now report the number of remaining pending sources during retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->