### PR TITLE
fix(types): populate notebook sources count

### DIFF
--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -407,6 +407,12 @@ class SourceSummary:
         }
 
 
+def _extract_notebook_sources_count(data: list[Any]) -> int:
+    """Extract the embedded source count from a notebook API payload."""
+    sources = data[1] if len(data) > 1 else None
+    return len(sources) if isinstance(sources, list) else 0
+
+
 @dataclass
 class Notebook:
     """Represents a NotebookLM notebook."""
@@ -429,7 +435,7 @@ class Notebook:
         """
         raw_title = data[0] if len(data) > 0 and isinstance(data[0], str) else ""
         title = raw_title.replace("thought\n", "").strip()
-        sources_count = len(data[1]) if len(data) > 1 and isinstance(data[1], list) else 0
+        sources_count = _extract_notebook_sources_count(data)
         notebook_id = data[2] if len(data) > 2 and isinstance(data[2], str) else ""
 
         created_at = None

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -429,6 +429,7 @@ class Notebook:
         """
         raw_title = data[0] if len(data) > 0 and isinstance(data[0], str) else ""
         title = raw_title.replace("thought\n", "").strip()
+        sources_count = len(data[1]) if len(data) > 1 and isinstance(data[1], list) else 0
         notebook_id = data[2] if len(data) > 2 and isinstance(data[2], str) else ""
 
         created_at = None
@@ -445,7 +446,13 @@ class Notebook:
         if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 1:
             is_owner = data[5][1] is False
 
-        return cls(id=notebook_id, title=title, created_at=created_at, is_owner=is_owner)
+        return cls(
+            id=notebook_id,
+            title=title,
+            created_at=created_at,
+            sources_count=sources_count,
+            is_owner=is_owner,
+        )
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ def mock_list_notebooks_response():
             [
                 [
                     "My First Notebook",
-                    [],
+                    [["src_001"], ["src_002"]],
                     "nb_001",
                     "📘",
                     None,
@@ -128,7 +128,7 @@ def mock_list_notebooks_response():
                 ],
                 [
                     "Research Notes",
-                    [],
+                    None,
                     "nb_002",
                     "📚",
                     None,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -99,7 +99,7 @@ def mock_list_notebooks_response():
             [
                 [
                     "My First Notebook",
-                    [],
+                    [["src_001"], ["src_002"]],
                     "nb_001",
                     "📘",
                     None,
@@ -107,7 +107,7 @@ def mock_list_notebooks_response():
                 ],
                 [
                     "Research Notes",
-                    [],
+                    None,
                     "nb_002",
                     "📚",
                     None,

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -26,6 +26,8 @@ class TestListNotebooks:
         assert all(isinstance(nb, Notebook) for nb in notebooks)
         assert notebooks[0].title == "My First Notebook"
         assert notebooks[0].id == "nb_001"
+        assert notebooks[0].sources_count == 2
+        assert notebooks[1].sources_count == 0
 
     @pytest.mark.asyncio
     async def test_list_notebooks_request_format(

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -31,7 +31,22 @@ class TestNotebook:
 
         assert notebook.id == "nb_123"
         assert notebook.title == "My Notebook"
+        assert notebook.sources_count == 0
         assert notebook.is_owner is True
+
+    def test_from_api_response_counts_sources(self):
+        """Test parsing notebook source count from embedded source entries."""
+        data = ["My Notebook", [["src_1"], ["src_2"], ["src_3"]], "nb_123", "📓"]
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.sources_count == 3
+
+    def test_from_api_response_none_sources_count_defaults_to_zero(self):
+        """Test parsing notebook source count when source entries are absent."""
+        data = ["My Notebook", None, "nb_123", "📓"]
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.sources_count == 0
 
     def test_from_api_response_with_timestamp(self):
         """Test parsing notebook with timestamp."""


### PR DESCRIPTION
## Summary

- Populate `Notebook.sources_count` from embedded source entries in notebook API payloads.
- Keep the fallback at `0` when the response omits source entries or returns `null`.
- Add unit and integration coverage for populated and absent source-entry payloads.

Fixes #349

## Live verification

Checked against the live NotebookLM API on 2026-05-09 with the local authenticated `firefox` profile:

- Before fix: `client.notebooks.list()` returned 84 notebooks, all with parsed `sources_count == 0`.
- `client.sources.list()` showed nonzero source counts for 83 successfully probed notebooks.
- After fix: parsed `Notebook.sources_count` matched `len(client.sources.list(nb.id))` across all 84 notebooks, including one malformed/empty source field parsed as `0`.

## Test plan

- [x] `uv run pytest tests/unit/test_types.py::TestNotebook tests/integration/test_notebooks.py::TestListNotebooks -q`
- [x] `uv run pytest -q`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/notebooklm`

Generated with [Codex](https://openai.com/codex)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebooks now include a sources count that accurately reports how many sources are associated with each notebook record.

* **Tests**
  * Added and updated integration and unit tests to verify sources counting across normal and edge cases (including missing or empty source data).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/350)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->