### PR TITLE
fix: two correctness bugs surfaced by multi-model review of PR #295

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -104,11 +104,10 @@ class SourcesAPI:
                 title = src[1] if len(src) > 1 else None
 
                 # Extract URL via the shared helper. GET_NOTEBOOK source entries
-                # use the same medium-nested metadata shape that
-                # Source.from_api_response handles with allow_bare_http=False —
-                # metadata[0] in that shape can pack unrelated data. Keep the
-                # two call sites consistent by disabling the bare-http fallback
-                # here too. Probe order is [7] > [5].
+                # use the same medium-nested metadata shape as
+                # Source.from_api_response, which doesn't support the bare-http
+                # [0] fallback (metadata[0] can pack unrelated data). Precedence
+                # is restricted to [7] > [5]; keep the two call sites aligned.
                 url = _extract_source_url(src[2] if len(src) > 2 else None, allow_bare_http=False)
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -103,9 +103,13 @@ class SourcesAPI:
                 src_id = src[0][0] if isinstance(src[0], list) else src[0]
                 title = src[1] if len(src) > 1 else None
 
-                # Extract URL via the shared helper. See types._extract_source_url
-                # for the probe order ([7] > [5] > bare http at [0]).
-                url = _extract_source_url(src[2] if len(src) > 2 else None)
+                # Extract URL via the shared helper. GET_NOTEBOOK source entries
+                # use the same medium-nested metadata shape that
+                # Source.from_api_response handles with allow_bare_http=False —
+                # metadata[0] in that shape can pack unrelated data. Keep the
+                # two call sites consistent by disabling the bare-http fallback
+                # here too. Probe order is [7] > [5].
+                url = _extract_source_url(src[2] if len(src) > 2 else None, allow_bare_http=False)
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]
                 created_at = None

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -237,11 +237,16 @@ def set_current_notebook(
     context_file.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
-def clear_context():
-    """Clear the current context."""
+def clear_context() -> bool:
+    """Clear the current context.
+
+    Returns True if a context file was removed, False if none existed.
+    """
     context_file = get_context_path()
     if context_file.exists():
         context_file.unlink()
+        return True
+    return False
 
 
 def get_current_conversation() -> str | None:

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -904,6 +904,18 @@ def register_session_commands(cli):
                 )
                 raise SystemExit(1) from exc
 
+        # Clear cached notebook / conversation context so post-logout commands
+        # don't silently reuse IDs from the previous account. When logout is
+        # part of the account-switch flow (see _ACCOUNT_MISMATCH_HINT in
+        # rpc/decoder.py), leaving context.json behind would cause the next
+        # `ask` / `use` to target the old account's notebook and surface
+        # misleading not-found / permission errors.
+        context_file = get_context_path()
+        context_existed = context_file.exists()
+        clear_context()
+        if context_existed:
+            removed_any = True
+
         if removed_any:
             console.print("[green]Logged out.[/green] Run 'notebooklm login' to sign in again.")
         else:

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -910,11 +910,18 @@ def register_session_commands(cli):
         # rpc/decoder.py), leaving context.json behind would cause the next
         # `ask` / `use` to target the old account's notebook and surface
         # misleading not-found / permission errors.
-        context_file = get_context_path()
-        context_existed = context_file.exists()
-        clear_context()
-        if context_existed:
-            removed_any = True
+        try:
+            if clear_context():
+                removed_any = True
+        except OSError as exc:
+            context_file = get_context_path()
+            logger.error("Failed to remove context file %s: %s", context_file, exc)
+            console.print(
+                f"[red]Cannot remove context file: {exc}[/red]\n"
+                "Close any running notebooklm commands and try again.\n"
+                f"If the problem persists, manually delete: {context_file}"
+            )
+            raise SystemExit(1) from exc
 
         if removed_any:
             console.print("[green]Logged out.[/green] Run 'notebooklm login' to sign in again.")

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -273,6 +273,61 @@ class TestSourcesAPI:
         assert sources[0].url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
 
     @pytest.mark.asyncio
+    async def test_list_sources_ignores_bare_http_at_index_0(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """metadata[0] must not be used as a URL fallback in list().
+
+        GET_NOTEBOOK source entries use the same medium-nested shape that
+        Source.from_api_response handles with allow_bare_http=False —
+        metadata[0] in that shape can pack unrelated http-like data. If the
+        bare-[0] fallback fires, list() would surface a bogus URL. Keep
+        allow_bare_http=False here so list() and from_api_response agree.
+        """
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "Test Notebook",
+                    [
+                        [
+                            ["src_bare"],
+                            "Source with bare http at [0]",
+                            [
+                                # metadata[0] is an http-like string that must
+                                # be ignored — it is not a source URL here.
+                                "http://unrelated.example.com/not-a-source-url",
+                                11,
+                                [1704240000, 0],
+                                None,
+                                5,
+                                None,
+                                None,
+                                None,  # metadata[7] empty → no web-page URL
+                            ],
+                            [None, 2],
+                        ],
+                    ],
+                    "nb_123",
+                    "📘",
+                    None,
+                    [None, None, None, None, None, [1704067200, 0]],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            sources = await client.sources.list("nb_123")
+
+        assert len(sources) == 1
+        assert sources[0].id == "src_bare"
+        assert sources[0].url is None
+
+    @pytest.mark.asyncio
     async def test_list_sources_index_7_wins_over_5(
         self,
         auth_tokens,

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1796,3 +1796,66 @@ class TestAuthLogoutCommand:
 
         assert result.exit_code == 1
         assert "Cannot" in result.output or "in use" in result.output.lower()
+
+    def test_auth_logout_clears_cached_notebook_context(self, runner, tmp_path, mock_context_file):
+        """Logout must remove context.json so the next command does not reuse
+        notebook_id / conversation_id from the previous account.
+
+        Issues #114 / #294 surfaced as "not found" / permission errors after an
+        account switch. The PR's account-mismatch hint steers users to
+        logout→login as the fix; the flow only works if context is actually
+        cleared on logout.
+        """
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text('{"cookies": []}')
+        browser_dir = tmp_path / "browser_profile"
+        browser_dir.mkdir()
+
+        # Simulate cached notebook / conversation from a previous session.
+        mock_context_file.write_text(
+            json.dumps(
+                {
+                    "notebook_id": "old-account-notebook",
+                    "conversation_id": "old-account-conversation",
+                }
+            )
+        )
+        assert mock_context_file.exists()
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "Logged out" in result.output
+        assert not mock_context_file.exists()
+
+    def test_auth_logout_no_context_file_does_not_error(self, runner, tmp_path, mock_context_file):
+        """Logout must tolerate a missing context.json without erroring.
+
+        clear_context() is a no-op when the file does not exist; assert that
+        the main logout path still succeeds.
+        """
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text('{"cookies": []}')
+        browser_dir = tmp_path / "browser_profile"
+        # No context file, no browser dir.
+
+        assert not mock_context_file.exists()
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0
+        assert "Logged out" in result.output

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1859,3 +1859,34 @@ class TestAuthLogoutCommand:
 
         assert result.exit_code == 0
         assert "Logged out" in result.output
+
+    def test_auth_logout_handles_os_error_on_context_unlink(
+        self, runner, tmp_path, mock_context_file
+    ):
+        """Logout must surface an OSError on context.json removal as SystemExit(1).
+
+        Parity with the existing handlers for storage_state.json and the browser
+        profile: a locked/unwritable context file should produce a clean
+        diagnostic message, not an unhandled traceback.
+        """
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text('{"cookies": []}')
+        browser_dir = tmp_path / "browser_profile"
+        # No browser dir — nothing to remove in that step.
+        mock_context_file.write_text('{"notebook_id": "stale"}')
+
+        with (
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+            patch(
+                "notebooklm.cli.session.clear_context",
+                side_effect=OSError("file in use"),
+            ),
+        ):
+            result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 1
+        assert "context file" in result.output.lower()

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1689,7 +1689,9 @@ class TestLoginBrowserCookies:
 
 
 class TestAuthLogoutCommand:
-    def test_auth_logout_deletes_storage_and_browser_profile(self, runner, tmp_path):
+    def test_auth_logout_deletes_storage_and_browser_profile(
+        self, runner, tmp_path, mock_context_file
+    ):
         """Test auth logout deletes both storage_state.json and browser_profile/."""
         storage_file = tmp_path / "storage.json"
         storage_file.write_text('{"cookies": []}')
@@ -1712,7 +1714,7 @@ class TestAuthLogoutCommand:
         assert not storage_file.exists()
         assert not browser_dir.exists()
 
-    def test_auth_logout_when_already_logged_out(self, runner, tmp_path):
+    def test_auth_logout_when_already_logged_out(self, runner, tmp_path, mock_context_file):
         """Test auth logout is a no-op with friendly message when not logged in."""
         storage_file = tmp_path / "storage.json"
         browser_dir = tmp_path / "browser_profile"
@@ -1730,7 +1732,7 @@ class TestAuthLogoutCommand:
         assert result.exit_code == 0
         assert "already" in result.output.lower() or "No active session" in result.output
 
-    def test_auth_logout_partial_state_only_storage(self, runner, tmp_path):
+    def test_auth_logout_partial_state_only_storage(self, runner, tmp_path, mock_context_file):
         """Test auth logout handles case where only storage_state.json exists."""
         storage_file = tmp_path / "storage.json"
         storage_file.write_text('{"cookies": []}')
@@ -1750,7 +1752,9 @@ class TestAuthLogoutCommand:
         assert "Logged out" in result.output
         assert not storage_file.exists()
 
-    def test_auth_logout_handles_permission_error_on_rmtree(self, runner, tmp_path):
+    def test_auth_logout_handles_permission_error_on_rmtree(
+        self, runner, tmp_path, mock_context_file
+    ):
         """Test auth logout handles locked browser profile gracefully."""
         storage_file = tmp_path / "storage.json"
         storage_file.write_text('{"cookies": []}')
@@ -1773,7 +1777,9 @@ class TestAuthLogoutCommand:
         assert result.exit_code == 1
         assert "in use" in result.output.lower() or "Cannot" in result.output
 
-    def test_auth_logout_handles_permission_error_on_unlink(self, runner, tmp_path):
+    def test_auth_logout_handles_permission_error_on_unlink(
+        self, runner, tmp_path, mock_context_file
+    ):
         """Test auth logout handles locked storage_state.json gracefully on Windows."""
         storage_file = tmp_path / "storage.json"
         storage_file.write_text('{"cookies": []}')


### PR DESCRIPTION
## Summary

Two independent correctness bugs surfaced while reviewing PR #295 with a
three-model panel (Claude + Gemini + Codex). The bugs live in code PR #295
does **not** touch, so splitting them into a separate PR keeps #295
scoped to the decoder-enrichment work it advertises.

Each commit is atomic and self-contained.

### 1. `auth logout` never cleared `context.json` (cli/session.py)

Logout removed `storage_state.json` and the browser profile but left
cached `notebook_id` / `conversation_id` behind. After re-login under a
different Google account, the next command silently reused the old
IDs and surfaced a not-found / permission error — the exact failure
mode the account-mismatch hint added in PR #295 tries to diagnose
(issues #114 / #294). The hint tells users to run
\`notebooklm auth logout && notebooklm login\`, so logout must actually
clear context for the remedy to work.

### 2. `sources.list()` used an unsafe URL fallback (\_sources.py)

\`sources.list()\` called \`_extract_source_url\` with the default
\`allow_bare_http=True\`, but GET_NOTEBOOK source entries use the same
medium-nested shape where \`Source.from_api_response\` explicitly sets
\`allow_bare_http=False\` — \`metadata[0]\` in that shape can pack
unrelated data, not a source URL. Fixtures show \`metadata[0]\` is
typically None so this is latent, but the contract mismatch is a real
correctness risk. Align the two call sites.

## Test plan

- [x] \`uv run pytest tests/unit/cli/test_session.py::TestAuthLogoutCommand\` — 7 passed (includes 2 new regression tests)
- [x] \`uv run pytest tests/integration/test_sources.py\` — all passing (includes 1 new regression test for \`metadata[0]\` fallback)
- [x] \`ruff format\`, \`ruff check\`, \`mypy\` all clean
- [ ] CI green across full matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now also clears cached notebook/conversation context and exits with a non-zero status while reporting a clear error if context removal fails.
  * Source listing no longer treats certain bare "http://" values as fallback URLs, preventing incorrect source URL assignment.

* **Tests**
  * Added integration and unit tests covering source URL parsing and logout/context removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->