### PR TITLE
fix(client): serialize keepalive save with close-path save; stop mutating caller auth

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import math
+import threading
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
@@ -173,6 +174,11 @@ class ClientCore:
             keepalive_storage_path if keepalive_storage_path is not None else auth.storage_path
         )
         self._keepalive_task: asyncio.Task[None] | None = None
+        # Serializes keepalive's worker-thread save with close()'s on-close save
+        # so that newer state always wins. Without this, an in-flight keepalive
+        # save kicked off before close() can finish *after* close()'s own save
+        # and clobber it (an older snapshot overwriting the freshest state).
+        self._save_lock = threading.Lock()
 
     async def open(self) -> None:
         """Open the HTTP client connection.
@@ -226,8 +232,18 @@ class ClientCore:
         if self._http_client:
             try:
                 # Sync refreshed cookies only when auth came from an explicit file.
+                # Hold ``_save_lock`` so we serialize with any keepalive save still
+                # finishing in a worker thread — close() owns the freshest jar
+                # and must win, not the older snapshot.
                 if self.auth.storage_path is not None:
-                    save_cookies_to_storage(self._http_client.cookies, self.auth.storage_path)
+                    storage_path = self.auth.storage_path
+                    cookies = self._http_client.cookies
+
+                    def _final_save() -> None:
+                        with self._save_lock:
+                            save_cookies_to_storage(cookies, storage_path)
+
+                    await asyncio.to_thread(_final_save)
             except Exception as e:
                 logger.warning("Failed to sync refreshed cookies during close: %s", e)
             finally:
@@ -275,25 +291,29 @@ class ClientCore:
                 if storage_path is None:
                     continue
 
-                # Snapshot the cookie jar on the event-loop thread before
-                # off-loading. ``httpx.Cookies`` is not documented as safe for
-                # concurrent access, and the live ``AsyncClient`` jar can keep
-                # mutating during the save (RPC redirects, the next poke
-                # iteration). ``copy.deepcopy`` on the jar fails (the internal
-                # ``http.cookiejar.CookieJar`` carries a non-picklable
-                # ``RLock``), so re-build a fresh jar by iterating the live
-                # one — which is exactly what ``httpx.Cookies(other_cookies)``
-                # does internally (`set_cookie` per cookie into a fresh
-                # ``CookieJar``). The iteration is atomic under the RLock, and
-                # ``http.cookiejar.Cookie`` objects are effectively immutable
-                # — a later ``set_cookie`` of the same name replaces the dict
-                # entry but does not mutate the previous object.
+                # Snapshot the cookie jar synchronously on the event-loop thread
+                # so the worker isn't iterating a live jar that the AsyncClient
+                # may be mutating. ``httpx.Cookies(other)`` builds a fresh
+                # ``CookieJar`` by re-inserting each cookie reference; cookies
+                # in ``http.cookiejar`` are replaced (not mutated) on update,
+                # so the snapshot is stable for the worker's read.
                 jar_snapshot = httpx.Cookies(client.cookies)
+
+                # Hold ``_save_lock`` so close()'s final save can't run
+                # concurrently with this one. close() also takes the lock,
+                # so even if our awaiter is cancelled, close() waits for
+                # us before doing its own write — newer state wins.
+                # Default-arg binding pins the loop-variable values to this
+                # iteration (not late-bound).
+                def _save_under_lock(
+                    jar=jar_snapshot, path=storage_path, lock=self._save_lock
+                ) -> None:
+                    with lock:
+                        save_cookies_to_storage(jar, path)
+
                 try:
-                    # save_cookies_to_storage performs sync disk I/O; off-load to
-                    # a worker thread so we don't stall the event loop on every
-                    # iteration (matters for short intervals or slow disks).
-                    await asyncio.to_thread(save_cookies_to_storage, jar_snapshot, storage_path)
+                    # Off-load disk I/O so we don't stall the event loop.
+                    await asyncio.to_thread(_save_under_lock)
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:  # noqa: BLE001

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -19,6 +19,7 @@ Example:
         result = await client.chat.ask(notebook_id, "What is this about?")
 """
 
+import dataclasses
 import logging
 import os
 import re
@@ -103,9 +104,12 @@ class NotebookLMClient:
         # the keepalive loop) writes to the same file. Without this, an
         # explicit ``storage_path=`` kwarg only reaches the keepalive loop
         # while ``auth.storage_path is None`` causes refresh and on-close
-        # saves to silently skip persistence.
-        if storage_path is not None:
-            auth.storage_path = storage_path
+        # saves to silently skip persistence. ``dataclasses.replace`` instead
+        # of in-place mutation so a caller reusing ``AuthTokens`` across
+        # multiple clients (with different storage paths) doesn't see one
+        # client's path leak into another.
+        if storage_path is not None and auth.storage_path != storage_path:
+            auth = dataclasses.replace(auth, storage_path=storage_path)
 
         # Pass refresh_auth as callback for automatic retry on auth failures
         # Note: refresh_auth calls update_auth_headers internally

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -304,11 +304,14 @@ class TestKeepaliveExplicitStoragePath:
             else:
                 pytest.fail("Rotated cookie was not persisted to the explicit storage path")
 
-    def test_explicit_storage_path_normalizes_onto_auth(self, tmp_path):
-        """The constructor copies ``storage_path`` onto ``auth.storage_path`` so
-        ``refresh_auth()`` and ``ClientCore.close()`` (which both read
+    def test_explicit_storage_path_normalizes_onto_auth_without_mutating_caller(self, tmp_path):
+        """The constructor exposes ``storage_path`` on ``client.auth`` so
+        ``refresh_auth()`` and ``ClientCore.close()`` (which read
         ``self._core.auth.storage_path`` directly, not the keepalive-specific
-        path) persist to the same file.
+        path) persist to the same file. Crucially, the caller's original
+        ``AuthTokens`` is *not* mutated, so reusing one ``AuthTokens`` across
+        multiple ``NotebookLMClient`` instances with different storage paths
+        is safe.
         """
         storage_path = tmp_path / "storage_state.json"
         storage_path.write_text('{"cookies": []}')
@@ -323,8 +326,49 @@ class TestKeepaliveExplicitStoragePath:
         client = NotebookLMClient(auth, storage_path=storage_path)
 
         assert client.auth.storage_path == storage_path, (
-            "Explicit storage_path must be normalized onto auth so non-keepalive "
+            "Explicit storage_path must be reflected on client.auth so non-keepalive "
             "code paths (refresh_auth, ClientCore.close) see the same file"
+        )
+        assert auth.storage_path is None, (
+            "Caller's AuthTokens must not be mutated — sharing one AuthTokens "
+            "across clients with different storage paths must not leak between them"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.no_default_keepalive_mock
+    async def test_close_persists_to_explicit_storage_path(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """``ClientCore.close()`` calls ``save_cookies_to_storage`` with the
+        explicit constructor ``storage_path`` even when keepalive never ran
+        and ``auth.storage_path`` was ``None`` originally — proving the
+        normalization actually wires the on-close save, not just the
+        keepalive loop.
+        """
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text('{"cookies": []}')
+        auth = AuthTokens(
+            cookies={"SID": "x"},
+            csrf_token="t",
+            session_id="s",
+            # storage_path intentionally None
+        )
+
+        save_calls: list[tuple[object, object]] = []
+
+        def spy(cookies, path):
+            save_calls.append((cookies, path))
+
+        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+
+        client = NotebookLMClient(auth, storage_path=storage_path)
+        async with client:
+            pass  # no RPC calls; keepalive disabled by default
+
+        # close()'s on-close save must have fired with the explicit storage_path
+        assert any(call[1] == storage_path for call in save_calls), (
+            f"Expected close() to persist to {storage_path}, "
+            f"but got: {[(type(c[0]).__name__, c[1]) for c in save_calls]}"
         )
 
 


### PR DESCRIPTION
Polish-stage follow-up to #342 (squash-merged at \`512bd01\`). Three reviewers (Claude, Gemini, Codex) independently flagged four issues; this PR resolves all of them.

## What this fixes

### 1. Cancellation ordering race in the keepalive save (Codex HIGH)
The keepalive loop already off-loads its save via \`asyncio.to_thread\`, which runs the worker on a thread-pool executor. When \`close()\` cancels the keepalive task, the worker thread keeps running to completion (CPython provides no general way to cancel an arbitrary running thread). \`close()\` then does its own *synchronous* save with the live jar and returns — and only afterwards does the older keepalive snapshot's save finish, **overwriting the freshest state**.

```
T=10s   keepalive snapshot (state A) taken
T=10s   keepalive worker starts writing state A
T=11s   close() cancels keepalive task; awaiter raises CancelledError
T=11s   close()'s synchronous save writes state B (newer) → file = B
T=11.001s  keepalive worker finishes writing state A → file = A  ← bug
```

**Fix:** introduce \`ClientCore._save_lock\` (\`threading.Lock\`). Both saves now hold it for the duration of \`save_cookies_to_storage\`. \`close()\` also off-loads through \`asyncio.to_thread\`, which serializes via the same lock. Even when the keepalive's awaiter is cancelled, \`close()\`'s save waits for the still-running worker to release the lock before writing — newest state always wins.

### 2. Mutating caller's \`AuthTokens\` (Claude / Gemini / Codex MEDIUM)
\`NotebookLMClient.__init__\` previously did \`auth.storage_path = storage_path\`. If the caller reuses one \`AuthTokens\` across multiple clients with different storage paths, those clients fight over a single mutable field. Switched to \`dataclasses.replace(auth, storage_path=storage_path)\` so the caller's original \`AuthTokens\` is untouched.

### 3. Snapshot atomicity comment overclaimed (all 3, MEDIUM)
The previous comment said the snapshot was \"atomic under the RLock\". \`http.cookiejar.CookieJar.__iter__\` does **not** acquire \`_cookies_lock\`; only specific methods like \`set_cookie\` do. The snapshot is safe in practice because (a) \`Cookie\` objects are effectively immutable in stdlib (replaced, not mutated, on update) and (b) the iteration runs on the event-loop thread without yielding. Reworded the comment to reflect what's actually true.

### 4. Test only asserted the constructor side effect (all 3, MEDIUM)
Added \`test_close_persists_to_explicit_storage_path\`: monkeypatches \`save_cookies_to_storage\`, constructs \`NotebookLMClient(auth, storage_path=path)\` with \`auth.storage_path=None\`, exits the \`async with\` block, and asserts the spy saw the explicit path. Catches a future refactor that keeps the constructor normalization but breaks the on-close persistence.

The previous test was renamed to \`test_explicit_storage_path_normalizes_onto_auth_without_mutating_caller\` and now also asserts the caller's \`auth\` object is left unchanged (locks in fix #2).

### 5. Late-binding closure (lint)
The keepalive's \`_save_under_lock\` def referenced loop variables \`jar_snapshot\` / \`storage_path\` / \`self._save_lock\` — \`B023\`. Bound them as default args.

## Test plan

- [x] \`uvx --from ruff==0.8.6 ruff format --check src/ tests/\` clean
- [x] \`uvx --from ruff==0.8.6 ruff check src/ tests/\` clean
- [x] \`mypy src/notebooklm --ignore-missing-imports\` clean
- [x] Full unit + integration suite: **2230 passed, 9 skipped**
- [x] 24 keepalive tests pass (was 23; one new test asserts close-path persistence)
- [ ] Manual smoke against a real account (deferred to maintainer)

## Why follow-up vs. amending #342

#342 auto-merged before the polish-stage three-way review completed. Forward-only follow-up keeps history linear; nothing about #342's content needed to be revised, only its *consequences* under the more thorough review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced thread safety for cookie persistence to prevent data conflicts during client shutdown.
  * Improved storage path handling during client initialization when reusing authentication credentials across multiple clients.

* **Tests**
  * Added comprehensive tests validating storage path behavior and cookie persistence on client closure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/343)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->