### PR TITLE
test(client): isolate default storage path test

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -124,21 +124,26 @@ class TestFromStorage:
             await NotebookLMClient.from_storage(str(tmp_path / "nonexistent.json"))
 
     @pytest.mark.asyncio
-    async def test_from_storage_with_default_path(self, httpx_mock: HTTPXMock):
+    async def test_from_storage_with_default_path(
+        self, tmp_path, monkeypatch, request, httpx_mock: HTTPXMock
+    ):
         """Test from_storage uses default path when none specified."""
-        from notebooklm.paths import get_storage_path
+        import notebooklm.paths as paths_mod
 
-        default_storage_path = get_storage_path()
+        real_storage_path = paths_mod.get_storage_path()
+        real_storage_mtime = (
+            real_storage_path.stat().st_mtime_ns if real_storage_path.exists() else None
+        )
 
-        # Create storage file at default location
-        if not default_storage_path.parent.exists():
-            default_storage_path.parent.mkdir(parents=True, exist_ok=True)
+        active_profile = paths_mod.get_active_profile()
+        request.addfinalizer(lambda: paths_mod.set_active_profile(active_profile))
+        paths_mod.set_active_profile(None)
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+        monkeypatch.setenv("NOTEBOOKLM_PROFILE", "default")
+        monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
 
-        # IMPORTANT: Back up existing auth file if it exists
-        backup_path = default_storage_path.with_suffix(".json.bak")
-        had_existing_file = default_storage_path.exists()
-        if had_existing_file:
-            backup_path.write_text(default_storage_path.read_text())
+        default_storage_path = paths_mod.get_storage_path()
+        assert tmp_path in default_storage_path.parents
 
         storage_state = {
             "cookies": [
@@ -147,24 +152,23 @@ class TestFromStorage:
             ]
         }
 
-        # Only run if we can write to default location
+        default_storage_path.parent.mkdir(parents=True, exist_ok=True)
+        default_storage_path.write_text(json.dumps(storage_state))
+
+        html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
+        httpx_mock.add_response(
+            url="https://notebooklm.google.com/",
+            content=html.encode(),
+        )
+
         try:
-            default_storage_path.write_text(json.dumps(storage_state))
-
-            html = '"SNlM0e":"csrf" "FdrFJe":"sess"'
-            httpx_mock.add_response(content=html.encode())
-
             client = await NotebookLMClient.from_storage()
             assert client.auth.cookies[("SID", ".google.com")] == "default_sid"
-        except PermissionError:
-            pytest.skip("Cannot write to default storage path")
         finally:
-            # Restore original file or clean up test file
-            if had_existing_file:
-                default_storage_path.write_text(backup_path.read_text())
-                backup_path.unlink()
-            elif default_storage_path.exists():
-                default_storage_path.unlink()
+            if real_storage_mtime is None:
+                assert not real_storage_path.exists()
+            else:
+                assert real_storage_path.stat().st_mtime_ns == real_storage_mtime
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- redirect the no-argument `NotebookLMClient.from_storage()` test to a tmp `NOTEBOOKLM_HOME`
- remove the backup/overwrite/restore dance against the ambient profile storage file
- add guards for env auth/profile state and assert the real storage file mtime is unchanged

Closes #379

## Test plan
- [x] `uv run pytest tests/unit/test_client.py::TestFromStorage::test_from_storage_with_default_path -q`
- [x] `uv run pytest tests/unit/test_client.py -q`
- [x] `uv run pytest -q`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pre-commit run --all-files`

## Polish
- Codex native review: no blocking issues after final changes
- Gemini CLI review: no issues on final diff
- Claude CLI review: low/nit findings only, no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and reliability for default storage path validation by using temporary directories and proper state restoration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/381)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->