### PR TITLE
docs(skill): align SKILL.md JSON examples with actual CLI output

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -202,14 +202,14 @@ Before starting workflows, verify the CLI is ready:
 Commands with `--json` return structured data for parsing:
 
 **Create notebook:**
-```
+```bash
 $ notebooklm create "Research" --json
 {"notebook": {"id": "abc123de-...", "title": "Research", "created_at": null}}
 # parse with: jq -r .notebook.id
 ```
 
 **Add source:**
-```
+```bash
 $ notebooklm source add "https://example.com" --json
 {"source": {"id": "def456...", "title": "Example", "type": "SourceType.URL", "url": "https://example.com"}}
 # parse with: jq -r .source.id
@@ -217,20 +217,20 @@ $ notebooklm source add "https://example.com" --json
 ```
 
 **Generate artifact:**
-```
+```bash
 $ notebooklm generate audio "Focus on key points" --json
 {"task_id": "xyz789...", "status": "pending"}
 # When run with --wait, completed status also includes a `url` field.
 ```
 
 **Chat with references:**
-```
+```bash
 $ notebooklm ask "What is X?" --json
 {"answer": "X is... [1] [2]", "conversation_id": "...", "turn_number": 1, "is_follow_up": false, "references": [{"source_id": "abc123...", "citation_number": 1, "cited_text": "Relevant passage from source..."}, {"source_id": "def456...", "citation_number": 2, "cited_text": "Another passage..."}]}
 ```
 
 **Source fulltext (get indexed content):**
-```
+```bash
 $ notebooklm source fulltext <source_id> --json
 {"source_id": "...", "title": "...", "content": "Full indexed text...", "url": null, "char_count": 12345}
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -211,7 +211,7 @@ $ notebooklm create "Research" --json
 **Add source:**
 ```bash
 $ notebooklm source add "https://example.com" --json
-{"source": {"id": "def456...", "title": "Example", "type": "SourceType.URL", "url": "https://example.com"}}
+{"source": {"id": "def456...", "title": "Example", "type": "SourceType.WEB_PAGE", "url": "https://example.com"}}
 # parse with: jq -r .source.id
 # Note: no `status` field on add — use `source list --json` or `source wait` to check processing state.
 ```
@@ -232,7 +232,7 @@ $ notebooklm ask "What is X?" --json
 **Source fulltext (get indexed content):**
 ```bash
 $ notebooklm source fulltext <source_id> --json
-{"source_id": "...", "title": "...", "content": "Full indexed text...", "url": null, "char_count": 12345}
+{"source_id": "...", "title": "...", "content": "Full indexed text...", "_type_code": null, "url": null, "char_count": 12345}
 ```
 
 **Understanding citations:** The `cited_text` in references is often a snippet or section header, not the full quoted passage. The `start_char`/`end_char` positions reference NotebookLM's internal chunked index, not the raw fulltext. Use `SourceFulltext.find_citation_context()` to locate citations:
@@ -444,12 +444,12 @@ notebooklm artifact list --json
 
 `notebooklm source list --json`:
 ```json
-{"notebook_id": "...", "notebook_title": "...", "sources": [{"index": 1, "id": "...", "title": "...", "type": "SourceType.URL", "url": "...", "status": "ready|processing|error", "status_id": 1, "created_at": "..."}], "count": 1}
+{"notebook_id": "...", "notebook_title": "...", "sources": [{"index": 1, "id": "...", "title": "...", "type": "SourceType.WEB_PAGE", "url": "...", "status": "ready|processing|error", "status_id": 1, "created_at": "..."}], "count": 1}
 ```
 
 `notebooklm artifact list --json`:
 ```json
-{"notebook_id": "...", "notebook_title": "...", "artifacts": [{"index": 1, "id": "...", "title": "...", "type": "Audio Overview", "type_id": 1, "status": "in_progress|pending|completed|unknown", "status_id": 1, "created_at": "..."}], "count": 1}
+{"notebook_id": "...", "notebook_title": "...", "artifacts": [{"index": 1, "id": "...", "title": "...", "type": "Audio", "type_id": 1, "status": "in_progress|pending|completed|unknown", "status_id": 1, "created_at": "..."}], "count": 1}
 ```
 
 **Status values:**

--- a/SKILL.md
+++ b/SKILL.md
@@ -204,19 +204,23 @@ Commands with `--json` return structured data for parsing:
 **Create notebook:**
 ```
 $ notebooklm create "Research" --json
-{"id": "abc123de-...", "title": "Research"}
+{"notebook": {"id": "abc123de-...", "title": "Research", "created_at": null}}
+# parse with: jq -r .notebook.id
 ```
 
 **Add source:**
 ```
 $ notebooklm source add "https://example.com" --json
-{"source_id": "def456...", "title": "Example", "status": "processing"}
+{"source": {"id": "def456...", "title": "Example", "type": "SourceType.URL", "url": "https://example.com"}}
+# parse with: jq -r .source.id
+# Note: no `status` field on add — use `source list --json` or `source wait` to check processing state.
 ```
 
 **Generate artifact:**
 ```
 $ notebooklm generate audio "Focus on key points" --json
 {"task_id": "xyz789...", "status": "pending"}
+# When run with --wait, completed status also includes a `url` field.
 ```
 
 **Chat with references:**
@@ -228,7 +232,7 @@ $ notebooklm ask "What is X?" --json
 **Source fulltext (get indexed content):**
 ```
 $ notebooklm source fulltext <source_id> --json
-{"source_id": "...", "title": "...", "char_count": 12345, "content": "Full indexed text..."}
+{"source_id": "...", "title": "...", "content": "Full indexed text...", "url": null, "char_count": 12345}
 ```
 
 **Understanding citations:** The `cited_text` in references is often a snippet or section header, not the full quoted passage. The `start_char`/`end_char` positions reference NotebookLM's internal chunked index, not the raw fulltext. Use `SourceFulltext.find_citation_context()` to locate citations:
@@ -239,7 +243,10 @@ if matches:
     context, pos = matches[0]  # First match; check len(matches) > 1 for duplicates
 ```
 
-**Extract IDs:** Parse the `id`, `source_id`, or `task_id` field from JSON output.
+**Extract IDs:** Singular endpoints wrap their result in an envelope —
+parse `.notebook.id` (from `create`), `.source.id` (from `source add`),
+or `.task_id` (from `generate *`). The chat `--json` references list uses
+`.references[].source_id`.
 
 ## Generation Types
 
@@ -256,11 +263,13 @@ All generate commands support:
 | Slide Deck | `generate slide-deck` | `--format [detailed\|presenter]`, `--length [default\|short]` | .pdf / .pptx |
 | Slide Revision | `generate revise-slide "prompt" --artifact <id> --slide N` | `--wait`, `--notebook` | *(re-downloads parent deck)* |
 | Infographic | `generate infographic` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]` | .png |
-| Report | `generate report` | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append "extra instructions"` | .md |
+| Report | `generate report` | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append "extra instructions"` (¹) | .md |
 | Mind Map | `generate mind-map` | *(sync, instant)* | .json |
 | Data Table | `generate data-table` | description required | .csv |
 | Quiz | `generate quiz` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]` | .json/.md/.html |
 | Flashcards | `generate flashcards` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]` | .json/.md/.html |
+
+¹ `--append` only customizes the built-in templates. With `--format custom`, pass the prompt as the positional `DESCRIPTION` argument (`notebooklm generate report "PROMPT" --format custom`); `--append` is silently ignored in that mode (the CLI prints a warning).
 
 ## Features Beyond the Web UI
 
@@ -346,10 +355,10 @@ When user wants full automation (generate and download when ready):
 
 When adding multiple sources and needing to wait for processing before chat/generation:
 
-1. Add sources with `--json` to capture IDs:
+1. Add sources with `--json` to capture IDs (parse with `jq -r .source.id`):
    ```bash
-   notebooklm source add "https://url1.com" --json  # → {"source_id": "abc..."}
-   notebooklm source add "https://url2.com" --json  # → {"source_id": "def..."}
+   notebooklm source add "https://url1.com" --json  # → {"source": {"id": "abc...", ...}}
+   notebooklm source add "https://url2.com" --json  # → {"source": {"id": "def...", ...}}
    ```
 2. **Spawn a background agent** to wait for all sources:
    ```
@@ -425,22 +434,22 @@ notebooklm artifact list --json
 
 `notebooklm list --json`:
 ```json
-{"notebooks": [{"id": "...", "title": "...", "created_at": "..."}]}
+{"notebooks": [{"index": 1, "id": "...", "title": "...", "is_owner": true, "created_at": "..."}], "count": 1}
 ```
 
 `notebooklm auth check --json`:
 ```json
-{"checks": {"storage_exists": true, "json_valid": true, "cookies_present": true, "sid_cookie": true, "token_fetch": true}, "details": {"storage_path": "...", "auth_source": "file", "cookies_found": ["SID", "HSID", "..."], "cookie_domains": [".google.com"]}}
+{"status": "ok", "checks": {"storage_exists": true, "json_valid": true, "cookies_present": true, "sid_cookie": true, "token_fetch": true}, "details": {"storage_path": "...", "auth_source": "file", "cookies_found": ["SID", "HSID", "..."], "cookie_domains": [".google.com"]}}
 ```
 
 `notebooklm source list --json`:
 ```json
-{"sources": [{"id": "...", "title": "...", "status": "ready|processing|error"}]}
+{"notebook_id": "...", "notebook_title": "...", "sources": [{"index": 1, "id": "...", "title": "...", "type": "SourceType.URL", "url": "...", "status": "ready|processing|error", "status_id": 1, "created_at": "..."}], "count": 1}
 ```
 
 `notebooklm artifact list --json`:
 ```json
-{"artifacts": [{"id": "...", "title": "...", "type": "Audio Overview", "status": "in_progress|pending|completed|unknown"}]}
+{"notebook_id": "...", "notebook_title": "...", "artifacts": [{"index": 1, "id": "...", "title": "...", "type": "Audio Overview", "type_id": 1, "status": "in_progress|pending|completed|unknown", "status_id": 1, "created_at": "..."}], "count": 1}
 ```
 
 **Status values:**


### PR DESCRIPTION
## Summary

Fixes #316. Brings the `--json` examples and JSON schemas in `SKILL.md` back in line with what the v0.3.4 CLI actually emits, so agents and scripts that follow the documented `jq` paths stop silently parsing `null` and breaking downstream commands.

The reporter was right on every point — singular endpoints wrap their result in an envelope, and several list-endpoint schemas were missing both their wrapper and a number of per-item fields.

## What changed in `SKILL.md`

- `create --json` example/schema → `{"notebook": {"id", "title", "created_at"}}`, with a `jq -r .notebook.id` hint.
- `source add --json` example/schema → `{"source": {"id", "title", "type", "url"}}`, with a `jq -r .source.id` hint and a note that there is no `status` field on add (check processing state via `source list --json` or `source wait`).
- `Extract IDs` guidance updated to reflect the envelope shapes for singular endpoints.
- Bulk-import workflow inline comments now show the real `{"source": {"id": ...}}` shape.
- `list --json` schema → adds `index`, `is_owner`, top-level `count`.
- `source list --json` schema → adds `notebook_id`/`notebook_title` wrapper, per-item `type`/`url`/`status_id`/`created_at`, top-level `count`.
- `artifact list --json` schema → adds `notebook_id`/`notebook_title` wrapper, per-item `type_id`/`status_id`/`created_at`, top-level `count`.
- `auth check --json` schema → adds top-level `status: "ok"|"error"`.
- `generate audio --json` example → notes that running with `--wait` also surfaces a `url` field on completion.
- `source fulltext --json` example → field order now matches the actual `asdict(SourceFulltext)` output.
- Generation Types table → footnote on `Report` clarifies that `--append` is silently ignored with `--format custom`; in custom mode the prompt must be passed as the positional `DESCRIPTION` argument (the CLI prints a warning, then drops the appended text). This was the "bonus pitfall" called out in the issue.

Each shape was cross-checked against the source — `cli/notebook.py` (`list`, `create`), `cli/source.py` (`source add`, `source list`, `source fulltext`), `cli/artifact.py` (`artifact list`), `cli/session.py` (`auth check`), `cli/generate.py` (`generate *`), and the `AskResult`/`ChatReference`/`SourceFulltext` dataclasses in `types.py`.

## Test plan

- [x] `ruff format src/ tests/` — no changes.
- [x] `ruff check src/ tests/` — All checks passed!
- [x] `mypy src/notebooklm --ignore-missing-imports` — Success: no issues found in 47 source files.
- [x] `pytest` — 2056 passed, 9 skipped (no test changes; this is docs-only).
- [x] Spot-checked each documented schema against the corresponding `json_output_response` call site.
- [ ] Reviewer eyeball: skim the rendered `SKILL.md` diff and confirm the new shapes are what they see when running the CLI locally.

## Out of scope (filed separately)

While auditing the file I noticed an unrelated bug in the Quick Reference at `SKILL.md` L183 (it shows `notebooklm notebook delete <id>` but no `notebook` subgroup exists — the actual command is top-level `notebooklm delete <id>`). That is a separate command-syntax doc bug, not a JSON-shape issue, so it will be filed as its own issue and fixed in a follow-up to keep this PR scoped to #316.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI docs to reflect envelope-style JSON outputs and new nested ID locations (e.g., notebook/source/task).
  * Example responses for source fulltext now include additional metadata fields.
  * Clarified report generation: --append only customizes built-in templates and is ignored for --format custom (CLI emits a warning).
  * Refreshed JSON schemas and examples for list/auth/source/artifact commands to include richer context, indexes, and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->