### PR TITLE
fix(auth): keep NotebookLM subdomain cookies

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -256,6 +256,17 @@ def _is_allowed_auth_domain(domain: str) -> bool:
     return domain in ALLOWED_COOKIE_DOMAINS or _is_google_domain(domain)
 
 
+def _auth_domain_priority(domain: str) -> int:
+    """Return duplicate-cookie priority for allowed auth domains."""
+    if domain == ".google.com":
+        return 3
+    if domain in {".notebooklm.google.com", "notebooklm.google.com"}:
+        return 2
+    if _is_google_domain(domain):
+        return 1
+    return 0
+
+
 def convert_rookiepy_cookies_to_storage_state(
     rookiepy_cookies: list[dict],
 ) -> dict[str, Any]:
@@ -321,7 +332,8 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
         .google.com and .google.com.sg), we use this priority order:
 
         1. .google.com (base domain) - ALWAYS preferred when present
-        2. Regional domains - used as fallback when base domain cookie is missing
+        2. NotebookLM subdomain - preferred for NotebookLM-specific cookies
+        3. Regional domains - used as fallback when higher-priority cookies are missing
 
         This prevents non-deterministic behavior where dict iteration order would
         determine which cookie value wins. See PR #34 for the bug this fixes.
@@ -346,6 +358,7 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
     """
     cookies = {}
     cookie_domains: dict[str, str] = {}  # Track which domain each cookie came from
+    cookie_priorities: dict[str, int] = {}
 
     for cookie in storage_state.get("cookies", []):
         domain = cookie.get("domain", "")
@@ -353,18 +366,20 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
         if not _is_allowed_auth_domain(domain) or not name:
             continue
 
-        # Prioritize .google.com cookies over regional domains (e.g., .google.de)
-        # to prevent wrong cookie values when the same name exists in multiple domains
-        is_base_domain = domain == ".google.com"
-        if name not in cookies or is_base_domain:
-            if name in cookies and is_base_domain:
+        # Prioritize stable domain classes over storage_state ordering to prevent
+        # wrong cookie values when the same name exists in multiple domains.
+        priority = _auth_domain_priority(domain)
+        if name not in cookies or priority > cookie_priorities[name]:
+            if name in cookies:
                 logger.debug(
-                    "Cookie %s: using .google.com value (overriding %s)",
+                    "Cookie %s: using %s value (overriding %s)",
                     name,
+                    domain,
                     cookie_domains[name],
                 )
             cookies[name] = cookie.get("value", "")
             cookie_domains[name] = domain
+            cookie_priorities[name] = priority
         else:
             logger.debug(
                 "Cookie %s: ignoring duplicate from %s (keeping %s)",

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -257,13 +257,20 @@ def _is_allowed_auth_domain(domain: str) -> bool:
 
 
 def _auth_domain_priority(domain: str) -> int:
-    """Return duplicate-cookie priority for allowed auth domains."""
+    """Return duplicate-cookie priority for allowed auth domains.
+
+    Higher value wins. Tiers are distinct so the resolved cookie is fully
+    deterministic regardless of storage_state ordering.
+    """
     if domain == ".google.com":
+        return 4
+    if domain == ".notebooklm.google.com":
         return 3
-    if domain in {".notebooklm.google.com", "notebooklm.google.com"}:
+    if domain == "notebooklm.google.com":
         return 2
     if _is_google_domain(domain):
         return 1
+    # Allowlisted but unranked domains (e.g. .googleusercontent.com) fall through.
     return 0
 
 
@@ -332,11 +339,15 @@ def extract_cookies_from_storage(storage_state: dict[str, Any]) -> dict[str, str
         .google.com and .google.com.sg), we use this priority order:
 
         1. .google.com (base domain) - ALWAYS preferred when present
-        2. NotebookLM subdomain - preferred for NotebookLM-specific cookies
-        3. Regional domains - used as fallback when higher-priority cookies are missing
+        2. .notebooklm.google.com (Playwright canonical NotebookLM subdomain)
+        3. notebooklm.google.com (no-dot NotebookLM subdomain)
+        4. Regional domains (e.g. .google.de, .google.com.sg, .google.co.uk)
+        5. Other allowlisted domains (e.g. .googleusercontent.com)
 
-        This prevents non-deterministic behavior where dict iteration order would
-        determine which cookie value wins. See PR #34 for the bug this fixes.
+        Within a single priority tier, the first occurrence in the list wins;
+        later duplicates at the same tier are ignored. Tiers are distinct so the
+        outcome is deterministic regardless of storage_state ordering. See PR #34
+        for the bug this fixes.
 
     Args:
         storage_state: Parsed JSON from Playwright's storage state file.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -49,6 +49,8 @@ MINIMUM_REQUIRED_COOKIES = {"SID"}
 # Includes googleusercontent.com for authenticated media downloads
 ALLOWED_COOKIE_DOMAINS = {
     ".google.com",
+    # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
+    ".notebooklm.google.com",
     "notebooklm.google.com",
     ".googleusercontent.com",
 }

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -123,6 +123,25 @@ class TestExtractCookies:
         assert cookies["SID"] == "sid_value"
         assert cookies["OSID"] == "osid_base"
 
+    def test_prefers_notebooklm_subdomain_cookie_over_regional(self):
+        """Test NotebookLM subdomain wins duplicate names from regional domains."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "sid_value", "domain": ".google.com"},
+                {"name": "OSID", "value": "osid_regional", "domain": ".google.de"},
+                {
+                    "name": "OSID",
+                    "value": "osid_subdomain",
+                    "domain": ".notebooklm.google.com",
+                },
+            ]
+        }
+
+        cookies = extract_cookies_from_storage(storage_state)
+
+        assert cookies["SID"] == "sid_value"
+        assert cookies["OSID"] == "osid_subdomain"
+
     def test_raises_if_missing_sid(self):
         storage_state = {
             "cookies": [
@@ -729,7 +748,7 @@ class TestAllowedCookieDomains:
         from notebooklm.auth import ALLOWED_COOKIE_DOMAINS
 
         assert ".google.com" in ALLOWED_COOKIE_DOMAINS
-        assert ".notebooklm.google.com" in ALLOWED_COOKIE_DOMAINS
+        assert any(domain == ".notebooklm.google.com" for domain in ALLOWED_COOKIE_DOMAINS)
         assert "notebooklm.google.com" in ALLOWED_COOKIE_DOMAINS
 
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -123,17 +123,16 @@ class TestExtractCookies:
         assert cookies["SID"] == "sid_value"
         assert cookies["OSID"] == "osid_base"
 
-    def test_prefers_notebooklm_subdomain_cookie_over_regional(self):
-        """Test NotebookLM subdomain wins duplicate names from regional domains."""
+    @pytest.mark.parametrize(
+        "notebooklm_domain", [".notebooklm.google.com", "notebooklm.google.com"]
+    )
+    def test_prefers_notebooklm_subdomain_cookie_over_regional(self, notebooklm_domain):
+        """Both NotebookLM subdomain forms win duplicate names from regional domains."""
         storage_state = {
             "cookies": [
                 {"name": "SID", "value": "sid_value", "domain": ".google.com"},
                 {"name": "OSID", "value": "osid_regional", "domain": ".google.de"},
-                {
-                    "name": "OSID",
-                    "value": "osid_subdomain",
-                    "domain": ".notebooklm.google.com",
-                },
+                {"name": "OSID", "value": "osid_subdomain", "domain": notebooklm_domain},
             ]
         }
 
@@ -141,6 +140,59 @@ class TestExtractCookies:
 
         assert cookies["SID"] == "sid_value"
         assert cookies["OSID"] == "osid_subdomain"
+
+    def test_prefers_dotted_notebooklm_over_no_dot_variant(self):
+        """Playwright canonical (.notebooklm.google.com) wins over the no-dot form."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "sid_value", "domain": ".google.com"},
+                {"name": "OSID", "value": "osid_no_dot", "domain": "notebooklm.google.com"},
+                {"name": "OSID", "value": "osid_dotted", "domain": ".notebooklm.google.com"},
+            ]
+        }
+
+        cookies = extract_cookies_from_storage(storage_state)
+
+        assert cookies["OSID"] == "osid_dotted"
+
+        # Reverse list order — dotted variant should still win deterministically.
+        storage_state["cookies"][1], storage_state["cookies"][2] = (
+            storage_state["cookies"][2],
+            storage_state["cookies"][1],
+        )
+        cookies = extract_cookies_from_storage(storage_state)
+        assert cookies["OSID"] == "osid_dotted"
+
+    def test_prefers_regional_over_googleusercontent(self):
+        """Regional Google cookies win over .googleusercontent.com (priority 0)."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "sid_value", "domain": ".google.com"},
+                {"name": "X", "value": "x_uc", "domain": ".googleusercontent.com"},
+                {"name": "X", "value": "x_regional", "domain": ".google.de"},
+            ]
+        }
+        cookies = extract_cookies_from_storage(storage_state)
+        assert cookies["X"] == "x_regional"
+
+        # Reverse order — regional should still win.
+        storage_state["cookies"][1], storage_state["cookies"][2] = (
+            storage_state["cookies"][2],
+            storage_state["cookies"][1],
+        )
+        cookies = extract_cookies_from_storage(storage_state)
+        assert cookies["X"] == "x_regional"
+
+    def test_first_google_com_duplicate_wins(self):
+        """Within the .google.com tier, the first occurrence wins; later duplicates are ignored."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "first", "domain": ".google.com"},
+                {"name": "SID", "value": "second", "domain": ".google.com"},
+            ]
+        }
+        cookies = extract_cookies_from_storage(storage_state)
+        assert cookies["SID"] == "first"
 
     def test_raises_if_missing_sid(self):
         storage_state = {
@@ -964,6 +1016,43 @@ class TestIsAllowedAuthDomain:
         assert _is_allowed_auth_domain("google.com.sg") is False
         assert _is_allowed_auth_domain("google.co.uk") is False
         assert _is_allowed_auth_domain("google.de") is False
+
+
+class TestAuthDomainPriority:
+    """Test `_auth_domain_priority` tier mapping for duplicate-cookie resolution."""
+
+    @pytest.mark.parametrize(
+        "domain,expected",
+        [
+            (".google.com", 4),
+            (".notebooklm.google.com", 3),
+            ("notebooklm.google.com", 2),
+            (".google.de", 1),
+            (".google.com.sg", 1),
+            (".google.co.uk", 1),
+            (".googleusercontent.com", 0),
+            ("evil.com", 0),
+            ("", 0),
+        ],
+    )
+    def test_priority_tiers(self, domain, expected):
+        from notebooklm.auth import _auth_domain_priority
+
+        assert _auth_domain_priority(domain) == expected
+
+    def test_priority_strict_ordering(self):
+        """Higher tiers strictly outrank lower tiers — no ties between named tiers."""
+        from notebooklm.auth import _auth_domain_priority
+
+        priorities = [
+            _auth_domain_priority(".google.com"),
+            _auth_domain_priority(".notebooklm.google.com"),
+            _auth_domain_priority("notebooklm.google.com"),
+            _auth_domain_priority(".google.de"),
+            _auth_domain_priority(".googleusercontent.com"),
+        ]
+        assert priorities == sorted(priorities, reverse=True)
+        assert len(set(priorities)) == len(priorities)
 
 
 class TestIsAllowedCookieDomainRegional:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -80,6 +80,49 @@ class TestExtractCookies:
         assert cookies["OSID"] == "osid_value"
         assert "OTHER" not in cookies
 
+    def test_extracts_osid_from_notebooklm_subdomain(self):
+        """Test OSID extraction from .notebooklm.google.com (Issue #329)."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "sid_value", "domain": ".google.com"},
+                {
+                    "name": "OSID",
+                    "value": "osid_subdomain",
+                    "domain": ".notebooklm.google.com",
+                },
+                {
+                    "name": "__Secure-OSID",
+                    "value": "secure_osid_subdomain",
+                    "domain": ".notebooklm.google.com",
+                },
+            ]
+        }
+
+        cookies = extract_cookies_from_storage(storage_state)
+
+        assert cookies["SID"] == "sid_value"
+        assert cookies["OSID"] == "osid_subdomain"
+        assert cookies["__Secure-OSID"] == "secure_osid_subdomain"
+
+    def test_prefers_base_domain_cookie_over_notebooklm_subdomain(self):
+        """Test .google.com still wins duplicate names from NotebookLM subdomain."""
+        storage_state = {
+            "cookies": [
+                {
+                    "name": "OSID",
+                    "value": "osid_subdomain",
+                    "domain": ".notebooklm.google.com",
+                },
+                {"name": "SID", "value": "sid_value", "domain": ".google.com"},
+                {"name": "OSID", "value": "osid_base", "domain": ".google.com"},
+            ]
+        }
+
+        cookies = extract_cookies_from_storage(storage_state)
+
+        assert cookies["SID"] == "sid_value"
+        assert cookies["OSID"] == "osid_base"
+
     def test_raises_if_missing_sid(self):
         storage_state = {
             "cookies": [
@@ -686,6 +729,7 @@ class TestAllowedCookieDomains:
         from notebooklm.auth import ALLOWED_COOKIE_DOMAINS
 
         assert ".google.com" in ALLOWED_COOKIE_DOMAINS
+        assert ".notebooklm.google.com" in ALLOWED_COOKIE_DOMAINS
         assert "notebooklm.google.com" in ALLOWED_COOKIE_DOMAINS
 
 
@@ -736,6 +780,11 @@ class TestIsGoogleDomain:
             (".google.zz", False),  # Invalid ccTLD
             (".google.xyz", False),  # Not in whitelist
             (".google.com.fake", False),  # Not in whitelist
+            (".notebooklm.google.com", False),  # Accepted by auth allowlist, not here
+            (".mail.google.com", False),
+            (".drive.google.com", False),
+            (".evilnotebooklm.google.com", False),
+            (".notebooklm.google.com.evil", False),
             (".notgoogle.com", False),
             (".evil-google.com", False),
             ("google.com", False),  # Missing leading dot
@@ -804,19 +853,21 @@ class TestIsGoogleDomain:
     @pytest.mark.parametrize(
         "domain",
         [
-            # Subdomains are not matched by _is_google_domain
+            # Subdomains without leading dot are still rejected
             "accounts.google.com",
             "lh3.google.com",
-            "accounts.google.de",  # Subdomain of regional
-            "lh3.google.co.uk",  # Subdomain of regional
-            ".accounts.google.de",  # With leading dot
+            # Subdomains of regional domains are still rejected (not whitelisted)
+            "accounts.google.de",
+            "lh3.google.co.uk",
+            ".accounts.google.de",  # Leading dot but regional subdomain
         ],
     )
     def test_rejects_subdomains(self, domain):
-        """Test that subdomains are rejected by _is_google_domain.
+        """Test that non-canonical subdomains are rejected by _is_google_domain.
 
-        _is_google_domain only matches domain-level cookies (with leading dot).
-        Subdomain matching is handled by _is_allowed_cookie_domain's suffix matching.
+        _is_google_domain only accepts .google.com and regional root domains
+        (.google.com.sg, etc). Auth extraction uses ALLOWED_COOKIE_DOMAINS for
+        auth-specific subdomains.
         """
         from notebooklm.auth import _is_google_domain
 
@@ -848,6 +899,7 @@ class TestIsAllowedAuthDomain:
 
         assert _is_allowed_auth_domain(".google.com") is True
         assert _is_allowed_auth_domain("notebooklm.google.com") is True
+        assert _is_allowed_auth_domain(".notebooklm.google.com") is True  # Issue #329
         assert _is_allowed_auth_domain(".googleusercontent.com") is True
 
     def test_accepts_all_regional_patterns(self):
@@ -879,6 +931,10 @@ class TestIsAllowedAuthDomain:
         from notebooklm.auth import _is_allowed_auth_domain
 
         assert _is_allowed_auth_domain("google.com.evil.sg") is False
+        assert _is_allowed_auth_domain(".mail.google.com") is False
+        assert _is_allowed_auth_domain(".evilnotebooklm.google.com") is False
+        assert _is_allowed_auth_domain(".google.com.evil") is False
+        assert _is_allowed_auth_domain(".evilnotebooklm.google.com.evil") is False
         assert _is_allowed_auth_domain(".not-google.com.sg") is False
         assert _is_allowed_auth_domain(".google.zz") is False  # Invalid ccTLD
 
@@ -1235,3 +1291,37 @@ class TestConvertRookiepyCookies:
         ]
         result = convert_rookiepy_cookies_to_storage_state(raw)
         assert len(result["cookies"]) == 1
+
+    def test_notebooklm_subdomain_included(self):
+        """Playwright-style NotebookLM subdomain cookies are kept."""
+        raw = [
+            {
+                "domain": ".notebooklm.google.com",
+                "name": "OSID",
+                "value": "x",
+                "path": "/",
+                "secure": True,
+                "expires": None,
+                "http_only": False,
+            }
+        ]
+        result = convert_rookiepy_cookies_to_storage_state(raw)
+        assert len(result["cookies"]) == 1
+        assert result["cookies"][0]["domain"] == ".notebooklm.google.com"
+        assert result["cookies"][0]["name"] == "OSID"
+
+    def test_other_google_subdomains_filtered(self):
+        """Auth conversion only keeps explicitly allowed Google subdomains."""
+        raw = [
+            {
+                "domain": ".mail.google.com",
+                "name": "OSID",
+                "value": "x",
+                "path": "/",
+                "secure": True,
+                "expires": None,
+                "http_only": False,
+            }
+        ]
+        result = convert_rookiepy_cookies_to_storage_state(raw)
+        assert result == {"cookies": [], "origins": []}


### PR DESCRIPTION
## Summary
- allow Playwright storage_state cookies from .notebooklm.google.com through the auth cookie allowlist
- keep _is_google_domain limited to Google base/regional root domains instead of broad subdomain matching
- add regression coverage for OSID extraction, auth-domain boundary checks, duplicate-name priority, and rookiepy conversion

Fixes #329

## Test plan
- uv run pytest tests/unit/test_auth.py -q
- uv run python -c 'from notebooklm.auth import _is_google_domain, _is_allowed_auth_domain; print(_is_google_domain(".notebooklm.google.com")); print(_is_allowed_auth_domain(".notebooklm.google.com")); print(_is_allowed_auth_domain(".mail.google.com"))'
- uv run ruff format src/ tests/ --check
- uv run ruff check src/ tests/
- uv run mypy src/notebooklm
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now accepts NotebookLM leading-dot subdomain cookies and applies a deterministic domain-priority when duplicate cookies exist so the intended cookie is chosen.

* **Tests**
  * Expanded unit tests to cover NotebookLM cookie acceptance, deterministic precedence across base, leading-dot and regional domains, first-occurrence within same tier, retention/filtering of scoped cookies, and rejection of malicious/impersonating domain patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->