### PR TITLE
chore: release v0.4.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,4 +32,10 @@ Put pure logic in `tests/unit/`, VCR-backed flows in `tests/integration/`, and a
 
 ## Commit, PR, and Agent Notes
 
-Follow the existing commit style: `feat(cli): ...`, `fix(cli): ...`, `refactor(test): ...`, `style: ...`. PRs should include a short summary, linked issue when relevant, and the commands run locally. For Codex or other parallel agents, prefer `--json`, pass explicit notebook IDs instead of relying on `notebooklm use`, and isolate concurrent runs with `NOTEBOOKLM_PROFILE=agent-<id>` (each profile gets its own context file under `~/.notebooklm/profiles/<name>/`); fall back to `NOTEBOOKLM_HOME=/tmp/agent-<id>` only when multiple home directories are required. In headless environments where Playwright login is impractical, authenticate via `notebooklm login --browser-cookies <browser>` (requires `pip install "notebooklm-py[cookies]"`).
+Follow the existing commit style: `feat(cli): ...`, `fix(cli): ...`, `refactor(test): ...`, `style: ...`. PRs should include a short summary, linked issue when relevant, and the commands run locally.
+
+For Codex or other parallel agents:
+
+- Prefer `--json` output and pass explicit notebook IDs instead of relying on `notebooklm use`.
+- Isolate concurrent runs with `NOTEBOOKLM_PROFILE=agent-<id>` so each agent gets its own context file under `~/.notebooklm/profiles/<name>/`. Fall back to `NOTEBOOKLM_HOME=/tmp/agent-<id>` only when separate home directories are required.
+- In headless environments where Playwright login is impractical, authenticate with `notebooklm login --browser-cookies <browser>` (requires `pip install "notebooklm-py[cookies]"`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 **Status:** Active
-**Last Updated:** 2026-03-13
+**Last Updated:** 2026-05-09
 
 ## Project Structure & Module Organization
 
@@ -32,4 +32,4 @@ Put pure logic in `tests/unit/`, VCR-backed flows in `tests/integration/`, and a
 
 ## Commit, PR, and Agent Notes
 
-Follow the existing commit style: `feat(cli): ...`, `fix(cli): ...`, `refactor(test): ...`, `style: ...`. PRs should include a short summary, linked issue when relevant, and the commands run locally. For Codex or other parallel agents, prefer `--json`, pass explicit notebook IDs instead of relying on `notebooklm use`, and isolate runs with `NOTEBOOKLM_HOME=/tmp/<agent-id>` when multiple agents share one machine.
+Follow the existing commit style: `feat(cli): ...`, `fix(cli): ...`, `refactor(test): ...`, `style: ...`. PRs should include a short summary, linked issue when relevant, and the commands run locally. For Codex or other parallel agents, prefer `--json`, pass explicit notebook IDs instead of relying on `notebooklm use`, and isolate concurrent runs with `NOTEBOOKLM_PROFILE=agent-<id>` (each profile gets its own context file under `~/.notebooklm/profiles/<name>/`); fall back to `NOTEBOOKLM_HOME=/tmp/agent-<id>` only when multiple home directories are required. In headless environments where Playwright login is impractical, authenticate via `notebooklm login --browser-cookies <browser>` (requires `pip install "notebooklm-py[cookies]"`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-09
+
+### Added
+- **Multi-account profiles** - Switch between Google accounts without re-authenticating (#227)
+  - `notebooklm profile create/list/use/rename/delete` commands
+  - Per-profile storage paths under `~/.notebooklm/profiles/<name>/`
+  - Implicit default profile preserved for backward compatibility
+- **Microsoft Edge SSO login** - `notebooklm login --browser msedge` for organizations that require Edge for SSO (#204)
+- **Browser cookie import** - Reuse cookies from your existing browser session without driving Playwright
+  - `notebooklm login --browser-cookies <browser>` (chrome, edge, firefox, safari, etc.)
+  - New `convert_rookiepy_cookies_to_storage_state()` Python helper
+  - Optional `[cookies]` extra installs `rookiepy` (`pip install "notebooklm-py[cookies]"`)
+- **EPUB source type** - Upload `.epub` files as notebook sources (#231)
+- **Agent skill installation** - Install the bundled NotebookLM skill into local AI agents (#206, #207)
+  - `notebooklm skill install` - Install into `~/.claude/skills/notebooklm` and `~/.agents/skills/notebooklm`
+  - `notebooklm skill status` - Check installation state
+  - `notebooklm agent show codex` / `notebooklm agent show claude` - Print bundled agent templates
+- **Mind map customization** - `client.artifacts.generate_mind_map()` now accepts `language` and `instructions` parameters (#252)
+- **`note list --json`** - Machine-readable note listings (#259)
+- **Bare status codes in decoder errors** - Decoder surfaces server status codes on null RPC results for clearer diagnostics (#114, #294)
+
+### Fixed
+- **Cross-domain cookie preservation** - Login storage state retains cookies across `google.com` and `notebooklm.google.com` subdomains, restoring sessions for regional domains
+- **NotebookLM subdomain cookies** - Subdomain cookies are no longer dropped during login (#334)
+- **Video artifact detection** - Correctly detect completed video media URLs in polling responses (#333)
+- **Research import on unavailable snapshots** - CLI gracefully handles missing source snapshots during research import (#335)
+- **Source import retry** - Filtered partial-import retry payloads and tightened verification to avoid false positives (#321, #327)
+- **Server-state verification on timeout** - Prevents duplicate inflation when source imports time out (#319)
+- **Playwright navigation interruption** - Handles updated Playwright behavior on already-authenticated sessions (#214, #322)
+- **Login subprocess on Windows** - Use `sys.executable` for Playwright subprocess calls (#279)
+- **Legacy Windows Unicode output** - Sanitized output streams for legacy Windows consoles (#324)
+- **Settings quota errors** - Use account limits when reporting create-quota failures (#328)
+- **Chat references** - Emit references only from the winning chunk to avoid >600-element duplication (#300, #310)
+- **Login retry mechanism** - Resolved race conditions and improved error handling on retry (#243)
+- **Quota detection during polling** - Detect quota / daily-limit failures during artifact polling (#240)
+- **Google account switching** - Fixed switching between Google accounts at login time (#246)
+- **YouTube URL extraction** - Extract YouTube URLs at deeply-nested response positions (#265)
+- **Bare-HTTP URL fallback** - Disabled brittle bare-HTTP fallback in `sources.list()` (#294)
+- **Logout context cleanup** - Clear the active notebook context on `notebooklm logout`
+- **Infographic URL extraction** - Aligned with download-path logic; added regression test (#229)
+- **Custom storage path for downloads** - Artifact downloads now respect custom auth storage paths (#235)
+- **Windows file permissions** - Skip Unix-only `0o600` calls on Windows and rely on Python 3.13+ ACL behavior (#225)
+- **TOCTOU protection** - Hardened directory creation in `session.py` (#225)
+
+### Changed
+- **`rookiepy` is an optional `[cookies]` extra** - Excluded from `[all]` to avoid Python 3.13+ install issues; install with `pip install "notebooklm-py[cookies]"`
+- **Login error detection** - Improved detection of missing browser binaries (e.g., `msedge` not installed)
+- **Skill installation paths** - Hardened to handle alternative `~/.claude` and `~/.agents` layouts
+- **`StudioContentType` deprecation extended** - Removal pushed from v0.4.0 to v0.5.0; existing imports continue to work with `DeprecationWarning`
+
+### Infrastructure
+- Pinned `ruff==0.8.6` in dev deps to match pre-commit configuration
+- Bumped `python-dotenv` (#299)
+- Bumped `pytest` in the `uv` group
+- Added contribution templates and PR quality guidelines for issues and PRs
+
 ## [0.3.4] - 2026-03-12
 
 ### Added
@@ -344,7 +400,8 @@ This is the initial public release of `notebooklm-py`. While core functionality 
 - **Authentication expiry**: CSRF tokens expire after some time. Re-run `notebooklm login` if you encounter auth errors.
 - **Large file uploads**: Files over 50MB may fail or timeout. Split large documents if needed.
 
-[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/teng-lin/notebooklm-py/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/teng-lin/notebooklm-py/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/teng-lin/notebooklm-py/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/teng-lin/notebooklm-py/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/teng-lin/notebooklm-py/compare/v0.3.1...v0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Multi-account profiles** - Switch between Google accounts without re-authenticating (#227)
-  - `notebooklm profile create/list/use/rename/delete` commands
+  - `notebooklm profile create/list/switch/rename/delete` commands
+  - Global `--profile` / `-p` flag and `NOTEBOOKLM_PROFILE` environment variable to scope any command to a profile
   - Per-profile storage paths under `~/.notebooklm/profiles/<name>/`
-  - Implicit default profile preserved for backward compatibility
+  - Implicit default profile preserved for backward compatibility; existing `~/.notebooklm/storage_state.json` is auto-detected as the default profile (no manual migration needed)
+- **`notebooklm doctor` diagnostic command** - `notebooklm doctor [--fix] [--json]` checks profile setup, auth, and migration status; reports actionable issues
 - **Microsoft Edge SSO login** - `notebooklm login --browser msedge` for organizations that require Edge for SSO (#204)
 - **Browser cookie import** - Reuse cookies from your existing browser session without driving Playwright
   - `notebooklm login --browser-cookies <browser>` (chrome, edge, firefox, safari, etc.)
@@ -56,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`rookiepy` is an optional `[cookies]` extra** - Excluded from `[all]` to avoid Python 3.13+ install issues; install with `pip install "notebooklm-py[cookies]"`
 - **Login error detection** - Improved detection of missing browser binaries (e.g., `msedge` not installed)
 - **Skill installation paths** - Hardened to handle alternative `~/.claude` and `~/.agents` layouts
-- **`StudioContentType` deprecation extended** - Removal pushed from v0.4.0 to v0.5.0; existing imports continue to work with `DeprecationWarning`
+- **Deprecation removal deferred to v0.5.0** - The deprecated APIs originally scheduled for removal in v0.4.0 — `StudioContentType`, `Source.source_type`, `SourceFulltext.source_type`, `Artifact.artifact_type`, `Artifact.variant`, and `DEFAULT_STORAGE_PATH` — continue to work and emit `DeprecationWarning`. Removal is now planned for v0.5.0 to give downstream users an extra release to migrate.
 
 ### Infrastructure
 - Pinned `ruff==0.8.6` in dev deps to match pre-commit configuration
@@ -212,8 +214,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`ARTIFACT_TYPE_DISPLAY`** - Unused constant replaced by `get_artifact_type_display()`
 
 ### Deprecated
-The following emit `DeprecationWarning` when accessed and will be removed in **v0.4.0**.
+The following emit `DeprecationWarning` when accessed and were originally scheduled for removal in v0.4.0.
 See [Migration Guide](docs/stability.md#migrating-from-v02x-to-v030) for upgrade instructions.
+
+> **Note:** Removal was subsequently deferred one release; see the [0.4.0] entry above. These names will now be removed in v0.5.0.
 
 - **`Source.source_type`** - Use `.kind` property instead (returns `SourceType` str enum)
 - **`Artifact.artifact_type`** - Use `.kind` property instead (returns `ArtifactType` str enum)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `notebooklm login --browser-cookies <browser>` (chrome, edge, firefox, safari, etc.)
   - New `convert_rookiepy_cookies_to_storage_state()` Python helper
   - Optional `[cookies]` extra installs `rookiepy` (`pip install "notebooklm-py[cookies]"`)
+  - Honors the active profile: `notebooklm --profile <name> login --browser-cookies <browser>` writes to that profile's `storage_state.json`. Note that cookie extraction always pulls the source browser's currently-active Google account for `google.com` / `notebooklm.google.com` — to populate multiple profiles from the same browser, switch the active Google account in the browser between runs (or use a separate browser per profile).
 - **EPUB source type** - Upload `.epub` files as notebook sources (#231)
 - **Agent skill installation** - Install the bundled NotebookLM skill into local AI agents (#206, #207)
   - `notebooklm skill install` - Install into `~/.claude/skills/notebooklm` and `~/.agents/skills/notebooklm`

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ notebooklm login
 # notebooklm login --browser msedge
 # Or reuse cookies from an already-logged-in browser session
 # notebooklm login --browser-cookies chrome
+# (combine with --profile to populate a specific profile;
+#  cookie import always uses the browser's active Google account
+#  for google.com domains, so switch accounts in the browser
+#  between runs to populate multiple profiles from one browser)
 
 # 2. Create a notebook and add sources
 notebooklm create "My Research"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 | Category | Capabilities |
 |----------|--------------|
 | **Notebooks** | Create, list, rename, delete |
-| **Sources** | URLs, YouTube, files (PDF, text, Markdown, Word, audio, video, images), Google Drive, pasted text; refresh, get guide/fulltext |
+| **Sources** | URLs, YouTube, files (PDF, text, Markdown, Word, EPUB, audio, video, images), Google Drive, pasted text; refresh, get guide/fulltext |
 | **Chat** | Questions, conversation history, custom personas |
 | **Research** | Web and Drive research agents (fast/deep modes) with auto-import |
 | **Sharing** | Public/private links, user permissions (viewer/editor), view level control |
@@ -83,6 +83,8 @@ These features are available via API/CLI but not exposed in NotebookLM's web int
 - **Save chat to notes** - Save Q&A answers or conversation history as notebook notes
 - **Source fulltext access** - Retrieve the indexed text content of any source
 - **Programmatic sharing** - Manage permissions without the UI
+- **Multi-account profiles** - Switch between Google accounts without re-authenticating
+- **Browser cookie import** - Reuse cookies from your existing browser session instead of driving Playwright
 
 ## Installation
 
@@ -93,6 +95,9 @@ pip install notebooklm-py
 # With browser login support (required for first-time setup)
 pip install "notebooklm-py[browser]"
 playwright install chromium
+
+# Optional: import cookies from your existing browser instead of running Playwright
+pip install "notebooklm-py[cookies]"
 ```
 
 If `playwright install chromium` fails with `TypeError: onExit is not a function`, see the Linux workaround in [Troubleshooting](docs/troubleshooting.md#linux).
@@ -122,6 +127,8 @@ pip install git+https://github.com/teng-lin/notebooklm-py@main
 notebooklm login
 # Or use Microsoft Edge (for orgs that require Edge for SSO)
 # notebooklm login --browser msedge
+# Or reuse cookies from an already-logged-in browser session
+# notebooklm login --browser-cookies chrome
 
 # 2. Create a notebook and add sources
 notebooklm create "My Research"
@@ -166,6 +173,8 @@ notebooklm metadata --json           # Export notebook metadata and sources
 notebooklm share status              # Inspect sharing state
 notebooklm source add-research "AI"  # Start web research and import sources
 notebooklm skill status              # Check local agent skill installation
+notebooklm profile list              # List all Google account profiles
+notebooklm profile use work          # Switch active account profile
 ```
 
 ### Python API

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ notebooklm login
 # notebooklm login --browser-cookies chrome
 # (combine with --profile to populate a specific profile;
 #  cookie import always uses the browser's active Google account
-#  for google.com domains, so switch accounts in the browser
-#  between runs to populate multiple profiles from one browser)
+#  for google.com / notebooklm.google.com, so switch accounts in
+#  the browser between runs to populate multiple profiles from
+#  one browser)
 
 # 2. Create a notebook and add sources
 notebooklm create "My Research"

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ notebooklm share status              # Inspect sharing state
 notebooklm source add-research "AI"  # Start web research and import sources
 notebooklm skill status              # Check local agent skill installation
 notebooklm profile list              # List all Google account profiles
-notebooklm profile use work          # Switch active account profile
+notebooklm profile switch work       # Switch active account profile
 ```
 
 ### Python API

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,12 @@
 
 ## Supported Versions
 
+Only the latest minor release receives security fixes. Earlier `0.x` releases predate the current API surface and are no longer maintained — please upgrade to the latest version.
+
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -348,7 +348,7 @@ When user wants full automation (generate and download when ready):
 3. `notebooklm source list` to verify
 
 **Source limits:** Varies by plan—Standard: 50, Plus: 100, Pro: 300, Ultra: 600 sources per notebook. See [NotebookLM plans](https://support.google.com/notebooklm/answer/16213268) for details. The CLI does not enforce these limits; they are applied by your NotebookLM account.
-**Supported types:** PDFs, YouTube URLs, web URLs, Google Docs, text files, Markdown, Word docs, audio files, video files, images
+**Supported types:** PDFs, YouTube URLs, web URLs, Google Docs, text files, Markdown, Word docs, EPUB, audio files, video files, images
 
 ### Bulk Import with Source Waiting (Subagent Pattern)
 **Time:** Varies by source count

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,7 +59,7 @@ For automated environments, multiple accounts, or parallel agent workflows:
 
 **Multiple accounts:** Use named profiles (`notebooklm profile create work`, then `notebooklm -p work login`). Alternatively, use different `NOTEBOOKLM_HOME` directories per account.
 
-**Parallel agents:** The CLI stores notebook context in a shared file (`~/.notebooklm/context.json`). Multiple concurrent agents using `notebooklm use` can overwrite each other's context.
+**Parallel agents:** The CLI stores notebook context per profile (`~/.notebooklm/profiles/<profile>/context.json`, with a legacy fallback to `~/.notebooklm/context.json` for the implicit default profile). Multiple concurrent agents that share a profile and use `notebooklm use` can overwrite each other's context — use one of the isolation strategies below.
 
 **Solutions for parallel workflows:**
 1. **Always use explicit notebook ID** (recommended): Pass `-n <notebook_id>` (for `wait`/`download` commands) or `--notebook <notebook_id>` (for others) instead of relying on `use`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -271,12 +271,12 @@ Authenticate with Google NotebookLM via browser.
 notebooklm login [OPTIONS]
 ```
 
-Opens a Chromium browser with a persistent profile. Log in to your Google account, then press Enter in the terminal to save the session.
+By default, opens a Chromium browser with a persistent profile. Log in to your Google account, then press Enter in the terminal to save the session. Use `--browser msedge` for Microsoft Edge, or `--browser-cookies <browser>` to import cookies from an already-logged-in browser without launching Playwright.
 
 **Options:**
 - `--storage PATH` - Where to save storage_state.json (default: `$NOTEBOOKLM_HOME/profiles/<profile>/storage_state.json`)
 - `--browser [chromium|msedge]` - Browser to use for login (default: `chromium`). Use `msedge` for Microsoft Edge.
-- `--browser-cookies [auto|chrome|edge|firefox|safari|brave|arc|...]` - Read cookies from an installed browser instead of launching Playwright. Defaults to `auto` (rookiepy auto-detect) when the flag is given without a value. Requires `pip install "notebooklm-py[cookies]"`.
+- `--browser-cookies <auto|chrome|edge|firefox|safari|brave|arc|...>` - Read cookies from an installed browser instead of launching Playwright. Pass an explicit browser name, or `auto` to let rookiepy auto-detect. Requires `pip install "notebooklm-py[cookies]"`.
 - `--fresh` - Start with a clean browser session (deletes the cached browser profile). Use to switch Google accounts. Has no effect with `--browser-cookies`.
 
 **Examples:**
@@ -291,7 +291,7 @@ notebooklm login --browser msedge
 notebooklm login --browser-cookies chrome
 
 # Auto-detect any supported browser via rookiepy
-notebooklm login --browser-cookies
+notebooklm login --browser-cookies auto
 
 # Populate a named profile via cookie import
 notebooklm --profile work login --browser-cookies chrome

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -274,8 +274,10 @@ notebooklm login [OPTIONS]
 Opens a Chromium browser with a persistent profile. Log in to your Google account, then press Enter in the terminal to save the session.
 
 **Options:**
-- `--storage PATH` - Where to save storage_state.json (default: `$NOTEBOOKLM_HOME/storage_state.json`)
+- `--storage PATH` - Where to save storage_state.json (default: `$NOTEBOOKLM_HOME/profiles/<profile>/storage_state.json`)
 - `--browser [chromium|msedge]` - Browser to use for login (default: `chromium`). Use `msedge` for Microsoft Edge.
+- `--browser-cookies [auto|chrome|edge|firefox|safari|brave|arc|...]` - Read cookies from an installed browser instead of launching Playwright. Defaults to `auto` (rookiepy auto-detect) when the flag is given without a value. Requires `pip install "notebooklm-py[cookies]"`.
+- `--fresh` - Start with a clean browser session (deletes the cached browser profile). Use to switch Google accounts. Has no effect with `--browser-cookies`.
 
 **Examples:**
 ```bash
@@ -284,7 +286,23 @@ notebooklm login
 
 # Use Microsoft Edge (for orgs that require Edge for SSO)
 notebooklm login --browser msedge
+
+# Reuse cookies from your already-logged-in Chrome session
+notebooklm login --browser-cookies chrome
+
+# Auto-detect any supported browser via rookiepy
+notebooklm login --browser-cookies
+
+# Populate a named profile via cookie import
+notebooklm --profile work login --browser-cookies chrome
+
+# Force a clean browser session before logging in
+notebooklm login --fresh
 ```
+
+**Notes on `--browser-cookies`:**
+- Honors `--profile` / `NOTEBOOKLM_PROFILE` and writes to that profile's `storage_state.json`.
+- Always extracts cookies for the source browser's currently-active Google account on `google.com` / `notebooklm.google.com`. To populate multiple profiles from one browser, switch the active Google account in the browser between runs (or use a different browser per profile).
 
 ### Session: `use`
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -95,6 +95,7 @@ pip install "notebooklm-py[cookies]"
 
 ```python
 import json
+import os
 import rookiepy
 from notebooklm import NotebookLMClient
 from notebooklm.auth import convert_rookiepy_cookies_to_storage_state
@@ -103,11 +104,15 @@ from notebooklm.auth import convert_rookiepy_cookies_to_storage_state
 raw = rookiepy.chrome(domains=[".google.com", "notebooklm.google.com"])
 storage_state = convert_rookiepy_cookies_to_storage_state(raw)
 
-# Persist for future runs
-with open("/path/to/storage_state.json", "w") as f:
+# Persist for future runs; restrict to owner-only on POSIX since this file holds auth cookies
+storage_path = "/path/to/storage_state.json"
+with open(storage_path, "w") as f:
     json.dump(storage_state, f)
+if os.name != "nt":
+    os.chmod(storage_path, 0o600)
 
-client = await NotebookLMClient.from_storage("/path/to/storage_state.json")
+async with await NotebookLMClient.from_storage(storage_path) as client:
+    notebooks = await client.notebooks.list()
 ```
 
 The helper converts the cookie list returned by `rookiepy` into the storage-state format `NotebookLMClient.from_storage()` expects — the actual cookie extraction (and Google-account selection) happens in the `rookiepy.<browser>(...)` call. As a result, the storage state reflects whichever Google account is currently active in the source browser on `google.com` / `notebooklm.google.com`. The CLI equivalent is `notebooklm login --browser-cookies <browser>`.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -85,6 +85,33 @@ client = NotebookLMClient(auth)
 auth = AuthTokens.from_storage(profile="work")
 ```
 
+**Building a storage state from existing browser cookies (`[cookies]` extra):**
+
+Install with the optional `cookies` extra to pull cookies from a locally installed browser via [rookiepy](https://pypi.org/project/rookiepy/) — useful for headless environments where you cannot run Playwright:
+
+```bash
+pip install "notebooklm-py[cookies]"
+```
+
+```python
+import json
+import rookiepy
+from notebooklm import AuthTokens, NotebookLMClient
+from notebooklm.auth import convert_rookiepy_cookies_to_storage_state
+
+# Pull Google cookies from Chrome (or .firefox(), .edge(), .safari(), .load() for auto-detect)
+raw = rookiepy.chrome(domains=[".google.com", "notebooklm.google.com"])
+storage_state = convert_rookiepy_cookies_to_storage_state(raw)
+
+# Persist for future runs
+with open("/path/to/storage_state.json", "w") as f:
+    json.dump(storage_state, f)
+
+client = await NotebookLMClient.from_storage("/path/to/storage_state.json")
+```
+
+The helper always extracts the source browser's currently-active Google account on `google.com` / `notebooklm.google.com`. The CLI equivalent is `notebooklm login --browser-cookies <browser>`.
+
 **Environment Variable Support:**
 
 The library respects these environment variables for authentication:

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -96,7 +96,7 @@ pip install "notebooklm-py[cookies]"
 ```python
 import json
 import rookiepy
-from notebooklm import AuthTokens, NotebookLMClient
+from notebooklm import NotebookLMClient
 from notebooklm.auth import convert_rookiepy_cookies_to_storage_state
 
 # Pull Google cookies from Chrome (or .firefox(), .edge(), .safari(), .load() for auto-detect)
@@ -110,7 +110,7 @@ with open("/path/to/storage_state.json", "w") as f:
 client = await NotebookLMClient.from_storage("/path/to/storage_state.json")
 ```
 
-The helper always extracts the source browser's currently-active Google account on `google.com` / `notebooklm.google.com`. The CLI equivalent is `notebooklm login --browser-cookies <browser>`.
+The helper converts the cookie list returned by `rookiepy` into the storage-state format `NotebookLMClient.from_storage()` expects — the actual cookie extraction (and Google-account selection) happens in the `rookiepy.<browser>(...)` call. As a result, the storage state reflects whichever Google account is currently active in the source browser on `google.com` / `notebooklm.google.com`. The CLI equivalent is `notebooklm login --browser-cookies <browser>`.
 
 **Environment Variable Support:**
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release Checklist
 
 **Status:** Active
-**Last Updated:** 2026-03-12
+**Last Updated:** 2026-05-09
 
 Checklist for releasing a new version of `notebooklm-py`.
 

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1,7 +1,7 @@
 # RPC & UI Reference
 
 **Status:** Active
-**Last Updated:** 2026-03-02
+**Last Updated:** 2026-05-09
 **Source of Truth:** `src/notebooklm/rpc/types.py`
 **Purpose:** Complete reference for RPC methods, UI selectors, and payload structures
 
@@ -22,14 +22,17 @@
 | `s0tc2d` | RENAME_NOTEBOOK | Rename, chat config, share access | `_notebooks.py`, `_chat.py` |
 | `WWINqb` | DELETE_NOTEBOOK | Delete a notebook | `_notebooks.py` |
 | `izAoDd` | ADD_SOURCE | Add URL/text/YouTube source | `_sources.py` |
-| `o4cbdc` | ADD_SOURCE_FILE | Register uploaded file | `_sources.py` |
+| `o4cbdc` | ADD_SOURCE_FILE | Register uploaded file (PDF, DOCX, EPUB, etc.) | `_sources.py` |
+| `hizoJc` | GET_SOURCE | Get source detail / fulltext | `_sources.py` |
 | `tGMBJ` | DELETE_SOURCE | Delete a source | `_sources.py` |
 | `b7Wfje` | UPDATE_SOURCE | Rename source | `_sources.py` |
+| `qXyaNe` | DISCOVER_SOURCES | Discover sources from a query | `_research.py` |
 | `tr032e` | GET_SOURCE_GUIDE | Get source summary | `_sources.py` |
 | `R7cb6c` | CREATE_ARTIFACT | Unified artifact generation | `_artifacts.py` |
 | `gArtLc` | LIST_ARTIFACTS | List artifacts in a notebook | `_artifacts.py` |
 | `V5N4be` | DELETE_ARTIFACT | Delete artifact | `_artifacts.py` |
-| `hPTbtc` | GET_CONVERSATION_ID | Get most recent conversation ID | `_chat.py` |
+| `KmcKPe` | REVISE_SLIDE | Revise an individual slide via prompt | `_artifacts.py` |
+| `hPTbtc` | GET_LAST_CONVERSATION_ID | Get most recent conversation ID | `_chat.py` |
 | `khqZz` | GET_CONVERSATION_TURNS | Get Q&A turns for a conversation | `_chat.py` |
 | `CYK0Xb` | CREATE_NOTE | Create a note (placeholder) | `_notes.py` |
 | `cYAfTb` | UPDATE_NOTE | Update note content/title | `_notes.py` |
@@ -67,6 +70,28 @@
 | 7 | Infographic | Infographic |
 | 8 | Slide Deck | Slide Deck |
 | 9 | Data Table | Data Table |
+
+### Source Type Codes (file uploads & sources)
+
+Internal integer codes returned by `GET_NOTEBOOK` / `LIST_SOURCES` and consumed by `Source.from_api_response()` (mapped to `SourceType` in `src/notebooklm/types.py`).
+
+| Code | `SourceType` | Used By |
+|------|--------------|---------|
+| 1 | `GOOGLE_DOCS` | Google Docs source |
+| 2 | `GOOGLE_SLIDES` | Google Slides source |
+| 3 | `PDF` | PDF upload |
+| 4 | `PASTED_TEXT` | Inline pasted text |
+| 5 | `WEB_PAGE` | Web URL source |
+| 8 | `MARKDOWN` | Markdown file |
+| 9 | `YOUTUBE` | YouTube URL |
+| 10 | `MEDIA` | Audio / video upload |
+| 11 | `DOCX` | Word document |
+| 13 | `IMAGE` | Image upload |
+| 14 | `GOOGLE_SPREADSHEET` | Google Sheets source |
+| 16 | `CSV` | CSV upload |
+| 17 | `EPUB` | EPUB upload (added in v0.4.0) |
+
+> Codes outside this map are surfaced as `SourceType.UNKNOWN` and emit `UnknownTypeWarning` on first occurrence so unmapped types don't crash callers.
 
 ---
 
@@ -397,7 +422,7 @@ params = [
 ]
 ```
 
-### RPC: GET_CONVERSATION_ID (hPTbtc)
+### RPC: GET_LAST_CONVERSATION_ID (hPTbtc)
 
 **Source:** `_chat.py::get_conversation_id()`
 
@@ -720,13 +745,19 @@ params = [
 
 ```python
 # RPC: GENERATE_MIND_MAP (yyryJe), NOT CREATE_ARTIFACT
+# Python signature:
+#   generate_mind_map(notebook_id, source_ids=None, language="en", instructions=None)
 params = [
     source_ids_nested,                            # 0: [[[sid]] for sid in source_ids]
     None,                                         # 1
     None,                                         # 2
     None,                                         # 3
     None,                                         # 4
-    ["interactive_mindmap", [["[CONTEXT]", ""]], ""],  # 5: Mind map command
+    [
+        "interactive_mindmap",                    # 5[0]: command name
+        [["[CONTEXT]", instructions or ""]],      # 5[1]: instructions (added in v0.4.0)
+        language,                                 # 5[2]: language code, e.g. "en" (added in v0.4.0)
+    ],
     None,                                         # 6
     [2, None, [1]],                               # 7: Fixed config
 ]

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -23,10 +23,8 @@
 | `WWINqb` | DELETE_NOTEBOOK | Delete a notebook | `_notebooks.py` |
 | `izAoDd` | ADD_SOURCE | Add URL/text/YouTube source | `_sources.py` |
 | `o4cbdc` | ADD_SOURCE_FILE | Register uploaded file (PDF, DOCX, EPUB, etc.) | `_sources.py` |
-| `hizoJc` | GET_SOURCE | Get source detail / fulltext | `_sources.py` |
 | `tGMBJ` | DELETE_SOURCE | Delete a source | `_sources.py` |
 | `b7Wfje` | UPDATE_SOURCE | Rename source | `_sources.py` |
-| `qXyaNe` | DISCOVER_SOURCES | Discover sources from a query | `_research.py` |
 | `tr032e` | GET_SOURCE_GUIDE | Get source summary | `_sources.py` |
 | `R7cb6c` | CREATE_ARTIFACT | Unified artifact generation | `_artifacts.py` |
 | `gArtLc` | LIST_ARTIFACTS | List artifacts in a notebook | `_artifacts.py` |

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -111,7 +111,7 @@ notebooklm.auth.convert_rookiepy_cookies_to_storage_state  # requires `pip insta
 notebooklm.rpc.*          # RPC protocol internals
 notebooklm._core.*        # Core infrastructure
 notebooklm._*.py          # All underscore-prefixed modules
-notebooklm.auth.*         # Auth internals (except AuthTokens)
+notebooklm.auth.*         # Auth internals (except AuthTokens and convert_rookiepy_cookies_to_storage_state)
 ```
 
 To use internal APIs, import them explicitly:
@@ -124,7 +124,7 @@ from notebooklm.rpc import RPCMethod, encode_rpc_request
 
 1. **Deprecation Notice**: Deprecated features emit `DeprecationWarning`
 2. **Documentation**: Deprecations are noted in docstrings and CHANGELOG
-3. **Removal Timeline**: Deprecated features are removed in the next major version
+3. **Removal Timeline**: Deprecated features are removed in the next major version. While the project is in 0.x, removal may instead occur in the next MINOR release after at least one MINOR cycle of `DeprecationWarning` (see "0.x Pre-1.0 Semantics" above).
 4. **Migration Guide**: Breaking changes include migration instructions
 
 ### Currently Deprecated

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -40,6 +40,11 @@ We follow [Semantic Versioning](https://semver.org/) with modifications for our 
    - Breaking changes require a major version bump
    - Deprecated APIs are marked with `DeprecationWarning` and documented
 
+3. **0.x Pre-1.0 Semantics**
+   - Per [SemVer §4](https://semver.org/#spec-item-4), the project is currently in 0.x and the public API is not yet considered stable.
+   - **MINOR** releases (e.g. 0.4.0 → 0.5.0) **may remove** previously deprecated public APIs. Removal is preceded by at least one MINOR release of `DeprecationWarning` notice.
+   - Once the project reaches 1.0.0, breaking changes will require a **MAJOR** bump as described above.
+
 ## Public API Surface
 
 The following are considered **public API** and are subject to stability guarantees:
@@ -95,8 +100,8 @@ DriveMimeType, ExportType
 AuthTokens
 # (DEFAULT_STORAGE_PATH is deprecated; use notebooklm.paths.get_storage_path())
 
-# Helpers (cookies extra)
-convert_rookiepy_cookies_to_storage_state  # requires `pip install "notebooklm-py[cookies]"`
+# Helpers (cookies extra) - imported from notebooklm.auth
+notebooklm.auth.convert_rookiepy_cookies_to_storage_state  # requires `pip install "notebooklm-py[cookies]"`
 ```
 
 ### Internal (May change without notice)
@@ -143,9 +148,9 @@ The following are deprecated and will be removed in **v0.5.0**:
 
 Version 0.4.0 is backward compatible with v0.3.x. Notable additions:
 
-- **Multi-account profiles** - Existing single-account setups continue to work as the implicit default profile. New accounts can be added via `notebooklm profile create <name>`.
+- **Multi-account profiles** - Existing single-account setups continue to work as the implicit default profile. Your existing `~/.notebooklm/storage_state.json` is auto-detected — no manual migration is required. New accounts can be added via `notebooklm profile create <name>`.
 - **`[cookies]` optional extra** - To reuse cookies from your existing browser, install with `pip install "notebooklm-py[cookies]"` (requires `rookiepy`).
-- **Deprecation removal deferred** - The deprecated attributes originally scheduled for v0.4.0 (`Source.source_type`, `Artifact.artifact_type`, `Artifact.variant`, `SourceFulltext.source_type`, `StudioContentType`) will now be removed in v0.5.0. They still emit `DeprecationWarning` — please migrate before v0.5.0.
+- **Deprecation removal deferred** - The deprecated attributes originally scheduled for v0.4.0 (`Source.source_type`, `Artifact.artifact_type`, `Artifact.variant`, `SourceFulltext.source_type`, `StudioContentType`, `DEFAULT_STORAGE_PATH`) will now be removed in v0.5.0. They still emit `DeprecationWarning` — please migrate before v0.5.0.
 
 ### Migrating from v0.2.x to v0.3.0
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,7 +1,7 @@
 # API Stability and Versioning
 
 **Status:** Active
-**Last Updated:** 2026-01-21
+**Last Updated:** 2026-05-09
 
 This document describes the stability guarantees and versioning policy for `notebooklm-py`.
 
@@ -64,6 +64,9 @@ Notebook, Source, Artifact, Note
 GenerationStatus, AskResult
 NotebookDescription, ConversationTurn
 ShareStatus, SharedUser, SourceFulltext
+NotebookMetadata, SourceSummary
+AccountLimits, AccountTier
+ChatReference, ReportSuggestion, SuggestedTopic
 
 # Exceptions (all inherit from NotebookLMError)
 NotebookLMError                    # Base exception
@@ -77,13 +80,23 @@ ArtifactError, ArtifactDownloadError, ArtifactNotFoundError, ArtifactNotReadyErr
 ChatError
 
 # Enums
-AudioFormat, VideoFormat, ExportType
+AudioFormat, AudioLength
+VideoFormat, VideoStyle
+QuizQuantity, QuizDifficulty
+InfographicOrientation, InfographicDetail, InfographicStyle
+SlideDeckFormat, SlideDeckLength
+ReportFormat
 SourceType, ArtifactType, SourceStatus
 ShareAccess, SharePermission, ShareViewLevel
 ChatGoal, ChatResponseLength, ChatMode
+DriveMimeType, ExportType
 
 # Auth
-AuthTokens, DEFAULT_STORAGE_PATH
+AuthTokens
+# (DEFAULT_STORAGE_PATH is deprecated; use notebooklm.paths.get_storage_path())
+
+# Helpers (cookies extra)
+convert_rookiepy_cookies_to_storage_state  # requires `pip install "notebooklm-py[cookies]"`
 ```
 
 ### Internal (May change without notice)
@@ -111,7 +124,7 @@ from notebooklm.rpc import RPCMethod, encode_rpc_request
 
 ### Currently Deprecated
 
-The following are deprecated and will be removed in **v0.4.0**:
+The following are deprecated and will be removed in **v0.5.0**:
 
 | Deprecated | Replacement | Notes |
 |------------|-------------|-------|
@@ -120,13 +133,24 @@ The following are deprecated and will be removed in **v0.4.0**:
 | `Artifact.variant` | `Artifact.kind` | Use `.is_quiz` / `.is_flashcards` |
 | `SourceFulltext.source_type` | `SourceFulltext.kind` | Returns `SourceType` str enum |
 | `StudioContentType` | `ArtifactType` | Str enum for user-facing code |
+| `DEFAULT_STORAGE_PATH` | `notebooklm.paths.get_storage_path()` | Module-level constant replaced by helper |
+
+> **Note:** These were originally targeted for removal in v0.4.0. The removal was deferred one release to give downstream users more time to migrate. They continue to emit `DeprecationWarning` and will be removed in v0.5.0.
 
 ## Migration Guides
+
+### Migrating from v0.3.x to v0.4.0
+
+Version 0.4.0 is backward compatible with v0.3.x. Notable additions:
+
+- **Multi-account profiles** - Existing single-account setups continue to work as the implicit default profile. New accounts can be added via `notebooklm profile create <name>`.
+- **`[cookies]` optional extra** - To reuse cookies from your existing browser, install with `pip install "notebooklm-py[cookies]"` (requires `rookiepy`).
+- **Deprecation removal deferred** - The deprecated attributes originally scheduled for v0.4.0 (`Source.source_type`, `Artifact.artifact_type`, `Artifact.variant`, `SourceFulltext.source_type`, `StudioContentType`) will now be removed in v0.5.0. They still emit `DeprecationWarning` — please migrate before v0.5.0.
 
 ### Migrating from v0.2.x to v0.3.0
 
 Version 0.3.0 introduces **deprecated** attributes that emit `DeprecationWarning` when accessed.
-These will be removed in v0.4.0. Update your code now to avoid breakage.
+These will be removed in v0.5.0. Update your code now to avoid breakage.
 
 #### 1. `Source.source_type` → `Source.kind`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooklm-py"
-version = "0.3.4"
+version = "0.4.0"
 description = "Unofficial Python library for automating Google NotebookLM"
 dynamic = ["readme"]
 requires-python = ">=3.10"

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -216,7 +216,7 @@ __all__ = [
     "ShareAccess",
     "ShareViewLevel",
     "SharePermission",
-    # Deprecated (will be removed in v0.4.0)
+    # Deprecated (will be removed in v0.5.0)
     "StudioContentType",
 ]
 
@@ -246,7 +246,7 @@ def __getattr__(name: str):
         from .rpc.types import ArtifactTypeCode
 
         warnings.warn(
-            "StudioContentType is deprecated, use ArtifactType instead. Will be removed in v0.4.0.",
+            "StudioContentType is deprecated, use ArtifactType instead. Will be removed in v0.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -413,7 +413,7 @@ def register_session_commands(cli):
         help=(
             "Read cookies from an installed browser instead of launching Playwright. "
             "Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... "
-            "Requires: pip install 'notebooklm[cookies]'"
+            "Requires: pip install 'notebooklm-py[cookies]'"
         ),
     )
     @click.option(

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -574,10 +574,10 @@ class Source:
 
         .. deprecated:: 0.3.0
             Use the ``.kind`` property which returns a ``SourceType`` enum.
-            Will be removed in v0.4.0.
+            Will be removed in v0.5.0.
         """
         warnings.warn(
-            "Source.source_type is deprecated, use .kind instead. Will be removed in v0.4.0.",
+            "Source.source_type is deprecated, use .kind instead. Will be removed in v0.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -712,11 +712,11 @@ class SourceFulltext:
 
         .. deprecated:: 0.3.0
             Use the ``.kind`` property which returns a ``SourceType`` enum.
-            Will be removed in v0.4.0.
+            Will be removed in v0.5.0.
         """
         warnings.warn(
             "SourceFulltext.source_type is deprecated, use .kind instead. "
-            "Will be removed in v0.4.0.",
+            "Will be removed in v0.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -816,10 +816,10 @@ class Artifact:
 
         .. deprecated:: 0.3.0
             Use the ``.kind`` property which returns an ``ArtifactType`` enum.
-            Will be removed in v0.4.0.
+            Will be removed in v0.5.0.
         """
         warnings.warn(
-            "Artifact.artifact_type is deprecated, use .kind instead. Will be removed in v0.4.0.",
+            "Artifact.artifact_type is deprecated, use .kind instead. Will be removed in v0.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -833,11 +833,11 @@ class Artifact:
 
         .. deprecated:: 0.3.0
             Use ``.kind == ArtifactType.QUIZ`` or ``.is_quiz`` / ``.is_flashcards``.
-            Will be removed in v0.4.0.
+            Will be removed in v0.5.0.
         """
         warnings.warn(
             "Artifact.variant is deprecated. Use .kind, .is_quiz, or .is_flashcards instead. "
-            "Will be removed in v0.4.0.",
+            "Will be removed in v0.5.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ wheels = [
 
 [[package]]
 name = "notebooklm-py"
-version = "0.3.4"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release prep for v0.4.0. Re-opened from #337 after a branch-rename (`claude/update-changelog-docs-y4TZA` → `release/v0.4.0`) auto-closed the original PR. Same SHAs.

## Summary

- Add v0.4.0 section to CHANGELOG.md covering multi-account profiles, `notebooklm doctor`, EPUB sources, browser-cookie import, Edge SSO login, agent skill install commands, and the auth/cookie + Windows reliability fixes accumulated since v0.3.4.
- Bump `pyproject.toml` to 0.4.0; align `uv.lock`.
- Defer v0.3.x deprecations (`Source.source_type`, `Artifact.artifact_type`, `Artifact.variant`, `SourceFulltext.source_type`, `StudioContentType`, `DEFAULT_STORAGE_PATH`) from v0.4.0 to v0.5.0 in warnings and \`__all__\` comment.
- Polish review applied: corrected \`profile use\` → \`profile switch\` in README/CHANGELOG; removed bare \`--browser-cookies\` example; added 0.x semver clause + legacy-storage-state migration note in stability.md; qualified \`convert_rookiepy_cookies_to_storage_state\` as \`notebooklm.auth.\` namespaced; nits across SKILL.md, python-api.md, cli/session.py.
- Refresh docs/releasing.md Last Updated stamp.

Re-opens #337.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account profiles with profile listing/switching and profile-aware authentication.
  * Browser cookie import for login and Playwright/headless guidance.
  * EPUB source support; agent skill installation and notebooklm doctor command.

* **Documentation**
  * Expanded CLI, Python API, RPC, and stability docs (mind-map options, auth/storage guidance, profile concurrency notes).

* **Other**
  * v0.4.0 release notes added; security support policy updated; deprecation removals deferred to v0.5.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/338)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->