### PR TITLE
docs(readme): add uv tool / pipx CLI-only install section (closes #210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ pip install "notebooklm-py[cookies]"
 
 If `playwright install chromium` fails with `TypeError: onExit is not a function`, see the Linux workaround in [Troubleshooting](docs/troubleshooting.md#linux).
 
+### CLI-only install (`uv tool` / `pipx`)
+
+If you only need the `notebooklm` CLI (not the Python library) and want it on your `$PATH` in an isolated environment, install with [`uv tool`](https://docs.astral.sh/uv/concepts/tools/) or [`pipx`](https://pipx.pypa.io/):
+
+```bash
+# uv (recommended on systems where uv is already the package manager)
+uv tool install notebooklm-py
+uv tool install "notebooklm-py[browser]"
+uv tool install "notebooklm-py[cookies]"
+
+# pipx equivalent
+pipx install notebooklm-py
+pipx install "notebooklm-py[browser]"
+```
+
+This is the right path for shell scripts, cron jobs, and ad-hoc terminal use — the `notebooklm` command stays available regardless of which project venv is active.
+
 ### Development Installation
 
 For contributors or testing unreleased features:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ uv tool install "notebooklm-py[cookies]"
 # pipx equivalent
 pipx install notebooklm-py
 pipx install "notebooklm-py[browser]"
+pipx install "notebooklm-py[cookies]"
 ```
 
 This is the right path for shell scripts, cron jobs, and ad-hoc terminal use — the `notebooklm` command stays available regardless of which project venv is active.


### PR DESCRIPTION
## Summary

Adds a CLI-only install section to README between the basic `pip install` block and "Development Installation":

```bash
uv tool install notebooklm-py
uv tool install "notebooklm-py[browser]"
uv tool install "notebooklm-py[cookies]"

pipx install notebooklm-py
pipx install "notebooklm-py[browser]"
```

## Why this shape

- The reporter (#210) flagged that `uv tool install` is the natural install for them — broken system pip, uses uv for everything. Adding the equivalent `pipx` line covers the parallel community who would expect to see it next to `uv tool`.
- Framed as **"CLI-only install"** to make the distinction clear: `pip install notebooklm-py` is correct when you want the *Python library*; `uv tool install` is correct when you only want `notebooklm` on `$PATH`. The new prose calls out shell-script / cron / ad-hoc terminal use as the trigger.
- Positioned between basic install and the "Development Installation" (`git+main`) block — same conceptual tier (install paths for end users), separate from the contributor path.
- Linked to canonical docs ([`uv tool`](https://docs.astral.sh/uv/concepts/tools/), [`pipx`](https://pipx.pypa.io/)) so users unfamiliar with either tool can self-orient.

## Test plan

- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] Visual review — section flows between the playwright-Linux note and Development Installation, doesn't disrupt the Quick Start that follows

Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "CLI-only install" section describing how to install the notebooklm CLI in an isolated environment via `uv tool` or `pipx`, including package names and extras, so users can run the CLI without a full project installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/384)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->