### PR TITLE
fix(chat): emit refs only from winning chunk (fixes #300)

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -448,20 +448,22 @@ class ChatAPI:
 
         lines = response_text.strip().split("\n")
         best_marked_answer = ""
+        best_marked_refs: list[ChatReference] = []
         best_unmarked_answer = ""
-        all_references: list[ChatReference] = []
+        best_unmarked_refs: list[ChatReference] = []
         server_conv_id: str | None = None
 
         def process_chunk(json_str: str) -> None:
-            """Process a JSON chunk, updating best answers and all_references."""
-            nonlocal best_marked_answer, best_unmarked_answer, server_conv_id
+            """Process a JSON chunk, updating best answer candidates and their refs."""
+            nonlocal best_marked_answer, best_marked_refs, best_unmarked_answer, best_unmarked_refs, server_conv_id
             text, is_answer, refs, conv_id = self._extract_answer_and_refs_from_chunk(json_str)
             if text:
                 if is_answer and len(text) > len(best_marked_answer):
                     best_marked_answer = text
+                    best_marked_refs = refs
                 elif not is_answer and len(text) > len(best_unmarked_answer):
                     best_unmarked_answer = text
-            all_references.extend(refs)
+                    best_unmarked_refs = refs
             if conv_id:
                 server_conv_id = conv_id
 
@@ -485,6 +487,7 @@ class ChatAPI:
         # Prefer marked answers; fall back to longest unmarked text
         if best_marked_answer:
             longest_answer = best_marked_answer
+            final_refs = best_marked_refs
         elif best_unmarked_answer:
             logger.warning(
                 "No marked answer found; falling back to longest unmarked "
@@ -492,8 +495,10 @@ class ChatAPI:
                 len(best_unmarked_answer),
             )
             longest_answer = best_unmarked_answer
+            final_refs = best_unmarked_refs
         else:
             longest_answer = ""
+            final_refs = []
 
         if not longest_answer:
             logger.warning(
@@ -502,11 +507,11 @@ class ChatAPI:
             )
 
         # Assign citation numbers based on order of appearance
-        for idx, ref in enumerate(all_references, start=1):
+        for idx, ref in enumerate(final_refs, start=1):
             if ref.citation_number is None:
                 ref.citation_number = idx
 
-        return longest_answer, all_references, server_conv_id
+        return longest_answer, final_refs, server_conv_id
 
     def _extract_answer_and_refs_from_chunk(
         self, json_str: str

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -455,7 +455,9 @@ class ChatAPI:
 
         def process_chunk(json_str: str) -> None:
             """Process a JSON chunk, updating best answer candidates and their refs."""
-            nonlocal best_marked_answer, best_marked_refs, best_unmarked_answer, best_unmarked_refs, server_conv_id
+            nonlocal best_marked_answer, best_marked_refs
+            nonlocal best_unmarked_answer, best_unmarked_refs
+            nonlocal server_conv_id
             text, is_answer, refs, conv_id = self._extract_answer_and_refs_from_chunk(json_str)
             if text:
                 if is_answer and len(text) > len(best_marked_answer):

--- a/tests/unit/test_chat_references.py
+++ b/tests/unit/test_chat_references.py
@@ -637,3 +637,110 @@ class TestAskWithReferences:
         # All references should have the same source_id
         for ref in result.references:
             assert ref.source_id == "aaaaaaaa-1234-5678-9012-abcdefabcdef"
+
+
+class TestMultiChunkReferenceInflation:
+    """Tests for issue #300: references inflated across multiple streaming chunks.
+
+    The API streams multiple progressive chunks. Each chunk with an answer
+    contains a full copy of the references. Before the fix, all_references
+    accumulated from every chunk, causing 600+ refs when only ~20 were cited.
+    """
+
+    @staticmethod
+    def _make_answer_chunk(answer_text: str, source_id: str, chunk_id: str) -> list:
+        """Build a single streaming inner_data chunk with one citation."""
+        return [
+            [
+                answer_text,
+                None,
+                [chunk_id, 12345],
+                None,
+                [
+                    [],
+                    None,
+                    None,
+                    [
+                        [
+                            [chunk_id],
+                            [
+                                None,
+                                None,
+                                0.9,
+                                [[None]],
+                                [[[10, 50, [[[5, 20, f"Text from {chunk_id}."]]]]]],
+                                [[[[source_id]]]],
+                                [chunk_id],
+                            ],
+                        ],
+                    ],
+                    1,
+                ],
+            ]
+        ]
+
+    @staticmethod
+    def _build_multi_chunk_response(*chunks: list) -> str:
+        parts = [")]}'"]
+        for chunk in chunks:
+            inner_json = json.dumps(chunk)
+            chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+            parts.append(f"\n{len(chunk_json)}\n{chunk_json}")
+        parts.append("\n")
+        return "".join(parts)
+
+    def test_multi_chunk_does_not_inflate_references(self, chat_api):
+        """References must not multiply when the API streams repeated chunks.
+
+        Issue #300: each streaming chunk repeated the full reference list, so
+        N chunks × M refs = N*M entries instead of M. The fix tracks refs
+        alongside the best answer instead of accumulating across all chunks.
+        """
+        source_id = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        short_chunk = self._make_answer_chunk("Short.", source_id, "chunk-1")
+        long_chunk = self._make_answer_chunk(
+            "This is the longer final answer from NotebookLM.", source_id, "chunk-2"
+        )
+
+        response = self._build_multi_chunk_response(short_chunk, long_chunk)
+        answer, refs, _ = chat_api._parse_ask_response_with_references(response)
+
+        assert answer == "This is the longer final answer from NotebookLM."
+        # One citation from the winning chunk only — not 2 (one per chunk)
+        assert len(refs) == 1, f"Expected 1 reference, got {len(refs)}"
+        assert refs[0].source_id == source_id
+
+    def test_many_chunks_still_single_ref_set(self, chat_api):
+        """Simulate 6 progressive streaming chunks (as in the bug report: 6×~67 = 402 sources)."""
+        source_id = "12345678-1234-1234-1234-123456789012"
+        chunks = [
+            self._make_answer_chunk(
+                f"Answer {'x' * i} final NotebookLM response.",
+                source_id,
+                f"chunk-{i}",
+            )
+            for i in range(1, 7)
+        ]
+
+        response = self._build_multi_chunk_response(*chunks)
+        _, refs, _ = chat_api._parse_ask_response_with_references(response)
+
+        # Should have exactly 1 reference from the longest (last) chunk, not 6
+        assert len(refs) == 1, f"Expected 1 reference, got {len(refs)} (references inflated across chunks)"
+
+    def test_refs_from_longest_winning_chunk(self, chat_api):
+        """Refs must come from the chunk that produced the longest answer."""
+        winning_source = "aaaabbbb-1111-2222-3333-ccccddddeeee"
+        losing_source = "11112222-3333-4444-5555-666677778888"
+
+        short_chunk = self._make_answer_chunk("Short answer.", losing_source, "chunk-short")
+        long_chunk = self._make_answer_chunk(
+            "This is definitively the longer, winning answer text.", winning_source, "chunk-long"
+        )
+
+        response = self._build_multi_chunk_response(short_chunk, long_chunk)
+        answer, refs, _ = chat_api._parse_ask_response_with_references(response)
+
+        assert answer == "This is definitively the longer, winning answer text."
+        assert len(refs) == 1
+        assert refs[0].source_id == winning_source, "Refs must belong to the winning chunk"

--- a/tests/unit/test_chat_references.py
+++ b/tests/unit/test_chat_references.py
@@ -693,7 +693,7 @@ class TestMultiChunkReferenceInflation:
         """References must not multiply when the API streams repeated chunks.
 
         Issue #300: each streaming chunk repeated the full reference list, so
-        N chunks × M refs = N*M entries instead of M. The fix tracks refs
+        N chunks x M refs = N*M entries instead of M. The fix tracks refs
         alongside the best answer instead of accumulating across all chunks.
         """
         source_id = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
@@ -711,7 +711,7 @@ class TestMultiChunkReferenceInflation:
         assert refs[0].source_id == source_id
 
     def test_many_chunks_still_single_ref_set(self, chat_api):
-        """Simulate 6 progressive streaming chunks (as in the bug report: 6×~67 = 402 sources)."""
+        """Simulate 6 progressive streaming chunks (as in the bug report: 6x~67 = 402 sources)."""
         source_id = "12345678-1234-1234-1234-123456789012"
         chunks = [
             self._make_answer_chunk(
@@ -726,7 +726,7 @@ class TestMultiChunkReferenceInflation:
         _, refs, _ = chat_api._parse_ask_response_with_references(response)
 
         # Should have exactly 1 reference from the longest (last) chunk, not 6
-        assert len(refs) == 1, f"Expected 1 reference, got {len(refs)} (references inflated across chunks)"
+        assert len(refs) == 1, f"Expected 1 reference, got {len(refs)}"
 
     def test_refs_from_longest_winning_chunk(self, chat_api):
         """Refs must come from the chunk that produced the longest answer."""


### PR DESCRIPTION
## Problem

`result.references` returned 600+ entries when a chat response contained only ~20 cited sources (issue #300).

**Root cause:** `_parse_ask_response_with_references` processes multiple streaming chunks via `process_chunk`. Each chunk that contains an answer also includes a full copy of the reference list. The old code called `all_references.extend(refs)` for *every* chunk, so references multiplied by chunk count:

```
6 chunks × 100 refs per chunk = 600 entries in result.references
```

Citation numbers were then assigned sequentially across all accumulated refs (1, 2, 3 … 600), not based on actual citations in the answer.

## Fix

Track refs alongside each best-answer candidate instead of accumulating from all chunks. Only the refs from the chunk that produced the longest marked answer (the "winning" chunk) are returned.

```python
# Before (in process_chunk):
all_references.extend(refs)   # accumulated from every chunk

# After:
if is_answer and len(text) > len(best_marked_answer):
    best_marked_answer = text
    best_marked_refs = refs   # refs travel with their answer candidate
```

The final `return` now uses `final_refs` (from the winning chunk) instead of `all_references`.

## Tests

Added `TestMultiChunkReferenceInflation` with three regression tests:

- `test_multi_chunk_does_not_inflate_references` — 2 chunks → 1 ref, not 2
- `test_many_chunks_still_single_ref_set` — 6 chunks → 1 ref, not 6 (mirrors the bug report numbers)
- `test_refs_from_longest_winning_chunk` — refs belong to the longer (winning) chunk, not the shorter one

All 21 existing chat-reference tests still pass; the 8 pre-existing `playwright`-related failures in `test_session.py` and `test_windows_compatibility.py` are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reference tracking so only citations from the selected answer candidate are returned, preventing duplicated or inflated references when responses arrive in multiple streamed chunks.

* **Tests**
  * Added unit tests covering streamed multi-chunk scenarios to ensure the parser selects the winning chunk and returns a single, correct reference list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->