### PR TITLE
feat(auth): extend ALLOWED_COOKIE_DOMAINS for sibling Google products

### DIFF
--- a/docs/auth-keepalive.md
+++ b/docs/auth-keepalive.md
@@ -1,0 +1,1335 @@
+# Auth keepalive — design notes and field findings
+
+> **Status:** design notes for the L1/L2/L3 keepalive code already in `main`
+> (L1 `RotateCookies` POST + 60 s mtime guard merged via
+> [#346](https://github.com/teng-lin/notebooklm-py/pull/346); concurrent-poke
+> throttling via [#348](https://github.com/teng-lin/notebooklm-py/pull/348);
+> L2 background task via
+> [#341](https://github.com/teng-lin/notebooklm-py/pull/341); L3
+> `notebooklm auth refresh` CLI shipped) plus the L5/L6 escalation paths that
+> are still proposed. Reflects empirical observations from a multi-hour A/B/C
+> field experiment in May 2026 and cross-project review of two ecosystem peers
+> ([HanaokaYuzu/Gemini-API](https://github.com/HanaokaYuzu/Gemini-API) and
+> [easychen/CookieCloud](https://github.com/easychen/CookieCloud)). Update as
+> the threat model evolves; flag stale claims with `<!-- stale: <date> -->`.
+
+## TL;DR
+
+NotebookLM has no public OAuth surface. The library authenticates by carrying
+Google session cookies (`SID`, `__Secure-1PSID`, `__Secure-1PSIDTS`, `OSID`,
+and friends) extracted from a real browser sign-in. Two clocks govern how long
+those cookies stay valid:
+
+- **`__Secure-1PSIDTS` rotates ~every 10 minutes server-side.** Without an
+  active rotation refresh, `*PSIDTS` ages out and every subsequent RPC call
+  fails with `Authentication expired or invalid` (issue
+  [#312](https://github.com/teng-lin/notebooklm-py/issues/312)).
+- **`SID` and `__Secure-1PSID`** have very long server-side lifetimes (months
+  to years for daily-active accounts) and effectively don't expire under
+  normal usage as long as Google sees periodic activity.
+
+A long-lived client must therefore drive `*PSIDTS` rotation itself. Empirically
+the cleanest mechanism is a direct `POST` to
+`https://accounts.google.com/RotateCookies` — Google's dedicated unsigned
+rotation endpoint. This is the L1 primitive at the bottom of a tiered
+recovery design that escalates progressively as failure modes get harder.
+
+The headline tradeoffs:
+
+| Layer | Mechanism | Cost | Survives DBSC? | Ship status |
+|---|---|---|---|---|
+| **L1** | Per-call `RotateCookies` POST + triple-guard throttle | ~150 ms / call (skipped if recently rotated) | No, but DBSC isn't enforced on this path today | Merged ([#346](https://github.com/teng-lin/notebooklm-py/pull/346) + [#348](https://github.com/teng-lin/notebooklm-py/pull/348)) |
+| **L2** | Background `keepalive=N` task | One POST every N s | Same as L1 | Merged ([#341](https://github.com/teng-lin/notebooklm-py/pull/341), races closed in [#342](https://github.com/teng-lin/notebooklm-py/pull/342)–[#344](https://github.com/teng-lin/notebooklm-py/pull/344)) |
+| **L3** | OS-scheduled `notebooklm auth refresh` | One POST per cron tick | Same as L1 | Merged (`auth refresh` subcommand) |
+| **L4** | `--browser-cookies <browser>` re-extract via rookiepy | One sqlite read + L1 POST | Yes (non-Chrome browsers not DBSC-enrolled) | Already supported (~16 browsers; Firefox is the recommended Windows path) |
+| **L5** | CDP-attach to user's running Chrome | Higher; needs Chrome on `:9222` | **Yes** (inherits Chrome's TPM-bound key) | Proposed; deferred until L1 weakens |
+| **L6** | CookieCloud client (browser extension + self-hosted server) | User infra; richest UX | **Yes** | Optional follow-up |
+
+A separate, complementary refresh hook also lives in the codebase:
+``NOTEBOOKLM_REFRESH_CMD`` ([#336](https://github.com/teng-lin/notebooklm-py/pull/336))
+runs an arbitrary user-supplied shell command on auth-expiry signals (the
+"`Authentication expired`" redirect), then retries token fetch once. It's
+orthogonal to L1–L3 — those proactively keep `*PSIDTS` fresh, while
+`NOTEBOOKLM_REFRESH_CMD` is the reactive "we lost the session anyway, run
+my recovery script" lever. See §9 below.
+
+L1 is empirically working today on every account type tested. L4 is the
+recommended unattended path for `notebooklm-py` users in May 2026. L5 is
+specified but not implemented; it's the durability insurance for the day
+Google extends DBSC enforcement to non-Chrome cookie paths.
+
+---
+
+## 1 · Problem statement
+
+NotebookLM uses Google's internal `batchexecute` RPC. There is no documented
+API key, no OAuth scope, no service account path. Every project that
+automates NotebookLM does so with **scraped session cookies** from a logged-in
+browser. The library exposes those via `notebooklm login` (Playwright-driven
+Google sign-in into a private Chromium profile) and
+`notebooklm login --browser-cookies <browser>` (rookiepy-driven extraction
+from an existing Chrome/Firefox/Edge profile).
+
+Both produce a `storage_state.json` file with the cookie set the library uses
+to authenticate every subsequent RPC. The keepalive question is: **what
+keeps `storage_state.json` valid as time passes between user-driven
+re-authentications?**
+
+The naïve answer ("cookies have expiry timestamps; trust them") is wrong on
+two counts:
+
+1. The most consequential auth cookie (`__Secure-1PSIDTS`) has an **explicit
+   server-side TTL of ~10 minutes** that's not encoded in the cookie's
+   `Expires` attribute. The on-disk `Expires` field is irrelevant to its
+   server-side validity.
+2. Even cookies with a year-long `Expires` will be **revoked early by Google's
+   risk model** if the access pattern looks unusual (no JS execution, no
+   browser fingerprint, IP changes, long inactivity gaps).
+
+So the library must actively refresh.
+
+---
+
+## 2 · Background: Google session auth, rotation, and DBSC
+
+This section establishes the vocabulary the rest of the doc uses. Skip
+ahead to §3 if you've already spent time inside Google's identity surface.
+
+### 2.1 The cookie taxonomy
+
+Google authenticates a browser session with a **family of ~15 cookies**,
+not a single bearer token. Each cookie has a distinct role; the family
+is designed so revoking or rotating any one slot doesn't invalidate the
+others. The cookie set is shared across `*.google.com` properties —
+Search, Drive, Gmail, NotebookLM, YouTube, Workspace — which is why a
+sign-in to any one of them produces auth artifacts the rest of the
+ecosystem will accept.
+
+Naming conventions:
+
+- **`__Secure-` prefix.** A browser-enforced rule: the cookie's `Secure`
+  attribute must be set, so it's never transmitted over plaintext HTTP.
+  Google sets this on every meaningful auth cookie.
+- **`__Host-` prefix.** Stricter than `__Secure-`. The cookie must also
+  set `Path=/`, must not set `Domain=` (so it's pinned to the exact
+  origin that issued it), and must be `Secure`. Used for the most
+  scope-sensitive cookies (`__Host-GAPS`, `__Host-1PLSID`, …).
+- **`1P` vs `3P`.** First-party vs third-party context. `__Secure-1PSID`
+  is the SID Google uses when the request originates from a
+  `*.google.com` page; `__Secure-3PSID` is the variant Google sends on
+  third-party pages that embed Google content (sign-in widgets, fonts
+  referers, …). They rotate independently and have slightly different
+  scopes. We typically need both because intermediate redirects during
+  rotation cross the 1P/3P boundary.
+- **`*SID` / `*SIDTS` / `*SIDCC`.** Three different cookie *families*,
+  not variants of one cookie. They cooperate to separate **identity** —
+  who you are, slow to change — from **freshness** — you're using the
+  session right now, fast to expire:
+
+  | Family | Role | Server-side TTL |
+  |---|---|---|
+  | `*SID` (also `HSID`, `SSID`, `APISID`, `SAPISID`, …) | Long-lived identity ("user X, session Y") | Months → ~1 year |
+  | `*SIDTS` (`__Secure-1PSIDTS`, `__Secure-3PSIDTS`) | Rotating freshness partner of `*SID` | **~10 min** |
+  | `*SIDCC` (`SIDCC`, `__Secure-1PSIDCC`, `__Secure-3PSIDCC`) | Per-request "session continuity check" | ~5 min sliding window |
+
+A few cookies sit outside this taxonomy:
+
+- **`OSID`, `__Secure-OSID`** — per-product session, set on
+  `notebooklm.google.com` and `myaccount.google.com`. Re-issued on each
+  sign-in; refreshes during normal product use.
+- **`LSID`, `__Host-1PLSID`, `__Host-3PLSID`** — identity-service
+  cookies on `accounts.google.com` itself. Long-lived.
+- **`__Host-GAPS`** — anti-takeover binding cookie. Long-lived; presence
+  is part of how Google detects suspicious cross-device session reuse.
+
+The library treats all of these uniformly: extract the full set at
+sign-in, persist them in `storage_state.json`, replay them on every
+RPC. `_is_allowed_cookie_domain` (in `auth.py`) is the gate that decides
+which Set-Cookie headers from a redirect chain are worth keeping; it
+matches against `ALLOWED_COOKIE_DOMAINS` plus the regional
+`google.<cctld>` set.
+
+### 2.2 How cookie rotation works
+
+"Rotation" here means: the server periodically issues a new value for a
+short-lived cookie (`Set-Cookie: __Secure-1PSIDTS=<fresh>; …`), and the
+browser is expected to overwrite its on-disk copy. If the browser falls
+behind, the server eventually stops accepting the old value and the
+session is dead until the user signs in again.
+
+Two clocks run in parallel:
+
+- The **identity clock** (`*SID`) ticks in months. Google extends it
+  silently as long as it sees activity; for a daily-active user it
+  effectively never expires.
+- The **freshness clock** (`*PSIDTS`) ticks in **~10 minute** intervals.
+  The server self-reports the cadence in the `RotateCookies` response
+  body as `["identity.hfcr",600]` (`hfcr` = "high-frequency cookie
+  rotation"; `600` = seconds). Every active browser must hit an
+  identity surface roughly that often, or `*PSIDTS` ages out and every
+  subsequent RPC fails with a redirect to
+  `accounts.google.com/v3/signin/...`.
+
+Server-driven, not client-driven: the client posts to a rotation
+endpoint, the server inspects the existing `*SID` (and optionally a
+DBSC proof — see §2.3), and if everything checks out it returns a fresh
+`*PSIDTS` in `Set-Cookie`. The client only chooses *when* to fire the
+rotation; the cadence is the server's call.
+
+> **Has Google shortened the 600 s cadence?** As of May 2026, no public
+> evidence suggests so. Gemini-API still defaults
+> `refresh_interval=600` ([source](https://github.com/HanaokaYuzu/Gemini-API/blob/master/src/gemini_webapi/utils/rotate_1psidts.py)),
+> the `["identity.hfcr",600]` self-report is unchanged in field
+> captures, and recent
+> [Gemini-API#319](https://github.com/HanaokaYuzu/Gemini-API/issues/319) /
+> [#203](https://github.com/HanaokaYuzu/Gemini-API/issues/203) reports
+> attribute "cookies expire after a few hours" to refresh-mechanism
+> failure (SID-class aging out once freshness rotation has stalled
+> entirely), not to a server-side TTL reduction.
+
+**Crucially: pure RPC traffic against `notebooklm.google.com` does not
+trigger rotation.** NotebookLM's `batchexecute` endpoint accepts the
+existing cookies and serves the request, but Google only mints a fresh
+`*PSIDTS` when something talks to the *identity* surface
+(`accounts.google.com`, `accounts.youtube.com/SetSID`, the NotebookLM
+homepage GET). A long-lived client that only calls `batchexecute` will
+silently drift past the rotation window and start failing. This is
+exactly the failure mode that motivates L1/L2/L3.
+
+Several identity surfaces *can* trigger rotation when touched:
+`accounts.google.com/CheckCookie`, `accounts.youtube.com/SetSID`, the
+NotebookLM homepage redirect chain, and the dedicated `RotateCookies`
+POST. We picked `RotateCookies` because it's the only one that rotates
+deterministically for both browser-bound and Firefox-extracted sessions
+(see §5.4).
+
+### 2.3 Device-Bound Session Credentials (DBSC)
+
+DBSC is Google's response to **infostealer cookie theft**: malware
+exfiltrates the cookie jar from a victim's machine, ships it to a
+remote attacker, who then replays the cookies from a different machine
+and inherits the victim's session. Until DBSC, the only practical
+defenses were Google's risk heuristics (new IP, no fingerprint,
+suspicious cadence) — useful but fundamentally guess-work.
+
+DBSC binds a session to **a private key that lives in tamper-resistant
+hardware** on the original device. The shape of the protocol:
+
+1. **At sign-in**, the browser generates a keypair *inside* a TPM (on
+   Windows) or the platform-attestation chain equivalent (Secure
+   Enclave on macOS, Strongbox on Android). The private key is
+   non-extractable by design — the OS will only sign things with it on
+   behalf of the calling process.
+2. The browser **registers the public key** with Google as part of the
+   sign-in flow. Google associates the public key with the new session.
+3. On every subsequent rotation, Google issues a **server-generated
+   nonce**. The browser **signs the nonce** with the TPM-bound private
+   key and sends the signature alongside the rotation request.
+4. Google validates the signature against the registered public key
+   before issuing fresh cookies. No valid signature → no rotation.
+
+The endpoint that enforces this is
+**`accounts.google.com/RotateBoundCookies`** — the bound-cookie analog
+of the unsigned `RotateCookies` we currently use. It returns rotated
+cookies only if the signature checks out.
+
+The protective property: an attacker who exfiltrates the cookie jar
+gets nothing time-limited. Within ~10 minutes the freshness cookie ages
+out, the attacker can't sign the next rotation, and the stolen session
+is dead.
+
+The [W3C DBSC spec](https://w3c.github.io/webappsec-dbsc/) is
+**deliberately structured** so that only browsers with hardware key
+attestation can implement it. There's no extension point a Python HTTP
+client could fulfill: even with TPM access (which Python doesn't have
+on any platform out of the box), Chrome additionally proves *integrity
+of the calling process* via platform attestation chains. This is why
+§7.4 calls a client-side DBSC implementation impossible.
+
+The current rollout (April 2026, Chrome 146 GA Windows) only enforces
+DBSC against **Chrome itself** — i.e. Chrome refuses to use cookies
+that weren't bound at sign-in, even on the same machine. Non-Chrome
+HTTP clients (httpx, curl, Firefox) can still hit the legacy unsigned
+`RotateCookies` endpoint without a DBSC proof. The day Google extends
+enforcement to that endpoint, every L1–L3 strategy in this document
+breaks at the same time, and the only escape is to parasitize a real
+DBSC-enrolled Chrome session (L5 / L6).
+
+### 2.4 How browser cookie extraction works (the L4 dependency)
+
+L4 (`notebooklm login --browser-cookies <browser>`) reads cookies
+directly out of an installed browser's profile rather than minting
+fresh ones via Playwright. Faster, doesn't require user interaction,
+and — for Firefox — produces a cookie set the unsigned `RotateCookies`
+endpoint accepts indefinitely. Some background on why this is harder
+than it sounds:
+
+- **Browsers store cookies in encrypted SQLite databases.** Chrome
+  keeps them in
+  `~/Library/Application Support/Google/Chrome/Default/Network/Cookies`
+  (macOS) and equivalents on other OSes; Firefox uses `cookies.sqlite`.
+  The schema is straightforward, but cookie *values* are encrypted at
+  rest.
+- **The encryption key lives in the OS credential store.** Chrome's
+  cookie key is held in Keychain under "Chrome Safe Storage" on macOS,
+  protected by DPAPI on Windows, and stored via libsecret/kwallet on
+  Linux. Reading cookies = reading the key from the OS store +
+  decrypting with AES-GCM.
+- **Chrome 127+ adds App-Bound Encryption (ABE).** A second layer where
+  the *value* is re-encrypted with a key bound to Chrome's signed
+  binary, rotated at every Chrome launch. This was added specifically
+  to defeat infostealers reading the SQLite + keychain in user space.
+  Reading ABE-encrypted cookies requires either (a) running as the
+  same signed binary, or (b) a Windows-admin / kernel-level bypass.
+- **`browser_cookie3` (the ecosystem default) does not handle ABE.**
+  As of May 2026, it returns garbage for Chrome cookies on Windows and
+  silently-incomplete data on macOS.
+- **`rookiepy` claims ABE support** but in practice requires admin
+  privileges from Chrome 130+ on Windows
+  ([rookie#50](https://github.com/thewh1teagle/rookie/issues/50)).
+- **Firefox doesn't have ABE.** Mozilla's threat model treats local
+  attackers (anything reading the user's home dir) as out-of-scope, so
+  Firefox cookies remain readable by any user-space process with file
+  access. This is what makes Firefox the recommended unattended option
+  in §8.3.
+
+The library uses `rookiepy` (Rust extension with a Python binding)
+rather than implementing extraction itself. `rookiepy` covers ~16
+browsers across all three platforms; `_ROOKIEPY_BROWSER_ALIASES` in
+`cli/session.py` maps user-facing names (`firefox`, `arc`, `vivaldi`,
+…) to its functions, and `convert_rookiepy_cookies_to_storage_state`
+in `auth.py` reshapes the result into a Playwright-compatible
+`storage_state.json`. From the rest of the codebase's perspective,
+browser-extracted cookies are indistinguishable from Playwright-minted
+ones.
+
+A note on cookie-jar fidelity: Google's set spans multiple domains
+(`.google.com`, `.accounts.google.com`, regional ccTLDs like
+`.google.co.uk`, plus `.notebooklm.google.com`). When extracting we ask
+for all of them — `_login_with_browser_cookies` builds the `domains`
+list from `ALLOWED_COOKIE_DOMAINS + GOOGLE_REGIONAL_CCTLDS` — because
+dropping any one silently breaks specific code paths (e.g. losing
+`.notebooklm.google.com`-scoped cookies breaks artifact downloads).
+
+### 2.5 Three timers people confuse
+
+When reading code or issue threads, distinguish:
+
+| Timer | Magnitude | Lives in | Meaning |
+|---|---|---|---|
+| **`*PSIDTS` server-side TTL** | ~600 s (10 min) | Google's identity surface | After this, Google rejects the cookie value. Self-reported as `["identity.hfcr",600]`. |
+| **`*SIDCC` sliding window** | ~5 min | Google's RPC surface | Different cookie family. Rotates on nearly every request; not load-bearing for our auth. |
+| **Client-side rotation throttle** | 60 s | Our `auth.py` and Gemini-API's `rotate_1psidts.py` | Don't fire two `RotateCookies` POSTs within a minute. Avoids 429. Has nothing to do with how often Google *requires* rotation. |
+
+Reports that "cookies are expiring faster" usually trace to either the
+session entering a risk-flagged state (§3.2) or to the rotation
+mechanism failing for hours and `*SID` finally aging out — not to a
+shorter server-side TTL.
+
+---
+
+## 3 · Threat model
+
+### 3.1 Cookie classes and their decay clocks
+
+| Cookie | Server-side TTL | Lifecycle |
+|---|---|---|
+| `__Secure-1PSIDTS` (and `*-3PSIDTS`) | ~10 min, declared by Google in `RotateCookies` response body as `[["identity.hfcr",600],...]` | Designed to be rotated frequently; the canonical "rotating freshness partner" of `*PSID` |
+| `SIDCC`, `__Secure-1PSIDCC`, `__Secure-3PSIDCC` | ~5 min sliding window | Rotates on nearly every request to Google; ephemeral, generally not load-bearing for auth |
+| `SID`, `HSID`, `SSID`, `APISID`, `SAPISID` | Months to ~1 year (issued `Max-Age`) | Long-lived identity; rotated by Chrome periodically through normal browsing but not by us |
+| `__Secure-1PSID`, `__Secure-3PSID`, `__Secure-1PAPISID`, `__Secure-3PAPISID` | Same as above, "Secure" cousins | Same lifecycle |
+| `OSID`, `__Secure-OSID` | Per-product session cookie set on `notebooklm.google.com` and `myaccount.google.com` | Re-issued on each sign-in; refreshes during normal product use |
+| `LSID`, `__Host-1PLSID`, `__Host-3PLSID` | Long-lived | Identity service cookies on `accounts.google.com` |
+| `__Host-GAPS` | Long-lived | Anti-takeover binding cookie |
+
+### 3.2 What kills a session in practice
+
+In rough order of likelihood:
+
+1. **`*PSIDTS` rotation drift.** Cookies on disk become stale because nothing
+   rotates them. Any RPC after the ~10–30 min grace period fails with a
+   redirect to `accounts.google.com/v3/signin/...`. **This is the dominant
+   failure mode for unattended use.**
+2. **Risk-scored revalidation.** Google flags the access pattern (new IP,
+   no fingerprint, suspicious cadence, geography mismatch) and forces full
+   re-auth. Less predictable; happens days-to-weeks into a long-running
+   deployment.
+3. **Password change or manual sign-out** anywhere — invalidates all
+   sessions instantly.
+4. **Workspace policy timeouts.** Some org admins enforce 8h/30d re-auth
+   intervals; varies by tenant.
+5. **DBSC enforcement (emerging).** Google is rolling out Device-Bound
+   Session Credentials. As of the GA on Chrome 146 Windows (April 9, 2026),
+   *Chrome* clients without a TPM-signed proof can't refresh `*PSIDTS`.
+   Currently does not affect non-Chrome HTTP clients (us); the legacy
+   unsigned `RotateCookies` path remains open. This is **the long-term
+   threat**.
+
+### 3.3 The DBSC timeline (as of May 2026)
+
+- **Apr 9, 2026:** Chrome 146 GA on Windows includes consumer-account DBSC
+  enforcement against Chrome clients ([blog.google
+  security](https://blog.google/security/protecting-cookies-with-device-bound-session-credentials/),
+  [Chrome dev blog](https://developer.chrome.com/blog/dbsc-windows-announcement)).
+  ~85% of active Windows Chrome installs are TPM 2.0 capable, per Google's
+  own telemetry.
+- **macOS:** "Upcoming Chrome release," no firm date.
+- **Linux:** Explicitly deferred. No timeline.
+- **Workspace:** Session-binding policy is admin-opt-in beta
+  ([Workspace admin docs](https://knowledge.workspace.google.com/admin/security/prevent-cookie-theft-with-session-binding)),
+  not enforced by default.
+- **Non-Chrome HTTP clients (us):** Not currently enforced. The unsigned
+  `RotateCookies` endpoint accepts our POSTs without DBSC challenge.
+
+`RotateBoundCookies` (the DBSC analog of `RotateCookies`) requires a
+TPM-bound private key registered with Google at sign-in. The
+[W3C DBSC spec](https://w3c.github.io/webappsec-dbsc/) is
+deliberately structured to prevent non-browser implementation. **There is no
+public OSS DBSC client outside Chrome itself, and there cannot be one
+without TPM access.**
+
+### 3.4 Internal threats: cookie-jar fidelity in the persistence pipeline
+
+A separate failure mode that's easy to misattribute to Google: the
+library can corrupt its own cookie state during the read-merge-write
+cycle. **If users report cookies "expiring fast" or "dying after a few
+hours", before assuming Google has changed something, walk this section
+first.** None of these are theoretical — they come straight from
+reading `auth.py` against the lifecycle of `NotebookLMClient` /
+`fetch_tokens_with_domains` / `save_cookies_to_storage`.
+
+#### 3.4.1 Stale in-memory clobbers fresh disk (the "few-hours" pattern)
+
+The most likely culprit when rotation seems to silently fail.
+`save_cookies_to_storage` (`auth.py:1003–1036`) merges the in-memory
+jar onto disk using a **value-difference rule**: for each cookie on
+disk, if the in-memory variant has a different value, write the
+in-memory value. There is no generation counter, no mtime comparison,
+and no dirty flag.
+
+Failure timeline:
+
+| t | Process A (long-lived, `keepalive=None`) | Process B (CLI invocation) | Disk state |
+|---|---|---|---|
+| 0 | `from_storage()` → reads `*PSIDTS=OLD` | — | `OLD` |
+| +5 m | working (batchexecute traffic only; never touches identity surface) | `from_storage()` rotates → `*PSIDTS=NEW` → saves under flock | `NEW` |
+| +10 m | `close()` → save runs under flock → reads disk (`NEW`) → A's in-memory (`OLD`) differs → **A writes `OLD`** | done | **`OLD` (clobbered)** |
+| +60 m+ | next request to `notebooklm.google.com` fails — rotation never effectively landed | | |
+
+The cross-process flock added in
+[#344](https://github.com/teng-lin/notebooklm-py/pull/344) prevents
+interleaved writes but not stale-overwrites-fresh.
+
+**Defensive comparison across the ecosystem.** This codebase is, as far
+as a survey can establish, the *most defensive* OSS implementation —
+and even we have this gap. Peers fare worse:
+
+| Project | Atomic temp-replace | Flock | Per-cookie merge | Stale-overwrite-fresh |
+|---|---|---|---|---|
+| `notebooklm-py` (us) | ✅ | ✅ (post-#344) | ✅ | ❌ (this section) |
+| HanaokaYuzu/Gemini-API | ❌ | ❌ | ❌ (full-jar overwrite) | ❌ |
+| yt-dlp ([cookies.py#L1333-L1352](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/cookies.py#L1333-L1352)) | ❌ (`f.truncate(0)` then write) | ❌ | ❌ (full-jar overwrite) | ❌ |
+| Bard-API, ytmusicapi, gpsoauth, browser_cookie3, rookiepy | n/a (read-only) | n/a | n/a | n/a |
+| easychen/CookieCloud | ❌ | ❌ | ❌ | ❌ (by design) |
+
+yt-dlp's design is read-mostly — cookies extracted fresh from the
+browser per invocation, no long-lived process mutating shared state —
+so it gets away with full-overwrite-no-flock-no-temp-replace. Our
+threat model (long-lived clients + cron-driven `auth refresh` +
+parallel CLI invocations all writing the same `storage_state.json`)
+genuinely needs the defenses we have, plus the §3.4.1 gap closed. The
+peer-ecosystem state of the art is "last writer wins, hope for the
+best."
+
+Possible fixes (not yet implemented):
+
+- **Re-read disk after flock acquisition**, compare each in-memory
+  cookie against the value loaded at `open()` time; only overwrite
+  cookies the in-process code actually changed (dirty-flag pattern).
+- **Generation counter** stamped on every cookie write — refuse to
+  downgrade.
+- **Write-only-deltas**: persist only cookies whose in-memory value
+  differs from open-time snapshot; leave the rest to disk.
+
+Mitigations available today:
+
+- Pass `keepalive=N` to long-lived `NotebookLMClient` instances so
+  rotation actually fires in-process (in-memory stays fresh, save is
+  always correct).
+- Or, run a single rotator (cron-driven `notebooklm auth refresh`) and
+  ensure no parallel long-lived processes write to the same
+  `storage_state.json`.
+
+#### 3.4.2 The `(name, domain)` collapse — `path` ignored
+
+Multiple paths in `auth.py` key cookies by `(name, domain)` and drop
+`path`:
+
+| Site | Effect |
+|---|---|
+| `extract_cookies_with_domains` (`auth.py:786`) | Two storage_state entries with same name+domain but different paths → first one wins, second silently dropped |
+| `_cookie_map_from_jar` (`auth.py:1227`) | Same collapse on the way out of httpx |
+| `cookies_by_key` in `save_cookies_to_storage` (`auth.py:997`) | Same collapse on save |
+
+RFC 6265 treats `path` as part of cookie identity. If Google ever
+path-scopes a rotation target — `OSID` for a per-product path is the
+likely candidate, since it's already per-product — we silently keep
+one variant and lose the rest. Empirically not a hot bug today, but a
+trip-wire for future protocol changes.
+
+Worse: the iteration order of `cookies_by_key`'s dict-comprehension
+over `cookie_jar.jar` is **not specified by `http.cookiejar`** —
+which variant survives the collapse depends on insertion order, which
+depends on the order Google sent its `Set-Cookie` headers in the
+response. So the bug is not just "we drop a variant" but "we
+non-deterministically drop a variant", which makes failures hard to
+reproduce.
+
+#### 3.4.3 Sibling Google products in the cookie allowlist
+
+> **Resolved in [#360](https://github.com/teng-lin/notebooklm-py/issues/360).**
+> `ALLOWED_COOKIE_DOMAINS` now covers sibling Google products
+> (`.youtube.com`, `accounts.youtube.com`, `drive.google.com`,
+> `docs.google.com`, `myaccount.google.com`, `mail.google.com`), and
+> the previously-split `_is_allowed_auth_domain` / `_is_allowed_cookie_domain`
+> filters have been collapsed into a single canonical policy
+> (`_is_allowed_cookie_domain`); the auth-side function is now a thin
+> alias. `_login_with_browser_cookies` automatically widens its rookiepy
+> `domains` list because it constructs it from `ALLOWED_COOKIE_DOMAINS`.
+
+**Original problem.** `ALLOWED_COOKIE_DOMAINS` (`auth.py:66-74`) was
+narrowly NotebookLM-shaped. Two layered issues:
+
+1. **The extraction gap.** `_login_with_browser_cookies`
+   (`cli/session.py:165-172`) passes `ALLOWED_COOKIE_DOMAINS +
+   regional ccTLDs` as the `domains` list to `rookiepy.load()`.
+   rookiepy was never asked for `.youtube.com`, `accounts.youtube.com`,
+   `drive.google.com`, `myaccount.google.com`, `mail.google.com`, or any
+   other sibling-product domain. They were absent from
+   `storage_state.json` from the moment of extraction. The Playwright
+   login path captured whatever the browser context touched, but
+   `extract_cookies_with_domains` (strict filter) dropped them at load
+   time. Either way, the runtime auth jar had nothing for those domains.
+
+2. **The strict-vs-broad filter asymmetry.** Two filters with different
+   policies — `_is_allowed_auth_domain` (exact match against
+   `ALLOWED_COOKIE_DOMAINS` ∪ regional ccTLDs) and
+   `_is_allowed_cookie_domain` (suffix-matches `.google.com`,
+   `.googleusercontent.com`, `.usercontent.google.com`). Auth-jar
+   building used the strict filter; persistence
+   (`save_cookies_to_storage`'s `cookies_by_key`) used the broad one.
+   The asymmetry zone — host-only cookies on subdomains like
+   `mail.google.com`, `myaccount.google.com`, `chat.google.com`,
+   `lh3.google.com` — got saved by the broad filter and dropped on
+   next reload by the strict one. Residue of the incomplete fix in
+   [#334 / `fea8315`](https://github.com/teng-lin/notebooklm-py/commit/fea8315)
+   that broadened persistence without symmetrically broadening extraction.
+
+**Why it didn't break in observed traffic.** Walking the cookies
+actually exercised today:
+
+- `batchexecute` RPC needs only `.google.com` / `accounts.google.com` /
+  `notebooklm.google.com` — strict-allowed.
+- YouTube/Drive source ingestion: `_sources.py` parses URLs locally;
+  the fetch happens server-side on NotebookLM's backend.
+- Artifact downloads: hit `*.googleusercontent.com` plus
+  `.google.com`-scoped auth cookies. Both strict-allowed.
+- Rotation: empirical capture (§5.3) shows `RotateCookies` returns 200
+  directly with `Set-Cookie: __Secure-*PSIDTS=…; Domain=.google.com`.
+  No traversal of `accounts.youtube.com` is required for the L1 path.
+
+So no auth-relevant cookie was dropped in current flows. The fix is
+defensive — symmetric extraction/save policy with sibling domains
+covered, so future protocol shifts (signed Drive URLs, `CheckCookie`
+chains, Drive-picker flows, YouTube-side rotation) don't turn the
+asymmetry into a hot bug.
+
+#### 3.4.4 The "differing-value-wins" merge heuristic
+
+`_find_cookie_for_storage` (`auth.py:1098–1119`) handles the case where
+`http.cookiejar` has normalized `Domain=accounts.google.com` to
+`.accounts.google.com`. It walks variant keys and returns the first
+candidate whose value differs from disk:
+
+```python
+for cookie in candidates:
+    if cookie.value != stored_value:
+        return cookie
+return candidates[0]
+```
+
+Two failure shapes:
+
+1. If multiple variants legitimately differ from disk after a
+   rotation, **set iteration order picks the winner.** Python set
+   iteration is implementation-defined (insertion-adjacent but not
+   guaranteed); the "right" variant is not specified anywhere.
+2. The fallback `return candidates[0]` after the loop is unreachable
+   in correct flows but inherits the same ordering ambiguity if it
+   ever fires.
+
+Low-priority hazard but worth flagging: when this gets it wrong, the
+symptom is "cookies look right on disk but fail when replayed."
+
+#### 3.4.5 `expires=-1` flattens age information
+
+`*PSIDTS` rotations come back from `RotateCookies` without `Max-Age` —
+they're "browser session" cookies. `_cookie_to_storage_state`
+(`auth.py:1080`) and `convert_rookiepy_cookies_to_storage_state`
+(`auth.py:402`) write them as `expires=-1` (Playwright session-cookie
+convention) and persist them indefinitely. This means:
+
+- A `*PSIDTS` rotated 30 seconds ago is indistinguishable on disk from
+  one rotated 30 hours ago.
+- We can't write a "stale on-disk" detector based on cookie metadata —
+  the only timestamp we have is the file's `mtime`.
+- Diagnostics that print `expires` for debugging show `-1` for the
+  cookie that matters most. Use file mtime instead.
+
+#### 3.4.6 `__Host-` invariants are not enforced
+
+`__Host-` prefix cookies (`__Host-GAPS`, `__Host-1PLSID`,
+`__Host-3PLSID`) **must** have empty `Domain` and `Path=/` per the
+prefix rule. `_cookie_to_storage_state` writes whatever
+`cookie.domain` happens to be at that point, so any normalization pass
+that adds a leading dot to a `__Host-` cookie produces an invalid
+shape. Browsers and well-behaved cookie jars discard these on load;
+silent drops would manifest as occasional auth-flow flakes.
+
+#### 3.4.7 Load-side attribute loss (round-trip erosion)
+
+Every load path uses `cookies.set(name, value, domain=domain)` —
+`build_httpx_cookies_from_storage` (`auth.py:822`) and
+`load_httpx_cookies` (`auth.py:741`) both. httpx's `Cookies.set`
+accepts only `name`, `value`, `domain`, and `path`; we pass none of
+the other attributes we faithfully wrote out via
+`_cookie_to_storage_state` (`secure`, `httpOnly`, `sameSite`,
+non-default `path`).
+
+Concretely, after one load:
+
+| Attribute | On disk | After load (in-memory) |
+|---|---|---|
+| `path` | whatever was written | always `/` (httpx default) |
+| `secure` | preserved on save | `False` (Cookie ctor default) |
+| `httpOnly` | preserved on save | `False` |
+| `sameSite` | always `"None"` (already hardcoded — see below) | not represented |
+
+If we save back without intervening Set-Cookie observations to refill
+the attributes, `_cookie_to_storage_state` (`auth.py:1080`) re-derives
+all of these from the in-memory cookie object, which now reflects the
+defaults. Each load+save cycle erodes attribute fidelity until disk
+stabilizes at `Path=/`, `secure=false`, `httpOnly=false`,
+`sameSite="None"`.
+
+For `__Host-`-prefixed cookies this is a logical violation
+(§3.4.6). For `__Secure-`-prefixed cookies the `Secure` attribute is
+client-side enforcement; Google's server doesn't reject the cookie
+just because we send it without a `Secure` assertion, so this is
+mostly latent. But the round-trip erosion is real and would bite any
+future cookie shape that does enforce attributes server-side.
+
+Related: `convert_rookiepy_cookies_to_storage_state` and
+`_cookie_to_storage_state` both **hardcode `sameSite: "None"`**
+(`auth.py:405`, `auth.py:1083`). Real Google cookies are a mix of
+`Lax` and `None`; we flatten them all to `None` on the way to disk.
+Probably benign for our cross-site flow but it's another cell of the
+fidelity table that's wrong.
+
+#### 3.4.8 Diagnostic checklist for "cookies expire fast"
+
+Before assuming Google has changed anything:
+
+1. **Compare the `__Secure-1PSIDTS` value on disk before and after a
+   `notebooklm` invocation.** If it doesn't change between calls
+   spaced > 60 s apart and there's no other process writing the file,
+   rotation isn't firing — check `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE`
+   and the mtime guard.
+2. **If multiple processes share the storage file**, run them with
+   `NOTEBOOKLM_LOG_LEVEL=DEBUG` and look for "Keepalive RotateCookies
+   skipped: storage refreshed before flock acquired" — that means the
+   guards are working. If you see fresh saves immediately followed by
+   sibling saves with stale values, you're hitting §3.4.1.
+3. **Check storage_state.json `mtime` cadence** — should be ≤ a few
+   minutes after each active session if rotation is landing. Hours-old
+   mtime means rotation isn't sticking.
+4. **Diff the cookie set across two invocations**. Cookies appearing
+   in one run and missing in the next now point primarily at path
+   collapse (§3.4.2); the §3.4.3 whitelist-asymmetry shape was closed
+   by [#360](https://github.com/teng-lin/notebooklm-py/issues/360).
+5. **Only after the above all check out**, investigate Google-side
+   causes (risk-scoring, Workspace policy, DBSC).
+
+
+---
+
+## 4 · The architecture
+
+The library uses a tiered design that progressively escalates as cheaper
+mechanisms fail. Each layer has a distinct trigger and target failure mode.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ L1: per-call RotateCookies POST                              │
+│   - fires inside _fetch_tokens_with_jar before homepage GET  │
+│   - cost: ~150ms per token fetch                             │
+│   - covers: short interactive use, every CLI invocation      │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (long-lived clients also do)
+┌──────────────────────────────────────────────────────────────┐
+│ L2: NotebookLMClient(keepalive=N) background task            │
+│   - asyncio.Task, fires _poke_session every N seconds        │
+│   - opt-in via parameter; floor 60s                          │
+│   - covers: agents, MCP servers, long-running workers        │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (idle profiles between processes)
+┌──────────────────────────────────────────────────────────────┐
+│ L3: notebooklm auth refresh (OS-scheduled)                   │
+│   - cron / launchd / systemd / Task Scheduler / k8s          │
+│   - calls fetch_tokens_with_domains, exits 0/1               │
+│   - covers: profiles idle > SIDTS window between Python runs │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (when L1's HTTP-only path weakens)
+┌──────────────────────────────────────────────────────────────┐
+│ L4: notebooklm login --browser-cookies firefox (cron)        │
+│   - rookiepy reads Firefox cookies.sqlite                    │
+│   - works without Keychain prompt on macOS                   │
+│   - DBSC-immune (Firefox isn't DBSC-enrolled by Google)      │
+│   - requires Firefox installed and signed in                 │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (when DBSC extends to non-Chrome paths)
+┌──────────────────────────────────────────────────────────────┐
+│ L5 (proposed): CDP-attach to user's running Chrome           │
+│   - Playwright connect_over_cdp("http://localhost:9222")     │
+│   - harvest cookies from user's signed-in daily Chrome       │
+│   - inherits Chrome's TPM-bound DBSC enrollment              │
+│   - requires Chrome with --remote-debugging-port=9222        │
+└──────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ (alternate L5: cross-machine federation)
+┌──────────────────────────────────────────────────────────────┐
+│ L6 (optional): CookieCloud client integration                │
+│   - browser extension watches user's daily Chrome cookies    │
+│   - encrypts (AES via CryptoJS) + uploads to self-hosted     │
+│     CookieCloud server                                       │
+│   - notebooklm-py pulls fresh cookies on demand              │
+│   - sidesteps Chrome 127+ App-Bound Encryption (extension    │
+│     reads via chrome.cookies API, not SQLite)                │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Each layer is a fallback for the next one above. The first three are
+HTTP-only (cheap, no browser dependency); L4 is the lightweight browser
+path; L5 is the durability insurance; L6 is the federation play.
+
+---
+
+## 5 · L1 deep dive — the `RotateCookies` primitive
+
+### 5.1 The endpoint
+
+```
+POST https://accounts.google.com/RotateCookies
+Content-Type: application/json
+Origin: https://accounts.google.com
+
+[000,"-0000000000000000000"]
+```
+
+The body is a **JSPB (JavaScript Protocol Buffers) sentinel**. JSPB is
+Google's array-shaped serialization format used by `batchexecute`,
+`RotateCookies`, and similar internal endpoints. The two-element body
+decomposes as:
+
+- `000` — an integer literal `0` written with leading zeros. Invalid in
+  strict JSON, valid in Google's JSPB parser. Probably a version or
+  operation tag in slot 0.
+- `"-0000000000000000000"` — a string of 19 zeros prefixed with `-`. This is
+  a **sentinel value** that means "I don't have a prior `__Secure-1PSIDTS`,
+  please mint a fresh one based on the persistent identity (`SID`/`PSID`)
+  alone." Without this sentinel the endpoint requires the client's current
+  `*PSIDTS` value as input.
+
+The pattern is borrowed from
+[`HanaokaYuzu/Gemini-API`](https://github.com/HanaokaYuzu/Gemini-API/blob/master/src/gemini_webapi/utils/rotate_1psidts.py),
+which has been using it in production with a sizable user base.
+
+### 5.2 The successful response
+
+```
+HTTP/1.1 200 OK
+Set-Cookie: __Secure-1PSIDTS=<new_value>; Domain=.google.com; Secure; HttpOnly
+Set-Cookie: __Secure-3PSIDTS=<new_value>; Domain=.google.com; Secure; HttpOnly
+Set-Cookie: SIDCC=<new_value>; Domain=.google.com; Secure
+Set-Cookie: __Secure-1PSIDCC=<new_value>; Domain=.google.com; Secure
+Set-Cookie: __Secure-3PSIDCC=<new_value>; Domain=.google.com; Secure
+
+)]}'  [["identity.hfcr",600],["di",<integer>]]
+```
+
+The `)]}'` prefix is Google's standard anti-XSSI token. The JSPB body
+(`[["identity.hfcr",600],["di",N]]`) appears to encode:
+
+- `["identity.hfcr",600]` — `identity.hfcr` likely "high-frequency cookie
+  rotation"; `600` is the recommended next-rotation interval in seconds
+  (10 minutes). **This validates the documented `*PSIDTS` rotation cadence
+  directly.**
+- `["di",N]` — opaque session/rotation counter (varies by profile).
+
+The library's [`save_cookies_to_storage`](../src/notebooklm/auth.py)
+captures the rotated `Set-Cookie` headers and persists them atomically to
+`storage_state.json`.
+
+### 5.3 Empirical validation (May 2026)
+
+Field experiment configuration:
+
+- **Probe A** (control): main code, no L1 poke, Playwright-extracted cookies.
+- **Probe B**: `feat/auth-keepalive-bg-task` branch, L1 `CheckCookie` poke,
+  Playwright-extracted cookies.
+- **Probe C**: re-extracts Firefox cookies every cycle, main code.
+- All probes run on a 5-minute cadence, instrumented to log redirect chains
+  and `Set-Cookie` headers from each endpoint.
+
+Results:
+
+| | Probes | OK | Failures | First failure | `*PSIDTS` rotated via |
+|---|---|---|---|---|---|
+| **A (control)** | 33 | 4 | 29 | T+20m | never (died) |
+| **B (CheckCookie L1)** | 35+ | 35+ | 0 | — | only via observation, not via the L1 GET (CheckCookie chain stops at 2 hops, no `SetSID`, no `*PSIDTS` in response) |
+| **C (Firefox re-extract)** | 22+ | 22+ | 0 | — | every probe (CheckCookie chain has 3 hops including `accounts.youtube.com/SetSID`) |
+
+Then we instrumented all probes to additionally hit `RotateCookies` directly
+as a measurement (no production code change yet):
+
+| | RotateCookies POST attempts | 200 + `*PSIDTS` in `Set-Cookie` | 401s |
+|---|---|---|---|
+| **B (Playwright/bound session)** | 6+ | **6+/6+** | 0 |
+| **C (Firefox/unbound session)** | 7+ | **7+/7+** | 0 |
+
+**100% rotation success rate across both session types.** No 401s, no
+DBSC challenges, no `Sec-Session-*` headers in any response. The unsigned
+`RotateCookies` POST is empirically the cleanest available rotation
+primitive for both bound and unbound sessions today.
+
+### 5.4 Why it's better than `CheckCookie`
+
+The previous L1 mechanism (commits `eae3eaf` through `8047718`) used
+`GET https://accounts.google.com/CheckCookie?continue=...notebooklm.google.com/`,
+relying on Google to issue a redirect chain that *might* go through
+`accounts.youtube.com/SetSID`, which *might* set fresh `*PSIDTS` cookies.
+Empirically:
+
+- **For Firefox-extracted (unbound) profiles:** the chain is 3 hops and
+  `SetSID` does set fresh `*PSIDTS`. Works.
+- **For Playwright-extracted (bound) profiles:** the chain is 2 hops, no
+  `SetSID` step, no `*PSIDTS` in any `Set-Cookie`. The poke touches the
+  identity surface (and, observably, extends server-side session validity
+  through some untracked mechanism — B's session lived hours longer than A
+  despite identical underlying cookies) but **does not rotate `*PSIDTS`**.
+
+This is why the L1 docstring was originally inaccurate: "elicits
+`__Secure-1PSIDTS` rotation" is true for unbound sessions and false for
+bound ones.
+
+`RotateCookies` POST removes the discretion: **direct rotation request,
+unconditional response, both session types.**
+
+### 5.5 Rate limiting and concurrency throttle
+
+Gemini-API observed that hammering `RotateCookies` triggers HTTP 429. The
+naïve mitigation is a **60-second cache-file mtime guard**: skip the POST if
+the storage state was rewritten within the last minute. The
+`[["identity.hfcr",600], ...]` self-reported interval is 600 s, so a 60 s
+floor leaves a comfortable order of magnitude of headroom.
+
+The merged implementation (`auth.py::_poke_session` and
+`auth.py::_rotate_cookies`, [#346](https://github.com/teng-lin/notebooklm-py/pull/346)
++ [#348](https://github.com/teng-lin/notebooklm-py/pull/348)) wraps the POST
+in **three concentric guards**, because a single mtime check is not enough
+once you have an L1 caller, an L2 background loop, and a fan-out of
+parallel CLI invocations all keyed to the same `storage_state.json`:
+
+1. **Disk mtime fast-path** (`_is_recently_rotated`). If
+   `storage_state.json` was rewritten within `_KEEPALIVE_RATE_LIMIT_SECONDS`
+   (60 s), skip without acquiring any lock. A `_KEEPALIVE_PRECISION_TOLERANCE`
+   of 2 s absorbs sub-second drift between `time.time()` and filesystem
+   mtime resolution (notably Windows NTFS at lower clock granularity).
+   A meaningfully-future mtime is treated as **not recent** — better to fire
+   one extra rotation than wedge the guard until wall time catches up.
+2. **In-process throttle** (`_get_poke_lock` + `_try_claim_rotation`).
+   Inside an `asyncio.Lock` keyed by `(running event loop, storage_path)`,
+   re-check the mtime *and* a per-profile monotonic timestamp stamped under
+   a `threading.Lock`. The atomic check-and-stamp deduplicates an
+   `asyncio.gather` fan-out so only one POST fires per process per
+   rate-limit window. The timestamp is bumped **before** the network await
+   so a 15 s timeout against a hung `accounts.google.com` does not let 10
+   fanned-out callers each wait the full timeout.
+3. **Cross-process non-blocking flock**
+   (`.storage_state.json.rotate.lock` via `LOCK_NB`). When `storage_path`
+   is set, try to take an exclusive flock; if another process holds it,
+   skip — they're rotating right now. This handles `xargs -P`, parallel
+   MCP workers, and similar parallel launches without queueing. The
+   rotation lock is intentionally distinct from the
+   `.storage_state.json.lock` used by `save_cookies_to_storage`, so a
+   long-running save doesn't block rotations or vice versa.
+
+The L2 background loop bypasses guards 1 and 2 (it's already self-paced via
+`keepalive_min_interval`) and calls `_rotate_cookies` directly, which still
+performs the atomic per-profile claim — so a layer-1 `_poke_session` on a
+sibling event loop sees the in-flight rotation and skips.
+
+### 5.6 Concurrency model: why three guards instead of one
+
+| Failure mode | Caught by |
+|---|---|
+| User runs 10 sequential `notebooklm` CLI invocations | Disk mtime fast-path |
+| `asyncio.gather([client.rpc(...) for _ in range(N)])` from one process | In-process `asyncio.Lock` + monotonic timestamp |
+| L1 caller racing the L2 keepalive loop on the same profile | Per-profile monotonic timestamp under `threading.Lock` |
+| Two CLI invocations or worker processes started simultaneously | Cross-process flock (`LOCK_NB`) |
+| Hung `accounts.google.com` causing 15 s-per-caller fan-out | Stamp-before-await: timestamp claimed before the network call |
+| Read-only filesystem / NFS without flock | Locks **fail open**: rotation proceeds rather than wedge forever |
+
+The per-`(loop, profile)` lock dictionary is held in a
+`WeakKeyDictionary` keyed on the loop *object*, so when a short-lived
+`asyncio.run()` loop is garbage-collected its inner dict is reclaimed
+automatically — bounded cache without an `id()`-reuse hazard.
+
+---
+
+## 6 · Comparison with related projects
+
+### 6.1 [`HanaokaYuzu/Gemini-API`](https://github.com/HanaokaYuzu/Gemini-API)
+
+Closest peer. Targets Google Bard / Gemini web UI rather than NotebookLM,
+but the auth surface is identical (same `*.google.com` cookies, same
+`RotateCookies` endpoint).
+
+**Strengths:**
+- The reference implementation of `RotateCookies` rotation
+  (`src/gemini_webapi/utils/rotate_1psidts.py`).
+- Cache-file-mtime rate-limit guard.
+- Cache file keyed by `__Secure-1PSID` value
+  (`.cached_cookies_<sid>.json`) — automatically scopes by Google account.
+- Default-on background refresh (`auto_refresh=True`, 600s interval) for
+  long-lived clients.
+- CLI explicitly opts out (`auto_refresh=False`) since each invocation
+  is short-lived.
+
+**Weaknesses:**
+- No reactive/recovery layer — when rotation fails, the client just dies.
+  No L4-equivalent to fall back to.
+- The init() docstring overpromises: claims to refresh "cookies and access
+  token" but the background loop only rotates cookies, never re-runs
+  `get_access_token`.
+- Uses curl_cffi (browser-impersonating TLS); we use httpx. Their tighter
+  fingerprint may explain why Gemini-API hasn't seen DBSC issues yet for
+  most users.
+
+**Canary:** issues
+[#310](https://github.com/HanaokaYuzu/Gemini-API/pull/310) (Apr 2026 —
+proposes "activity warmup + browser impersonation" as workaround for
+Chrome's DBSC-related compat issues) and
+[#319](https://github.com/HanaokaYuzu/Gemini-API/issues/319) (Apr 2026 —
+`UNAUTHENTICATED` after rotation). When #310 ships as default, the simple
+sentinel pattern is decaying.
+
+### 6.2 [`easychen/CookieCloud`](https://github.com/easychen/CookieCloud)
+
+A different category — browser-companion cookie federation. Browser
+extension (Chrome/Edge/Firefox) watches cookies on configured domains,
+encrypts with AES-CryptoJS using `MD5(uuid+password)[:16]` as key,
+periodically uploads to a self-hosted server. Clients (Python, Go, JS, Deno)
+download and decrypt.
+
+**Strengths:**
+- **Sidesteps Chrome 127+ App-Bound Encryption entirely.** The extension
+  reads cookies via Chrome's own `chrome.cookies` API, not by reading the
+  SQLite DB.
+- DBSC-immune for the same reason — the cookies are sourced from the user's
+  daily Chrome which handles all DBSC dance internally.
+- Server is tiny (a Node.js or PHP daemon, single Docker container).
+- End-to-end encrypted; server never sees plaintext.
+- Cross-machine — your cron on a remote server can pull cookies refreshed
+  by your laptop's daily Chrome.
+- Active maintenance (v1.0.3 May 2026), Python client
+  ([`PyCookieCloud`](https://github.com/lupohan44/PyCookieCloud)) is ~200
+  LOC to integrate.
+
+**Weaknesses:**
+- Requires user to install browser extension AND self-host server.
+- No upstream NotebookLM/Gemini integration — would need to be built.
+- Some Chinese-origin codebase elements may give pause to Western
+  enterprise users; the project itself is MIT, code is auditable.
+
+### 6.3 [`dsdanielpark/Bard-API`](https://github.com/dsdanielpark/Bard-API) (archived)
+
+Historical reference. **Archived April 2024.** No automated refresh — users
+manually re-paste cookies on every breakage. Issue
+[#231](https://github.com/dsdanielpark/Bard-API/issues/231) is the canonical
+"we can't reliably automate `SNlM0e` refresh" thread that motivated
+Gemini-API's design. The failure mode of *not* having an L1+ design is
+visible here: project archived because manual cookie management was
+untenable.
+
+### 6.4 Crosscuts
+
+Common patterns across the projects reviewed:
+
+- **Docstring rot is universal.** Every project surveyed has docstrings that
+  overpromise about what the refresh mechanism does. Worth being defensive
+  about in our own.
+- **`SID`-keyed cache files** (Gemini-API) are a nicer pattern than
+  profile-name-keyed. Worth consideration for #345 MEDIUM-3.
+- **Reactive-only is insufficient.** Bard-API's no-automated-refresh design
+  ended in archival; users gave up because manual re-paste was
+  untenable. Demonstrates why proactive L1/L2/L3 matters even when L4/L5
+  recovery is in place.
+
+---
+
+## 7 · What we tried and ruled out
+
+These approaches were investigated and rejected; documented here so future
+contributors don't re-investigate them.
+
+### 7.1 `undetected-chromedriver` / `selenium-stealth`
+
+**Verdict: Don't use for Google login.**
+
+- `ultrafunkamsterdam/undetected-chromedriver` — author has effectively
+  migrated to `nodriver`. Google login broken since Chrome 110, re-broken
+  on each major Chrome bump. Active issues against Chrome 142 in Jan 2026.
+- `diprajpatra/selenium-stealth` — no meaningful release in years.
+- The 2026 fork `praise2112/selenium-stealth` is more current but still
+  loses to Google's signal-fusion model (TLS, behavioral, fingerprint).
+
+Consensus across multiple 2026 guides: stop using WebDriver-based stealth
+for Google flows.
+
+### 7.2 `puppeteer-extra-plugin-stealth` / `playwright-stealth`
+
+**Verdict: Don't use for `accounts.google.com` flows.**
+
+Long-standing Google-login bugs:
+[`berstend/puppeteer-extra#588`](https://github.com/berstend/puppeteer-extra/issues/588)
+(2022, unfixed),
+[`#898`](https://github.com/berstend/puppeteer-extra/issues/898)
+(Chrome 122 broke meet.google.com).
+
+Python `playwright-stealth` (v2.x) is the most active variant but Scrapfly
+and AlterLab guides explicitly warn it patches *fingerprint leaks only*, not
+TLS, IP reputation, or behavioral signals. Effective for resumed sessions
+where cookies are already present, fails for fresh sign-in.
+
+### 7.3 Persistent Playwright headless context as keepalive daemon
+
+**Verdict: Don't ship.**
+
+Two unresolved Playwright bugs make this fragile:
+
+- [`microsoft/playwright#36139`](https://github.com/microsoft/playwright/issues/36139)
+  — cookies missing in headless `launch_persistent_context`.
+- [`microsoft/playwright#35466`](https://github.com/microsoft/playwright/issues/35466)
+  — profile DB corruption in long-lived contexts.
+
+If a headless-Playwright option is needed, prefer **CDP-attach** (Playwright
+`connect_over_cdp` to user's running Chrome) — different code path, not
+exposed to either bug.
+
+### 7.4 Client-side DBSC implementation
+
+**Verdict: Impossible from Python.**
+
+The W3C DBSC spec is structured around a TPM-bound private key that signs
+nonces from the server. Without TPM access (which isn't directly exposed
+through Python on any platform) and the platform attestation chain Chrome
+implements, no non-Chrome client can satisfy `RotateBoundCookies`. No
+public OSS DBSC client exists; the spec is deliberately designed to prevent
+one.
+
+If/when DBSC extends to non-Chrome cookie paths, the only escape is to
+parasitize a real DBSC-enrolled Chrome session via L5 (CDP attach) or L6
+(CookieCloud).
+
+### 7.5 Cookie database read on Chrome 127+
+
+**Verdict: Increasingly unreliable; prefer Firefox.**
+
+Chrome 127 introduced **App-Bound Encryption** for cookies on Windows.
+`browser_cookie3` (latest v0.20.1) does **not** handle ABE; rookiepy claims
+to but requires admin from Chrome 130+
+([rookie#50](https://github.com/thewh1teagle/rookie/issues/50)). The
+yt-dlp ecosystem has converged on
+"[only Firefox `--cookies-from-browser` reliably works in 2026](https://dev.to/osovsky/6-ways-to-get-youtube-cookies-for-yt-dlp-in-2026-only-1-works-2cnb)."
+
+Pragmatic forks for ABE bypass exist (CyberArk's "C4 Bomb",
+xaitax/Chrome-App-Bound-Encryption-Decryption) but are infostealer-adjacent
+and inappropriate for shipping in a legitimate CLI.
+
+**Library recommendation:** Document `--browser-cookies firefox` as the
+recommended path on Windows. Keep `--browser-cookies chrome` working but
+note it may require admin or Keychain prompts.
+
+---
+
+## 8 · Recommendations by use case
+
+### 8.1 Interactive desktop user
+
+Just `notebooklm login`. The Playwright Chromium flow handles it. Re-login
+when prompted (typically days to weeks between prompts).
+
+### 8.2 Long-lived in-process client (agent, MCP server, worker)
+
+```python
+async with await NotebookLMClient.from_storage(keepalive=600) as client:
+    ...
+```
+
+L1 fires on `from_storage()`, L2 fires every 600s while the client is open.
+This was sufficient through the entire 24h+ window of our experiment.
+
+### 8.3 Unattended / headless / CI / cron
+
+Two stacks, in order of preference:
+
+**Preferred (today, May 2026):**
+
+1. Sign in to NotebookLM **once** in Firefox (or any rookiepy-supported
+   browser — see note below).
+2. `notebooklm login --browser-cookies firefox -p <profile>`.
+3. Schedule a cron / launchd / systemd job:
+   ```
+   7,27,47 */1 * * * notebooklm --profile <profile> auth refresh
+   ```
+   (Off-minute schedule avoids fleet collision.)
+4. Keep Firefox running with at least one Google tab. Even closed-Firefox
+   works for hours-to-days as long as `RotateCookies` keeps succeeding from
+   `SID` alone, but a running Firefox is an extra layer of resilience.
+
+> **Browser support:** `--browser-cookies` accepts any of the ~16 browsers
+> rookiepy can read on the host platform — `arc`, `brave`, `chrome`,
+> `chromium`, `edge`, `firefox`, `ie`, `librewolf`, `octo`, `opera`,
+> `opera-gx`, `safari`, `vivaldi`, `zen`. **Firefox is the recommended
+> path on Windows** specifically because Chrome 127+ App-Bound Encryption
+> makes Chrome cookie reads admin-or-bust (see §7.5). On macOS and Linux,
+> any of the listed browsers work; Firefox just sidesteps the Keychain
+> prompt that Chrome / Brave / Edge trigger on first read. See
+> `_ROOKIEPY_BROWSER_ALIASES` in `cli/session.py` for the canonical list.
+
+**With cookie federation (best UX, requires self-hosting):**
+
+1. Self-host CookieCloud server.
+2. Install CookieCloud browser extension in your daily Chrome, configure to
+   sync `*.google.com`.
+3. Use `PyCookieCloud` to pull cookies on demand (L6 — proposed, not yet
+   shipped in `notebooklm-py`).
+
+### 8.4 Workspace / Enterprise account with admin session-binding
+
+Currently **not supported.** Document as such. The admin-policy session
+binding is a Workspace-only beta and requires DBSC-compatible flows.
+Library users should request an exemption from their admin or use a
+personal Google account for automation.
+
+---
+
+## 9 · Operational levers (environment variables)
+
+Two env vars in `auth.py` exist as escape hatches around the keepalive
+machinery. Documented here so operators don't have to grep for them.
+
+### 9.1 `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`
+
+Disables the `RotateCookies` POST entirely. Both L1 (`_poke_session` inside
+`_fetch_tokens_with_jar`) and L2 (the `_keepalive_loop` background task) honour
+this. The L2 task still wakes on its interval — only the network call becomes
+a no-op — so to disable the loop *itself* pass `keepalive=None` to
+`NotebookLMClient`.
+
+When to set it:
+
+- **Restricted networks** where outbound POSTs to `accounts.google.com` are
+  blocked or rate-limited at the egress layer.
+- **Regression triage** — if a user reports auth failures, asking them to
+  re-run with this flag isolates whether the rotation poke is the cause.
+- **Test environments** that mock the auth surface and don't want real
+  POSTs leaking out.
+
+### 9.2 `NOTEBOOKLM_REFRESH_CMD=<shell-command>`
+
+Reactive recovery hook (merged in
+[#336](https://github.com/teng-lin/notebooklm-py/pull/336),
+`auth.py::_should_try_refresh` and `_run_refresh_cmd`). When token fetch
+fails with an auth-expiry signal (the
+"`Authentication expired or invalid`" / `accounts.google.com` redirect),
+the library:
+
+1. Runs the configured shell command via `subprocess.run(..., shell=True)`
+   with a 60 s timeout.
+2. Sets `NOTEBOOKLM_REFRESH_PROFILE` and `NOTEBOOKLM_REFRESH_STORAGE_PATH`
+   in the child env so the script knows which profile to refresh.
+3. Sets `_NOTEBOOKLM_REFRESH_ATTEMPTED=1` in the child env to prevent
+   recursive refresh loops if the script itself invokes `notebooklm`.
+4. Reloads cookies from `storage_state.json`, replays token fetch once.
+
+A `ContextVar` (`_REFRESH_ATTEMPTED_CONTEXT`) gates same-task retries in
+the parent process, and `_REFRESH_LOCK` + `_REFRESH_GENERATIONS` ensure
+that a fan-out of N concurrent failing requests triggers exactly one
+refresh, not N.
+
+This is **orthogonal** to L1–L3:
+
+- L1/L2/L3 keep `*PSIDTS` fresh proactively (no-op when nothing's broken).
+- `NOTEBOOKLM_REFRESH_CMD` runs only on auth-expiry failure — it's the
+  reactive last line of defense, useful when the upstream refresh has
+  already failed (e.g. password change, manual sign-out, DBSC enforcement
+  arriving on this client tomorrow). Common shapes:
+
+  ```bash
+  # Re-extract from running Firefox
+  export NOTEBOOKLM_REFRESH_CMD='notebooklm login --browser-cookies firefox'
+
+  # Sync from a CookieCloud server
+  export NOTEBOOKLM_REFRESH_CMD='/opt/scripts/pull-cookies-from-cloud.sh'
+  ```
+
+  The library does not validate the command's contents — the operator is
+  responsible for ensuring it produces a valid `storage_state.json`.
+
+---
+
+## 10 · Canaries and signals
+
+When to panic:
+
+| Signal | Source | What it means | Action |
+|---|---|---|---|
+| `RotateCookies` returns 401 in production | Library logs | DBSC has been extended to non-Chrome paths for at least some accounts | Escalate to L5 (CDP-attach) implementation |
+| `RotateCookies` returns 200 but no `*PSIDTS` in `Set-Cookie` | Library logs | Silent failure mode — cookies on disk are not being rotated | Add WARN log and alert on this; manual re-auth required |
+| [HanaokaYuzu/Gemini-API#310](https://github.com/HanaokaYuzu/Gemini-API/pull/310) merges as default | GitHub | Activity-warmup workaround needed in production for the broader Gemini-API user base | Plan to mirror their approach within 4 weeks |
+| [HanaokaYuzu/Gemini-API#319](https://github.com/HanaokaYuzu/Gemini-API/issues/319) gets "me too" reports | GitHub | Account-specific failures spreading | Investigate whether our user base is affected |
+| Chrome macOS DBSC GA announced | [Chrome dev blog](https://developer.chrome.com/) | macOS users will start getting DBSC enrollment | 3–6 months warning before consumer accounts may be enforced |
+| Workspace session-binding moves out of beta | [Workspace admin docs](https://knowledge.workspace.google.com/admin/security/) | More org admins will enable it | Document explicit non-support clearer |
+
+---
+
+## 11 · Open questions
+
+Things we don't know that would inform future iterations:
+
+- **Exact `*PSIDTS` server-side TTL distribution.** We've seen the
+  `["identity.hfcr",600]` declared interval. Anecdotal data from
+  Gemini-API/Bard-API issue threads suggests 5-60 min variation by account.
+  Real longitudinal data would let us tune L2's 60s floor more precisely.
+- **What kept Probe B alive past T+20m without `*PSIDTS` rotation?** B used
+  `CheckCookie` GET as L1, which observably did *not* rotate `*PSIDTS`.
+  Yet B's session survived hours past A's death (same cookies, no L1).
+  Most likely: server-side "session touched" extension via the unsigned
+  rotation endpoint or identity-surface hit. Untested hypothesis.
+- **DBSC enrollment status for Playwright-launched Chromium.** We assumed
+  Playwright Chromium's session is non-DBSC-bound on macOS/Linux (no TPM)
+  but might be bound on Windows. Untested. If Playwright Chromium can
+  register a DBSC key, L5-A becomes more viable than current research
+  suggests.
+- **Whether `RotateBoundCookies` returns interpretable error codes** for
+  unsigned attempts. Could let us detect DBSC enforcement transition
+  proactively rather than reactively.
+
+---
+
+## 12 · References
+
+### Project peers
+
+- [HanaokaYuzu/Gemini-API](https://github.com/HanaokaYuzu/Gemini-API) —
+  reference for `RotateCookies` rotation
+  ([source](https://github.com/HanaokaYuzu/Gemini-API/blob/master/src/gemini_webapi/utils/rotate_1psidts.py))
+- [easychen/CookieCloud](https://github.com/easychen/CookieCloud) +
+  [PyCookieCloud](https://github.com/lupohan44/PyCookieCloud)
+- [dsdanielpark/Bard-API](https://github.com/dsdanielpark/Bard-API) (archived)
+
+### Cookie extraction libraries
+
+- [`borisbabic/browser_cookie3`](https://github.com/borisbabic/browser_cookie3)
+- [`thewh1teagle/rookie`](https://github.com/thewh1teagle/rookie) (rookiepy)
+- [`n8henrie/pycookiecheat`](https://github.com/n8henrie/pycookiecheat)
+
+### DBSC
+
+- [Google's DBSC GA announcement (Apr 2026)](https://blog.google/security/protecting-cookies-with-device-bound-session-credentials/)
+- [Chrome DBSC Windows GA blog](https://developer.chrome.com/blog/dbsc-windows-announcement)
+- [W3C DBSC spec](https://w3c.github.io/webappsec-dbsc/)
+- [Google Workspace session-binding (beta)](https://knowledge.workspace.google.com/admin/security/prevent-cookie-theft-with-session-binding)
+
+### Internal references
+
+- [#312 — `*PSIDTS` rotation requires `accounts.google.com` touch](https://github.com/teng-lin/notebooklm-py/issues/312)
+- [#297 — `NOTEBOOKLM_REFRESH_CMD` proposal](https://github.com/teng-lin/notebooklm-py/issues/297) /
+  [#336 — implementation merged](https://github.com/teng-lin/notebooklm-py/pull/336)
+- [#341 — L2 background keepalive task](https://github.com/teng-lin/notebooklm-py/pull/341)
+- [#342 / #343 / #344 — keepalive race fixes](https://github.com/teng-lin/notebooklm-py/pull/342)
+- [#345 — Auth keepalive umbrella issue](https://github.com/teng-lin/notebooklm-py/issues/345) /
+  [#346 — L1 RotateCookies POST + 60 s mtime guard merged](https://github.com/teng-lin/notebooklm-py/pull/346)
+- [#347 / #348 — concurrent-poke throttle (three-guard model)](https://github.com/teng-lin/notebooklm-py/pull/348)
+
+---
+
+## Changelog
+
+- **2026-05-09** — Initial writeup. Captures the field experiment results,
+  cross-project review, RotateCookies-vs-CheckCookie finding, and the
+  L1–L6 tiered architecture. DBSC threat model reflects rollout state as
+  of Chrome 146 GA Windows.
+- **2026-05-09 (rev 2)** — Synced doc to merged code state.
+  - L1 (`RotateCookies` POST) is now merged via #346, not "proposed in
+    #345"; concurrent-poke throttle merged via #348.
+  - Section 5.5 rewritten to describe the **three concentric guards**
+    actually implemented (disk mtime fast-path → in-process
+    `asyncio.Lock` + per-profile monotonic timestamp under
+    `threading.Lock` → cross-process non-blocking flock on
+    `.storage_state.json.rotate.lock`). New §5.6 maps each failure mode to
+    the guard that catches it.
+  - New §9 documents `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1` and
+    `NOTEBOOKLM_REFRESH_CMD` (the latter merged in #336 — proactive
+    L1/L2/L3 vs reactive `REFRESH_CMD` distinction made explicit).
+    Subsequent sections renumbered (Canaries → §10, Open questions → §11,
+    References → §12).
+  - §8.3 clarifies that `--browser-cookies` accepts any of the ~16
+    rookiepy-supported browsers (Firefox is the *Windows* recommendation,
+    not a global one) and points at `_ROOKIEPY_BROWSER_ALIASES`.
+- **2026-05-09 (rev 3)** — Added §2 *Background* covering the cookie
+  taxonomy (`__Secure-` / `__Host-` prefixes, 1P vs 3P, the
+  `*SID`/`*SIDTS`/`*SIDCC` family split), the rotation model (the
+  identity vs freshness clocks, why `batchexecute` traffic doesn't
+  rotate), the DBSC protocol (TPM-bound nonce signing,
+  `RotateBoundCookies`, why no Python client can implement it), and how
+  `rookiepy` extracts cookies from encrypted browser stores
+  (Keychain/DPAPI/libsecret + Chrome 127+ App-Bound Encryption). New
+  §2.5 disambiguates the three timers people confuse (server-side
+  `*PSIDTS` TTL, `*SIDCC` window, client-side throttle). Verified via
+  web search that no public evidence (as of 2026-05-09) suggests Google
+  has shortened `*PSIDTS` rotation below the historical 600 s cadence;
+  that note is captured inline in §2.2. Renumbered all sections from
+  the old §2 onward (§2 → §3, …, §11 → §12), and updated the few §-
+  cross-references in body text. No semantic changes to §3–§12 content.
+- **2026-05-09 (rev 4)** — Added §3.4 *Internal threats: cookie-jar
+  fidelity in the persistence pipeline*. Documents six fidelity hazards
+  in `auth.py` with file:line references, the most important being
+  §3.4.1 — a stale-overwrites-fresh race that the post-#344 cross-
+  process flock does **not** cover. Verified via librarian survey of
+  peer projects (Gemini-API, Bard-API, ytmusicapi, gpsoauth,
+  CookieCloud, browser_cookie3, rookiepy) that none of them defend
+  against this pattern either; HanaokaYuzu/Gemini-API
+  ([client.py#L275-L306](https://github.com/HanaokaYuzu/Gemini-API/blob/fbe0790599ac8ee77692dabdce88a96110a33294/src/gemini_webapi/client.py#L275-L306))
+  is more vulnerable than us (no flock, full overwrite on `close()`).
+  §3.4.7 adds a diagnostic checklist for "cookies expire fast" reports
+  that walks internal-causes-first before assuming Google changed
+  anything — relevant to triaging the hour-scale-survival pattern in
+  Gemini-API [#203](https://github.com/HanaokaYuzu/Gemini-API/issues/203)
+  and similar reports.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -78,6 +78,7 @@ MINIMUM_REQUIRED_COOKIES = {"SID"}
 # extends what we ask the browser for at login time.
 ALLOWED_COOKIE_DOMAINS = {
     ".google.com",
+    "google.com",  # Host-only Domain=google.com cookies (rare but possible)
     # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
     ".notebooklm.google.com",
     "notebooklm.google.com",
@@ -85,6 +86,9 @@ ALLOWED_COOKIE_DOMAINS = {
     "accounts.google.com",  # Required for token refresh redirects
     ".accounts.google.com",  # http.cookiejar may normalize Domain=accounts.google.com
     # Sibling Google products — auth/rotation flows may traverse these.
+    # Both dotted and non-dotted variants are listed so that http.cookiejar
+    # normalization (which can add a leading dot) doesn't drop a cookie at the
+    # next extraction; same defensive pattern as accounts.google.com above.
     ".youtube.com",
     "youtube.com",
     "accounts.youtube.com",
@@ -98,6 +102,7 @@ ALLOWED_COOKIE_DOMAINS = {
     # Optional — not load-bearing in any current flow, but kept for symmetry
     # with what a logged-in browser session actually holds.
     "mail.google.com",
+    ".mail.google.com",
 }
 
 # Regional Google ccTLDs where Google may set auth cookies

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -61,8 +61,21 @@ CookieInput: TypeAlias = DomainCookieMap | FlatCookieMap
 # Minimum required cookies (must have at least SID for basic auth)
 MINIMUM_REQUIRED_COOKIES = {"SID"}
 
-# Cookie domains to extract from storage state
-# Includes googleusercontent.com for authenticated media downloads
+# Cookie domains to extract from storage state.
+#
+# Includes:
+#   - notebooklm.google.com (the API host)
+#   - .google.com / accounts.google.com (auth + token refresh)
+#   - .googleusercontent.com (authenticated media downloads)
+#   - sibling Google products (YouTube, Drive, Docs, myaccount, mail) so future
+#     auth/rotation flows that traverse those domains have cookies available.
+#     See issue #360 for the rationale; these are not load-bearing in any
+#     current code path but make the allowlist symmetric with what a logged-in
+#     browser session actually carries.
+#
+# This set is also fed verbatim to ``rookiepy.load(domains=...)`` by
+# ``_login_with_browser_cookies``, so adding a domain here automatically
+# extends what we ask the browser for at login time.
 ALLOWED_COOKIE_DOMAINS = {
     ".google.com",
     # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
@@ -71,6 +84,20 @@ ALLOWED_COOKIE_DOMAINS = {
     ".googleusercontent.com",
     "accounts.google.com",  # Required for token refresh redirects
     ".accounts.google.com",  # http.cookiejar may normalize Domain=accounts.google.com
+    # Sibling Google products — auth/rotation flows may traverse these.
+    ".youtube.com",
+    "youtube.com",
+    "accounts.youtube.com",
+    ".accounts.youtube.com",
+    "drive.google.com",
+    ".drive.google.com",
+    "docs.google.com",
+    ".docs.google.com",
+    "myaccount.google.com",
+    ".myaccount.google.com",
+    # Optional — not load-bearing in any current flow, but kept for symmetry
+    # with what a logged-in browser session actually holds.
+    "mail.google.com",
 }
 
 # Regional Google ccTLDs where Google may set auth cookies
@@ -325,18 +352,32 @@ def _is_google_domain(domain: str) -> bool:
 def _is_allowed_auth_domain(domain: str) -> bool:
     """Check if a cookie domain is allowed for auth cookie extraction.
 
-    Includes exact matches against ALLOWED_COOKIE_DOMAINS plus regional
-    Google domains (e.g., .google.com.sg, .google.co.uk, .google.de) where
-    SID cookies may be set for users in those regions.
+    Thin alias of :func:`_is_allowed_cookie_domain`. Both auth-jar building
+    and download-cookie loading (and the persistence path that filters which
+    cookies get saved back) share a single allowlist policy:
+
+    1. Exact match against :data:`ALLOWED_COOKIE_DOMAINS` (covers the API host,
+       sibling Google products like YouTube/Drive/Docs/myaccount, and the
+       leading-dot variants ``http.cookiejar`` may normalize to).
+    2. Regional Google ccTLDs (``.google.com.sg``, ``.google.co.uk``,
+       ``.google.de``, …) where SID cookies may be set for users in those
+       regions.
+    3. Suffix matches for Google subdomains (``lh3.google.com``,
+       ``accounts.google.com``) and ``.googleusercontent.com`` /
+       ``.usercontent.google.com`` for authenticated media downloads.
+
+    The previous strict / broad split (#334 / fea8315) created an asymmetry
+    where ``save_cookies_to_storage`` would persist cookies that the next
+    extraction would silently drop. Issue #360 collapsed both filters into
+    this single policy.
 
     Args:
         domain: Cookie domain to check (e.g., '.google.com', '.google.com.sg')
 
     Returns:
-        True if domain is allowed for auth cookies.
+        True if domain is allowed for auth/download cookies.
     """
-    # Check if domain is in the primary allowlist or is a valid Google domain (base or regional)
-    return domain in ALLOWED_COOKIE_DOMAINS or _is_google_domain(domain)
+    return _is_allowed_cookie_domain(domain)
 
 
 def _auth_domain_priority(domain: str) -> int:
@@ -668,19 +709,33 @@ def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
 
 
 def _is_allowed_cookie_domain(domain: str) -> bool:
-    """Check if a cookie domain is allowed for downloads.
+    """Canonical cookie-domain allowlist for both auth and downloads.
 
-    Uses a combination of:
-    1. Exact matches against ALLOWED_COOKIE_DOMAINS
-    2. Valid Google domains (including regional like .google.com.sg, .google.co.uk)
-    3. Suffix matching for Google subdomains (lh3.google.com, etc.)
-    4. Suffix matching for googleusercontent.com domains
+    This is the single source of truth for "is this cookie domain one we
+    accept?". Both the auth-extraction path and the download path go through
+    here — :func:`_is_allowed_auth_domain` is a thin alias preserved for
+    call-site readability. See issue #360 for why the split was collapsed.
+
+    A domain is allowed if any of the following holds:
+
+    1. Exact match against :data:`ALLOWED_COOKIE_DOMAINS` (the API host,
+       sibling Google products like ``.youtube.com`` / ``drive.google.com`` /
+       ``docs.google.com`` / ``myaccount.google.com``, ``accounts.google.com``,
+       and the leading-dot variants ``http.cookiejar`` may normalize to).
+    2. Valid Google domain via :func:`_is_google_domain` (regional ccTLDs:
+       ``.google.com.sg``, ``.google.co.uk``, ``.google.de``, …).
+    3. Subdomain of ``.google.com``, ``.googleusercontent.com``, or
+       ``.usercontent.google.com`` (e.g. ``lh3.google.com``,
+       ``lh3.googleusercontent.com``).
+
+    The leading-dot suffix check ensures lookalikes like ``evil-google.com``
+    are rejected.
 
     Args:
         domain: Cookie domain to check (e.g., '.google.com', 'lh3.google.com')
 
     Returns:
-        True if domain is allowed for downloads.
+        True if domain is allowed for auth/download cookies.
     """
     # Exact match against the primary allowlist
     if domain in ALLOWED_COOKIE_DOMAINS:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1259,9 +1259,30 @@ class TestAllowedCookieDomains:
         """Test ALLOWED_COOKIE_DOMAINS contains expected domains."""
         from notebooklm.auth import ALLOWED_COOKIE_DOMAINS
 
+        # Core NotebookLM/Google auth domains
         assert ".google.com" in ALLOWED_COOKIE_DOMAINS
         assert any(domain == ".notebooklm.google.com" for domain in ALLOWED_COOKIE_DOMAINS)
         assert "notebooklm.google.com" in ALLOWED_COOKIE_DOMAINS
+        assert ".googleusercontent.com" in ALLOWED_COOKIE_DOMAINS
+        assert "accounts.google.com" in ALLOWED_COOKIE_DOMAINS
+
+        # Sibling Google product domains added in issue #360
+        for domain in (
+            ".youtube.com",
+            "youtube.com",
+            "accounts.youtube.com",
+            ".accounts.youtube.com",
+            "drive.google.com",
+            ".drive.google.com",
+            "docs.google.com",
+            ".docs.google.com",
+            "myaccount.google.com",
+            ".myaccount.google.com",
+            "mail.google.com",
+        ):
+            assert (
+                domain in ALLOWED_COOKIE_DOMAINS
+            ), f"Expected {domain!r} in ALLOWED_COOKIE_DOMAINS (issue #360)"
 
 
 # =============================================================================
@@ -1449,28 +1470,53 @@ class TestIsAllowedAuthDomain:
         assert _is_allowed_auth_domain(".google.de") is True  # Germany
         assert _is_allowed_auth_domain(".google.fr") is True  # France
 
+    def test_accepts_sibling_google_products(self):
+        """Test accepts sibling Google product domains (issue #360)."""
+        from notebooklm.auth import _is_allowed_auth_domain
+
+        # YouTube
+        assert _is_allowed_auth_domain(".youtube.com") is True
+        assert _is_allowed_auth_domain("youtube.com") is True
+        assert _is_allowed_auth_domain("accounts.youtube.com") is True
+        assert _is_allowed_auth_domain(".accounts.youtube.com") is True
+        # Drive / Docs / myaccount / mail
+        assert _is_allowed_auth_domain("drive.google.com") is True
+        assert _is_allowed_auth_domain(".drive.google.com") is True
+        assert _is_allowed_auth_domain("docs.google.com") is True
+        assert _is_allowed_auth_domain(".docs.google.com") is True
+        assert _is_allowed_auth_domain("myaccount.google.com") is True
+        assert _is_allowed_auth_domain(".myaccount.google.com") is True
+        assert _is_allowed_auth_domain("mail.google.com") is True
+
     def test_rejects_unrelated_domains(self):
         """Test rejects non-Google domains."""
         from notebooklm.auth import _is_allowed_auth_domain
 
-        assert _is_allowed_auth_domain(".youtube.com") is False
         assert _is_allowed_auth_domain("evil.com") is False
         assert _is_allowed_auth_domain(".evil-google.com") is False
+        assert _is_allowed_auth_domain(".not-youtube.com") is False
+        assert _is_allowed_auth_domain("notyoutube.com") is False
 
     def test_rejects_malicious_google_lookalikes(self):
         """Test rejects domains that look like Google but aren't."""
         from notebooklm.auth import _is_allowed_auth_domain
 
         assert _is_allowed_auth_domain("google.com.evil.sg") is False
-        assert _is_allowed_auth_domain(".mail.google.com") is False
-        assert _is_allowed_auth_domain(".evilnotebooklm.google.com") is False
+        # Note: post-#360 unification, .mail.google.com is accepted (it's a
+        # legitimate Google-owned subdomain). Only foreign suffixes are rejected.
         assert _is_allowed_auth_domain(".google.com.evil") is False
         assert _is_allowed_auth_domain(".evilnotebooklm.google.com.evil") is False
         assert _is_allowed_auth_domain(".not-google.com.sg") is False
         assert _is_allowed_auth_domain(".google.zz") is False  # Invalid ccTLD
 
     def test_requires_leading_dot_for_regional(self):
-        """Test regional domains must have leading dot."""
+        """Test regional domains require leading dot.
+
+        Regional ccTLDs like ``google.com.sg`` (no leading dot) are not in
+        ALLOWED_COOKIE_DOMAINS and are not accepted by ``_is_google_domain``
+        (which requires the leading dot for regional patterns) or by the
+        suffix paths (which require the leading-dot suffix).
+        """
         from notebooklm.auth import _is_allowed_auth_domain
 
         assert _is_allowed_auth_domain("google.com.sg") is False
@@ -1542,13 +1588,27 @@ class TestIsAllowedCookieDomainRegional:
         assert _is_allowed_cookie_domain("accounts.google.com") is True
         assert _is_allowed_cookie_domain("lh3.googleusercontent.com") is True
 
+    def test_accepts_sibling_google_products(self):
+        """Test accepts sibling Google product domains (issue #360)."""
+        from notebooklm.auth import _is_allowed_cookie_domain
+
+        assert _is_allowed_cookie_domain(".youtube.com") is True
+        assert _is_allowed_cookie_domain("youtube.com") is True
+        assert _is_allowed_cookie_domain("accounts.youtube.com") is True
+        assert _is_allowed_cookie_domain(".accounts.youtube.com") is True
+        assert _is_allowed_cookie_domain("drive.google.com") is True
+        assert _is_allowed_cookie_domain("docs.google.com") is True
+        assert _is_allowed_cookie_domain("myaccount.google.com") is True
+        assert _is_allowed_cookie_domain("mail.google.com") is True
+
     def test_rejects_invalid_domains(self):
         """Test rejects invalid domains."""
         from notebooklm.auth import _is_allowed_cookie_domain
 
         assert _is_allowed_cookie_domain(".google.zz") is False
         assert _is_allowed_cookie_domain("evil-google.com") is False
-        assert _is_allowed_cookie_domain(".youtube.com") is False
+        assert _is_allowed_cookie_domain(".not-youtube.com") is False
+        assert _is_allowed_cookie_domain("notyoutube.com") is False
 
 
 class TestExtractCookiesRegionalDomains:
@@ -1649,23 +1709,20 @@ class TestExtractCookiesRegionalDomains:
         cookies = extract_cookies_from_storage(storage_state)
         assert cookies["SID"] == "sid_global", ".google.com should win (regional first)"
 
-    def test_rejects_youtube_sid_but_accepts_regional_sid(self):
-        """Test rejects SID from youtube but accepts from regional Google domain."""
+    def test_regional_google_sid_outranks_sibling_product_sid(self):
+        """Regional Google SID outranks YouTube SID when both are present.
+
+        Post-#360 the allowlist accepts sibling-product cookies, but the
+        priority ladder still prefers a regional Google SID over a YouTube
+        SID when both are seen, because YouTube falls into the unranked tier
+        (priority 0) and regional Google domains sit at priority 1.
+        """
         storage_state = {
             "cookies": [
-                # YouTube SID should be rejected (not a Google auth domain)
                 {"name": "SID", "value": "youtube_sid", "domain": ".youtube.com"},
+                {"name": "SID", "value": "regional_sid", "domain": ".google.com.sg"},
             ]
         }
-
-        # Should fail because no valid SID from allowed domain
-        with pytest.raises(ValueError, match="Missing required cookies"):
-            extract_cookies_from_storage(storage_state)
-
-        # But if we add a regional Google SID, it should work
-        storage_state["cookies"].append(
-            {"name": "SID", "value": "regional_sid", "domain": ".google.com.sg"}
-        )
         cookies = extract_cookies_from_storage(storage_state)
         assert cookies["SID"] == "regional_sid"
 
@@ -1747,6 +1804,146 @@ class TestLoadHttpxCookiesRegional:
 
         cookies = load_httpx_cookies(path=storage_file)
         assert cookies.get("SID", domain=".google.de") == "sid_de"
+
+
+class TestSiblingGoogleProductExtraction:
+    """Test cookie extraction from sibling Google product domains (issue #360).
+
+    Pre-#360 the auth allowlist was strictly NotebookLM-shaped: cookies on
+    ``.youtube.com``, ``drive.google.com``, ``docs.google.com``,
+    ``myaccount.google.com``, and ``.mail.google.com`` were dropped at
+    extraction. The unified allowlist now keeps them so future flows that
+    traverse those domains have the cookies they need.
+    """
+
+    SIBLING_DOMAINS = [
+        ".youtube.com",
+        "youtube.com",
+        "accounts.youtube.com",
+        ".accounts.youtube.com",
+        "drive.google.com",
+        ".drive.google.com",
+        "docs.google.com",
+        ".docs.google.com",
+        "myaccount.google.com",
+        ".myaccount.google.com",
+        "mail.google.com",
+    ]
+
+    @pytest.mark.parametrize("domain", SIBLING_DOMAINS)
+    def test_extract_cookies_with_domains_keeps_sibling_cookies(self, domain):
+        """``extract_cookies_with_domains`` retains sibling-product cookies."""
+        storage_state = {
+            "cookies": [
+                # Required SID on .google.com so extraction doesn't fail
+                {"name": "SID", "value": "base_sid", "domain": ".google.com"},
+                # Sibling-product cookie that pre-#360 would have been dropped
+                {"name": "PRODUCT_TOKEN", "value": "sibling", "domain": domain},
+            ]
+        }
+        cookie_map = extract_cookies_with_domains(storage_state)
+        assert ("PRODUCT_TOKEN", domain) in cookie_map
+        assert cookie_map[("PRODUCT_TOKEN", domain)] == "sibling"
+
+    @pytest.mark.parametrize("domain", SIBLING_DOMAINS)
+    def test_load_httpx_cookies_keeps_sibling_cookies(self, tmp_path, domain):
+        """``load_httpx_cookies`` (download path) accepts sibling-product cookies."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "base_sid", "domain": ".google.com"},
+                {"name": "PRODUCT_TOKEN", "value": "sibling", "domain": domain},
+            ]
+        }
+        storage_file = tmp_path / "storage.json"
+        storage_file.write_text(json.dumps(storage_state))
+
+        cookies = load_httpx_cookies(path=storage_file)
+        assert cookies.get("PRODUCT_TOKEN", domain=domain) == "sibling"
+
+    @pytest.mark.parametrize("domain", SIBLING_DOMAINS)
+    def test_convert_rookiepy_keeps_sibling_cookies(self, domain):
+        """rookiepy → storage_state conversion keeps sibling-product cookies."""
+        raw = [
+            {
+                "domain": domain,
+                "name": "PRODUCT_TOKEN",
+                "value": "sibling",
+                "path": "/",
+                "secure": True,
+                "expires": None,
+                "http_only": False,
+            }
+        ]
+        result = convert_rookiepy_cookies_to_storage_state(raw)
+        assert len(result["cookies"]) == 1
+        assert result["cookies"][0]["domain"] == domain
+
+    def test_strict_allowlisted_domains_still_work(self):
+        """Regression: pre-existing strict-allowlisted domains keep working.
+
+        Ensures the unification didn't accidentally drop any of the original
+        canonical NotebookLM auth domains.
+        """
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "v1", "domain": ".google.com"},
+                {"name": "HSID", "value": "v2", "domain": ".google.com"},
+                {"name": "OSID", "value": "v3", "domain": "notebooklm.google.com"},
+                {"name": "OSID2", "value": "v4", "domain": ".notebooklm.google.com"},
+                {"name": "ACC", "value": "v5", "domain": "accounts.google.com"},
+                {"name": "ACC2", "value": "v6", "domain": ".accounts.google.com"},
+                {"name": "MEDIA", "value": "v7", "domain": ".googleusercontent.com"},
+            ]
+        }
+        cookie_map = extract_cookies_with_domains(storage_state)
+        assert ("SID", ".google.com") in cookie_map
+        assert ("HSID", ".google.com") in cookie_map
+        assert ("OSID", "notebooklm.google.com") in cookie_map
+        assert ("OSID2", ".notebooklm.google.com") in cookie_map
+        assert ("ACC", "accounts.google.com") in cookie_map
+        assert ("ACC2", ".accounts.google.com") in cookie_map
+        assert ("MEDIA", ".googleusercontent.com") in cookie_map
+
+    def test_unified_filter_rejects_unrelated_domains(self):
+        """Regression: cookies from unrelated domains are still rejected."""
+        storage_state = {
+            "cookies": [
+                {"name": "SID", "value": "v1", "domain": ".google.com"},
+                {"name": "EVIL", "value": "x", "domain": ".evil.com"},
+                {"name": "EVIL2", "value": "y", "domain": ".not-google.com"},
+                {"name": "EVIL3", "value": "z", "domain": ".evil-google.com"},
+                {"name": "EVIL4", "value": "w", "domain": ".not-youtube.com"},
+            ]
+        }
+        cookie_map = extract_cookies_with_domains(storage_state)
+        kept_names = {name for name, _ in cookie_map}
+        assert kept_names == {"SID"}
+
+
+class TestRookiepyDomainsCoverage:
+    """Confirm ``_login_with_browser_cookies`` would request sibling domains.
+
+    The login path constructs its rookiepy ``domains`` list from
+    ``ALLOWED_COOKIE_DOMAINS + regional ccTLDs``, so adding a domain to the
+    constant automatically widens what we ask the browser for. This test pins
+    that contract — if someone narrows the constant later, the contract here
+    flags it.
+    """
+
+    def test_allowlist_covers_sibling_products(self):
+        from notebooklm.auth import ALLOWED_COOKIE_DOMAINS
+
+        for domain in (
+            ".youtube.com",
+            "accounts.youtube.com",
+            "drive.google.com",
+            "docs.google.com",
+            "myaccount.google.com",
+        ):
+            assert domain in ALLOWED_COOKIE_DOMAINS, (
+                f"{domain!r} must be in ALLOWED_COOKIE_DOMAINS so "
+                "_login_with_browser_cookies asks rookiepy for it (issue #360)"
+            )
 
 
 class TestConvertRookiepyCookies:
@@ -1878,18 +2075,64 @@ class TestConvertRookiepyCookies:
         assert result["cookies"][0]["domain"] == ".notebooklm.google.com"
         assert result["cookies"][0]["name"] == "OSID"
 
-    def test_other_google_subdomains_filtered(self):
-        """Auth conversion only keeps explicitly allowed Google subdomains."""
+    def test_sibling_google_product_subdomains_kept(self):
+        """Auth conversion keeps sibling Google product cookies (issue #360).
+
+        Pre-#360 the auth allowlist was strict and dropped subdomains like
+        ``.mail.google.com``. The unified allowlist now matches the broader
+        download policy so cookies from ``.youtube.com``, ``drive.google.com``,
+        ``docs.google.com``, ``myaccount.google.com``, and ``.mail.google.com``
+        survive extraction.
+        """
         raw = [
             {
-                "domain": ".mail.google.com",
-                "name": "OSID",
-                "value": "x",
+                "domain": domain,
+                "name": "SID",
+                "value": "v",
                 "path": "/",
                 "secure": True,
                 "expires": None,
                 "http_only": False,
             }
+            for domain in (
+                ".mail.google.com",
+                ".youtube.com",
+                ".drive.google.com",
+                ".docs.google.com",
+                ".myaccount.google.com",
+            )
+        ]
+        result = convert_rookiepy_cookies_to_storage_state(raw)
+        kept_domains = {c["domain"] for c in result["cookies"]}
+        assert kept_domains == {
+            ".mail.google.com",
+            ".youtube.com",
+            ".drive.google.com",
+            ".docs.google.com",
+            ".myaccount.google.com",
+        }
+
+    def test_unrelated_domains_still_filtered(self):
+        """Cookies from non-Google domains are still dropped."""
+        raw = [
+            {
+                "domain": ".evil.com",
+                "name": "SID",
+                "value": "x",
+                "path": "/",
+                "secure": True,
+                "expires": None,
+                "http_only": False,
+            },
+            {
+                "domain": ".not-google.com",
+                "name": "SID",
+                "value": "x",
+                "path": "/",
+                "secure": True,
+                "expires": None,
+                "http_only": False,
+            },
         ]
         result = convert_rookiepy_cookies_to_storage_state(raw)
         assert result == {"cookies": [], "origins": []}

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1259,15 +1259,21 @@ class TestAllowedCookieDomains:
         """Test ALLOWED_COOKIE_DOMAINS contains expected domains."""
         from notebooklm.auth import ALLOWED_COOKIE_DOMAINS
 
-        # Core NotebookLM/Google auth domains
-        assert ".google.com" in ALLOWED_COOKIE_DOMAINS
-        assert any(domain == ".notebooklm.google.com" for domain in ALLOWED_COOKIE_DOMAINS)
-        assert "notebooklm.google.com" in ALLOWED_COOKIE_DOMAINS
-        assert ".googleusercontent.com" in ALLOWED_COOKIE_DOMAINS
-        assert "accounts.google.com" in ALLOWED_COOKIE_DOMAINS
-
-        # Sibling Google product domains added in issue #360
-        for domain in (
+        # Single set-difference assertion. CodeQL's
+        # py/incomplete-url-substring-sanitization heuristic flags per-line
+        # ``"<literal>" in ALLOWED_COOKIE_DOMAINS`` patterns as if they were
+        # substring sanitization of a URL, even though this is set-membership
+        # against a constant. The set-diff form has no string-in-string
+        # appearance and reads at least as clearly.
+        expected = {
+            # Core NotebookLM/Google auth domains
+            ".google.com",
+            ".notebooklm.google.com",
+            "notebooklm.google.com",
+            ".googleusercontent.com",
+            "accounts.google.com",
+            ".accounts.google.com",
+            # Sibling Google product domains added in issue #360
             ".youtube.com",
             "youtube.com",
             "accounts.youtube.com",
@@ -1279,10 +1285,9 @@ class TestAllowedCookieDomains:
             "myaccount.google.com",
             ".myaccount.google.com",
             "mail.google.com",
-        ):
-            assert (
-                domain in ALLOWED_COOKIE_DOMAINS
-            ), f"Expected {domain!r} in ALLOWED_COOKIE_DOMAINS (issue #360)"
+        }
+        missing = expected - ALLOWED_COOKIE_DOMAINS
+        assert not missing, f"ALLOWED_COOKIE_DOMAINS is missing: {missing}"
 
 
 # =============================================================================

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1268,6 +1268,7 @@ class TestAllowedCookieDomains:
         expected = {
             # Core NotebookLM/Google auth domains
             ".google.com",
+            "google.com",
             ".notebooklm.google.com",
             "notebooklm.google.com",
             ".googleusercontent.com",
@@ -1285,6 +1286,7 @@ class TestAllowedCookieDomains:
             "myaccount.google.com",
             ".myaccount.google.com",
             "mail.google.com",
+            ".mail.google.com",
         }
         missing = expected - ALLOWED_COOKIE_DOMAINS
         assert not missing, f"ALLOWED_COOKIE_DOMAINS is missing: {missing}"
@@ -1833,6 +1835,7 @@ class TestSiblingGoogleProductExtraction:
         "myaccount.google.com",
         ".myaccount.google.com",
         "mail.google.com",
+        ".mail.google.com",
     ]
 
     @pytest.mark.parametrize("domain", SIBLING_DOMAINS)


### PR DESCRIPTION
Closes #360.

## Summary

The cookie allowlist was narrowly NotebookLM-shaped and split across two
asymmetric filters. This PR:

1. **Extends `ALLOWED_COOKIE_DOMAINS`** to cover sibling Google products
   (`.youtube.com`, `accounts.youtube.com`, `drive.google.com`,
   `docs.google.com`, `myaccount.google.com`, `mail.google.com`, plus the
   leading-dot variants `http.cookiejar` may normalize to).
   `_login_with_browser_cookies` feeds this set verbatim to
   `rookiepy.load()`, so the login path automatically asks the browser
   for these cookies now.

2. **Unifies the two domain filters.** `_is_allowed_auth_domain` is now
   a thin alias of `_is_allowed_cookie_domain` (the broader policy). The
   pre-existing strict/broad split — residue of #334 / `fea8315` — meant
   cookies the persistence path saved would be silently dropped on the
   next extraction. Both call sites now share a single canonical policy
   with one documented docstring.

3. **Updates `docs/auth-keepalive.md` §3.4.3** with a Resolved callout.

Cookie priority for duplicate SIDs is unchanged: `.google.com` still
outranks regional ccTLDs (priority 1) and sibling-product domains (the
unranked tier, priority 0). When SID exists on both `.google.com` and
`.youtube.com`, the `.google.com` value still wins deterministically.

## Out of scope

Per the issue, the following are deliberately not touched in this PR:

- `save_cookies_to_storage` merge logic (#361 territory)
- `_loaded_cookie_snapshot` on `ClientCore`
- `refresh_auth` in `client.py`
- Path-aware cookie keying

## Test plan

- [x] All 2325 existing unit tests pass
- [x] `ruff format`, `ruff check`, `mypy` all clean
- [x] New parametrized tests cover extraction + download-cookie loading +
      rookiepy conversion for each new sibling domain
- [x] Regression test covering pre-existing strict-allowlisted domains
- [x] Existing `_is_allowed_auth_domain` / `_is_allowed_cookie_domain`
      tests updated to reflect the unified policy
- [ ] CI green on the PR
- [ ] Manual smoke test (deferred; per acceptance criteria, recommended
      before merge): `notebooklm login --browser-cookies firefox` then
      every source-add flow (URL, Drive doc, YouTube)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added authentication keepalive strategy design document outlining session management architecture and failure models.

* **Improvements**
  * Expanded authentication support to recognize cookies from additional Google product domains (YouTube, Drive, Docs, myaccount, mail) for enhanced session handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/362)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->