### PR TITLE
fix(cli): filter partial import retry payload

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -33,7 +33,7 @@ from ..types import ArtifactType
 from ._encoding import safe_echo
 
 if TYPE_CHECKING:
-    from ..types import Artifact
+    from ..types import Artifact, Source
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ def _has_no_url_entry(sources: list[dict]) -> bool:
     return any(_source_url_norm(source) is None for source in sources)
 
 
-def _imported_source_entry(source) -> dict[str, str]:
+def _imported_source_entry(source: "Source") -> dict[str, str]:
     return {"id": source.id, "title": source.title or source.url or ""}
 
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -231,15 +231,14 @@ async def import_with_retry(
                         return _merge_imported_sources(
                             imported, verified_imported, verified_imported_ids
                         )
+                    source_norms = [(source, _source_url_norm(source)) for source in sources]
                     removed_urls_norm = {
                         url
-                        for source in sources
-                        if (url := _source_url_norm(source)) in current_urls_norm
+                        for _, url in source_norms
+                        if url is not None and url in current_urls_norm
                     }
                     filtered_sources = [
-                        source
-                        for source in sources
-                        if _source_url_norm(source) not in current_urls_norm
+                        source for source, url in source_norms if url not in current_urls_norm
                     ]
                     if len(filtered_sources) != len(sources):
                         removed_count = len(sources) - len(filtered_sources)

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -97,6 +97,38 @@ def _normalize_url(url: str) -> str:
     )
 
 
+def _source_url_norm(source: dict) -> str | None:
+    url = source.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    return _normalize_url(url)
+
+
+def _requested_urls_norm(sources: list[dict]) -> set[str]:
+    return {url for source in sources if (url := _source_url_norm(source))}
+
+
+def _has_no_url_entry(sources: list[dict]) -> bool:
+    return any(_source_url_norm(source) is None for source in sources)
+
+
+def _imported_source_entry(source) -> dict[str, str]:
+    return {"id": source.id, "title": source.title or source.url or ""}
+
+
+def _merge_imported_sources(
+    imported: list[dict[str, str]],
+    verified_imported: list[dict[str, str]],
+    verified_imported_ids: set[str],
+) -> list[dict[str, str]]:
+    if not verified_imported:
+        return imported
+    return [
+        *verified_imported,
+        *(entry for entry in imported if entry.get("id") not in verified_imported_ids),
+    ]
+
+
 async def import_with_retry(
     client,
     notebook_id: str,
@@ -123,17 +155,15 @@ async def import_with_retry(
     started_at = time.monotonic()
     delay = initial_delay
     attempt = 1
+    verified_imported: list[dict[str, str]] = []
+    verified_imported_ids: set[str] = set()
 
-    requested_urls_norm = {
-        _normalize_url(url) for s in sources if isinstance((url := s.get("url")), str) and url
-    }
+    requested_urls_norm = _requested_urls_norm(sources)
     # Track whether the request itself includes any non-URL entries (research
     # reports, pasted text). If it doesn't, we must NOT include concurrent
     # no-URL additions in the synthesized return — those would be unrelated
     # sources reported as "imported" by this call.
-    requested_has_no_url_entry = any(
-        not (isinstance(s.get("url"), str) and s.get("url")) for s in sources
-    )
+    requested_has_no_url_entry = _has_no_url_entry(sources)
 
     # Snapshot baseline source IDs so the post-timeout probe can identify
     # truly-new sources. We anchor the verified-success condition on URLs of
@@ -154,7 +184,8 @@ async def import_with_retry(
 
     while True:
         try:
-            return await client.research.import_sources(notebook_id, task_id, sources)
+            imported = await client.research.import_sources(notebook_id, task_id, sources)
+            return _merge_imported_sources(imported, verified_imported, verified_imported_ids)
         except RPCTimeoutError:
             elapsed = time.monotonic() - started_at
             remaining = max_elapsed - elapsed
@@ -167,6 +198,7 @@ async def import_with_retry(
                     current = await client.sources.list(notebook_id)
                     new_sources = [src for src in current if src.id not in baseline_ids]
                     new_urls_norm = {_normalize_url(src.url) for src in new_sources if src.url}
+                    current_urls_norm = {_normalize_url(src.url) for src in current if src.url}
                     # Success requires every requested URL to appear among the
                     # *new* sources. Trivial-true cases (pre-existing URLs) and
                     # concurrent unrelated additions both fail this check.
@@ -190,12 +222,63 @@ async def import_with_retry(
                         # are included only if the request itself had no-URL
                         # entries — otherwise they're concurrent unrelated
                         # additions and don't belong in the return.
-                        return [
-                            {"id": src.id, "title": src.title or src.url or ""}
+                        imported = [
+                            _imported_source_entry(src)
                             for src in new_sources
                             if (src.url and _normalize_url(src.url) in requested_urls_norm)
                             or (not src.url and requested_has_no_url_entry)
                         ]
+                        return _merge_imported_sources(
+                            imported, verified_imported, verified_imported_ids
+                        )
+                    removed_urls_norm = {
+                        url
+                        for source in sources
+                        if (url := _source_url_norm(source)) in current_urls_norm
+                    }
+                    filtered_sources = [
+                        source
+                        for source in sources
+                        if _source_url_norm(source) not in current_urls_norm
+                    ]
+                    if len(filtered_sources) != len(sources):
+                        removed_count = len(sources) - len(filtered_sources)
+                        for src in new_sources:
+                            if (
+                                src.url
+                                and _normalize_url(src.url) in removed_urls_norm
+                                and src.id not in verified_imported_ids
+                            ):
+                                verified_imported.append(_imported_source_entry(src))
+                                verified_imported_ids.add(src.id)
+                        sources = filtered_sources
+                        requested_urls_norm = _requested_urls_norm(sources)
+                        requested_has_no_url_entry = _has_no_url_entry(sources)
+                        if not sources:
+                            logger.warning(
+                                "IMPORT_RESEARCH timed out for notebook %s but "
+                                "sources.list shows all requested URLs already "
+                                "present; treating as success and skipping retry "
+                                "to avoid duplicate inflation",
+                                notebook_id,
+                            )
+                            if not json_output:
+                                console.print(
+                                    "[yellow]Import RPC timed out, but all "
+                                    "requested sources are already present — "
+                                    "skipping retry.[/yellow]"
+                                )
+                            return _merge_imported_sources(
+                                [], verified_imported, verified_imported_ids
+                            )
+                        logger.warning(
+                            "IMPORT_RESEARCH timed out for notebook %s after "
+                            "%d requested source(s) were already present; retrying "
+                            "with %d remaining source(s)",
+                            notebook_id,
+                            removed_count,
+                            len(sources),
+                        )
                 except (NetworkError, RPCError) as probe_exc:
                     # CancelledError is a BaseException, not Exception, and is
                     # not in this tuple — it propagates naturally for callers

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -897,6 +897,192 @@ class TestImportWithRetry:
         mock_sleep.assert_awaited_once_with(5)
 
     @pytest.mark.asyncio
+    async def test_partial_timeout_retries_only_missing_urls(self):
+        """If a timed-out import partially committed URLs, the retry payload
+        must drop already-visible URLs to avoid duplicating them.
+        """
+        imported_src = MagicMock(id="src_1", title="Source 1", url="https://one.example.com")
+        sources = [
+            {"url": "https://one.example.com", "title": "Source 1"},
+            {"url": "https://two.example.com", "title": "Source 2"},
+            {"url": "https://three.example.com", "title": "Source 3"},
+        ]
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # baseline
+                [imported_src],  # post-timeout probe — 1 of 3 is visible
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_2", "title": "Source 2"}, {"id": "src_3", "title": "Source 3"}],
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                sources,
+                initial_delay=5,
+            )
+
+        assert imported == [
+            {"id": "src_1", "title": "Source 1"},
+            {"id": "src_2", "title": "Source 2"},
+            {"id": "src_3", "title": "Source 3"},
+        ]
+        assert client.research.import_sources.await_count == 2
+        first_call_sources = client.research.import_sources.await_args_list[0].args[2]
+        retry_call_sources = client.research.import_sources.await_args_list[1].args[2]
+        assert first_call_sources == sources
+        assert retry_call_sources == [
+            {"url": "https://two.example.com", "title": "Source 2"},
+            {"url": "https://three.example.com", "title": "Source 3"},
+        ]
+        mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_partial_timeout_preserves_report_entries_for_retry(self):
+        """Filtering URL entries that are already visible must leave no-URL
+        report entries in the retry payload.
+        """
+        imported_src = MagicMock(id="src_1", title="Source 1", url="https://one.example.com")
+        report_entry = {
+            "title": "Research Report",
+            "report_markdown": "# Findings\n...",
+            "result_type": 5,
+        }
+        sources = [
+            {"url": "https://one.example.com", "title": "Source 1"},
+            {"url": "https://two.example.com", "title": "Source 2"},
+            report_entry,
+        ]
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # baseline
+                [imported_src],  # post-timeout probe — URL 1 is visible
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                [{"id": "src_2", "title": "Source 2"}, {"id": "src_report", "title": "Report"}],
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                sources,
+                initial_delay=5,
+            )
+
+        assert imported == [
+            {"id": "src_1", "title": "Source 1"},
+            {"id": "src_2", "title": "Source 2"},
+            {"id": "src_report", "title": "Report"},
+        ]
+        retry_call_sources = client.research.import_sources.await_args_list[1].args[2]
+        assert retry_call_sources == [
+            {"url": "https://two.example.com", "title": "Source 2"},
+            report_entry,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_partial_timeout_merges_prior_verified_sources_on_later_verified_success(self):
+        """When multiple timeouts happen, later verified-success returns must
+        include sources verified during earlier partial probes.
+        """
+        source_1 = MagicMock(id="src_1", title="Source 1", url="https://one.example.com")
+        source_2 = MagicMock(id="src_2", title="Source 2", url="https://two.example.com")
+        sources = [
+            {"url": "https://one.example.com", "title": "Source 1"},
+            {"url": "https://two.example.com", "title": "Source 2"},
+        ]
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [],  # baseline
+                [source_1],  # first timeout — only URL 1 is visible, so retry URL 2
+                [source_1, source_2],  # second timeout — URL 2 is now visible
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                sources,
+                initial_delay=5,
+            )
+
+        assert imported == [
+            {"id": "src_1", "title": "Source 1"},
+            {"id": "src_2", "title": "Source 2"},
+        ]
+        assert client.research.import_sources.await_count == 2
+        retry_call_sources = client.research.import_sources.await_args_list[1].args[2]
+        assert retry_call_sources == [{"url": "https://two.example.com", "title": "Source 2"}]
+        mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_partial_timeout_skips_retry_when_filter_removes_all_sources(self):
+        """If every requested URL is already visible after the timeout, there
+        is nothing left to retry.
+        """
+        existing_src = MagicMock(id="src_existing", title="Old", url="https://example.com")
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                [existing_src],  # baseline already has the URL
+                [existing_src],  # post-timeout probe still shows it
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console") as mock_console,
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Old (request)"}],
+                initial_delay=5,
+            )
+
+        assert imported == []
+        assert client.research.import_sources.await_count == 1
+        mock_sleep.assert_not_awaited()
+        assert mock_console.print.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_retries_when_pre_existing_url_meets_concurrent_unrelated_addition(
         self,
     ):
@@ -904,7 +1090,8 @@ class TestImportWithRetry:
         before the import, AND a concurrent session added an unrelated source
         during the timeout window. The verified-success branch must NOT fire
         — neither the pre-existing URL nor the unrelated addition is proof
-        our import wrote anything. The legacy retry path must run.
+        our import wrote anything. The retry payload filter should still avoid
+        re-adding the requested URL because it is already present.
         """
         existing_src = MagicMock(id="src_existing", title="Old", url="https://example.com")
         unrelated_src = MagicMock(
@@ -940,11 +1127,9 @@ class TestImportWithRetry:
                 initial_delay=5,
             )
 
-        # Must retry — neither the pre-existing match nor the unrelated new
-        # source proves the requested URL was actually written by this call.
-        assert client.research.import_sources.await_count == 2
-        mock_sleep.assert_awaited_once_with(5)
-        assert imported == [{"id": "src_existing", "title": "Old"}]
+        assert imported == []
+        assert client.research.import_sources.await_count == 1
+        mock_sleep.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returned_list_includes_non_url_sources_like_research_reports(self):
@@ -1086,8 +1271,8 @@ class TestImportWithRetry:
         """If the requested URL was already in the notebook before the import
         and the post-timeout snapshot shows no truly-new source matching it,
         verification must NOT fire — even though `requested_urls.issubset(
-        current_urls)` is trivially true. Otherwise a failed re-import of an
-        existing URL silently reports success.
+        current_urls)` is trivially true. The retry filter then drops the
+        already-present URL instead of re-adding a duplicate.
         """
         existing_src = MagicMock(id="src_existing", title="Old", url="https://example.com")
         client = MagicMock()
@@ -1117,10 +1302,9 @@ class TestImportWithRetry:
                 initial_delay=5,
             )
 
-        # Must retry — the URL being pre-existing isn't proof our import wrote.
-        assert client.research.import_sources.await_count == 2
-        mock_sleep.assert_awaited_once_with(5)
-        assert imported == [{"id": "src_existing", "title": "Old"}]
+        assert client.research.import_sources.await_count == 1
+        mock_sleep.assert_not_awaited()
+        assert imported == []
 
     @pytest.mark.asyncio
     async def test_report_only_import_bounded_retries_on_persistent_timeout(self):


### PR DESCRIPTION
## Summary
- Filter already-visible URL sources out of `import_with_retry` retry payloads after partial IMPORT_RESEARCH timeouts.
- Preserve verified partial import results across subsequent retries and verified-success exits.
- Add unit coverage for partial URL retries, report/no-URL preservation, repeated timeouts, and all-already-present short-circuit behavior.

Closes #323

## Test plan
- [x] `uv run pytest tests/unit/cli/test_helpers.py -k ImportWithRetry`
- [x] `uv run pytest`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Polish notes
- Native review found and fixed a repeated-timeout merge edge case.
- Gemini CLI review completed; no blocking issues after the merge fix.
- Claude CLI review timed out after 180s with no output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate import entries when retries occur.
  * Improve timeout recovery so partial/overlapping imports are correctly filtered, synthesized, and merged across retries.
  * Suppress false-positive reimports for sources already present on the server; preserve no-URL entries only when originally requested.

* **Tests**
  * Expanded test coverage for retry and partial-timeout scenarios to validate merging, filtering, verified-success behavior, and no-retry cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->