### PR TITLE
fix(settings): use account limits for create quota errors

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -700,7 +700,7 @@ result = await client.settings.set_output_language("ja")  # Japanese
 print(f"Language set to: {result}")
 ```
 
-**Important:** Language is a **GLOBAL setting** that affects all notebooks in your account. Supported languages include:
+**Important:** Language is a **GLOBAL setting** that affects all notebooks in your account. The tier string is internal NotebookLM metadata; use `get_account_limits()` for quota decisions because the raw tier name may not match the active notebook/source limits. Supported languages include:
 - `en` (English), `ja` (日本語), `zh_Hans` (中文简体), `zh_Hant` (中文繁體)
 - `ko` (한국어), `es` (Español), `fr` (Français), `de` (Deutsch), `pt_BR` (Português)
 - And [over 70 other languages](cli-reference.md#language-commands-notebooklm-language-cmd)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -677,6 +677,8 @@ await client.notes.delete_mind_map(nb_id, mind_map_id)
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
 | `get_output_language()` | none | `Optional[str]` | Get current output language setting |
+| `get_account_limits()` | none | `AccountLimits` | Get account-level limits such as max notebooks and sources per notebook |
+| `get_account_tier()` | none | `AccountTier` | Get current NotebookLM subscription tier |
 | `set_output_language(language)` | `str` | `Optional[str]` | Set output language for artifact generation |
 
 **Example:**
@@ -684,6 +686,14 @@ await client.notes.delete_mind_map(nb_id, mind_map_id)
 # Get current language setting
 lang = await client.settings.get_output_language()
 print(f"Current language: {lang}")  # e.g., "en", "ja", "zh_Hans"
+
+# Get server-reported account limits
+limits = await client.settings.get_account_limits()
+print(f"Notebook limit: {limits.notebook_limit}")
+
+# Get current NotebookLM subscription tier
+tier = await client.settings.get_account_tier()
+print(f"Account tier: {tier.plan_name or tier.tier}")
 
 # Set language for artifact generation
 result = await client.settings.set_output_language("ja")  # Japanese

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1379,6 +1379,9 @@ await rpc_call(
 # "NOTEBOOKLM_TIER_PRO"
 # "NOTEBOOKLM_TIER_PRO_CONSUMER_USER"
 # "NOTEBOOKLM_TIER_PRO_DASHER_END_USER"
+#
+# Treat this as internal account metadata. Use GET_USER_SETTINGS limits for
+# notebook/source quota decisions.
 ```
 
 ### RPC: GET_USER_SETTINGS (ZwVcOc)

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -53,6 +53,7 @@
 | `fejl7e` | REMOVE_RECENTLY_VIEWED | Remove notebook from recent list | `_notebooks.py` |
 | `ZwVcOc` | GET_USER_SETTINGS | Get user settings including output language | `_settings.py` |
 | `hT54vc` | SET_USER_SETTINGS | Set user settings (e.g., output language) | `_settings.py` |
+| `ozz5Z` | GET_USER_TIER | Get current NotebookLM subscription tier | `_settings.py` |
 
 ### Content Type Codes (ArtifactTypeCode)
 
@@ -1348,6 +1349,38 @@ await rpc_call(
 
 Global user settings that affect all notebooks in an account.
 
+### RPC: GET_USER_TIER (ozz5Z)
+
+**Source:** `_settings.py::get_account_tier()`
+
+Get the current NotebookLM subscription tier from the homepage context.
+
+```python
+params = [
+    [
+        [
+            [
+                [None, "1", 627],
+                [None, None, None, None, None, None, None, None, None, [None, None, 2]],
+                1,
+            ]
+        ]
+    ]
+]
+
+await rpc_call(
+    RPCMethod.GET_USER_TIER,
+    params,
+    source_path="/",
+)
+
+# Response includes a string like:
+# "NOTEBOOKLM_TIER_STANDARD"
+# "NOTEBOOKLM_TIER_PRO"
+# "NOTEBOOKLM_TIER_PRO_CONSUMER_USER"
+# "NOTEBOOKLM_TIER_PRO_DASHER_END_USER"
+```
+
 ### RPC: GET_USER_SETTINGS (ZwVcOc)
 
 **Source:** `_settings.py::get_output_language()`
@@ -1377,6 +1410,8 @@ await rpc_call(
 # ]]
 #
 # Language code at: result[0][2][4][0]
+# Notebook limit at: result[0][1][1]
+# Source limit at: result[0][1][2]
 ```
 
 ### RPC: SET_USER_SETTINGS (hT54vc)

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -66,6 +66,7 @@ from .exceptions import (
     NetworkError,
     # Domain: Notebooks
     NotebookError,
+    NotebookLimitError,
     # Base
     NotebookLMError,
     NotebookNotFoundError,
@@ -170,6 +171,7 @@ __all__ = [
     # Domain Exceptions: Notebooks
     "NotebookError",
     "NotebookNotFoundError",
+    "NotebookLimitError",
     # Domain Exceptions: Chat
     "ChatError",
     # Domain Exceptions: Sources

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -86,6 +86,8 @@ from .exceptions import (
 
 # Public API: Types and dataclasses
 from .types import (
+    AccountLimits,
+    AccountTier,
     Artifact,
     ArtifactType,
     AskResult,
@@ -137,6 +139,8 @@ __all__ = [
     # Auth
     "AuthTokens",
     # Types
+    "AccountLimits",
+    "AccountTier",
     "Notebook",
     "NotebookDescription",
     "NotebookMetadata",

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ._core import ClientCore
+from .exceptions import KNOWN_NOTEBOOK_LIMITS, NotebookLimitError, RPCError
 from .rpc import RPCMethod
 from .types import Notebook, NotebookDescription, SuggestedTopic
 
@@ -12,6 +13,16 @@ if TYPE_CHECKING:
     from ._sources import SourcesAPI
 
 logger = logging.getLogger(__name__)
+
+CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3
+
+
+def _infer_known_notebook_limit(count: int) -> int | None:
+    """Infer whether a notebook count is at or one short of a known limit."""
+    for limit in sorted(KNOWN_NOTEBOOK_LIMITS, reverse=True):
+        if limit - 1 <= count <= limit:
+            return limit
+    return None
 
 
 class NotebooksAPI:
@@ -67,10 +78,48 @@ class NotebooksAPI:
         """
         logger.debug("Creating notebook: %s", title)
         params = [title, None, None, [2], [1]]
-        result = await self._core.rpc_call(RPCMethod.CREATE_NOTEBOOK, params)
+        try:
+            result = await self._core.rpc_call(RPCMethod.CREATE_NOTEBOOK, params)
+        except RPCError as exc:
+            await self._raise_quota_error_if_detected(exc)
+            raise
         notebook = Notebook.from_api_response(result)
         logger.debug("Created notebook: %s", notebook.id)
         return notebook
+
+    async def _raise_quota_error_if_detected(self, error: RPCError) -> None:
+        """Convert CREATE_NOTEBOOK invalid-argument failures into quota errors."""
+        if (
+            error.method_id != RPCMethod.CREATE_NOTEBOOK.value
+            or error.rpc_code != CREATE_NOTEBOOK_QUOTA_RPC_CODE
+        ):
+            return
+
+        # The backend reports quota exhaustion as code 3 rather than a typed
+        # limit error, so verify with a one-off count before changing the error.
+        try:
+            notebooks = await self.list()
+        except Exception:
+            logger.debug(
+                "Could not list notebooks after CREATE_NOTEBOOK failure; "
+                "leaving original RPC error unchanged",
+                exc_info=True,
+            )
+            return
+
+        owned_count = sum(1 for notebook in notebooks if notebook.is_owner)
+        # Keep the window intentionally tight to avoid hiding genuine invalid
+        # argument failures for accounts that are not near a known limit.
+        inferred_limit = _infer_known_notebook_limit(owned_count)
+        if inferred_limit is None:
+            return
+
+        raise NotebookLimitError(
+            owned_count,
+            limit=inferred_limit,
+            known_limits=KNOWN_NOTEBOOK_LIMITS,
+            original_error=error,
+        ) from error
 
     async def get(self, notebook_id: str) -> Notebook:
         """Get notebook details.

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -5,9 +5,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ._core import ClientCore
-from .exceptions import KNOWN_NOTEBOOK_LIMITS, NotebookLimitError, RPCError
+from ._settings import build_get_user_settings_params, extract_account_limits
+from .exceptions import NotebookLimitError, RPCError
 from .rpc import RPCMethod
-from .types import Notebook, NotebookDescription, SuggestedTopic
+from .types import AccountLimits, Notebook, NotebookDescription, SuggestedTopic
 
 if TYPE_CHECKING:
     from ._sources import SourcesAPI
@@ -15,14 +16,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3
-
-
-def _infer_known_notebook_limit(count: int) -> int | None:
-    """Infer whether a notebook count is at or one short of a known limit."""
-    for limit in sorted(KNOWN_NOTEBOOK_LIMITS, reverse=True):
-        if limit - 1 <= count <= limit:
-            return limit
-    return None
 
 
 class NotebooksAPI:
@@ -96,7 +89,22 @@ class NotebooksAPI:
             return
 
         # The backend reports quota exhaustion as code 3 rather than a typed
-        # limit error, so verify with a one-off count before changing the error.
+        # limit error, so verify against the account's advertised limit before
+        # changing the exception type.
+        try:
+            account_limits = await self._get_account_limits()
+        except Exception:
+            logger.debug(
+                "Could not fetch account limits after CREATE_NOTEBOOK failure; "
+                "leaving original RPC error unchanged",
+                exc_info=True,
+            )
+            return
+
+        notebook_limit = account_limits.notebook_limit
+        if notebook_limit is None:
+            return
+
         try:
             notebooks = await self.list()
         except Exception:
@@ -108,18 +116,25 @@ class NotebooksAPI:
             return
 
         owned_count = sum(1 for notebook in notebooks if notebook.is_owner)
-        # Keep the window intentionally tight to avoid hiding genuine invalid
-        # argument failures for accounts that are not near a known limit.
-        inferred_limit = _infer_known_notebook_limit(owned_count)
-        if inferred_limit is None:
+        # Allow one notebook of slack because list results can lag a failed
+        # create or omit service-internal notebooks that still count.
+        if owned_count < max(notebook_limit - 1, 0):
             return
 
         raise NotebookLimitError(
             owned_count,
-            limit=inferred_limit,
-            known_limits=KNOWN_NOTEBOOK_LIMITS,
+            limit=notebook_limit,
             original_error=error,
         ) from error
+
+    async def _get_account_limits(self) -> AccountLimits:
+        """Fetch NotebookLM account limits from user settings."""
+        result = await self._core.rpc_call(
+            RPCMethod.GET_USER_SETTINGS,
+            build_get_user_settings_params(),
+            source_path="/",
+        )
+        return extract_account_limits(result)
 
     async def get(self, notebook_id: str) -> Notebook:
         """Get notebook details.

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -2,11 +2,47 @@
 
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 from ._core import ClientCore
 from .rpc import RPCMethod
+from .types import AccountLimits, AccountTier
 
 logger = logging.getLogger(__name__)
+
+_ACCOUNT_LIMITS_PATH = (0, 1)
+_NOTEBOOK_LIMIT_INDEX = 1
+_SOURCE_LIMIT_INDEX = 2
+_TIER_PREFIX = "NOTEBOOKLM_TIER_"
+_TIER_PLAN_NAMES = {
+    "NOTEBOOKLM_TIER_STANDARD": "Standard",
+    "NOTEBOOKLM_TIER_PLUS": "Google AI Plus",
+    "NOTEBOOKLM_TIER_PRO": "Google AI Pro",
+    "NOTEBOOKLM_TIER_PRO_CONSUMER_USER": "Google AI Pro Consumer",
+    "NOTEBOOKLM_TIER_PRO_DASHER_END_USER": "Google Workspace Pro",
+    "NOTEBOOKLM_TIER_ULTRA": "Google AI Ultra",
+}
+
+
+def build_get_user_settings_params() -> list[Any]:
+    """Build GET_USER_SETTINGS params without sharing a mutable list."""
+    return [
+        None,
+        [1, None, None, None, None, None, None, None, None, None, [1]],
+    ]
+
+
+def build_get_user_tier_params() -> list[Any]:
+    """Build GET_USER_TIER params for the NotebookLM homepage context."""
+    return [
+        [
+            [
+                [None, "1", 627],
+                [None, None, None, None, None, None, None, None, None, [None, None, 2]],
+                1,
+            ]
+        ]
+    ]
 
 
 def _extract_nested_value(data: list | None, path: Sequence[int]) -> str | None:
@@ -26,6 +62,68 @@ def _extract_nested_value(data: list | None, path: Sequence[int]) -> str | None:
         return result or None  # type: ignore[return-value]
     except (TypeError, IndexError):
         return None
+
+
+def _extract_nested_list(data: list | None, path: Sequence[int]) -> list[Any] | None:
+    """Extract a nested list by following an index path."""
+    result: Any = data
+    try:
+        for idx in path:
+            if not isinstance(result, list):
+                return None
+            result = result[idx]
+    except IndexError:
+        return None
+    return result if isinstance(result, list) else None
+
+
+def _positive_int(value: Any) -> int | None:
+    """Return value only when it is a positive int, excluding bools."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    return None
+
+
+def extract_account_limits(data: list | None) -> AccountLimits:
+    """Extract account-level limits from GET_USER_SETTINGS response data."""
+    limits = _extract_nested_list(data, _ACCOUNT_LIMITS_PATH)
+    if limits is None:
+        return AccountLimits()
+
+    raw_limits = tuple(limits)
+    notebook_limit = (
+        _positive_int(limits[_NOTEBOOK_LIMIT_INDEX])
+        if len(limits) > _NOTEBOOK_LIMIT_INDEX
+        else None
+    )
+    source_limit = (
+        _positive_int(limits[_SOURCE_LIMIT_INDEX]) if len(limits) > _SOURCE_LIMIT_INDEX else None
+    )
+    return AccountLimits(
+        notebook_limit=notebook_limit,
+        source_limit=source_limit,
+        raw_limits=raw_limits,
+    )
+
+
+def _find_tier_string(value: Any) -> str | None:
+    """Find the first NotebookLM tier string in a nested response."""
+    stack = [value]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, str) and item.startswith(_TIER_PREFIX):
+            return item
+        if isinstance(item, list):
+            stack.extend(reversed(item))
+    return None
+
+
+def extract_account_tier(data: list | None) -> AccountTier:
+    """Extract the NotebookLM subscription tier from GET_USER_TIER response data."""
+    tier = _find_tier_string(data)
+    return AccountTier(tier=tier, plan_name=_TIER_PLAN_NAMES.get(tier) if tier else None)
 
 
 class SettingsAPI:
@@ -99,18 +197,57 @@ class SettingsAPI:
         """
         logger.debug("Fetching user settings to get output language")
 
-        # Params structure: [null,[1,null,null,null,null,null,null,null,null,null,[1]]]
-        params = [None, [1, None, None, None, None, None, None, None, None, None, [1]]]
-
         result = await self._core.rpc_call(
             RPCMethod.GET_USER_SETTINGS,
-            params,
+            build_get_user_settings_params(),
             source_path="/",
         )
 
         current_language = _extract_nested_value(result, self._GET_SETTINGS_PATH)
         self._log_language_result(current_language, "Current output language")
         return current_language
+
+    async def get_account_limits(self) -> AccountLimits:
+        """Get account-level limits advertised by NotebookLM user settings.
+
+        Returns:
+            AccountLimits with parsed notebook/source limits when present.
+        """
+        logger.debug("Fetching user settings to get account limits")
+
+        result = await self._core.rpc_call(
+            RPCMethod.GET_USER_SETTINGS,
+            build_get_user_settings_params(),
+            source_path="/",
+        )
+
+        limits = extract_account_limits(result)
+        if limits.notebook_limit is not None:
+            logger.debug("Notebook limit from user settings: %s", limits.notebook_limit)
+        else:
+            logger.debug("Could not parse account limits from response")
+        return limits
+
+    async def get_account_tier(self) -> AccountTier:
+        """Get the NotebookLM subscription tier for the current account.
+
+        Returns:
+            AccountTier with the raw tier string and a friendly plan name when known.
+        """
+        logger.debug("Fetching user tier")
+
+        result = await self._core.rpc_call(
+            RPCMethod.GET_USER_TIER,
+            build_get_user_tier_params(),
+            source_path="/",
+        )
+
+        tier = extract_account_tier(result)
+        if tier.tier:
+            logger.debug("NotebookLM account tier: %s", tier.tier)
+        else:
+            logger.debug("Could not parse account tier from response")
+        return tier
 
     def _log_language_result(self, language: str | None, success_prefix: str) -> None:
         """Log the result of a language operation."""

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -18,7 +18,6 @@ _TIER_PLAN_NAMES = {
     "NOTEBOOKLM_TIER_STANDARD": "Standard",
     "NOTEBOOKLM_TIER_PLUS": "Google AI Plus",
     "NOTEBOOKLM_TIER_PRO": "Google AI Pro",
-    "NOTEBOOKLM_TIER_PRO_CONSUMER_USER": "Google AI Pro Consumer",
     "NOTEBOOKLM_TIER_PRO_DASHER_END_USER": "Google Workspace Pro",
     "NOTEBOOKLM_TIER_ULTRA": "Google AI Ultra",
 }

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -15,6 +15,7 @@ from ..exceptions import (
     AuthError,
     ConfigurationError,
     NetworkError,
+    NotebookLimitError,
     NotebookLMError,
     RateLimitError,
     RPCError,
@@ -116,6 +117,14 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
             json_output,
             1,
             hint="Check your internet connection and try again.",
+        )
+    except NotebookLimitError as e:
+        _output_error(
+            str(e),
+            "NOTEBOOK_LIMIT",
+            json_output,
+            1,
+            extra=e.to_error_response_extra(),
         )
     except NotebookLMError as e:
         extra_info: dict[str, Any] | None = None

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -27,7 +27,7 @@ from ..auth import (
     fetch_tokens,
     load_auth_from_storage,
 )
-from ..exceptions import NetworkError, RPCError, RPCTimeoutError
+from ..exceptions import NetworkError, NotebookLimitError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
 from ..types import ArtifactType
 from ._encoding import safe_echo
@@ -730,6 +730,13 @@ def with_client(f):
         except Exception as e:
             log_result("failed", str(e))
             if json_output:
+                if isinstance(e, NotebookLimitError):
+                    json_error_response(
+                        "NOTEBOOK_LIMIT",
+                        str(e),
+                        extra=e.to_error_response_extra(),
+                    )
+                    return
                 json_error_response("ERROR", str(e))
             else:
                 handle_error(e)

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -14,6 +14,8 @@ Example:
 
 from __future__ import annotations
 
+from typing import Any
+
 __all__ = [
     # Base
     "NotebookLMError",
@@ -34,6 +36,7 @@ __all__ = [
     # Domain: Notebooks
     "NotebookError",
     "NotebookNotFoundError",
+    "NotebookLimitError",
     # Domain: Chat
     "ChatError",
     # Domain: Sources
@@ -302,6 +305,11 @@ class NotebookError(NotebookLMError):
     """Base for notebook operations."""
 
 
+# Observed in issue #309 reports from May 2026. Keep detection conservative:
+# these service-side limits can change before the API exposes typed quota errors.
+KNOWN_NOTEBOOK_LIMITS = (100, 500)
+
+
 class NotebookNotFoundError(NotebookError):
     """Notebook not found.
 
@@ -312,6 +320,60 @@ class NotebookNotFoundError(NotebookError):
     def __init__(self, notebook_id: str):
         self.notebook_id = notebook_id
         super().__init__(f"Notebook not found: {notebook_id}")
+
+
+class NotebookLimitError(NotebookError):
+    """Notebook quota appears to be exhausted.
+
+    Attributes:
+        current_count: Number of owned notebooks returned by the list API.
+        limit: Inferred NotebookLM notebook limit, if known.
+        known_limits: Known free/paid NotebookLM notebook limits.
+        original_error: The underlying RPC failure from create.
+    """
+
+    def __init__(
+        self,
+        current_count: int,
+        *,
+        limit: int | None = None,
+        known_limits: tuple[int, ...] = KNOWN_NOTEBOOK_LIMITS,
+        original_error: RPCError | None = None,
+    ):
+        self.current_count = current_count
+        self.limit = limit
+        self.known_limits = known_limits
+        self.original_error = original_error
+
+        count_text = str(current_count)
+        if limit is not None:
+            count_text = f"{current_count}/{limit}"
+
+        known_text = ", ".join(str(value) for value in known_limits)
+        message = (
+            "Cannot create notebook: account appears to be at or very near the "
+            f"NotebookLM notebook limit ({count_text} owned notebooks reported). "
+            "Delete old notebooks at https://notebooklm.google.com and try again."
+        )
+        if known_limits:
+            message += f" Known NotebookLM limits include: {known_text}."
+        if original_error is not None:
+            message += f" Original RPC error: {original_error}"
+        super().__init__(message)
+
+    def to_error_response_extra(self) -> dict[str, Any]:
+        """Return structured fields for CLI JSON error responses."""
+        extra: dict[str, Any] = {
+            "current_count": self.current_count,
+            "limit": self.limit,
+            "known_limits": list(self.known_limits),
+        }
+        if self.original_error is not None:
+            if self.original_error.method_id is not None:
+                extra["method_id"] = self.original_error.method_id
+            if self.original_error.rpc_code is not None:
+                extra["rpc_code"] = self.original_error.rpc_code
+        return extra
 
 
 # =============================================================================

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -305,11 +305,6 @@ class NotebookError(NotebookLMError):
     """Base for notebook operations."""
 
 
-# Observed in issue #309 reports from May 2026. Keep detection conservative:
-# these service-side limits can change before the API exposes typed quota errors.
-KNOWN_NOTEBOOK_LIMITS = (100, 500)
-
-
 class NotebookNotFoundError(NotebookError):
     """Notebook not found.
 
@@ -327,8 +322,8 @@ class NotebookLimitError(NotebookError):
 
     Attributes:
         current_count: Number of owned notebooks returned by the list API.
-        limit: Inferred NotebookLM notebook limit, if known.
-        known_limits: Known free/paid NotebookLM notebook limits.
+        limit: Server-reported NotebookLM notebook limit, if known.
+        known_limits: Optional known NotebookLM notebook limits to include in output.
         original_error: The underlying RPC failure from create.
     """
 
@@ -337,7 +332,7 @@ class NotebookLimitError(NotebookError):
         current_count: int,
         *,
         limit: int | None = None,
-        known_limits: tuple[int, ...] = KNOWN_NOTEBOOK_LIMITS,
+        known_limits: tuple[int, ...] = (),
         original_error: RPCError | None = None,
     ):
         self.current_count = current_count
@@ -366,8 +361,9 @@ class NotebookLimitError(NotebookError):
         extra: dict[str, Any] = {
             "current_count": self.current_count,
             "limit": self.limit,
-            "known_limits": list(self.known_limits),
         }
+        if self.known_limits:
+            extra["known_limits"] = list(self.known_limits)
         if self.original_error is not None:
             if self.original_error.method_id is not None:
                 extra["method_id"] = self.original_error.method_id

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -78,6 +78,7 @@ class RPCMethod(str, Enum):
     # User settings
     GET_USER_SETTINGS = "ZwVcOc"  # Get user settings including output language
     SET_USER_SETTINGS = "hT54vc"  # Set user settings (e.g., output language)
+    GET_USER_TIER = "ozz5Z"  # Get NotebookLM subscription tier from homepage context
 
 
 class ArtifactTypeCode(int, Enum):

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -82,7 +82,7 @@ class AccountLimits:
 
 @dataclass(frozen=True)
 class AccountTier:
-    """NotebookLM subscription tier returned by the homepage tier RPC."""
+    """Raw NotebookLM tier metadata returned by the homepage tier RPC."""
 
     tier: str | None = None
     plan_name: str | None = None

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -71,6 +71,23 @@ class UnknownTypeWarning(UserWarning):
     pass
 
 
+@dataclass(frozen=True)
+class AccountLimits:
+    """Account-level limits returned by NotebookLM user settings."""
+
+    notebook_limit: int | None = None
+    source_limit: int | None = None
+    raw_limits: tuple[Any, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class AccountTier:
+    """NotebookLM subscription tier returned by the homepage tier RPC."""
+
+    tier: str | None = None
+    plan_name: str | None = None
+
+
 class SourceType(str, Enum):
     """User-facing source types.
 

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -107,6 +107,39 @@ class TestSettingsAPI:
 
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_get_account_limits(self, httpx_mock: HTTPXMock, auth_tokens, build_rpc_response):
+        """Test getting account limits from user settings."""
+        response_data = [
+            [
+                None,
+                [6, 500, 300, 500000, 2],
+                [True, None, None, True, ["en"]],
+            ]
+        ]
+        response = build_rpc_response(RPCMethod.GET_USER_SETTINGS, response_data)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.settings.get_account_limits()
+
+        assert result.notebook_limit == 500
+        assert result.source_limit == 300
+        assert result.raw_limits == (6, 500, 300, 500000, 2)
+
+    @pytest.mark.asyncio
+    async def test_get_account_tier(self, httpx_mock: HTTPXMock, auth_tokens, build_rpc_response):
+        """Test getting account tier."""
+        response_data = [[[[None, "1", 627], [[1613, [None, "NOTEBOOKLM_TIER_STANDARD"]]], 0]]]
+        response = build_rpc_response(RPCMethod.GET_USER_TIER, response_data)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            result = await client.settings.get_account_tier()
+
+        assert result.tier == "NOTEBOOKLM_TIER_STANDARD"
+        assert result.plan_name == "Standard"
+
 
 class TestLoginLanguageSync:
     """Integration test for syncing server language to local config after login."""

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -10,6 +10,7 @@ from notebooklm.exceptions import (
     AuthError,
     ConfigurationError,
     NetworkError,
+    NotebookLimitError,
     RateLimitError,
     RPCError,
     ValidationError,
@@ -114,6 +115,21 @@ class TestHandleErrorsJsonOutput:
         assert data["error"] is True
         assert "method_id" not in data
 
+    def test_notebook_limit_error_json_includes_quota_context(self, capsys):
+        """NotebookLimitError should produce a specific JSON error code."""
+        with pytest.raises(SystemExit), handle_errors(json_output=True):
+            raise NotebookLimitError(499, limit=500)
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"] is True
+        assert data["code"] == "NOTEBOOK_LIMIT"
+        assert data["current_count"] == 499
+        assert data["limit"] == 500
+        assert data["known_limits"] == [100, 500]
+        assert "method_id" not in data
+        assert "rpc_code" not in data
+
     def test_unexpected_error_json_format(self, capsys):
         """Unexpected errors should produce UNEXPECTED_ERROR code."""
         with pytest.raises(SystemExit), handle_errors(json_output=True):
@@ -146,6 +162,15 @@ class TestHandleErrorsTextOutput:
         output = capsys.readouterr().err
         assert "Network error" in output
         assert "internet connection" in output
+
+    def test_notebook_limit_error_text_includes_quota_context(self, capsys):
+        """NotebookLimitError should show notebook count in text mode."""
+        with pytest.raises(SystemExit), handle_errors(json_output=False):
+            raise NotebookLimitError(499, limit=500)
+
+        output = capsys.readouterr().err
+        assert "notebook limit" in output.lower()
+        assert "499/500" in output
 
     def test_unexpected_error_shows_bug_report_hint(self, capsys):
         """Unexpected errors should show bug report hint."""

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -126,7 +126,7 @@ class TestHandleErrorsJsonOutput:
         assert data["code"] == "NOTEBOOK_LIMIT"
         assert data["current_count"] == 499
         assert data["limit"] == 500
-        assert data["known_limits"] == [100, 500]
+        assert "known_limits" not in data
         assert "method_id" not in data
         assert "rpc_code" not in data
 

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -172,7 +172,7 @@ class TestNotebookCreate:
             assert data["code"] == "NOTEBOOK_LIMIT"
             assert data["current_count"] == 499
             assert data["limit"] == 500
-            assert data["known_limits"] == [100, 500]
+            assert "known_limits" not in data
             assert data["method_id"] == RPCMethod.CREATE_NOTEBOOK.value
             assert data["rpc_code"] == 3
 

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -8,7 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
+from notebooklm.exceptions import NotebookLimitError, RPCError
 from notebooklm.notebooklm_cli import cli
+from notebooklm.rpc import RPCMethod
 from notebooklm.types import AskResult, Notebook
 
 from .conftest import create_mock_client, patch_client_for_module, patch_main_cli_client
@@ -146,6 +148,48 @@ class TestNotebookCreate:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["notebook"]["id"] == "new_nb_id"
+
+    def test_notebook_create_json_quota_error(self, runner, mock_auth):
+        """Create emits structured JSON when notebook quota is detected."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            original = RPCError(
+                "RPC CCqFvf returned null result with status code 3 (Invalid argument).",
+                method_id=RPCMethod.CREATE_NOTEBOOK.value,
+                rpc_code=3,
+            )
+            mock_client.notebooks.create = AsyncMock(
+                side_effect=NotebookLimitError(499, limit=500, original_error=original)
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Test Notebook", "--json"])
+
+            assert result.exit_code == 1
+            data = json.loads(result.output)
+            assert data["code"] == "NOTEBOOK_LIMIT"
+            assert data["current_count"] == 499
+            assert data["limit"] == 500
+            assert data["known_limits"] == [100, 500]
+            assert data["method_id"] == RPCMethod.CREATE_NOTEBOOK.value
+            assert data["rpc_code"] == 3
+
+    def test_notebook_create_text_quota_error(self, runner, mock_auth):
+        """Create emits an actionable text error when notebook quota is detected."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(side_effect=NotebookLimitError(499, limit=500))
+            mock_client_cls.return_value = mock_client
+
+            with patch("notebooklm.cli.helpers.fetch_tokens", new_callable=AsyncMock) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Test Notebook"])
+
+            assert result.exit_code == 1
+            assert "notebook limit" in result.output.lower()
+            assert "499/500" in result.output
 
 
 # =============================================================================

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -31,6 +31,7 @@ from notebooklm.exceptions import (
     UnknownRPCMethodError,
     ValidationError,
 )
+from notebooklm.types import AccountLimits, AccountTier
 
 
 class TestExceptionHierarchy:
@@ -102,6 +103,13 @@ class TestExceptionHierarchy:
         """NotebookLimitError is available from the public package namespace."""
         assert notebooklm.NotebookLimitError is NotebookLimitError
         assert "NotebookLimitError" in notebooklm.__all__
+
+    def test_account_types_are_exported_from_package(self):
+        """Account limit and tier types are available from the public package namespace."""
+        assert notebooklm.AccountLimits is AccountLimits
+        assert notebooklm.AccountTier is AccountTier
+        assert "AccountLimits" in notebooklm.__all__
+        assert "AccountTier" in notebooklm.__all__
 
 
 class TestRPCErrorAttributes:
@@ -231,7 +239,7 @@ class TestDomainExceptions:
 
         assert e.current_count == 499
         assert e.limit == 500
-        assert e.known_limits == (100, 500)
+        assert e.known_limits == ()
         assert e.original_error is original
         assert "499/500" in str(e)
         assert "notebook limit" in str(e).lower()
@@ -244,7 +252,6 @@ class TestDomainExceptions:
         assert e.to_error_response_extra() == {
             "current_count": 499,
             "limit": 500,
-            "known_limits": [100, 500],
             "method_id": "CCqFvf",
             "rpc_code": 3,
         }
@@ -255,6 +262,14 @@ class TestDomainExceptions:
 
         assert e.known_limits == ()
         assert "Known NotebookLM limits include" not in str(e)
+
+    def test_notebook_limit_error_preserves_explicit_known_limits(self):
+        """NotebookLimitError keeps explicit known limits for compatibility."""
+        e = NotebookLimitError(499, limit=500, known_limits=(100, 500))
+
+        assert e.known_limits == (100, 500)
+        assert "Known NotebookLM limits include: 100, 500" in str(e)
+        assert e.to_error_response_extra()["known_limits"] == [100, 500]
 
     def test_source_not_found_has_source_id(self):
         """SourceNotFoundError stores source_id."""

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import notebooklm
 from notebooklm.exceptions import (
     ArtifactDownloadError,
     ArtifactError,
@@ -15,6 +16,7 @@ from notebooklm.exceptions import (
     DecodingError,
     NetworkError,
     NotebookError,
+    NotebookLimitError,
     NotebookLMError,
     NotebookNotFoundError,
     RateLimitError,
@@ -50,6 +52,7 @@ class TestExceptionHierarchy:
             RPCTimeoutError,
             NotebookError,
             NotebookNotFoundError,
+            NotebookLimitError,
             ChatError,
             SourceError,
             SourceAddError,
@@ -94,6 +97,11 @@ class TestExceptionHierarchy:
         assert issubclass(ArtifactNotReadyError, ArtifactError)
         assert issubclass(ArtifactParseError, ArtifactError)
         assert issubclass(ArtifactDownloadError, ArtifactError)
+
+    def test_notebook_limit_error_is_exported_from_package(self):
+        """NotebookLimitError is available from the public package namespace."""
+        assert notebooklm.NotebookLimitError is NotebookLimitError
+        assert "NotebookLimitError" in notebooklm.__all__
 
 
 class TestRPCErrorAttributes:
@@ -215,6 +223,38 @@ class TestDomainExceptions:
         e = NotebookNotFoundError("nb_123")
         assert e.notebook_id == "nb_123"
         assert "nb_123" in str(e)
+
+    def test_notebook_limit_error_has_count_and_limit(self):
+        """NotebookLimitError stores quota context."""
+        original = RPCError("create failed", method_id="CCqFvf", rpc_code=3)
+        e = NotebookLimitError(499, limit=500, original_error=original)
+
+        assert e.current_count == 499
+        assert e.limit == 500
+        assert e.known_limits == (100, 500)
+        assert e.original_error is original
+        assert "499/500" in str(e)
+        assert "notebook limit" in str(e).lower()
+
+    def test_notebook_limit_error_json_extra_includes_original_rpc_context(self):
+        """NotebookLimitError exposes structured JSON metadata."""
+        original = RPCError("create failed", method_id="CCqFvf", rpc_code=3)
+        e = NotebookLimitError(499, limit=500, original_error=original)
+
+        assert e.to_error_response_extra() == {
+            "current_count": 499,
+            "limit": 500,
+            "known_limits": [100, 500],
+            "method_id": "CCqFvf",
+            "rpc_code": 3,
+        }
+
+    def test_notebook_limit_error_handles_empty_known_limits(self):
+        """NotebookLimitError omits known-limit sentence when none are provided."""
+        e = NotebookLimitError(499, limit=500, known_limits=())
+
+        assert e.known_limits == ()
+        assert "Known NotebookLM limits include" not in str(e)
 
     def test_source_not_found_has_source_id(self):
         """SourceNotFoundError stores source_id."""

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -1,0 +1,155 @@
+"""Unit tests for notebook operations."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._notebooks import NotebooksAPI, _infer_known_notebook_limit
+from notebooklm.exceptions import NetworkError, NotebookLimitError, RPCError
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import Notebook
+
+
+def _make_api() -> NotebooksAPI:
+    core = MagicMock()
+    core.rpc_call = AsyncMock()
+    return NotebooksAPI(core, sources_api=MagicMock())
+
+
+def _owned_notebooks(count: int) -> list[Notebook]:
+    return [Notebook(id=f"owned_{i}", title=f"Owned {i}", is_owner=True) for i in range(count)]
+
+
+def _shared_notebooks(count: int) -> list[Notebook]:
+    return [Notebook(id=f"shared_{i}", title=f"Shared {i}", is_owner=False) for i in range(count)]
+
+
+def _create_invalid_argument_error(
+    *, method_id: str = RPCMethod.CREATE_NOTEBOOK.value, rpc_code: int = 3
+) -> RPCError:
+    return RPCError(
+        "RPC CCqFvf returned null result with status code 3 (Invalid argument).",
+        method_id=method_id,
+        rpc_code=rpc_code,
+    )
+
+
+class TestInferKnownNotebookLimit:
+    def test_free_limit_boundary(self):
+        assert _infer_known_notebook_limit(99) == 100
+        assert _infer_known_notebook_limit(100) == 100
+
+    def test_paid_limit_boundary(self):
+        assert _infer_known_notebook_limit(499) == 500
+        assert _infer_known_notebook_limit(500) == 500
+
+    def test_non_boundary_count_is_not_classified(self):
+        assert _infer_known_notebook_limit(0) is None
+        assert _infer_known_notebook_limit(98) is None
+        assert _infer_known_notebook_limit(250) is None
+        assert _infer_known_notebook_limit(498) is None
+        assert _infer_known_notebook_limit(600) is None
+
+
+class TestCreateNotebookQuotaDetection:
+    @pytest.mark.asyncio
+    async def test_create_invalid_argument_near_paid_limit_raises_limit_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(return_value=_owned_notebooks(499))
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("Daily News")
+
+        assert exc_info.value.current_count == 499
+        assert exc_info.value.limit == 500
+        assert exc_info.value.original_error is original
+        assert "499/500" in str(exc_info.value)
+        api.list.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_argument_near_free_limit_raises_limit_error(self):
+        api = _make_api()
+        api._core.rpc_call = AsyncMock(side_effect=_create_invalid_argument_error())
+        api.list = AsyncMock(return_value=_owned_notebooks(100))
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("Free Limit")
+
+        assert exc_info.value.current_count == 100
+        assert exc_info.value.limit == 100
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_argument_away_from_limit_preserves_rpc_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(return_value=_owned_notebooks(250))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Probably Bad Payload")
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio
+    async def test_non_quota_rpc_code_preserves_rpc_error_without_listing(self):
+        api = _make_api()
+        original = _create_invalid_argument_error(rpc_code=13)
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Internal Failure")
+
+        assert exc_info.value is original
+        api.list.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_create_method_preserves_rpc_error_without_listing(self):
+        api = _make_api()
+        original = _create_invalid_argument_error(method_id=RPCMethod.GET_NOTEBOOK.value)
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Unexpected Method")
+
+        assert exc_info.value is original
+        api.list.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_shared_notebooks_do_not_trigger_owned_quota_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(return_value=_owned_notebooks(20) + _shared_notebooks(479))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Shared Notebooks Should Not Count")
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio
+    async def test_list_failure_preserves_original_create_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(side_effect=NetworkError("list failed"))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("List Fails")
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio
+    async def test_list_parse_bug_preserves_original_create_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api.list = AsyncMock(side_effect=ValueError("bad notebook data"))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("List Parse Fails")
+
+        assert exc_info.value is original

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -4,10 +4,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from notebooklm._notebooks import NotebooksAPI, _infer_known_notebook_limit
+from notebooklm._notebooks import NotebooksAPI
 from notebooklm.exceptions import NetworkError, NotebookLimitError, RPCError
 from notebooklm.rpc import RPCMethod
-from notebooklm.types import Notebook
+from notebooklm.types import AccountLimits, Notebook
 
 
 def _make_api() -> NotebooksAPI:
@@ -34,21 +34,10 @@ def _create_invalid_argument_error(
     )
 
 
-class TestInferKnownNotebookLimit:
-    def test_free_limit_boundary(self):
-        assert _infer_known_notebook_limit(99) == 100
-        assert _infer_known_notebook_limit(100) == 100
-
-    def test_paid_limit_boundary(self):
-        assert _infer_known_notebook_limit(499) == 500
-        assert _infer_known_notebook_limit(500) == 500
-
-    def test_non_boundary_count_is_not_classified(self):
-        assert _infer_known_notebook_limit(0) is None
-        assert _infer_known_notebook_limit(98) is None
-        assert _infer_known_notebook_limit(250) is None
-        assert _infer_known_notebook_limit(498) is None
-        assert _infer_known_notebook_limit(600) is None
+def _set_account_limit(api: NotebooksAPI, limit: int | None) -> AsyncMock:
+    mock = AsyncMock(return_value=AccountLimits(notebook_limit=limit))
+    api._get_account_limits = mock  # type: ignore[method-assign]
+    return mock
 
 
 class TestCreateNotebookQuotaDetection:
@@ -57,6 +46,7 @@ class TestCreateNotebookQuotaDetection:
         api = _make_api()
         original = _create_invalid_argument_error()
         api._core.rpc_call = AsyncMock(side_effect=original)
+        account_limits = _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(499))
 
         with pytest.raises(NotebookLimitError) as exc_info:
@@ -66,12 +56,28 @@ class TestCreateNotebookQuotaDetection:
         assert exc_info.value.limit == 500
         assert exc_info.value.original_error is original
         assert "499/500" in str(exc_info.value)
+        account_limits.assert_awaited_once()
         api.list.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_argument_at_paid_limit_raises_limit_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(NotebookLimitError) as exc_info:
+            await api.create("At Paid Limit")
+
+        assert exc_info.value.current_count == 500
+        assert exc_info.value.limit == 500
 
     @pytest.mark.asyncio
     async def test_create_invalid_argument_near_free_limit_raises_limit_error(self):
         api = _make_api()
         api._core.rpc_call = AsyncMock(side_effect=_create_invalid_argument_error())
+        _set_account_limit(api, 100)
         api.list = AsyncMock(return_value=_owned_notebooks(100))
 
         with pytest.raises(NotebookLimitError) as exc_info:
@@ -81,10 +87,24 @@ class TestCreateNotebookQuotaDetection:
         assert exc_info.value.limit == 100
 
     @pytest.mark.asyncio
-    async def test_create_invalid_argument_away_from_limit_preserves_rpc_error(self):
+    async def test_create_invalid_argument_uses_account_limit_not_free_boundary(self):
         api = _make_api()
         original = _create_invalid_argument_error()
         api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, 500)
+        api.list = AsyncMock(return_value=_owned_notebooks(100))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Paid Account At Free Boundary")
+
+        assert exc_info.value is original
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_argument_away_from_server_limit_preserves_rpc_error(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(250))
 
         with pytest.raises(RPCError) as exc_info:
@@ -97,12 +117,16 @@ class TestCreateNotebookQuotaDetection:
         api = _make_api()
         original = _create_invalid_argument_error(rpc_code=13)
         api._core.rpc_call = AsyncMock(side_effect=original)
+        api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
+            return_value=AccountLimits(notebook_limit=500)
+        )
         api.list = AsyncMock(return_value=_owned_notebooks(500))
 
         with pytest.raises(RPCError) as exc_info:
             await api.create("Internal Failure")
 
         assert exc_info.value is original
+        api._get_account_limits.assert_not_awaited()
         api.list.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -110,12 +134,16 @@ class TestCreateNotebookQuotaDetection:
         api = _make_api()
         original = _create_invalid_argument_error(method_id=RPCMethod.GET_NOTEBOOK.value)
         api._core.rpc_call = AsyncMock(side_effect=original)
+        api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
+            return_value=AccountLimits(notebook_limit=500)
+        )
         api.list = AsyncMock(return_value=_owned_notebooks(500))
 
         with pytest.raises(RPCError) as exc_info:
             await api.create("Unexpected Method")
 
         assert exc_info.value is original
+        api._get_account_limits.assert_not_awaited()
         api.list.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -123,6 +151,7 @@ class TestCreateNotebookQuotaDetection:
         api = _make_api()
         original = _create_invalid_argument_error()
         api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(20) + _shared_notebooks(479))
 
         with pytest.raises(RPCError) as exc_info:
@@ -131,10 +160,57 @@ class TestCreateNotebookQuotaDetection:
         assert exc_info.value is original
 
     @pytest.mark.asyncio
+    async def test_account_limit_failure_preserves_original_create_error_without_listing(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
+            side_effect=NetworkError("settings failed")
+        )
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Settings Fails")
+
+        assert exc_info.value is original
+        api.list.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_account_limit_rpc_error_preserves_original_create_error_without_listing(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RPCError("settings failed")
+        )
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("Settings RPC Fails")
+
+        assert exc_info.value is original
+        api.list.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_account_limit_preserves_original_create_error_without_listing(self):
+        api = _make_api()
+        original = _create_invalid_argument_error()
+        api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, None)
+        api.list = AsyncMock(return_value=_owned_notebooks(500))
+
+        with pytest.raises(RPCError) as exc_info:
+            await api.create("No Limit")
+
+        assert exc_info.value is original
+        api.list.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_list_failure_preserves_original_create_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
         api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, 500)
         api.list = AsyncMock(side_effect=NetworkError("list failed"))
 
         with pytest.raises(RPCError) as exc_info:
@@ -147,9 +223,28 @@ class TestCreateNotebookQuotaDetection:
         api = _make_api()
         original = _create_invalid_argument_error()
         api._core.rpc_call = AsyncMock(side_effect=original)
+        _set_account_limit(api, 500)
         api.list = AsyncMock(side_effect=ValueError("bad notebook data"))
 
         with pytest.raises(RPCError) as exc_info:
             await api.create("List Parse Fails")
 
         assert exc_info.value is original
+
+    @pytest.mark.asyncio
+    async def test_get_account_limits_uses_user_settings_rpc(self):
+        api = _make_api()
+        api._core.rpc_call = AsyncMock(return_value=[[None, [6, 500, 300, 500000, 2]]])
+
+        limits = await api._get_account_limits()
+
+        assert limits == AccountLimits(
+            notebook_limit=500,
+            source_limit=300,
+            raw_limits=(6, 500, 300, 500000, 2),
+        )
+        api._core.rpc_call.assert_awaited_once_with(
+            RPCMethod.GET_USER_SETTINGS,
+            [None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+            source_path="/",
+        )

--- a/tests/unit/test_rpc_types.py
+++ b/tests/unit/test_rpc_types.py
@@ -57,6 +57,10 @@ class TestRPCMethod:
         """Test LIST_ARTIFACTS RPC ID."""
         assert RPCMethod.LIST_ARTIFACTS == "gArtLc"
 
+    def test_get_user_tier(self):
+        """Test GET_USER_TIER RPC ID."""
+        assert RPCMethod.GET_USER_TIER == "ozz5Z"
+
     def test_rpc_method_is_string(self):
         """Test RPCMethod values are strings (for JSON serialization)."""
         assert isinstance(RPCMethod.LIST_NOTEBOOKS.value, str)

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -86,11 +86,11 @@ def test_extract_account_limits_returns_empty_for_malformed_response(response):
 
 
 def test_extract_account_tier_from_nested_response():
-    response = [[[[None, "1", 627], [[1613, [None, "NOTEBOOKLM_TIER_PRO_CONSUMER_USER"]]], 0]]]
+    response = [[[[None, "1", 627], [[1613, [None, "NOTEBOOKLM_TIER_PRO"]]], 0]]]
 
     assert extract_account_tier(response) == AccountTier(
-        tier="NOTEBOOKLM_TIER_PRO_CONSUMER_USER",
-        plan_name="Google AI Pro Consumer",
+        tier="NOTEBOOKLM_TIER_PRO",
+        plan_name="Google AI Pro",
     )
 
 

--- a/tests/unit/test_user_settings_api.py
+++ b/tests/unit/test_user_settings_api.py
@@ -1,0 +1,156 @@
+"""Unit tests for user settings parsing."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._settings import (
+    SettingsAPI,
+    build_get_user_settings_params,
+    build_get_user_tier_params,
+    extract_account_limits,
+    extract_account_tier,
+)
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import AccountLimits, AccountTier
+
+
+def test_build_get_user_settings_params_returns_fresh_params():
+    first = build_get_user_settings_params()
+    second = build_get_user_settings_params()
+
+    assert first == [None, [1, None, None, None, None, None, None, None, None, None, [1]]]
+    assert first is not second
+    assert first[1] is not second[1]
+
+
+def test_build_get_user_tier_params_returns_fresh_params():
+    first = build_get_user_tier_params()
+    second = build_get_user_tier_params()
+
+    assert first == [
+        [
+            [
+                [None, "1", 627],
+                [None, None, None, None, None, None, None, None, None, [None, None, 2]],
+                1,
+            ]
+        ]
+    ]
+    assert first is not second
+    assert first[0] is not second[0]
+
+
+def test_get_user_tier_params_match_captured_request_shape():
+    params = build_get_user_tier_params()
+
+    assert params[0][0][0] == [None, "1", 627]
+    assert params[0][0][1][9] == [None, None, 2]
+    assert params[0][0][2] == 1
+
+
+def test_extract_account_limits_from_user_settings_response():
+    limits = extract_account_limits([[None, [6, 500, 300, 500000, 2]]])
+
+    assert limits == AccountLimits(
+        notebook_limit=500,
+        source_limit=300,
+        raw_limits=(6, 500, 300, 500000, 2),
+    )
+
+
+def test_extract_account_limits_preserves_raw_limit_positions():
+    limits = extract_account_limits([[None, [True, 100, "source-limit", None]]])
+
+    assert limits.notebook_limit == 100
+    assert limits.source_limit is None
+    assert limits.raw_limits == (True, 100, "source-limit", None)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        [],
+        [[None]],
+        [[None, None]],
+        [[None, ["tier", "500"]]],
+        [[None, [True, False, "300"]]],
+    ],
+)
+def test_extract_account_limits_returns_empty_for_malformed_response(response):
+    limits = extract_account_limits(response)
+
+    assert limits.notebook_limit is None
+    assert limits.source_limit is None
+
+
+def test_extract_account_tier_from_nested_response():
+    response = [[[[None, "1", 627], [[1613, [None, "NOTEBOOKLM_TIER_PRO_CONSUMER_USER"]]], 0]]]
+
+    assert extract_account_tier(response) == AccountTier(
+        tier="NOTEBOOKLM_TIER_PRO_CONSUMER_USER",
+        plan_name="Google AI Pro Consumer",
+    )
+
+
+def test_extract_account_tier_returns_empty_for_malformed_response():
+    assert extract_account_tier([[["no tier here"]]]) == AccountTier()
+
+
+@pytest.mark.parametrize("response", [None, []])
+def test_extract_account_tier_handles_empty_response(response):
+    assert extract_account_tier(response) == AccountTier()
+
+
+def test_extract_account_tier_preserves_unknown_tier_string():
+    response = [[["NOTEBOOKLM_TIER_FUTURE"]]]
+
+    assert extract_account_tier(response) == AccountTier(
+        tier="NOTEBOOKLM_TIER_FUTURE",
+        plan_name=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_account_limits_calls_user_settings_rpc():
+    core = MagicMock()
+    core.rpc_call = AsyncMock(return_value=[[None, [6, 200, 100, 500000, 1]]])
+    api = SettingsAPI(core)
+
+    limits = await api.get_account_limits()
+
+    assert limits == AccountLimits(
+        notebook_limit=200,
+        source_limit=100,
+        raw_limits=(6, 200, 100, 500000, 1),
+    )
+    core.rpc_call.assert_awaited_once_with(
+        RPCMethod.GET_USER_SETTINGS,
+        [None, [1, None, None, None, None, None, None, None, None, None, [1]]],
+        source_path="/",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_account_tier_calls_user_tier_rpc():
+    core = MagicMock()
+    core.rpc_call = AsyncMock(return_value=[[[[None, "NOTEBOOKLM_TIER_STANDARD"]]]])
+    api = SettingsAPI(core)
+
+    tier = await api.get_account_tier()
+
+    assert tier == AccountTier(tier="NOTEBOOKLM_TIER_STANDARD", plan_name="Standard")
+    core.rpc_call.assert_awaited_once_with(
+        RPCMethod.GET_USER_TIER,
+        [
+            [
+                [
+                    [None, "1", 627],
+                    [None, None, None, None, None, None, None, None, None, [None, None, 2]],
+                    1,
+                ]
+            ]
+        ],
+        source_path="/",
+    )


### PR DESCRIPTION
## Summary
- add typed AccountLimits and AccountTier models exposed from the public package API
- add SettingsAPI.get_account_limits() using GET_USER_SETTINGS (ZwVcOc) to parse server-reported notebook/source limits
- add SettingsAPI.get_account_tier() using the homepage tier RPC (ozz5Z) to expose raw NotebookLM tier metadata
- update notebook create quota detection to use the server-reported notebook limit before converting CREATE_NOTEBOOK status code 3 into NotebookLimitError
- keep create failure handling conservative: if account limits or notebook listing fail, preserve the original RPCError
- keep CLI NOTEBOOK_LIMIT output structured, including current_count, limit, and original RPC metadata when available
- document the settings/tier RPCs and Python API additions

Fixes #309

## Why the scope expanded
The first implementation inferred free/paid quota from owned notebook count near known limits. That was too fragile because NotebookLM account metadata and server limits can diverge from hardcoded assumptions. This revision uses the account settings RPC for the actual notebook/source limits and adds the tier RPC as a typed settings helper for visibility. Quota detection intentionally uses the numeric limit, not the tier string.

## Live validation
Read-only live checks were run against the active default profile:
- account_email: xxx.xxx@gmail.com
- GET_USER_SETTINGS raw_limits: [1, 100, 50, 500000, 1]
- parsed notebook_limit: 100
- parsed source_limit: 50
- GET_USER_TIER tier: NOTEBOOKLM_TIER_PRO_CONSUMER_USER
- parsed plan_name: null (left unmapped because the active limits are Standard-like)
- owned_notebook_count: 59

## Cross-check with notebooklm-mcp-cli
The sibling repo documents the same homepage `ozz5Z` tier RPC and the same `ZwVcOc` limits tuple, but does not implement tier parsing in product code. It also treats `ozz5Z` as a dual-use RPC: homepage params return tier metadata, notebook-context params are URL source v2.

## Test plan
- uv run ruff format src/ tests/ --check
- uv run ruff check src/ tests/
- uv run mypy src/notebooklm
- uv run pytest (2130 passed, 9 skipped; existing warnings, before the final tier-label doc/test tweak)
- uv run pytest tests/unit/test_user_settings_api.py tests/integration/test_settings.py tests/unit/test_exceptions.py tests/unit/test_notebook_api.py -q (77 passed, after final tier-label tweak)
- uv run pre-commit run --all-files
- live read-only GET_USER_SETTINGS / GET_USER_TIER check against the default profile

## Notes for reviewers
- The quota conversion allows one notebook of slack below the reported limit because list results can lag a failed create or omit service-internal notebooks that still count.
- Account tier is exposed for callers as raw metadata, but create quota detection does not map tier to limits.
- CLI JSON omits known_limits unless explicitly supplied, avoiding an empty diagnostic field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Query your account limits (notebook and source quotas) and subscription tier information through the API
  * Improved error handling when notebook quota limits are exceeded, providing clear feedback on current usage versus your limits
  * Enhanced quota enforcement detection during notebook creation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->