### PR TITLE
feat(env): NOTEBOOKLM_HL env var (closes #393)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -137,8 +137,12 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 All generate commands support:
 - `--source/-s` to select specific sources (repeatable)
 - `--json` for machine-readable output (returns `task_id` and `status`)
-- `--language` to override output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)
 - `--retry N` to automatically retry on rate limits with exponential backoff
+
+Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`, `study-guide`, `infographic`, `slide-deck`, `data-table`, `mind-map`) also support:
+- `--language` to override output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)
+
+`quiz`, `flashcards`, and `revise-slide` do not accept `--language`.
 
 | Command | Options | Example |
 |---------|---------|---------|

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -137,7 +137,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 All generate commands support:
 - `--source/-s` to select specific sources (repeatable)
 - `--json` for machine-readable output (returns `task_id` and `status`)
-- `--language` to override output language (defaults to config or 'en')
+- `--language` to override output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)
 - `--retry N` to automatically retry on rate limits with exponential backoff
 
 | Command | Options | Example |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -139,7 +139,7 @@ All generate commands support:
 - `--json` for machine-readable output (returns `task_id` and `status`)
 - `--retry N` to automatically retry on rate limits with exponential backoff
 
-Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`, `study-guide`, `infographic`, `slide-deck`, `data-table`, `mind-map`) also support:
+Language-aware generate commands (`audio`, `video`, `cinematic-video`, `report`, `infographic`, `slide-deck`, `data-table`, `mind-map`) also support:
 - `--language` to override output language (precedence: `--language` > `NOTEBOOKLM_HL` env > config > `'en'`)
 
 `quiz`, `flashcards`, and `revise-slide` do not accept `--language`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_HOME` | Base directory for all files | `~/.notebooklm` |
 | `NOTEBOOKLM_PROFILE` | Active profile name | `default` |
 | `NOTEBOOKLM_AUTH_JSON` | Inline authentication JSON (for CI/CD) | - |
-| `NOTEBOOKLM_HL` | Default interface/output language (BCP-47 code) | `en` |
+| `NOTEBOOKLM_HL` | Default interface/output language code (e.g. `en`, `ja`, `zh_Hans`) | `en` |
 | `NOTEBOOKLM_LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | `WARNING` |
 | `NOTEBOOKLM_DEBUG_RPC` | Legacy: Enable RPC debug logging (use `LOG_LEVEL=DEBUG` instead) | `false` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,7 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_HOME` | Base directory for all files | `~/.notebooklm` |
 | `NOTEBOOKLM_PROFILE` | Active profile name | `default` |
 | `NOTEBOOKLM_AUTH_JSON` | Inline authentication JSON (for CI/CD) | - |
+| `NOTEBOOKLM_HL` | Default interface/output language (BCP-47 code) | `en` |
 | `NOTEBOOKLM_LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | `WARNING` |
 | `NOTEBOOKLM_DEBUG_RPC` | Legacy: Enable RPC debug logging (use `LOG_LEVEL=DEBUG` instead) | `false` |
 
@@ -145,6 +146,26 @@ notebooklm list  # Works without any file on disk
 5. `~/.notebooklm/storage_state.json` (legacy fallback)
 
 **Note:** Cannot run `notebooklm login` when `NOTEBOOKLM_AUTH_JSON` is set.
+
+### NOTEBOOKLM_HL
+
+Sets the default interface/output language used by the client. The value is
+passed as the `hl` query parameter on every batchexecute RPC call and is the
+fallback language for the `generate audio|video|slide-deck|infographic|
+data-table|mind-map|report` commands and their `ArtifactsAPI` equivalents:
+
+```bash
+export NOTEBOOKLM_HL=ja
+notebooklm generate audio "deep dive"   # Japanese audio overview
+```
+
+Surrounding whitespace is stripped; an empty or whitespace-only value falls
+back to `en`. For the generate commands, the resolution order is:
+
+1. `--language` CLI flag
+2. `NOTEBOOKLM_HL` environment variable
+3. `language` value from the active profile's config
+4. `en` (built-in default)
 
 ## CLI Options
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 import httpx
 
 from ._core import ClientCore
+from ._env import get_default_language
 from .auth import load_httpx_cookies
 from .exceptions import ValidationError
 from .rpc import (
@@ -362,7 +363,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
         audio_format: AudioFormat | None = None,
         audio_length: AudioLength | None = None,
@@ -372,7 +373,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Custom instructions for the podcast hosts.
             audio_format: DEEP_DIVE, BRIEF, CRITIQUE, or DEBATE.
             audio_length: SHORT, DEFAULT, or LONG.
@@ -380,6 +382,8 @@ class ArtifactsAPI:
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -419,7 +423,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
         video_format: VideoFormat | None = None,
         video_style: VideoStyle | None = None,
@@ -429,7 +433,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Custom instructions for video generation.
             video_format: EXPLAINER or BRIEF.
             video_style: AUTO_SELECT, CLASSIC, WHITEBOARD, etc.
@@ -437,6 +442,8 @@ class ArtifactsAPI:
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -478,7 +485,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a Cinematic Video Overview.
@@ -498,12 +505,15 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Custom instructions for video generation.
 
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -542,7 +552,7 @@ class ArtifactsAPI:
         notebook_id: str,
         report_format: ReportFormat = ReportFormat.BRIEFING_DOC,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         custom_prompt: str | None = None,
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
@@ -552,7 +562,8 @@ class ArtifactsAPI:
             notebook_id: The notebook ID.
             report_format: BRIEFING_DOC, STUDY_GUIDE, BLOG_POST, or CUSTOM.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             custom_prompt: Prompt for CUSTOM format. Falls back to a generic
                 default if None.
             extra_instructions: Additional instructions appended to the built-in
@@ -562,6 +573,8 @@ class ArtifactsAPI:
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -639,7 +652,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a study guide report.
@@ -649,12 +662,15 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             extra_instructions: Additional instructions appended to the default template.
 
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         return await self.generate_report(
             notebook_id,
             report_format=ReportFormat.STUDY_GUIDE,
@@ -780,7 +796,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
         orientation: InfographicOrientation | None = None,
         detail_level: InfographicDetail | None = None,
@@ -791,7 +807,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Custom instructions for infographic generation.
             orientation: LANDSCAPE, PORTRAIT, or SQUARE.
             detail_level: CONCISE, STANDARD, or DETAILED.
@@ -800,6 +817,8 @@ class ArtifactsAPI:
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -835,7 +854,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
         slide_format: SlideDeckFormat | None = None,
         slide_length: SlideDeckLength | None = None,
@@ -845,7 +864,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Custom instructions for slide deck generation.
             slide_format: DETAILED_DECK or PRESENTER_SLIDES.
             slide_length: DEFAULT or SHORT.
@@ -853,6 +873,8 @@ class ArtifactsAPI:
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -939,7 +961,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a data table.
@@ -947,12 +969,15 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Description of desired table structure.
 
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -989,7 +1014,7 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
         source_ids: builtins.list[str] | None = None,
-        language: str = "en",
+        language: str | None = None,
         instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map.
@@ -1000,7 +1025,8 @@ class ArtifactsAPI:
         Args:
             notebook_id: The notebook ID.
             source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code (default: "en").
+            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
+                environment variable, defaulting to ``"en"``.
             instructions: Custom instructions for the mind map.
 
         Returns:
@@ -1008,6 +1034,8 @@ class ArtifactsAPI:
         """
         import json as json_module
 
+        if language is None:
+            language = get_default_language()
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -15,6 +15,7 @@ from urllib.parse import quote, urlencode
 import httpx
 
 from ._core import ClientCore
+from ._env import get_default_language
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import RPCMethod, get_query_url
 from .types import AskResult, ChatReference, ConversationTurn
@@ -133,7 +134,7 @@ class ChatAPI:
         self._core._reqid_counter += 100000
         url_params = {
             "bl": os.environ.get("NOTEBOOKLM_BL", _DEFAULT_BL),
-            "hl": "en",
+            "hl": get_default_language(),
             "_reqid": str(self._core._reqid_counter),
             "rt": "c",
         }

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -13,6 +13,7 @@ from urllib.parse import urlencode
 
 import httpx
 
+from ._env import get_default_language
 from .auth import (
     AuthTokens,
     CookieSaveResult,
@@ -457,6 +458,7 @@ class ClientCore:
             "rpcids": rpc_method.value,
             "source-path": source_path,
             "f.sid": self.auth.session_id,
+            "hl": get_default_language(),
             "rt": "c",
         }
         return f"{get_batchexecute_url()}?{urlencode(params)}"

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -1,4 +1,9 @@
-"""Runtime environment helpers for NotebookLM endpoints."""
+"""Runtime environment helpers for NotebookLM endpoints and defaults.
+
+Centralises lookup of environment variables that influence the live behavior
+of the client. Keeping these here avoids scattering ``os.environ.get`` calls
+across the codebase and gives each override a single, documented entry point.
+"""
 
 from __future__ import annotations
 
@@ -49,3 +54,20 @@ def get_base_url() -> str:
 def get_base_host() -> str:
     """Return the configured NotebookLM host."""
     return urlparse(get_base_url()).hostname or PERSONAL_BASE_HOST
+
+
+def get_default_language() -> str:
+    """Return the user's preferred interface language.
+
+    Reads the ``NOTEBOOKLM_HL`` environment variable. Falls back to ``"en"``
+    when the variable is unset or empty.
+
+    This value is threaded into two places:
+
+    * The ``hl`` URL query parameter on every batchexecute RPC call
+      (``_core._build_url`` and ``_chat.ask``).
+    * The default ``language`` argument of the language-aware
+      ``ArtifactsAPI.generate_*`` methods, which embed the code into the
+      RPC payload.
+    """
+    return os.environ.get("NOTEBOOKLM_HL", "") or "en"

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -59,8 +59,8 @@ def get_base_host() -> str:
 def get_default_language() -> str:
     """Return the user's preferred interface language.
 
-    Reads the ``NOTEBOOKLM_HL`` environment variable. Falls back to ``"en"``
-    when the variable is unset or empty.
+    Reads the ``NOTEBOOKLM_HL`` environment variable. Surrounding whitespace
+    is stripped; unset, empty, or whitespace-only values fall back to ``"en"``.
 
     This value is threaded into two places:
 
@@ -70,4 +70,5 @@ def get_default_language() -> str:
       ``ArtifactsAPI.generate_*`` methods, which embed the code into the
       RPC payload.
     """
-    return os.environ.get("NOTEBOOKLM_HL", "") or "en"
+    raw = os.environ.get("NOTEBOOKLM_HL", "") or ""
+    return raw.strip() or "en"

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -345,7 +345,11 @@ def generate():
     type=click.Choice(["short", "default", "long"]),
     default="default",
 )
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
 @retry_option
@@ -443,7 +447,11 @@ def generate_audio(
     ),
     default="auto",
 )
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
 @retry_option
@@ -569,7 +577,11 @@ generate.add_command(_cinematic_video_gen_cmd)
     type=click.Choice(["default", "short"]),
     default="default",
 )
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
 @retry_option
@@ -871,7 +883,11 @@ def generate_flashcards(
     type=click.Choice(list(_INFOGRAPHIC_STYLE_MAP)),
     default="auto",
 )
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
 @retry_option
@@ -946,7 +962,11 @@ def generate_infographic(
     default=None,
     help="Notebook ID (uses current if not set)",
 )
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
 @retry_option
@@ -1005,7 +1025,11 @@ def generate_data_table(
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option("--instructions", default=None, help="Custom instructions for the mind map")
 @json_option
 @with_client
@@ -1084,7 +1108,11 @@ def _output_mind_map_result(result: Any, json_output: bool) -> None:
     help="Notebook ID (uses current if not set)",
 )
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
-@click.option("--language", default=None, help="Output language (default: from config or 'en')")
+@click.option(
+    "--language",
+    default=None,
+    help="Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+)
 @click.option(
     "--append",
     "append_instructions",

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import click
 
-from .._env import get_default_language
 from ..client import NotebookLMClient
 from ..types import (
     AudioFormat,
@@ -163,9 +162,7 @@ def resolve_language(language: str | None) -> str:
     config_lang = get_language()
     if config_lang is not None:
         return config_lang
-    # Falls back through get_default_language() so an explicitly-empty
-    # NOTEBOOKLM_HL still becomes the documented DEFAULT_LANGUAGE.
-    return get_default_language() or DEFAULT_LANGUAGE
+    return DEFAULT_LANGUAGE
 
 
 async def handle_generation_result(

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -14,11 +14,13 @@ Commands:
 """
 
 import asyncio
+import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 import click
 
+from .._env import get_default_language
 from ..client import NotebookLMClient
 from ..types import (
     AudioFormat,
@@ -135,11 +137,11 @@ async def generate_with_retry(
 
 
 def resolve_language(language: str | None) -> str:
-    """Resolve language from CLI flag, config, or default.
+    """Resolve language from CLI flag, NOTEBOOKLM_HL env, config, or default.
 
-    Priority: CLI flag > config file > "en" default.
-    Uses explicit None checks to avoid treating empty string as falsy.
-    Validates that the language code is supported.
+    Priority: ``--language`` flag > ``NOTEBOOKLM_HL`` env var > config file
+    > "en" default. Uses explicit None checks to avoid treating empty
+    string as falsy. Validates each candidate against the supported list.
     """
     if language is not None:
         if language not in SUPPORTED_LANGUAGES:
@@ -149,10 +151,21 @@ def resolve_language(language: str | None) -> str:
                 param_hint="'--language'",
             )
         return language
+    env_lang = os.environ.get("NOTEBOOKLM_HL", "")
+    if env_lang:
+        if env_lang not in SUPPORTED_LANGUAGES:
+            raise click.BadParameter(
+                f"Unknown language code: {env_lang}\n"
+                "Run 'notebooklm language list' to see supported codes.",
+                param_hint="'NOTEBOOKLM_HL'",
+            )
+        return env_lang
     config_lang = get_language()
     if config_lang is not None:
         return config_lang
-    return DEFAULT_LANGUAGE
+    # Falls back through get_default_language() so an explicitly-empty
+    # NOTEBOOKLM_HL still becomes the documented DEFAULT_LANGUAGE.
+    return get_default_language() or DEFAULT_LANGUAGE
 
 
 async def handle_generation_result(

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -161,6 +161,12 @@ def resolve_language(language: str | None) -> str:
         return env_lang
     config_lang = get_language()
     if config_lang is not None:
+        if config_lang not in SUPPORTED_LANGUAGES:
+            raise click.BadParameter(
+                f"Unknown language code in config: {config_lang}\n"
+                "Run 'notebooklm language list' to see supported codes.",
+                param_hint="config",
+            )
         return config_lang
     return DEFAULT_LANGUAGE
 

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -150,7 +150,7 @@ def resolve_language(language: str | None) -> str:
                 param_hint="'--language'",
             )
         return language
-    env_lang = os.environ.get("NOTEBOOKLM_HL", "")
+    env_lang = os.environ.get("NOTEBOOKLM_HL", "").strip()
     if env_lang:
         if env_lang not in SUPPORTED_LANGUAGES:
             raise click.BadParameter(

--- a/src/notebooklm/rpc/encoder.py
+++ b/src/notebooklm/rpc/encoder.py
@@ -68,37 +68,3 @@ def build_request_body(
     body = "&".join(body_parts) + "&"
     logger.debug("Built request body: size=%d bytes", len(body))
     return body
-
-
-def build_url_params(
-    rpc_method: RPCMethod,
-    source_path: str = "/",
-    session_id: str | None = None,
-    bl: str | None = None,
-) -> dict[str, str]:
-    """
-    Build URL query parameters for batchexecute request.
-
-    Args:
-        rpc_method: RPC method being called
-        source_path: Source path context (e.g., /notebook/{id})
-        session_id: Session ID (FdrFJe value)
-        bl: Build label (changes periodically, optional)
-
-    Returns:
-        Dict of query parameters
-    """
-    params = {
-        "rpcids": rpc_method.value,
-        "source-path": source_path,
-        "hl": "en",
-        "rt": "c",  # Chunked response mode
-    }
-
-    if session_id:
-        params["f.sid"] = session_id
-
-    if bl:
-        params["bl"] = bl
-
-    return params

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -2440,3 +2440,91 @@ class TestWaitForCompletionDeprecated:
                 assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
 
         assert result.status == "completed"
+
+
+def _decoded_request_body(request) -> str:
+    """Return the readable URL-decoded body of the latest CREATE_ARTIFACT POST.
+
+    The batchexecute payload double-encodes the inner params (the f.req
+    array is JSON, and one of its slots is itself a JSON-encoded string),
+    so we further normalise the embedded backslash-escaped quotes back to
+    plain ``"`` to make substring assertions stable.
+    """
+    from urllib.parse import unquote_plus
+
+    raw = unquote_plus(request.content.decode("utf-8"))
+    # Collapse the JSON-in-JSON escaping so that '"ja"' literally appears.
+    return raw.replace('\\"', '"')
+
+
+class TestGenerateUsesNotebookLMHL:
+    """The 9 language-aware generate_* methods must honor NOTEBOOKLM_HL when
+    the caller does not pass an explicit language argument, and the explicit
+    argument must still win when both are present.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        ["generate_audio", "generate_video", "generate_report"],
+    )
+    async def test_generate_uses_env_language_when_none(
+        self,
+        method_name,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        monkeypatch,
+    ):
+        """NOTEBOOKLM_HL=ja, no language arg -> outgoing RPC carries 'ja'."""
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+
+        create_response = build_rpc_response(
+            RPCMethod.CREATE_ARTIFACT,
+            [["artifact_123", "Title", "2024-01-05", None, 1]],
+        )
+        httpx_mock.add_response(content=create_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            method = getattr(client.artifacts, method_name)
+            await method(notebook_id="nb_123", source_ids=["src_001"])
+
+        body = _decoded_request_body(httpx_mock.get_requests()[-1])
+        # The language code is embedded as a quoted JSON string inside the
+        # nested params list. Assert presence/absence.
+        assert '"ja"' in body
+        assert '"en"' not in body
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        ["generate_audio", "generate_video", "generate_report"],
+    )
+    async def test_generate_explicit_language_overrides_env(
+        self,
+        method_name,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        monkeypatch,
+    ):
+        """NOTEBOOKLM_HL=ja but explicit language='ko' -> outgoing carries 'ko'."""
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+
+        create_response = build_rpc_response(
+            RPCMethod.CREATE_ARTIFACT,
+            [["artifact_123", "Title", "2024-01-05", None, 1]],
+        )
+        httpx_mock.add_response(content=create_response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            method = getattr(client.artifacts, method_name)
+            await method(
+                notebook_id="nb_123",
+                source_ids=["src_001"],
+                language="ko",
+            )
+
+        body = _decoded_request_body(httpx_mock.get_requests()[-1])
+        assert '"ko"' in body
+        assert '"ja"' not in body

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -2457,6 +2457,59 @@ def _decoded_request_body(request) -> str:
     return raw.replace('\\"', '"')
 
 
+_LANGUAGE_AWARE_GENERATORS = [
+    "generate_audio",
+    "generate_video",
+    "generate_cinematic_video",
+    "generate_report",
+    "generate_study_guide",
+    "generate_infographic",
+    "generate_slide_deck",
+    "generate_data_table",
+    "generate_mind_map",
+]
+
+
+def _register_generate_responses(method_name: str, httpx_mock, build_rpc_response) -> int:
+    """Register the HTTP responses required for one ``generate_*`` call and
+    return the index of the request that carries the language code.
+
+    Most language-aware generators issue a single CREATE_ARTIFACT call.
+    ``generate_mind_map`` is the outlier: it calls GENERATE_MIND_MAP first,
+    then CREATE_NOTE + UPDATE_NOTE to persist the result. The language code
+    is embedded only in the first request, so the assertion target differs.
+    """
+    if method_name == "generate_mind_map":
+        # GENERATE_MIND_MAP returns mind-map JSON; subsequent note RPCs persist it.
+        httpx_mock.add_response(
+            content=build_rpc_response(
+                RPCMethod.GENERATE_MIND_MAP,
+                [['{"name": "Root", "children": []}', None, ["note_xyz"]]],
+            ).encode()
+        )
+        httpx_mock.add_response(
+            content=build_rpc_response(
+                RPCMethod.CREATE_NOTE,
+                [["note_xyz"]],
+            ).encode()
+        )
+        httpx_mock.add_response(
+            content=build_rpc_response(
+                RPCMethod.UPDATE_NOTE,
+                [["note_xyz"]],
+            ).encode()
+        )
+        return 0  # language travels with the first (GENERATE_MIND_MAP) request
+
+    httpx_mock.add_response(
+        content=build_rpc_response(
+            RPCMethod.CREATE_ARTIFACT,
+            [["artifact_123", "Title", "2024-01-05", None, 1]],
+        ).encode()
+    )
+    return -1  # last (and only) request carries the language
+
+
 class TestGenerateUsesNotebookLMHL:
     """The 9 language-aware generate_* methods must honor NOTEBOOKLM_HL when
     the caller does not pass an explicit language argument, and the explicit
@@ -2464,10 +2517,7 @@ class TestGenerateUsesNotebookLMHL:
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "method_name",
-        ["generate_audio", "generate_video", "generate_report"],
-    )
+    @pytest.mark.parametrize("method_name", _LANGUAGE_AWARE_GENERATORS)
     async def test_generate_uses_env_language_when_none(
         self,
         method_name,
@@ -2479,27 +2529,20 @@ class TestGenerateUsesNotebookLMHL:
         """NOTEBOOKLM_HL=ja, no language arg -> outgoing RPC carries 'ja'."""
         monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
 
-        create_response = build_rpc_response(
-            RPCMethod.CREATE_ARTIFACT,
-            [["artifact_123", "Title", "2024-01-05", None, 1]],
-        )
-        httpx_mock.add_response(content=create_response.encode())
+        request_index = _register_generate_responses(method_name, httpx_mock, build_rpc_response)
 
         async with NotebookLMClient(auth_tokens) as client:
             method = getattr(client.artifacts, method_name)
             await method(notebook_id="nb_123", source_ids=["src_001"])
 
-        body = _decoded_request_body(httpx_mock.get_requests()[-1])
+        body = _decoded_request_body(httpx_mock.get_requests()[request_index])
         # The language code is embedded as a quoted JSON string inside the
         # nested params list. Assert presence/absence.
         assert '"ja"' in body
         assert '"en"' not in body
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "method_name",
-        ["generate_audio", "generate_video", "generate_report"],
-    )
+    @pytest.mark.parametrize("method_name", _LANGUAGE_AWARE_GENERATORS)
     async def test_generate_explicit_language_overrides_env(
         self,
         method_name,
@@ -2511,11 +2554,7 @@ class TestGenerateUsesNotebookLMHL:
         """NOTEBOOKLM_HL=ja but explicit language='ko' -> outgoing carries 'ko'."""
         monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
 
-        create_response = build_rpc_response(
-            RPCMethod.CREATE_ARTIFACT,
-            [["artifact_123", "Title", "2024-01-05", None, 1]],
-        )
-        httpx_mock.add_response(content=create_response.encode())
+        request_index = _register_generate_responses(method_name, httpx_mock, build_rpc_response)
 
         async with NotebookLMClient(auth_tokens) as client:
             method = getattr(client.artifacts, method_name)
@@ -2525,6 +2564,6 @@ class TestGenerateUsesNotebookLMHL:
                 language="ko",
             )
 
-        body = _decoded_request_body(httpx_mock.get_requests()[-1])
+        body = _decoded_request_body(httpx_mock.get_requests()[request_index])
         assert '"ko"' in body
         assert '"ja"' not in body

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -1808,3 +1808,91 @@ class TestExtractTextPassagesNonIntEndChar:
         cited_text, start_char, end_char = client.chat._extract_text_passages(cite_inner)
         assert start_char == 100
         assert end_char is None  # not set since passage_data[1] was not int
+
+
+class TestChatHL:
+    """ask() must include the NOTEBOOKLM_HL interface language in the URL."""
+
+    @pytest.mark.asyncio
+    async def test_ask_url_contains_hl_from_env(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        monkeypatch,
+    ):
+        """When NOTEBOOKLM_HL=ja, the chat POST URL carries hl=ja."""
+        import json
+        import re
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+
+        inner_data = [
+            [
+                "answer",
+                None,
+                [12345],
+                None,
+                [[], None, None, [], 1],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=response_body.encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.chat.ask(
+                notebook_id="test_nb",
+                question="Q",
+                source_ids=["src_001"],
+            )
+
+        request = httpx_mock.get_requests()[-1]
+        assert "hl=ja" in str(request.url)
+
+    @pytest.mark.asyncio
+    async def test_ask_url_defaults_hl_to_en(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        monkeypatch,
+    ):
+        """When NOTEBOOKLM_HL is unset, the chat URL carries hl=en."""
+        import json
+        import re
+
+        monkeypatch.delenv("NOTEBOOKLM_HL", raising=False)
+
+        inner_data = [
+            [
+                "answer",
+                None,
+                [12345],
+                None,
+                [[], None, None, [], 1],
+            ]
+        ]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
+
+        httpx_mock.add_response(
+            url=re.compile(r".*GenerateFreeFormStreamed.*"),
+            content=response_body.encode(),
+            method="POST",
+        )
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.chat.ask(
+                notebook_id="test_nb",
+                question="Q",
+                source_ids=["src_001"],
+            )
+
+        request = httpx_mock.get_requests()[-1]
+        assert "hl=en" in str(request.url)

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -566,3 +566,29 @@ class TestCrossDomainCookiePreservation:
 
             # The redirect cookie must survive
             assert http.cookies.get("__Secure-1PSIDCC", domain=".google.com") == "from_redirect"
+
+
+class TestBuildUrlHL:
+    """_build_url() must thread NOTEBOOKLM_HL into the batchexecute URL.
+
+    This is the load-bearing site for setting the interface language on
+    every RPC call.
+    """
+
+    def test_build_url_defaults_hl_to_en(self, auth_tokens, monkeypatch):
+        monkeypatch.delenv("NOTEBOOKLM_HL", raising=False)
+        core = ClientCore(auth_tokens)
+        url = core._build_url(RPCMethod.LIST_NOTEBOOKS)
+        assert "hl=en" in url
+
+    def test_build_url_includes_hl_from_env(self, auth_tokens, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+        core = ClientCore(auth_tokens)
+        url = core._build_url(RPCMethod.LIST_NOTEBOOKS)
+        assert "hl=ja" in url
+
+    def test_build_url_empty_env_falls_back_to_en(self, auth_tokens, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_HL", "")
+        core = ClientCore(auth_tokens)
+        url = core._build_url(RPCMethod.LIST_NOTEBOOKS)
+        assert "hl=en" in url

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1159,6 +1159,26 @@ class TestResolveLanguageDirect:
             result = generate_module.resolve_language(None)
         assert result == "ja"
 
+    def test_resolve_language_treats_whitespace_env_as_unset(self, monkeypatch):
+        """Whitespace-only NOTEBOOKLM_HL falls through to config, not rejected."""
+        import importlib
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "   ")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value="ja"):
+            result = generate_module.resolve_language(None)
+        assert result == "ja"
+
+    def test_resolve_language_treats_whitespace_env_as_unset_no_config(self, monkeypatch):
+        """Whitespace-only NOTEBOOKLM_HL with no config falls through to default."""
+        import importlib
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "   ")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value=None):
+            result = generate_module.resolve_language(None)
+        assert result == "en"
+
 
 # =============================================================================
 # _OUTPUT_GENERATION_STATUS DIRECT TESTS

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1080,6 +1080,61 @@ class TestResolveLanguageDirect:
             result = generate_module.resolve_language(None)
         assert result == "en"
 
+    def test_env_overrides_config(self, monkeypatch):
+        """NOTEBOOKLM_HL set, config also set, no flag → env wins over config."""
+        import importlib
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value="zh_Hans"):
+            result = generate_module.resolve_language(None)
+        assert result == "ja"
+
+    def test_flag_overrides_env(self, monkeypatch):
+        """Explicit --language argument wins over NOTEBOOKLM_HL env var."""
+        import importlib
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value="zh_Hans"):
+            result = generate_module.resolve_language("ko")
+        assert result == "ko"
+
+    def test_env_only_no_config(self, monkeypatch):
+        """NOTEBOOKLM_HL set, no config, no flag → env wins over default."""
+        import importlib
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value=None):
+            result = generate_module.resolve_language(None)
+        assert result == "ja"
+
+    def test_empty_env_falls_through_to_config(self, monkeypatch):
+        """Empty NOTEBOOKLM_HL is treated as unset and config wins."""
+        import importlib
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value="zh_Hans"):
+            result = generate_module.resolve_language(None)
+        assert result == "zh_Hans"
+
+    def test_invalid_env_raises_bad_parameter(self, monkeypatch):
+        """An unsupported NOTEBOOKLM_HL value still gets validated."""
+        import importlib
+
+        import click
+
+        monkeypatch.setenv("NOTEBOOKLM_HL", "xx_INVALID")
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with (
+            patch.object(generate_module, "get_language", return_value=None),
+            pytest.raises(click.BadParameter) as exc_info,
+        ):
+            generate_module.resolve_language(None)
+        assert "xx_INVALID" in str(exc_info.value)
+
 
 # =============================================================================
 # _OUTPUT_GENERATION_STATUS DIRECT TESTS

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1135,6 +1135,30 @@ class TestResolveLanguageDirect:
             generate_module.resolve_language(None)
         assert "xx_INVALID" in str(exc_info.value)
 
+    def test_resolve_language_rejects_invalid_config_value(self):
+        """An unsupported language stored in the config file gets validated."""
+        import importlib
+
+        import click
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with (
+            patch.object(generate_module, "get_language", return_value="xx_INVALID"),
+            pytest.raises(click.BadParameter) as exc_info,
+        ):
+            generate_module.resolve_language(None)
+        assert "xx_INVALID" in str(exc_info.value)
+        assert "notebooklm language list" in str(exc_info.value)
+
+    def test_resolve_language_accepts_valid_config_value(self):
+        """A supported language stored in the config file is returned as-is."""
+        import importlib
+
+        generate_module = importlib.import_module("notebooklm.cli.generate")
+        with patch.object(generate_module, "get_language", return_value="ja"):
+            result = generate_module.resolve_language(None)
+        assert result == "ja"
+
 
 # =============================================================================
 # _OUTPUT_GENERATION_STATUS DIRECT TESTS

--- a/tests/unit/test_encoder.py
+++ b/tests/unit/test_encoder.py
@@ -2,7 +2,7 @@
 
 import json
 
-from notebooklm.rpc.encoder import build_request_body, build_url_params, encode_rpc_request
+from notebooklm.rpc.encoder import build_request_body, encode_rpc_request
 from notebooklm.rpc.types import RPCMethod
 
 
@@ -116,77 +116,3 @@ class TestBuildRequestBody:
 
         assert "f.req=" in body
         assert "at=token" in body
-
-
-class TestBuildUrlParams:
-    def test_basic_params(self):
-        """Test basic URL params with only method."""
-        result = build_url_params(RPCMethod.LIST_NOTEBOOKS)
-
-        assert result["rpcids"] == RPCMethod.LIST_NOTEBOOKS.value
-        assert result["source-path"] == "/"
-        assert result["hl"] == "en"
-        assert result["rt"] == "c"
-        assert "f.sid" not in result
-        assert "bl" not in result
-
-    def test_with_source_path(self):
-        """Test URL params with custom source path."""
-        result = build_url_params(RPCMethod.GET_NOTEBOOK, source_path="/notebook/abc123")
-
-        assert result["rpcids"] == RPCMethod.GET_NOTEBOOK.value
-        assert result["source-path"] == "/notebook/abc123"
-
-    def test_with_session_id(self):
-        """Test URL params with session ID."""
-        result = build_url_params(RPCMethod.LIST_NOTEBOOKS, session_id="session_12345")
-
-        assert result["f.sid"] == "session_12345"
-
-    def test_with_build_label(self):
-        """Test URL params with build label."""
-        result = build_url_params(
-            RPCMethod.LIST_NOTEBOOKS, bl="boq_labs-tailwind-frontend_20250101"
-        )
-
-        assert result["bl"] == "boq_labs-tailwind-frontend_20250101"
-
-    def test_all_optional_params(self):
-        """Test URL params with all optional parameters."""
-        result = build_url_params(
-            RPCMethod.CREATE_NOTEBOOK,
-            source_path="/notebook/xyz789",
-            session_id="sess_abc",
-            bl="build_label_123",
-        )
-
-        assert result["rpcids"] == RPCMethod.CREATE_NOTEBOOK.value
-        assert result["source-path"] == "/notebook/xyz789"
-        assert result["hl"] == "en"
-        assert result["rt"] == "c"
-        assert result["f.sid"] == "sess_abc"
-        assert result["bl"] == "build_label_123"
-
-    def test_empty_session_id_not_included(self):
-        """Test that empty session_id is not included."""
-        result = build_url_params(RPCMethod.LIST_NOTEBOOKS, session_id=None)
-
-        assert "f.sid" not in result
-
-    def test_empty_bl_not_included(self):
-        """Test that empty bl is not included."""
-        result = build_url_params(RPCMethod.LIST_NOTEBOOKS, bl=None)
-
-        assert "bl" not in result
-
-    def test_various_rpc_methods(self):
-        """Test URL params for different RPC methods."""
-        methods = [
-            (RPCMethod.DELETE_NOTEBOOK, RPCMethod.DELETE_NOTEBOOK.value),
-            (RPCMethod.ADD_SOURCE, RPCMethod.ADD_SOURCE.value),
-            (RPCMethod.SUMMARIZE, "VfAZjd"),
-        ]
-
-        for method, expected_id in methods:
-            result = build_url_params(method)
-            assert result["rpcids"] == expected_id

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -19,3 +19,15 @@ def test_get_default_language_empty_env_falls_back(monkeypatch):
     """An empty NOTEBOOKLM_HL value falls back to 'en' rather than ''."""
     monkeypatch.setenv("NOTEBOOKLM_HL", "")
     assert get_default_language() == "en"
+
+
+def test_get_default_language_strips_whitespace(monkeypatch):
+    """Surrounding whitespace in NOTEBOOKLM_HL is stripped."""
+    monkeypatch.setenv("NOTEBOOKLM_HL", "  ja  ")
+    assert get_default_language() == "ja"
+
+
+def test_get_default_language_whitespace_only_falls_back(monkeypatch):
+    """A whitespace-only NOTEBOOKLM_HL value falls back to 'en'."""
+    monkeypatch.setenv("NOTEBOOKLM_HL", "   ")
+    assert get_default_language() == "en"

--- a/tests/unit/test_env.py
+++ b/tests/unit/test_env.py
@@ -1,0 +1,21 @@
+"""Unit tests for notebooklm._env (NOTEBOOKLM_HL handling)."""
+
+from notebooklm._env import get_default_language
+
+
+def test_get_default_language_defaults_to_en(monkeypatch):
+    """When NOTEBOOKLM_HL is unset, get_default_language() returns 'en'."""
+    monkeypatch.delenv("NOTEBOOKLM_HL", raising=False)
+    assert get_default_language() == "en"
+
+
+def test_get_default_language_reads_env(monkeypatch):
+    """When NOTEBOOKLM_HL is set, get_default_language() returns its value."""
+    monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+    assert get_default_language() == "ja"
+
+
+def test_get_default_language_empty_env_falls_back(monkeypatch):
+    """An empty NOTEBOOKLM_HL value falls back to 'en' rather than ''."""
+    monkeypatch.setenv("NOTEBOOKLM_HL", "")
+    assert get_default_language() == "en"


### PR DESCRIPTION
## Summary

Adds a `NOTEBOOKLM_HL` environment variable that sets the default
interface language for both:

1. The `hl=` URL query parameter on every batchexecute RPC call.
2. The `language=` default of the 9 language-aware `ArtifactsAPI.generate_*`
   methods (audio, video, cinematic_video, report, study_guide,
   infographic, slide_deck, data_table, mind_map).

It mirrors the existing `NOTEBOOKLM_BL` pattern in `_chat.py`.

Closes #393.

## What was live vs dead

Before this PR there were three runtime URL-related sites and only TWO
were actually live:

| Site | Status | Effect |
|---|---|---|
| `src/notebooklm/_chat.py` query params | **Live** — runs on every `chat.ask()` | Hardcoded `hl=en` |
| `src/notebooklm/_core._build_url()` | **Live** — runs on every `rpc_call()` | **Had no `hl` param at all** |
| `src/notebooklm/rpc/encoder.build_url_params()` | **Dead** — not re-exported in `rpc/__init__.py`, no callers | Looked like the source of truth but did nothing |

Patching only `_chat.py` (the obvious site) would have fixed chat but
left every other RPC un-localised. The load-bearing edit is `_core._build_url`.

## Wire-up sites

1. `src/notebooklm/_env.py` (new) — `get_default_language()` helper.
2. `src/notebooklm/_core._build_url()` — adds `"hl": get_default_language()`
   to the params dict so every batchexecute call is localised.
3. `src/notebooklm/_chat.py` — replaces hardcoded `"hl": "en"` with the helper.
4. `src/notebooklm/_artifacts.py` — for the 9 language-aware
   `generate_*` methods, switches the default to `None` and resolves it
   via `get_default_language()` inside the body so the env var also
   defaults the per-payload `language` slot, not just the URL.
5. `src/notebooklm/cli/generate.resolve_language()` — new precedence
   `--language > NOTEBOOKLM_HL > config > "en"`, with the env value
   validated against `SUPPORTED_LANGUAGES`.

## Dead-code deletion

`rpc/encoder.build_url_params()` is removed along with its
`TestBuildUrlParams` test class (the only callers). It was never
re-exported from `notebooklm.rpc` and could mislead future
contributors into thinking it controlled the live URL.

## Test plan

- [x] `tests/unit/test_env.py` — env unset / set / empty
- [x] `tests/integration/test_core.py::TestBuildUrlHL` — `_build_url`
      URL carries `hl=` from env (this is the load-bearing assertion)
- [x] `tests/integration/test_chat.py::TestChatHL` — chat POST URL
      carries `hl=` from env
- [x] `tests/integration/test_artifacts.py::TestGenerateUsesNotebookLMHL`
      — parameterized over `generate_audio` / `generate_video` /
      `generate_report` for both "env defaults" and "explicit arg
      overrides env"
- [x] `tests/unit/cli/test_generate.py::TestResolveLanguageDirect`
      — new tests for env-overrides-config, flag-overrides-env,
      empty-env-falls-through, invalid-env-raises
- [x] `ruff format --check . && ruff check . && mypy src/notebooklm && pytest`
      — all green (2413 passed, 9 skipped e2e)

Closes #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NOTEBOOKLM_HL env var as the default interface/output language; language is sent as hl on RPCs and used as a fallback
  * Language resolution: --language → NOTEBOOKLM_HL → config → en; quiz, flashcards, and revise-slide ignore --language
  * Shared generate options now list --retry N

* **Documentation**
  * Updated CLI and configuration docs with NOTEBOOKLM_HL, hl usage, and precedence

* **Tests**
  * Added unit and integration tests covering NOTEBOOKLM_HL and language-resolution behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/397)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->