### PR TITLE
fix(cli): handle unavailable source snapshots during research import

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -51,11 +51,27 @@ class SourcesAPI:
         """
         self._core = core
 
-    async def list(self, notebook_id: str) -> list[Source]:
+    @staticmethod
+    def _handle_malformed_list_response(
+        notebook_id: str,
+        message: str,
+        *log_args: object,
+        strict: bool,
+        error_detail: str = "API response structure changed",
+    ) -> list[Source]:
+        logger.warning(message, notebook_id, *log_args)
+        if strict:
+            raise RPCError(f"Could not list sources for {notebook_id}: {error_detail}")
+        return []
+
+    async def list(self, notebook_id: str, *, strict: bool = False) -> list[Source]:
         """List all sources in a notebook.
 
         Args:
             notebook_id: The notebook ID.
+            strict: Raise RPCError on malformed source-list responses instead
+                of returning an empty list. Intended for internal flows where
+                a malformed snapshot must not be treated as an empty notebook.
 
         Returns:
             List of Source objects.
@@ -69,31 +85,32 @@ class SourcesAPI:
         )
 
         if not notebook or not isinstance(notebook, list) or len(notebook) == 0:
-            logger.warning(
+            return self._handle_malformed_list_response(
+                notebook_id,
                 "Empty or invalid notebook response when listing sources for %s "
                 "(API response structure may have changed)",
-                notebook_id,
+                strict=strict,
             )
-            return []
 
         nb_info = notebook[0]
         if not isinstance(nb_info, list) or len(nb_info) <= 1:
-            logger.warning(
+            return self._handle_malformed_list_response(
+                notebook_id,
                 "Unexpected notebook structure for %s: expected list with sources at index 1 "
                 "(API structure may have changed)",
-                notebook_id,
+                strict=strict,
             )
-            return []
 
         sources_list = nb_info[1]
         if not isinstance(sources_list, list):
-            logger.warning(
+            return self._handle_malformed_list_response(
+                notebook_id,
                 "Sources data for %s is not a list (type=%s), returning empty list "
                 "(API structure may have changed)",
-                notebook_id,
                 type(sources_list).__name__,
+                strict=strict,
+                error_detail=f"sources data is {type(sources_list).__name__}, not list",
             )
-            return []
 
         # Convert raw source data to Source objects
         sources = []

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -59,7 +59,7 @@ class SourcesAPI:
         strict: bool,
         error_detail: str = "API response structure changed",
     ) -> list[Source]:
-        logger.warning(message, notebook_id, *log_args)
+        logger.warning("SourcesAPI.list: " + message, notebook_id, *log_args)
         if strict:
             raise RPCError(f"Could not list sources for {notebook_id}: {error_detail}")
         return []

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -149,6 +149,11 @@ async def import_with_retry(
     a copy of the same sources (a single timeout cascade can otherwise inflate
     a 60-source import to 300+ sources across 5-6 retries).
 
+    If the pre-import source snapshot is unavailable, retries still filter out
+    URLs that are already visible after each timeout, but the returned list may
+    undercount server-side imports because the function cannot prove those
+    sources were absent before this call.
+
     This is intentionally CLI-only policy. Library consumers calling
     `client.research.import_sources()` directly still get one-shot behavior.
     """
@@ -171,7 +176,7 @@ async def import_with_retry(
     # additions from another session and pre-existing URLs cannot satisfy it.
     baseline_ids: set[str] | None
     try:
-        baseline = await client.sources.list(notebook_id)
+        baseline = await client.sources.list(notebook_id, strict=True)
         baseline_ids = {src.id for src in baseline}
     except (NetworkError, RPCError) as snapshot_exc:
         logger.warning(
@@ -193,16 +198,20 @@ async def import_with_retry(
             # Verify server-side state before retrying. The IMPORT_RESEARCH RPC
             # frequently times out at the client (30s) after a successful
             # server-side write; retrying then duplicates every source.
-            if baseline_ids is not None and requested_urls_norm:
+            if requested_urls_norm:
                 try:
-                    current = await client.sources.list(notebook_id)
-                    new_sources = [src for src in current if src.id not in baseline_ids]
+                    current = await client.sources.list(notebook_id, strict=True)
+                    new_sources = (
+                        [src for src in current if src.id not in baseline_ids]
+                        if baseline_ids is not None
+                        else []
+                    )
                     new_urls_norm = {_normalize_url(src.url) for src in new_sources if src.url}
                     current_urls_norm = {_normalize_url(src.url) for src in current if src.url}
                     # Success requires every requested URL to appear among the
                     # *new* sources. Trivial-true cases (pre-existing URLs) and
                     # concurrent unrelated additions both fail this check.
-                    if requested_urls_norm.issubset(new_urls_norm):
+                    if baseline_ids is not None and requested_urls_norm.issubset(new_urls_norm):
                         logger.warning(
                             "IMPORT_RESEARCH timed out for notebook %s but "
                             "sources.list shows all %d requested URLs among "

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -1041,6 +1041,34 @@ class TestListSourcesMalformedResponse:
 
         assert sources == []
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("rpc_result", "message"),
+        [
+            ([], "API response structure changed"),
+            (["just_a_string"], "API response structure changed"),
+            ([["just_a_title"]], "API response structure changed"),
+            ([["Notebook Title", None]], "sources data is NoneType, not list"),
+        ],
+    )
+    async def test_list_sources_strict_raises_for_malformed_response(
+        self,
+        rpc_result,
+        message,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Strict mode exposes malformed source-list responses to callers
+        that must distinguish API-structure failures from empty notebooks.
+        """
+        response = build_rpc_response(RPCMethod.GET_NOTEBOOK, rpc_result)
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(RPCError, match=message):
+                await client.sources.list("nb_123", strict=True)
+
 
 class TestListSourcesParsingEdgeCases:
     """Tests for list() per-source parsing edge cases (lines 100-143)."""

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -120,8 +120,9 @@ def create_mock_client():
             MockNotebook("notebook_test", "Notebook Test"),
         ]
 
-    def make_source_list(notebook_id):
+    def make_source_list(notebook_id, *, strict=False):
         """Return source list that matches common test IDs."""
+        del strict
         return [
             MockSource("src_1", "Source One"),
             MockSource("src_2", "Source Two"),

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -1092,6 +1092,11 @@ class TestImportWithRetry:
 
         assert imported == []
         assert client.research.import_sources.await_count == 2
+        assert client.sources.list.await_count == 3
+        assert all(
+            awaited_call.kwargs.get("strict") is True
+            for awaited_call in client.sources.list.await_args_list
+        )
         assert client.research.import_sources.await_args_list[0].args[2] == sources
         assert client.research.import_sources.await_args_list[1].args[2] == [
             {"url": "https://two.example.com", "title": "Source 2"},

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -30,7 +30,7 @@ from notebooklm.cli.helpers import (
     set_current_notebook,
     with_client,
 )
-from notebooklm.exceptions import NetworkError, RPCTimeoutError
+from notebooklm.exceptions import NetworkError, RPCError, RPCTimeoutError
 from notebooklm.types import ArtifactType
 
 # =============================================================================
@@ -1046,6 +1046,57 @@ class TestImportWithRetry:
         assert client.research.import_sources.await_count == 2
         retry_call_sources = client.research.import_sources.await_args_list[1].args[2]
         assert retry_call_sources == [{"url": "https://two.example.com", "title": "Source 2"}]
+        mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_failure_deduplicates_retries_without_verified_success(self):
+        """A malformed pre-import snapshot must not masquerade as an empty
+        notebook. Without a reliable baseline we can still drop URLs already
+        visible after a timeout, but we must not classify all current rows as
+        newly imported by this call.
+        """
+        source_1 = MagicMock(id="src_1", title="Source 1", url="https://one.example.com")
+        source_2 = MagicMock(id="src_2", title="Source 2", url="https://two.example.com")
+        source_3 = MagicMock(id="src_3", title="Source 3", url="https://three.example.com")
+        sources = [
+            {"url": "https://one.example.com", "title": "Source 1"},
+            {"url": "https://two.example.com", "title": "Source 2"},
+            {"url": "https://three.example.com", "title": "Source 3"},
+        ]
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[
+                RPCError("snapshot unavailable"),
+                [source_1],
+                [source_1, source_2, source_3],
+            ]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=[
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+                RPCTimeoutError("Timed out", timeout_seconds=30.0),
+            ]
+        )
+
+        with (
+            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch("notebooklm.cli.helpers.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                sources,
+                initial_delay=5,
+            )
+
+        assert imported == []
+        assert client.research.import_sources.await_count == 2
+        assert client.research.import_sources.await_args_list[0].args[2] == sources
+        assert client.research.import_sources.await_args_list[1].args[2] == [
+            {"url": "https://two.example.com", "title": "Source 2"},
+            {"url": "https://three.example.com", "title": "Source 3"},
+        ]
         mock_sleep.assert_awaited_once_with(5)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add strict source-list parsing so research import retry verification can distinguish malformed API responses from empty notebooks
- keep retry deduplication active when the pre-import baseline is unavailable, while disabling new-source verified-success attribution without a reliable baseline
- cover strict malformed source-list responses and unavailable-baseline retry filtering

## Root cause
`SourcesAPI.list()` returned `[]` for malformed source-list payloads such as `None`, so `import_with_retry()` treated a failed pre-import snapshot as a reliable empty notebook. Later timeout probes then classified all current rows as new, which could trigger incorrect verified-success behavior and inflated import accounting.

## Test plan
- `uv run pytest tests/unit/cli/test_helpers.py::TestImportWithRetry tests/integration/test_sources.py::TestListSourcesMalformedResponse -q`
- `uv run pytest tests/unit tests/integration -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/notebooklm`
- `uv run pre-commit run --all-files`

Closes #331

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Source listing gains an optional strict validation mode to surface malformed responses.

* **Bug Fixes**
  * Improved handling and clearer error messages for malformed or unexpected API responses.
  * Enhanced import retry verification to better detect newly added sources and avoid duplicate retries when snapshots fail.

* **Tests**
  * Added regression and unit tests covering malformed responses and import-retry edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->