### PR TITLE
feat(auth): add logout command and --fresh flag for login

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -368,7 +368,13 @@ def register_session_commands(cli):
             "Requires: pip install 'notebooklm[cookies]'"
         ),
     )
-    def login(storage, browser, browser_cookies):
+    @click.option(
+        "--fresh",
+        is_flag=True,
+        default=False,
+        help="Clear cached browser profile before login (use to switch Google accounts).",
+    )
+    def login(storage, browser, browser_cookies, fresh):
         """Log in to NotebookLM via browser.
 
         Opens a browser window for Google login. After logging in,
@@ -399,6 +405,18 @@ def register_session_commands(cli):
 
         storage_path = Path(storage) if storage else get_storage_path()
         browser_profile = get_browser_profile_dir()
+
+        # Clear cached browser profile to allow switching Google accounts
+        if fresh:
+            import shutil
+
+            if browser_profile.exists():
+                shutil.rmtree(browser_profile)
+                console.print("[yellow]Cleared cached browser profile.[/yellow]")
+            if storage_path.exists():
+                storage_path.unlink()
+                console.print("[yellow]Cleared saved auth state.[/yellow]")
+
         if sys.platform == "win32":
             # On Windows < Python 3.13, mode= is ignored by mkdir(). On
             # Python 3.13+, mode= applies Windows ACLs that can be overly
@@ -948,3 +966,32 @@ def register_session_commands(cli):
             console.print(
                 "\n[yellow]Cookies may be expired. Run 'notebooklm login' to refresh.[/yellow]"
             )
+
+    @auth_group.command("logout")
+    def auth_logout():
+        """Log out by clearing saved auth state and browser profile.
+
+        Removes the storage_state.json and the cached browser profile
+        for the current profile. After logout, run 'notebooklm login'
+        to authenticate with a different account.
+        """
+        import shutil
+
+        storage_path = get_storage_path()
+        browser_profile = get_browser_profile_dir()
+
+        cleared = False
+        if storage_path.exists():
+            storage_path.unlink()
+            console.print("[green]Removed auth state.[/green]")
+            cleared = True
+        if browser_profile.exists():
+            shutil.rmtree(browser_profile)
+            console.print("[green]Removed cached browser profile.[/green]")
+            cleared = True
+
+        if cleared:
+            console.print("\n[green]Logged out successfully.[/green]")
+            console.print("[dim]Run 'notebooklm login' to sign in again.[/dim]")
+        else:
+            console.print("[yellow]No auth state found — already logged out.[/yellow]")


### PR DESCRIPTION
## Summary
- Fixes #246: Cannot switch Google accounts due to cached browser profile
- Adds `notebooklm auth logout` command — clears both `storage_state.json` and browser profile
- Adds `notebooklm login --fresh` flag — clears cached browser profile before login to allow account switching

## Usage
```bash
# Switch accounts: logout then login
notebooklm auth logout
notebooklm login

# Or use --fresh to clear and login in one step
notebooklm login --fresh
```

## Test plan
- [x] Lint, format, type check all pass
- [x] Full test suite: 2013 passed, 9 skipped
- [x] `notebooklm login --help` shows `--fresh` flag
- [x] `notebooklm auth logout --help` shows correct usage
- [ ] Manual: `notebooklm login --fresh` allows switching to a different Google account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--fresh` flag to login command to reset cached browser profile and authentication state before logging in
  * Added `auth logout` command to clear all authentication and cached browser data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->