### PR TITLE
fix(auth): close cross-process and refresh-path save races

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -217,6 +217,43 @@ class ClientCore:
                     self._keepalive_loop(self._keepalive_interval)
                 )
 
+    async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
+        """Persist a cookie jar through the shared save lock.
+
+        Single chokepoint used by ``close()``, the keepalive loop, and
+        ``NotebookLMClient.refresh_auth``. Routes every save through:
+
+        1. **Snapshot the jar** on the event-loop thread so the worker isn't
+           iterating a live ``AsyncClient.cookies`` that may be mutating
+           (RPC redirects, the next poke iteration).
+        2. **Hold ``self._save_lock``** (a ``threading.Lock``) for the duration
+           of the off-loaded write. Multiple writers in the same process
+           serialize through this lock so the newer caller always wins.
+        3. **Off-load** the actual save to a worker thread via
+           ``asyncio.to_thread`` so disk I/O never stalls the event loop.
+
+        Cross-process serialization is handled at a different layer — the
+        OS-level file lock inside :func:`save_cookies_to_storage` itself.
+
+        Args:
+            jar: The cookie jar to persist. A copy is taken on the loop thread
+                before the worker reads it.
+            path: Storage path. Falls back to ``self._keepalive_storage_path``,
+                which itself falls back to ``self.auth.storage_path``. If both
+                are ``None``, the call is a no-op.
+        """
+        effective_path = path if path is not None else self._keepalive_storage_path
+        if effective_path is None:
+            return
+
+        snapshot = httpx.Cookies(jar)
+
+        def _save(s=snapshot, p=effective_path, lock=self._save_lock) -> None:
+            with lock:
+                save_cookies_to_storage(s, p)
+
+        await asyncio.to_thread(_save)
+
     async def close(self) -> None:
         """Close the HTTP client connection.
 
@@ -231,19 +268,12 @@ class ClientCore:
 
         if self._http_client:
             try:
-                # Sync refreshed cookies only when auth came from an explicit file.
-                # Hold ``_save_lock`` so we serialize with any keepalive save still
-                # finishing in a worker thread — close() owns the freshest jar
-                # and must win, not the older snapshot.
-                if self.auth.storage_path is not None:
-                    storage_path = self.auth.storage_path
-                    cookies = self._http_client.cookies
-
-                    def _final_save() -> None:
-                        with self._save_lock:
-                            save_cookies_to_storage(cookies, storage_path)
-
-                    await asyncio.to_thread(_final_save)
+                # Single source of truth for the on-close save: takes the
+                # in-process lock, snapshots, off-loads. Serializes naturally
+                # with any keepalive save still finishing in a worker thread
+                # — close() owns the freshest jar and must win, not the older
+                # snapshot.
+                await self.save_cookies(self._http_client.cookies)
             except Exception as e:
                 logger.warning("Failed to sync refreshed cookies during close: %s", e)
             finally:
@@ -287,39 +317,18 @@ class ClientCore:
                     logger.debug("Keepalive poke failed (non-fatal): %s", exc)
                     continue
 
-                storage_path = self._keepalive_storage_path
-                if storage_path is None:
+                if self._keepalive_storage_path is None:
                     continue
 
-                # Snapshot the cookie jar synchronously on the event-loop thread
-                # so the worker isn't iterating a live jar that the AsyncClient
-                # may be mutating. ``httpx.Cookies(other)`` builds a fresh
-                # ``CookieJar`` by re-inserting each cookie reference; cookies
-                # in ``http.cookiejar`` are replaced (not mutated) on update,
-                # so the snapshot is stable for the worker's read.
-                jar_snapshot = httpx.Cookies(client.cookies)
-
-                # Hold ``_save_lock`` so close()'s final save can't run
-                # concurrently with this one. close() also takes the lock,
-                # so even if our awaiter is cancelled, close() waits for
-                # us before doing its own write — newer state wins.
-                # Default-arg binding pins the loop-variable values to this
-                # iteration (not late-bound).
-                def _save_under_lock(
-                    jar=jar_snapshot, path=storage_path, lock=self._save_lock
-                ) -> None:
-                    with lock:
-                        save_cookies_to_storage(jar, path)
-
                 try:
-                    # Off-load disk I/O so we don't stall the event loop.
-                    await asyncio.to_thread(_save_under_lock)
+                    # save_cookies handles snapshot + lock + off-load.
+                    await self.save_cookies(client.cookies)
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:  # noqa: BLE001
                     logger.warning(
                         "Keepalive cookie persistence to %s failed: %s",
-                        storage_path,
+                        self._keepalive_storage_path,
                         exc,
                     )
         except asyncio.CancelledError:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -249,6 +249,7 @@ class ClientCore:
         snapshot = httpx.Cookies(jar)
 
         def _save(s=snapshot, p=effective_path, lock=self._save_lock) -> None:
+            """Worker-thread save: hold the in-process lock around the disk write."""
             with lock:
                 save_cookies_to_storage(s, p)
 

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -28,11 +28,13 @@ Security Notes:
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -849,6 +851,57 @@ def build_cookie_jar(
     return jar
 
 
+@contextlib.contextmanager
+def _file_lock_exclusive(lock_path: Path) -> Any:
+    """Cross-process exclusive lock on ``lock_path`` for the duration of the block.
+
+    Multiple Python processes that all save to the same ``storage_state.json``
+    (e.g. a long-running ``NotebookLMClient(keepalive=...)`` worker plus a
+    cron-driven ``notebooklm auth refresh``) would otherwise race on the read-
+    merge-write cycle and lose updates. The lock is held on a sentinel file
+    sibling to the storage file (``.storage_state.json.lock``), since locking
+    the storage file itself would interfere with the atomic temp-rename below.
+
+    POSIX uses ``fcntl.flock``, Windows uses ``msvcrt.locking``; both are
+    blocking. The lock is per-process: threads within one process aren't
+    serialized — that's the intra-process ``threading.Lock`` in ``ClientCore``.
+    If the lock can't be acquired (e.g. unsupported filesystem like NFS where
+    flock semantics vary), the save proceeds without locking and a DEBUG log
+    line records the fallback; correctness on NFS is best-effort.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    locked = False
+    try:
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            locked = True
+        except OSError as exc:
+            logger.debug("save_cookies_to_storage: file lock unavailable (%s); proceeding", exc)
+        yield
+    finally:
+        if locked:
+            try:
+                if sys.platform == "win32":
+                    import msvcrt
+
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError as exc:
+                logger.debug("save_cookies_to_storage: failed to release file lock (%s)", exc)
+        os.close(fd)
+
+
 def save_cookies_to_storage(cookie_jar: httpx.Cookies, path: Path | None = None) -> None:
     """Save an updated httpx.Cookies jar back to Playwright storage_state.json.
 
@@ -857,6 +910,12 @@ def save_cookies_to_storage(cookie_jar: httpx.Cookies, path: Path | None = None)
     serialized back to disk so the session remains valid across CLI invocations.
 
     If auth was loaded from an environment variable (no file), this is a no-op.
+
+    Cross-process safety: the read-merge-write cycle is wrapped in an OS-level
+    file lock (``.storage_state.json.lock``) so concurrent writers from
+    different Python processes (e.g. an in-process ``NotebookLMClient`` keepalive
+    plus a cron-driven ``notebooklm auth refresh``) serialize cleanly rather
+    than tearing or losing updates.
 
     Args:
         cookie_jar: The httpx.Cookies object containing the latest cookies.
@@ -874,81 +933,85 @@ def save_cookies_to_storage(cookie_jar: httpx.Cookies, path: Path | None = None)
         logger.debug("Skipping cookie sync: No storage file path available")
         return
 
-    if not path.exists():
-        logger.debug("Skipping cookie sync: Storage file not found at %s", path)
-        return
+    lock_path = path.with_name(f".{path.name}.lock")
+    with _file_lock_exclusive(lock_path):
+        if not path.exists():
+            logger.debug("Skipping cookie sync: Storage file not found at %s", path)
+            return
 
-    try:
-        storage_data = json.loads(path.read_text(encoding="utf-8"))
-    except Exception as e:
-        logger.warning("Failed to read storage state for cookie sync: %s", e)
-        return
+        try:
+            storage_data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning("Failed to read storage state for cookie sync: %s", e)
+            return
 
-    if not isinstance(storage_data, dict) or "cookies" not in storage_data:
-        return
+        if not isinstance(storage_data, dict) or "cookies" not in storage_data:
+            return
 
-    cookies_by_key = {
-        (cookie.name, cookie.domain): cookie
-        for cookie in cookie_jar.jar
-        if cookie.name and cookie.domain and _is_allowed_cookie_domain(cookie.domain)
-    }
+        cookies_by_key = {
+            (cookie.name, cookie.domain): cookie
+            for cookie in cookie_jar.jar
+            if cookie.name and cookie.domain and _is_allowed_cookie_domain(cookie.domain)
+        }
 
-    updated_count = 0
-    stored_keys: set[CookieKey] = set()
-    for stored_cookie in storage_data["cookies"]:
-        name = stored_cookie.get("name")
-        domain = stored_cookie.get("domain", "")
-        if not name or not domain:
-            continue
+        updated_count = 0
+        stored_keys: set[CookieKey] = set()
+        for stored_cookie in storage_data["cookies"]:
+            name = stored_cookie.get("name")
+            domain = stored_cookie.get("domain", "")
+            if not name or not domain:
+                continue
 
-        key = (name, domain)
-        stored_keys.update(_cookie_key_variants(key))
-        refreshed_cookie = _find_cookie_for_storage(cookies_by_key, key, stored_cookie.get("value"))
-        if refreshed_cookie is None:
-            continue
+            key = (name, domain)
+            stored_keys.update(_cookie_key_variants(key))
+            refreshed_cookie = _find_cookie_for_storage(
+                cookies_by_key, key, stored_cookie.get("value")
+            )
+            if refreshed_cookie is None:
+                continue
 
-        new_expires = refreshed_cookie.expires if refreshed_cookie.expires is not None else -1
-        changed = (
-            stored_cookie.get("value") != refreshed_cookie.value
-            or stored_cookie.get("expires") != new_expires
-        )
-        if changed:
-            stored_cookie["value"] = refreshed_cookie.value
-            stored_cookie["expires"] = new_expires
-            stored_cookie["path"] = refreshed_cookie.path or stored_cookie.get("path", "/")
-            stored_cookie["secure"] = refreshed_cookie.secure
-            stored_cookie["httpOnly"] = _cookie_is_http_only(refreshed_cookie)
+            new_expires = refreshed_cookie.expires if refreshed_cookie.expires is not None else -1
+            changed = (
+                stored_cookie.get("value") != refreshed_cookie.value
+                or stored_cookie.get("expires") != new_expires
+            )
+            if changed:
+                stored_cookie["value"] = refreshed_cookie.value
+                stored_cookie["expires"] = new_expires
+                stored_cookie["path"] = refreshed_cookie.path or stored_cookie.get("path", "/")
+                stored_cookie["secure"] = refreshed_cookie.secure
+                stored_cookie["httpOnly"] = _cookie_is_http_only(refreshed_cookie)
+                updated_count += 1
+
+        for key, cookie in cookies_by_key.items():
+            if key in stored_keys:
+                continue
+            storage_data["cookies"].append(_cookie_to_storage_state(cookie))
             updated_count += 1
 
-    for key, cookie in cookies_by_key.items():
-        if key in stored_keys:
-            continue
-        storage_data["cookies"].append(_cookie_to_storage_state(cookie))
-        updated_count += 1
-
-    if updated_count > 0:
-        temp_path: Path | None = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                "w",
-                encoding="utf-8",
-                dir=path.parent,
-                prefix=f".{path.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as temp_file:
-                temp_file.write(json.dumps(storage_data, indent=2))
-                temp_path = Path(temp_file.name)
-            os.chmod(temp_path, 0o600)
-            temp_path.replace(path)
-            logger.debug("Successfully synced %d refreshed cookies to %s", updated_count, path)
-        except Exception as e:
-            logger.warning("Failed to write updated cookies to %s: %s", path, e)
-            if temp_path is not None:
-                try:
-                    temp_path.unlink(missing_ok=True)
-                except Exception as cleanup_err:
-                    logger.debug("Failed to clean up temp file %s: %s", temp_path, cleanup_err)
+        if updated_count > 0:
+            temp_path: Path | None = None
+            try:
+                with tempfile.NamedTemporaryFile(
+                    "w",
+                    encoding="utf-8",
+                    dir=path.parent,
+                    prefix=f".{path.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as temp_file:
+                    temp_file.write(json.dumps(storage_data, indent=2))
+                    temp_path = Path(temp_file.name)
+                os.chmod(temp_path, 0o600)
+                temp_path.replace(path)
+                logger.debug("Successfully synced %d refreshed cookies to %s", updated_count, path)
+            except Exception as e:
+                logger.warning("Failed to write updated cookies to %s: %s", path, e)
+                if temp_path is not None:
+                    try:
+                        temp_path.unlink(missing_ok=True)
+                    except Exception as cleanup_err:
+                        logger.debug("Failed to clean up temp file %s: %s", temp_path, cleanup_err)
 
 
 def _cookie_is_http_only(cookie: Any) -> bool:

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -1000,7 +1000,7 @@ def save_cookies_to_storage(cookie_jar: httpx.Cookies, path: Path | None = None)
                     suffix=".tmp",
                     delete=False,
                 ) as temp_file:
-                    temp_file.write(json.dumps(storage_data, indent=2))
+                    temp_file.write(json.dumps(storage_data, indent=2, ensure_ascii=False))
                     temp_path = Path(temp_file.name)
                 os.chmod(temp_path, 0o600)
                 temp_path.replace(path)

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -254,9 +254,12 @@ class NotebookLMClient:
         self._core.update_auth_headers()
 
         # Persist refreshed cookies back to disk so the next CLI invocation
-        # picks up the updated short-lived tokens (e.g., __Secure-1PSIDCC)
-        from .auth import save_cookies_to_storage
-
-        save_cookies_to_storage(http_client.cookies, self._core.auth.storage_path)
+        # picks up the updated short-lived tokens (e.g., __Secure-1PSIDCC).
+        # Routed through ClientCore.save_cookies so it serializes with the
+        # keepalive worker and the on-close save via ``_save_lock`` — without
+        # that, refresh_auth's synchronous save can race with an in-flight
+        # keepalive save and an older snapshot can clobber the freshly
+        # refreshed tokens.
+        await self._core.save_cookies(http_client.cookies)
 
         return self._core.auth

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -414,3 +414,157 @@ class TestKeepalivePersistence:
             data = json.loads(storage_path.read_text())
             cookie_names = {c["name"] for c in data["cookies"]}
             assert "__Secure-1PSIDTS" in cookie_names
+
+
+class TestSaveCookiesUnification:
+    """Tests for ClientCore.save_cookies — the single chokepoint that close,
+    keepalive, and refresh_auth all route through."""
+
+    @pytest.mark.asyncio
+    async def test_save_cookies_takes_in_process_lock_before_writing(self, tmp_path, monkeypatch):
+        """``ClientCore.save_cookies`` holds ``_save_lock`` for the duration of
+        the worker-thread write, so an older snapshot can't clobber a newer one
+        within the same process."""
+        from notebooklm._core import ClientCore
+
+        auth = AuthTokens(
+            cookies={"SID": "x"},
+            csrf_token="t",
+            session_id="s",
+            storage_path=tmp_path / "storage_state.json",
+        )
+        (tmp_path / "storage_state.json").write_text('{"cookies": []}')
+        core = ClientCore(auth)
+
+        lock_held_during_save: list[bool] = []
+
+        def spy(jar, path):
+            # If the in-process lock is properly held, this assertion is true.
+            lock_held_during_save.append(core._save_lock.locked())
+
+        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+
+        await core.save_cookies(httpx.Cookies())
+
+        assert lock_held_during_save == [True], (
+            "save_cookies must hold _save_lock for the duration of "
+            "save_cookies_to_storage so newer state always wins"
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_auth_routes_save_through_save_cookies(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """``refresh_auth`` no longer calls ``save_cookies_to_storage`` directly;
+        it routes through ``ClientCore.save_cookies`` so the in-process lock is
+        held — preventing an older keepalive snapshot from clobbering the
+        freshly-refreshed tokens."""
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text(
+            json.dumps(
+                {
+                    "cookies": [
+                        {
+                            "name": "SID",
+                            "value": "x",
+                            "domain": ".google.com",
+                            "path": "/",
+                        },
+                    ]
+                }
+            )
+        )
+        auth = AuthTokens(
+            cookies={"SID": "x", "HSID": "y"},
+            csrf_token="old_csrf",
+            session_id="old_session",
+            storage_path=storage_path,
+        )
+
+        # NotebookLM homepage with new tokens (refresh_auth scrapes these)
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            content=b'<html><script>window.WIZ_global_data={"SNlM0e":"new_csrf","FdrFJe":"new_sid"};</script></html>',
+        )
+
+        client = NotebookLMClient(auth)
+
+        save_calls: list[bool] = []
+
+        def spy(jar, path):
+            # Lock must be held when refresh_auth's save fires
+            save_calls.append(client._core._save_lock.locked())
+
+        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+
+        async with client:
+            await client.refresh_auth()
+
+        # At least one save (refresh_auth) plus close()'s on-close save.
+        assert len(save_calls) >= 1
+        assert all(save_calls), (
+            "Every save fired during refresh_auth + close must be under the "
+            f"in-process lock; got {save_calls}"
+        )
+
+
+class TestCrossProcessFileLock:
+    """Tests for the OS-level file lock inside save_cookies_to_storage that
+    serializes writes from different Python processes (e.g. an in-process
+    keepalive plus a cron-driven `notebooklm auth refresh`)."""
+
+    def test_save_cookies_to_storage_acquires_file_lock(self, tmp_path, monkeypatch):
+        """``save_cookies_to_storage`` calls ``fcntl.flock(LOCK_EX)`` (POSIX)
+        before reading or writing the storage file."""
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("POSIX-specific test; Windows uses msvcrt.locking")
+
+        import fcntl
+
+        from notebooklm.auth import save_cookies_to_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text(
+            '{"cookies": [{"name": "SID", "value": "old", "domain": ".google.com", "path": "/"}]}'
+        )
+
+        flock_calls: list[int] = []
+        original_flock = fcntl.flock
+
+        def spy_flock(fd, op):
+            flock_calls.append(op)
+            return original_flock(fd, op)
+
+        monkeypatch.setattr("fcntl.flock", spy_flock)
+
+        jar = httpx.Cookies()
+        jar.set("SID", "new", domain=".google.com", path="/")
+
+        save_cookies_to_storage(jar, storage_path)
+
+        assert (
+            fcntl.LOCK_EX in flock_calls
+        ), f"Expected an LOCK_EX call before the save, got: {flock_calls}"
+        assert (
+            fcntl.LOCK_UN in flock_calls
+        ), f"Expected an LOCK_UN call after the save, got: {flock_calls}"
+
+    def test_save_cookies_to_storage_creates_lock_sentinel(self, tmp_path):
+        """The lock file is a sibling of the storage file with a `.lock` suffix
+        so the storage file itself is free for the atomic temp-rename."""
+        from notebooklm.auth import save_cookies_to_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text(
+            '{"cookies": [{"name": "SID", "value": "old", "domain": ".google.com", "path": "/"}]}'
+        )
+
+        jar = httpx.Cookies()
+        jar.set("SID", "new", domain=".google.com", path="/")
+
+        save_cookies_to_storage(jar, storage_path)
+
+        lock_path = storage_path.with_name(f".{storage_path.name}.lock")
+        assert lock_path.exists(), f"Expected lock sentinel at {lock_path}"

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -439,7 +439,7 @@ class TestSaveCookiesUnification:
         lock_held_during_save: list[bool] = []
 
         def spy(jar, path):
-            # If the in-process lock is properly held, this assertion is true.
+            """Record whether ``_save_lock`` is held at the moment of the disk write."""
             lock_held_during_save.append(core._save_lock.locked())
 
         monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
@@ -492,7 +492,7 @@ class TestSaveCookiesUnification:
         save_calls: list[bool] = []
 
         def spy(jar, path):
-            # Lock must be held when refresh_auth's save fires
+            """Record whether ``_save_lock`` is held when refresh_auth's save fires."""
             save_calls.append(client._core._save_lock.locked())
 
         monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
@@ -534,6 +534,7 @@ class TestCrossProcessFileLock:
         original_flock = fcntl.flock
 
         def spy_flock(fd, op):
+            """Record each ``fcntl.flock`` operation while still performing it."""
             flock_calls.append(op)
             return original_flock(fd, op)
 


### PR DESCRIPTION
## Summary

Closes two narrow races on `storage_state.json` that the in-process lock from #343 didn't cover.

### A) `refresh_auth` bypassed the in-process lock

`NotebookLMClient.refresh_auth` previously called `save_cookies_to_storage` synchronously. A keepalive worker that started writing earlier (`asyncio.to_thread`) could finish *after* `refresh_auth`'s synchronous write returned — clobbering the freshly refreshed tokens with an older in-memory snapshot.

### B) External writers can tear the read-merge-write

When the in-process keepalive runs alongside a cron-driven `notebooklm auth refresh` (the recommended OS-scheduler recipe), two Python processes interleave the read-merge-write on the same `storage_state.json`. A Python-level lock can't serialize across processes; an OS lock has to.

## Changes

- **`ClientCore.save_cookies`** — single chokepoint: snapshot the jar on the loop thread, hold `_save_lock`, off-load via `asyncio.to_thread`. `close()`, the keepalive loop, and `refresh_auth` all route through it.
- **OS-level file lock** in `save_cookies_to_storage` — `fcntl.flock(LOCK_EX)` on POSIX, `msvcrt.locking` on Windows, on a sibling sentinel (\`.<storage>.lock\`) so the storage file itself is free for the atomic temp-rename. Lock failure falls back to no-lock with a DEBUG log (best-effort on filesystems like NFS where flock semantics vary).

## Test plan

- [x] `TestSaveCookiesUnification`:
  - `save_cookies` holds `_save_lock` for the duration of the worker-thread write.
  - `refresh_auth` routes its save through `save_cookies` (lock held).
- [x] `TestCrossProcessFileLock`:
  - `save_cookies_to_storage` issues `LOCK_EX`/`LOCK_UN` (POSIX-only; monkeypatched).
  - Sentinel `.<name>.lock` is created beside the storage file.
- [x] `pytest tests/unit tests/integration` — 2234 pass, 9 skipped.
- [x] `ruff format`, `ruff check`, `mypy` clean.

## Follow-up to

#341 (keepalive), #342 (snapshot/normalize), #343 (in-process lock + close-vs-keepalive ordering).

Addresses the unresolved review concerns on #343:
- Lock-vs-`refresh_auth` (3213774938)
- Snapshot during `close()` (now centralized in `save_cookies`) (3213774940)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified cookie persistence path that centralizes and consistently persists authentication cookies (including on close and keepalive).

* **Bug Fixes**
  * Added cross-process file locking and in-process synchronization to prevent race conditions when multiple processes access cookie storage.
  * More reliable, atomic cookie updates to storage.

* **Tests**
  * Added tests covering unified persistence, in-process locking, and cross-process file-lock behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/344)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->