### PR TITLE
fix(types): harden timestamp parsing

### DIFF
--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -295,6 +295,14 @@ def _extract_source_url(metadata: Any, *, allow_bare_http: bool = True) -> str |
     return url
 
 
+def _datetime_from_timestamp(value: Any) -> datetime | None:
+    """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
+    try:
+        return datetime.fromtimestamp(value)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
 def _extract_source_created_at(metadata: Any) -> datetime | None:
     """Extract a source creation timestamp from a ``src[2]`` metadata array."""
     if not isinstance(metadata, list) or len(metadata) <= 2:
@@ -304,10 +312,7 @@ def _extract_source_created_at(metadata: Any) -> datetime | None:
     if not isinstance(timestamp_list, list) or not timestamp_list:
         return None
 
-    try:
-        return datetime.fromtimestamp(timestamp_list[0])
-    except (TypeError, ValueError):
-        return None
+    return _datetime_from_timestamp(timestamp_list[0])
 
 
 def _is_valid_artifact_url(value: Any) -> bool:
@@ -550,10 +555,7 @@ class Notebook:
         if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 5:
             ts_data = data[5][5]
             if isinstance(ts_data, list) and len(ts_data) > 0:
-                try:
-                    created_at = datetime.fromtimestamp(ts_data[0])
-                except (TypeError, ValueError):
-                    pass
+                created_at = _datetime_from_timestamp(ts_data[0])
 
         # Extract ownership - data[5][1] = False means owner, True means shared
         is_owner = True
@@ -990,10 +992,7 @@ class Artifact:
         # Extract timestamp from data[15][0]
         created_at = None
         if len(data) > 15 and isinstance(data[15], list) and len(data[15]) > 0:
-            try:
-                created_at = datetime.fromtimestamp(data[15][0])
-            except (TypeError, ValueError):
-                pass
+            created_at = _datetime_from_timestamp(data[15][0])
 
         # Extract variant code from data[9][1][0] for quiz/flashcard distinction
         variant = None
@@ -1057,10 +1056,7 @@ class Artifact:
             if len(inner) > 2 and isinstance(inner[2], list) and len(inner[2]) > 2:
                 ts_data = inner[2][2]
                 if isinstance(ts_data, list) and len(ts_data) > 0:
-                    try:
-                        created_at = datetime.fromtimestamp(ts_data[0])
-                    except (TypeError, ValueError):
-                        pass
+                    created_at = _datetime_from_timestamp(ts_data[0])
 
         return cls(
             id=str(mind_map_id),
@@ -1265,10 +1261,7 @@ class Note:
 
         created_at = None
         if len(data) > 3 and isinstance(data[3], list) and len(data[3]) > 0:
-            try:
-                created_at = datetime.fromtimestamp(data[3][0])
-            except (TypeError, ValueError):
-                pass
+            created_at = _datetime_from_timestamp(data[3][0])
 
         return cls(
             id=str(note_id),

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,6 +1,7 @@
 """Unit tests for types module dataclasses and parsing."""
 
 import warnings
+from unittest.mock import patch
 
 import pytest
 
@@ -21,6 +22,35 @@ from notebooklm.types import (
     SourceType,
     UnknownTypeWarning,
 )
+
+
+class TestTimestampParsing:
+    def test_datetime_from_timestamp_valid_value(self):
+        """Timestamp helper should preserve valid epoch-second values."""
+        from notebooklm.types import _datetime_from_timestamp
+
+        ts = 1704067200
+        parsed = _datetime_from_timestamp(ts)
+
+        assert parsed is not None
+        assert parsed.timestamp() == ts
+
+    def test_datetime_from_timestamp_oserror(self):
+        """Platform-specific timestamp errors should normalize to None."""
+        from notebooklm.types import _datetime_from_timestamp
+
+        with patch("notebooklm.types.datetime") as mock_datetime:
+            mock_datetime.fromtimestamp.side_effect = OSError("timestamp out of range")
+            parsed = _datetime_from_timestamp(1704067200)
+
+        assert parsed is None
+
+    @pytest.mark.parametrize("value", ["bad", None, float("inf"), float("-inf")])
+    def test_datetime_from_timestamp_invalid_value(self, value):
+        """Invalid or out-of-range timestamp values should normalize to None."""
+        from notebooklm.types import _datetime_from_timestamp
+
+        assert _datetime_from_timestamp(value) is None
 
 
 class TestNotebook:
@@ -110,6 +140,22 @@ class TestNotebook:
 
         assert notebook.created_at is None
 
+    def test_from_api_response_out_of_range_timestamp(self):
+        """Platform timestamp range errors should not escape notebook parsing."""
+        data = [
+            "Notebook",
+            [],
+            "nb_123",
+            "📓",
+            None,
+            [None, None, None, None, None, [1704067200, 0]],
+        ]
+
+        data[5][5][0] = float("inf")
+        notebook = Notebook.from_api_response(data)
+
+        assert notebook.created_at is None
+
     def test_from_api_response_non_string_title(self):
         """Test parsing when title is not a string."""
         data = [123, [], "nb_123", "📓"]
@@ -157,6 +203,21 @@ class TestSource:
 
         assert source.created_at is not None
         assert source.created_at.timestamp() == ts
+
+    def test_from_api_response_nested_format_out_of_range_timestamp(self):
+        """Source timestamp range errors should produce None rather than raising."""
+        data = [
+            [
+                ["src_ts"],
+                "Timestamped Source",
+                [None, None, [1704067200, 0], None, 5, None, None, ["https://example.com"]],
+            ]
+        ]
+
+        data[0][2][2][0] = float("inf")
+        source = Source.from_api_response(data)
+
+        assert source.created_at is None
 
     def test_from_api_response_deeply_nested(self):
         """Test parsing deeply nested format."""
@@ -475,6 +536,47 @@ class TestArtifact:
 
         assert artifact.created_at is not None
         assert artifact.created_at.timestamp() == ts
+
+    def test_from_api_response_out_of_range_timestamp(self):
+        """Artifact timestamp range errors should produce None rather than raising."""
+        data = [
+            "art_123",
+            "Audio",
+            1,
+            None,
+            3,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            [float("inf")],
+        ]
+        artifact = Artifact.from_api_response(data)
+
+        assert artifact.created_at is None
+
+    def test_from_mind_map_out_of_range_timestamp(self):
+        """Mind map timestamp range errors should produce None rather than raising."""
+        data = [
+            "mind_map_123",
+            [
+                "mind_map_123",
+                "{}",
+                [1, "user_id", [float("inf"), 0]],
+                None,
+                "Mind Map",
+            ],
+        ]
+        artifact = Artifact.from_mind_map(data)
+
+        assert artifact is not None
+        assert artifact.created_at is None
 
     def test_from_api_response_audio_url(self):
         """Completed audio artifacts expose their download URL."""
@@ -1011,6 +1113,13 @@ class TestNote:
 
         assert note.created_at is not None
         assert note.created_at.timestamp() == ts
+
+    def test_from_api_response_out_of_range_timestamp(self):
+        """Note timestamp range errors should produce None rather than raising."""
+        data = ["note_123", "Title", "Content", [float("inf")]]
+        note = Note.from_api_response(data, "nb_123")
+
+        assert note.created_at is None
 
     def test_from_api_response_empty(self):
         """Test parsing with minimal data."""


### PR DESCRIPTION
## Summary
- centralize timestamp conversion behind a helper that returns None for invalid or out-of-range values
- route Notebook, Source, Artifact, mind map, and Note parsing through the helper
- add direct helper coverage plus call-site tests for out-of-range timestamps
- completes the timestamp-hardening portion of #354; fixture-backed sources_count coverage landed in #356

## Test plan
- [x] PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/unit/test_types.py tests/integration/test_notebooks.py tests/integration/test_sources.py -p no:cacheprovider
- [x] PYTHONPATH=src uv run ruff check src/notebooklm/types.py tests/unit/test_types.py tests/integration/test_notebooks.py tests/integration/test_sources.py --cache-dir /tmp/ruff-issue-354
- [x] PYTHONPATH=src uv run ruff format --check src/notebooklm/types.py tests/unit/test_types.py
- [x] PYTHONPATH=src uv run mypy src/notebooklm --cache-dir=/tmp/mypy-issue-354

Fixes #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of timestamp parsing to handle invalid or out-of-range values gracefully.

* **Tests**
  * Added comprehensive test coverage for timestamp parsing edge cases and error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/357)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->