### PR TITLE
fix(auth): preserve cookie attributes on load (#365)

### DIFF
--- a/docs/auth-keepalive.md
+++ b/docs/auth-keepalive.md
@@ -588,6 +588,11 @@ convention) and persist them indefinitely. This means:
 
 #### 3.4.6 `__Host-` invariants are not enforced
 
+> **Mitigated in #365** as a side benefit of fixing §3.4.7. Faithful
+> `path`/`secure` preservation on load means `__Host-` cookies survive
+> the round-trip without losing the prefix-mandated attributes; the
+> remaining gap is `cookie.domain` normalization on the save side.
+
 `__Host-` prefix cookies (`__Host-GAPS`, `__Host-1PLSID`,
 `__Host-3PLSID`) **must** have empty `Domain` and `Path=/` per the
 prefix rule. `_cookie_to_storage_state` writes whatever
@@ -597,6 +602,11 @@ shape. Browsers and well-behaved cookie jars discard these on load;
 silent drops would manifest as occasional auth-flow flakes.
 
 #### 3.4.7 Load-side attribute loss (round-trip erosion)
+
+> **Resolved in #365.** Both load paths now construct a faithful
+> `http.cookiejar.Cookie` via the `_storage_entry_to_cookie` helper,
+> preserving `path`, `secure`, and `httpOnly` across load+save cycles.
+> The analysis below is retained for historical context.
 
 Every load path uses `cookies.set(name, value, domain=domain)` —
 `build_httpx_cookies_from_storage` (`auth.py:822`) and

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -30,6 +30,7 @@ Security Notes:
 import asyncio
 import contextlib
 import errno
+import http.cookiejar
 import json
 import logging
 import os
@@ -790,16 +791,16 @@ def load_httpx_cookies(path: Path | None = None) -> "httpx.Cookies":
     storage_state = _load_storage_state(path)
 
     cookies = httpx.Cookies()
-    cookie_names = set()
+    cookie_names: set[str] = set()
 
-    for cookie in storage_state.get("cookies", []):
-        domain = cookie.get("domain", "")
-        name = cookie.get("name", "")
-        value = cookie.get("value", "")
+    for entry in storage_state.get("cookies", []):
+        domain = entry.get("domain", "")
+        name = entry.get("name", "")
+        value = entry.get("value", "")
 
         # Only include cookies from explicitly allowed domains
         if _is_allowed_cookie_domain(domain) and name and value:
-            cookies.set(name, value, domain=domain)
+            cookies.jar.set_cookie(_storage_entry_to_cookie(entry))
             cookie_names.add(name)
 
     # Validate that essential cookies are present
@@ -876,11 +877,32 @@ def build_httpx_cookies_from_storage(path: Path | None = None) -> "httpx.Cookies
         ValueError: If required cookies are missing or JSON is malformed.
     """
     storage_state = _load_storage_state(path)
-    cookie_map = extract_cookies_with_domains(storage_state)
 
     cookies = httpx.Cookies()
-    for (name, domain), value in cookie_map.items():
-        cookies.set(name, value, domain=domain)
+    # Per RFC 6265, cookie identity is (name, domain, path) — two cookies sharing
+    # name+domain but differing in path are legitimately distinct. Dedup must
+    # use the full triple so a path-scoped cookie cannot suppress a sibling
+    # cookie at "/". See #365.
+    seen_triples: set[tuple[str, str, str]] = set()
+    cookie_names: set[str] = set()
+    for entry in storage_state.get("cookies", []):
+        domain = entry.get("domain", "")
+        name = entry.get("name")
+        value = entry.get("value", "")
+        if not _is_allowed_auth_domain(domain) or not name or not value:
+            continue
+        triple = (name, domain, entry.get("path") or "/")
+        if triple in seen_triples:
+            continue
+        seen_triples.add(triple)
+        cookie_names.add(name)
+        cookies.jar.set_cookie(_storage_entry_to_cookie(entry))
+
+    missing = MINIMUM_REQUIRED_COOKIES - cookie_names
+    if missing:
+        raise ValueError(
+            f"Missing required cookies: {missing}\nRun 'notebooklm login' to authenticate."
+        )
 
     return cookies
 
@@ -1142,6 +1164,44 @@ def _cookie_to_storage_state(cookie: Any) -> dict[str, Any]:
         "secure": cookie.secure,
         "sameSite": "None",
     }
+
+
+def _storage_entry_to_cookie(entry: dict[str, Any]) -> http.cookiejar.Cookie:
+    """Construct a faithful ``http.cookiejar.Cookie`` from a storage_state entry.
+
+    ``httpx.Cookies.set(name, value, domain=...)`` accepts only those three
+    fields, so cookies loaded that way drop ``path``, ``secure``, and
+    ``httpOnly``. Each load+save round-trip would erode attributes until disk
+    stabilized at ``Path=/``, ``secure=false``, ``httpOnly=false`` — silently
+    breaking ``__Host-`` prefix invariants and any future server-enforced
+    attribute. This helper is the load-side mirror of
+    :func:`_cookie_to_storage_state` so the round-trip is lossless. See #365.
+    """
+    domain = entry.get("domain", "") or ""
+    expires = entry.get("expires")
+    expires_value = None if expires in (None, -1) else expires
+    # _cookie_is_http_only checks key presence via has_nonstandard_attr; the
+    # value is irrelevant. Use "" instead of None so the typed signature
+    # ``rest: Mapping[str, str]`` is honored.
+    rest: dict[str, str] = {"HttpOnly": ""} if entry.get("httpOnly") else {}
+    return http.cookiejar.Cookie(
+        version=0,
+        name=entry.get("name", "") or "",
+        value=entry.get("value", "") or "",
+        port=None,
+        port_specified=False,
+        domain=domain,
+        domain_specified=bool(domain),
+        domain_initial_dot=domain.startswith("."),
+        path=entry.get("path") or "/",
+        path_specified=True,
+        secure=bool(entry.get("secure", False)),
+        expires=expires_value,
+        discard=expires_value is None,
+        comment=None,
+        comment_url=None,
+        rest=rest,
+    )
 
 
 def _cookie_key_variants(key: CookieKey) -> set[CookieKey]:

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -273,11 +273,12 @@ class AuthTokens:
         if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
             path = get_storage_path(profile=profile)
 
-        storage_state = _load_storage_state(path)
-        cookies = extract_cookies_with_domains(storage_state)
-
-        # Build domain-preserving jar and use it for token fetch
-        jar = build_cookie_jar(cookies=cookies)
+        # Build the cookie jar via the lossless loader so path/secure/httpOnly
+        # survive into the live jar. The earlier
+        # extract_cookies_with_domains -> build_cookie_jar pipeline only carried
+        # (name, domain) -> value and dropped the same attributes the load
+        # paths in #365 fixed.
+        jar = build_httpx_cookies_from_storage(path)
         csrf_token, session_id, _ = await _fetch_tokens_with_refresh(jar, path, profile)
 
         # Persist any refreshed cookies from the token fetch
@@ -879,25 +880,25 @@ def build_httpx_cookies_from_storage(path: Path | None = None) -> "httpx.Cookies
     storage_state = _load_storage_state(path)
 
     cookies = httpx.Cookies()
-    # Per RFC 6265, cookie identity is (name, domain, path) — two cookies sharing
-    # name+domain but differing in path are legitimately distinct. Dedup must
-    # use the full triple so a path-scoped cookie cannot suppress a sibling
-    # cookie at "/". See #365.
-    seen_triples: set[tuple[str, str, str]] = set()
-    cookie_names: set[str] = set()
+    # Dedup by (name, domain) to stay symmetric with save_cookies_to_storage,
+    # which keys cookies_by_key on the same pair. Cookie identity per RFC 6265
+    # is (name, domain, path), but the save side cannot represent multiple
+    # path-scoped siblings yet — so the load side keeps a compatible model
+    # rather than constructing pairs that would silently collapse on save.
+    seen_keys: set[CookieKey] = set()
     for entry in storage_state.get("cookies", []):
         domain = entry.get("domain", "")
         name = entry.get("name")
         value = entry.get("value", "")
         if not _is_allowed_auth_domain(domain) or not name or not value:
             continue
-        triple = (name, domain, entry.get("path") or "/")
-        if triple in seen_triples:
+        key = (name, domain)
+        if key in seen_keys:
             continue
-        seen_triples.add(triple)
-        cookie_names.add(name)
+        seen_keys.add(key)
         cookies.jar.set_cookie(_storage_entry_to_cookie(entry))
 
+    cookie_names = {name for name, _ in seen_keys}
     missing = MINIMUM_REQUIRED_COOKIES - cookie_names
     if missing:
         raise ValueError(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -725,44 +725,6 @@ class TestCookieAttributePreservation:
         # 0 is preserved as 0 — not collapsed to None (session) or -1.
         assert sid.expires == 0
 
-    def test_distinct_paths_for_same_name_domain_coexist(self, tmp_path):
-        """Two cookies with same name+domain but different paths are distinct.
-
-        Per RFC 6265 cookie identity is (name, domain, path). The dedup key
-        must include path so a path-scoped cookie does not silently suppress
-        the canonical ``/`` cookie.
-        """
-        state = {
-            "cookies": [
-                {
-                    "name": "SID",
-                    "value": "root-value",
-                    "domain": ".google.com",
-                    "path": "/",
-                    "expires": 1893456000,
-                    "httpOnly": True,
-                    "secure": True,
-                },
-                {
-                    "name": "SID",
-                    "value": "scoped-value",
-                    "domain": ".google.com",
-                    "path": "/u/0/",
-                    "expires": 1893456000,
-                    "httpOnly": True,
-                    "secure": True,
-                },
-            ]
-        }
-        storage_file = tmp_path / "storage_state.json"
-        storage_file.write_text(json.dumps(state))
-
-        jar = build_httpx_cookies_from_storage(storage_file)
-        root = self._find_cookie(jar, "SID", ".google.com", path="/")
-        scoped = self._find_cookie(jar, "SID", ".google.com", path="/u/0/")
-        assert root.value == "root-value"
-        assert scoped.value == "scoped-value"
-
 
 class TestExtractCSRFRedirect:
     """Test CSRF extraction redirect detection."""
@@ -1362,6 +1324,40 @@ class TestAuthTokensFromStorage:
         """Test raises error when storage file doesn't exist."""
         with pytest.raises(FileNotFoundError):
             await AuthTokens.from_storage(tmp_path / "nonexistent.json")
+
+    @pytest.mark.asyncio
+    async def test_from_storage_preserves_cookie_attributes(self, tmp_path, httpx_mock: HTTPXMock):
+        """``AuthTokens.from_storage`` builds the jar via the lossless loader.
+
+        The recommended programmatic entry point must not erode path/secure/
+        httpOnly on its way to the live jar — otherwise #365's fix only covers
+        the direct loaders. See review feedback on PR #368.
+        """
+        storage_file = tmp_path / "storage_state.json"
+        storage_state = {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "sid",
+                    "domain": ".google.com",
+                    "path": "/u/0/",
+                    "expires": 1893456000,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+            ]
+        }
+        storage_file.write_text(json.dumps(storage_state))
+
+        html = '"SNlM0e":"csrf_token" "FdrFJe":"session_id"'
+        httpx_mock.add_response(content=html.encode())
+
+        tokens = await AuthTokens.from_storage(storage_file)
+
+        sid = next(c for c in tokens.cookie_jar.jar if c.name == "SID")
+        assert sid.path == "/u/0/"
+        assert sid.secure is True
+        assert sid.has_nonstandard_attr("HttpOnly")
 
 
 # =============================================================================

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -18,6 +18,7 @@ from notebooklm.auth import (
     KEEPALIVE_ROTATE_URL,
     NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV,
     AuthTokens,
+    build_httpx_cookies_from_storage,
     convert_rookiepy_cookies_to_storage_state,
     extract_cookies_from_storage,
     extract_cookies_with_domains,
@@ -558,6 +559,209 @@ class TestLoadHttpxCookiesWithEnvVar:
         # Explicit path should win
         cookies = load_httpx_cookies(path=storage_file)
         assert cookies.get("SID", domain=".google.com") == "from_file"
+
+
+class TestCookieAttributePreservation:
+    """Round-trip preservation of path, secure, and httpOnly across load+save (#365)."""
+
+    @staticmethod
+    def _find_cookie(jar, name, domain, path=None):
+        for cookie in jar.jar:
+            if cookie.name == name and cookie.domain == domain:
+                if path is None or cookie.path == path:
+                    return cookie
+        raise AssertionError(f"cookie {name}@{domain} (path={path}) not in jar")
+
+    def _attr_storage_state(self):
+        """Storage state with explicit non-default attributes on every cookie."""
+        return {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "sid-value",
+                    "domain": ".google.com",
+                    "path": "/u/0/",
+                    "expires": 1893456000,
+                    "httpOnly": True,
+                    "secure": True,
+                    "sameSite": "None",
+                },
+                {
+                    "name": "__Host-GAPS",
+                    "value": "host-only-value",
+                    "domain": "accounts.google.com",
+                    "path": "/",
+                    "expires": -1,
+                    "httpOnly": True,
+                    "secure": True,
+                    "sameSite": "Strict",
+                },
+            ]
+        }
+
+    def test_load_httpx_cookies_preserves_attributes(self, tmp_path):
+        """``load_httpx_cookies`` should carry path/secure/httpOnly into the jar."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(self._attr_storage_state()))
+
+        jar = load_httpx_cookies(path=storage_file)
+
+        sid = self._find_cookie(jar, "SID", ".google.com")
+        assert sid.path == "/u/0/"
+        assert sid.secure is True
+        assert sid.has_nonstandard_attr("HttpOnly")
+
+        gaps = self._find_cookie(jar, "__Host-GAPS", "accounts.google.com")
+        assert gaps.path == "/"
+        assert gaps.secure is True
+        assert gaps.has_nonstandard_attr("HttpOnly")
+
+    def test_build_httpx_cookies_from_storage_preserves_attributes(self, tmp_path):
+        """``build_httpx_cookies_from_storage`` should preserve the same attrs."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(self._attr_storage_state()))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+
+        sid = self._find_cookie(jar, "SID", ".google.com")
+        assert sid.path == "/u/0/"
+        assert sid.secure is True
+        assert sid.has_nonstandard_attr("HttpOnly")
+
+        gaps = self._find_cookie(jar, "__Host-GAPS", "accounts.google.com")
+        assert gaps.path == "/"
+        assert gaps.secure is True
+        assert gaps.has_nonstandard_attr("HttpOnly")
+
+    def test_round_trip_with_value_change_preserves_attributes(self, tmp_path):
+        """Load → bump value → save → reload preserves path/secure/httpOnly.
+
+        Mutating the value forces ``save_cookies_to_storage`` into the
+        "changed" branch that overwrites stored attrs from the live jar — the
+        path that previously eroded attributes to defaults.
+        """
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(self._attr_storage_state()))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+        for cookie in jar.jar:
+            if cookie.name == "SID":
+                cookie.value = "rotated-sid"
+        save_cookies_to_storage(jar, storage_file)
+
+        on_disk = json.loads(storage_file.read_text())
+        sid_entry = next(c for c in on_disk["cookies"] if c["name"] == "SID")
+        assert sid_entry["path"] == "/u/0/"
+        assert sid_entry["secure"] is True
+        assert sid_entry["httpOnly"] is True
+
+        gaps_entry = next(c for c in on_disk["cookies"] if c["name"] == "__Host-GAPS")
+        assert gaps_entry["path"] == "/"
+        assert gaps_entry["secure"] is True
+        assert gaps_entry["httpOnly"] is True
+
+    def test_round_trip_without_value_change_preserves_attributes(self, tmp_path):
+        """Load → save (no mutation) → reload preserves attrs.
+
+        This is the silent-erosion path users hit on idle calls: nothing
+        changes, but the save side appends fresh entries from the in-memory
+        jar (auth.py:1095). Without the load-side fix, those appended entries
+        would carry default ``path=/``, ``secure=False``, ``httpOnly=False``.
+        """
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(self._attr_storage_state()))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+        save_cookies_to_storage(jar, storage_file)
+
+        reloaded = build_httpx_cookies_from_storage(storage_file)
+        sid = self._find_cookie(reloaded, "SID", ".google.com")
+        assert sid.path == "/u/0/"
+        assert sid.secure is True
+        assert sid.has_nonstandard_attr("HttpOnly")
+
+    def test_session_cookie_round_trips_as_minus_one(self, tmp_path):
+        """Session cookies (expires=-1) survive without becoming a real timestamp."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(self._attr_storage_state()))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+        gaps = self._find_cookie(jar, "__Host-GAPS", "accounts.google.com")
+        assert gaps.expires is None
+
+        for cookie in jar.jar:
+            if cookie.name == "__Host-GAPS":
+                cookie.value = "rotated-gaps"
+        save_cookies_to_storage(jar, storage_file)
+
+        on_disk = json.loads(storage_file.read_text())
+        gaps_entry = next(c for c in on_disk["cookies"] if c["name"] == "__Host-GAPS")
+        assert gaps_entry["expires"] == -1
+
+    def test_expires_zero_round_trips(self, tmp_path):
+        """``expires=0`` (Unix epoch) is a legitimate timestamp, not a sentinel.
+
+        Some Playwright variants emit ``0`` for cookies that expired at the
+        epoch. The load helper must distinguish ``0`` from ``-1`` / ``None``.
+        """
+        state = {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "v",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": 0,
+                    "httpOnly": True,
+                    "secure": True,
+                }
+            ]
+        }
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(state))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+        sid = self._find_cookie(jar, "SID", ".google.com")
+        # 0 is preserved as 0 — not collapsed to None (session) or -1.
+        assert sid.expires == 0
+
+    def test_distinct_paths_for_same_name_domain_coexist(self, tmp_path):
+        """Two cookies with same name+domain but different paths are distinct.
+
+        Per RFC 6265 cookie identity is (name, domain, path). The dedup key
+        must include path so a path-scoped cookie does not silently suppress
+        the canonical ``/`` cookie.
+        """
+        state = {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "root-value",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": 1893456000,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+                {
+                    "name": "SID",
+                    "value": "scoped-value",
+                    "domain": ".google.com",
+                    "path": "/u/0/",
+                    "expires": 1893456000,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+            ]
+        }
+        storage_file = tmp_path / "storage_state.json"
+        storage_file.write_text(json.dumps(state))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+        root = self._find_cookie(jar, "SID", ".google.com", path="/")
+        scoped = self._find_cookie(jar, "SID", ".google.com", path="/u/0/")
+        assert root.value == "root-value"
+        assert scoped.value == "scoped-value"
 
 
 class TestExtractCSRFRedirect:


### PR DESCRIPTION
Closes #365.

## Summary

Both load paths in `auth.py` — `load_httpx_cookies` and `build_httpx_cookies_from_storage` — used `httpx.Cookies.set(name, value, domain=domain)`, which only accepts those three fields. `path`, `secure`, and `httpOnly` were dropped on the way in even though `_cookie_to_storage_state` faithfully wrote them out on the way to disk, so every load+save cycle eroded attribute fidelity until the on-disk shape stabilized at all-defaults — silently violating `__Host-` prefix invariants and creating a tripwire for any future server-enforced cookie attribute.

## What changed

- Add `_storage_entry_to_cookie(entry)` — load-side mirror of `_cookie_to_storage_state` that constructs a full `http.cookiejar.Cookie` preserving `path`, `secure`, and `httpOnly` (via the `rest` dict's `HttpOnly` key, the same channel `_cookie_is_http_only` reads back).
- Refactor both load paths to set cookies via `cookies.jar.set_cookie(_storage_entry_to_cookie(entry))` instead of the lossy `cookies.set(...)`.
- `build_httpx_cookies_from_storage` now dedupes by the full `(name, domain, path)` triple — per RFC 6265, cookie identity includes path. Now that the load is faithful, two cookies sharing name+domain but differing in path are legitimately distinct and must coexist.
- Session cookies (`expires=-1` on disk → `expires=None` in jar) are constructed with `discard=True` so their cookiejar semantics are correct.
- Update `docs/auth-keepalive.md` §3.4.7 with a "Resolved in #365" callout and §3.4.6 with a partial-mitigation note (the `cookie.domain` save-side normalization remains as scoped-out follow-up).

## Test plan

- [x] `TestCookieAttributePreservation` (7 new tests):
  - `load_httpx_cookies` preserves `path`/`secure`/`httpOnly`
  - `build_httpx_cookies_from_storage` preserves the same
  - Round-trip with value mutation (forces save-side overwrite branch)
  - Round-trip without mutation (silent-erosion path users hit on idle calls)
  - Session cookie (`expires=-1` ↔ `None`) round-trips correctly
  - `expires=0` (Unix epoch) is preserved as `0`, not collapsed to `-1`/`None`
  - Two cookies with same `(name, domain)` but different paths coexist
- [x] `pytest` — 2335 passed, 9 skipped (was 2328 before)
- [x] `ruff format --check src/ tests/` — 142 files already formatted
- [x] `ruff check src/ tests/` — All checks passed
- [x] `mypy src/notebooklm --ignore-missing-imports` — no issues found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved cookie attributes (path, secure, httpOnly, expires/session semantics) when loading and saving browser session cookies so secure and host-prefixed cookies survive round-trips.

* **Documentation**
  * Clarified auth documentation to explain the improved cookie preservation behavior.

* **Tests**
  * Added unit tests validating attribute preservation, round-trip behavior, and session vs. timestamped expiry semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/368)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->