### PR TITLE
feat(auth): auto-refresh cookies via NOTEBOOKLM_REFRESH_CMD on expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Auto-refresh on auth expiry** - `fetch_tokens` now optionally runs a user-provided refresh command when a Google session cookie has expired, reloads cookies from storage, and retries once. Opt in by setting the `NOTEBOOKLM_REFRESH_CMD` environment variable to a script that rewrites `~/.notebooklm/storage_state.json` (e.g. a sync script reading from a cookie vault). Covers every CLI entry point without changing the public API. A process-scoped flag prevents retry loops.
+
 ## [0.3.4] - 2026-03-12
 
 ### Added

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -31,6 +31,8 @@ import json
 import logging
 import os
 import re
+import shlex
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -642,22 +644,55 @@ def load_httpx_cookies(path: Path | None = None) -> "httpx.Cookies":
     return cookies
 
 
-async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
-    """Fetch CSRF token and session ID from NotebookLM homepage.
+NOTEBOOKLM_REFRESH_CMD_ENV = "NOTEBOOKLM_REFRESH_CMD"
+_REFRESH_ATTEMPTED_ENV = "_NOTEBOOKLM_REFRESH_ATTEMPTED"
+_AUTH_ERROR_SIGNALS = (
+    "authentication expired",
+    "redirected to",
+    "run 'notebooklm login'",
+)
 
-    Makes an authenticated request to NotebookLM and extracts the required
-    tokens from the page HTML.
 
-    Args:
-        cookies: Dict of Google auth cookies
+def _should_try_refresh(err: Exception) -> bool:
+    """True when an auth failure should trigger NOTEBOOKLM_REFRESH_CMD."""
+    if os.environ.get(_REFRESH_ATTEMPTED_ENV):
+        return False
+    if not os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV):
+        return False
+    msg = str(err).lower()
+    return any(sig in msg for sig in _AUTH_ERROR_SIGNALS)
 
-    Returns:
-        Tuple of (csrf_token, session_id)
+
+def _run_refresh_cmd() -> None:
+    """Run ``NOTEBOOKLM_REFRESH_CMD`` once per process to refresh stored cookies.
 
     Raises:
-        httpx.HTTPError: If request fails
-        ValueError: If tokens cannot be extracted from response
+        RuntimeError: If the refresh command is missing, times out, or exits
+            non-zero.
     """
+    cmd = os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV)
+    if not cmd:
+        raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} is not set; cannot refresh cookies.")
+    os.environ[_REFRESH_ATTEMPTED_ENV] = "1"
+    try:
+        result = subprocess.run(
+            shlex.split(cmd),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError) as refresh_err:
+        raise RuntimeError(
+            f"{NOTEBOOKLM_REFRESH_CMD_ENV} failed to execute: {refresh_err}"
+        ) from refresh_err
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} exited {result.returncode}: {stderr}")
+    logger.info("NotebookLM cookies refreshed via %s", NOTEBOOKLM_REFRESH_CMD_ENV)
+
+
+async def _fetch_tokens_once(cookies: dict[str, str]) -> tuple[str, str]:
+    """Single-shot token fetch without refresh (inner implementation)."""
     logger.debug("Fetching CSRF and session tokens from NotebookLM")
     cookie_header = "; ".join(f"{k}={v}" for k, v in cookies.items())
 
@@ -685,3 +720,50 @@ async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
 
         logger.debug("Authentication tokens obtained successfully")
         return csrf, session_id
+
+
+async def fetch_tokens(cookies: dict[str, str]) -> tuple[str, str]:
+    """Fetch CSRF token and session ID from NotebookLM homepage.
+
+    Makes an authenticated request to NotebookLM and extracts the required
+    tokens from the page HTML.
+
+    Automatic refresh
+    -----------------
+    If ``NOTEBOOKLM_REFRESH_CMD`` is set and the first attempt raises a
+    ``ValueError`` matching a known auth-expiry signal, this function runs
+    the refresh command, reloads cookies from the default storage location,
+    updates ``cookies`` in place, and retries once. A process-scoped flag
+    prevents infinite refresh loops.
+
+    The refresh command is expected to rewrite the storage file at the
+    default path (typically ``~/.notebooklm/storage_state.json``). One common
+    pattern is a script that syncs Google cookies from a cookie vault such as
+    a browser extension.
+
+    Args:
+        cookies: Dict of Google auth cookies. Mutated in place on refresh.
+
+    Returns:
+        Tuple of (csrf_token, session_id)
+
+    Raises:
+        httpx.HTTPError: If request fails
+        ValueError: If tokens cannot be extracted (after optional refresh)
+        RuntimeError: If ``NOTEBOOKLM_REFRESH_CMD`` is set but fails
+    """
+    try:
+        return await _fetch_tokens_once(cookies)
+    except ValueError as err:
+        if not _should_try_refresh(err):
+            raise
+        logger.warning(
+            "NotebookLM auth failed (%s). Running %s to refresh cookies.",
+            err,
+            NOTEBOOKLM_REFRESH_CMD_ENV,
+        )
+        _run_refresh_cmd()
+        fresh = load_auth_from_storage()
+        cookies.clear()
+        cookies.update(fresh)
+        return await _fetch_tokens_once(cookies)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -555,6 +555,129 @@ class TestFetchTokens:
         assert "HSID=hsid_value" in cookie_header
 
 
+class TestFetchTokensAutoRefresh:
+    """Test NOTEBOOKLM_REFRESH_CMD auto-refresh behavior in fetch_tokens."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_refresh_flag(self, monkeypatch):
+        # Ensure each test starts with no prior attempt flag
+        monkeypatch.delenv("_NOTEBOOKLM_REFRESH_ATTEMPTED", raising=False)
+        monkeypatch.delenv("NOTEBOOKLM_REFRESH_CMD", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_when_env_unset(self, httpx_mock: HTTPXMock):
+        """Auth error propagates unchanged when NOTEBOOKLM_REFRESH_CMD is not set."""
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/signin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/signin",
+            content=b"<html>Login</html>",
+        )
+
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await fetch_tokens({"SID": "stale"})
+
+    @pytest.mark.asyncio
+    async def test_refresh_retries_once_and_succeeds(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """On auth failure, runs refresh cmd, reloads cookies, retries successfully."""
+        # Stage 1: write a stale cookie file
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(
+            json.dumps({"cookies": [{"name": "SID", "value": "stale", "domain": ".google.com"}]})
+        )
+        monkeypatch.setattr("notebooklm.auth.get_storage_path", lambda: storage_file)
+
+        # Refresh command rewrites the file with a fresh SID
+        fresh_file = tmp_path / "fresh_cookies.json"
+        fresh_file.write_text(
+            json.dumps({"cookies": [{"name": "SID", "value": "fresh", "domain": ".google.com"}]})
+        )
+        refresh_script = tmp_path / "refresh.sh"
+        refresh_script.write_text(f"#!/usr/bin/env bash\ncp {fresh_file} {storage_file}\n")
+        refresh_script.chmod(0o755)
+        monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", str(refresh_script))
+
+        # First HTTP call: auth redirect
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/signin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/signin",
+            content=b"<html>Login</html>",
+        )
+        # Second HTTP call (after refresh): success
+        html = '"SNlM0e":"csrf_ok" "FdrFJe":"sess_ok"'
+        httpx_mock.add_response(url="https://notebooklm.google.com/", content=html.encode())
+
+        cookies = {"SID": "stale"}
+        csrf, session_id = await fetch_tokens(cookies)
+
+        assert csrf == "csrf_ok"
+        assert session_id == "sess_ok"
+        # Cookies dict was mutated in place with fresh values
+        assert cookies["SID"] == "fresh"
+
+    @pytest.mark.asyncio
+    async def test_refresh_does_not_loop(self, tmp_path, monkeypatch, httpx_mock: HTTPXMock):
+        """If refresh fails to fix auth, second failure propagates (no infinite loop)."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(
+            json.dumps({"cookies": [{"name": "SID", "value": "stale", "domain": ".google.com"}]})
+        )
+        monkeypatch.setattr("notebooklm.auth.get_storage_path", lambda: storage_file)
+
+        # Refresh is a no-op (still stale after)
+        refresh_script = tmp_path / "refresh.sh"
+        refresh_script.write_text("#!/usr/bin/env bash\nexit 0\n")
+        refresh_script.chmod(0o755)
+        monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", str(refresh_script))
+
+        # Both attempts hit the same redirect
+        for _ in range(2):
+            httpx_mock.add_response(
+                url="https://notebooklm.google.com/",
+                status_code=302,
+                headers={"Location": "https://accounts.google.com/signin"},
+            )
+            httpx_mock.add_response(
+                url="https://accounts.google.com/signin",
+                content=b"<html>Login</html>",
+            )
+
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await fetch_tokens({"SID": "stale"})
+
+    @pytest.mark.asyncio
+    async def test_refresh_cmd_nonzero_exit_becomes_runtime_error(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Refresh command failure surfaces as RuntimeError, not silent auth error."""
+        refresh_script = tmp_path / "refresh.sh"
+        refresh_script.write_text("#!/usr/bin/env bash\necho 'vault unavailable' >&2\nexit 1\n")
+        refresh_script.chmod(0o755)
+        monkeypatch.setenv("NOTEBOOKLM_REFRESH_CMD", str(refresh_script))
+
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            status_code=302,
+            headers={"Location": "https://accounts.google.com/signin"},
+        )
+        httpx_mock.add_response(
+            url="https://accounts.google.com/signin",
+            content=b"<html>Login</html>",
+        )
+
+        with pytest.raises(RuntimeError, match="exited 1"):
+            await fetch_tokens({"SID": "stale"})
+
+
 class TestAuthTokensFromStorage:
     """Test AuthTokens.from_storage class method."""
 


### PR DESCRIPTION
Closes #297.

## Summary

- Adds opt-in auto-refresh of Google auth cookies when `fetch_tokens` detects an expired session.
- Opt in by setting `NOTEBOOKLM_REFRESH_CMD` to a shell command that rewrites the default storage file (e.g. a sync script that reads from a browser-extension cookie vault, a secrets manager, or a `rookiepy` exporter).
- When unset, behavior is unchanged — no API break.
- One wrap in `fetch_tokens` covers every CLI path: `AuthTokens.from_storage`, `cli/helpers.get_client`, `cli/download.py`, etc.
- Retry is one-shot per process (process-scoped env flag) so a broken refresh script can't cause an infinite loop.

## Why at `fetch_tokens`?

It is the single point every auth-using caller funnels through. Wrapping here avoids editing five CLI call sites, keeps the public API stable, and makes the opt-in apply uniformly to notebook ops, chat, downloads, and research.

## Behavior matrix

| Env var | fetch_tokens outcome | Behavior |
|---|---|---|
| unset | success | identical to today |
| unset | auth redirect | identical to today (raises `ValueError`) |
| set   | success | identical to today (no extra calls) |
| set   | auth redirect → refresh succeeds | runs `$NOTEBOOKLM_REFRESH_CMD`, reloads cookies from disk, retries once (logs a `WARNING`) |
| set   | auth redirect → refresh still stale | re-raises the original `ValueError` after one retry (no loop) |
| set   | refresh command exits non-zero | `RuntimeError` with captured stderr |

## In-place cookie mutation

On refresh, the passed `cookies` dict is updated in place so callers who kept a reference (`AuthTokens.from_storage`, `cli/helpers.get_client`, `cli/download.py`) see fresh values without needing code changes. This is documented in the updated docstring. I considered returning cookies instead but that would widen the signature and require touching every call site.

## Tests

Four new unit tests in `TestFetchTokensAutoRefresh`:

- `test_no_refresh_when_env_unset` — regression check: absent env var = exact current behavior
- `test_refresh_retries_once_and_succeeds` — happy path: mock auth failure → run real shell script that rewrites storage → retry succeeds, cookies mutated in place
- `test_refresh_does_not_loop` — safety: refresh that fails to fix auth must not loop, must propagate original error
- `test_refresh_cmd_nonzero_exit_becomes_runtime_error` — failed refresh surfaces as RuntimeError with captured stderr

Full auth suite passes (144/144), `ruff check` and `ruff format --check` clean.

## Test plan

- [x] `pytest tests/unit/test_auth.py` — 144 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] End-to-end smoke test: installed the same patch in my local pipx venv, corrupted SID, ran `notebooklm list` with `NOTEBOOKLM_REFRESH_CMD=/path/to/cookie-sync` → refresh triggered, cookies replaced on disk, command succeeded without manual `notebooklm login`
- [ ] Maintainer review for API shape preference (env-var vs. callable, inline mutation vs. return value)

Happy to iterate if you'd prefer a different surface (e.g. gating via config file instead of env var, or exposing as `AuthTokens.from_storage(auto_refresh=True)` keyword).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in automatic session refresh when authentication expires. Configure the `NOTEBOOKLM_REFRESH_CMD` environment variable to specify a custom refresh command. When triggered, the system updates authentication state and automatically retries operations once.

* **Tests**
  * Added comprehensive test coverage for session refresh scenarios, including success cases, retry logic, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->