### PR TITLE
fix(cli): handle updated Playwright navigation interruption

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -68,6 +68,10 @@ LOGIN_MAX_RETRIES = 3
 # Playwright's TargetClosedError class (introduced in v1.41). If a future
 # version changes this message, the error will propagate unhandled (safe fallback).
 TARGET_CLOSED_ERROR = "Target page, context or browser has been closed"
+_NAVIGATION_INTERRUPTED_MARKERS = (
+    "navigation interrupted",
+    "interrupted by another navigation",
+)
 BROWSER_CLOSED_HELP = (
     "[red]The browser window was closed during login.[/red]\n"
     "This can happen when switching Google accounts in a persistent browser session.\n\n"
@@ -88,6 +92,13 @@ CONNECTION_ERROR_HELP = (
     "  3. Wait a few minutes before retrying\n"
     "  4. Check if notebooklm.google.com is accessible in your browser"
 )
+
+
+def _is_navigation_interrupted_error(error: str | Exception) -> bool:
+    """Return True for Playwright navigation races that are safe to ignore."""
+    error_str = str(error).lower()
+    return any(marker in error_str for marker in _NAVIGATION_INTERRUPTED_MARKERS)
+
 
 # Maps user-facing browser names to rookiepy function names.
 _ROOKIEPY_BROWSER_ALIASES: dict[str, str] = {
@@ -605,9 +616,9 @@ def register_session_commands(cli):
                                     # Recovered page also dead -- context/browser is gone
                                     console.print(BROWSER_CLOSED_HELP)
                                     raise SystemExit(1) from inner_exc
-                                elif "Navigation interrupted" not in str(inner_exc):
+                                elif not _is_navigation_interrupted_error(inner_exc):
                                     raise
-                        elif "Navigation interrupted" not in error_str:
+                        elif not _is_navigation_interrupted_error(error_str):
                             raise
 
                 current_url = page.url

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -208,10 +208,20 @@ class TestLoginCommand:
 
             yield mock_page
 
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "Page.goto: Navigation interrupted by another one",
+            (
+                'Page.goto: Navigation to "https://accounts.google.com/" is interrupted by '
+                'another navigation to "https://notebooklm.google.com/"'
+            ),
+        ],
+    )
     def test_login_handles_navigation_interrupted_error(
-        self, runner, mock_login_browser_with_storage
+        self, runner, mock_login_browser_with_storage, error_message
     ):
-        """Test login succeeds when page.goto raises 'Navigation interrupted' (#214)."""
+        """Test login succeeds when page.goto raises navigation interruption errors."""
         mock_page = mock_login_browser_with_storage
         from playwright.sync_api import Error as PlaywrightError
 
@@ -224,7 +234,7 @@ class TestLoginCommand:
             # First goto (NOTEBOOKLM_URL before login) succeeds
             # Second and third (cookie-forcing) raise navigation interrupted
             if call_count >= 2:
-                raise PlaywrightError("Page.goto: Navigation interrupted by another one")
+                raise PlaywrightError(error_message)
 
         mock_page.goto.side_effect = goto_side_effect
         mock_page.url = original_url
@@ -237,7 +247,7 @@ class TestLoginCommand:
     def test_login_reraises_non_navigation_playwright_errors(
         self, runner, mock_login_browser_with_storage
     ):
-        """Test login re-raises PlaywrightError that isn't 'Navigation interrupted'."""
+        """Test login re-raises PlaywrightError that is not a navigation interruption."""
         mock_page = mock_login_browser_with_storage
         from playwright.sync_api import Error as PlaywrightError
 
@@ -598,6 +608,59 @@ class TestLoginCommand:
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
         # Verify new_page was called to get a fresh page after the stale one died
+        mock_context.new_page.assert_called()
+
+    def test_login_ignores_navigation_interrupted_after_recovering_page(self, runner, tmp_path):
+        """Test recovered pages can also hit the Playwright navigation race (#317)."""
+        storage_file = tmp_path / "storage.json"
+        browser_dir = tmp_path / "profile"
+
+        with (
+            patch("notebooklm.cli.session._ensure_chromium_installed"),
+            patch("playwright.sync_api.sync_playwright") as mock_pw,
+            patch("notebooklm.cli.session.get_storage_path", return_value=storage_file),
+            patch(
+                "notebooklm.cli.session.get_browser_profile_dir",
+                return_value=browser_dir,
+            ),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch("builtins.input", return_value=""),
+        ):
+            from playwright.sync_api import Error as PlaywrightError
+
+            mock_context = MagicMock()
+            mock_page_stale = MagicMock()
+            mock_page_recovered = MagicMock()
+            mock_page_recovered.url = "https://notebooklm.google.com/"
+
+            goto_call_count = 0
+
+            def stale_goto_side_effect(url, **kwargs):
+                nonlocal goto_call_count
+                goto_call_count += 1
+                if goto_call_count == 1:
+                    return
+                raise PlaywrightError("Page.goto: Target page, context or browser has been closed")
+
+            mock_page_stale.goto.side_effect = stale_goto_side_effect
+            mock_page_stale.url = "https://notebooklm.google.com/"
+            mock_page_recovered.goto.side_effect = PlaywrightError(
+                'Page.goto: Navigation to "https://accounts.google.com/" is interrupted by '
+                'another navigation to "https://notebooklm.google.com/"'
+            )
+            mock_context.pages = [mock_page_stale]
+            mock_context.new_page.return_value = mock_page_recovered
+            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+
+            mock_launch = (
+                mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
+            )
+            mock_launch.return_value = mock_context
+
+            result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0
+        assert "Authentication saved" in result.output
         mock_context.new_page.assert_called()
 
     def test_login_shows_browser_closed_message_after_exhausting_retries(self, runner, tmp_path):


### PR DESCRIPTION
## Summary
- Broaden the post-login Playwright navigation-race matcher to handle the current \"is interrupted by another navigation\" wording.
- Preserve unrelated Playwright error propagation and TargetClosedError recovery behavior.
- Add regression coverage for both direct cookie-forcing navigation and recovered-page retry paths.

## Test plan
- [x] uv run pytest
- [x] uv run ruff check src/ tests/
- [x] uv run ruff format --check src/notebooklm/cli/session.py tests/unit/cli/test_session.py
- [x] uv run mypy src/notebooklm/cli/session.py
- [x] git diff --check

Fixes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened login flow to gracefully handle navigation interrupts that could cause intermittent login failures

* **Tests**
  * Added comprehensive test coverage for multiple navigation interrupt error scenarios to prevent regressions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->