### PR TITLE
fix(artifacts): detect completed video media URLs correctly

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2415,7 +2415,7 @@ class ArtifactsAPI:
         - art[2]: artifact_type (ArtifactTypeCode enum value)
         - art[4]: status_code (ArtifactStatus enum value)
         - art[6][5]: audio media URL list
-        - art[8][i][0][0]: video media URL (nested list of URL entries)
+        - art[8][i][0][0]: video media URL string (within nested variants and entries)
         - art[16][3]: slide deck PDF URL
 
         Args:

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2415,7 +2415,7 @@ class ArtifactsAPI:
         - art[2]: artifact_type (ArtifactTypeCode enum value)
         - art[4]: status_code (ArtifactStatus enum value)
         - art[6][5]: audio media URL list
-        - art[8]: video metadata containing URL list
+        - art[8][i][0][0]: video media URL (nested list of URL entries)
         - art[16][3]: slide deck PDF URL
 
         Args:
@@ -2439,12 +2439,16 @@ class ArtifactsAPI:
                 return False
 
             elif artifact_type == ArtifactTypeCode.VIDEO.value:
-                # Video URLs are in art[8] - check for any valid URL in the list
+                # Video URLs live at art[8][i][0][0] - mirror download_video's
+                # structure check so wait_for_completion and download agree.
                 if len(art) > 8 and isinstance(art[8], list):
                     return any(
-                        self._is_valid_media_url(item[0])
+                        isinstance(item, list)
+                        and len(item) > 0
+                        and isinstance(item[0], list)
+                        and len(item[0]) > 0
+                        and self._is_valid_media_url(item[0][0])
                         for item in art[8]
-                        if isinstance(item, list) and len(item) > 0
                     )
                 return False
 

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -2152,7 +2152,9 @@ class TestGetArtifactTypeNameAndIsMediaReady:
         build_rpc_response,
     ):
         """poll_status returns 'completed' for video when art[8] has valid URL."""
-        # Video artifact with art[8] containing a URL
+        # Video artifact with art[8] containing a URL.
+        # Real-API shape: art[8][i][0][0] holds the URL string (matches the
+        # structure parsed by download_video).
         video_artifact = [
             "video_task",
             "Video Overview",
@@ -2162,7 +2164,7 @@ class TestGetArtifactTypeNameAndIsMediaReady:
             None,
             None,
             None,
-            [["https://storage.googleapis.com/video.mp4"]],  # art[8]
+            [[["https://storage.googleapis.com/video.mp4"]]],  # art[8]
         ]
         response = build_rpc_response(RPCMethod.LIST_ARTIFACTS, [[video_artifact]])
         httpx_mock.add_response(content=response.encode())

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -484,7 +484,12 @@ class TestIsMediaReady:
         assert api._is_media_ready(art, 1) is False
 
     def test_video_with_valid_url(self, mock_artifacts_api):
-        """Test video artifact with valid URL returns True."""
+        """Test video artifact with valid URL returns True.
+
+        Mirrors the structure parsed by ``download_video``: art[8] is a list of
+        variants, each variant a list of URL entries, each URL entry a list with
+        the URL string at index 0.
+        """
         api, _ = mock_artifacts_api
         art = [
             "artifact_id",
@@ -495,7 +500,8 @@ class TestIsMediaReady:
             None,
             None,
             None,
-            [["https://video.url/file.mp4", None, "video/mp4"]],  # art[8]
+            # art[8][i][0][0] holds the URL
+            [[["https://video.url/file.mp4", None, "video/mp4"]]],
         ]
         assert api._is_media_ready(art, 3) is True
 
@@ -519,6 +525,51 @@ class TestIsMediaReady:
         """Test video artifact with truncated structure returns False."""
         api, _ = mock_artifacts_api
         art = ["artifact_id", "title", 3, None, 3, None, None]  # Too short (no art[8])
+        assert api._is_media_ready(art, 3) is False
+
+    def test_video_pre_url_metadata_returns_false(self, mock_artifacts_api):
+        """Regression for issue #330: pre-URL metadata must not register as ready.
+
+        Before the URL is populated, the inner URL-entry list is empty (or
+        missing the URL string). The previous implementation passed this list
+        to ``_is_valid_media_url`` directly and got ``False`` by accident,
+        which masked the broken structural check. Verify the empty-inner-list
+        case explicitly.
+        """
+        api, _ = mock_artifacts_api
+        art = [
+            "artifact_id",
+            "title",
+            3,
+            None,
+            3,
+            None,
+            None,
+            None,
+            [[[]]],  # variant present, URL entry present, but URL not yet set
+        ]
+        assert api._is_media_ready(art, 3) is False
+
+    def test_video_legacy_two_level_shape_returns_false(self, mock_artifacts_api):
+        """Issue #330 regression: a 2-level art[8] (no URL-entry wrapper) is invalid.
+
+        The buggy implementation accidentally accepted this shape because
+        ``item[0]`` happened to be a string. The real API never returns this
+        shape, and accepting it would let ``wait_for_completion`` claim ready
+        on payloads that ``download_video`` cannot parse.
+        """
+        api, _ = mock_artifacts_api
+        art = [
+            "artifact_id",
+            "title",
+            3,
+            None,
+            3,
+            None,
+            None,
+            None,
+            [["https://video.url/file.mp4", None, "video/mp4"]],
+        ]
         assert api._is_media_ready(art, 3) is False
 
     def test_slide_deck_with_valid_url(self, mock_artifacts_api):


### PR DESCRIPTION
## Summary

`_is_media_ready` for VIDEO checked `art[8][i][0]` as the URL string, but
`download_video` parses `art[8][i][0][0]` (variants → URL entries →
`[url, ?, mime]`). The mismatch meant `poll_status` kept downgrading
COMPLETED back to PROCESSING for videos that were actually ready, and
`wait_for_completion` polled until the configured timeout (e.g. 3600s)
even though the video was visible in the browser.

Reported by @catdance124 in #330 with reproduction details and a suggested
fix that mirrors `download_video`. This PR adopts that direction and
additionally repairs the test fixtures that were encoding the buggy shape.

## Related Issue

Closes #330

## Changes

- `src/notebooklm/_artifacts.py`
  - VIDEO branch of `_is_media_ready` now reads the URL at `art[8][i][0][0]`,
    mirroring the structure check used by `download_video()` so
    `wait_for_completion` and download agree on what "ready" means.
  - Updated the structure note in the docstring.
- `tests/unit/test_artifacts_coverage.py`
  - Fixed `test_video_with_valid_url` — its `art[8]` fixture was 2-deep,
    which is why this bug never tripped a unit test.
  - Added `test_video_pre_url_metadata_returns_false` covering the
    pre-completion shape `[[[]]]` (variant + URL entry present, URL not
    yet populated) — the on-the-wire situation described in the issue.
  - Added `test_video_legacy_two_level_shape_returns_false` to lock in
    the contract that the wrong 2-deep shape no longer leaks through.
- `tests/integration/test_artifacts.py`
  - Updated `test_poll_status_video_completed_with_valid_url` fixture to
    the correct 3-deep `art[8]` shape; the previous fixture matched the
    buggy structure and would have started failing once
    `_is_media_ready` was fixed.

AUDIO, SLIDE_DECK, INFOGRAPHIC, and non-media branches are unchanged.

## Test Plan

- [x] Tested locally on macOS, Python 3.13
- [x] Targeted tests pass:
  - `uv run pytest tests/unit/test_artifacts_coverage.py::TestIsMediaReady -q` — 20 passed
  - `uv run pytest tests/integration/test_artifacts.py::TestGetArtifactTypeNameAndIsMediaReady -q` — 7 passed
- [x] Full suite passes: `uv run pytest -q` — 2136 passed, 9 skipped
- [x] Linting passes: `uv run ruff check src/ tests/`
- [x] Formatting passes: `uv run ruff format --check src/ tests/`
- [x] Type checking passes: `uv run mypy src/notebooklm --ignore-missing-imports`

## Notes

The issue report identified the implementation mismatch, but the existing
unit fixture also encoded the old 2-deep shape. This PR updates that
fixture to the real API shape and adds negative coverage for the legacy
shape so the contract is explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected video artifact readiness detection to properly identify valid nested download URLs.
  * Enhanced validation to prevent incomplete or legacy-shaped video artifacts from being incorrectly marked as ready.

* **Tests**
  * Expanded and added tests to cover valid nested video URL shapes and regressions for invalid/legacy cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->