### PR TITLE
fix(auth): unify flat-cookie selection across loaders (#375)

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -397,10 +397,11 @@ def flatten_cookie_map(cookies: CookieInput | None) -> FlatCookieMap:
     Duplicate-name resolution mirrors :func:`extract_cookies_from_storage`:
     domains are ranked by :func:`_auth_domain_priority` (``.google.com`` >
     ``.notebooklm.google.com`` > ``notebooklm.google.com`` > regional > other).
-    Without this, names like ``OSID`` / ``OTZ`` — which only live on non-base
-    hosts (``myaccount.google.com`` and ``notebooklm.google.com``) — would
-    resolve by dict-iteration order, diverging from the CLI's storage loader.
-    See issue #375.
+    Named tiers are strictly distinct, so the cross-tier case from #375 (e.g.
+    ``OSID`` on ``myaccount.google.com`` (tier 0) vs ``notebooklm.google.com``
+    (tier 2)) resolves the same way regardless of input order. Within a single
+    tier, first occurrence in iteration order wins — matching
+    :func:`extract_cookies_from_storage`'s within-tier semantics.
     """
     flat: FlatCookieMap = {}
     priorities: dict[str, int] = {}

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -314,10 +314,10 @@ class AuthTokens:
     def flat_cookies(self) -> FlatCookieMap:
         """Return a legacy name→value cookie mapping.
 
-        When the same cookie name exists on multiple domains, the base
-        ``.google.com`` value wins for compatibility with the previous flat
-        representation. Domain-aware HTTP operations should use ``cookie_jar``
-        or ``cookies`` directly instead.
+        Duplicate-name resolution follows :func:`_auth_domain_priority` so the
+        result matches what :func:`load_auth_from_storage` produces for the same
+        storage state (see issue #375). Domain-aware HTTP operations should use
+        ``cookie_jar`` or ``cookies`` directly instead.
         """
         return flatten_cookie_map(self.cookies)
 
@@ -392,13 +392,24 @@ def normalize_cookie_map(cookies: CookieInput | None) -> DomainCookieMap:
 
 
 def flatten_cookie_map(cookies: CookieInput | None) -> FlatCookieMap:
-    """Flatten domain-aware cookies for legacy raw Cookie header callers."""
+    """Flatten domain-aware cookies for legacy raw Cookie header callers.
+
+    Duplicate-name resolution mirrors :func:`extract_cookies_from_storage`:
+    domains are ranked by :func:`_auth_domain_priority` (``.google.com`` >
+    ``.notebooklm.google.com`` > ``notebooklm.google.com`` > regional > other).
+    Without this, names like ``OSID`` / ``OTZ`` — which only live on non-base
+    hosts (``myaccount.google.com`` and ``notebooklm.google.com``) — would
+    resolve by dict-iteration order, diverging from the CLI's storage loader.
+    See issue #375.
+    """
     flat: FlatCookieMap = {}
+    priorities: dict[str, int] = {}
 
     for (name, domain), value in normalize_cookie_map(cookies).items():
-        is_base_domain = domain == ".google.com"
-        if name not in flat or is_base_domain:
+        priority = _auth_domain_priority(domain)
+        if name not in flat or priority > priorities[name]:
             flat[name] = value
+            priorities[name] = priority
 
     return flat
 
@@ -767,12 +778,18 @@ def _load_storage_state(path: Path | None = None) -> dict[str, Any]:
 
 
 def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
-    """Load Google cookies from storage.
+    """Load Google cookies from storage as a flat name→value dict.
 
     Loads authentication cookies with the following precedence:
     1. Explicit path argument (from --storage CLI flag)
     2. NOTEBOOKLM_AUTH_JSON environment variable (inline JSON, no file needed)
     3. File at $NOTEBOOKLM_HOME/storage_state.json (or ~/.notebooklm/storage_state.json)
+
+    Duplicate-name resolution follows :func:`_auth_domain_priority`, matching
+    :attr:`AuthTokens.flat_cookies` for the same storage state — previously the
+    two paths disagreed on names that live only on non-base hosts (e.g.
+    ``OSID`` on ``myaccount.google.com`` vs ``notebooklm.google.com``). See
+    issue #375.
 
     Args:
         path: Path to storage_state.json. If provided, takes precedence over env vars.

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1574,8 +1574,9 @@ class TestLoaderFlatCookieParity:
         storage_file = tmp_path / "storage_state.json"
         storage_state = {
             "cookies": [
-                # Minimum required cookies on .google.com so both loaders accept.
+                # Tier 1 required cookies on .google.com so both loaders accept.
                 {"name": "SID", "value": "sid", "domain": ".google.com"},
+                {"name": "__Secure-1PSIDTS", "value": "psidts", "domain": ".google.com"},
                 {"name": "HSID", "value": "hsid", "domain": ".google.com"},
                 {"name": "SSID", "value": "ssid", "domain": ".google.com"},
                 # OSID only exists on non-base hosts; myaccount comes first so a
@@ -1618,8 +1619,12 @@ class TestLoaderFlatCookieParity:
                     "domain": ".google.com.sg",
                 },
                 {"name": "SID", "value": "from-base", "domain": ".google.com"},
+                {"name": "__Secure-1PSIDTS", "value": "psidts", "domain": ".google.com"},
                 {"name": "HSID", "value": "hsid", "domain": ".google.com"},
                 {"name": "SSID", "value": "ssid", "domain": ".google.com"},
+                # Tier 2 binding — silences the secondary-binding warning that
+                # would otherwise log on every load (issue #372).
+                {"name": "OSID", "value": "osid", "domain": "notebooklm.google.com"},
             ]
         }
         storage_file.write_text(json.dumps(storage_state))

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1553,6 +1553,87 @@ class TestAuthTokensFromStorage:
         assert sid.has_nonstandard_attr("HttpOnly")
 
 
+class TestLoaderFlatCookieParity:
+    """Regression tests for #375.
+
+    ``load_auth_from_storage`` (CLI helper) and ``AuthTokens.from_storage``
+    (library entry point) must agree on the flat name→value mapping for the
+    same storage_state — otherwise out-of-tree scripts that read
+    ``auth.cookie_header`` see different cookies depending on which loader
+    produced them.
+    """
+
+    @pytest.mark.asyncio
+    async def test_osid_on_non_base_domains_matches(self, tmp_path, httpx_mock: HTTPXMock) -> None:
+        """OSID lives on myaccount.google.com and notebooklm.google.com only.
+
+        The deterministic priority order (``_auth_domain_priority``) ranks
+        ``notebooklm.google.com`` (2) above unranked allowlisted hosts (0),
+        so both loaders must surface the notebooklm.google.com value.
+        """
+        storage_file = tmp_path / "storage_state.json"
+        storage_state = {
+            "cookies": [
+                # Minimum required cookies on .google.com so both loaders accept.
+                {"name": "SID", "value": "sid", "domain": ".google.com"},
+                {"name": "HSID", "value": "hsid", "domain": ".google.com"},
+                {"name": "SSID", "value": "ssid", "domain": ".google.com"},
+                # OSID only exists on non-base hosts; myaccount comes first so a
+                # naive first-wins flattener would pick it, but the priority
+                # rules say notebooklm.google.com must win.
+                {
+                    "name": "OSID",
+                    "value": "from-myaccount",
+                    "domain": "myaccount.google.com",
+                },
+                {
+                    "name": "OSID",
+                    "value": "from-notebooklm",
+                    "domain": "notebooklm.google.com",
+                },
+            ]
+        }
+        storage_file.write_text(json.dumps(storage_state))
+
+        html = '"SNlM0e":"csrf_token" "FdrFJe":"session_id"'
+        httpx_mock.add_response(content=html.encode())
+
+        cli_cookies = load_auth_from_storage(storage_file)
+        lib_tokens = await AuthTokens.from_storage(storage_file)
+
+        assert cli_cookies["OSID"] == lib_tokens.flat_cookies["OSID"]
+        assert cli_cookies["OSID"] == "from-notebooklm"
+
+    @pytest.mark.asyncio
+    async def test_base_domain_still_wins_on_both_paths(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ) -> None:
+        """When .google.com is present it must win on both loaders."""
+        storage_file = tmp_path / "storage_state.json"
+        storage_state = {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "from-regional",
+                    "domain": ".google.com.sg",
+                },
+                {"name": "SID", "value": "from-base", "domain": ".google.com"},
+                {"name": "HSID", "value": "hsid", "domain": ".google.com"},
+                {"name": "SSID", "value": "ssid", "domain": ".google.com"},
+            ]
+        }
+        storage_file.write_text(json.dumps(storage_state))
+
+        html = '"SNlM0e":"csrf_token" "FdrFJe":"session_id"'
+        httpx_mock.add_response(content=html.encode())
+
+        cli_cookies = load_auth_from_storage(storage_file)
+        lib_tokens = await AuthTokens.from_storage(storage_file)
+
+        assert cli_cookies["SID"] == "from-base"
+        assert lib_tokens.flat_cookies["SID"] == "from-base"
+
+
 # =============================================================================
 # COOKIE DOMAIN VALIDATION TESTS
 # =============================================================================
@@ -2918,10 +2999,9 @@ class TestPokeConcurrencyThrottling:
             await auth_module._poke_session(client, storage_path)
 
         poke_requests = [r for r in httpx_mock.get_requests() if _POKE_URL_RE.match(str(r.url))]
-        assert len(poke_requests) == 1, (
-            f"infra failure must fail open and let rotation proceed; "
-            f"got {len(poke_requests)} POSTs"
-        )
+        assert (
+            len(poke_requests) == 1
+        ), f"infra failure must fail open and let rotation proceed; got {len(poke_requests)} POSTs"
 
     @pytest.mark.asyncio
     @pytest.mark.no_default_keepalive_mock


### PR DESCRIPTION
## Summary

Fixes #375. `load_auth_from_storage` (CLI helper) and `AuthTokens.from_storage` (library entry point) previously produced different flat `name → value` cookie mappings for the same `storage_state.json` when a cookie name lived only on non-base Google hosts.

Concrete case from the issue (profile `peopleconf`):

| loader | flat `OSID` came from |
|---|---|
| `NotebookLMClient.from_storage(profile=\"peopleconf\")` | `myaccount.google.com` |
| `load_auth_from_storage()` | `notebooklm.google.com` |

**Root cause:** the CLI path already ranked duplicates with `_auth_domain_priority` (`.google.com` > `.notebooklm.google.com` > `notebooklm.google.com` > regional > other). The library path went `build_httpx_cookies_from_storage` → `_cookie_map_from_jar` → `flatten_cookie_map`, and `flatten_cookie_map` only special-cased `.google.com` — so for `OSID` (no `.google.com` entry), the result was effectively dict-iteration-order.

**Fix:** `flatten_cookie_map` now applies `_auth_domain_priority`, so the library's `AuthTokens.flat_cookies` resolves duplicates with the same ranking the CLI loader has always used. Both loaders now agree.

This is option 2 from the issue ("make duplicate-name selection deterministic"). Option 1 (CLI delegates to library) was tried but reverted — it would have silently dropped empty-value cookies and lost the richer `extract_cookies_from_storage` error diagnostic, neither of which #375 calls for. The surgical fix here only changes the resolution rule.

After #374 this is invisible on the upload path (httpx scopes by `Domain` attribute via the cookie jar), but `AuthTokens.cookie_header` / `flat_cookies` remain public, and `scripts/diagnose_get_notebook.py` / `scripts/check_rpc_health.py` hand-roll the same flatten — so the divergence was a real footgun for anyone debugging \"CLI works, SDK doesn't.\"

## Test plan

- [x] New `TestLoaderFlatCookieParity::test_osid_on_non_base_domains_matches` — reproduces the exact #375 scenario (OSID on `myaccount.google.com` listed before `notebooklm.google.com`, no `.google.com` entry). Pre-fix: CLI returns `from-notebooklm`, library returns `from-myaccount`. Post-fix: both return `from-notebooklm`.
- [x] New `TestLoaderFlatCookieParity::test_base_domain_still_wins_on_both_paths` — pins the `.google.com` precedence on both loaders so it can't silently regress.
- [x] Full unit suite green: 253 tests in `tests/unit/test_auth.py`, 2337 total.
- [x] `ruff format --check`, `ruff check`, `mypy src/notebooklm --ignore-missing-imports` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deterministic handling of duplicate cookie names in authentication, aligning flat cookie resolution with domain-aware priority for consistent auth behavior.

* **Tests**
  * Added regression tests to verify parity between storage-based and flattened cookie views, including domain-priority scenarios.

* **Documentation**
  * Clarified cookie flattening and loader behavior to reflect domain-priority resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/376)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->