### PR TITLE
fix(cli): dedupe sources before IMPORT_RESEARCH retry (closes #241)

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -90,34 +90,53 @@ async def import_with_retry(
 ) -> list[dict[str, str]]:
     """Retry research import on RPC timeouts with exponential backoff.
 
+    On retry, already-imported sources are filtered out to prevent duplicates.
+
     This is intentionally CLI-only policy. Library consumers calling
     `client.research.import_sources()` directly still get one-shot behavior.
     """
     started_at = time.monotonic()
     delay = initial_delay
     attempt = 1
+    pending_sources = list(sources)
 
     while True:
         try:
-            return await client.research.import_sources(notebook_id, task_id, sources)
+            return await client.research.import_sources(notebook_id, task_id, pending_sources)
         except RPCTimeoutError:
             elapsed = time.monotonic() - started_at
             remaining = max_elapsed - elapsed
             if remaining <= 0:
                 raise
 
+            # Filter out already-imported sources to prevent duplicates
+            try:
+                existing = await client.sources.list(notebook_id)
+                existing_urls = {s.url for s in existing if s.url}
+                pending_sources = [s for s in pending_sources if s.get("url") not in existing_urls]
+                if not pending_sources:
+                    logger.info("All sources already imported; no retry needed")
+                    if not json_output:
+                        console.print("[green]All sources already imported.[/green]")
+                    return []
+            except Exception as exc:
+                # If listing fails, retry with current pending list
+                logger.debug("Failed to list existing sources for deduplication: %s", exc)
+
             sleep_for = min(delay, max_delay, remaining)
             logger.warning(
-                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs (attempt %d, %.1fs elapsed)",
+                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs "
+                "(attempt %d, %.1fs elapsed, %d sources remaining)",
                 notebook_id,
                 sleep_for,
                 attempt + 1,
                 elapsed,
+                len(pending_sources),
             )
             if not json_output:
                 console.print(
                     f"[yellow]Import timed out; retrying in {sleep_for:.0f}s "
-                    f"(attempt {attempt + 1})[/yellow]"
+                    f"(attempt {attempt + 1}, {len(pending_sources)} remaining)[/yellow]"
                 )
             await asyncio.sleep(sleep_for)
             delay = min(delay * backoff_factor, max_delay)


### PR DESCRIPTION
## Summary

When `import_with_retry` in `cli/helpers.py` hits an `RPCTimeoutError`, it currently re-submits the full sources list unchanged. In practice the NLM server has often completed the import by then (the RPC timeout is client-side, not server-side cancellation), so each retry produces another full duplicate set. This is Issue #241.

This PR applies the same approach as PR #286: between retries, list the notebook's existing sources and filter `pending_sources` by URL. If nothing remains, return early. If listing fails, fall back to retrying the current pending list.

## Empirical evidence

Reproduced in an isolated venv, query: "Tailscale subnet router setup on Hetzner VPS", against the same Google account. Deep research, `research wait --import-all`.

| | v0.3.3 (no retry loop) | v0.3.4 (current main) | v0.3.4 + this PR |
|---|---|---|---|
| URLs discovered | 42 | 56–70 typical | 54 |
| Sources imported | 41 | 351–370 typical | 64 |
| Duplicates | 0 | 234–300 | 9 |
| Dupe ratio | 1.0× | 3–6× | 1.17× |

The residual 9 dupes in the patched run are a server-side race (sources in flight when the retry fires) rather than a client-side retry loop, so they'd need a different fix (e.g., server-side idempotency on IMPORT_RESEARCH). The ~25–33× reduction in client-induced duplication is what this PR delivers.

## Test results

4/4 existing `TestImportWithRetry` tests still pass with no modification. 1471 other unit tests pass; the 8 pre-existing Playwright-related failures and 11 errors in `tests/unit/cli/test_session.py` and `tests/unit/test_windows_compatibility.py` are identical on unpatched `main` in the same environment — unrelated to this change.

## Context / acknowledgment

Issue #241 has been open since 2026-04-03 and has bitten every user running deep research — in our case, deduplication was taking ~40% of every notebook-build session. PRs #286 and #257 proposed similar fixes earlier and were closed unmerged. #286 was closed with concern that the submitter was a burner account; that concern doesn't apply here (this is a long-standing personal account, and we've been running the fork in production).

Happy to adjust the diff — is there specific guidance on what blocked those earlier PRs? I kept the approach close to #286 because it was the cleanest and the filter-then-retry pattern reads naturally against the current CLI-only retry policy comment already in the function.

Closes #241.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source import reliability with smarter retry logic that detects and skips already-imported sources, reducing redundant processing.
  * Enhanced timeout handling during source imports with clearer status messages about remaining sources to process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->