### PR TITLE
feat(cli): add --timeout to source add and source add-research (closes #192, #194)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -111,9 +111,9 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | Command | Arguments | Options | Example |
 |---------|-----------|---------|---------|
 | `list` | - | - | `source list` |
-| `add <content>` | URL/file/text | - | `source add "https://..."` |
+| `add <content>` | URL/file/text | `--title`, `--type`, `--mime-type`, `--timeout`, `--json` | `source add "https://..." --timeout 90` |
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
-| `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait` | `source add-research "AI" --mode deep --no-wait` |
+| `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait`, `--timeout` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
 | `fulltext <id>` | Source ID | `--json`, `-o FILE` | `source fulltext src123 -o content.txt` |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
@@ -541,6 +541,7 @@ notebooklm source add-research <query> [OPTIONS]
 - `--from [web|drive]` - Search source (default: web)
 - `--import-all` - Automatically import all found sources (works with blocking mode)
 - `--no-wait` - Start research and return immediately (non-blocking)
+- `--timeout SECONDS` - Retry budget for `--import-all` when the IMPORT_RESEARCH RPC times out (default: 1800). Mirrors `research wait --timeout`. Has no effect without `--import-all`.
 
 **Examples:**
 ```bash
@@ -552,6 +553,9 @@ notebooklm source add-research "Project Alpha" --from drive --mode deep
 
 # Non-blocking deep research for agent workflows
 notebooklm source add-research "AI safety papers" --mode deep --no-wait
+
+# Bounded import-retry budget for large result sets
+notebooklm source add-research "AI papers" --mode deep --import-all --timeout 3600
 ```
 
 ### Research: `status`

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -230,9 +230,20 @@ def source_list(ctx, notebook_id, json_output, client_auth):
 )
 @click.option("--title", help="Custom title for text and uploaded-file sources")
 @click.option("--mime-type", help="MIME type for file sources")
+@click.option(
+    "--timeout",
+    default=None,
+    type=float,
+    help=(
+        "HTTP request timeout in seconds (default: 30, from the library). "
+        "Increase when adding slow URLs or large files that exceed the default."
+    ),
+)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
-def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_output, client_auth):
+def source_add(
+    ctx, content, notebook_id, source_type, title, mime_type, timeout, json_output, client_auth
+):
     """Add a source to a notebook.
 
     \b
@@ -271,8 +282,12 @@ def source_add(ctx, content, notebook_id, source_type, title, mime_type, json_ou
             detected_type = "text"
             file_title = title or "Pasted Text"
 
+    client_kwargs: dict = {}
+    if timeout is not None:
+        client_kwargs["timeout"] = timeout
+
     async def _run():
-        async with NotebookLMClient(client_auth) as client:
+        async with NotebookLMClient(client_auth, **client_kwargs) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id)
             if detected_type == "url" or detected_type == "youtube":
                 src = await client.sources.add_url(nb_id_resolved, content)
@@ -547,9 +562,19 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
     is_flag=True,
     help="Start research and return immediately (use 'research status/wait' to monitor)",
 )
+@click.option(
+    "--timeout",
+    default=1800,
+    type=int,
+    help=(
+        "Retry budget in seconds for --import-all when the IMPORT_RESEARCH RPC "
+        "times out (default: 1800). Mirrors 'research wait --timeout'. "
+        "Has no effect without --import-all."
+    ),
+)
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, no_wait, client_auth
+    ctx, query, notebook_id, search_source, mode, import_all, no_wait, timeout, client_auth
 ):
     """Search web or drive and add sources from results.
 
@@ -608,6 +633,7 @@ def source_add_research(
                         nb_id_resolved,
                         task_id,
                         sources,
+                        max_elapsed=timeout,
                     )
                     console.print(f"[green]Imported {len(imported)} sources[/green]")
             else:

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -239,6 +239,53 @@ class TestSourceAdd:
             data = json.loads(result.output)
             assert data["source"]["id"] == "src_new"
 
+    def test_source_add_timeout_flag_threaded_to_client(self, runner, mock_auth):
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_url = AsyncMock(
+                return_value=Source(id="src_t", title="X", url="https://example.com")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add",
+                        "https://example.com",
+                        "-n",
+                        "nb_123",
+                        "--timeout",
+                        "120",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            assert mock_client_cls.call_args.kwargs["timeout"] == 120.0
+
+    def test_source_add_default_does_not_override_client_timeout(self, runner, mock_auth):
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.add_url = AsyncMock(
+                return_value=Source(id="src_d", title="Y", url="https://example.com")
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["source", "add", "https://example.com", "-n", "nb_123"]
+                )
+
+            assert result.exit_code == 0
+            assert "timeout" not in mock_client_cls.call_args.kwargs
+
 
 # =============================================================================
 # SOURCE GET TESTS
@@ -720,7 +767,47 @@ class TestSourceAddResearch:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=1800,
         )
+
+    def test_add_research_timeout_flag_threaded_to_import_with_retry(self, runner, mock_auth):
+        with (
+            patch_client_for_module("source") as mock_client_cls,
+            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_t1"})
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_t1",
+                    "sources": [{"title": "S", "url": "http://example.com"}],
+                    "report": "",
+                }
+            )
+            mock_import.return_value = [{"id": "src_t1", "title": "S"}]
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add-research",
+                        "topic",
+                        "--import-all",
+                        "--timeout",
+                        "600",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert mock_import.await_args.kwargs["max_elapsed"] == 600
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds a `--timeout` option to two `source` commands. Same flag name, two different layers of the stack:

### `source add --timeout SECS`  (closes #192)

Overrides the HTTP request timeout (default: **30s** from `DEFAULT_TIMEOUT` in `_core.py`) for the entire `source add` run by passing through to `NotebookLMClient(client_auth, timeout=...)`.

- **Why:** the reporter in #192 hit `ADD_SOURCE failed after 30.057s: Request timed out` on a slow URL (`geeksforgeeks.org`), with no CLI surface to lift the ceiling.
- **Now:**
  ```bash
  notebooklm source add https://slow.example/long --timeout 120
  ```
- **Sentinel `None` default**: when the flag isn't passed, `NotebookLMClient` is constructed *without* a `timeout` kwarg — preserving exact prior behavior (library default of 30s) for every other call site.

### `source add-research --timeout SECS`  (closes #194)

Sets `max_elapsed` on `import_with_retry` for `--import-all` (default: **1800s**). Mirrors `research wait --timeout` semantics so the same import operation has the same retry budget regardless of which command initiates it.

- **Why:** #194 (owner-authored) flagged the asymmetry — `research wait --import-all` honors a command-level `--timeout`, but `source add-research --import-all` previously fell back to the helper's hard-coded 1800s.
- **Now:**
  ```bash
  notebooklm source add-research "AI papers" --mode deep --import-all --timeout 3600
  ```
- **Default kept at 1800s** (matching the prior implicit budget) so existing scripts that rely on the long ceiling don't regress.

## Tests

- ✏️ Updated `test_add_research_with_import_all_uses_retry_helper` — the call assertion now includes `max_elapsed=1800` (newly a keyword arg).
- ➕ `test_source_add_timeout_flag_threaded_to_client` — `--timeout 120` lands on `NotebookLMClient(..., timeout=120.0)`.
- ➕ `test_source_add_default_does_not_override_client_timeout` — without `--timeout`, no `timeout` kwarg is passed (library default preserved).
- ➕ `test_add_research_timeout_flag_threaded_to_import_with_retry` — `--timeout 600 --import-all` lands on `import_with_retry(max_elapsed=600)`.

## Docs

- `docs/cli-reference.md` — quick-reference table options column for both commands, plus a dedicated `--timeout` bullet and bounded `--import-all` example in the **Source: `add-research`** detail section.

## Test plan

- [x] `ruff format src/ tests/` clean
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] `pytest tests/unit/cli/test_source.py -q` → 60/60 pass
- [x] Full `pytest -q` → 2354 passed, 9 skipped (was 2351 before — 3 new tests)
- [x] Sanity-check `--help` rendering on both commands

Closes #192
Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--timeout` option to `source add` command for controlling operation duration.
  * Added `--timeout` option to `source add-research` command to set retry budget for import operations.

* **Documentation**
  * Updated CLI reference with new command options and usage examples.

* **Tests**
  * Added test coverage for timeout option handling in both commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/385)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->