### PR TITLE
fix(client): snapshot keepalive cookie jar + normalize explicit storage_path onto auth

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -282,13 +282,13 @@ class ClientCore:
                 # iteration). ``copy.deepcopy`` on the jar fails (the internal
                 # ``http.cookiejar.CookieJar`` carries a non-picklable
                 # ``RLock``), so re-build a fresh jar by iterating the live
-                # one. The iteration itself is atomic under the RLock, and
+                # one — which is exactly what ``httpx.Cookies(other_cookies)``
+                # does internally (`set_cookie` per cookie into a fresh
+                # ``CookieJar``). The iteration is atomic under the RLock, and
                 # ``http.cookiejar.Cookie`` objects are effectively immutable
                 # — a later ``set_cookie`` of the same name replaces the dict
                 # entry but does not mutate the previous object.
-                jar_snapshot = httpx.Cookies()
-                for cookie in client.cookies.jar:
-                    jar_snapshot.jar.set_cookie(cookie)
+                jar_snapshot = httpx.Cookies(client.cookies)
                 try:
                     # save_cookies_to_storage performs sync disk I/O; off-load to
                     # a worker thread so we don't stall the event loop on every

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -275,11 +275,25 @@ class ClientCore:
                 if storage_path is None:
                     continue
 
+                # Snapshot the cookie jar on the event-loop thread before
+                # off-loading. ``httpx.Cookies`` is not documented as safe for
+                # concurrent access, and the live ``AsyncClient`` jar can keep
+                # mutating during the save (RPC redirects, the next poke
+                # iteration). ``copy.deepcopy`` on the jar fails (the internal
+                # ``http.cookiejar.CookieJar`` carries a non-picklable
+                # ``RLock``), so re-build a fresh jar by iterating the live
+                # one. The iteration itself is atomic under the RLock, and
+                # ``http.cookiejar.Cookie`` objects are effectively immutable
+                # — a later ``set_cookie`` of the same name replaces the dict
+                # entry but does not mutate the previous object.
+                jar_snapshot = httpx.Cookies()
+                for cookie in client.cookies.jar:
+                    jar_snapshot.jar.set_cookie(cookie)
                 try:
                     # save_cookies_to_storage performs sync disk I/O; off-load to
                     # a worker thread so we don't stall the event loop on every
                     # iteration (matters for short intervals or slow disks).
-                    await asyncio.to_thread(save_cookies_to_storage, client.cookies, storage_path)
+                    await asyncio.to_thread(save_cookies_to_storage, jar_snapshot, storage_path)
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:  # noqa: BLE001

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -98,6 +98,15 @@ class NotebookLMClient:
                 60 s) to avoid accidentally rate-limiting Google's identity
                 surface.
         """
+        # Normalize the effective storage path onto the auth object so every
+        # downstream code path (refresh_auth, ClientCore.close on-close save,
+        # the keepalive loop) writes to the same file. Without this, an
+        # explicit ``storage_path=`` kwarg only reaches the keepalive loop
+        # while ``auth.storage_path is None`` causes refresh and on-close
+        # saves to silently skip persistence.
+        if storage_path is not None:
+            auth.storage_path = storage_path
+
         # Pass refresh_auth as callback for automatic retry on auth failures
         # Note: refresh_auth calls update_auth_headers internally
         self._core = ClientCore(
@@ -106,7 +115,7 @@ class NotebookLMClient:
             refresh_callback=self.refresh_auth,
             keepalive=keepalive,
             keepalive_min_interval=keepalive_min_interval,
-            keepalive_storage_path=storage_path,
+            keepalive_storage_path=auth.storage_path,
         )
 
         # Initialize sub-client APIs

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -304,6 +304,29 @@ class TestKeepaliveExplicitStoragePath:
             else:
                 pytest.fail("Rotated cookie was not persisted to the explicit storage path")
 
+    def test_explicit_storage_path_normalizes_onto_auth(self, tmp_path):
+        """The constructor copies ``storage_path`` onto ``auth.storage_path`` so
+        ``refresh_auth()`` and ``ClientCore.close()`` (which both read
+        ``self._core.auth.storage_path`` directly, not the keepalive-specific
+        path) persist to the same file.
+        """
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text('{"cookies": []}')
+        auth = AuthTokens(
+            cookies={"SID": "x"},
+            csrf_token="t",
+            session_id="s",
+            # storage_path intentionally None
+        )
+        assert auth.storage_path is None
+
+        client = NotebookLMClient(auth, storage_path=storage_path)
+
+        assert client.auth.storage_path == storage_path, (
+            "Explicit storage_path must be normalized onto auth so non-keepalive "
+            "code paths (refresh_auth, ClientCore.close) see the same file"
+        )
+
 
 class TestKeepalivePersistence:
     @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #341 addressing two MAJOR CodeRabbit findings that arrived after the auto-merge.

## What changed

### 1. `src/notebooklm/_core.py` — snapshot cookie jar before off-load
The previous code passed the live `AsyncClient.cookies` into `asyncio.to_thread(save_cookies_to_storage, ...)`. `httpx.Cookies` is not documented as safe for concurrent access, and the live jar keeps mutating during the save (RPC redirects, the next poke iteration). That is a TOCTOU race with the worker thread.

`copy.deepcopy` on the jar fails — `http.cookiejar.CookieJar` carries a non-picklable `_thread.RLock`. So we rebuild a fresh `httpx.Cookies` by iterating the live jar:

```python
jar_snapshot = httpx.Cookies()
for cookie in client.cookies.jar:
    jar_snapshot.jar.set_cookie(cookie)
```

The iteration itself is atomic under the RLock; `http.cookiejar.Cookie` objects are effectively immutable (a subsequent `set_cookie` of the same name replaces the dict entry but does not mutate the prior object), so reusing references is safe.

### 2. `src/notebooklm/client.py` — normalize storage_path onto auth
`NotebookLMClient(auth, storage_path=X)` previously threaded `X` into the keepalive loop only. `refresh_auth()` and `ClientCore.close()` (the on-close persist) still read `self._core.auth.storage_path` directly, so when `auth.storage_path` was `None` those two paths silently skipped persistence. Now the constructor copies `storage_path` onto `auth.storage_path` so all three paths see the same file:

```python
if storage_path is not None:
    auth.storage_path = storage_path
```

## Closes / relates to

- Follows up #341 (already merged via `29419e8`)
- Addresses CodeRabbit comments [r3213740995](https://github.com/teng-lin/notebooklm-py/pull/341#discussion_r3213740995) and [r3213740997](https://github.com/teng-lin/notebooklm-py/pull/341#discussion_r3213740997)

## Test plan

- [x] `uvx --from ruff==0.8.6 ruff format --check src/ tests/` — clean
- [x] `uvx --from ruff==0.8.6 ruff check src/ tests/` — clean
- [x] `mypy src/notebooklm --ignore-missing-imports` — clean
- [x] Full unit + integration suite: **2229 passed, 9 skipped**
- [x] 23 keepalive tests pass (was 22; one new test asserts `auth.storage_path` normalization)
- [ ] Manual smoke against a real account (deferred to maintainer)

## Why follow-up vs. amend

#341 auto-merged before the CodeRabbit comments landed. Forward-only follow-up keeps history linear and reviewable; nothing about #341's commits needed to be revised, only their consequences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie persistence to avoid saving a mutable live cookie jar during active sessions.
  * Ensure an explicitly provided storage path is consistently used for session storage and persistence.

* **Tests**
  * Added test coverage verifying explicit storage path normalization and keepalive persistence behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/342)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->