### PR TITLE
refactor(api): consolidate URL extraction; surface Notebook/Source/Artifact fields (#349)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -50,6 +50,9 @@ from .types import (
     ArtifactType,
     GenerationStatus,
     ReportSuggestion,
+    _extract_artifact_url,
+    _extract_infographic_artifact_url,
+    _is_valid_artifact_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -1102,49 +1105,17 @@ class ArtifactsAPI:
         if not audio_art:
             raise ArtifactNotReadyError("audio")
 
-        # Extract URL from metadata[6][5]
-        try:
-            metadata = audio_art[6]
-            if not isinstance(metadata, list) or len(metadata) <= 5:
-                raise ArtifactParseError(
-                    "audio",
-                    artifact_id=artifact_id,
-                    details="Invalid audio metadata structure",
-                )
-
-            media_list = metadata[5]
-            if not isinstance(media_list, list) or len(media_list) == 0:
-                raise ArtifactParseError(
-                    "audio",
-                    artifact_id=artifact_id,
-                    details="No media URLs found",
-                )
-
-            url = None
-            for item in media_list:
-                if isinstance(item, list) and len(item) > 2 and item[2] == "audio/mp4":
-                    url = item[0]
-                    break
-
-            if not url and len(media_list) > 0 and isinstance(media_list[0], list):
-                url = media_list[0][0]
-
-            if not url:
-                raise ArtifactDownloadError(
-                    "audio",
-                    artifact_id=artifact_id,
-                    details="Could not extract download URL",
-                )
-
-            return await self._download_url(url, output_path)
-
-        except (IndexError, TypeError) as e:
+        # Route through the shared extractor so readiness checks, Artifact.url,
+        # GenerationStatus.url, and downloads all agree on the same URL.
+        url = _extract_artifact_url(audio_art, ArtifactTypeCode.AUDIO.value)
+        if not url:
             raise ArtifactParseError(
                 "audio",
                 artifact_id=artifact_id,
-                details=f"Failed to parse audio artifact structure: {e}",
-                cause=e,
-            ) from e
+                details="Could not extract download URL from artifact metadata",
+            )
+
+        return await self._download_url(url, output_path)
 
     async def download_video(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
@@ -1181,50 +1152,17 @@ class ArtifactsAPI:
         if not video_art:
             raise ArtifactNotReadyError("video_overview")
 
-        # Extract URL from metadata[8]
-        try:
-            if len(video_art) <= 8:
-                raise ArtifactParseError("video_artifact", details="Invalid structure")
-
-            metadata = video_art[8]
-            if not isinstance(metadata, list):
-                raise ArtifactParseError("video_metadata", details="Invalid structure")
-
-            media_list = None
-            for item in metadata:
-                if (
-                    isinstance(item, list)
-                    and len(item) > 0
-                    and isinstance(item[0], list)
-                    and len(item[0]) > 0
-                    and isinstance(item[0][0], str)
-                    and item[0][0].startswith("http")
-                ):
-                    media_list = item
-                    break
-
-            if not media_list:
-                raise ArtifactParseError("media", details="No media URLs found")
-
-            url = None
-            for item in media_list:
-                if isinstance(item, list) and len(item) > 2 and item[2] == "video/mp4":
-                    url = item[0]
-                    if item[1] == 4:
-                        break
-
-            if not url and len(media_list) > 0:
-                url = media_list[0][0]
-
-            if not url:
-                raise ArtifactDownloadError("media", details="Could not extract download URL")
-
-            return await self._download_url(url, output_path)
-
-        except (IndexError, TypeError) as e:
+        # Route through the shared extractor so readiness checks, Artifact.url,
+        # GenerationStatus.url, and downloads all agree on the same URL.
+        url = _extract_artifact_url(video_art, ArtifactTypeCode.VIDEO.value)
+        if not url:
             raise ArtifactParseError(
-                "video_artifact", details=f"Failed to parse structure: {e}", cause=e
-            ) from e
+                "video_artifact",
+                artifact_id=artifact_id,
+                details="Could not extract download URL from artifact metadata",
+            )
+
+        return await self._download_url(url, output_path)
 
     async def download_infographic(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
@@ -1261,11 +1199,10 @@ class ArtifactsAPI:
         if not info_art:
             raise ArtifactNotReadyError("infographic")
 
-        # Reuse the shared helper so readiness checks and downloads agree on
-        # which URL to select (both now iterate forward, preferring the
-        # canonical content URL at a lower index).
+        # Route through the shared extractor so readiness checks and downloads
+        # agree on which URL to select.
         try:
-            url = self._find_infographic_url(info_art)
+            url = _extract_artifact_url(info_art, ArtifactTypeCode.INFOGRAPHIC.value)
             if not url:
                 raise ArtifactParseError("infographic", details="Could not find metadata")
             return await self._download_url(url, output_path)
@@ -1768,10 +1705,12 @@ class ArtifactsAPI:
                 error_msg: str | None = None
                 if status == "failed":
                     error_msg = self._extract_artifact_error(art)
+                url = _extract_artifact_url(art, artifact_type)
 
                 return GenerationStatus(
                     task_id=task_id,
                     status=status,
+                    url=url,
                     error=error_msg,
                 )
 
@@ -2364,44 +2303,12 @@ class ArtifactsAPI:
             return str(artifact_type)
 
     def _is_valid_media_url(self, value: Any) -> bool:
-        """Check if value is a valid HTTP(S) URL.
-
-        Args:
-            value: The value to check.
-
-        Returns:
-            True if value is a string starting with http:// or https://.
-        """
-        return isinstance(value, str) and value.startswith(("http://", "https://"))
+        """Check if value is a valid HTTP(S) URL."""
+        return _is_valid_artifact_url(value)
 
     def _find_infographic_url(self, art: builtins.list[Any]) -> str | None:
-        """Extract infographic image URL from artifact data.
-
-        Infographic URLs are deeply nested in the artifact structure.
-        This method searches forward through the artifact to prefer the
-        canonical content URL over any later URL-containing fields.
-
-        Args:
-            art: Raw artifact data from _list_raw().
-
-        Returns:
-            The image URL if found, None otherwise.
-        """
-        for item in art:
-            if not isinstance(item, list) or len(item) <= 2:
-                continue
-            content = item[2]
-            if not isinstance(content, list) or len(content) == 0:
-                continue
-            first_content = content[0]
-            if not isinstance(first_content, list) or len(first_content) <= 1:
-                continue
-            img_data = first_content[1]
-            if isinstance(img_data, list) and len(img_data) > 0:
-                url = img_data[0]
-                if self._is_valid_media_url(url):
-                    return url
-        return None
+        """Extract infographic image URL from artifact data."""
+        return _extract_infographic_artifact_url(art)
 
     def _is_media_ready(self, art: builtins.list[Any], artifact_type: int) -> bool:
         """Check if media artifact has URLs populated.
@@ -2427,42 +2334,8 @@ class ArtifactsAPI:
             Returns True on unexpected structure (defensive fallback).
         """
         try:
-            if artifact_type == ArtifactTypeCode.AUDIO.value:
-                # Audio URL is at art[6][5] - check for non-empty media list
-                if len(art) > 6 and isinstance(art[6], list) and len(art[6]) > 5:
-                    media_list = art[6][5]
-                    if isinstance(media_list, list) and len(media_list) > 0:
-                        # Check first item has a valid URL
-                        first_item = media_list[0]
-                        if isinstance(first_item, list) and len(first_item) > 0:
-                            return self._is_valid_media_url(first_item[0])
-                return False
-
-            elif artifact_type == ArtifactTypeCode.VIDEO.value:
-                # Video URLs live at art[8][i][0][0] - mirror download_video's
-                # structure check so wait_for_completion and download agree.
-                if len(art) > 8 and isinstance(art[8], list):
-                    return any(
-                        isinstance(item, list)
-                        and len(item) > 0
-                        and isinstance(item[0], list)
-                        and len(item[0]) > 0
-                        and self._is_valid_media_url(item[0][0])
-                        for item in art[8]
-                    )
-                return False
-
-            elif artifact_type == ArtifactTypeCode.INFOGRAPHIC.value:
-                return self._find_infographic_url(art) is not None
-
-            elif artifact_type == ArtifactTypeCode.SLIDE_DECK.value:
-                # Slide deck PDF URL is at art[16][3]
-                return (
-                    len(art) > 16
-                    and isinstance(art[16], list)
-                    and len(art[16]) > 3
-                    and self._is_valid_media_url(art[16][3])
-                )
+            if artifact_type in _MEDIA_ARTIFACT_TYPES:
+                return _extract_artifact_url(art, artifact_type) is not None
 
             # Non-media artifacts (Report, Quiz, Flashcard, Data Table, Mind Map):
             # Status code alone is sufficient for these types

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -4,7 +4,6 @@ import asyncio
 import builtins
 import logging
 import re
-from datetime import datetime
 from pathlib import Path
 from time import monotonic
 from typing import Any
@@ -24,6 +23,7 @@ from .types import (
     SourceNotFoundError,
     SourceProcessingError,
     SourceTimeoutError,
+    _extract_source_created_at,
     _extract_source_url,
 )
 
@@ -128,14 +128,7 @@ class SourcesAPI:
                 url = _extract_source_url(src[2] if len(src) > 2 else None, allow_bare_http=False)
 
                 # Extract timestamp from src[2][2] - [seconds, nanoseconds]
-                created_at = None
-                if len(src) > 2 and isinstance(src[2], list) and len(src[2]) > 2:
-                    timestamp_list = src[2][2]
-                    if isinstance(timestamp_list, list) and len(timestamp_list) > 0:
-                        try:
-                            created_at = datetime.fromtimestamp(timestamp_list[0])
-                        except (TypeError, ValueError):
-                            pass
+                created_at = _extract_source_created_at(src[2] if len(src) > 2 else None)
 
                 # Extract status from src[3][1]
                 # See SourceStatus enum for valid values
@@ -729,15 +722,13 @@ class SourcesAPI:
             if len(result) > 0 and isinstance(result[0], list) and len(result[0]) > 1:
                 title = result[0][1] if isinstance(result[0][1], str) else ""
 
-                # Source type at result[0][2][4]
+                # Source type at result[0][2][4]; source URLs may be stored
+                # at [7][0] for web/PDF sources or [5][0] for YouTube sources.
                 if len(result[0]) > 2 and isinstance(result[0][2], list):
-                    if len(result[0][2]) > 4:
-                        source_type = result[0][2][4]
-
-                    # URL at result[0][2][7][0]
-                    if len(result[0][2]) > 7 and isinstance(result[0][2][7], list):
-                        if len(result[0][2][7]) > 0:
-                            url = result[0][2][7][0]
+                    metadata = result[0][2]
+                    if len(metadata) > 4:
+                        source_type = metadata[4]
+                    url = _extract_source_url(metadata, allow_bare_http=False)
 
             # Content blocks at result[3][0]
             # Each block may be nested arrays with text strings

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -32,6 +32,7 @@ from .exceptions import (
 # Re-export enums from rpc/types.py for convenience
 from .rpc.types import (
     ArtifactStatus,
+    ArtifactTypeCode,
     AudioFormat,
     AudioLength,
     ChatGoal,
@@ -292,6 +293,113 @@ def _extract_source_url(metadata: Any, *, allow_bare_http: bool = True) -> str |
         if isinstance(candidate, str) and candidate.startswith("http"):
             url = candidate
     return url
+
+
+def _extract_source_created_at(metadata: Any) -> datetime | None:
+    """Extract a source creation timestamp from a ``src[2]`` metadata array."""
+    if not isinstance(metadata, list) or len(metadata) <= 2:
+        return None
+
+    timestamp_list = metadata[2]
+    if not isinstance(timestamp_list, list) or not timestamp_list:
+        return None
+
+    try:
+        return datetime.fromtimestamp(timestamp_list[0])
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_valid_artifact_url(value: Any) -> bool:
+    """Return True when ``value`` looks like a downloadable artifact URL."""
+    return isinstance(value, str) and value.startswith(("http://", "https://"))
+
+
+def _extract_audio_artifact_url(data: list[Any]) -> str | None:
+    if len(data) <= 6 or not isinstance(data[6], list) or len(data[6]) <= 5:
+        return None
+
+    media_list = data[6][5]
+    if not isinstance(media_list, list):
+        return None
+
+    for item in media_list:
+        if (
+            isinstance(item, list)
+            and len(item) > 2
+            and item[2] == "audio/mp4"
+            and _is_valid_artifact_url(item[0])
+        ):
+            return item[0]
+
+    for item in media_list:
+        if isinstance(item, list) and item and _is_valid_artifact_url(item[0]):
+            return item[0]
+
+    return None
+
+
+def _extract_video_artifact_url(data: list[Any]) -> str | None:
+    if len(data) <= 8 or not isinstance(data[8], list):
+        return None
+
+    fallback_url = None
+    for media_list in data[8]:
+        if not isinstance(media_list, list):
+            continue
+        for item in media_list:
+            if not isinstance(item, list) or not item or not _is_valid_artifact_url(item[0]):
+                continue
+            if fallback_url is None:
+                fallback_url = item[0]
+            if len(item) > 2 and item[2] == "video/mp4":
+                if len(item) > 1 and item[1] == 4:
+                    return item[0]
+                fallback_url = item[0]
+
+    return fallback_url
+
+
+def _extract_infographic_artifact_url(data: list[Any]) -> str | None:
+    for item in data:
+        if not isinstance(item, list) or len(item) <= 2:
+            continue
+        content = item[2]
+        if not isinstance(content, list) or not content:
+            continue
+        first_content = content[0]
+        if not isinstance(first_content, list) or len(first_content) <= 1:
+            continue
+        img_data = first_content[1]
+        if isinstance(img_data, list) and img_data and _is_valid_artifact_url(img_data[0]):
+            return img_data[0]
+    return None
+
+
+def _extract_slide_deck_artifact_url(data: list[Any]) -> str | None:
+    """Extract the slide-deck PDF URL. The PPTX URL at ``data[16][4]`` is not
+    surfaced — callers wanting PPTX should use ``download_slide_deck(output_format="pptx")``."""
+    if (
+        len(data) > 16
+        and isinstance(data[16], list)
+        and len(data[16]) > 3
+        and _is_valid_artifact_url(data[16][3])
+    ):
+        return data[16][3]
+    return None
+
+
+def _extract_artifact_url(data: list[Any], artifact_type: int | None) -> str | None:
+    """Extract a public download URL from known artifact response shapes."""
+    if artifact_type == ArtifactTypeCode.AUDIO.value:
+        return _extract_audio_artifact_url(data)
+    if artifact_type == ArtifactTypeCode.VIDEO.value:
+        return _extract_video_artifact_url(data)
+    if artifact_type == ArtifactTypeCode.INFOGRAPHIC.value:
+        return _extract_infographic_artifact_url(data)
+    if artifact_type == ArtifactTypeCode.SLIDE_DECK.value:
+        return _extract_slide_deck_artifact_url(data)
+    return None
 
 
 __all__ = [
@@ -657,8 +765,15 @@ class Source:
                         and isinstance(metadata[4], int)
                         else None
                     )
+                    created_at = _extract_source_created_at(metadata)
 
-                    return cls(id=str(source_id), title=title, url=url, _type_code=type_code)
+                    return cls(
+                        id=str(source_id),
+                        title=title,
+                        url=url,
+                        _type_code=type_code,
+                        created_at=created_at,
+                    )
 
                 # Deeply-nested shape: extract URL (via shared helper) and
                 # type code from entry[2] if present. Full precedence applies:
@@ -670,12 +785,14 @@ class Source:
                     if metadata is not None and len(metadata) > 4 and isinstance(metadata[4], int)
                     else None
                 )
+                created_at = _extract_source_created_at(metadata)
 
                 return cls(
                     id=str(source_id),
                     title=title,
                     url=url,
                     _type_code=type_code,
+                    created_at=created_at,
                 )
 
         # Simple flat format: [id, title] or [id, title, ...]
@@ -795,7 +912,8 @@ class Artifact:
         kind: Artifact type as ArtifactType enum (str enum, comparable to strings).
         status: Processing status (1=processing, 2=pending, 3=completed, 4=failed).
         created_at: When the artifact was created.
-        url: Download URL (if available).
+        url: Download URL (if available). For slide decks this is the PDF URL
+            only — PPTX is fetched separately via ``download_slide_deck(output_format="pptx")``.
 
     Example:
         artifact.kind == ArtifactType.AUDIO  # True
@@ -884,12 +1002,15 @@ class Artifact:
             if isinstance(options, list) and len(options) > 0:
                 variant = options[0]
 
+        url = _extract_artifact_url(data, artifact_type if isinstance(artifact_type, int) else None)
+
         return cls(
             id=str(artifact_id),
             title=str(title),
             _artifact_type=artifact_type,
             status=status,
             created_at=created_at,
+            url=url,
             _variant=variant,
         )
 

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -1629,7 +1629,7 @@ class TestDownloadAudioErrorPaths:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(ArtifactParseError, match="Invalid audio metadata structure"):
+            with pytest.raises(ArtifactParseError, match="Could not extract download URL"):
                 await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
 
     @pytest.mark.asyncio
@@ -1654,7 +1654,7 @@ class TestDownloadAudioErrorPaths:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(ArtifactParseError, match="No media URLs found"):
+            with pytest.raises(ArtifactParseError, match="Could not extract download URL"):
                 await client.artifacts.download_audio("nb_123", "/tmp/audio.mp4")
 
     @pytest.mark.asyncio

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -157,6 +157,57 @@ class TestGetNotebook:
         assert isinstance(notebook, Notebook)
         assert notebook.id == "nb_123"
         assert notebook.title == "Test Notebook"
+        # data[1] holds the source list in the GET_NOTEBOOK shape, same as LIST.
+        assert notebook.sources_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_notebook_sources_count_matches_real_payload(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Regression: ``Notebook.sources_count`` is derived from ``data[1]``.
+
+        Pinned to the shape captured in ``tests/cassettes/notebooks_get.yaml``
+        (a real GET_NOTEBOOK response) — two PDF source entries at index 1.
+        If Google ever moves the source list, this test fails before any
+        downstream code that depends on ``sources_count`` (notably the
+        divergence warning in ``_notebooks.py``) silently produces a wrong
+        count.
+        """
+        response = build_rpc_response(
+            RPCMethod.GET_NOTEBOOK,
+            [
+                [
+                    "TypeScript Fundamentals",
+                    [
+                        [
+                            ["fdfc8ac4-3237-4f2a-8a79-3e24297a7040"],
+                            "Programming TypeScript.pdf",
+                            [None, 87289, [1767921640, 565022000], None, 3, None, 1],
+                            [None, 2],
+                        ],
+                        [
+                            ["ddd31154-74a0-484a-a24c-aff796acae2f"],
+                            "typescript-book.pdf",
+                            [None, 22183, [1767921620, 707149000], None, 3, None, 1],
+                            [None, 2],
+                        ],
+                    ],
+                    "c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e",
+                    "📘",
+                    None,
+                    [None, None, None, None, None, [1768963937, 237838000]],
+                ]
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            notebook = await client.notebooks.get("c3f6285f-1709-44c4-9cd6-e95cf0ea4f5e")
+
+        assert notebook.sources_count == 2
 
     @pytest.mark.asyncio
     async def test_get_notebook_uses_source_path(

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -1635,6 +1635,48 @@ class TestGetFulltextEdgeCases:
         assert "main content" in fulltext.content
 
     @pytest.mark.asyncio
+    async def test_get_fulltext_youtube_url_at_index_5(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Regression: YouTube fulltext metadata stores URL at result[0][2][5][0]."""
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                [
+                    "src_yt",
+                    "YouTube Video",
+                    [
+                        None,
+                        0,
+                        None,
+                        None,
+                        9,
+                        [
+                            "https://www.youtube.com/watch?v=dcWU-qD8ISQ",
+                            "dcWU-qD8ISQ",
+                            "john newquist",
+                        ],
+                        None,
+                        None,
+                    ],
+                ],
+                None,
+                None,
+                [[["Transcript content."]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext("nb_123", "src_yt")
+
+        assert fulltext._type_code == 9
+        assert fulltext.url == "https://www.youtube.com/watch?v=dcWU-qD8ISQ"
+
+    @pytest.mark.asyncio
     async def test_get_fulltext_source_type_only_empty_url_list(
         self,
         auth_tokens,

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -753,6 +753,7 @@ class TestPollStatusMediaReadiness:
 
         status = await api.poll_status("nb_123", "task_123")
         assert status.status == "completed"
+        assert status.url == "https://audio.url/file.mp4"
 
     @pytest.mark.asyncio
     async def test_poll_status_audio_completed_without_url(self, mock_artifacts_api):
@@ -777,6 +778,70 @@ class TestPollStatusMediaReadiness:
         status = await api.poll_status("nb_123", "task_123")
         # Should downgrade to in_progress because URL is missing
         assert status.status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_video_completed_with_url(self, mock_artifacts_api):
+        """poll_status surfaces the video download URL when extractable."""
+        api, mock_core = mock_artifacts_api
+
+        mock_core.rpc_call.return_value = [
+            [
+                [
+                    "task_123",
+                    "Video Overview",
+                    3,  # VIDEO
+                    None,
+                    3,  # COMPLETED
+                    None,
+                    None,
+                    None,
+                    [[["https://video.url/file.mp4", 4, "video/mp4"]]],
+                ]
+            ]
+        ]
+
+        status = await api.poll_status("nb_123", "task_123")
+        assert status.status == "completed"
+        assert status.url == "https://video.url/file.mp4"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_infographic_completed_with_url(self, mock_artifacts_api):
+        """poll_status surfaces the infographic image URL when extractable."""
+        api, mock_core = mock_artifacts_api
+
+        mock_core.rpc_call.return_value = [
+            [
+                [
+                    "task_123",
+                    "Infographic",
+                    7,  # INFOGRAPHIC
+                    None,
+                    3,  # COMPLETED
+                    [None, None, [["ignored", ["https://image.url/info.png"]]]],
+                ]
+            ]
+        ]
+
+        status = await api.poll_status("nb_123", "task_123")
+        assert status.status == "completed"
+        assert status.url == "https://image.url/info.png"
+
+    @pytest.mark.asyncio
+    async def test_poll_status_slide_deck_completed_with_url(self, mock_artifacts_api):
+        """poll_status surfaces the slide-deck PDF URL when extractable."""
+        api, mock_core = mock_artifacts_api
+
+        mock_core.rpc_call.return_value = [
+            [
+                ["task_123", "Slides", 8, None, 3]
+                + [None] * 11
+                + [[None, None, None, "https://slides.url/deck.pdf"]]
+            ]
+        ]
+
+        status = await api.poll_status("nb_123", "task_123")
+        assert status.status == "completed"
+        assert status.url == "https://slides.url/deck.pdf"
 
     @pytest.mark.asyncio
     async def test_poll_status_video_completed_without_url(self, mock_artifacts_api):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -143,6 +143,21 @@ class TestSource:
         assert source.title == "Nested Source"
         assert source.url == "https://example.com"
 
+    def test_from_api_response_nested_format_with_timestamp(self):
+        """Source.from_api_response should preserve creation timestamps when present."""
+        ts = 1704067200
+        data = [
+            [
+                ["src_ts"],
+                "Timestamped Source",
+                [None, None, [ts, 0], None, 5, None, None, ["https://example.com"]],
+            ]
+        ]
+        source = Source.from_api_response(data)
+
+        assert source.created_at is not None
+        assert source.created_at.timestamp() == ts
+
     def test_from_api_response_deeply_nested(self):
         """Test parsing deeply nested format."""
         data = [
@@ -461,6 +476,166 @@ class TestArtifact:
         assert artifact.created_at is not None
         assert artifact.created_at.timestamp() == ts
 
+    def test_from_api_response_audio_url(self):
+        """Completed audio artifacts expose their download URL."""
+        data = [
+            "art_audio",
+            "Audio",
+            1,
+            None,
+            3,
+            None,
+            [None, None, None, None, None, [["https://audio.example/file.mp4", None, "audio/mp4"]]],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://audio.example/file.mp4"
+
+    def test_from_api_response_video_url_prefers_mp4_quality(self):
+        """Video artifacts expose the preferred MP4 download URL."""
+        data = [
+            "art_video",
+            "Video",
+            3,
+            None,
+            3,
+            None,
+            None,
+            None,
+            [
+                [
+                    ["https://video.example/low.webm", 1, "video/webm"],
+                    ["https://video.example/high.mp4", 4, "video/mp4"],
+                ]
+            ],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://video.example/high.mp4"
+
+    def test_from_api_response_video_url_returns_last_mp4_when_no_quality_4(self):
+        """When no quality-4 MP4 is present, the last MP4 wins (documents the
+        implicit ordering used by both the extractor and download_video)."""
+        data = [
+            "art_video",
+            "Video",
+            3,
+            None,
+            3,
+            None,
+            None,
+            None,
+            [
+                [
+                    ["https://video.example/first.mp4", 2, "video/mp4"],
+                    ["https://video.example/middle.webm", 1, "video/webm"],
+                    ["https://video.example/last.mp4", 3, "video/mp4"],
+                ]
+            ],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://video.example/last.mp4"
+
+    def test_from_api_response_video_url_falls_back_to_first_non_mp4(self):
+        """With no MP4 in any variant, the first valid URL is returned."""
+        data = [
+            "art_video",
+            "Video",
+            3,
+            None,
+            3,
+            None,
+            None,
+            None,
+            [
+                [
+                    ["https://video.example/a.webm", 1, "video/webm"],
+                    ["https://video.example/b.webm", 2, "video/webm"],
+                ]
+            ],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://video.example/a.webm"
+
+    def test_from_api_response_audio_url_finds_mp4_at_non_zero_position(self):
+        """Audio extractor must find an audio/mp4 entry even when it is not the
+        first item in the media list — regression against the legacy
+        first-item-only check."""
+        data = [
+            "art_audio",
+            "Audio",
+            1,
+            None,
+            3,
+            None,
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                [
+                    ["https://audio.example/preview.bin", None, "application/octet-stream"],
+                    ["https://audio.example/file.mp4", None, "audio/mp4"],
+                ],
+            ],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://audio.example/file.mp4"
+
+    def test_from_api_response_audio_url_falls_back_to_first_url_when_no_mp4(self):
+        """If no audio/mp4 entry exists, the first valid URL is returned."""
+        data = [
+            "art_audio",
+            "Audio",
+            1,
+            None,
+            3,
+            None,
+            [
+                None,
+                None,
+                None,
+                None,
+                None,
+                [
+                    ["https://audio.example/a.ogg", None, "audio/ogg"],
+                    ["https://audio.example/b.wav", None, "audio/wav"],
+                ],
+            ],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://audio.example/a.ogg"
+
+    def test_from_api_response_infographic_url(self):
+        """Infographic artifacts expose their image URL."""
+        data = [
+            "art_info",
+            "Infographic",
+            7,
+            None,
+            3,
+            [None, None, [["ignored", ["https://image.example/info.png"]]]],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://image.example/info.png"
+
+    def test_from_api_response_slide_deck_url(self):
+        """Slide deck artifacts expose the PDF URL."""
+        data = (
+            ["art_slides", "Slides", 8, None, 3]
+            + [None] * 11
+            + [[None, None, None, "https://slides.example/deck.pdf"]]
+        )
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.url == "https://slides.example/deck.pdf"
+
     def test_from_api_response_with_variant(self):
         """Test parsing artifact with variant code (quiz/flashcards)."""
         data = ["art_quiz", "Quiz", 4, None, 3, None, None, None, None, [None, [2]]]
@@ -558,6 +733,58 @@ class TestArtifact:
         artifact = Artifact.from_api_response(["id", "Audio", 1, None, 3])
 
         assert artifact.report_subtype is None
+
+
+class TestExtractArtifactUrlMalformedShapes:
+    """Defensive coverage for the URL extractor helpers — every malformed-shape
+    branch must return ``None`` instead of raising, so callers (Artifact.url,
+    GenerationStatus.url, _is_media_ready, download_audio/video/infographic)
+    can rely on the helper as a single source of truth."""
+
+    def test_extract_artifact_url_unknown_type_returns_none(self):
+        from notebooklm.types import _extract_artifact_url
+
+        assert _extract_artifact_url(["any", "data"], None) is None
+        assert _extract_artifact_url(["any", "data"], 99) is None
+
+    def test_extract_audio_handles_short_or_non_list_data(self):
+        from notebooklm.types import _extract_audio_artifact_url
+
+        assert _extract_audio_artifact_url([1, 2, 3]) is None  # too short
+        assert _extract_audio_artifact_url([0] * 6 + ["not_a_list"]) is None  # data[6] not list
+        assert _extract_audio_artifact_url([0] * 6 + [[1, 2, 3]]) is None  # data[6] too short
+        assert _extract_audio_artifact_url([0] * 6 + [[0] * 5 + ["not_a_list"]]) is None
+        assert _extract_audio_artifact_url([0] * 6 + [[0] * 5 + [[]]]) is None  # empty media list
+
+    def test_extract_video_handles_short_or_non_list_data(self):
+        from notebooklm.types import _extract_video_artifact_url
+
+        assert _extract_video_artifact_url([1, 2, 3]) is None  # too short
+        assert _extract_video_artifact_url([0] * 8 + ["not_a_list"]) is None
+        assert _extract_video_artifact_url([0] * 8 + [[]]) is None  # empty data[8]
+        assert _extract_video_artifact_url([0] * 8 + [["not_a_list"]]) is None
+        assert _extract_video_artifact_url([0] * 8 + [[[None, None, "video/mp4"]]]) is None
+
+    def test_extract_infographic_handles_malformed_data(self):
+        from notebooklm.types import _extract_infographic_artifact_url
+
+        assert _extract_infographic_artifact_url([]) is None
+        assert _extract_infographic_artifact_url(["not_a_list"]) is None
+        assert _extract_infographic_artifact_url([[1]]) is None  # item too short
+        assert _extract_infographic_artifact_url([[1, 2, "not_a_list"]]) is None
+        assert _extract_infographic_artifact_url([[1, 2, []]]) is None  # empty content
+        assert _extract_infographic_artifact_url([[1, 2, [["only_one"]]]]) is None
+
+    def test_extract_slide_deck_handles_short_or_non_string_data(self):
+        from notebooklm.types import _extract_slide_deck_artifact_url
+
+        assert _extract_slide_deck_artifact_url([1, 2, 3]) is None  # too short
+        assert _extract_slide_deck_artifact_url([0] * 16 + ["not_a_list"]) is None
+        assert _extract_slide_deck_artifact_url([0] * 16 + [[1, 2, 3]]) is None  # too short
+        assert _extract_slide_deck_artifact_url([0] * 16 + [[None, None, None, 12345]]) is None
+        assert (
+            _extract_slide_deck_artifact_url([0] * 16 + [[None, None, None, "ftp://bad"]]) is None
+        )
 
 
 class TestArtifactKindProperty:


### PR DESCRIPTION
## Summary

API-surface audit (#349) — consolidates duplicated array-shape parsing into shared helpers in `types.py` and routes the API/RPC code through them so readiness checks, `Artifact.url`, `GenerationStatus.url`, and download paths agree on the same URL-selection contract.

### New helpers (`types.py`)
- `_extract_artifact_url` + per-type extractors (audio/video/infographic/slide_deck) with `mp4-quality-4 > any-mp4 > first-valid-URL` ordering.
- `_extract_source_created_at` for the `[seconds, nanoseconds]` timestamp pair.
- `_is_valid_artifact_url` for `http(s)` URL validation.

### Surfaced fields
- `Notebook.sources_count` — derived from `data[1]` (LIST and GET shapes).
- `Source.created_at` — populated in nested + deeply-nested response paths.
- `Artifact.url` — populated for media types. **Slide decks expose only the PDF URL**; PPTX is still fetched via `download_slide_deck(output_format="pptx")`.
- `GenerationStatus.url` — populated by `poll_status` for media types.

### Routing
- `download_audio`, `download_video`, `download_infographic` now delegate URL selection to `_extract_artifact_url`. The previous granular `ArtifactParseError` messages collapse to a single `"Could not extract download URL from artifact metadata"`.
- `_is_media_ready` / `_artifact_has_url` collapse to delegation.
- `SourcesAPI.get_fulltext` uses `_extract_source_url(allow_bare_http=False)`, fixing **YouTube fulltext URL extraction** (URL at `metadata[5][0]` was previously missed).
- `_is_valid_media_url` and `_find_infographic_url` remain as thin shims for backward test-surface compatibility.

## Why

Before this PR, `_is_media_ready` (used by `wait_for_completion`) and `download_audio` / `download_video` parsed the same nested array shapes independently. They could disagree — readiness reporting "ready" while download raised `ArtifactDownloadError`, or vice versa. `Artifact.url` and `GenerationStatus.url` were also unset, so callers had no way to inspect the download URL without invoking `download_*`. Single source of truth removes that whole class of contract bug and makes the URL inspectable up-front.

## Test plan
- [x] `pytest -q` — 2275 passed, 9 skipped (was 2262 on `main`; +13 new tests)
- [x] `ruff format src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/notebooklm --ignore-missing-imports` — clean
- [x] Audio/video URL ladder coverage (last-mp4-wins, first-non-mp4 fallback, mp4-at-non-zero-position, no-mp4 fallback)
- [x] Defensive malformed-shape tests for all four URL extractors
- [x] `GET_NOTEBOOK` `sources_count` regression test pinned to a real-cassette shape (2-PDF response from `tests/cassettes/notebooks_get.yaml`)
- [x] YouTube fulltext URL regression test (`metadata[5][0]`)
- [x] `GenerationStatus.url` tests for video, infographic, slide-deck `poll_status`
- [x] Deeply-nested `Source.created_at` parsing test

## Behavior changes worth flagging on review

1. **Audio readiness is more lenient.** The old `_is_media_ready` only inspected `media_list[0]` for audio; the new helper searches the whole list for `audio/mp4`. Real-world impact: completed audio with the mp4 entry not at position 0 is now correctly recognized as ready.
2. **`download_audio` / `download_video` exception messages** consolidate to one `"Could not extract download URL from artifact metadata"` (still `ArtifactParseError`). Two existing test message-matchers updated.
3. **Video URL fallback ladder is now explicit and tested.** The "last MP4 wins when no quality-4 MP4 exists" behavior matches the old `download_video`; pinned by `test_from_api_response_video_url_returns_last_mp4_when_no_quality_4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebooks now include `sources_count` field indicating the number of sources.
  * Status polling now returns the media download URL for generated artifacts.

* **Bug Fixes**
  * Improved reliability of media URL extraction for audio, video, infographic, and slide-deck downloads.
  * Enhanced error messaging for media extraction failures.
  * Strengthened source metadata parsing for timestamps and URLs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/356)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->