### PR TITLE
test(e2e): add --profile pytest flag and profile-scope notebook ID cache

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -134,6 +134,40 @@ uv run pytest
 uv run pytest tests/e2e -m readonly        # Read-only tests only
 uv run pytest tests/e2e -m "not variants"  # Skip parameter variants
 uv run pytest tests/e2e --include-variants # All tests including variants
+
+# Select a profile for E2E tests
+uv run pytest tests/e2e -m e2e --profile work
+```
+
+### Selecting a profile for E2E tests
+
+The E2E suite picks up the active NotebookLM profile from (highest precedence first):
+
+1. `--profile <name>` pytest flag
+2. `NOTEBOOKLM_PROFILE` environment variable
+3. `default_profile` from `~/.notebooklm/config.json`
+4. `default`
+
+The auto-created notebook ID cache files
+(`generation_notebook_id`, `multi_source_notebook_id`) are written under the
+active profile directory (`~/.notebooklm/profiles/<name>/`), so each profile
+keeps its own cache and never reuses notebook IDs from another Google account.
+
+#### Notebook ID env vars are profile-agnostic
+
+The notebook ID env vars (`NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID`,
+`NOTEBOOKLM_GENERATION_NOTEBOOK_ID`, `NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID`)
+are **not** profile-scoped — they're read as-is regardless of which profile
+is active. If you set them in `.env` and switch profiles, the test will try
+to access notebooks that don't exist in the other Google account.
+
+**Recommendation:** leave the generation/multi-source env vars unset and let
+the per-profile cache files handle it. Only `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID`
+needs to be set; if you switch profiles often, override it inline:
+
+```bash
+NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID=<work-nb-id> \
+  uv run pytest tests/e2e -m e2e --profile work
 ```
 
 ### Test Structure

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -30,9 +30,12 @@ from notebooklm.paths import get_profile_dir
 # 1. At module import (via ``_argv_profile``) so the module-level
 #    ``requires_auth = pytest.mark.skipif(not has_auth(), ...)`` below resolves
 #    auth under the selected profile. ``pytest_configure`` runs *after*
-#    conftest import, which is too late for that marker.
+#    conftest import, which is too late for that marker. The early peek only
+#    sees ``sys.argv`` — flags injected via ``addopts`` in ``pytest.ini`` /
+#    ``pyproject.toml`` are not visible until ``pytest_configure``.
 # 2. In ``pytest_configure``, as a backstop for invocations that mutate
-#    sys.argv after conftest is imported (e.g. ``pytest.main(args=...)``).
+#    sys.argv after conftest is imported (e.g. ``pytest.main(args=...)``)
+#    and to pick up ``--profile`` from ``addopts``.
 #
 # ``pytest_unconfigure`` restores the prior env var so the mutation does not
 # leak across the rest of the pytest process (matters for IDE/in-process runs).
@@ -44,13 +47,22 @@ _PROFILE_PRIOR: tuple[bool, str | None] | None = None
 
 
 def _argv_profile(argv: list[str] | None = None) -> str | None:
-    """Extract ``--profile NAME`` or ``--profile=NAME`` from argv."""
+    """Extract ``--profile NAME`` or ``--profile=NAME`` from argv.
+
+    Iterates from the end so the *last* occurrence wins (matching argparse
+    semantics for ``action="store"``), and rejects values that look like
+    another flag (``--profile --verbose`` should not consume ``--verbose``
+    as the profile name).
+    """
     args = sys.argv if argv is None else argv
-    for i, arg in enumerate(args):
-        if arg == "--profile" and i + 1 < len(args):
-            return args[i + 1]
+    for i in range(len(args) - 1, -1, -1):
+        arg = args[i]
         if arg.startswith("--profile="):
             return arg.split("=", 1)[1]
+        if arg == "--profile" and i + 1 < len(args):
+            value = args[i + 1]
+            if not value.startswith("-"):
+                return value
     return None
 
 
@@ -469,7 +481,8 @@ async def generation_notebook_id(client):
 
     This fixture uses a hybrid approach:
     1. Check NOTEBOOKLM_GENERATION_NOTEBOOK_ID env var
-    2. If not set, check for stored ID in NOTEBOOKLM_HOME/generation_notebook_id
+    2. If not set, check for a stored ID in the active profile cache
+       (~/.notebooklm/profiles/<name>/generation_notebook_id)
     3. If not found, auto-create a notebook and store its ID
 
     All notebook IDs (env var or stored) are verified to exist before use.
@@ -673,7 +686,8 @@ async def multi_source_notebook_id(client):
 
     This fixture uses a hybrid approach similar to generation_notebook_id:
     1. Check NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID env var
-    2. If not set, check for stored ID
+    2. If not set, check for a stored ID in the active profile cache
+       (~/.notebooklm/profiles/<name>/multi_source_notebook_id)
     3. If not found, auto-create a notebook with 3 sources
 
     All IDs are verified to exist before use.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import sys
 import warnings
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -18,7 +19,54 @@ except ImportError:
 
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens, load_auth_from_storage
-from notebooklm.paths import get_home_dir
+from notebooklm.paths import get_profile_dir
+
+# =============================================================================
+# --profile flag plumbing
+# =============================================================================
+# `--profile NAME` selects the NotebookLM profile for the test session by
+# setting ``NOTEBOOKLM_PROFILE``. The flag is applied in two places:
+#
+# 1. At module import (via ``_argv_profile``) so the module-level
+#    ``requires_auth = pytest.mark.skipif(not has_auth(), ...)`` below resolves
+#    auth under the selected profile. ``pytest_configure`` runs *after*
+#    conftest import, which is too late for that marker.
+# 2. In ``pytest_configure``, as a backstop for invocations that mutate
+#    sys.argv after conftest is imported (e.g. ``pytest.main(args=...)``).
+#
+# ``pytest_unconfigure`` restores the prior env var so the mutation does not
+# leak across the rest of the pytest process (matters for IDE/in-process runs).
+
+# Records prior NOTEBOOKLM_PROFILE state on first mutation; ``None`` means we
+# never mutated. ``(was_set, value)`` lets unconfigure restore an existing
+# value or pop the var entirely.
+_PROFILE_PRIOR: tuple[bool, str | None] | None = None
+
+
+def _argv_profile(argv: list[str] | None = None) -> str | None:
+    """Extract ``--profile NAME`` or ``--profile=NAME`` from argv."""
+    args = sys.argv if argv is None else argv
+    for i, arg in enumerate(args):
+        if arg == "--profile" and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("--profile="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def _apply_profile(profile: str) -> None:
+    """Set ``NOTEBOOKLM_PROFILE``; record prior state for ``pytest_unconfigure``."""
+    global _PROFILE_PRIOR
+    if _PROFILE_PRIOR is None:
+        _PROFILE_PRIOR = (
+            "NOTEBOOKLM_PROFILE" in os.environ,
+            os.environ.get("NOTEBOOKLM_PROFILE"),
+        )
+    os.environ["NOTEBOOKLM_PROFILE"] = profile
+
+
+if _early := _argv_profile():
+    _apply_profile(_early)
 
 # =============================================================================
 # Constants
@@ -82,13 +130,43 @@ requires_auth = pytest.mark.skipif(
 
 
 def pytest_addoption(parser):
-    """Add --include-variants option for e2e tests."""
+    """Add E2E test command-line options."""
     parser.addoption(
         "--include-variants",
         action="store_true",
         default=False,
         help="Include variant tests (skipped by default to save API quota)",
     )
+    parser.addoption(
+        "--profile",
+        action="store",
+        default=None,
+        metavar="NAME",
+        help="NotebookLM profile to use for E2E tests (overrides NOTEBOOKLM_PROFILE env var)",
+    )
+
+
+def pytest_configure(config):
+    """Re-apply --profile after CLI parsing (backstop for the import-time peek).
+
+    Precedence: --profile flag > NOTEBOOKLM_PROFILE env var > config default.
+    """
+    profile = config.getoption("--profile")
+    if profile:
+        _apply_profile(profile)
+
+
+def pytest_unconfigure(config):
+    """Restore the original ``NOTEBOOKLM_PROFILE`` if we mutated it."""
+    global _PROFILE_PRIOR
+    if _PROFILE_PRIOR is None:
+        return
+    was_set, prev = _PROFILE_PRIOR
+    _PROFILE_PRIOR = None
+    if was_set and prev is not None:
+        os.environ["NOTEBOOKLM_PROFILE"] = prev
+    else:
+        os.environ.pop("NOTEBOOKLM_PROFILE", None)
 
 
 def pytest_collection_modifyitems(config, items):
@@ -247,8 +325,8 @@ _generation_cleanup_done = False
 
 
 def _get_generation_notebook_id_path() -> Path:
-    """Get the path to the generation notebook ID file."""
-    return get_home_dir() / GENERATION_NOTEBOOK_ID_FILE
+    """Get the path to the generation notebook ID file (per active profile)."""
+    return get_profile_dir() / GENERATION_NOTEBOOK_ID_FILE
 
 
 def _load_stored_generation_notebook_id() -> str | None:
@@ -465,8 +543,8 @@ _multi_source_cleanup_done = False
 
 
 def _get_multi_source_notebook_id_path() -> Path:
-    """Get the path to the multi-source notebook ID file."""
-    return get_home_dir() / MULTI_SOURCE_NOTEBOOK_ID_FILE
+    """Get the path to the multi-source notebook ID file (per active profile)."""
+    return get_profile_dir() / MULTI_SOURCE_NOTEBOOK_ID_FILE
 
 
 def _load_stored_multi_source_notebook_id() -> str | None:

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -92,3 +92,11 @@ class TestArgvProfile:
     def test_long_form_missing_value_returns_none(self):
         argv = ["pytest", "--profile"]
         assert _load_e2e_conftest()._argv_profile(argv) is None
+
+    def test_last_occurrence_wins(self):
+        argv = ["pytest", "--profile", "foo", "--profile", "bar"]
+        assert _load_e2e_conftest()._argv_profile(argv) == "bar"
+
+    def test_long_form_rejects_dash_prefixed_value(self):
+        argv = ["pytest", "--profile", "--verbose"]
+        assert _load_e2e_conftest()._argv_profile(argv) is None

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -1,0 +1,94 @@
+"""Unit tests for E2E conftest CLI options.
+
+Covers the --profile flag added in issue #339 without spinning up the full
+E2E suite (which requires real auth).
+
+The E2E conftest is loaded by file path because `tests/` is not a Python
+package (no `__init__.py`), so a normal `from tests.e2e import conftest`
+import would fail under pytest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+CONFTEST_PATH = Path(__file__).resolve().parents[1] / "e2e" / "conftest.py"
+
+
+def _load_e2e_conftest() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("e2e_conftest", CONFTEST_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_config(profile: str | None) -> SimpleNamespace:
+    return SimpleNamespace(getoption=lambda name: profile if name == "--profile" else None)
+
+
+class TestProfileOptionLifecycle:
+    """pytest_configure + pytest_unconfigure round-trip."""
+
+    def test_round_trip_no_prior_env(self, monkeypatch):
+        monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+        conftest = _load_e2e_conftest()
+        config = _make_config("work")
+
+        conftest.pytest_configure(config)
+        assert os.environ.get("NOTEBOOKLM_PROFILE") == "work"
+
+        conftest.pytest_unconfigure(config)
+        assert "NOTEBOOKLM_PROFILE" not in os.environ
+
+    def test_round_trip_restores_prior_env(self, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_PROFILE", "preset")
+        conftest = _load_e2e_conftest()
+        config = _make_config("work")
+
+        conftest.pytest_configure(config)
+        assert os.environ.get("NOTEBOOKLM_PROFILE") == "work"
+
+        conftest.pytest_unconfigure(config)
+        assert os.environ.get("NOTEBOOKLM_PROFILE") == "preset"
+
+    def test_no_flag_with_prior_env_is_noop(self, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_PROFILE", "preset")
+        conftest = _load_e2e_conftest()
+        config = _make_config(None)
+
+        conftest.pytest_configure(config)
+        conftest.pytest_unconfigure(config)
+        assert os.environ.get("NOTEBOOKLM_PROFILE") == "preset"
+
+    def test_no_flag_without_prior_env_is_noop(self, monkeypatch):
+        monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+        conftest = _load_e2e_conftest()
+        config = _make_config(None)
+
+        conftest.pytest_configure(config)
+        conftest.pytest_unconfigure(config)
+        assert "NOTEBOOKLM_PROFILE" not in os.environ
+
+
+class TestArgvProfile:
+    """Parsing of --profile out of argv (used at import time)."""
+
+    def test_long_form(self):
+        argv = ["pytest", "--profile", "work", "tests/e2e"]
+        assert _load_e2e_conftest()._argv_profile(argv) == "work"
+
+    def test_equals_form(self):
+        argv = ["pytest", "--profile=work", "tests/e2e"]
+        assert _load_e2e_conftest()._argv_profile(argv) == "work"
+
+    def test_absent(self):
+        argv = ["pytest", "tests/e2e", "-m", "e2e"]
+        assert _load_e2e_conftest()._argv_profile(argv) is None
+
+    def test_long_form_missing_value_returns_none(self):
+        argv = ["pytest", "--profile"]
+        assert _load_e2e_conftest()._argv_profile(argv) is None


### PR DESCRIPTION
Closes #339.

## Summary

- Add `--profile NAME` to the E2E pytest harness so test runs can target a specific NotebookLM profile without exporting `NOTEBOOKLM_PROFILE` first (`pytest tests/e2e -m e2e --profile work`). Precedence: CLI flag > `NOTEBOOKLM_PROFILE` env var > `config.json` default > `default`.
- Apply `--profile` at **conftest import time** as well as in `pytest_configure`. The import-time apply is required because `requires_auth = pytest.mark.skipif(not has_auth(), ...)` evaluates `has_auth()` before `pytest_configure` fires; without it, `--profile` would not affect the auth-skip decision.
- `pytest_unconfigure` restores the prior `NOTEBOOKLM_PROFILE` so the mutation does not leak across the rest of the pytest process (matters for IDE in-process runs and `pytest tests/` mixed sessions).
- Profile-scope the auto-created notebook ID cache files (`generation_notebook_id`, `multi_source_notebook_id`) by switching from `get_home_dir()` to `get_profile_dir()`. Each profile now keeps its own cache and never reuses notebook IDs from another Google account.
- Document (option B from the issue) that the notebook ID env vars (`NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID`, `NOTEBOOKLM_GENERATION_NOTEBOOK_ID`, `NOTEBOOKLM_MULTI_SOURCE_NOTEBOOK_ID`) are profile-agnostic; recommend leaving the auto-managed ones unset.

## Acceptance criteria (from #339)

- [x] `pytest tests/e2e -m e2e --profile <name>` selects the named profile.
- [x] Precedence is documented (`docs/development.md`).
- [x] Notebook ID env-var behavior across profiles is decided and documented (option B).
- [x] Auto-created notebook ID cache files are written under `get_profile_dir()`.
- [x] No regression for existing single-profile users — flag defaults to `None`, env-var path unchanged. Pre-existing cache files at `~/.notebooklm/generation_notebook_id` are orphaned (worst case: one extra notebook creation on first run, as accepted in the issue).

## Migration note

Existing local cache files at `~/.notebooklm/generation_notebook_id` and `~/.notebooklm/multi_source_notebook_id` will be orphaned. The fixtures auto-create on missing-file, so the worst-case cost is one wasted notebook creation per profile on first run. No migration shim, per the issue's recommendation.

## Test plan

- [x] `ruff format src/ tests/ && ruff check src/ tests/ && mypy src/notebooklm --ignore-missing-imports && pytest` — 2183 passed, 9 skipped.
- [x] New unit tests in `tests/unit/test_e2e_conftest_options.py` cover the configure/unconfigure round-trip (with and without a prior env var) and the argv parser (`--profile NAME`, `--profile=NAME`, absent, missing value).
- [x] `pytest tests/e2e --collect-only --profile=work` and `--profile=` (empty) and `NOTEBOOKLM_PROFILE=preset` all collect 156 tests cleanly.
- [ ] Live E2E run with `--profile work` against a real account (deferred — covered by nightly E2E once merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced E2E testing guidance with profile selection instructions, precedence rules, per-profile cache behavior, and recommendations for managing notebook ID environment variables.

* **Tests**
  * Added unit tests covering the new E2E profile option and its lifecycle and parsing behaviors.

* **Bug Fixes**
  * E2E test run now applies profiles consistently and avoids leaking profile state between runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/340)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->