### PR TITLE
docs(skill): fix non-existent notebook delete/--help references (closes #326)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -181,7 +181,7 @@ Before starting workflows, verify the CLI is ready:
 | Download quiz (markdown) | `notebooklm download quiz --format markdown quiz.md` |
 | Download flashcards | `notebooklm download flashcards cards.json` |
 | Download flashcards (markdown) | `notebooklm download flashcards --format markdown cards.md` |
-| Delete notebook | `notebooklm delete <id>` |
+| Delete notebook | `notebooklm delete -n <id>` |
 | List languages | `notebooklm language list` |
 | Get language | `notebooklm language get` |
 | Set language | `notebooklm language set zh_Hans` |

--- a/SKILL.md
+++ b/SKILL.md
@@ -181,7 +181,7 @@ Before starting workflows, verify the CLI is ready:
 | Download quiz (markdown) | `notebooklm download quiz --format markdown quiz.md` |
 | Download flashcards | `notebooklm download flashcards cards.json` |
 | Download flashcards (markdown) | `notebooklm download flashcards --format markdown cards.md` |
-| Delete notebook | `notebooklm notebook delete <id>` |
+| Delete notebook | `notebooklm delete <id>` |
 | List languages | `notebooklm language list` |
 | Get language | `notebooklm language get` |
 | Set language | `notebooklm language set zh_Hans` |
@@ -578,7 +578,6 @@ notebooklm language get --local  # Read local config only
 notebooklm --help              # Main commands
 notebooklm auth check          # Diagnose auth issues
 notebooklm auth check --test   # Full auth validation with network test
-notebooklm notebook --help     # Notebook management
 notebooklm source --help       # Source management
 notebooklm research --help     # Research status/wait
 notebooklm generate --help     # Content generation

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -84,7 +84,7 @@ See [Configuration](configuration.md) for details on environment variables and C
 |---------|-------------|---------|
 | `list` | List all notebooks | `notebooklm list` |
 | `create <title>` | Create notebook | `notebooklm create "Research"` |
-| `delete <id>` | Delete notebook | `notebooklm delete abc123` |
+| `delete -n <id>` | Delete notebook (uses current notebook if `-n` omitted) | `notebooklm delete -n abc123` |
 | `rename <title>` | Rename current notebook | `notebooklm rename "New Title"` |
 | `summary` | Get AI summary | `notebooklm summary` |
 


### PR DESCRIPTION
## Summary

Two stale references in `SKILL.md` to a non-existent `notebook` click subgroup:

1. **Quick Reference row (line 184):** `notebooklm notebook delete <id>` → `notebooklm delete <id>`. The notebook commands are registered at the top level (`cli/notebook.py:32-203`: `list`, `create`, `delete`, `rename`, `summary`, `metadata`), which is the canonical form used by README, `docs/cli-reference.md`, and every other row in SKILL.md itself.

2. **"Discover what's available" section (line 581):** dropped `notebooklm notebook --help` — there is no `notebook` group to inspect, and the row two lines above (`notebooklm --help`) already covers it.

## Why this fix shape (vs adding a `notebook` subgroup)

The current asymmetry — notebook commands flat at the top level, `source`/`note`/`artifact` grouped — is intentional: notebooks are the root object of the CLI, so `notebooklm list` reads as "list notebooks" and `notebooklm source list` reads as "list sources (of the current notebook)." Adding a `notebook` subgroup would either be a breaking change (every existing script that runs `notebooklm list` breaks) or double the help surface with aliases. Fixing the doc keeps the intentional design and removes the only two places where SKILL.md disagrees with itself.

## Test plan

- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] `grep -rn "notebooklm notebook" SKILL.md README.md docs/` → 0 hits after fix (was 2)
- [x] Visual: remaining `Notebook Management` Quick Reference rows (list/create/use/rename/delete/summary) are now internally consistent — all use the top-level form

Closes #326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected quick-reference command entry for deleting notebooks.
  * Updated CLI reference to document the `-n <id>` form for delete; omitting `-n` deletes the current notebook.
  * Removed an outdated troubleshooting help line.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/383)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/383)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->