### PR TITLE
fix(cli): support legacy Windows Unicode output

### DIFF
--- a/src/notebooklm/cli/_encoding.py
+++ b/src/notebooklm/cli/_encoding.py
@@ -7,9 +7,9 @@ import sys
 import click
 
 
-def replace_unencodable(text: str, stream) -> str:
+def replace_unencodable(text: str, stream: object | None) -> str:
     """Replace characters that cannot be encoded by a text stream."""
-    encoding = getattr(stream, "encoding", None) or "utf-8"
+    encoding = (getattr(stream, "encoding", "utf-8") or "utf-8") if stream else "utf-8"
     try:
         return text.encode(encoding, errors="replace").decode(encoding, errors="replace")
     except LookupError:

--- a/src/notebooklm/cli/_encoding.py
+++ b/src/notebooklm/cli/_encoding.py
@@ -1,0 +1,25 @@
+"""Encoding-safe CLI output helpers."""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+
+def replace_unencodable(text: str, stream) -> str:
+    """Replace characters that cannot be encoded by a text stream."""
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        return text.encode(encoding, errors="replace").decode(encoding, errors="replace")
+    except LookupError:
+        return text.encode("ascii", errors="replace").decode("ascii")
+
+
+def safe_echo(message: str, *, err: bool = False) -> None:
+    """Echo text, replacing unencodable characters if the first write fails."""
+    try:
+        click.echo(message, err=err)
+    except UnicodeEncodeError:
+        stream = sys.stderr if err else sys.stdout
+        click.echo(replace_unencodable(message, stream), err=err)

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -45,7 +45,7 @@ def _output_error(
         response: dict = {"error": True, "code": code, "message": message}
         if extra:
             response.update(extra)
-        safe_echo(json.dumps(response, indent=2))
+        click.echo(json.dumps(response, indent=2))  # json.dumps defaults to ASCII-safe output.
     else:
         safe_echo(message, err=True)
         if hint:

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -20,6 +20,7 @@ from ..exceptions import (
     RPCError,
     ValidationError,
 )
+from ._encoding import safe_echo
 
 
 def _output_error(
@@ -44,11 +45,11 @@ def _output_error(
         response: dict = {"error": True, "code": code, "message": message}
         if extra:
             response.update(extra)
-        click.echo(json.dumps(response, indent=2))
+        safe_echo(json.dumps(response, indent=2))
     else:
-        click.echo(message, err=True)
+        safe_echo(message, err=True)
         if hint:
-            click.echo(hint, err=True)
+            safe_echo(hint, err=True)
     raise SystemExit(exit_code)
 
 
@@ -80,7 +81,7 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
         if json_output:
             _output_error("Cancelled by user", "CANCELLED", True, 130)
         else:
-            click.echo("\nCancelled.", err=True)
+            safe_echo("\nCancelled.", err=True)
             raise SystemExit(130) from None
     except RateLimitError as e:
         retry_msg = f" Retry after {e.retry_after}s." if e.retry_after else ""

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -29,6 +29,7 @@ from ..auth import (
 from ..exceptions import RPCTimeoutError
 from ..paths import get_context_path
 from ..types import ArtifactType
+from ._encoding import safe_echo
 
 if TYPE_CHECKING:
     from ..types import Artifact
@@ -496,7 +497,11 @@ async def resolve_source_ids(
 
 def handle_error(e: Exception):
     """Handle and display errors consistently."""
-    console.print(f"[red]Error: {e}[/red]")
+    message = f"Error: {e}"
+    try:
+        console.print(f"[red]{message}[/red]")
+    except UnicodeEncodeError:
+        safe_echo(message, err=True)
     raise SystemExit(1)
 
 

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -44,6 +44,8 @@ from pathlib import Path
 
 def _reconfigure_output_stream(stream) -> None:
     """Use UTF-8 with replacement for active Windows text streams."""
+    if stream is None:
+        return
     reconfigure = getattr(stream, "reconfigure", None)
     if not callable(reconfigure):
         return
@@ -201,7 +203,6 @@ cli.add_command(profile)
 
 
 def main():
-    _configure_windows_runtime()
     cli()
 
 

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -37,22 +37,41 @@ import os
 from pathlib import Path
 
 # =============================================================================
-# WINDOWS COMPATIBILITY FIXES (issue #75, #79, #80)
+# WINDOWS COMPATIBILITY FIXES (issue #75, #79, #80, #318)
 # Must be applied before any async code runs
 # =============================================================================
 
-if sys.platform == "win32":
+
+def _reconfigure_output_stream(stream) -> None:
+    """Use UTF-8 with replacement for active Windows text streams."""
+    reconfigure = getattr(stream, "reconfigure", None)
+    if not callable(reconfigure):
+        return
+    try:
+        reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError, TypeError, ValueError):
+        pass
+
+
+def _configure_windows_runtime() -> None:
+    """Apply Windows runtime fixes before Click and Rich command modules load."""
+    if sys.platform != "win32":
+        return
+
     # Fix #79: Windows asyncio ProactorEventLoop can hang indefinitely at IOCP layer
     # (GetQueuedCompletionStatus) in certain environments like Sandboxie.
     # SelectorEventLoop avoids this issue.
-    import asyncio
-
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-    # Fix #80: Non-English Windows systems (cp950, cp932, etc.) can fail with
-    # UnicodeEncodeError when outputting Unicode characters like checkmarks.
-    # Setting PYTHONUTF8 ensures consistent UTF-8 encoding.
+    # Fix #80/#318: changing PYTHONUTF8 after startup does not update the already
+    # created stdout/stderr TextIOWrappers. Reconfigure the live streams so Rich's
+    # legacy Windows renderer can write emoji and other Unicode output safely.
     os.environ.setdefault("PYTHONUTF8", "1")
+    _reconfigure_output_stream(sys.stdout)
+    _reconfigure_output_stream(sys.stderr)
+
+
+_configure_windows_runtime()
 
 import click
 
@@ -182,17 +201,7 @@ cli.add_command(profile)
 
 
 def main():
-    # Windows-specific fixes
-    if sys.platform == "win32":
-        # Force UTF-8 encoding for Unicode output on non-English Windows systems
-        # Prevents UnicodeEncodeError when displaying Unicode characters (✓, ✗, box drawing)
-        # on systems with legacy encodings (cp950, cp932, cp936, etc.)
-        os.environ.setdefault("PYTHONUTF8", "1")
-
-        # Fix asyncio hanging issue - use WindowsSelectorEventLoopPolicy instead of
-        # default ProactorEventLoop to avoid IOCP blocking on network operations
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
+    _configure_windows_runtime()
     cli()
 
 

--- a/tests/unit/cli/test_encoding.py
+++ b/tests/unit/cli/test_encoding.py
@@ -21,6 +21,9 @@ class TestReplaceUnencodable:
     def test_uses_utf8_when_stream_encoding_is_missing(self):
         assert replace_unencodable("web 🌐", DummyStream(None)) == "web 🌐"
 
+    def test_uses_utf8_when_stream_is_none(self):
+        assert replace_unencodable("web 🌐", None) == "web 🌐"
+
     def test_unknown_encoding_falls_back_to_ascii_replacement(self):
         assert replace_unencodable("web 🌐", DummyStream("not-a-codec")) == "web ?"
 

--- a/tests/unit/cli/test_encoding.py
+++ b/tests/unit/cli/test_encoding.py
@@ -1,0 +1,85 @@
+"""Tests for encoding-safe CLI output helpers."""
+
+from unittest.mock import patch
+
+import notebooklm.cli._encoding as encoding_module
+from notebooklm.cli._encoding import replace_unencodable, safe_echo
+
+
+class DummyStream:
+    def __init__(self, encoding):
+        self.encoding = encoding
+
+
+class TestReplaceUnencodable:
+    def test_preserves_text_encodable_by_stream(self):
+        assert replace_unencodable("plain text", DummyStream("cp950")) == "plain text"
+
+    def test_replaces_text_not_encodable_by_stream(self):
+        assert replace_unencodable("web 🌐", DummyStream("cp950")) == "web ?"
+
+    def test_uses_utf8_when_stream_encoding_is_missing(self):
+        assert replace_unencodable("web 🌐", DummyStream(None)) == "web 🌐"
+
+    def test_unknown_encoding_falls_back_to_ascii_replacement(self):
+        assert replace_unencodable("web 🌐", DummyStream("not-a-codec")) == "web ?"
+
+
+class TestSafeEcho:
+    def test_echoes_original_message_when_first_write_succeeds(self):
+        with patch("notebooklm.cli._encoding.click.echo") as mock_echo:
+            safe_echo("web 🌐")
+
+        mock_echo.assert_called_once_with("web 🌐", err=False)
+
+    def test_replaces_stdout_text_when_first_write_cannot_encode(self):
+        class DummyStdout:
+            encoding = "cp950"
+
+        calls = []
+
+        def flaky_echo(message=None, **kwargs):
+            if not calls:
+                calls.append((message, kwargs.get("err", False)))
+                raise UnicodeEncodeError(
+                    "cp950",
+                    str(message),
+                    4,
+                    5,
+                    "illegal multibyte sequence",
+                )
+            calls.append((message, kwargs.get("err", False)))
+
+        with (
+            patch("notebooklm.cli._encoding.click.echo", side_effect=flaky_echo),
+            patch.object(encoding_module.sys, "stdout", DummyStdout()),
+        ):
+            safe_echo("web 🌐")
+
+        assert calls == [("web 🌐", False), ("web ?", False)]
+
+    def test_replaces_stderr_text_when_first_write_cannot_encode(self):
+        class DummyStderr:
+            encoding = "cp950"
+
+        calls = []
+
+        def flaky_echo(message=None, **kwargs):
+            if not calls:
+                calls.append((message, kwargs.get("err", False)))
+                raise UnicodeEncodeError(
+                    "cp950",
+                    str(message),
+                    4,
+                    5,
+                    "illegal multibyte sequence",
+                )
+            calls.append((message, kwargs.get("err", False)))
+
+        with (
+            patch("notebooklm.cli._encoding.click.echo", side_effect=flaky_echo),
+            patch.object(encoding_module.sys, "stderr", DummyStderr()),
+        ):
+            safe_echo("web 🌐", err=True)
+
+        assert calls == [("web 🌐", True), ("web ?", True)]

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import notebooklm.cli._encoding as encoding_module
 from notebooklm.cli.error_handler import handle_errors
 from notebooklm.exceptions import (
     AuthError,
@@ -165,6 +166,36 @@ class TestHandleErrorsTextOutput:
         data = json.loads(output)
         # Hint text should not be in the JSON structure
         assert "login" not in json.dumps(data).lower()
+
+    def test_text_output_falls_back_when_stream_cannot_encode(self, monkeypatch):
+        """Error reporting should not mask the original error with UnicodeEncodeError."""
+
+        class DummyStderr:
+            encoding = "cp950"
+
+        calls = []
+
+        def flaky_echo(message=None, **kwargs):
+            err = kwargs.get("err", False)
+            if not calls:
+                calls.append((message, err))
+                raise UnicodeEncodeError(
+                    "cp950",
+                    str(message),
+                    0,
+                    1,
+                    "illegal multibyte sequence",
+                )
+            calls.append((message, err))
+
+        monkeypatch.setattr(encoding_module.click, "echo", flaky_echo)
+        monkeypatch.setattr(encoding_module.sys, "stderr", DummyStderr())
+
+        with pytest.raises(SystemExit), handle_errors(json_output=False):
+            raise RuntimeError("bad 🌐")
+
+        assert calls[0] == ("Unexpected error: bad 🌐", True)
+        assert calls[1] == ("Unexpected error: bad ?", True)
 
 
 class TestHandleErrorsKeyboardInterrupt:

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import notebooklm.cli._encoding as encoding_module
 from notebooklm import Artifact
 from notebooklm.cli.helpers import (
     clear_context,
@@ -372,6 +373,44 @@ class TestHandleError:
             mock_console.print.assert_called_once()
             call_args = mock_console.print.call_args[0][0]
             assert "Test error" in call_args
+
+    def test_falls_back_when_console_cannot_encode_error(self):
+        class DummyStderr:
+            encoding = "cp950"
+
+        calls = []
+
+        def flaky_echo(message=None, **kwargs):
+            err = kwargs.get("err", False)
+            if not calls:
+                calls.append((message, err))
+                raise UnicodeEncodeError(
+                    "cp950",
+                    str(message),
+                    0,
+                    1,
+                    "illegal multibyte sequence",
+                )
+            calls.append((message, err))
+
+        with (
+            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch("notebooklm.cli._encoding.click.echo", side_effect=flaky_echo),
+            patch.object(encoding_module.sys, "stderr", DummyStderr()),
+        ):
+            mock_console.print.side_effect = UnicodeEncodeError(
+                "cp950",
+                "Error: broken 🌐",
+                14,
+                15,
+                "illegal multibyte sequence",
+            )
+
+            with pytest.raises(SystemExit) as exc_info:
+                handle_error(ValueError("broken 🌐"))
+
+        assert exc_info.value.code == 1
+        assert calls == [("Error: broken 🌐", True), ("Error: broken ?", True)]
 
 
 class TestHandleAuthError:

--- a/tests/unit/test_windows_compatibility.py
+++ b/tests/unit/test_windows_compatibility.py
@@ -219,15 +219,14 @@ class TestWindowsUTF8Mode:
         stderr = DummyStream()
         policies = []
 
+        monkeypatch.setitem(
+            notebooklm_cli.asyncio.__dict__,
+            "WindowsSelectorEventLoopPolicy",
+            DummyPolicy,
+        )
         monkeypatch.setattr(notebooklm_cli.sys, "platform", "win32")
         monkeypatch.setattr(notebooklm_cli.sys, "stdout", stdout)
         monkeypatch.setattr(notebooklm_cli.sys, "stderr", stderr)
-        monkeypatch.setattr(
-            notebooklm_cli.asyncio,
-            "WindowsSelectorEventLoopPolicy",
-            DummyPolicy,
-            raising=False,
-        )
         monkeypatch.setattr(
             notebooklm_cli.asyncio,
             "set_event_loop_policy",

--- a/tests/unit/test_windows_compatibility.py
+++ b/tests/unit/test_windows_compatibility.py
@@ -189,6 +189,12 @@ class TestWindowsUTF8Mode:
 
         notebooklm_cli._reconfigure_output_stream(object())
 
+    def test_reconfigure_output_stream_ignores_missing_stream(self):
+        """Detached Windows processes may not have standard streams."""
+        from notebooklm import notebooklm_cli
+
+        notebooklm_cli._reconfigure_output_stream(None)
+
     def test_reconfigure_output_stream_ignores_reconfigure_errors(self):
         """A failed best-effort reconfigure should not abort CLI startup."""
         from notebooklm import notebooklm_cli

--- a/tests/unit/test_windows_compatibility.py
+++ b/tests/unit/test_windows_compatibility.py
@@ -150,8 +150,97 @@ class TestWindowsUTF8Mode:
 
     Non-English Windows systems (cp950, cp932, cp936, etc.) can fail with
     UnicodeEncodeError when outputting Unicode characters like checkmarks.
-    The fix sets PYTHONUTF8=1 at CLI startup.
+    The fix sets PYTHONUTF8=1 and reconfigures live stdout/stderr at CLI startup.
     """
+
+    def test_windows_runtime_is_noop_on_non_windows(self, monkeypatch):
+        """Non-Windows platforms should not mutate streams or event loop policy."""
+        from notebooklm import notebooklm_cli
+
+        class DummyStream:
+            def __init__(self):
+                self.reconfigure_calls = []
+
+            def reconfigure(self, **kwargs):
+                self.reconfigure_calls.append(kwargs)
+
+        stdout = DummyStream()
+        stderr = DummyStream()
+
+        monkeypatch.setattr(notebooklm_cli.sys, "platform", "linux")
+        monkeypatch.setattr(notebooklm_cli.sys, "stdout", stdout)
+        monkeypatch.setattr(notebooklm_cli.sys, "stderr", stderr)
+        monkeypatch.setattr(
+            notebooklm_cli.asyncio,
+            "set_event_loop_policy",
+            lambda policy: pytest.fail("event loop policy should not be set on non-Windows"),
+        )
+        monkeypatch.delenv("PYTHONUTF8", raising=False)
+
+        notebooklm_cli._configure_windows_runtime()
+
+        assert "PYTHONUTF8" not in os.environ
+        assert stdout.reconfigure_calls == []
+        assert stderr.reconfigure_calls == []
+
+    def test_reconfigure_output_stream_ignores_unsupported_stream(self):
+        """Streams without reconfigure support should be ignored."""
+        from notebooklm import notebooklm_cli
+
+        notebooklm_cli._reconfigure_output_stream(object())
+
+    def test_reconfigure_output_stream_ignores_reconfigure_errors(self):
+        """A failed best-effort reconfigure should not abort CLI startup."""
+        from notebooklm import notebooklm_cli
+
+        class BrokenStream:
+            def reconfigure(self, **kwargs):
+                raise OSError("stream is closed")
+
+        notebooklm_cli._reconfigure_output_stream(BrokenStream())
+
+    def test_windows_runtime_reconfigures_active_output_streams(self, monkeypatch):
+        """Simulate Windows startup and verify existing streams are made UTF-8-safe."""
+        from notebooklm import notebooklm_cli
+
+        class DummyStream:
+            encoding = "cp950"
+
+            def __init__(self):
+                self.reconfigure_calls = []
+
+            def reconfigure(self, **kwargs):
+                self.reconfigure_calls.append(kwargs)
+
+        class DummyPolicy:
+            pass
+
+        stdout = DummyStream()
+        stderr = DummyStream()
+        policies = []
+
+        monkeypatch.setattr(notebooklm_cli.sys, "platform", "win32")
+        monkeypatch.setattr(notebooklm_cli.sys, "stdout", stdout)
+        monkeypatch.setattr(notebooklm_cli.sys, "stderr", stderr)
+        monkeypatch.setattr(
+            notebooklm_cli.asyncio,
+            "WindowsSelectorEventLoopPolicy",
+            DummyPolicy,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            notebooklm_cli.asyncio,
+            "set_event_loop_policy",
+            lambda policy: policies.append(policy),
+        )
+        monkeypatch.delenv("PYTHONUTF8", raising=False)
+
+        notebooklm_cli._configure_windows_runtime()
+
+        assert os.environ["PYTHONUTF8"] == "1"
+        assert stdout.reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
+        assert stderr.reconfigure_calls == [{"encoding": "utf-8", "errors": "replace"}]
+        assert isinstance(policies[0], DummyPolicy)
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
     def test_utf8_mode_enabled(self):


### PR DESCRIPTION
## Summary
- Reconfigure live stdout/stderr to UTF-8 with replacement on Windows before Click/Rich CLI modules load
- Add a shared encoding-safe CLI output helper and use it for centralized and legacy error paths
- Add regression coverage for CP950-style Unicode failures, safe fallback output, and Windows runtime setup paths

Closes #318

## Test plan
- [x] uv run ruff check src/ tests/
- [x] uv run pytest -q
- [x] uv run mypy src/notebooklm
- [x] uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI output now robustly handles Unicode encode errors by retrying with sanitized replacement characters, preventing crashes and ensuring messages (stdout/stderr) display reliably.
  * Windows runtime handling consolidated and improved to enable UTF-8 output and reconfigure active stdout/stderr for consistent cross-platform behavior.

* **Tests**
  * Added tests for encoding-safe CLI output, error-handler fallbacks, helpers, and Windows UTF-8/runtime reconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->