### PR TITLE
feat(decoder): surface bare status code on null RPC results (#114, #294)

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -310,9 +310,12 @@ def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
     if not isinstance(error_info, list) or len(error_info) != 1:
         return None
     code = error_info[0]
-    if not isinstance(code, int) or code < 0 or code > 16:
+    # type(code) is int (not isinstance) — bool is a subclass of int, so
+    # isinstance(True, int) is True and would accept [true] as code 1.
+    # Gate on _GRPC_STATUS_MESSAGES membership so this auto-tracks the table.
+    if type(code) is not int or code not in _GRPC_STATUS_MESSAGES:
         return None
-    return code, _GRPC_STATUS_MESSAGES.get(code, f"Error {code}")
+    return code, _GRPC_STATUS_MESSAGES[code]
 
 
 def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str] | None:
@@ -476,16 +479,15 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
             status = _find_wrb_status(chunks, rpc_id)
             if status is not None:
                 code, label = status
-                message = (
-                    f"RPC {rpc_id} returned null result with status code {code} "
-                    f"({label}).{_ACCOUNT_MISMATCH_HINT}"
-                )
-                # Route NOT_FOUND / PERMISSION_DENIED through ClientError so the
-                # _core.is_auth_error check does not misclassify them as auth
-                # failures and trigger a spurious token-refresh retry.
+                message = f"RPC {rpc_id} returned null result with status code {code} ({label})."
+                # Route NOT_FOUND (5) / PERMISSION_DENIED (7) through ClientError
+                # so _core.is_auth_error does not misclassify them as auth
+                # failures and trigger a spurious token-refresh retry. The
+                # account-routing hint is only relevant for these two codes —
+                # other codes (e.g. INTERNAL 13) get a plain message.
                 if code in (5, 7):
                     raise ClientError(
-                        message,
+                        message + _ACCOUNT_MISMATCH_HINT,
                         method_id=rpc_id,
                         rpc_code=code,
                         found_ids=found_ids,

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -55,6 +55,40 @@ class RPCErrorCode(IntEnum):
     SERVER_ERROR = 500  # Internal server error
 
 
+# gRPC canonical status codes (google.rpc.Code) embedded by the batchexecute
+# backend at index 5 of a `wrb.fr` response when the RPC returns null result
+# data. The bare single-element form `[code]` is what issues #114 and #294
+# observed on the wire.
+_GRPC_STATUS_MESSAGES: dict[int, str] = {
+    0: "OK",
+    1: "Cancelled",
+    2: "Unknown",
+    3: "Invalid argument",
+    4: "Deadline exceeded",
+    5: "Not found",
+    6: "Already exists",
+    7: "Permission denied",
+    8: "Resource exhausted",
+    9: "Failed precondition",
+    10: "Aborted",
+    11: "Out of range",
+    12: "Not implemented",
+    13: "Internal",
+    14: "Unavailable",
+    15: "Data loss",
+    16: "Unauthenticated",
+}
+
+# Hint appended to NOT_FOUND / PERMISSION_DENIED messages. Deliberately avoids
+# the substrings checked by AUTH_ERROR_PATTERNS in _core.py so these errors
+# don't incorrectly trigger the auth-refresh retry path.
+_ACCOUNT_MISMATCH_HINT = (
+    " If you have multiple Google accounts signed in, this is commonly an "
+    "account-routing mismatch — the request defaults to account index 0 when "
+    "no authuser is set. See issues #114 and #294 for context."
+)
+
+
 # Error code to human-readable message mapping
 _ERROR_CODE_MESSAGES: dict[int, tuple[str, bool]] = {
     # (message, is_retryable)
@@ -253,6 +287,57 @@ def collect_rpc_ids(chunks: list[Any]) -> list[str]:
     return found_ids
 
 
+def _extract_status_code(error_info: Any) -> tuple[int, str] | None:
+    """Extract a bare status code from a wrb.fr error_info block.
+
+    Returns ``(code, label)`` only for the bare single-element form ``[code]``
+    in the gRPC canonical range (0-16). Longer structures (e.g. the
+    ``[8, None, [[UserDisplayableError, ...]]]`` rate-limit shape) are handled
+    by the UserDisplayableError path and fall through here by returning
+    ``None``.
+
+    Note: we do not claim these codes are unambiguously gRPC — REMOVE_RECENTLY_VIEWED
+    returns ``[13]`` on what the client treats as a successful no-op (see
+    tests/cassettes/notebooks_remove_from_recent.yaml). Callers must respect
+    ``allow_null`` semantics before treating the code as an error.
+
+    Args:
+        error_info: Value at index 5 of a ``wrb.fr`` response item.
+
+    Returns:
+        ``(code, label)`` tuple for a recognized bare status, else ``None``.
+    """
+    if not isinstance(error_info, list) or len(error_info) != 1:
+        return None
+    code = error_info[0]
+    if not isinstance(code, int) or code < 0 or code > 16:
+        return None
+    return code, _GRPC_STATUS_MESSAGES.get(code, f"Error {code}")
+
+
+def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str] | None:
+    """Locate bare status code at index 5 of a wrb.fr entry for ``rpc_id``.
+
+    Used by ``decode_response`` to enrich the null-result error message when
+    the server explicitly flagged the RPC with a status code.
+    """
+    for chunk in chunks:
+        if not isinstance(chunk, list):
+            continue
+        items = chunk if (chunk and isinstance(chunk[0], list)) else [chunk]
+        for item in items:
+            if not isinstance(item, list) or len(item) < 6:
+                continue
+            if item[0] != "wrb.fr" or item[1] != rpc_id:
+                continue
+            if item[2] is not None or item[5] is None:
+                continue
+            status = _extract_status_code(item[5])
+            if status is not None:
+                return status
+    return None
+
+
 def _contains_user_displayable_error(obj: Any) -> bool:
     """Check if object contains a UserDisplayableError marker.
 
@@ -385,7 +470,34 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
 
         if rpc_id in found_ids:
             # RPC ID was found but extract_rpc_result returned None
-            # This means wrb.fr had null result_data without UserDisplayableError
+            # This means wrb.fr had null result_data without UserDisplayableError.
+            # Enrich the message if the server attached a bare status code at
+            # index 5 (issues #114 / #294 showed GET_NOTEBOOK returning [5]).
+            status = _find_wrb_status(chunks, rpc_id)
+            if status is not None:
+                code, label = status
+                message = (
+                    f"RPC {rpc_id} returned null result with status code {code} "
+                    f"({label}).{_ACCOUNT_MISMATCH_HINT}"
+                )
+                # Route NOT_FOUND / PERMISSION_DENIED through ClientError so the
+                # _core.is_auth_error check does not misclassify them as auth
+                # failures and trigger a spurious token-refresh retry.
+                if code in (5, 7):
+                    raise ClientError(
+                        message,
+                        method_id=rpc_id,
+                        rpc_code=code,
+                        found_ids=found_ids,
+                        raw_response=response_preview,
+                    )
+                raise RPCError(
+                    message,
+                    method_id=rpc_id,
+                    rpc_code=code,
+                    found_ids=found_ids,
+                    raw_response=response_preview,
+                )
             raise RPCError(
                 f"RPC {rpc_id} returned null result data "
                 f"(possible server error or parameter mismatch)",

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -555,7 +555,12 @@ class TestNullResultStatusCodeEnrichment:
         self._assert_no_auth_patterns(message)
 
     def test_internal_code_raises_plain_rpc_error(self):
-        """[13] with allow_null=False → RPCError (not ClientError) with rpc_code=13."""
+        """[13] with allow_null=False → RPCError (not ClientError) with rpc_code=13.
+
+        The account-routing hint (mentioning authuser / issues #114, #294) is
+        only meaningful for NOT_FOUND / PERMISSION_DENIED. Other codes like
+        INTERNAL must not carry it — it would mislead users about the cause.
+        """
         with pytest.raises(RPCError) as exc_info:
             decode_response(self._build_raw([13]), self.RPC_ID)
 
@@ -564,6 +569,8 @@ class TestNullResultStatusCodeEnrichment:
         message = str(exc_info.value)
         assert "status code 13" in message
         assert "Internal" in message
+        assert "authuser" not in message.lower()
+        assert "#114" not in message and "#294" not in message
         self._assert_no_auth_patterns(message)
 
     def test_unauthenticated_code_does_not_become_auth_error(self):
@@ -613,6 +620,22 @@ class TestNullResultStatusCodeEnrichment:
         for code in (5, 7, 13, 16, 99):
             result = decode_response(self._build_raw([code]), self.RPC_ID, allow_null=True)
             assert result is None, f"allow_null=True leaked for code {code}"
+
+    def test_boolean_error_info_is_not_treated_as_status_code(self):
+        """[true] must not be accepted as code 1 — bool is a subclass of int.
+
+        ``json.loads('[true]')`` yields ``[True]`` and ``isinstance(True, int)``
+        is ``True`` in Python, so a lax type check would misread a boolean as
+        status code 1 (CANCELLED). Guard with ``type(...) is int``.
+        """
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(self._build_raw([True]), self.RPC_ID)
+
+        assert not isinstance(exc_info.value, ClientError)
+        assert exc_info.value.rpc_code is None
+        message = str(exc_info.value)
+        assert "returned null result data" in message
+        assert "status code" not in message
 
 
 class TestAuthError:

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -5,6 +5,8 @@ import json
 import pytest
 
 from notebooklm.rpc.decoder import (
+    AuthError,
+    ClientError,
     RateLimitError,
     RPCError,
     collect_rpc_ids,
@@ -232,6 +234,30 @@ class TestExtractRPCResult:
 
         with pytest.raises(RateLimitError, match="rate limit"):
             extract_rpc_result(chunks, RPCMethod.LIST_NOTEBOOKS.value)
+
+    def test_allow_null_preserves_passthrough_for_nonzero_codes(self):
+        """allow_null=True callers must not see status-code enrichment.
+
+        REMOVE_RECENTLY_VIEWED legitimately returns `[13]` at index 5 as part
+        of a successful no-op response the caller opts into with
+        allow_null=True (see tests/cassettes/notebooks_remove_from_recent.yaml).
+        Don't raise in that case.
+        """
+        chunk = json.dumps(
+            [
+                "wrb.fr",
+                RPCMethod.REMOVE_RECENTLY_VIEWED.value,
+                None,
+                None,
+                None,
+                [13],
+                "generic",
+            ]
+        )
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+        result = decode_response(raw, RPCMethod.REMOVE_RECENTLY_VIEWED.value, allow_null=True)
+        assert result is None
 
 
 class TestDecodeResponse:
@@ -472,6 +498,121 @@ class TestIssue114Reproduction:
         with pytest.raises(RPCError) as exc_info:
             decode_response(raw, self.RPC_ID)
         assert self.RPC_ID in exc_info.value.found_ids
+
+
+class TestNullResultStatusCodeEnrichment:
+    """Verify decode_response enriches null-result errors with status codes.
+
+    Issues #114 / #294 saw GET_NOTEBOOK return a wrb.fr entry where result_data
+    is null and index 5 carries a bare `[code]`. These tests pin the new
+    enrichment path: NOT_FOUND / PERMISSION_DENIED must surface as ClientError
+    (so _core.is_auth_error does not misclassify them and retry on a token
+    refresh), other codes stay as RPCError, and the hint never contains any
+    AUTH_ERROR_PATTERNS substring.
+    """
+
+    RPC_ID = RPCMethod.GET_NOTEBOOK.value
+
+    # Must stay in sync with _core.AUTH_ERROR_PATTERNS.
+    _AUTH_PATTERNS = ("authentication", "expired", "unauthorized", "login", "re-authenticate")
+
+    def _build_raw(self, error_info: list | None) -> str:
+        chunk = json.dumps(["wrb.fr", self.RPC_ID, None, None, None, error_info, "generic"])
+        return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+    def _assert_no_auth_patterns(self, message: str) -> None:
+        lower = message.lower()
+        for pattern in self._AUTH_PATTERNS:
+            assert pattern not in lower, (
+                f"Message contains AUTH_ERROR_PATTERN {pattern!r}: would trigger "
+                f"spurious auth-refresh retry in _core.is_auth_error: {message!r}"
+            )
+
+    def test_not_found_raises_client_error(self):
+        """[5] → ClientError with rpc_code=5, 'Not found', authuser hint."""
+        with pytest.raises(ClientError) as exc_info:
+            decode_response(self._build_raw([5]), self.RPC_ID)
+
+        assert exc_info.value.rpc_code == 5
+        assert exc_info.value.method_id == self.RPC_ID
+        assert self.RPC_ID in exc_info.value.found_ids
+        message = str(exc_info.value)
+        assert "Not found" in message
+        assert "status code 5" in message
+        assert "authuser" in message.lower()
+        assert "#114" in message and "#294" in message
+        self._assert_no_auth_patterns(message)
+
+    def test_permission_denied_raises_client_error(self):
+        """[7] → ClientError with rpc_code=7, 'Permission denied'."""
+        with pytest.raises(ClientError) as exc_info:
+            decode_response(self._build_raw([7]), self.RPC_ID)
+
+        assert exc_info.value.rpc_code == 7
+        message = str(exc_info.value)
+        assert "Permission denied" in message
+        assert "status code 7" in message
+        self._assert_no_auth_patterns(message)
+
+    def test_internal_code_raises_plain_rpc_error(self):
+        """[13] with allow_null=False → RPCError (not ClientError) with rpc_code=13."""
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(self._build_raw([13]), self.RPC_ID)
+
+        assert not isinstance(exc_info.value, ClientError)
+        assert exc_info.value.rpc_code == 13
+        message = str(exc_info.value)
+        assert "status code 13" in message
+        assert "Internal" in message
+        self._assert_no_auth_patterns(message)
+
+    def test_unauthenticated_code_does_not_become_auth_error(self):
+        """[16] Unauthenticated stays plain RPCError — we do not infer auth.
+
+        The bare code is too ambiguous (see the REMOVE_RECENTLY_VIEWED [13]
+        success cassette) to auto-route into auth-refresh. Stay conservative.
+        """
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(self._build_raw([16]), self.RPC_ID)
+
+        assert not isinstance(exc_info.value, ClientError)
+        assert not isinstance(exc_info.value, AuthError)
+        assert exc_info.value.rpc_code == 16
+        message = str(exc_info.value)
+        # The label itself contains no AUTH_ERROR_PATTERNS substring; guard it.
+        self._assert_no_auth_patterns(message)
+
+    def test_out_of_range_code_falls_through_to_generic_error(self):
+        """[99] is outside 0-16 gRPC range → no enrichment, generic message."""
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(self._build_raw([99]), self.RPC_ID)
+
+        assert not isinstance(exc_info.value, ClientError)
+        assert exc_info.value.rpc_code is None
+        message = str(exc_info.value)
+        assert "returned null result data" in message
+        assert "status code" not in message
+
+    def test_multi_element_error_info_falls_through(self):
+        """[5, null, 'x'] is not the bare form — no enrichment."""
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(self._build_raw([5, None, "x"]), self.RPC_ID)
+
+        assert not isinstance(exc_info.value, ClientError)
+        assert exc_info.value.rpc_code is None
+        message = str(exc_info.value)
+        assert "returned null result data" in message
+        assert "status code" not in message
+
+    def test_allow_null_suppresses_enrichment_for_client_error_codes(self):
+        """allow_null=True must short-circuit even for [5] / [7].
+
+        Fire-and-forget callers (REMOVE_RECENTLY_VIEWED, RENAME_NOTEBOOK, share)
+        opt into null results. They must not trip on enrichment.
+        """
+        for code in (5, 7, 13, 16, 99):
+            result = decode_response(self._build_raw([code]), self.RPC_ID, allow_null=True)
+            assert result is None, f"allow_null=True leaked for code {code}"
 
 
 class TestAuthError:


### PR DESCRIPTION
GET_NOTEBOOK reports on issues #114 and #294 both showed the same wire
pattern: wrb.fr with result_data=null and a bare [code] at index 5 (most
often [5] NOT_FOUND). We swallowed that signal and raised a generic
"returned null result data" RPCError, giving users nothing actionable.

Now decode_response enriches the null-result error with the code and its
gRPC canonical label when present. Codes 5 (Not found) and 7 (Permission
denied) raise ClientError so _core.is_auth_error does not misclassify
them and trigger a spurious token-refresh retry; other in-range codes
raise RPCError with rpc_code set. An account-routing hint mentioning
authuser and issues #114/#294 is attached — worded carefully to avoid
AUTH_ERROR_PATTERNS substrings in _core.py.

Conservative on purpose: we only act on the bare single-element [code]
shape in 0-16, and only when allow_null=False. REMOVE_RECENTLY_VIEWED's
successful [13] response (see notebooks_remove_from_recent.yaml) uses
allow_null=True and is unaffected — covered by a new regression test.

https://claude.ai/code/session_01Y4tZhr1WswYMTEfUnubTSm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC error reporting: extract embedded status codes to enrich null-result errors, classify “Not found” and “Permission denied” differently, and avoid false positives for non-bare or out-of-range codes.
  * Source parsing no longer treats unrelated bare-HTTP strings as a URL when listing sources.
  * Logout now clears cached notebook/conversation context and updates post-logout messaging accordingly.

* **Tests**
  * Expanded unit and integration tests covering status-code handling, allow-null behavior, source parsing, logout context removal, and absence of sensitive auth hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->