### PR TITLE
fix: extract YouTube source URL from src[2][5] (#265)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -102,12 +102,28 @@ class SourcesAPI:
                 src_id = src[0][0] if isinstance(src[0], list) else src[0]
                 title = src[1] if len(src) > 1 else None
 
-                # Extract URL if present (at src[2][7])
+                # Extract URL. The API stores URLs at several indices of src[2]
+                # depending on source type:
+                #   [7] -> [url] for web page / PDF sources
+                #   [5] -> [url, video_id, channel_name] for YouTube sources
+                #   [0] -> bare URL string as last-resort fallback
                 url = None
-                if len(src) > 2 and isinstance(src[2], list) and len(src[2]) > 7:
-                    url_list = src[2][7]
-                    if isinstance(url_list, list) and len(url_list) > 0:
-                        url = url_list[0]
+                if len(src) > 2 and isinstance(src[2], list):
+                    if len(src[2]) > 7:
+                        url_list = src[2][7]
+                        if isinstance(url_list, list) and len(url_list) > 0:
+                            url = url_list[0]
+                    if not url and len(src[2]) > 5:
+                        yt_data = src[2][5]
+                        if (
+                            isinstance(yt_data, list)
+                            and len(yt_data) > 0
+                            and isinstance(yt_data[0], str)
+                        ):
+                            url = yt_data[0]
+                    if not url and len(src[2]) > 0:
+                        if isinstance(src[2][0], str) and src[2][0].startswith("http"):
+                            url = src[2][0]
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]
                 created_at = None

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -24,6 +24,7 @@ from .types import (
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
+    _extract_source_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -102,28 +103,9 @@ class SourcesAPI:
                 src_id = src[0][0] if isinstance(src[0], list) else src[0]
                 title = src[1] if len(src) > 1 else None
 
-                # Extract URL. The API stores URLs at several indices of src[2]
-                # depending on source type:
-                #   [7] -> [url] for web page / PDF sources
-                #   [5] -> [url, video_id, channel_name] for YouTube sources
-                #   [0] -> bare URL string as last-resort fallback
-                url = None
-                if len(src) > 2 and isinstance(src[2], list):
-                    if len(src[2]) > 7:
-                        url_list = src[2][7]
-                        if isinstance(url_list, list) and len(url_list) > 0:
-                            url = url_list[0]
-                    if not url and len(src[2]) > 5:
-                        yt_data = src[2][5]
-                        if (
-                            isinstance(yt_data, list)
-                            and len(yt_data) > 0
-                            and isinstance(yt_data[0], str)
-                        ):
-                            url = yt_data[0]
-                    if not url and len(src[2]) > 0:
-                        if isinstance(src[2][0], str) and src[2][0].startswith("http"):
-                            url = src[2][0]
+                # Extract URL via the shared helper. See types._extract_source_url
+                # for the probe order ([7] > [5] > bare http at [0]).
+                url = _extract_source_url(src[2] if len(src) > 2 else None)
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]
                 created_at = None

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -610,7 +610,9 @@ class Source:
 
                     return cls(id=str(source_id), title=title, url=url, _type_code=type_code)
 
-                # Deeply nested: continue with URL and type code extraction
+                # Deeply nested: continue with URL and type code extraction.
+                # See _sources.py list() for the full index map; YouTube URLs
+                # live at entry[2][5][0].
                 url = None
                 type_code = None
                 if len(entry) > 2 and isinstance(entry[2], list):
@@ -618,6 +620,14 @@ class Source:
                         url_list = entry[2][7]
                         if isinstance(url_list, list) and len(url_list) > 0:
                             url = url_list[0]
+                    if not url and len(entry[2]) > 5:
+                        yt_data = entry[2][5]
+                        if (
+                            isinstance(yt_data, list)
+                            and len(yt_data) > 0
+                            and isinstance(yt_data[0], str)
+                        ):
+                            url = yt_data[0]
                     if not url and len(entry[2]) > 0:
                         if isinstance(entry[2][0], str) and entry[2][0].startswith("http"):
                             url = entry[2][0]

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -582,13 +582,33 @@ class Source:
                     source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
                     title = entry[1] if len(entry) > 1 else None
 
-                    # Try to extract URL if present
+                    # Try to extract URL if present. See _sources.py list() for
+                    # the full index map; YouTube URLs live at entry[2][5][0].
                     url = None
                     if len(entry) > 2 and isinstance(entry[2], list):
                         if len(entry[2]) > 7 and isinstance(entry[2][7], list):
                             url = entry[2][7][0] if entry[2][7] else None
+                        if not url and len(entry[2]) > 5:
+                            yt_data = entry[2][5]
+                            if (
+                                isinstance(yt_data, list)
+                                and len(yt_data) > 0
+                                and isinstance(yt_data[0], str)
+                            ):
+                                url = yt_data[0]
 
-                    return cls(id=str(source_id), title=title, url=url, _type_code=None)
+                    # Also parse the type code here so youtube sources are
+                    # identified correctly even in the medium-nested shape.
+                    type_code = None
+                    if (
+                        len(entry) > 2
+                        and isinstance(entry[2], list)
+                        and len(entry[2]) > 4
+                        and isinstance(entry[2][4], int)
+                    ):
+                        type_code = entry[2][4]
+
+                    return cls(id=str(source_id), title=title, url=url, _type_code=type_code)
 
                 # Deeply nested: continue with URL and type code extraction
                 url = None

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -586,8 +586,10 @@ class Source:
                     # the full index map; YouTube URLs live at entry[2][5][0].
                     url = None
                     if len(entry) > 2 and isinstance(entry[2], list):
-                        if len(entry[2]) > 7 and isinstance(entry[2][7], list):
-                            url = entry[2][7][0] if entry[2][7] else None
+                        if len(entry[2]) > 7:
+                            url_list = entry[2][7]
+                            if isinstance(url_list, list) and len(url_list) > 0:
+                                url = url_list[0]
                         if not url and len(entry[2]) > 5:
                             yt_data = entry[2][5]
                             if (

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -244,6 +244,39 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     return result
 
 
+def _extract_source_url(metadata: Any, *, allow_bare_http: bool = True) -> str | None:
+    """Extract a source URL from a ``src[2]`` metadata array.
+
+    NotebookLM stores source URLs at different indices of the metadata array
+    depending on the source type:
+
+    - ``metadata[7]`` → ``[url]`` for web page / PDF sources
+    - ``metadata[5]`` → ``[url, video_id, channel_name]`` for YouTube sources
+    - ``metadata[0]`` → bare URL string for some older/alternate shapes
+
+    Precedence is ``[7] > [5] > [0]``. The ``[0]`` fallback is gated by
+    ``allow_bare_http`` because medium-nested ``from_api_response`` shapes
+    don't support it (``metadata[0]`` can pack unrelated data there).
+    Returns ``None`` if ``metadata`` is not a list or no probe matches.
+    """
+    if not isinstance(metadata, list):
+        return None
+    url: str | None = None
+    if len(metadata) > 7:
+        url_list = metadata[7]
+        if isinstance(url_list, list) and len(url_list) > 0:
+            url = url_list[0]
+    if not url and len(metadata) > 5:
+        yt_data = metadata[5]
+        if isinstance(yt_data, list) and len(yt_data) > 0 and isinstance(yt_data[0], str):
+            url = yt_data[0]
+    if not url and allow_bare_http and len(metadata) > 0:
+        candidate = metadata[0]
+        if isinstance(candidate, str) and candidate.startswith("http"):
+            url = candidate
+    return url
+
+
 __all__ = [
     # Dataclasses
     "Notebook",
@@ -582,60 +615,31 @@ class Source:
                     source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
                     title = entry[1] if len(entry) > 1 else None
 
-                    # Try to extract URL if present. See _sources.py list() for
-                    # the full index map; YouTube URLs live at entry[2][5][0].
-                    url = None
-                    if len(entry) > 2 and isinstance(entry[2], list):
-                        if len(entry[2]) > 7:
-                            url_list = entry[2][7]
-                            if isinstance(url_list, list) and len(url_list) > 0:
-                                url = url_list[0]
-                        if not url and len(entry[2]) > 5:
-                            yt_data = entry[2][5]
-                            if (
-                                isinstance(yt_data, list)
-                                and len(yt_data) > 0
-                                and isinstance(yt_data[0], str)
-                            ):
-                                url = yt_data[0]
-
-                    # Also parse the type code here so youtube sources are
-                    # identified correctly even in the medium-nested shape.
-                    type_code = None
-                    if (
-                        len(entry) > 2
-                        and isinstance(entry[2], list)
-                        and len(entry[2]) > 4
-                        and isinstance(entry[2][4], int)
-                    ):
-                        type_code = entry[2][4]
+                    # Extract URL and type code from entry[2] via the shared
+                    # helper. Medium-nested shapes don't support the bare-http
+                    # [0] fallback, so precedence is restricted to [7] > [5].
+                    metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
+                    url = _extract_source_url(metadata, allow_bare_http=False)
+                    type_code = (
+                        metadata[4]
+                        if metadata is not None
+                        and len(metadata) > 4
+                        and isinstance(metadata[4], int)
+                        else None
+                    )
 
                     return cls(id=str(source_id), title=title, url=url, _type_code=type_code)
 
-                # Deeply nested: continue with URL and type code extraction.
-                # See _sources.py list() for the full index map; YouTube URLs
-                # live at entry[2][5][0].
-                url = None
-                type_code = None
-                if len(entry) > 2 and isinstance(entry[2], list):
-                    if len(entry[2]) > 7:
-                        url_list = entry[2][7]
-                        if isinstance(url_list, list) and len(url_list) > 0:
-                            url = url_list[0]
-                    if not url and len(entry[2]) > 5:
-                        yt_data = entry[2][5]
-                        if (
-                            isinstance(yt_data, list)
-                            and len(yt_data) > 0
-                            and isinstance(yt_data[0], str)
-                        ):
-                            url = yt_data[0]
-                    if not url and len(entry[2]) > 0:
-                        if isinstance(entry[2][0], str) and entry[2][0].startswith("http"):
-                            url = entry[2][0]
-                    # Extract type code at entry[2][4] if available
-                    if len(entry[2]) > 4 and isinstance(entry[2][4], int):
-                        type_code = entry[2][4]
+                # Deeply-nested shape: extract URL (via shared helper) and
+                # type code from entry[2] if present. Full precedence applies:
+                # [7] > [5] > bare-http at [0].
+                metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
+                url = _extract_source_url(metadata)
+                type_code = (
+                    metadata[4]
+                    if metadata is not None and len(metadata) > 4 and isinstance(metadata[4], int)
+                    else None
+                )
 
                 return cls(
                     id=str(source_id),

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -217,6 +217,62 @@ class TestSourcesAPI:
         assert sources[2].kind == "youtube"
 
     @pytest.mark.asyncio
+    async def test_list_sources_youtube_url_at_index_5(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Regression test for issue #265: YouTube URLs are stored at src[2][5][0].
+
+        The real NotebookLM API stores YouTube metadata at src[2][5] as
+        [url, video_id, channel_name], with src[2][7] = None. The list() method
+        must extract the URL from [5] when [7] is not populated.
+        """
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [
+                        [
+                            ["src_yt"],
+                            "YouTube Video",
+                            [
+                                None,
+                                11,
+                                [1704240000, 0],
+                                None,
+                                9,  # YOUTUBE type code
+                                [
+                                    "https://www.youtube.com/watch?v=dcWU-qD8ISQ",
+                                    "dcWU-qD8ISQ",
+                                    "john newquist",
+                                ],
+                                None,
+                                None,  # [7] is None for YouTube sources
+                            ],
+                            [None, 2],
+                        ],
+                    ],
+                    "nb_123",
+                    "📘",
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].id == "src_yt"
+        assert sources[0].kind == "youtube"
+        assert sources[0].url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
+
+    @pytest.mark.asyncio
     async def test_list_sources_empty(
         self,
         auth_tokens,

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -273,6 +273,51 @@ class TestSourcesAPI:
         assert sources[0].url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
 
     @pytest.mark.asyncio
+    async def test_list_sources_index_7_wins_over_5(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """When both src[2][7] and src[2][5] are populated, [7] wins."""
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [
+                        [
+                            ["src_both"],
+                            "Hybrid",
+                            [
+                                None,
+                                11,
+                                [1704240000, 0],
+                                None,
+                                5,
+                                ["https://shouldnt.win/5"],
+                                None,
+                                ["https://should.win/7"],
+                            ],
+                            [None, 2],
+                        ],
+                    ],
+                    "nb_123",
+                    "📘",
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].url == "https://should.win/7"
+
+    @pytest.mark.asyncio
     async def test_list_sources_empty(
         self,
         auth_tokens,

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -161,6 +161,68 @@ class TestSource:
         assert source.kind == SourceType.YOUTUBE
         assert source.kind == "youtube"  # str enum comparison
 
+    def test_from_api_response_deeply_nested_youtube_url_at_index_5(self):
+        """Regression test for issue #265: deeply-nested YouTube payloads store
+        the URL at entry[2][5][0]; entry[2][7] is None. from_api_response must
+        read the URL from index 5 when index 7 is unpopulated.
+        """
+        data = [
+            [
+                [
+                    ["src_yt_deep"],
+                    "YouTube Video",
+                    [
+                        None,
+                        None,
+                        None,
+                        None,
+                        9,  # YOUTUBE type code
+                        [
+                            "https://www.youtube.com/watch?v=dcWU-qD8ISQ",
+                            "dcWU-qD8ISQ",
+                            "john newquist",
+                        ],
+                        None,
+                        None,  # [7] is None for YouTube sources
+                    ],
+                ]
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.id == "src_yt_deep"
+        assert source.kind == SourceType.YOUTUBE
+        assert source.url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
+
+    def test_from_api_response_medium_nested_youtube_url_at_index_5(self):
+        """Regression test for issue #265: medium-nested YouTube payloads also
+        store the URL at entry[2][5][0] with entry[2][7] = None.
+        """
+        data = [
+            [
+                ["src_yt_mid"],
+                "YouTube Video",
+                [
+                    None,
+                    None,
+                    None,
+                    None,
+                    9,
+                    [
+                        "https://www.youtube.com/watch?v=dcWU-qD8ISQ",
+                        "dcWU-qD8ISQ",
+                        "john newquist",
+                    ],
+                    None,
+                    None,
+                ],
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.id == "src_yt_mid"
+        assert source.url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
+
     def test_from_api_response_web_page_source(self):
         """Test that web page sources are parsed with type code 5."""
         data = [

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -126,7 +126,7 @@ class TestSource:
 
         assert source.id == "src_456"
         assert source.title == "Nested Source"
-        # URL extraction depends on nesting level - verify ID and title parsed correctly
+        assert source.url == "https://example.com"
 
     def test_from_api_response_deeply_nested(self):
         """Test parsing deeply nested format."""

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -222,6 +222,65 @@ class TestSource:
 
         assert source.id == "src_yt_mid"
         assert source.url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
+        assert source.kind == SourceType.YOUTUBE
+
+    def test_from_api_response_index_5_empty_list_does_not_crash(self):
+        """entry[2][5] == [] must not produce a URL and must not raise."""
+        data = [
+            [
+                [
+                    ["src_empty5"],
+                    "Weird Source",
+                    [None, None, None, None, 9, [], None, None],
+                ]
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.id == "src_empty5"
+        assert source.url is None
+
+    def test_from_api_response_index_5_non_string_first_element(self):
+        """entry[2][5][0] that isn't a string must not be used as a URL."""
+        data = [
+            [
+                [
+                    ["src_non_str"],
+                    "Weird Source",
+                    [None, None, None, None, 9, [123, "xyz", "chan"], None, None],
+                ]
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.id == "src_non_str"
+        assert source.url is None
+
+    def test_from_api_response_index_7_still_wins_over_5(self):
+        """When both [7] and [5] are populated, [7] takes precedence (matches
+        list() behaviour in _sources.py).
+        """
+        data = [
+            [
+                [
+                    ["src_both"],
+                    "Hybrid Source",
+                    [
+                        None,
+                        None,
+                        None,
+                        None,
+                        5,
+                        ["https://shouldnt.win/5"],
+                        None,
+                        ["https://should.win/7"],
+                    ],
+                ]
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.url == "https://should.win/7"
 
     def test_from_api_response_web_page_source(self):
         """Test that web page sources are parsed with type code 5."""


### PR DESCRIPTION
## Summary

Fixes #265: `Source.url` is always `None` for YouTube sources returned by `client.sources.list()`, `client.sources.get()`, and `Source.from_api_response()`.

The NotebookLM `GET_NOTEBOOK` RPC stores YouTube URLs at `src[2][5][0]` as a `[url, video_id, channel_name]` tuple, while web/PDF URLs live at `src[2][7]`. The previous code only probed `[7]` (and `[0]` as fallback in one spot), so YouTube URLs were silently dropped.

This PR adds a probe for `src[2][5]` between the existing `[7]` and `[0]` probes in three extraction sites:

- `SourcesAPI.list()` in `src/notebooklm/_sources.py`
- `Source.from_api_response()` medium-nested branch in `src/notebooklm/types.py`
- `Source.from_api_response()` deeply-nested branch in `src/notebooklm/types.py`

Precedence is consistent everywhere: `[7] > [5] > [0]` (medium-nested omits `[0]`, preserving prior behavior).

**Latent bug also fixed:** the medium-nested branch of `from_api_response` now parses `_type_code` from `entry[2][4]` — previously hard-coded to `None`, which meant YouTube sources emerging from this branch always had `kind == UNKNOWN`.

## Live API verification

Reproduced against the real API before opening this PR:

```
src[2][4] = 9  (YOUTUBE type code)
src[2][5] = ['https://www.youtube.com/watch?v=jNQXAC9IVRw', 'jNQXAC9IVRw', 'jawed']
src[2][7] = None
```

- Pre-fix extraction (`[7]` only) → `None` ← bug reproduced.
- Post-fix extraction (`[7] > [5] > [0]`) → the URL ← fix works.
- `client.sources.list()` against live API → `Source.url` populated, `kind = SourceType.YOUTUBE`.

## Why the bug slipped through

No existing VCR cassette contained a real type-9 YouTube source. Every ``youtube.com/watch`` URL in the recorded traffic had been added as a web-page source (type code 5, URL at `[7]`). The pre-existing ``test_list_sources`` case using type=9 + URL-at-[7] was a synthetic shape that didn't match production. The new tests use the reporter's real payload shape.

## Test plan

- [x] 5 new unit tests in ``tests/unit/test_types.py::TestSource``: medium-nested YouTube, deeply-nested YouTube, empty ``[5]`` list, non-string ``[5][0]``, ``[7]`` wins over ``[5]`` when both populated.
- [x] 2 new integration tests in ``tests/integration/test_sources.py::TestSourcesAPI``: ``list()`` YouTube URL at ``[5]``, ``list()`` ``[7]`` wins over ``[5]``.
- [x] 1 existing test tightened (``test_from_api_response_nested_format`` now asserts URL).
- [x] Backward compat: existing ``test_list_sources`` continues to pass — ``[7]`` code path unchanged.
- [x] Full suite: ``ruff format``, ``ruff check``, ``mypy``, full ``pytest`` (2020 tests) all pass.
- [x] Live API reproducer confirms bug + fix end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved source URL extraction with ordered fallbacks to handle multiple nested response formats
  * More reliable YouTube source detection and URL parsing from varied API payloads

* **Tests**
  * Added integration tests validating URL selection and precedence
  * Expanded unit tests for nested parsing edge cases, empty/non-string values, and regression coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->