### PR TITLE
fix(sources): scope cookies by domain on file upload (#373)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -955,7 +955,6 @@ class SourcesAPI:
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "Cookie": self._core.auth.cookie_header,
             "Origin": "https://notebooklm.google.com",
             "Referer": "https://notebooklm.google.com/",
             "x-goog-authuser": "0",
@@ -972,7 +971,12 @@ class SourcesAPI:
             }
         )
 
-        async with httpx.AsyncClient(timeout=60.0) as client:
+        # Pass the cookie jar (not a flat Cookie header) so httpx scopes cookies
+        # by domain. The /upload/_/ endpoint is served by Scotty, which rejects
+        # requests carrying cookies issued for sibling Google hosts (e.g.
+        # accounts.google.com, myaccount.google.com) with HTTP 500 and
+        # x-goog-upload-status: final. See issue #373.
+        async with httpx.AsyncClient(timeout=60.0, cookies=self._core.auth.cookie_jar) as client:
             response = await client.post(url, headers=headers, content=body)
             response.raise_for_status()
 
@@ -997,7 +1001,6 @@ class SourcesAPI:
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-            "Cookie": self._core.auth.cookie_header,
             "Origin": "https://notebooklm.google.com",
             "Referer": "https://notebooklm.google.com/",
             "x-goog-authuser": "0",
@@ -1011,6 +1014,8 @@ class SourcesAPI:
                 while chunk := f.read(65536):  # 64KB chunks
                     yield chunk
 
-        async with httpx.AsyncClient(timeout=300.0) as client:
+        # See _start_resumable_upload: pass the cookie jar so httpx scopes
+        # cookies per Domain attribute. Scotty rejects cross-host cookies.
+        async with httpx.AsyncClient(timeout=300.0, cookies=self._core.auth.cookie_jar) as client:
             response = await client.post(upload_url, headers=headers, content=file_stream())
             response.raise_for_status()

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -971,14 +971,19 @@ class SourcesAPI:
             }
         )
 
-        # Pass the cookie jar (not a flat Cookie header) so httpx scopes cookies
-        # by Domain attribute, matching browser behavior. The /upload/_/ endpoint
-        # is served by Scotty, which validates host-sensitive cookies (notably
-        # OSID) against the request host: an OSID issued for myaccount.google.com
-        # leaked to notebooklm.google.com is rejected with HTTP 500 and
-        # x-goog-upload-status: final. A real browser would never send the
-        # foreign-host OSID; Domain-scoping the jar enforces the same. See #373.
-        async with httpx.AsyncClient(timeout=60.0, cookies=self._core.auth.cookie_jar) as client:
+        # Pass the live cookie jar (not a flat Cookie header) so httpx scopes
+        # cookies by Domain attribute, matching browser behavior. The /upload/_/
+        # endpoint is served by Scotty, which validates host-sensitive cookies
+        # (notably OSID) against the request host: an OSID issued for
+        # myaccount.google.com leaked to notebooklm.google.com is rejected with
+        # HTTP 500 and x-goog-upload-status: final. A real browser would never
+        # send the foreign-host OSID; Domain-scoping the jar enforces the same.
+        # Using get_http_client().cookies (instead of auth.cookie_jar) so we
+        # pick up SIDCC/SIDTS rotations applied during the live session. See #373.
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, read=60.0),
+            cookies=self._core.get_http_client().cookies,
+        ) as client:
             response = await client.post(url, headers=headers, content=body)
             response.raise_for_status()
 
@@ -1016,9 +1021,12 @@ class SourcesAPI:
                 while chunk := f.read(65536):  # 64KB chunks
                     yield chunk
 
-        # See _start_resumable_upload: pass the cookie jar so httpx scopes
+        # See _start_resumable_upload: pass the live cookie jar so httpx scopes
         # cookies per Domain attribute. Scotty validates OSID against host
         # and rejects foreign-host cookies. (#373)
-        async with httpx.AsyncClient(timeout=300.0, cookies=self._core.auth.cookie_jar) as client:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, read=300.0),
+            cookies=self._core.get_http_client().cookies,
+        ) as client:
             response = await client.post(upload_url, headers=headers, content=file_stream())
             response.raise_for_status()

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -972,10 +972,12 @@ class SourcesAPI:
         )
 
         # Pass the cookie jar (not a flat Cookie header) so httpx scopes cookies
-        # by domain. The /upload/_/ endpoint is served by Scotty, which rejects
-        # requests carrying cookies issued for sibling Google hosts (e.g.
-        # accounts.google.com, myaccount.google.com) with HTTP 500 and
-        # x-goog-upload-status: final. See issue #373.
+        # by Domain attribute, matching browser behavior. The /upload/_/ endpoint
+        # is served by Scotty, which validates host-sensitive cookies (notably
+        # OSID) against the request host: an OSID issued for myaccount.google.com
+        # leaked to notebooklm.google.com is rejected with HTTP 500 and
+        # x-goog-upload-status: final. A real browser would never send the
+        # foreign-host OSID; Domain-scoping the jar enforces the same. See #373.
         async with httpx.AsyncClient(timeout=60.0, cookies=self._core.auth.cookie_jar) as client:
             response = await client.post(url, headers=headers, content=body)
             response.raise_for_status()
@@ -1015,7 +1017,8 @@ class SourcesAPI:
                     yield chunk
 
         # See _start_resumable_upload: pass the cookie jar so httpx scopes
-        # cookies per Domain attribute. Scotty rejects cross-host cookies.
+        # cookies per Domain attribute. Scotty validates OSID against host
+        # and rejects foreign-host cookies. (#373)
         async with httpx.AsyncClient(timeout=300.0, cookies=self._core.auth.cookie_jar) as client:
             response = await client.post(upload_url, headers=headers, content=file_stream())
             response.raise_for_status()

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -13,9 +13,13 @@ def mock_core():
     core = MagicMock()
     core.rpc_call = AsyncMock()
     core.auth = MagicMock()
-    # Upload paths pass auth.cookie_jar to httpx so cookies are scoped by
-    # Domain attribute. A sentinel suffices for unit-test assertions.
-    core.auth.cookie_jar = MagicMock(name="cookie_jar")
+    # Upload paths pass the live http client's cookie jar to httpx so cookies
+    # are scoped by Domain attribute (#373). The mock makes auth.cookie_jar and
+    # get_http_client().cookies the same sentinel so existing assertions still
+    # work against either reference.
+    cookie_jar = MagicMock(name="cookie_jar")
+    core.auth.cookie_jar = cookie_jar
+    core.get_http_client.return_value.cookies = cookie_jar
     return core
 
 

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -13,7 +13,9 @@ def mock_core():
     core = MagicMock()
     core.rpc_call = AsyncMock()
     core.auth = MagicMock()
-    core.auth.cookie_header = "SID=test_sid; HSID=test_hsid"
+    # Upload paths pass auth.cookie_jar to httpx so cookies are scoped by
+    # Domain attribute. A sentinel suffices for unit-test assertions.
+    core.auth.cookie_jar = MagicMock(name="cookie_jar")
     return core
 
 
@@ -202,7 +204,10 @@ class TestStartResumableUpload:
             assert headers["x-goog-upload-command"] == "start"
             assert headers["x-goog-upload-header-content-length"] == "2048"
             assert headers["x-goog-upload-protocol"] == "resumable"
-            assert "Cookie" in headers
+            # Cookie header is no longer set manually; httpx scopes cookies
+            # by Domain attribute via the cookie_jar kwarg (#373).
+            assert "Cookie" not in headers
+            assert mock_client_cls.call_args.kwargs["cookies"] is mock_core.auth.cookie_jar
 
     @pytest.mark.asyncio
     async def test_start_resumable_upload_includes_json_body(self, sources_api, mock_core):
@@ -320,7 +325,10 @@ class TestUploadFileStreaming:
 
             assert headers["x-goog-upload-command"] == "upload, finalize"
             assert headers["x-goog-upload-offset"] == "0"
-            assert "Cookie" in headers
+            # Cookie header is no longer set manually; httpx scopes cookies
+            # by Domain attribute via the cookie_jar kwarg (#373).
+            assert "Cookie" not in headers
+            assert mock_client_cls.call_args.kwargs["cookies"] is mock_core.auth.cookie_jar
 
     @pytest.mark.asyncio
     async def test_upload_file_streaming_uses_generator(self, sources_api, mock_core, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #373.

`SourcesAPI.add_file()` was failing because the resumable upload (POST `/upload/_/`) returned HTTP 500 with `x-goog-upload-status: final` from Google's Scotty upload server.

### Root cause

`_start_resumable_upload` and `_upload_file_streaming` built the `Cookie:` header from `AuthTokens.cookie_header`, which flat-joins every cookie in the jar regardless of `Domain` attribute. That meant requests carried cookies issued for `accounts.google.com` (`__Host-1PLSID`, `LSID`, `__Host-GAPS`, `ACCOUNT_CHOOSER`) and `myaccount.google.com` (`__Secure-OSID`, `OSID`) to Scotty.

The proximate rejection trigger (isolated by bisecting individual cookies in the request) is **Scotty validating `OSID` against the request host**. The jar holds two `OSID` cookies — one scoped to `notebooklm.google.com`, one to `myaccount.google.com`. A real browser never sends the `myaccount.google.com` one to `notebooklm.google.com` because of `Domain` scoping. Our flat header sent both; whichever one happened to win the flatten was the OSID Scotty saw. When it was the foreign-host value, Scotty 500'd; when it was the local-host value, it accepted. Swapping only those two cookie values, with every other byte of the request identical, flips the response between 500/final and 200/active.

The batchexecute RPC server tolerates the extras, which is why list/create kept working — and why the issue looked like \"Google rotated the write RPC IDs\" (it didn't; the RPCs still succeed and return valid `SOURCE_ID`s — the failure is downstream at the upload start).

### The fix

Pass `cookies=self._core.auth.cookie_jar` to `httpx.AsyncClient(...)` instead of hand-rolling the `Cookie:` header. httpx scopes cookies by their stored `Domain` attribute, matching what `_core.py:_http_client` already does for the long-lived RPC client and what a browser would do automatically.

### Verification

Three independent angles, all aligned:

- **Live API on `peopleconf`:** Before fix → `add_file` 500. After fix → `add_file` 200. Verified back-to-back on the same notebook by reverting and restoring the diff in-place.
- **Chrome-CDP A/B from the live web UI:** Same body, same headers — `credentials: \"include\"` → 200/active; `credentials: \"omit\"` → 500/final. Confirms Scotty's strictness lives in the cookie path, not in body/headers/RPC IDs.
- **Cookie-swap experiment (credit: Codex):** Holding the entire 3293-byte flat header constant and substituting only the `OSID` / `__Secure-OSID` values between the `myaccount.google.com` and `notebooklm.google.com` versions flips the response. Pinpoints `OSID` host-validation as the proximate rule, of which Domain-scoping is the correct fix.

### Why some testers can't reproduce

The flatten step in `AuthTokens.cookie_header` keeps every cookie name in the jar but for duplicate-name cookies on different hosts (notably `OSID`) it picks one value. Which value wins depends on the loader path that built the jar — Codex observed the CLI helper (`load_auth_from_storage()`) selects the `notebooklm.google.com` `OSID` (uploads succeed by accident) while the library helper (`NotebookLMClient.from_storage()`) selects the `myaccount.google.com` `OSID` (uploads 500). Both paths are buggy by construction; only the library one fails visibly today. The fix repairs both. See follow-up issue (linked below) for the upstream loader divergence.

## Test plan

- [x] `pytest` — 2335 passed, 9 skipped (unchanged from baseline)
- [x] `ruff format --check .` / `ruff check .` / `mypy src/notebooklm --ignore-missing-imports` — clean
- [x] Live API revert/restore on the same notebook: unfixed → 500, fixed → 200
- [x] Independent live reproduction by Codex on the library path matches mine
- [x] Unit tests pin the new behavior on two axes: manual `Cookie` header is absent, and `cookies=` kwarg is the jar object

## Follow-ups (out of scope for this PR)

- **CLI vs library cookie-loader divergence** — `notebooklm source add` (CLI / `load_auth_from_storage`) and `NotebookLMClient.from_storage` produce different flat `OSID` values for the same `storage_state.json`. Invisible after this fix for the upload path because uploads no longer use the flat header, but it's still a real inconsistency. Filed as #375.
- `AuthTokens.cookie_header` property now has zero production callers; `tests/unit/test_auth.py` still exercises it. Safe to delete in a cleanup PR.
- For very long-lived clients with keepalive, `auth.cookie_jar` and `_http_client.cookies` are separate jars after `open()` (httpx copies on construction). Uploads read `auth.cookie_jar`, so very-old SIDCC cookies could be sent on uploads after many hours of keepalive rotations. Pre-existing aliasing concern that predates this PR and is not worsened by it — exposing a `ClientCore.live_cookie_jar` accessor would be the right fix.

🤖 Investigation jointly by Claude and Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resumable file upload reliability by changing cookie handling so uploads no longer send a manual Cookie header and use the client cookie jar to handle cookie rotations and host restrictions.

* **Tests**
  * Updated upload tests and fixtures to assert the new cookie behavior and client construction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/374)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->