### PR TITLE
fix(cli): tighten import_with_retry verification to avoid false positives

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -16,6 +16,7 @@ import os
 import time
 from functools import wraps
 from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
 
 import click
 from rich.console import Console
@@ -76,6 +77,25 @@ def run_async(coro):
     return asyncio.run(coro)
 
 
+def _normalize_url(url: str) -> str:
+    """Lowercase scheme + host and strip a trailing slash for comparison.
+
+    Server-side URL storage normalizes case and trailing slashes; client-side
+    requests may not. Compare via this helper to avoid false-negative misses
+    when verifying that a requested URL appears post-import.
+    """
+    parsed = urlsplit(url)
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/"),
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
 async def import_with_retry(
     client,
     notebook_id: str,
@@ -103,27 +123,25 @@ async def import_with_retry(
     delay = initial_delay
     attempt = 1
 
-    requested_urls = {url for s in sources if isinstance((url := s.get("url")), str) and url}
+    requested_urls_norm = {
+        _normalize_url(url) for s in sources if isinstance((url := s.get("url")), str) and url
+    }
 
-    # Snapshot baseline source URLs AND IDs so we can detect server-side success
-    # on timeout by computing the delta after each failed import RPC. URLs drive
-    # the detection condition (was the import seen on the server?); IDs filter
-    # the return value to only the truly new sources, which avoids reporting
-    # pre-existing rows as "imported" and also captures non-URL sources such as
-    # research-report entries.
-    baseline_urls: set[str] | None
+    # Snapshot baseline source IDs so the post-timeout probe can identify
+    # truly-new sources. We anchor the verified-success condition on URLs of
+    # *new* sources — not on a baseline→current URL delta — so concurrent
+    # additions from another session and pre-existing URLs cannot satisfy it.
     baseline_ids: set[str] | None
     try:
         baseline = await client.sources.list(notebook_id)
-        baseline_urls = {src.url for src in baseline if src.url}
         baseline_ids = {src.id for src in baseline}
-    except Exception as snapshot_exc:  # noqa: BLE001 - probe is best-effort; any failure falls back to legacy retry
-        logger.debug(
-            "Pre-import sources.list snapshot failed for %s: %s",
+    except (RPCTimeoutError, ConnectionError, OSError) as snapshot_exc:
+        logger.warning(
+            "Pre-import sources.list snapshot failed for %s: %s; "
+            "verified-success path disabled for this call",
             notebook_id,
             snapshot_exc,
         )
-        baseline_urls = None
         baseline_ids = None
 
     while True:
@@ -136,47 +154,57 @@ async def import_with_retry(
             # Verify server-side state before retrying. The IMPORT_RESEARCH RPC
             # frequently times out at the client (30s) after a successful
             # server-side write; retrying then duplicates every source.
-            if baseline_urls is not None and baseline_ids is not None and requested_urls:
+            if baseline_ids is not None and requested_urls_norm:
                 try:
                     current = await client.sources.list(notebook_id)
-                    current_urls = {src.url for src in current if src.url}
-                    delta_urls = current_urls - baseline_urls
-                    new_ids = {src.id for src in current} - baseline_ids
-                    # Either all requested URLs are now visible, or the delta
-                    # size matches what we tried to import. The latter is
-                    # robust to server-side URL normalization.
-                    if requested_urls.issubset(current_urls) or len(delta_urls) >= len(
-                        requested_urls
-                    ):
+                    new_sources = [src for src in current if src.id not in baseline_ids]
+                    new_urls_norm = {_normalize_url(src.url) for src in new_sources if src.url}
+                    # Success requires every requested URL to appear among the
+                    # *new* sources. Trivial-true cases (pre-existing URLs) and
+                    # concurrent unrelated additions both fail this check.
+                    if requested_urls_norm.issubset(new_urls_norm):
                         logger.warning(
                             "IMPORT_RESEARCH timed out for notebook %s but "
-                            "sources.list shows %d new sources; treating as "
-                            "success and skipping retry to avoid duplicate inflation",
+                            "sources.list shows all %d requested URLs among "
+                            "new sources; treating as success and skipping "
+                            "retry to avoid duplicate inflation",
                             notebook_id,
-                            len(new_ids),
+                            len(requested_urls_norm),
                         )
                         if not json_output:
                             console.print(
                                 f"[yellow]Import RPC timed out, but server-side "
-                                f"verified {len(new_ids)} new sources — "
-                                f"skipping retry.[/yellow]"
+                                f"verified {len(requested_urls_norm)} requested "
+                                f"sources — skipping retry.[/yellow]"
                             )
-                        # Return only sources whose IDs appeared after the
-                        # baseline probe. This avoids surfacing pre-existing
-                        # rows that happen to share a requested URL, and it
-                        # captures non-URL imports (e.g. research reports).
+                        # Return only new sources that match a requested URL
+                        # (or have no URL — captures research-report entries).
                         return [
                             {"id": src.id, "title": src.title or src.url or ""}
-                            for src in current
-                            if src.id in new_ids
+                            for src in new_sources
+                            if not src.url or _normalize_url(src.url) in requested_urls_norm
                         ]
-                except Exception as probe_exc:  # noqa: BLE001 - probe is best-effort
+                except asyncio.CancelledError:
+                    raise
+                except (RPCTimeoutError, ConnectionError, OSError) as probe_exc:
                     logger.warning(
                         "Failed to probe server state after timeout: %s; falling back to retry",
                         probe_exc,
                     )
 
             if remaining <= 0:
+                raise
+
+            # Report-only imports (no URLs to verify) can't use the success
+            # check above. Cap retries at one to bound worst-case duplicate
+            # inflation for report entries when timeouts persist.
+            if not requested_urls_norm and attempt >= 2:
+                logger.warning(
+                    "IMPORT_RESEARCH timed out for notebook %s with no URLs to "
+                    "verify; giving up after %d attempts to bound duplicate inflation",
+                    notebook_id,
+                    attempt,
+                )
                 raise
 
             sleep_for = min(delay, max_delay, remaining)

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -27,7 +27,7 @@ from ..auth import (
     fetch_tokens,
     load_auth_from_storage,
 )
-from ..exceptions import RPCTimeoutError
+from ..exceptions import NetworkError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
 from ..types import ArtifactType
 
@@ -126,6 +126,13 @@ async def import_with_retry(
     requested_urls_norm = {
         _normalize_url(url) for s in sources if isinstance((url := s.get("url")), str) and url
     }
+    # Track whether the request itself includes any non-URL entries (research
+    # reports, pasted text). If it doesn't, we must NOT include concurrent
+    # no-URL additions in the synthesized return — those would be unrelated
+    # sources reported as "imported" by this call.
+    requested_has_no_url_entry = any(
+        not (isinstance(s.get("url"), str) and s.get("url")) for s in sources
+    )
 
     # Snapshot baseline source IDs so the post-timeout probe can identify
     # truly-new sources. We anchor the verified-success condition on URLs of
@@ -135,7 +142,7 @@ async def import_with_retry(
     try:
         baseline = await client.sources.list(notebook_id)
         baseline_ids = {src.id for src in baseline}
-    except (RPCTimeoutError, ConnectionError, OSError) as snapshot_exc:
+    except (NetworkError, RPCError) as snapshot_exc:
         logger.warning(
             "Pre-import sources.list snapshot failed for %s: %s; "
             "verified-success path disabled for this call",
@@ -177,16 +184,21 @@ async def import_with_retry(
                                 f"verified {len(requested_urls_norm)} requested "
                                 f"sources — skipping retry.[/yellow]"
                             )
-                        # Return only new sources that match a requested URL
-                        # (or have no URL — captures research-report entries).
+                        # Return only new sources that match a requested URL.
+                        # No-URL new sources (research reports, pasted text)
+                        # are included only if the request itself had no-URL
+                        # entries — otherwise they're concurrent unrelated
+                        # additions and don't belong in the return.
                         return [
                             {"id": src.id, "title": src.title or src.url or ""}
                             for src in new_sources
-                            if not src.url or _normalize_url(src.url) in requested_urls_norm
+                            if (src.url and _normalize_url(src.url) in requested_urls_norm)
+                            or (not src.url and requested_has_no_url_entry)
                         ]
-                except asyncio.CancelledError:
-                    raise
-                except (RPCTimeoutError, ConnectionError, OSError) as probe_exc:
+                except (NetworkError, RPCError) as probe_exc:
+                    # CancelledError is a BaseException, not Exception, and is
+                    # not in this tuple — it propagates naturally for callers
+                    # that need to cancel the operation cleanly.
                     logger.warning(
                         "Failed to probe server state after timeout: %s; falling back to retry",
                         probe_exc,

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -1089,7 +1089,7 @@ class TestImportWithRetry:
         verification path. To bound the worst-case duplicate inflation, the
         retry loop must give up after a small number of attempts rather than
         burning the full ``max_elapsed`` budget — otherwise a persistent
-        timeout still produces 5–6× duplicate reports.
+        timeout still produces 5-6x duplicate reports.
 
         Patches ``time.monotonic`` to never advance past budget, so the only
         thing that can bound the loop is an explicit retry cap on the

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -29,7 +29,7 @@ from notebooklm.cli.helpers import (
     set_current_notebook,
     with_client,
 )
-from notebooklm.exceptions import RPCTimeoutError
+from notebooklm.exceptions import NetworkError, RPCTimeoutError
 from notebooklm.types import ArtifactType
 
 # =============================================================================
@@ -909,9 +909,10 @@ class TestImportWithRetry:
 
     @pytest.mark.asyncio
     async def test_returned_list_includes_non_url_sources_like_research_reports(self):
-        """Sources without a URL (e.g. deep-research report entries) must
-        still be surfaced in the imported list when they're new — filtering
-        by ID rather than by URL match handles that.
+        """When the request includes a research-report entry (no URL, only
+        title + ``report_markdown``), the verified-success return value must
+        surface the matching new no-URL source so callers can count it as
+        imported.
         """
         # A new research-report entry with no URL.
         report_src = MagicMock(id="src_report", title="Research Report", url=None)
@@ -936,12 +937,60 @@ class TestImportWithRetry:
                 client,
                 "nb_123",
                 "task_123",
-                [{"url": "https://example.com", "title": "Source 1"}],
+                [
+                    # Mixed request: one URL + one report entry.
+                    {"url": "https://example.com", "title": "Source 1"},
+                    {
+                        "title": "Research Report",
+                        "report_markdown": "# Findings\n...",
+                        "result_type": 5,
+                    },
+                ],
             )
 
         # Both sources are returned — the report (no URL) and the URL source.
         ids_returned = {entry["id"] for entry in imported}
         assert ids_returned == {"src_report", "src_new"}
+
+    @pytest.mark.asyncio
+    async def test_does_not_over_report_concurrent_no_url_source(self):
+        """When the request has NO no-URL entries (URLs only), a concurrent
+        no-URL source added during the timeout window must NOT be reported
+        as imported — even if the requested URL itself was successfully
+        written. Otherwise the caller's `len(imported)` overstates what this
+        call actually added.
+        """
+        # The user's URL did import successfully.
+        new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com")
+        # A concurrent session added a research report during the same window.
+        concurrent_report = MagicMock(
+            id="src_concurrent_report", title="Unrelated Report", url=None
+        )
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # empty baseline
+                [new_src, concurrent_report],
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+            )
+
+        # Only the requested URL's source is returned; the concurrent report
+        # is not part of this call's contribution.
+        assert imported == [{"id": "src_new", "title": "Source 1"}]
 
     @pytest.mark.asyncio
     async def test_does_not_falsely_succeed_on_unrelated_concurrent_source(self):
@@ -1092,7 +1141,7 @@ class TestImportWithRetry:
         client.sources.list = AsyncMock(
             side_effect=[
                 [],  # baseline
-                ConnectionError("probe down"),  # post-timeout probe fails
+                NetworkError("probe down"),  # post-timeout probe fails
                 [new_src],  # post-retry probe (would succeed if reached, unused)
             ]
         )

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -1,5 +1,6 @@
 """Tests for CLI helper functions."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -644,7 +645,11 @@ class TestRunAsync:
 class TestImportWithRetry:
     @pytest.mark.asyncio
     async def test_retries_rpc_timeout_then_succeeds(self):
+        # Empty baseline + empty post-timeout probe → verification fails →
+        # falls through to legacy retry. This exercises the retry path
+        # explicitly rather than relying on a snapshot exception.
         client = MagicMock()
+        client.sources.list = AsyncMock(return_value=[])
         client.research.import_sources = AsyncMock(
             side_effect=[
                 RPCTimeoutError("Timed out", timeout_seconds=30.0),
@@ -673,6 +678,7 @@ class TestImportWithRetry:
     @pytest.mark.asyncio
     async def test_retries_silently_for_json_output(self):
         client = MagicMock()
+        client.sources.list = AsyncMock(return_value=[])
         client.research.import_sources = AsyncMock(
             side_effect=[
                 RPCTimeoutError("Timed out", timeout_seconds=30.0),
@@ -697,11 +703,18 @@ class TestImportWithRetry:
     @pytest.mark.asyncio
     async def test_raises_after_elapsed_budget(self):
         client = MagicMock()
+        client.sources.list = AsyncMock(return_value=[])
         error = RPCTimeoutError("Timed out", timeout_seconds=30.0)
         client.research.import_sources = AsyncMock(side_effect=error)
 
+        # time.monotonic is read once at start, then on each timeout. We need
+        # enough values to cover the snapshot path plus the timeout-handling
+        # path (elapsed check). Past-budget on second read forces the raise.
         with (
-            patch("notebooklm.cli.helpers.time.monotonic", side_effect=[0.0, 1801.0]),
+            patch(
+                "notebooklm.cli.helpers.time.monotonic",
+                side_effect=[0.0, 1801.0],
+            ),
             patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             pytest.raises(RPCTimeoutError),
         ):
@@ -718,6 +731,7 @@ class TestImportWithRetry:
     @pytest.mark.asyncio
     async def test_does_not_retry_non_timeout_error(self):
         client = MagicMock()
+        client.sources.list = AsyncMock(return_value=[])
         client.research.import_sources = AsyncMock(side_effect=ValueError("boom"))
 
         with (
@@ -778,13 +792,13 @@ class TestImportWithRetry:
         assert mock_console.print.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_skips_retry_when_delta_size_matches_requested(self):
-        """URL-set match isn't required — a delta of size >= len(requested_urls)
-        also counts as success, so server-side URL normalization (trailing
-        slashes, etc.) doesn't force a duplicating retry.
+    async def test_skips_retry_when_url_normalization_matches(self):
+        """Server-side URL normalization (case folding, trailing-slash strip)
+        is handled by normalizing both sides before the subset check, so a
+        cosmetic difference between request and stored URL doesn't force a
+        duplicating retry.
         """
-        # Server stored a normalized URL (no trailing slash) different from what
-        # we requested, but the delta count matches.
+        # Server stored a normalized URL (no trailing slash, lowercased).
         new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com")
         client = MagicMock()
         client.sources.list = AsyncMock(
@@ -805,11 +819,10 @@ class TestImportWithRetry:
                 client,
                 "nb_123",
                 "task_123",
-                # Trailing slash differs from server-normalized form.
-                [{"url": "https://example.com/", "title": "Source 1"}],
+                # Trailing slash + uppercase host differ from server-normalized form.
+                [{"url": "https://Example.com/", "title": "Source 1"}],
             )
 
-        # Synthesized list includes the normalized URL via the delta path.
         assert imported == [{"id": "src_new", "title": "Source 1"}]
         assert client.research.import_sources.await_count == 1
         mock_sleep.assert_not_awaited()
@@ -845,31 +858,39 @@ class TestImportWithRetry:
         mock_sleep.assert_awaited_once_with(5)
 
     @pytest.mark.asyncio
-    async def test_returned_list_excludes_pre_existing_sources_with_matching_urls(self):
-        """If a requested URL was ALREADY present in the notebook before the
-        import, ``requested_urls.issubset(current_urls)`` is trivially true
-        even when nothing new was imported. The returned list must be filtered
-        by source IDs added since the baseline probe — not by URL match —
-        otherwise downstream callers (which use ``len(imported)``) overstate
-        what this call added.
+    async def test_retries_when_pre_existing_url_meets_concurrent_unrelated_addition(
+        self,
+    ):
+        """Combined edge case: the requested URL was already in the notebook
+        before the import, AND a concurrent session added an unrelated source
+        during the timeout window. The verified-success branch must NOT fire
+        — neither the pre-existing URL nor the unrelated addition is proof
+        our import wrote anything. The legacy retry path must run.
         """
-        # The notebook already contains a source for the URL we'll request.
         existing_src = MagicMock(id="src_existing", title="Old", url="https://example.com")
-        # And there's an unrelated brand-new source the probe sees.
-        new_src = MagicMock(id="src_new", title="New", url="https://other.example.com")
+        unrelated_src = MagicMock(
+            id="src_unrelated",
+            title="Unrelated (concurrent)",
+            url="https://other.example.com",
+        )
         client = MagicMock()
         client.sources.list = AsyncMock(
             side_effect=[
                 [existing_src],  # baseline already has the requested URL
-                [existing_src, new_src],  # post-timeout: one truly new source
+                # post-timeout: pre-existing + unrelated concurrent addition,
+                # but no truly-new source matching the requested URL.
+                [existing_src, unrelated_src],
             ]
         )
         client.research.import_sources = AsyncMock(
-            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_existing", "title": "Old"}],
+            ]
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch("notebooklm.cli.helpers.console"),
         ):
             imported = await import_with_retry(
@@ -877,12 +898,14 @@ class TestImportWithRetry:
                 "nb_123",
                 "task_123",
                 [{"url": "https://example.com", "title": "Old (request)"}],
+                initial_delay=5,
             )
 
-        # Only the source whose ID was NOT in the baseline should be returned.
-        # The pre-existing source must NOT be reported as imported even though
-        # its URL matches a requested URL.
-        assert imported == [{"id": "src_new", "title": "New"}]
+        # Must retry — neither the pre-existing match nor the unrelated new
+        # source proves the requested URL was actually written by this call.
+        assert client.research.import_sources.await_count == 2
+        mock_sleep.assert_awaited_once_with(5)
+        assert imported == [{"id": "src_existing", "title": "Old"}]
 
     @pytest.mark.asyncio
     async def test_returned_list_includes_non_url_sources_like_research_reports(self):
@@ -919,3 +942,262 @@ class TestImportWithRetry:
         # Both sources are returned — the report (no URL) and the URL source.
         ids_returned = {entry["id"] for entry in imported}
         assert ids_returned == {"src_report", "src_new"}
+
+    @pytest.mark.asyncio
+    async def test_does_not_falsely_succeed_on_unrelated_concurrent_source(self):
+        """Concurrent activity from another session (e.g. web UI, parallel CLI)
+        can add unrelated sources during the import window. The verification
+        condition must NOT fire on those — success must require the *requested*
+        URLs to actually appear among the new sources, not just that the post-
+        timeout source count grew.
+
+        Without this guard, a real timeout coinciding with any concurrent
+        addition would skip the retry and return the unrelated source as
+        "imported" — silently losing the user's import.
+        """
+        unrelated_src = MagicMock(
+            id="src_unrelated",
+            title="Unrelated",
+            url="https://other.example.com",
+        )
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # baseline: empty
+                # Post-timeout: only the unrelated concurrent addition is
+                # visible; our requested URL is NOT there.
+                [unrelated_src],
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_new", "title": "Source 1"}],
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+                initial_delay=5,
+            )
+
+        # Must retry, not falsely return the unrelated source.
+        assert imported == [{"id": "src_new", "title": "Source 1"}]
+        assert client.research.import_sources.await_count == 2
+        mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_does_not_falsely_succeed_on_pre_existing_requested_url(self):
+        """If the requested URL was already in the notebook before the import
+        and the post-timeout snapshot shows no truly-new source matching it,
+        verification must NOT fire — even though `requested_urls.issubset(
+        current_urls)` is trivially true. Otherwise a failed re-import of an
+        existing URL silently reports success.
+        """
+        existing_src = MagicMock(id="src_existing", title="Old", url="https://example.com")
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [existing_src],  # baseline: already has the URL
+                [existing_src],  # post-timeout: nothing changed
+                [existing_src],  # post-retry probe (if reached)
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_existing", "title": "Old"}],
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Old (request)"}],
+                initial_delay=5,
+            )
+
+        # Must retry — the URL being pre-existing isn't proof our import wrote.
+        assert client.research.import_sources.await_count == 2
+        mock_sleep.assert_awaited_once_with(5)
+        assert imported == [{"id": "src_existing", "title": "Old"}]
+
+    @pytest.mark.asyncio
+    async def test_report_only_import_bounded_retries_on_persistent_timeout(self):
+        """Report-only deep-research imports (no URLs) can't use the URL-match
+        verification path. To bound the worst-case duplicate inflation, the
+        retry loop must give up after a small number of attempts rather than
+        burning the full ``max_elapsed`` budget — otherwise a persistent
+        timeout still produces 5–6× duplicate reports.
+
+        Patches ``time.monotonic`` to never advance past budget, so the only
+        thing that can bound the loop is an explicit retry cap on the
+        no-URL path.
+        """
+        # All sources are report-only: no `url` field.
+        client = MagicMock()
+        client.sources.list = AsyncMock(return_value=[])
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            # Time budget never expires — only the retry cap can stop the loop.
+            patch(
+                "notebooklm.cli.helpers.time.monotonic",
+                return_value=0.0,
+            ),
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.console"),
+            pytest.raises(RPCTimeoutError),
+        ):
+            await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [
+                    {
+                        "title": "Research Report",
+                        "report_markdown": "# Findings\n...",
+                        "result_type": 5,
+                    }
+                ],
+                initial_delay=1,
+            )
+
+        # At most 2 attempts (1 original + 1 retry) before raising — bounded.
+        assert client.research.import_sources.await_count <= 2
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_retry_when_post_timeout_probe_raises(self):
+        """If the post-timeout ``sources.list`` probe itself fails (transient
+        network blip, server hiccup), the function must log and fall back to
+        the legacy retry path rather than crashing or skipping verification
+        silently.
+        """
+        new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com")
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # baseline
+                ConnectionError("probe down"),  # post-timeout probe fails
+                [new_src],  # post-retry probe (would succeed if reached, unused)
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_new", "title": "Source 1"}],
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+                initial_delay=5,
+            )
+
+        assert imported == [{"id": "src_new", "title": "Source 1"}]
+        # Probe failure → legacy retry path → 2 import attempts.
+        assert client.research.import_sources.await_count == 2
+        mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_verified_success_suppresses_console_output_when_json_output(self):
+        """The verified-success branch's user-visible notice must respect the
+        ``json_output`` flag — JSON consumers should not see human-readable
+        text spliced into stdout.
+        """
+        new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com")
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[[], [new_src]],
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.console") as mock_console,
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+                json_output=True,
+            )
+
+        assert imported == [{"id": "src_new", "title": "Source 1"}]
+        mock_console.print.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_propagates_cancelled_error(self):
+        """``asyncio.CancelledError`` from the pre-import snapshot must
+        propagate so callers can cleanly cancel the operation. A bare
+        ``except Exception`` would swallow it and continue running.
+        """
+        client = MagicMock()
+        client.sources.list = AsyncMock(side_effect=asyncio.CancelledError())
+        client.research.import_sources = AsyncMock()
+
+        with pytest.raises(asyncio.CancelledError):
+            await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+            )
+
+        # The import should never run — cancellation aborted the snapshot.
+        client.research.import_sources.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_probe_propagates_cancelled_error(self):
+        """``asyncio.CancelledError`` from the post-timeout probe must
+        propagate, not be swallowed and converted into a retry.
+        """
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # baseline OK
+                asyncio.CancelledError(),  # probe cancelled
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.console"),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+            )
+
+        # Only the original attempt — no retry after cancellation.
+        assert client.research.import_sources.await_count == 1

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -1108,7 +1108,7 @@ class TestImportWithRetry:
                 "notebooklm.cli.helpers.time.monotonic",
                 return_value=0.0,
             ),
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch("notebooklm.cli.helpers.console"),
             pytest.raises(RPCTimeoutError),
         ):
@@ -1126,8 +1126,11 @@ class TestImportWithRetry:
                 initial_delay=1,
             )
 
-        # At most 2 attempts (1 original + 1 retry) before raising — bounded.
-        assert client.research.import_sources.await_count <= 2
+        # Exactly 2 attempts (1 original + 1 retry) before raising. `<= 2`
+        # would also pass if the retry disappeared entirely, which would mask
+        # a regression — assert the cap and the single backoff sleep.
+        assert client.research.import_sources.await_count == 2
+        mock_sleep.assert_awaited_once_with(1)
 
     @pytest.mark.asyncio
     async def test_falls_back_to_retry_when_post_timeout_probe_raises(self):


### PR DESCRIPTION
## Summary

Closes #320 (follow-up to #319).

#319 fixed the duplicate-inflation cascade in `import_with_retry` (closes #241). A multi-model code review (Claude + Codex + Gemini) flagged two false-positive failure modes in the verification heuristic:

1. **Pre-existing URL false positive.** `requested_urls.issubset(current_urls)` was trivially true whenever the requested URL was already in the notebook before the import — so a real timeout on a re-import of an existing URL silently reported success.
2. **Concurrent-activity false positive.** `len(delta_urls) >= len(requested_urls)` could be satisfied by any concurrent activity (other CLI session, web UI, parallel script) adding unrelated sources during the timeout window — resulting in unrelated sources being surfaced as "imported".

In both cases the synthesized return value reported the wrong sources to the caller.

## Approach

Anchor the success condition on **URL-of-*new*-source match** rather than on baseline→current URL deltas:

```python
new_sources = [s for s in current if s.id not in baseline_ids]
new_urls_norm = {_normalize_url(s.url) for s in new_sources if s.url}
requested_urls_norm = {_normalize_url(u) for u in requested_urls}

if requested_urls_norm.issubset(new_urls_norm):
    # success — every requested URL appears among truly-new sources
    return [...]
```

This eliminates both false positives:
- Pre-existing URLs are filtered out by the `id not in baseline_ids` step → can't satisfy the subset check.
- Concurrent unrelated additions don't have URLs in `requested_urls_norm` → can't satisfy the subset check.

URL normalization (lowercase scheme + host, strip trailing slash) on both sides replaces the count-based branch — handles server-side URL canonicalization without the count-comparison vulnerability.

## Other changes

- **Narrow exception handling.** Both `except Exception` blocks become `except (RPCTimeoutError, ConnectionError, OSError)`; `asyncio.CancelledError` is explicitly re-raised so cancellation propagates cleanly. Coding errors (`AttributeError`, `TypeError`) now fail loudly instead of being swallowed.
- **Bounded retry for report-only imports.** When `requested_urls_norm` is empty (deep-research report-only imports — `result_type=5`, no URL), there's no signal to verify success. Cap retries at 1 (2 attempts total) so a persistent timeout can't produce 5–6× duplicate report entries.
- **Fix the four legacy tests** to explicitly mock `client.sources.list = AsyncMock(...)`. They previously passed by accident on `TypeError` from un-async-mocked attributes being swallowed by the broad `except`; with narrowed exceptions they need real mocks.
- **Rewrite test #4** (`test_returned_list_excludes_pre_existing_sources_with_matching_urls`) which codified the broken concurrent-unrelated-addition behavior. The new test (`test_retries_when_pre_existing_url_meets_concurrent_unrelated_addition`) asserts retry instead of false success.
- **Add coverage** for: probe-itself-fails fallback, `json_output=True` × verified-success path, snapshot `CancelledError` propagation, probe `CancelledError` propagation.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_helpers.py::TestImportWithRetry` — 16/16 pass
- [x] Full unit suite — `1522 passed, 5 skipped`
- [x] `ruff format src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/notebooklm --ignore-missing-imports` — clean

## Notes

- This is a tightening, not a regression — current `main` (post-#319) is strictly better than pre-#319 `main`, and this PR is strictly better than current `main`.
- The new `_normalize_url` helper uses `urllib.parse.urlsplit`/`urlunsplit` from the stdlib; no new dependencies.
- The bounded retry only kicks in for report-only imports; URL-bearing imports use the verification path (which has its own bounded behavior via `max_elapsed`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * URL normalization for import verification (case/trailing-slash tolerant); success now requires newly added requested sources to be present. Non-URL imports handled correctly. Added bounded retries for report-only imports, improved timeout handling, and suppression of verified-success console notices when JSON output is requested; cancellation errors now propagate.

* **Tests**
  * Expanded coverage for import retry behavior, URL-normalization, concurrent-addition edge cases, timeout/error propagation, and JSON-output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->