### PR TITLE
fix(sources): fix rename race + audio transient status=3 (closes #388, #391)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -31,18 +31,13 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
-# Source type codes where status=ERROR is genuinely terminal.
-# Audio/media (code 10) and unclassified (None / 0) sources can briefly
-# report status=3 during transcription before settling at status=2,
-# so they must keep polling instead of raising. See #391.
-#
-# This is intentionally a hand-maintained whitelist (not derived from
-# _SOURCE_TYPE_CODE_MAP minus {10}): if Google adds a new audio-adjacent
-# code with the same transient-status=3 behavior, a derived set would
-# silently regress the fix. Keep the codes here in sync with
-# _SOURCE_TYPE_CODE_MAP in types.py — adding a code here opts it in to
-# strict terminal-error semantics.
-_NON_AUDIO_TERMINAL_TYPES: frozenset[int] = frozenset({1, 2, 3, 4, 5, 8, 9, 11, 13, 14, 16, 17})
+# Source type codes where status=3 (ERROR) is transient rather than
+# terminal. Audio/media (10) and unclassified (None / 0) sources can
+# briefly report status=3 during transcription/classification before
+# settling at status=2. All other types (PDFs, web, YouTube, etc.) treat
+# status=3 as a terminal failure. New unknown types default to terminal
+# — fail fast rather than silently looping until timeout. See #391.
+_TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
 
 
 class SourcesAPI:
@@ -258,8 +253,7 @@ class SourcesAPI:
                 return source
 
             if source.is_error:
-                type_code = source._type_code
-                if type_code in _NON_AUDIO_TERMINAL_TYPES:
+                if source._type_code not in _TRANSIENT_ERROR_TYPES:
                     raise SourceProcessingError(source_id, source.status)
                 # For audio (type 10) or unclassified (None / 0) sources,
                 # status=3 can be a transient state during transcription —
@@ -287,7 +281,7 @@ class SourcesAPI:
 
         Polls until the source is visible in the notebook listing and has a
         non-ERROR status (or, for audio/unclassified sources, a transient
-        ERROR — see ``_NON_AUDIO_TERMINAL_TYPES``). Returns as soon as the
+        ERROR — see ``_TRANSIENT_ERROR_TYPES``). Returns as soon as the
         source exists, without waiting for full processing.
 
         This is intended for narrow follow-up RPCs like UPDATE_SOURCE that
@@ -327,8 +321,7 @@ class SourcesAPI:
                 last_status = source.status
 
                 if source.is_error:
-                    type_code = source._type_code
-                    if type_code in _NON_AUDIO_TERMINAL_TYPES:
+                    if source._type_code not in _TRANSIENT_ERROR_TYPES:
                         raise SourceProcessingError(source_id, source.status)
                     # Transient ERROR for audio (type 10) or unclassified
                     # (None / 0) — keep polling. See #391.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -4,7 +4,6 @@ import asyncio
 import builtins
 import logging
 import re
-from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 from typing import Any
@@ -29,6 +28,13 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Source type codes where status=ERROR is genuinely terminal.
+# Audio/media (10) and unclassified (None / 0) sources can briefly
+# report status=3 during transcription before settling at status=2.
+# See #391.
+_NON_AUDIO_TERMINAL_TYPES: frozenset[int] = frozenset({1, 2, 3, 4, 5, 8, 9, 11, 13, 14, 16, 17})
 
 
 class SourcesAPI:
@@ -244,7 +250,12 @@ class SourcesAPI:
                 return source
 
             if source.is_error:
-                raise SourceProcessingError(source_id, source.status)
+                type_code = source._type_code
+                if type_code in _NON_AUDIO_TERMINAL_TYPES:
+                    raise SourceProcessingError(source_id, source.status)
+                # For audio (type 10) or unclassified (None / 0) sources,
+                # status=3 can be a transient state during transcription —
+                # keep polling instead of treating it as terminal. See #391.
 
             # Don't sleep longer than remaining time
             remaining = timeout - (monotonic() - start)
@@ -470,38 +481,41 @@ class SourcesAPI:
         # Step 3: Stream upload file content (memory-efficient)
         await self._upload_file_streaming(upload_url, file_path)
 
-        # Return source with the ID we got from registration
-        # Note: _type_code is None because the actual type is determined
-        # by the API after processing (PDF, TEXT, IMAGE, etc.)
-        # Use wait=True or get() to retrieve the actual type after processing
-        source = Source(
-            id=source_id,
-            title=filename,
-            _type_code=None,  # Placeholder until processed
-        )
+        # Step 4: Wait for the source to be fully registered BEFORE renaming.
+        # The UPDATE_SOURCE RPC silently no-ops against an unregistered source
+        # (returns success-shaped data, but the title change never propagates),
+        # so a custom-title request must force a brief wait even when the
+        # caller passed wait=False. See #388.
+        should_wait = wait or (title is not None and title != filename)
+        if should_wait:
+            source = await self.wait_until_ready(notebook_id, source_id, timeout=wait_timeout)
+        else:
+            # Note: _type_code is None because the actual type is determined
+            # by the API after processing (PDF, TEXT, IMAGE, etc.). Callers
+            # can use wait=True or get() to retrieve the resolved type.
+            source = Source(
+                id=source_id,
+                title=filename,
+                _type_code=None,  # Placeholder until processed
+            )
 
-        # Step 4: Apply custom title if requested. The file-add RPC ignores any
-        # title hint, so a separate UPDATE_SOURCE call is the only way to honor
-        # the caller's intent.
+        # Step 5: Apply custom title now that the source is registered. The
+        # file-add RPC ignores any title hint, so a separate UPDATE_SOURCE
+        # call is the only way to honor the caller's intent.
         if title is not None and title != filename:
             try:
-                renamed = await self.rename(notebook_id, source_id, title)
-                # Use any metadata UPDATE_SOURCE returned, but force _type_code
-                # back to None because rename runs before file processing finishes.
-                source = replace(renamed, _type_code=None)
+                source = await self.rename(notebook_id, source_id, title)
             except (RPCError, NetworkError):
                 # Don't fail the whole upload if the rename fails — the file is
-                # already uploaded. Surface a warning so the caller can retry.
+                # already uploaded and registered. Surface a warning so the
+                # caller can retry. The registered source (from the forced wait
+                # above) is returned with its server-side title.
                 logger.warning(
-                    "Source %s uploaded but rename to %r failed; keeping default title %r",
+                    "Source %s uploaded but rename to %r failed",
                     source_id,
                     title,
-                    filename,
                     exc_info=True,
                 )
-
-        if wait:
-            return await self.wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
 
         return source
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -527,8 +527,9 @@ class SourcesAPI:
                 # Only merge the new title onto the waited source. rename()'s
                 # response shape can be sparse (UPDATE_SOURCE sometimes returns
                 # just an id + title) and would otherwise null out _type_code,
-                # url, and created_at that wait_until_ready() populated.
-                source = replace(source, title=renamed.title)
+                # url, and created_at that wait_until_ready() populated. Fall
+                # back to the requested title if rename's response omits it.
+                source = replace(source, title=renamed.title or title)
             except (RPCError, NetworkError):
                 # Don't fail the whole upload if the rename fails — the file is
                 # already uploaded and registered. Surface a warning so the

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -31,9 +31,16 @@ logger = logging.getLogger(__name__)
 
 
 # Source type codes where status=ERROR is genuinely terminal.
-# Audio/media (10) and unclassified (None / 0) sources can briefly
-# report status=3 during transcription before settling at status=2.
-# See #391.
+# Audio/media (code 10) and unclassified (None / 0) sources can briefly
+# report status=3 during transcription before settling at status=2,
+# so they must keep polling instead of raising. See #391.
+#
+# This is intentionally a hand-maintained whitelist (not derived from
+# _SOURCE_TYPE_CODE_MAP minus {10}): if Google adds a new audio-adjacent
+# code with the same transient-status=3 behavior, a derived set would
+# silently regress the fix. Keep the codes here in sync with
+# _SOURCE_TYPE_CODE_MAP in types.py — adding a code here opts it in to
+# strict terminal-error semantics.
 _NON_AUDIO_TERMINAL_TYPES: frozenset[int] = frozenset({1, 2, 3, 4, 5, 8, 9, 11, 13, 14, 16, 17})
 
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -274,6 +274,77 @@ class SourcesAPI:
             await asyncio.sleep(sleep_time)
             interval = min(interval * backoff_factor, max_interval)
 
+    async def wait_until_registered(
+        self,
+        notebook_id: str,
+        source_id: str,
+        timeout: float = 30.0,
+        initial_interval: float = 0.5,
+        max_interval: float = 5.0,
+        backoff_factor: float = 1.5,
+    ) -> Source:
+        """Wait for a source to be registered server-side (status >= PROCESSING).
+
+        Polls until the source is visible in the notebook listing and has a
+        non-ERROR status (or, for audio/unclassified sources, a transient
+        ERROR — see ``_NON_AUDIO_TERMINAL_TYPES``). Returns as soon as the
+        source exists, without waiting for full processing.
+
+        This is intended for narrow follow-up RPCs like UPDATE_SOURCE that
+        only require the source to be registered, not fully processed.
+        Registration is fast (seconds) even for long audio sources, so the
+        default timeout is much shorter than ``wait_until_ready``'s.
+
+        Args:
+            notebook_id: The notebook ID.
+            source_id: The source ID to wait for.
+            timeout: Maximum time to wait in seconds (default: 30).
+            initial_interval: Initial polling interval in seconds (default: 0.5).
+            max_interval: Maximum polling interval in seconds (default: 5).
+            backoff_factor: Multiplier for polling interval (default: 1.5).
+
+        Returns:
+            The registered Source object (status is PROCESSING, READY, or
+            PREPARING).
+
+        Raises:
+            SourceTimeoutError: If timeout is reached before source is registered.
+            SourceProcessingError: If source reports a terminal ERROR for a
+                non-transient source type.
+        """
+        start = monotonic()
+        interval = initial_interval
+        last_status: int | None = None
+
+        while True:
+            elapsed = monotonic() - start
+            if elapsed >= timeout:
+                raise SourceTimeoutError(source_id, timeout, last_status)
+
+            source = await self.get(notebook_id, source_id)
+
+            if source is not None:
+                last_status = source.status
+
+                if source.is_error:
+                    type_code = source._type_code
+                    if type_code in _NON_AUDIO_TERMINAL_TYPES:
+                        raise SourceProcessingError(source_id, source.status)
+                    # Transient ERROR for audio (type 10) or unclassified
+                    # (None / 0) — keep polling. See #391.
+                else:
+                    # Any non-error status (PROCESSING, READY, PREPARING)
+                    # means the source is registered server-side; we're done.
+                    return source
+
+            remaining = timeout - (monotonic() - start)
+            if remaining <= 0:
+                raise SourceTimeoutError(source_id, timeout, last_status)
+
+            sleep_time = min(interval, remaining)
+            await asyncio.sleep(sleep_time)
+            interval = min(interval * backoff_factor, max_interval)
+
     async def wait_for_sources(
         self,
         notebook_id: str,
@@ -450,18 +521,22 @@ class SourcesAPI:
                 the post-upload rename fails, the upload is preserved, a warning
                 is logged, and the returned source keeps the filename title.
 
-                Important: supplying a non-default title forces a brief wait
-                for the source to become registered *before* the rename is
-                issued, even when ``wait=False``. The UPDATE_SOURCE RPC
-                silently no-ops against an unregistered source, so blocking
-                here is the only way to honor the caller's intent. ``wait_timeout``
-                bounds this forced wait. See #388.
-            wait: If True, wait for source to be ready before returning. Note
-                that supplying ``title`` also forces a pre-rename wait
-                regardless of this flag — see the ``title`` parameter above.
-            wait_timeout: Maximum seconds to wait if ``wait=True``. Also bounds
-                the forced pre-rename wait triggered by a custom ``title``
-                (even when ``wait=False``). Default: 120.
+                Important: supplying a non-default title forces a brief
+                registration wait (~seconds) for the source to become visible
+                server-side *before* the rename is issued, even when
+                ``wait=False``. The UPDATE_SOURCE RPC silently no-ops against
+                an unregistered source, so blocking here is the only way to
+                honor the caller's intent. This narrow wait completes once
+                the source's status is non-ERROR (or transient-ERROR for
+                audio); it does NOT wait for full processing. See #388.
+            wait: If True, wait for source to be fully ready before returning.
+                Note that supplying ``title`` also forces a narrow pre-rename
+                registration wait regardless of this flag — see the ``title``
+                parameter above.
+            wait_timeout: Maximum seconds to wait if ``wait=True``. Also caps
+                the narrow registration wait triggered by a custom ``title``
+                (which is otherwise bounded by a 30s default to keep callers
+                that passed ``wait=False`` fast). Default: 120.
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.
@@ -500,14 +575,27 @@ class SourcesAPI:
         # Step 3: Stream upload file content (memory-efficient)
         await self._upload_file_streaming(upload_url, file_path)
 
-        # Step 4: Wait for the source to be fully registered BEFORE renaming.
+        # Step 4: Ensure the source is registered server-side BEFORE renaming.
         # The UPDATE_SOURCE RPC silently no-ops against an unregistered source
         # (returns success-shaped data, but the title change never propagates),
-        # so a custom-title request must force a brief wait even when the
-        # caller passed wait=False. See #388.
-        should_wait = wait or (title is not None and title != filename)
-        if should_wait:
+        # so a custom-title request must force a brief registration wait even
+        # when the caller passed wait=False. See #388.
+        #
+        # When wait=True the caller asked for full processing; use
+        # wait_until_ready. When only a custom title was supplied, use the
+        # narrower wait_until_registered (default 30s) so wait=False callers
+        # don't pay the full processing latency just to get a rename through.
+        needs_title_rename = title is not None and title != filename
+        if wait:
             source = await self.wait_until_ready(notebook_id, source_id, timeout=wait_timeout)
+        elif needs_title_rename:
+            # Cap the narrow wait at min(wait_timeout, 30) — registration is
+            # fast (seconds), so honor a tighter user-supplied bound but cap
+            # the default at 30s rather than blocking on full processing.
+            registered_timeout = min(wait_timeout, 30.0)
+            source = await self.wait_until_registered(
+                notebook_id, source_id, timeout=registered_timeout
+            )
         else:
             # Note: _type_code is None because the actual type is determined
             # by the API after processing (PDF, TEXT, IMAGE, etc.). Callers

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -576,26 +576,27 @@ class SourcesAPI:
         #
         # When wait=True the caller asked for full processing; use
         # wait_until_ready. When only a custom title was supplied, use the
-        # narrower wait_until_registered (default 30s) so wait=False callers
-        # don't pay the full processing latency just to get a rename through.
+        # narrower wait_until_registered so wait=False callers don't pay the
+        # full processing latency just to get a rename through.
         needs_title_rename = title is not None and title != filename
         if wait:
             source = await self.wait_until_ready(notebook_id, source_id, timeout=wait_timeout)
         elif needs_title_rename:
-            # Cap the narrow wait at min(wait_timeout, 30) — registration is
-            # fast (seconds), so honor a tighter user-supplied bound but cap
-            # the default at 30s rather than blocking on full processing.
-            registered_timeout = min(wait_timeout, 30.0)
-            source = await self.wait_until_registered(
-                notebook_id, source_id, timeout=registered_timeout
-            )
+            # Honor the caller's wait_timeout directly — wait_until_registered
+            # polls and returns on the first PROCESSING/READY status, so the
+            # narrow wait still completes fast for typical sources even when
+            # the upper bound is generous (e.g. long-audio callers passing 300s).
+            source = await self.wait_until_registered(notebook_id, source_id, timeout=wait_timeout)
         else:
-            # Note: _type_code is None because the actual type is determined
-            # by the API after processing (PDF, TEXT, IMAGE, etc.). Callers
-            # can use wait=True or get() to retrieve the resolved type.
+            # Fire-and-forget placeholder. _type_code is None because the
+            # actual type is determined by the API after processing (PDF,
+            # TEXT, IMAGE, etc.). status=PROCESSING reflects that the source
+            # has been registered but not yet processed — callers can use
+            # wait=True or get() to retrieve the resolved state.
             source = Source(
                 id=source_id,
                 title=filename,
+                status=SourceStatus.PROCESSING,
                 _type_code=None,  # Placeholder until processed
             )
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -4,6 +4,7 @@ import asyncio
 import builtins
 import logging
 import re
+from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 from typing import Any
@@ -448,8 +449,19 @@ class SourcesAPI:
                 trailing whitespace is stripped; empty titles are rejected. If
                 the post-upload rename fails, the upload is preserved, a warning
                 is logged, and the returned source keeps the filename title.
-            wait: If True, wait for source to be ready before returning.
-            wait_timeout: Maximum seconds to wait if wait=True (default: 120).
+
+                Important: supplying a non-default title forces a brief wait
+                for the source to become registered *before* the rename is
+                issued, even when ``wait=False``. The UPDATE_SOURCE RPC
+                silently no-ops against an unregistered source, so blocking
+                here is the only way to honor the caller's intent. ``wait_timeout``
+                bounds this forced wait. See #388.
+            wait: If True, wait for source to be ready before returning. Note
+                that supplying ``title`` also forces a pre-rename wait
+                regardless of this flag — see the ``title`` parameter above.
+            wait_timeout: Maximum seconds to wait if ``wait=True``. Also bounds
+                the forced pre-rename wait triggered by a custom ``title``
+                (even when ``wait=False``). Default: 120.
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.
@@ -511,7 +523,12 @@ class SourcesAPI:
         # call is the only way to honor the caller's intent.
         if title is not None and title != filename:
             try:
-                source = await self.rename(notebook_id, source_id, title)
+                renamed = await self.rename(notebook_id, source_id, title)
+                # Only merge the new title onto the waited source. rename()'s
+                # response shape can be sparse (UPDATE_SOURCE sometimes returns
+                # just an id + title) and would otherwise null out _type_code,
+                # url, and created_at that wait_until_ready() populated.
+                source = replace(source, title=renamed.title)
             except (RPCError, NetworkError):
                 # Don't fail the whole upload if the rename fails — the file is
                 # already uploaded and registered. Surface a warning so the

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -526,10 +526,11 @@ class SourcesAPI:
                 Note that supplying ``title`` also forces a narrow pre-rename
                 registration wait regardless of this flag — see the ``title``
                 parameter above.
-            wait_timeout: Maximum seconds to wait if ``wait=True``. Also caps
-                the narrow registration wait triggered by a custom ``title``
-                (which is otherwise bounded by a 30s default to keep callers
-                that passed ``wait=False`` fast). Default: 120.
+            wait_timeout: Maximum seconds to wait if ``wait=True``. Also bounds
+                the narrow registration wait triggered by a custom ``title``;
+                that wait returns on the first PROCESSING/READY poll so it
+                completes in seconds for typical sources regardless of this
+                value. Default: 120.
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -2511,7 +2511,10 @@ class TestWaitUntilReadyErrorPaths:
         """Test wait_until_ready() raises SourceProcessingError when source is in ERROR state (line 235)."""
         from notebooklm.types import SourceProcessingError
 
-        # Source has ERROR status (status=3)
+        # Source has ERROR status (status=3). Use a non-audio terminal type
+        # (3 = PDF) at metadata[4] so the audio-tolerance gate (#391) does
+        # not keep polling. Audio (type 10) and unclassified types can briefly
+        # report status=3 transiently; PDF cannot.
         response = build_rpc_response(
             RPCMethod.GET_NOTEBOOK,
             [
@@ -2521,7 +2524,7 @@ class TestWaitUntilReadyErrorPaths:
                         [
                             ["src_error"],
                             "Failed Source",
-                            [None, 0],
+                            [None, 0, None, None, 3],  # metadata[4]=3 (PDF)
                             [None, 3],  # status=ERROR
                         ]
                     ],

--- a/tests/unit/test_source_status.py
+++ b/tests/unit/test_source_status.py
@@ -296,6 +296,108 @@ class TestWaitUntilReady:
         assert sleep_intervals[1] >= sleep_intervals[0] * 1.5
 
 
+class TestWaitUntilRegistered:
+    """Tests for wait_until_registered helper (narrow forced-rename wait)."""
+
+    @pytest.fixture
+    def sources_api(self):
+        core = MagicMock()
+        return SourcesAPI(core)
+
+    @pytest.mark.asyncio
+    async def test_wait_until_registered_returns_on_processing(self, sources_api):
+        """Status=PROCESSING (1) on first poll → return immediately."""
+        processing = Source(id="src_1", status=SourceStatus.PROCESSING, _type_code=8)
+
+        with patch.object(sources_api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = processing
+
+            result = await sources_api.wait_until_registered("nb_1", "src_1", timeout=10.0)
+
+            assert result is processing
+            assert mock_get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_wait_until_registered_returns_on_ready(self, sources_api):
+        """Status=READY (2) on first poll → return immediately."""
+        ready = Source(id="src_1", status=SourceStatus.READY, _type_code=8)
+
+        with patch.object(sources_api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = ready
+
+            result = await sources_api.wait_until_registered("nb_1", "src_1", timeout=10.0)
+
+            assert result is ready
+            assert mock_get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_wait_until_registered_polls_when_not_yet_visible(self, sources_api):
+        """Source not yet in list → keep polling; return once it appears with status=PROCESSING."""
+        processing = Source(id="src_1", status=SourceStatus.PROCESSING, _type_code=8)
+
+        call_count = 0
+
+        async def mock_get(notebook_id, source_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None  # Not yet visible in listing
+            return processing
+
+        with patch.object(sources_api, "get", side_effect=mock_get):
+            result = await sources_api.wait_until_registered(
+                "nb_1", "src_1", timeout=10.0, initial_interval=0.01
+            )
+
+        assert result is processing
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_until_registered_respects_audio_transient(self, sources_api):
+        """Audio (type 10) transient ERROR → keep polling; return on next non-error status."""
+        transient_error = Source(id="src_audio", status=SourceStatus.ERROR, _type_code=10)
+        processing = Source(id="src_audio", status=SourceStatus.PROCESSING, _type_code=10)
+
+        call_count = 0
+
+        async def mock_get(notebook_id, source_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return transient_error
+            return processing
+
+        with patch.object(sources_api, "get", side_effect=mock_get):
+            result = await sources_api.wait_until_registered(
+                "nb_1", "src_audio", timeout=10.0, initial_interval=0.01
+            )
+
+        assert result is processing
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_until_registered_raises_on_non_transient_error(self, sources_api):
+        """Status=ERROR for a non-transient type (e.g. PDF type_code=3) → raise immediately."""
+        pdf_error = Source(id="src_pdf", status=SourceStatus.ERROR, _type_code=3)
+
+        with patch.object(sources_api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = pdf_error
+
+            with pytest.raises(SourceProcessingError):
+                await sources_api.wait_until_registered("nb_1", "src_pdf", timeout=10.0)
+
+    @pytest.mark.asyncio
+    async def test_wait_until_registered_times_out(self, sources_api):
+        """If the source never registers, wait_until_registered raises SourceTimeoutError."""
+        with patch.object(sources_api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+
+            with pytest.raises(SourceTimeoutError):
+                await sources_api.wait_until_registered(
+                    "nb_1", "src_1", timeout=0.05, initial_interval=0.02
+                )
+
+
 class TestWaitForSources:
     """Tests for wait_for_sources method."""
 

--- a/tests/unit/test_source_status.py
+++ b/tests/unit/test_source_status.py
@@ -142,7 +142,9 @@ class TestWaitUntilReady:
     @pytest.mark.asyncio
     async def test_raises_processing_error_on_error_status(self, sources_api):
         """Test that wait_until_ready raises SourceProcessingError on ERROR status."""
-        error_source = Source(id="src_1", status=SourceStatus.ERROR)
+        # Use a non-audio terminal type (e.g. PDF, type_code=3) so the new
+        # audio-tolerance gate doesn't keep polling and trigger a timeout.
+        error_source = Source(id="src_1", status=SourceStatus.ERROR, _type_code=3)
 
         with patch.object(sources_api, "get", new_callable=AsyncMock) as mock_get:
             mock_get.return_value = error_source
@@ -151,6 +153,78 @@ class TestWaitUntilReady:
                 await sources_api.wait_until_ready("nb_1", "src_1", timeout=10.0)
 
             assert exc_info.value.source_id == "src_1"
+            assert exc_info.value.status == SourceStatus.ERROR
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_tolerates_transient_status3_for_audio(self, sources_api):
+        """Audio sources (type_code=10) briefly report status=3 during transcription
+        before settling at status=2. wait_until_ready should keep polling instead of
+        raising SourceProcessingError on the first status=3 observation.
+        """
+        transient_error = Source(id="src_audio", status=SourceStatus.ERROR, _type_code=10)
+        ready = Source(id="src_audio", status=SourceStatus.READY, _type_code=10)
+
+        call_count = 0
+
+        async def mock_get(notebook_id, source_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return transient_error
+            return ready
+
+        with patch.object(sources_api, "get", side_effect=mock_get):
+            result = await sources_api.wait_until_ready(
+                "nb_1", "src_audio", timeout=10.0, initial_interval=0.01
+            )
+
+        assert result.is_ready
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("type_code", [None, 0], ids=["none", "zero"])
+    async def test_wait_until_ready_tolerates_transient_status3_for_unclassified(
+        self, sources_api, type_code
+    ):
+        """Sources with no type code yet (None / 0) can also briefly report
+        status=3 during processing. Keep polling rather than raising.
+        """
+        transient_error = Source(id="src_x", status=SourceStatus.ERROR, _type_code=type_code)
+        # Once the source is classified as audio (type 10) and ready,
+        # the loop should return it.
+        ready = Source(id="src_x", status=SourceStatus.READY, _type_code=10)
+
+        call_count = 0
+
+        async def mock_get(notebook_id, source_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return transient_error
+            return ready
+
+        with patch.object(sources_api, "get", side_effect=mock_get):
+            result = await sources_api.wait_until_ready(
+                "nb_1", "src_x", timeout=10.0, initial_interval=0.01
+            )
+
+        assert result.is_ready, f"expected ready for type_code={type_code!r}"
+
+    @pytest.mark.asyncio
+    async def test_wait_until_ready_still_raises_on_pdf_status3(self, sources_api):
+        """Non-audio terminal types (e.g. PDF type_code=3) must still raise
+        SourceProcessingError on status=3 — the audio tolerance is gated by
+        type_code and should not regress the existing error-detection path.
+        """
+        pdf_error = Source(id="src_pdf", status=SourceStatus.ERROR, _type_code=3)
+
+        with patch.object(sources_api, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = pdf_error
+
+            with pytest.raises(SourceProcessingError) as exc_info:
+                await sources_api.wait_until_ready("nb_1", "src_pdf", timeout=10.0)
+
+            assert exc_info.value.source_id == "src_pdf"
             assert exc_info.value.status == SourceStatus.ERROR
 
     @pytest.mark.asyncio

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -484,6 +484,10 @@ class TestAddFile:
     ):
         """A non-null title that differs from the filename should trigger a rename
         and surface in the returned Source (regression test for #313).
+
+        Per #388, supplying a title forces a brief wait before the rename so the
+        UPDATE_SOURCE RPC reaches a registered source instead of silently
+        no-opping.
         """
         test_file = tmp_path / "boring-filename.md"
         test_file.write_bytes(b"# content\n")
@@ -493,6 +497,12 @@ class TestAddFile:
             [[[["src_md"]]]],
             [[[["src_md"], "Real Intended Title", [None, None, None, None, 8]]]],
         ]
+        # The forced pre-rename wait is mocked — we don't want this test to
+        # depend on the wait_until_ready polling implementation. It returns the
+        # registered source so add_file then issues the rename RPC.
+        sources_api.wait_until_ready = AsyncMock(
+            return_value=Source(id="src_md", title="boring-filename.md", _type_code=8)
+        )
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -511,17 +521,20 @@ class TestAddFile:
 
         assert result.id == "src_md"
         assert result.title == "Real Intended Title"
-        assert result.kind == "unknown"
         # 1 register + 1 rename
         assert mock_core.rpc_call.call_count == 2
         rename_params = mock_core.rpc_call.call_args_list[1].args[1]
         assert rename_params == [None, ["src_md"], [[["Real Intended Title"]]]]
+        sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_md", timeout=120.0)
 
     @pytest.mark.asyncio
-    async def test_add_file_with_custom_title_renames_before_wait(
+    async def test_add_file_with_custom_title_renames_after_wait(
         self, sources_api, mock_core, tmp_path
     ):
-        """When wait=True, the custom title rename should happen before polling."""
+        """The custom-title rename must run AFTER the source is fully registered
+        server-side, otherwise the UPDATE_SOURCE RPC silently no-ops (#388).
+        With wait=True the order is: register -> upload -> wait -> rename.
+        """
         test_file = tmp_path / "boring-filename.md"
         test_file.write_bytes(b"# content\n")
 
@@ -534,8 +547,10 @@ class TestAddFile:
             assert notebook_id == "nb_123"
             assert source_id == "src_md"
             assert timeout == 120.0
-            assert mock_core.rpc_call.call_count == 2
-            return Source(id=source_id, title="Real Intended Title")
+            # Wait must happen BEFORE the rename: at this point only the
+            # registration RPC has been issued.
+            assert mock_core.rpc_call.call_count == 1
+            return Source(id=source_id, title="boring-filename.md", _type_code=8)
 
         sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
 
@@ -559,6 +574,120 @@ class TestAddFile:
 
         assert result.title == "Real Intended Title"
         sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_md", timeout=120.0)
+        # After the wait, the rename RPC fires — so the final RPC count is 2.
+        assert mock_core.rpc_call.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_add_file_with_title_forces_wait_when_wait_false(
+        self, sources_api, mock_core, tmp_path
+    ):
+        """Even with wait=False, supplying a custom title must force a brief wait
+        so the rename hits a registered source instead of silently no-opping (#388).
+        """
+        test_file = tmp_path / "boring-filename.md"
+        test_file.write_bytes(b"# content\n")
+
+        mock_core.rpc_call.side_effect = [
+            [[[["src_md"]]]],
+            [[[["src_md"], "Real Intended Title", [None, None, None, None, 8]]]],
+        ]
+
+        async def wait_side_effect(notebook_id, source_id, *, timeout):
+            # Forwarded wait_timeout — default 120.0 in this call.
+            assert timeout == 120.0
+            # Wait runs BEFORE the rename: at this point only the register
+            # RPC has been issued.
+            assert mock_core.rpc_call.call_count == 1
+            return Source(id=source_id, title="boring-filename.md", _type_code=8)
+
+        sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
+
+        mock_start_response = MagicMock()
+        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_upload_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+            mock_client_cls.return_value = mock_client
+
+            result = await sources_api.add_file(
+                "nb_123",
+                str(test_file),
+                title="Real Intended Title",
+            )
+
+        assert result.title == "Real Intended Title"
+        sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_md", timeout=120.0)
+
+    @pytest.mark.asyncio
+    async def test_add_file_with_title_forwards_wait_timeout(
+        self, sources_api, mock_core, tmp_path
+    ):
+        """The caller's wait_timeout must reach the forced-wait path so long
+        audio uploads can override the 120s default.
+        """
+        test_file = tmp_path / "podcast.mp3"
+        test_file.write_bytes(b"fake audio")
+
+        mock_core.rpc_call.side_effect = [
+            [[[["src_audio"]]]],
+            [[[["src_audio"], "Episode 1", [None, None, None, None, 10]]]],
+        ]
+
+        sources_api.wait_until_ready = AsyncMock(
+            return_value=Source(id="src_audio", title="podcast.mp3", _type_code=10)
+        )
+
+        mock_start_response = MagicMock()
+        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_upload_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+            mock_client_cls.return_value = mock_client
+
+            await sources_api.add_file(
+                "nb_123",
+                str(test_file),
+                title="Episode 1",
+                wait_timeout=600.0,
+            )
+
+        sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_audio", timeout=600.0)
+
+    @pytest.mark.asyncio
+    async def test_add_file_no_title_no_wait_does_not_wait(self, sources_api, mock_core, tmp_path):
+        """Back-compat: wait=False with no custom title must NOT call
+        wait_until_ready — preserves the existing fast-return semantics.
+        """
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"fake pdf content")
+
+        mock_core.rpc_call.return_value = [[[["src_pdf"]]]]
+        sources_api.wait_until_ready = AsyncMock()
+
+        mock_start_response = MagicMock()
+        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_upload_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+            mock_client_cls.return_value = mock_client
+
+            result = await sources_api.add_file("nb_123", str(test_file))
+
+        assert result.id == "src_pdf"
+        assert result.title == "test.pdf"
+        sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("title", ["", "   "])
@@ -616,8 +745,8 @@ class TestAddFile:
     async def test_add_file_rename_failure_keeps_upload(
         self, sources_api, mock_core, tmp_path, caplog, rename_error
     ):
-        """A failing rename must not lose the already-uploaded file; the source
-        is returned with the default filename title and a warning is logged.
+        """A failing rename must not lose the already-uploaded file; the
+        registered source is returned and a warning is logged.
         """
         import logging
 
@@ -626,10 +755,14 @@ class TestAddFile:
 
         # Registration succeeds; rename raises a library-level expected error
         # (representative of what `self.rename` actually raises in the wild).
+        # The forced wait between register and rename is mocked separately.
         mock_core.rpc_call.side_effect = [
             [[[["src_doc"]]]],
             rename_error,
         ]
+        sources_api.wait_until_ready = AsyncMock(
+            return_value=Source(id="src_doc", title="doc.txt", _type_code=4)
+        )
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -645,6 +778,7 @@ class TestAddFile:
             with caplog.at_level(logging.WARNING, logger="notebooklm._sources"):
                 result = await sources_api.add_file("nb_123", str(test_file), title="Custom")
 
+        # The already-registered source is preserved.
         assert result.id == "src_doc"
         assert result.title == "doc.txt"
         warning_records = [
@@ -655,7 +789,10 @@ class TestAddFile:
 
     @pytest.mark.asyncio
     async def test_add_file_rename_failure_still_waits(self, sources_api, mock_core, tmp_path):
-        """A failed custom-title rename should not prevent wait=True polling."""
+        """A failed custom-title rename should not prevent wait=True polling.
+        With the new ordering, wait runs BEFORE rename, so this verifies the
+        wait still happens and the upload is preserved when the rename fails.
+        """
         test_file = tmp_path / "doc.txt"
         test_file.write_bytes(b"content")
 
@@ -668,8 +805,9 @@ class TestAddFile:
             assert notebook_id == "nb_123"
             assert source_id == "src_doc"
             assert timeout == 120.0
-            assert mock_core.rpc_call.call_count == 2
-            return Source(id=source_id, title="doc.txt")
+            # Wait runs BEFORE rename — only the register RPC has fired.
+            assert mock_core.rpc_call.call_count == 1
+            return Source(id=source_id, title="doc.txt", _type_code=4)
 
         sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
 

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -6,6 +6,7 @@ import pytest
 
 from notebooklm._sources import SourcesAPI
 from notebooklm.exceptions import NetworkError, RPCError, ValidationError
+from notebooklm.rpc.types import SourceStatus
 from notebooklm.types import Source
 
 
@@ -526,8 +527,12 @@ class TestAddFile:
         assert mock_core.rpc_call.call_count == 2
         rename_params = mock_core.rpc_call.call_args_list[1].args[1]
         assert rename_params == [None, ["src_md"], [[["Real Intended Title"]]]]
-        # Narrow wait (default 30s cap) — not the full wait_until_ready.
-        sources_api.wait_until_registered.assert_awaited_once_with("nb_123", "src_md", timeout=30.0)
+        # Narrow wait uses the caller's wait_timeout (default 120s) — not the
+        # full wait_until_ready. wait_until_registered returns on first
+        # PROCESSING/READY status so the bound stays cheap in practice.
+        sources_api.wait_until_registered.assert_awaited_once_with(
+            "nb_123", "src_md", timeout=120.0
+        )
         sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
@@ -596,8 +601,10 @@ class TestAddFile:
         ]
 
         async def wait_side_effect(notebook_id, source_id, *, timeout):
-            # Narrow registration wait — default cap is 30s for wait=False.
-            assert timeout == 30.0
+            # Narrow registration wait — wait_timeout default (120s) is forwarded
+            # verbatim. wait_until_registered returns on the first non-PREPARING
+            # status, so the bound stays cheap.
+            assert timeout == 120.0
             # Wait runs BEFORE the rename: at this point only the register
             # RPC has been issued.
             assert mock_core.rpc_call.call_count == 1
@@ -624,16 +631,20 @@ class TestAddFile:
             )
 
         assert result.title == "Real Intended Title"
-        sources_api.wait_until_registered.assert_awaited_once_with("nb_123", "src_md", timeout=30.0)
+        sources_api.wait_until_registered.assert_awaited_once_with(
+            "nb_123", "src_md", timeout=120.0
+        )
         sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_with_title_forwards_wait_timeout(
         self, sources_api, mock_core, tmp_path
     ):
-        """The caller's wait_timeout must cap the narrow registration wait, but
-        the wait stays narrow (capped at 30s default) when wait=False — large
-        wait_timeout values don't extend the forced-wait beyond the cap.
+        """The caller's wait_timeout must be forwarded verbatim to the narrow
+        registration wait. The wait_until_registered helper polls and returns
+        on first PROCESSING/READY response, so generous bounds (e.g. long
+        audio uploads passing wait_timeout=600) stay cheap in practice while
+        still honoring the caller's intent if registration is unusually slow.
         """
         test_file = tmp_path / "podcast.mp3"
         test_file.write_bytes(b"fake audio")
@@ -666,9 +677,9 @@ class TestAddFile:
                 wait_timeout=600.0,
             )
 
-        # min(600.0, 30.0) = 30.0 — narrow wait stays narrow.
+        # wait_timeout is forwarded directly — no min() cap.
         sources_api.wait_until_registered.assert_awaited_once_with(
-            "nb_123", "src_audio", timeout=30.0
+            "nb_123", "src_audio", timeout=600.0
         )
         sources_api.wait_until_ready.assert_not_called()
 
@@ -699,6 +710,39 @@ class TestAddFile:
         assert result.id == "src_pdf"
         assert result.title == "test.pdf"
         sources_api.wait_until_ready.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_file_no_title_no_wait_returns_processing_status(
+        self, sources_api, mock_core, tmp_path
+    ):
+        """The fire-and-forget placeholder Source returned when wait=False and
+        no custom title is supplied must carry status=PROCESSING. Previously
+        it defaulted to READY, so callers saw is_ready=True on a source that
+        had only just been registered. Regression guard for the CodeRabbit
+        comment on #396.
+        """
+        test_file = tmp_path / "test.pdf"
+        test_file.write_bytes(b"fake pdf content")
+
+        mock_core.rpc_call.return_value = [[[["src_pdf"]]]]
+        sources_api.wait_until_ready = AsyncMock()
+
+        mock_start_response = MagicMock()
+        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_upload_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+            mock_client_cls.return_value = mock_client
+
+            result = await sources_api.add_file("nb_123", str(test_file))
+
+        assert result.status == SourceStatus.PROCESSING
+        assert result.is_processing is True
+        assert result.is_ready is False
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("title", ["", "   "])

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -497,12 +497,13 @@ class TestAddFile:
             [[[["src_md"]]]],
             [[[["src_md"], "Real Intended Title", [None, None, None, None, 8]]]],
         ]
-        # The forced pre-rename wait is mocked — we don't want this test to
-        # depend on the wait_until_ready polling implementation. It returns the
+        # The forced pre-rename registration wait is mocked — we don't want
+        # this test to depend on the polling implementation. It returns the
         # registered source so add_file then issues the rename RPC.
-        sources_api.wait_until_ready = AsyncMock(
+        sources_api.wait_until_registered = AsyncMock(
             return_value=Source(id="src_md", title="boring-filename.md", _type_code=8)
         )
+        sources_api.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -525,7 +526,9 @@ class TestAddFile:
         assert mock_core.rpc_call.call_count == 2
         rename_params = mock_core.rpc_call.call_args_list[1].args[1]
         assert rename_params == [None, ["src_md"], [[["Real Intended Title"]]]]
-        sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_md", timeout=120.0)
+        # Narrow wait (default 30s cap) — not the full wait_until_ready.
+        sources_api.wait_until_registered.assert_awaited_once_with("nb_123", "src_md", timeout=30.0)
+        sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_with_custom_title_renames_after_wait(
@@ -593,14 +596,15 @@ class TestAddFile:
         ]
 
         async def wait_side_effect(notebook_id, source_id, *, timeout):
-            # Forwarded wait_timeout — default 120.0 in this call.
-            assert timeout == 120.0
+            # Narrow registration wait — default cap is 30s for wait=False.
+            assert timeout == 30.0
             # Wait runs BEFORE the rename: at this point only the register
             # RPC has been issued.
             assert mock_core.rpc_call.call_count == 1
             return Source(id=source_id, title="boring-filename.md", _type_code=8)
 
-        sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
+        sources_api.wait_until_registered = AsyncMock(side_effect=wait_side_effect)
+        sources_api.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -620,14 +624,16 @@ class TestAddFile:
             )
 
         assert result.title == "Real Intended Title"
-        sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_md", timeout=120.0)
+        sources_api.wait_until_registered.assert_awaited_once_with("nb_123", "src_md", timeout=30.0)
+        sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_with_title_forwards_wait_timeout(
         self, sources_api, mock_core, tmp_path
     ):
-        """The caller's wait_timeout must reach the forced-wait path so long
-        audio uploads can override the 120s default.
+        """The caller's wait_timeout must cap the narrow registration wait, but
+        the wait stays narrow (capped at 30s default) when wait=False — large
+        wait_timeout values don't extend the forced-wait beyond the cap.
         """
         test_file = tmp_path / "podcast.mp3"
         test_file.write_bytes(b"fake audio")
@@ -637,9 +643,10 @@ class TestAddFile:
             [[[["src_audio"], "Episode 1", [None, None, None, None, 10]]]],
         ]
 
-        sources_api.wait_until_ready = AsyncMock(
+        sources_api.wait_until_registered = AsyncMock(
             return_value=Source(id="src_audio", title="podcast.mp3", _type_code=10)
         )
+        sources_api.wait_until_ready = AsyncMock()
 
         mock_start_response = MagicMock()
         mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
@@ -659,7 +666,11 @@ class TestAddFile:
                 wait_timeout=600.0,
             )
 
-        sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_audio", timeout=600.0)
+        # min(600.0, 30.0) = 30.0 — narrow wait stays narrow.
+        sources_api.wait_until_registered.assert_awaited_once_with(
+            "nb_123", "src_audio", timeout=30.0
+        )
+        sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_no_title_no_wait_does_not_wait(self, sources_api, mock_core, tmp_path):
@@ -760,7 +771,7 @@ class TestAddFile:
             [[[["src_doc"]]]],
             rename_error,
         ]
-        sources_api.wait_until_ready = AsyncMock(
+        sources_api.wait_until_registered = AsyncMock(
             return_value=Source(id="src_doc", title="doc.txt", _type_code=4)
         )
 
@@ -813,7 +824,7 @@ class TestAddFile:
             [[[["src_audio"]]]],
             None,  # Triggers rename()'s Source(id=source_id, title=new_title) fallback
         ]
-        sources_api.wait_until_ready = AsyncMock(
+        sources_api.wait_until_registered = AsyncMock(
             return_value=Source(
                 id="src_audio",
                 title="podcast.mp3",
@@ -842,6 +853,52 @@ class TestAddFile:
         assert result._type_code == 10
         assert result.url == "https://example.com/audio"
         assert result.created_at == created_at
+
+    @pytest.mark.asyncio
+    async def test_add_file_title_uses_narrow_wait_not_full_wait(
+        self, sources_api, mock_core, tmp_path
+    ):
+        """With wait=False but a custom title, add_file must call the narrow
+        wait_until_registered helper, NOT the full wait_until_ready. This is
+        the regression guard for the HIGH gemini-code-assist comment on #396:
+        callers that pass wait=False should not be blocked on full processing
+        just because they wanted to set a title.
+        """
+        test_file = tmp_path / "long-audio.mp3"
+        test_file.write_bytes(b"fake audio")
+
+        mock_core.rpc_call.side_effect = [
+            [[[["src_audio"]]]],
+            [[[["src_audio"], "My Title", [None, None, None, None, 10]]]],
+        ]
+
+        sources_api.wait_until_registered = AsyncMock(
+            return_value=Source(id="src_audio", title="long-audio.mp3", _type_code=10)
+        )
+        sources_api.wait_until_ready = AsyncMock()
+
+        mock_start_response = MagicMock()
+        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_upload_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+            mock_client_cls.return_value = mock_client
+
+            await sources_api.add_file(
+                "nb_123",
+                str(test_file),
+                title="My Title",
+                wait=False,
+            )
+
+        # Narrow wait was used...
+        sources_api.wait_until_registered.assert_awaited_once()
+        # ...and the full wait was NOT.
+        sources_api.wait_until_ready.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_add_file_rename_failure_still_waits(self, sources_api, mock_core, tmp_path):

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -788,6 +788,62 @@ class TestAddFile:
         assert warning_records[0].exc_info is not None
 
     @pytest.mark.asyncio
+    async def test_add_file_with_title_preserves_waited_metadata(
+        self, sources_api, mock_core, tmp_path
+    ):
+        """Renaming after the forced wait must not null out _type_code/url/created_at.
+
+        UPDATE_SOURCE's response shape can be sparse (see the rename() fallback
+        for ``result is None`` in _sources.py). If add_file naively overwrites
+        the fully-populated Source from wait_until_ready() with rename()'s
+        sparse return value, the source loses its real type code, URL, and
+        timestamp. Only the title should be taken from the rename response.
+        """
+        from datetime import datetime, timezone
+
+        test_file = tmp_path / "podcast.mp3"
+        test_file.write_bytes(b"fake audio")
+
+        created_at = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        # First rpc_call serves file registration. Second serves rename() —
+        # which returns a sparse Source (only id + new title) so we can verify
+        # the merge preserves type_code/url/created_at from the waited source.
+        mock_core.rpc_call.side_effect = [
+            [[[["src_audio"]]]],
+            None,  # Triggers rename()'s Source(id=source_id, title=new_title) fallback
+        ]
+        sources_api.wait_until_ready = AsyncMock(
+            return_value=Source(
+                id="src_audio",
+                title="podcast.mp3",
+                _type_code=10,
+                url="https://example.com/audio",
+                created_at=created_at,
+            )
+        )
+
+        mock_start_response = MagicMock()
+        mock_start_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+        mock_upload_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = [mock_start_response, mock_upload_response]
+            mock_client_cls.return_value = mock_client
+
+            result = await sources_api.add_file("nb_123", str(test_file), title="Episode 1")
+
+        # New title is applied...
+        assert result.title == "Episode 1"
+        # ...but the metadata populated by wait_until_ready() survives.
+        assert result._type_code == 10
+        assert result.url == "https://example.com/audio"
+        assert result.created_at == created_at
+
+    @pytest.mark.asyncio
     async def test_add_file_rename_failure_still_waits(self, sources_api, mock_core, tmp_path):
         """A failed custom-title rename should not prevent wait=True polling.
         With the new ordering, wait runs BEFORE rename, so this verifies the


### PR DESCRIPTION
## Summary

Two bugs in the file-upload flow that interact and must ship together.

### Bug 1 — #388: `add_file(..., title="...")` silently drops the rename

`client.sources.add_file(nb, path, title="X")` with default `wait=False` fired the rename RPC before the source was fully registered server-side. The RPC returned success-shaped data, but the rename never propagated and the source kept its original filename. No error surfaced.

**Fix:** `add_file` now waits BEFORE issuing the rename. When the caller passes `title=` we force a brief wait even with `wait=False`, forwarding `wait_timeout` so long audio uploads can override the 120s default.

### Bug 2 — #391: audio uploads fail on transient status=3

`wait_until_ready` treated any `status=3` as a terminal `SourceProcessingError`. In practice, audio/media (type 10) and unclassified (None/0) sources briefly report `status=3` during transcription before settling at `status=2`. PDFs/text/web/YouTube do have `status=3` as terminal.

**Fix:** `_NON_AUDIO_TERMINAL_TYPES` whitelist (1, 2, 3, 4, 5, 8, 9, 11, 13, 14, 16, 17). For audio (10) and unclassified (None/0), keep polling instead of raising. The library-wide default `timeout=120.0` is unchanged.

### Why one PR

#388's forced pre-rename wait hits the same `wait_until_ready` path for audio. Without #391's tolerance, every audio upload with a custom title would crash on the transient status=3.

## Test plan

- [x] `test_wait_until_ready_tolerates_transient_status3_for_audio` — type=10, status=3 then status=2 → returns ready
- [x] `test_wait_until_ready_tolerates_transient_status3_for_unclassified` (parametrized None / 0) — same
- [x] `test_wait_until_ready_still_raises_on_pdf_status3` — type=3 (PDF) + status=3 still raises (no regression)
- [x] `test_add_file_with_custom_title_renames_after_wait` — verifies call order: register → upload → wait → rename
- [x] `test_add_file_with_title_forces_wait_when_wait_false` — wait=False + title → wait_until_ready called
- [x] `test_add_file_with_title_forwards_wait_timeout` — caller's wait_timeout reaches the forced-wait path
- [x] `test_add_file_no_title_no_wait_does_not_wait` — back-compat: wait=False, no title → no wait
- [x] `test_add_file_rename_failure_keeps_upload` — rename raises RPCError/NetworkError, registered source is returned, warning logged
- [x] Pre-commit: `ruff format --check . && ruff check . && mypy src/notebooklm --ignore-missing-imports && pytest` → 2409 passed, 9 skipped
- [ ] E2E sanity check against a live account once CI is green

Closes #388
Closes #391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treat specific error types as transient during source processing.
  * Added a registration-wait helper that returns once a source is server-registered (may still be processing).

* **Bug Fixes**
  * Upload flow: supplying a custom title forces a brief pre-rename registration wait even with wait=False; rename failures now log a warning and preserve registered metadata.

* **Tests**
  * Expanded unit and integration tests for transient-error tolerance, registration waits, and rename sequencing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/396)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->