### PR TITLE
fix(auth): replace raw Cookie header with httpx cookie jar

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -138,11 +138,18 @@ class ClientCore:
                 write=self._timeout,
                 pool=self._timeout,
             )
+            # Use httpx cookie jar instead of raw Cookie header.
+            # Raw headers are dropped on cross-domain redirects, which breaks
+            # auth when Google redirects to accounts.google.com (#273).
+            jar = httpx.Cookies()
+            for name, value in self.auth.cookies.items():
+                jar.set(name, value, domain=".google.com")
+
             self._http_client = httpx.AsyncClient(
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-                    "Cookie": self.auth.cookie_header,
                 },
+                cookies=jar,
                 timeout=timeout,
             )
 
@@ -161,7 +168,7 @@ class ClientCore:
         return self._http_client is not None
 
     def update_auth_headers(self) -> None:
-        """Update HTTP client headers with current auth tokens.
+        """Update HTTP client cookies with current auth tokens.
 
         Call this after modifying auth tokens (e.g., after refresh_auth())
         to ensure the HTTP client uses the updated credentials.
@@ -171,7 +178,10 @@ class ClientCore:
         """
         if not self._http_client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
-        self._http_client.headers["Cookie"] = self.auth.cookie_header
+        jar = httpx.Cookies()
+        for name, value in self.auth.cookies.items():
+            jar.set(name, value, domain=".google.com")
+        self._http_client.cookies = jar
 
     def _build_url(self, rpc_method: RPCMethod, source_path: str = "/") -> str:
         """Build the batchexecute URL for an RPC call.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -138,18 +138,11 @@ class ClientCore:
                 write=self._timeout,
                 pool=self._timeout,
             )
-            # Use httpx cookie jar instead of raw Cookie header.
-            # Raw headers are dropped on cross-domain redirects, which breaks
-            # auth when Google redirects to accounts.google.com (#273).
-            jar = httpx.Cookies()
-            for name, value in self.auth.cookies.items():
-                jar.set(name, value, domain=".google.com")
-
             self._http_client = httpx.AsyncClient(
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
                 },
-                cookies=jar,
+                cookies=self.auth.to_cookie_jar(),
                 timeout=timeout,
             )
 
@@ -178,10 +171,8 @@ class ClientCore:
         """
         if not self._http_client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
-        jar = httpx.Cookies()
         for name, value in self.auth.cookies.items():
-            jar.set(name, value, domain=".google.com")
-        self._http_client.cookies = jar
+            self._http_client.cookies.set(name, value, domain=".google.com")
 
     def _build_url(self, rpc_method: RPCMethod, source_path: str = "/") -> str:
         """Build the batchexecute URL for an RPC call.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -164,6 +164,18 @@ class AuthTokens:
         """
         return "; ".join(f"{k}={v}" for k, v in self.cookies.items())
 
+    def to_cookie_jar(self) -> "httpx.Cookies":
+        """Create an httpx cookie jar from auth cookies.
+
+        Uses httpx.Cookies instead of raw Cookie headers so that cookies
+        are correctly sent on cross-domain redirects (e.g., when Google
+        redirects to accounts.google.com to refresh short-lived cookies).
+
+        Returns:
+            httpx.Cookies jar with all auth cookies set on .google.com domain.
+        """
+        return _build_cookie_jar(self.cookies)
+
     @classmethod
     async def from_storage(
         cls, path: Path | None = None, profile: str | None = None
@@ -642,6 +654,19 @@ def load_httpx_cookies(path: Path | None = None) -> "httpx.Cookies":
     return cookies
 
 
+def _build_cookie_jar(cookies: dict[str, str]) -> httpx.Cookies:
+    """Build an httpx cookie jar from a flat cookies dict.
+
+    Uses httpx.Cookies instead of raw Cookie headers so that cookies
+    are correctly sent on cross-domain redirects (e.g., when Google
+    redirects to accounts.google.com to refresh short-lived cookies).
+    """
+    jar = httpx.Cookies()
+    for name, value in cookies.items():
+        jar.set(name, value, domain=".google.com")
+    return jar
+
+
 async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
     """Fetch CSRF token and session ID from NotebookLM homepage.
 
@@ -660,13 +685,7 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
     """
     logger.debug("Fetching CSRF and session tokens from NotebookLM")
 
-    # Use httpx cookie jar instead of raw Cookie header.
-    # Raw headers are dropped on cross-domain redirects (e.g., when Google
-    # redirects to accounts.google.com to refresh short-lived cookies).
-    # The cookie jar correctly sends domain-appropriate cookies on redirects.
-    jar = httpx.Cookies()
-    for name, value in cookies.items():
-        jar.set(name, value, domain=".google.com")
+    jar = _build_cookie_jar(cookies)
 
     async with httpx.AsyncClient(cookies=jar) as client:
         response = await client.get(

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -659,12 +659,18 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
         ValueError: If tokens cannot be extracted from response
     """
     logger.debug("Fetching CSRF and session tokens from NotebookLM")
-    cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
-    async with httpx.AsyncClient() as client:
+    # Use httpx cookie jar instead of raw Cookie header.
+    # Raw headers are dropped on cross-domain redirects (e.g., when Google
+    # redirects to accounts.google.com to refresh short-lived cookies).
+    # The cookie jar correctly sends domain-appropriate cookies on redirects.
+    jar = httpx.Cookies()
+    for name, value in cookies.items():
+        jar.set(name, value, domain=".google.com")
+
+    async with httpx.AsyncClient(cookies=jar) as client:
         response = await client.get(
             "https://notebooklm.google.com/",
-            headers={"Cookie": cookie_header},
             follow_redirects=True,
             timeout=30.0,
         )


### PR DESCRIPTION
## Summary
- Fixes #273: Auth fails after ~10 min due to raw Cookie header being dropped on cross-domain redirects
- Replaces raw `Cookie:` header with `httpx.Cookies` cookie jar in `fetch_tokens()` and `ClientCore.open()`
- Also updates `update_auth_headers()` to use cookie jar for consistency
- The cookie jar correctly sends domain-appropriate cookies when Google redirects to `accounts.google.com`

## Test plan
- [x] Lint, format, type check all pass
- [x] Full test suite: 2013 passed, 9 skipped
- [ ] Manual: verify auth survives >10 min sessions without re-login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched authentication to use a proper cookie jar instead of injecting raw cookie headers.
  * Token fetching now leverages the cookie jar for requests, removing manual header manipulation.
  * Results in more reliable and compatible authentication handling across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->