### PR TITLE
docs: improve installation instructions with uv and pip setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,28 @@ These features are available via API/CLI but not exposed in NotebookLM's web int
 
 ## Installation
 
+### Using `uv` (recommended)
+
+[`uv`](https://docs.astral.sh/uv/) installs the CLI into an isolated environment in a single command — no manual venv setup required. This avoids the PEP 668 restriction that blocks direct `pip install` calls against many system Python installations.
+
 ```bash
+# Basic installation
+uv tool install notebooklm-py
+
+# With browser login support (required for first-time setup)
+uv tool install "notebooklm-py[browser]"
+playwright install chromium
+```
+
+### Using `pip`
+
+`pip install` requires an activated virtual environment on most modern systems:
+
+```bash
+# Create and activate a virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
 # Basic installation
 pip install notebooklm-py
 


### PR DESCRIPTION
## Summary

- Add a `uv tool install` section to the README as the recommended installation path, surfacing a single-command install for `uv` users.
- Rewrite the `pip` section to include the required `python3 -m venv` + `source .venv/bin/activate` steps so readers aren't tripped up by PEP 668 when installing against a system Python.

## Related Issue

1. **Issue #210** asked whether `uv tool install notebooklm-py` (and the `[browser]` variant) should be documented for `uv` users. It's the cleanest install path and deserves first-class placement.
2. The current `pip install notebooklm-py` snippet omits virtual-environment setup. On modern Python distributions that enforce PEP 668 (Homebrew Python, Debian/Ubuntu system Python, etc.), running `pip install` directly fails with `externally-managed-environment`. New users hit this immediately.

## Changes

- `README.md` — Installation section restructured into two subsections:
  - `### Using uv (recommended)` — `uv tool install notebooklm-py` and `uv tool install "notebooklm-py[browser]"`.
  - `### Using pip` — now shows the full `venv` + `activate` + `pip install` flow.

## Test Plan

- [x] I tested these changes locally
- [x] Tests pass (`pytest`)
- [x] Linting passes (`ruff check src/ tests/`)
- [x] Formatting passes (`ruff format --check src/ tests/`)
- [x] Type checking passes (`mypy src/notebooklm --ignore-missing-imports`)

Additional manual verification:
- [x] Rendered the README locally to confirm the new subsections display correctly.
- [x] Verified `uv tool install notebooklm-py` installs the CLI and `notebooklm --help` works.
- [x] Verified the documented `pip` flow (venv → activate → `pip install`) works end-to-end.

## Notes

Docs-only change, no code paths touched, no CI impact beyond markdown linting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `uv` package manager installation instructions, including optional setup for browser login support
  * Clarified that a virtual environment must be activated before using pip to install the package
  * Improved installation section organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->