### PR TITLE
refactor(artifacts): remove media URL shim methods

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -51,8 +51,6 @@ from .types import (
     GenerationStatus,
     ReportSuggestion,
     _extract_artifact_url,
-    _extract_infographic_artifact_url,
-    _is_valid_artifact_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -2301,14 +2299,6 @@ class ArtifactsAPI:
             return ArtifactTypeCode(artifact_type).name
         except ValueError:
             return str(artifact_type)
-
-    def _is_valid_media_url(self, value: Any) -> bool:
-        """Check if value is a valid HTTP(S) URL."""
-        return _is_valid_artifact_url(value)
-
-    def _find_infographic_url(self, art: builtins.list[Any]) -> str | None:
-        """Extract infographic image URL from artifact data."""
-        return _extract_infographic_artifact_url(art)
 
     def _is_media_ready(self, art: builtins.list[Any], artifact_type: int) -> bool:
         """Check if media artifact has URLs populated.

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -380,50 +380,6 @@ class TestDeprecationWarnings:
 # =============================================================================
 
 
-class TestIsValidMediaUrl:
-    """Test _is_valid_media_url helper method."""
-
-    def test_valid_https_url(self, mock_artifacts_api):
-        """Test that valid HTTPS URL returns True."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url("https://example.com/audio.mp3") is True
-
-    def test_valid_http_url(self, mock_artifacts_api):
-        """Test that valid HTTP URL returns True."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url("http://example.com/video.mp4") is True
-
-    def test_invalid_string_no_protocol(self, mock_artifacts_api):
-        """Test that string without http(s) returns False."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url("example.com/audio.mp3") is False
-
-    def test_invalid_ftp_url(self, mock_artifacts_api):
-        """Test that FTP URL returns False."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url("ftp://example.com/file.mp3") is False
-
-    def test_empty_string(self, mock_artifacts_api):
-        """Test that empty string returns False."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url("") is False
-
-    def test_none_value(self, mock_artifacts_api):
-        """Test that None returns False."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url(None) is False
-
-    def test_integer_value(self, mock_artifacts_api):
-        """Test that integer returns False."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url(123) is False
-
-    def test_list_value(self, mock_artifacts_api):
-        """Test that list returns False."""
-        api, _ = mock_artifacts_api
-        assert api._is_valid_media_url(["https://example.com"]) is False
-
-
 class TestIsMediaReady:
     """Test _is_media_ready helper method."""
 
@@ -531,10 +487,9 @@ class TestIsMediaReady:
         """Regression for issue #330: pre-URL metadata must not register as ready.
 
         Before the URL is populated, the inner URL-entry list is empty (or
-        missing the URL string). The previous implementation passed this list
-        to ``_is_valid_media_url`` directly and got ``False`` by accident,
-        which masked the broken structural check. Verify the empty-inner-list
-        case explicitly.
+        missing the URL string). Verify the empty-inner-list case explicitly so
+        readiness depends on the URL-entry structure rather than accidental
+        validation failure.
         """
         api, _ = mock_artifacts_api
         art = [
@@ -598,7 +553,7 @@ class TestIsMediaReady:
     def test_infographic_with_valid_url(self, mock_artifacts_api):
         """Test infographic artifact with valid URL returns True.
 
-        The _find_infographic_url method iterates backwards through art, looking for:
+        The shared infographic extractor scans artifact entries looking for:
         - item[2] = non-empty list (content)
         - item[2][0] = list with len > 1 (first_content)
         - item[2][0][1] = non-empty list (img_data)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -20,7 +20,28 @@ from notebooklm.types import (
     SourceFulltext,
     SourceType,
     UnknownTypeWarning,
+    _is_valid_artifact_url,
 )
+
+
+class TestArtifactUrlValidation:
+    """Test the canonical artifact URL validation helper."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("https://example.com/audio.mp3", True),
+            ("http://example.com/video.mp4", True),
+            ("example.com/audio.mp3", False),
+            ("ftp://example.com/file.mp3", False),
+            ("", False),
+            (None, False),
+            (123, False),
+            (["https://example.com"], False),
+        ],
+    )
+    def test_url_validation(self, value, expected):
+        assert _is_valid_artifact_url(value) is expected
 
 
 class TestNotebook:


### PR DESCRIPTION
## Summary
- remove private ArtifactsAPI media URL pass-through shims
- port URL validation coverage to the canonical helper in the types test suite
- update stale readiness-test wording after shim removal

## Test plan
- [x] PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/unit/test_artifacts_coverage.py tests/unit/test_types.py tests/integration/test_artifacts.py -p no:cacheprovider
- [x] PYTHONPATH=src uv run ruff check src/notebooklm/_artifacts.py tests/unit/test_artifacts_coverage.py tests/unit/test_types.py --cache-dir /tmp/ruff-issue-355
- [x] PYTHONPATH=src uv run ruff format --check src/notebooklm/_artifacts.py tests/unit/test_artifacts_coverage.py tests/unit/test_types.py
- [x] PYTHONPATH=src uv run mypy src/notebooklm --cache-dir=/tmp/mypy-issue-355

Fixes #355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized media readiness checks so audio, video, infographics, and slide decks are considered ready only when their URLs are available; removed redundant URL extraction/validation helpers.

* **Tests**
  * Added focused URL-validation tests and updated media-readiness scenarios; removed obsolete media-URL test class and clarified related test comments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/358)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->