### PR TITLE
fix(cli): preserve CJK/emoji in --json output (closes #390)

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -11,8 +11,6 @@ Commands:
     suggestions Get AI-suggested report topics
 """
 
-import json
-
 import click
 from rich.table import Table
 
@@ -429,7 +427,7 @@ def artifact_suggestions(ctx, notebook_id, json_output, client_auth):
                     {"title": s.title, "description": s.description, "prompt": s.prompt}
                     for s in suggestions
                 ]
-                console.print(json.dumps(data, indent=2, ensure_ascii=False))
+                json_output_response(data)
                 return
 
             table = Table(title="Suggested Reports")

--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -429,7 +429,7 @@ def artifact_suggestions(ctx, notebook_id, json_output, client_auth):
                     {"title": s.title, "description": s.description, "prompt": s.prompt}
                     for s in suggestions
                 ]
-                console.print(json.dumps(data, indent=2))
+                console.print(json.dumps(data, indent=2, ensure_ascii=False))
                 return
 
             table = Table(title="Suggested Reports")

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -12,7 +12,6 @@ Commands:
     flashcards   Download flashcard deck
 """
 
-import json
 from collections.abc import Awaitable, Callable
 from functools import partial
 from pathlib import Path
@@ -31,6 +30,7 @@ from .download_helpers import (
 from .helpers import (
     console,
     handle_error,
+    json_output_response,
     require_notebook,
     resolve_notebook_id,
     run_async,
@@ -660,7 +660,7 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
         )
 
         if json_output:
-            console.print(json.dumps(result, indent=2, ensure_ascii=False))
+            json_output_response(result)
             return
 
         _display_download_result(result, artifact_type)

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -660,7 +660,7 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
         )
 
         if json_output:
-            console.print(json.dumps(result, indent=2))
+            console.print(json.dumps(result, indent=2, ensure_ascii=False))
             return
 
         _display_download_result(result, artifact_type)

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -46,7 +46,7 @@ def _output_error(
         response: dict = {"error": True, "code": code, "message": message}
         if extra:
             response.update(extra)
-        click.echo(json.dumps(response, indent=2))  # json.dumps defaults to ASCII-safe output.
+        click.echo(json.dumps(response, indent=2, ensure_ascii=False))
     else:
         safe_echo(message, err=True)
         if hint:

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -46,7 +46,7 @@ def _output_error(
         response: dict = {"error": True, "code": code, "message": message}
         if extra:
             response.update(extra)
-        click.echo(json.dumps(response, indent=2, ensure_ascii=False))
+        click.echo(json.dumps(response, indent=2, default=str, ensure_ascii=False))
     else:
         safe_echo(message, err=True)
         if hint:

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -804,7 +804,7 @@ def json_error_response(code: str, message: str, extra: dict | None = None) -> N
     response = {"error": True, "code": code, "message": message}
     if extra:
         response.update(extra)
-    click.echo(json.dumps(response, indent=2, ensure_ascii=False))
+    click.echo(json.dumps(response, indent=2, default=str, ensure_ascii=False))
     raise SystemExit(1)
 
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -790,7 +790,7 @@ def with_client(f):
 
 def json_output_response(data: dict) -> None:
     """Print JSON response (no colors for machine parsing)."""
-    click.echo(json.dumps(data, indent=2, default=str))
+    click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
 
 
 def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
@@ -804,7 +804,7 @@ def json_error_response(code: str, message: str, extra: dict | None = None) -> N
     response = {"error": True, "code": code, "message": message}
     if extra:
         response.update(extra)
-    click.echo(json.dumps(response, indent=2))
+    click.echo(json.dumps(response, indent=2, ensure_ascii=False))
     raise SystemExit(1)
 
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -788,7 +788,7 @@ def with_client(f):
 # =============================================================================
 
 
-def json_output_response(data: dict) -> None:
+def json_output_response(data: dict | list) -> None:
     """Print JSON response (no colors for machine parsing)."""
     click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
 

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -586,6 +586,33 @@ class TestArtifactSuggestions:
             assert len(data) == 1
             assert data[0]["title"] == "Topic 1"
 
+    def test_artifact_suggestions_json_preserves_unicode(self, runner, mock_auth):
+        """CJK / emoji in suggestion titles should be emitted as real UTF-8."""
+        with patch_client_for_module("artifact") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.suggest_reports = AsyncMock(
+                return_value=[
+                    MagicMock(title="中文主题 🚀", description="说明", prompt="问题"),
+                ]
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["artifact", "suggestions", "-n", "nb_123", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data[0]["title"] == "中文主题 🚀"
+            assert data[0]["description"] == "说明"
+            assert data[0]["prompt"] == "问题"
+            # Raw output must contain real CJK/emoji, not escaped sequences.
+            assert "中文主题" in result.output
+            assert "🚀" in result.output
+            assert "\\u" not in result.output
+
 
 # =============================================================================
 # COMMAND EXISTENCE TESTS

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -1,5 +1,6 @@
 """Tests for download CLI commands."""
 
+import json
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -389,6 +390,42 @@ class TestDownloadFlags:
 
             # File should remain unchanged
             assert output_file.read_bytes() == b"existing content"
+
+
+# =============================================================================
+# JSON OUTPUT UNICODE TESTS
+# =============================================================================
+
+
+class TestDownloadJsonOutputUnicode:
+    def test_download_json_output_preserves_unicode(self, runner, mock_auth):
+        """`download <type> --json` should emit CJK / emoji as real UTF-8, not \\uXXXX."""
+        fake_result = {
+            "artifact_id": "audio_123",
+            "title": "中文音频 🎧",
+            "output_path": "音频.mp3",
+        }
+
+        async def fake_download_generic(*args, **kwargs):
+            return fake_result
+
+        with (
+            patch.object(download_module, "_download_artifacts_generic", fake_download_generic),
+            patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch,
+        ):
+            mock_fetch.return_value = ("csrf", "session")
+            result = runner.invoke(cli, ["download", "audio", "--json", "-n", "nb_123"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["title"] == "中文音频 🎧"
+        assert data["output_path"] == "音频.mp3"
+        # Raw output must contain real CJK/emoji, not escaped sequences.
+        assert "中文音频" in result.output
+        assert "🎧" in result.output
+        assert "\\u" not in result.output
 
 
 # =============================================================================

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -141,6 +141,19 @@ class TestHandleErrorsJsonOutput:
         assert data["code"] == "UNEXPECTED_ERROR"
         assert "Something broke" in data["message"]
 
+    def test_error_handler_json_output_preserves_unicode(self, capsys):
+        """CJK / emoji in error messages should be emitted as real UTF-8."""
+        with pytest.raises(SystemExit), handle_errors(json_output=True):
+            raise ValidationError("笔记本未找到 🔍")
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert "笔记本未找到 🔍" in data["message"]
+        # Raw output must contain real CJK/emoji, not escaped sequences.
+        assert "笔记本未找到" in output
+        assert "🔍" in output
+        assert "\\u" not in output
+
 
 class TestHandleErrorsTextOutput:
     """Test text error output with hints."""

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -163,7 +163,7 @@ class TestHandleErrorsJsonOutput:
                 "PATH_ERROR",
                 json_output=True,
                 exit_code=1,
-                extra={"path": Path("/tmp/x")},
+                extra={"path": Path("tmp_test_path")},
             )
 
         assert exc_info.value.code == 1
@@ -172,7 +172,7 @@ class TestHandleErrorsJsonOutput:
         assert data["error"] is True
         assert data["code"] == "PATH_ERROR"
         assert data["message"] == "Bad path"
-        assert data["path"] == str(Path("/tmp/x"))
+        assert data["path"] == str(Path("tmp_test_path"))
 
 
 class TestHandleErrorsTextOutput:

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -172,7 +172,7 @@ class TestHandleErrorsJsonOutput:
         assert data["error"] is True
         assert data["code"] == "PATH_ERROR"
         assert data["message"] == "Bad path"
-        assert "/tmp/x" in data["path"]
+        assert data["path"] == str(Path("/tmp/x"))
 
 
 class TestHandleErrorsTextOutput:

--- a/tests/unit/cli/test_error_handler.py
+++ b/tests/unit/cli/test_error_handler.py
@@ -1,11 +1,12 @@
 """Tests for centralized CLI error handling."""
 
 import json
+from pathlib import Path
 
 import pytest
 
 import notebooklm.cli._encoding as encoding_module
-from notebooklm.cli.error_handler import handle_errors
+from notebooklm.cli.error_handler import _output_error, handle_errors
 from notebooklm.exceptions import (
     AuthError,
     ConfigurationError,
@@ -153,6 +154,25 @@ class TestHandleErrorsJsonOutput:
         assert "笔记本未找到" in output
         assert "🔍" in output
         assert "\\u" not in output
+
+    def test_output_error_serializes_path_in_extra(self, capsys):
+        """_output_error must not crash on non-primitive extras like pathlib.Path."""
+        with pytest.raises(SystemExit) as exc_info:
+            _output_error(
+                "Bad path",
+                "PATH_ERROR",
+                json_output=True,
+                exit_code=1,
+                extra={"path": Path("/tmp/x")},
+            )
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["error"] is True
+        assert data["code"] == "PATH_ERROR"
+        assert data["message"] == "Bad path"
+        assert "/tmp/x" in data["path"]
 
 
 class TestHandleErrorsTextOutput:

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -232,6 +232,20 @@ class TestJsonOutputResponse:
         assert data["nested"]["key"] == "value"
         assert data["list"] == [1, 2, 3]
 
+    def test_json_output_response_preserves_unicode(self, capsys):
+        """CJK / emoji characters should be emitted as real UTF-8, not \\uXXXX."""
+        json_output_response({"title": "中文笔记本", "emoji": "🚀"})
+
+        captured = capsys.readouterr()
+        # Round-trip must still parse.
+        data = json.loads(captured.out)
+        assert data["title"] == "中文笔记本"
+        assert data["emoji"] == "🚀"
+        # Raw output must contain real CJK chars, not escaped sequences.
+        assert "中文笔记本" in captured.out
+        assert "🚀" in captured.out
+        assert "\\u" not in captured.out
+
 
 class TestJsonErrorResponse:
     def test_outputs_error_json_and_exits(self, capsys):
@@ -245,6 +259,20 @@ class TestJsonErrorResponse:
         assert data["error"] is True
         assert data["code"] == "TEST_ERROR"
         assert data["message"] == "Test error message"
+
+    def test_json_error_response_preserves_unicode(self, capsys):
+        """Error messages with CJK / emoji should be emitted as real UTF-8."""
+        with pytest.raises(SystemExit):
+            json_error_response("ERROR", "笔记本不存在 🚫", extra={"title": "中文"})
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["message"] == "笔记本不存在 🚫"
+        assert data["title"] == "中文"
+        assert "笔记本不存在" in captured.out
+        assert "🚫" in captured.out
+        assert "中文" in captured.out
+        assert "\\u" not in captured.out
 
 
 # =============================================================================

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -273,6 +274,18 @@ class TestJsonErrorResponse:
         assert "🚫" in captured.out
         assert "中文" in captured.out
         assert "\\u" not in captured.out
+
+    def test_json_error_response_serializes_path_in_extra(self, capsys):
+        """Non-primitive values like pathlib.Path must not crash the error reporter."""
+        with pytest.raises(SystemExit):
+            json_error_response("ERROR", "Bad path", extra={"path": Path("/tmp/x")})
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["error"] is True
+        assert data["code"] == "ERROR"
+        assert data["message"] == "Bad path"
+        assert "/tmp/x" in data["path"]
 
 
 # =============================================================================

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -285,7 +285,7 @@ class TestJsonErrorResponse:
         assert data["error"] is True
         assert data["code"] == "ERROR"
         assert data["message"] == "Bad path"
-        assert "/tmp/x" in data["path"]
+        assert data["path"] == str(Path("/tmp/x"))
 
 
 # =============================================================================

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -278,14 +278,14 @@ class TestJsonErrorResponse:
     def test_json_error_response_serializes_path_in_extra(self, capsys):
         """Non-primitive values like pathlib.Path must not crash the error reporter."""
         with pytest.raises(SystemExit):
-            json_error_response("ERROR", "Bad path", extra={"path": Path("/tmp/x")})
+            json_error_response("ERROR", "Bad path", extra={"path": Path("tmp_test_path")})
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert data["error"] is True
         assert data["code"] == "ERROR"
         assert data["message"] == "Bad path"
-        assert data["path"] == str(Path("/tmp/x"))
+        assert data["path"] == str(Path("tmp_test_path"))
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

`json.dumps()` defaults to `ensure_ascii=True`, which escapes any non-ASCII character as `\uXXXX`. CLI `--json` output for users with CJK or emoji in notebook titles, artifact titles, error messages, etc. becomes unreadable in terminals, grep, logs, and diffs — even though the JSON is technically valid.

## Reproduction

```bash
python -c 'import json; print(json.dumps({"title": "中文笔记本"}, indent=2))'
```

**Before:**

```
{
  "title": "中文笔记本"
}
```

**After (via fixed helpers):**

```bash
python -c "from notebooklm.cli.helpers import json_output_response; json_output_response({'title': '中文笔记本'})"
```

```
{
  "title": "中文笔记本"
}
```

## Sites changed

Five direct-emit `json.dumps` calls now pass `ensure_ascii=False`:

- `src/notebooklm/cli/helpers.py` — `json_output_response`, `json_error_response`
- `src/notebooklm/cli/error_handler.py` — JSON error path (removed the stale "ASCII-safe" comment)
- `src/notebooklm/cli/download.py` — `download <type> --json`
- `src/notebooklm/cli/artifact.py` — `artifact suggestions --json`

Existing `ensure_ascii=False` file-write calls in `helpers.py:434,472` are left alone. `_notebooks.py` is docstring-only (tracked separately under #399) and not touched.

## Test plan

5 new TDD-first unit tests (RED → fix → GREEN), each asserting raw CJK / emoji bytes appear in stdout AND `\\u` escapes do not:

- [x] `test_json_output_response_preserves_unicode` (helpers)
- [x] `test_json_error_response_preserves_unicode` (helpers)
- [x] `test_error_handler_json_output_preserves_unicode` (error_handler)
- [x] `test_artifact_suggestions_json_preserves_unicode` (artifact)
- [x] `test_download_json_output_preserves_unicode` (download)
- [x] Full pre-commit: `ruff format --check . && ruff check . && mypy src/notebooklm --ignore-missing-imports && pytest` — 2407 passed, 9 skipped

Closes #390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON CLI output now preserves non-ASCII characters (emoji, CJK), uses a unified helper for consistent formatting, and serializes non-standard values as strings when needed.

* **Tests**
  * Added tests verifying JSON-formatted command output and error messages preserve Unicode and correctly serialize path-like/extra values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/394)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->