### PR TITLE
fix(ci): tolerate transient chat rate-limits in e2e

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,6 +107,11 @@ jobs:
       run: playwright install-deps
 
     - name: Run E2E tests
+      id: e2e
+      # Don't fail the job here — the cool-down retry step below gets a shot
+      # at any failures. If both this step and the retry fail, the retry's
+      # exit code is what marks the job red.
+      continue-on-error: true
       env:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
@@ -115,13 +120,37 @@ jobs:
       run: |
         echo "Testing branch: ${{ needs.resolve-branch.outputs.branch }}"
         TEST_FILTER="${{ inputs.test_filter }}"
+        # --reruns 1 catches sub-minute network blips; longer chat-throttle
+        # recovery is handled by the cool-down retry step below.
         if [ -n "$TEST_FILTER" ]; then
           # Run specific test(s) when filter provided
-          pytest "$TEST_FILTER" -s -v --tb=short --reruns 2 --reruns-delay 30
+          pytest "$TEST_FILTER" -s -v --tb=short --reruns 1 --reruns-delay 30
         elif [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
           # Linux: run all E2E tests except variants
-          pytest tests/e2e -m "not variants" -s -v --tb=short --reruns 2 --reruns-delay 30
+          pytest tests/e2e -m "not variants" -s -v --tb=short --reruns 1 --reruns-delay 30
         else
           # Windows: run only read-only tests (safer, avoids write operations)
-          pytest tests/e2e -m "readonly and not variants" -s -v --tb=short --reruns 2 --reruns-delay 30
+          pytest tests/e2e -m "readonly and not variants" -s -v --tb=short --reruns 1 --reruns-delay 30
         fi
+
+    - name: Retry failed E2E tests after 10-min cool-down
+      # Re-runs only the tests that failed in the previous step. The
+      # skip-on-chat-rate-limit fixture (tests/e2e/conftest.py) is still active,
+      # so any test that's *still* throttled after the cool-down becomes a skip
+      # rather than a red CI — Google-side rejections shouldn't fail nightly.
+      if: steps.e2e.outcome == 'failure'
+      env:
+        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
+        NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
+        NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
+      shell: bash
+      run: |
+        # Guard against re-running the full suite if pytest crashed before
+        # writing the lastfailed cache (would otherwise burn ~30 min).
+        if [ ! -f .pytest_cache/v/cache/lastfailed ]; then
+          echo "No lastfailed cache from previous step; skipping cool-down retry."
+          exit 0
+        fi
+        echo "Initial E2E run failed. Sleeping 600s before retrying failed tests."
+        sleep 600
+        pytest --last-failed -s -v --tb=short

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,9 +108,8 @@ jobs:
 
     - name: Run E2E tests
       id: e2e
-      # Don't fail the job here — the cool-down retry step below gets a shot
-      # at any failures. If both this step and the retry fail, the retry's
-      # exit code is what marks the job red.
+      # Don't fail the job here — the retry step below gets a 10-min cool-down
+      # shot at any failures, and its exit code is what marks the job red.
       continue-on-error: true
       env:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
@@ -134,10 +133,8 @@ jobs:
         fi
 
     - name: Retry failed E2E tests after 10-min cool-down
-      # Re-runs only the tests that failed in the previous step. The
-      # skip-on-chat-rate-limit fixture (tests/e2e/conftest.py) is still active,
-      # so any test that's *still* throttled after the cool-down becomes a skip
-      # rather than a red CI — Google-side rejections shouldn't fail nightly.
+      # Tests still throttled after the cool-down become skips via the
+      # _install_chat_rate_limit_skip fixture in tests/e2e/conftest.py.
       if: steps.e2e.outcome == 'failure'
       env:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
@@ -145,11 +142,13 @@ jobs:
         NOTEBOOKLM_GENERATION_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_GENERATION_NOTEBOOK_ID }}
       shell: bash
       run: |
-        # Guard against re-running the full suite if pytest crashed before
-        # writing the lastfailed cache (would otherwise burn ~30 min).
+        # Missing lastfailed after a failed e2e step means pytest crashed
+        # before writing the cache (import error, OOM, etc.) — that's a real
+        # failure, not a recoverable rate-limit, so fail the job rather than
+        # silently going green.
         if [ ! -f .pytest_cache/v/cache/lastfailed ]; then
-          echo "No lastfailed cache from previous step; skipping cool-down retry."
-          exit 0
+          echo "::error::No lastfailed cache from previous step; pytest likely crashed before running tests."
+          exit 1
         fi
         echo "Initial E2E run failed. Sleeping 600s before retrying failed tests."
         sleep 600

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -107,9 +107,8 @@ jobs:
     - name: Run E2E tests
       id: e2e
       if: github.repository == 'teng-lin/notebooklm-py'
-      # Don't fail the job here — the cool-down retry step below gets a shot
-      # at any failures. If both this step and the retry fail, the retry's
-      # exit code is what marks the job red.
+      # Don't fail the job here — the retry step below gets a 10-min cool-down
+      # shot at any failures, and its exit code is what marks the job red.
       continue-on-error: true
       shell: bash
       env:
@@ -125,14 +124,13 @@ jobs:
           echo "::error::NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID secret is not configured"
           exit 1
         fi
-        # --reruns 1 catches sub-minute network blips; longer chat-throttle
-        # recovery is handled by the cool-down retry step below.
-        pytest tests/e2e -m "not variants" --reruns 1 -v
+        # --reruns 1 --reruns-delay 30 catches sub-minute network blips;
+        # longer chat-throttle recovery is handled by the cool-down retry below.
+        pytest tests/e2e -m "not variants" --reruns 1 --reruns-delay 30 -v
 
     - name: Retry failed E2E tests after 10-min cool-down
-      # Re-runs only the tests that failed above. The skip-on-chat-rate-limit
-      # fixture (tests/e2e/conftest.py) is still active, so anything still
-      # throttled after the cool-down becomes a skip rather than red CI.
+      # Tests still throttled after the cool-down become skips via the
+      # _install_chat_rate_limit_skip fixture in tests/e2e/conftest.py.
       if: steps.e2e.outcome == 'failure'
       shell: bash
       env:
@@ -140,11 +138,12 @@ jobs:
         NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
       run: |
         source verify-venv/bin/activate
-        # Guard against re-running the full suite if pytest crashed before
-        # writing the lastfailed cache.
+        # Missing lastfailed after a failed e2e step means pytest crashed
+        # before writing the cache (import error, OOM, etc.) — fail the job
+        # rather than silently going green.
         if [ ! -f .pytest_cache/v/cache/lastfailed ]; then
-          echo "No lastfailed cache from previous step; skipping cool-down retry."
-          exit 0
+          echo "::error::No lastfailed cache from previous step; pytest likely crashed before running tests."
+          exit 1
         fi
         echo "Initial E2E run failed. Sleeping 600s before retrying failed tests."
         sleep 600

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -105,7 +105,12 @@ jobs:
         echo "E2E tests were not run because this workflow is executing on a fork." >> $GITHUB_STEP_SUMMARY
 
     - name: Run E2E tests
+      id: e2e
       if: github.repository == 'teng-lin/notebooklm-py'
+      # Don't fail the job here — the cool-down retry step below gets a shot
+      # at any failures. If both this step and the retry fail, the retry's
+      # exit code is what marks the job red.
+      continue-on-error: true
       shell: bash
       env:
         NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
@@ -120,4 +125,27 @@ jobs:
           echo "::error::NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID secret is not configured"
           exit 1
         fi
-        pytest tests/e2e -m "not variants" --reruns 2 -v
+        # --reruns 1 catches sub-minute network blips; longer chat-throttle
+        # recovery is handled by the cool-down retry step below.
+        pytest tests/e2e -m "not variants" --reruns 1 -v
+
+    - name: Retry failed E2E tests after 10-min cool-down
+      # Re-runs only the tests that failed above. The skip-on-chat-rate-limit
+      # fixture (tests/e2e/conftest.py) is still active, so anything still
+      # throttled after the cool-down becomes a skip rather than red CI.
+      if: steps.e2e.outcome == 'failure'
+      shell: bash
+      env:
+        NOTEBOOKLM_AUTH_JSON: ${{ secrets.NOTEBOOKLM_AUTH_JSON }}
+        NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID: ${{ secrets.NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID }}
+      run: |
+        source verify-venv/bin/activate
+        # Guard against re-running the full suite if pytest crashed before
+        # writing the lastfailed cache.
+        if [ ! -f .pytest_cache/v/cache/lastfailed ]; then
+          echo "No lastfailed cache from previous step; skipping cool-down retry."
+          exit 0
+        fi
+        echo "Initial E2E run failed. Sleeping 600s before retrying failed tests."
+        sleep 600
+        pytest --last-failed -v

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,7 +19,39 @@ except ImportError:
 
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens, load_auth_from_storage
+from notebooklm.exceptions import ChatError
 from notebooklm.paths import get_profile_dir
+
+# Markers in ChatError messages that indicate a server-side rate-limit /
+# quota rejection (not a client bug). See _install_chat_rate_limit_skip.
+_RATE_LIMIT_PHRASES = ("rate limit", "rate limited", "rejected by the api")
+
+
+def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
+    """Wrap ``client.chat.ask`` to translate rate-limit ChatErrors into skips.
+
+    Why: Google occasionally throttles chat on the CI account in ways that
+    longer reruns don't clear (window > 60s, sometimes > 10min). Those are
+    not regressions in this code — they're account-side rejections — so we
+    surface them as ``pytest.skip`` instead of failures.
+
+    Only the exact rate-limit / "rejected by the API" message family is
+    suppressed; other ``ChatError`` causes (HTTP errors, auth failures,
+    parse errors) still raise normally so real defects stay visible.
+    """
+    original_ask = client.chat.ask
+
+    async def _ask_with_skip(*args, **kwargs):
+        try:
+            return await original_ask(*args, **kwargs)
+        except ChatError as e:
+            msg = str(e).lower()
+            if any(phrase in msg for phrase in _RATE_LIMIT_PHRASES):
+                pytest.skip(str(e))
+            raise
+
+    client.chat.ask = _ask_with_skip
+
 
 # =============================================================================
 # --profile flag plumbing
@@ -238,6 +270,7 @@ def auth_tokens() -> AuthTokens:
 @pytest.fixture
 async def client(auth_tokens) -> AsyncGenerator[NotebookLMClient, None]:
     async with NotebookLMClient(auth_tokens, storage_path=auth_tokens.storage_path) as c:
+        _install_chat_rate_limit_skip(c)
         yield c
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,22 +22,18 @@ from notebooklm.auth import AuthTokens, load_auth_from_storage
 from notebooklm.exceptions import ChatError
 from notebooklm.paths import get_profile_dir
 
-# Markers in ChatError messages that indicate a server-side rate-limit /
-# quota rejection (not a client bug). See _install_chat_rate_limit_skip.
+# Substrings in ChatError messages that mark a server-side rate-limit / quota
+# rejection rather than a client bug. Google throttles chat on the CI account
+# in ways that 60s reruns don't clear; surface those as skips so nightly
+# doesn't go red for account-side rejections.
 _RATE_LIMIT_PHRASES = ("rate limit", "rate limited", "rejected by the api")
 
 
 def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
-    """Wrap ``client.chat.ask`` to translate rate-limit ChatErrors into skips.
+    """Wrap ``client.chat.ask`` so rate-limit ``ChatError``s become skips.
 
-    Why: Google occasionally throttles chat on the CI account in ways that
-    longer reruns don't clear (window > 60s, sometimes > 10min). Those are
-    not regressions in this code — they're account-side rejections — so we
-    surface them as ``pytest.skip`` instead of failures.
-
-    Only the exact rate-limit / "rejected by the API" message family is
-    suppressed; other ``ChatError`` causes (HTTP errors, auth failures,
-    parse errors) still raise normally so real defects stay visible.
+    Non-rate-limit ``ChatError``s (HTTP, auth, parse) still raise so real
+    defects stay visible.
     """
     original_ask = client.chat.ask
 
@@ -45,8 +41,7 @@ def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
         try:
             return await original_ask(*args, **kwargs)
         except ChatError as e:
-            msg = str(e).lower()
-            if any(phrase in msg for phrase in _RATE_LIMIT_PHRASES):
+            if any(phrase in str(e).lower() for phrase in _RATE_LIMIT_PHRASES):
                 pytest.skip(str(e))
             raise
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,11 +22,17 @@ from notebooklm.auth import AuthTokens, load_auth_from_storage
 from notebooklm.exceptions import ChatError
 from notebooklm.paths import get_profile_dir
 
-# Substrings in ChatError messages that mark a server-side rate-limit / quota
-# rejection rather than a client bug. Google throttles chat on the CI account
-# in ways that 60s reruns don't clear; surface those as skips so nightly
-# doesn't go red for account-side rejections.
-_RATE_LIMIT_PHRASES = ("rate limit", "rate limited", "rejected by the api")
+# Substrings in ChatError / skip messages that mark a server-side rate-limit
+# or quota rejection rather than a client bug. Covers both the explicit
+# UserDisplayableError message and the HTTP-status-wrapped 429 path in
+# _chat.py:156, plus the generation skip phrase in assert_generation_started.
+_RATE_LIMIT_PHRASES = (
+    "rate limit",
+    "rate limited",
+    "rejected by the api",
+    "429",
+    "too many requests",
+)
 
 
 def _install_chat_rate_limit_skip(client: NotebookLMClient) -> None:
@@ -231,7 +237,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if not nodeids:
         return
 
-    terminalreporter.write_sep("=", f"chat rate-limit skips ({len(nodeids)})", yellow=True)
+    terminalreporter.write_sep("=", f"rate-limit skips ({len(nodeids)})", yellow=True)
     for nodeid in nodeids:
         terminalreporter.write_line(f"  {nodeid}")
 
@@ -239,7 +245,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if summary_path:
         try:
             with open(summary_path, "a", encoding="utf-8") as f:
-                f.write(f"\n### Chat rate-limit skips: {len(nodeids)}\n\n")
+                f.write(f"\n### Rate-limit skips: {len(nodeids)}\n\n")
                 for nodeid in nodeids:
                     f.write(f"- `{nodeid}`\n")
         except OSError:
@@ -247,7 +253,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
     if os.environ.get("GITHUB_ACTIONS"):
         joined = ", ".join(nodeids)
-        print(f"::warning::{len(nodeids)} chat test(s) skipped due to rate-limit: {joined}")
+        print(f"::warning::{len(nodeids)} test(s) skipped due to rate-limit: {joined}")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -208,6 +208,48 @@ def pytest_unconfigure(config):
         os.environ.pop("NOTEBOOKLM_PROFILE", None)
 
 
+def _skip_reason(report) -> str:
+    longrepr = report.longrepr
+    if isinstance(longrepr, tuple) and len(longrepr) >= 3:
+        return str(longrepr[2])
+    return str(longrepr) if longrepr else ""
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Surface chat rate-limit skips so they're visible despite green CI.
+
+    Without this, the L1 skip-fixture (_install_chat_rate_limit_skip) makes
+    Google-side throttling invisible — the job stays green but coverage
+    silently degrades. Emit a pytest summary section plus, on GitHub Actions,
+    a warning annotation and step-summary entry.
+    """
+    nodeids = [
+        report.nodeid
+        for report in terminalreporter.stats.get("skipped", [])
+        if any(phrase in _skip_reason(report).lower() for phrase in _RATE_LIMIT_PHRASES)
+    ]
+    if not nodeids:
+        return
+
+    terminalreporter.write_sep("=", f"chat rate-limit skips ({len(nodeids)})", yellow=True)
+    for nodeid in nodeids:
+        terminalreporter.write_line(f"  {nodeid}")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as f:
+                f.write(f"\n### Chat rate-limit skips: {len(nodeids)}\n\n")
+                for nodeid in nodeids:
+                    f.write(f"- `{nodeid}`\n")
+        except OSError:
+            pass
+
+    if os.environ.get("GITHUB_ACTIONS"):
+        joined = ", ".join(nodeids)
+        print(f"::warning::{len(nodeids)} chat test(s) skipped due to rate-limit: {joined}")
+
+
 def pytest_collection_modifyitems(config, items):
     """Skip variant tests by default unless --include-variants is passed."""
     if config.getoption("--include-variants"):

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -282,9 +282,9 @@ class TestChatReferencesE2E:
 
         # All reference source IDs should exist in the notebook
         for ref in result.references:
-            assert ref.source_id in source_ids, (
-                f"Reference source_id {ref.source_id} not found in notebook sources"
-            )
+            assert (
+                ref.source_id in source_ids
+            ), f"Reference source_id {ref.source_id} not found in notebook sources"
 
     @pytest.mark.asyncio
     async def test_cited_text_matches_source_content(self, client, multi_source_notebook_id):

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -7,33 +7,8 @@ Run with: pytest tests/e2e/test_chat.py -m e2e
 import pytest
 
 from notebooklm import AskResult, ChatReference
-from notebooklm.exceptions import ChatError
 
 from .conftest import requires_auth
-
-_RATE_LIMIT_PHRASES = ("rate limit", "rate limited", "rejected by the api")
-
-
-@pytest.fixture(autouse=True)
-async def _skip_on_chat_rate_limit(client):
-    """Auto-skip any test that hits a chat API rate limit.
-
-    Only skips on actual rate limit errors (ChatError with rate-limit message).
-    Other ChatErrors (HTTP failures, auth errors, etc.) are re-raised so they
-    show as failures rather than silently skipping.
-    """
-    original_ask = client.chat.ask
-
-    async def _ask_with_skip(*args, **kwargs):
-        try:
-            return await original_ask(*args, **kwargs)
-        except ChatError as e:
-            msg = str(e).lower()
-            if any(phrase in msg for phrase in _RATE_LIMIT_PHRASES):
-                pytest.skip(str(e))
-            raise
-
-    client.chat.ask = _ask_with_skip
 
 
 @pytest.mark.e2e
@@ -307,9 +282,9 @@ class TestChatReferencesE2E:
 
         # All reference source IDs should exist in the notebook
         for ref in result.references:
-            assert (
-                ref.source_id in source_ids
-            ), f"Reference source_id {ref.source_id} not found in notebook sources"
+            assert ref.source_id in source_ids, (
+                f"Reference source_id {ref.source_id} not found in notebook sources"
+            )
 
     @pytest.mark.asyncio
     async def test_cited_text_matches_source_content(self, client, multi_source_notebook_id):

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -100,3 +100,65 @@ class TestArgvProfile:
     def test_long_form_rejects_dash_prefixed_value(self):
         argv = ["pytest", "--profile", "--verbose"]
         assert _load_e2e_conftest()._argv_profile(argv) is None
+
+
+class TestRateLimitSkipSummary:
+    """pytest_terminal_summary surfaces chat rate-limit skips so green CI doesn't hide drift."""
+
+    @staticmethod
+    def _make_reporter(reports):
+        write_calls: list[tuple] = []
+        return SimpleNamespace(
+            stats={"skipped": reports},
+            write_sep=lambda *a, **kw: write_calls.append(("sep", a, kw)),
+            write_line=lambda *a, **kw: write_calls.append(("line", a, kw)),
+            _writes=write_calls,
+        )
+
+    @staticmethod
+    def _skipped(nodeid: str, reason: str) -> SimpleNamespace:
+        return SimpleNamespace(nodeid=nodeid, longrepr=("file.py", 1, f"Skipped: {reason}"))
+
+    def test_counts_only_rate_limit_skips(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter(
+            [
+                self._skipped("t::a", "Chat request was rate limited"),
+                self._skipped("t::b", "no auth configured"),
+                self._skipped("t::c", "rejected by the API"),
+            ]
+        )
+        conftest.pytest_terminal_summary(tr, 0, None)
+
+        summary = (tmp_path / "summary.md").read_text()
+        assert "Chat rate-limit skips: 2" in summary
+        assert "t::a" in summary and "t::c" in summary
+        assert "t::b" not in summary
+        assert "::warning::2 chat test(s)" in capsys.readouterr().out
+
+    def test_no_skips_emits_nothing(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter([self._skipped("t::a", "no auth configured")])
+        conftest.pytest_terminal_summary(tr, 0, None)
+
+        assert not (tmp_path / "summary.md").exists()
+        assert capsys.readouterr().out == ""
+        assert tr._writes == []
+
+    def test_no_github_env_skips_annotations(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+        conftest = _load_e2e_conftest()
+
+        tr = self._make_reporter([self._skipped("t::a", "rate limited")])
+        conftest.pytest_terminal_summary(tr, 0, None)
+
+        # Still emits the pytest section locally — just no GH-specific bits.
+        assert any(call[0] == "sep" for call in tr._writes)
+        assert capsys.readouterr().out == ""

--- a/tests/unit/test_e2e_conftest_options.py
+++ b/tests/unit/test_e2e_conftest_options.py
@@ -129,15 +129,17 @@ class TestRateLimitSkipSummary:
                 self._skipped("t::a", "Chat request was rate limited"),
                 self._skipped("t::b", "no auth configured"),
                 self._skipped("t::c", "rejected by the API"),
+                self._skipped("t::d", "Chat request failed with HTTP 429: ..."),
+                self._skipped("t::e", "Too Many Requests"),
             ]
         )
         conftest.pytest_terminal_summary(tr, 0, None)
 
         summary = (tmp_path / "summary.md").read_text()
-        assert "Chat rate-limit skips: 2" in summary
-        assert "t::a" in summary and "t::c" in summary
+        assert "Rate-limit skips: 4" in summary
+        assert all(nid in summary for nid in ("t::a", "t::c", "t::d", "t::e"))
         assert "t::b" not in summary
-        assert "::warning::2 chat test(s)" in capsys.readouterr().out
+        assert "::warning::4 test(s) skipped" in capsys.readouterr().out
 
     def test_no_skips_emits_nothing(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))


### PR DESCRIPTION
## Summary

Two-layer defense against Google-side chat throttling on the CI account, which has been turning ~7 e2e tests red per nightly even though the same queries pass on other accounts at the same wall-clock time.

- **L1 — Skip-fixture in `tests/e2e/conftest.py`.** Promotes `_skip_on_chat_rate_limit` from `test_chat.py` into the shared `client` fixture so every e2e test that uses `client.chat.ask` auto-skips on rate-limit `ChatError` (the existing 3-phrase match: `rate limit`, `rate limited`, `rejected by the api`). Other `ChatError` causes still raise normally so real defects stay visible. Now covers `test_source_selection.py` and `test_notebooks.py`, which previously didn't have this protection.
- **L2 — 10-min cool-down retry in CI.** Replaces `--reruns 2 --reruns-delay 30` (which sleeps per-test attempt — would balloon to ~140 min if bumped to 10-min delay × 2 reruns × 7 tests) with `--reruns 1 --reruns-delay 30` plus a single `if: steps.e2e.outcome == 'failure'` retry step that sleeps 600s once and runs `pytest --last-failed`. Initial step is `continue-on-error: true` so a passing retry actually greens the job. Retry has a guard against missing lastfailed cache (pytest crash before first cache write) to avoid accidentally re-running the full suite.

Applied to both `nightly.yml` and `verify-package.yml` (both have hit chat rate-limits on the CI account per project memory).

## Behavior matrix

| Scenario | Outcome |
|---|---|
| Real chat regression | Red (both phases fail with non-rate-limit error) |
| Sub-minute network blip | Recovered by `--reruns 1` |
| 1–10 min account throttle | Recovered by sleep+`--lf` retry |
| Throttle > 10 min or daily quota | Skipped via L1 fixture, nightly stays green |

## Test plan

- [x] Pre-commit: `ruff format`, `ruff check`, `mypy src/notebooklm` clean on touched files
- [x] Unit + integration: 2338 passed, 9 skipped
- [x] Targeted e2e on `peopleconf` profile: all 5 previously-CI-failing tests pass cleanly under the new conftest fixture (`TestChatWithSourceSelection` × 4 + `TestNotebookAsk::test_ask_notebook`)
- [x] `pytest tests/e2e --collect-only`: 156 tests collected, no errors
- [ ] Trigger a manual `nightly` workflow_dispatch to validate the new retry step shape (will do after merge unless reviewer wants pre-merge dry-run)

## Notes / open questions

- 10 min is a starting point. If we observe rate-limits where 10 min isn't enough, the L1 fixture still catches them as skips — so we can tune the cool-down later without nightly going red in the meantime.
- The L1 fixture only wraps `client.chat.ask` (the entry point hit by all 7 CI failures). If future tests use other chat-touching methods that can return rate-limit errors, the wrap should be extended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized CI-safe handling to skip tests when server-side chat rate limits occur, with a terminal summary and GitHub annotations when applicable.
  * Removed duplicate per-test autouse skip logic and added unit tests covering the new skip-summary behavior.

* **Chores**
  * E2E workflow: made initial E2E step non-fatal, reduced immediate reruns from two to one, and added a 10‑minute cool-down retry that reruns only previously failing tests (and fails if failure state is missing).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/380)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->