### PR TITLE
feat(client): support enterprise host and cited imports

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -423,6 +423,7 @@ class ArtifactsAPI:
         instructions: str | None = None,
         video_format: VideoFormat | None = None,
         video_style: VideoStyle | None = None,
+        style_prompt: str | None = None,
     ) -> GenerationStatus:
         """Generate a Video Overview.
 
@@ -433,10 +434,19 @@ class ArtifactsAPI:
             instructions: Custom instructions for video generation.
             video_format: EXPLAINER or BRIEF.
             video_style: AUTO_SELECT, CLASSIC, WHITEBOARD, etc.
+            style_prompt: Custom visual style instructions. Requires
+                ``video_style=VideoStyle.CUSTOM``.
 
         Returns:
             GenerationStatus with task_id for polling.
         """
+        if video_format == VideoFormat.CINEMATIC and style_prompt:
+            raise ValidationError("style_prompt is not supported for cinematic videos")
+        if video_style == VideoStyle.CUSTOM and not style_prompt:
+            raise ValidationError("style_prompt is required when video_style is CUSTOM")
+        if style_prompt and video_style != VideoStyle.CUSTOM:
+            raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
+
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -445,6 +455,17 @@ class ArtifactsAPI:
 
         format_code = video_format.value if video_format else None
         style_code = video_style.value if video_style else None
+
+        video_config = [
+            source_ids_double,
+            language,
+            instructions,
+            None,
+            format_code,
+            style_code,
+        ]
+        if style_prompt:
+            video_config.append(style_prompt)
 
         params = [
             [2],
@@ -461,14 +482,7 @@ class ArtifactsAPI:
                 [
                     None,
                     None,
-                    [
-                        source_ids_double,
-                        language,
-                        instructions,
-                        None,
-                        format_code,
-                        style_code,
-                    ],
+                    video_config,
                 ],
             ],
         ]

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -16,7 +16,7 @@ import httpx
 
 from ._core import ClientCore
 from .exceptions import ChatError, NetworkError, ValidationError
-from .rpc import QUERY_URL, RPCMethod
+from .rpc import RPCMethod, get_query_url
 from .types import AskResult, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class ChatAPI:
             url_params["f.sid"] = self._core.auth.session_id
 
         query_string = urlencode(url_params)
-        url = f"{QUERY_URL}?{query_string}"
+        url = f"{get_query_url()}?{query_string}"
 
         http_client = self._core.get_http_client()
         try:
@@ -617,7 +617,10 @@ class ChatAPI:
         except ChatError:
             raise
         except Exception:
-            pass  # Ignore parse failures; let normal empty-answer handling proceed
+            logger.debug(
+                "Could not parse chat error payload; continuing with empty-answer handling",
+                exc_info=True,
+            )
 
     def _parse_citations(self, first: list) -> list[ChatReference]:
         """Parse citation details from response structure.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -24,7 +24,6 @@ from .auth import (
     snapshot_cookie_jar,
 )
 from .rpc import (
-    BATCHEXECUTE_URL,
     AuthError,
     ClientError,
     NetworkError,
@@ -36,6 +35,7 @@ from .rpc import (
     build_request_body,
     decode_response,
     encode_rpc_request,
+    get_batchexecute_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -278,6 +278,7 @@ class ClientCore:
         effective_path = path if path is not None else self._keepalive_storage_path
         if effective_path is None:
             return
+        save_path: Path = effective_path
 
         jar_copy = httpx.Cookies(jar)
         # Computed on the loop thread off ``jar_copy`` so the worker can refresh
@@ -287,7 +288,7 @@ class ClientCore:
 
         def _save(
             s: httpx.Cookies = jar_copy,
-            p: Path = effective_path,
+            p: Path = save_path,
             lock: threading.Lock = self._save_lock,
             post: CookieSnapshot = post_save_snapshot,
             client: ClientCore = self,
@@ -453,7 +454,7 @@ class ClientCore:
             "f.sid": self.auth.session_id,
             "rt": "c",
         }
-        return f"{BATCHEXECUTE_URL}?{urlencode(params)}"
+        return f"{get_batchexecute_url()}?{urlencode(params)}"
 
     async def rpc_call(
         self,

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -1,0 +1,50 @@
+"""Runtime environment helpers for NotebookLM endpoints."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+DEFAULT_BASE_URL = "https://notebooklm.google.com"
+PERSONAL_BASE_HOST = "notebooklm.google.com"
+ENTERPRISE_BASE_HOST = "notebooklm.cloud.google.com"
+
+_ALLOWED_BASE_HOSTS = frozenset({PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST})
+
+
+def get_base_url() -> str:
+    """Return the configured NotebookLM base URL.
+
+    ``NOTEBOOKLM_BASE_URL`` is constrained to known Google-owned NotebookLM hosts
+    because the value is used for authenticated requests.
+    """
+    configured = os.environ.get("NOTEBOOKLM_BASE_URL")
+    raw = (configured.strip() if configured is not None else DEFAULT_BASE_URL).rstrip("/")
+    if not raw:
+        raw = DEFAULT_BASE_URL
+    parsed = urlparse(raw)
+    path = parsed.path.rstrip("/")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("NOTEBOOKLM_BASE_URL has an invalid port") from exc
+    host = parsed.hostname
+    if (
+        parsed.scheme != "https"
+        or host not in _ALLOWED_BASE_HOSTS
+        or port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or path
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        allowed = ", ".join(sorted(_ALLOWED_BASE_HOSTS))
+        raise ValueError(f"NOTEBOOKLM_BASE_URL must use https and one of: {allowed}")
+    return f"https://{host}"
+
+
+def get_base_host() -> str:
+    """Return the configured NotebookLM host."""
+    return urlparse(get_base_url()).hostname or PERSONAL_BASE_HOST

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ._core import ClientCore
+from ._env import get_base_url
 from ._settings import build_get_user_settings_params, extract_account_limits
 from .exceptions import NotebookLimitError, RPCError
 from .rpc import RPCMethod
@@ -343,7 +344,7 @@ class NotebooksAPI:
         )
 
         # Build share URL
-        base_url = f"https://notebooklm.google.com/notebook/{notebook_id}"
+        base_url = f"{get_base_url()}/notebook/{notebook_id}"
         if public and artifact_id:
             url = f"{base_url}?artifactId={artifact_id}"
         elif public:
@@ -370,7 +371,7 @@ class NotebooksAPI:
         Returns:
             The share URL string.
         """
-        base_url = f"https://notebooklm.google.com/notebook/{notebook_id}"
+        base_url = f"{get_base_url()}/notebook/{notebook_id}"
         if artifact_id:
             return f"{base_url}?artifactId={artifact_id}"
         return base_url

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -5,7 +5,10 @@ and importing discovered sources into notebooks.
 """
 
 import logging
+import re
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from ._core import ClientCore
 from .exceptions import ValidationError
@@ -18,6 +21,21 @@ _RESEARCH_RESULT_TYPE_ALIASES = {
     "drive": 2,
     "report": 5,
 }
+
+_URL_PATTERN = re.compile(r"https?://[^\s<>\]\)\"']+")
+_MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]+\]\((https?://[^\s\)]+)")
+_MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+\]\((https?://[^\s\)]+)")
+_TRAILING_URL_PUNCTUATION = ".,;:!?"
+
+
+@dataclass(frozen=True)
+class CitedSourceSelection:
+    """Result of applying cited-only filtering to research sources."""
+
+    sources: list[dict[str, Any]]
+    cited_url_count: int
+    matched_url_source_count: int
+    used_fallback: bool = False
 
 
 class ResearchAPI:
@@ -80,6 +98,93 @@ class ResearchAPI:
             return ""
         chunks = [chunk for chunk in src[6] if isinstance(chunk, str) and chunk]
         return "\n\n".join(chunks)
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        """Normalize source/report URLs for citation matching."""
+        parsed = urlsplit(url.rstrip(_TRAILING_URL_PUNCTUATION))
+        return urlunsplit(
+            (
+                parsed.scheme.lower(),
+                parsed.netloc.lower(),
+                parsed.path.rstrip("/"),
+                parsed.query,
+                parsed.fragment,
+            )
+        )
+
+    @classmethod
+    def extract_report_urls(cls, report: str) -> set[str]:
+        """Extract normalized URLs from research report markdown/text."""
+        if not report:
+            return set()
+
+        urls = {
+            cls._normalize_url(match.group(1)) for match in _MARKDOWN_LINK_PATTERN.finditer(report)
+        }
+        urls.update(cls._normalize_url(match.group(0)) for match in _URL_PATTERN.finditer(report))
+        image_urls = {
+            cls._normalize_url(match.group(1)) for match in _MARKDOWN_IMAGE_PATTERN.finditer(report)
+        }
+        urls.difference_update(image_urls)
+        return {url for url in urls if url.startswith(("http://", "https://"))}
+
+    @classmethod
+    def select_cited_sources(
+        cls,
+        sources: list[dict[str, Any]],
+        report: str,
+    ) -> CitedSourceSelection:
+        """Return research sources cited by the completed report.
+
+        Report entries are preserved so deep-research import still brings in the
+        generated report itself. If no cited URL subset can be resolved, falls
+        back to the original source list to avoid an empty import surprise.
+        """
+        cited_urls = cls.extract_report_urls(report)
+        if not cited_urls:
+            logger.warning(
+                "Cited-only research import requested, but no cited URLs were found; "
+                "falling back to all importable research sources"
+            )
+            return CitedSourceSelection(
+                sources=sources,
+                cited_url_count=0,
+                matched_url_source_count=0,
+                used_fallback=True,
+            )
+
+        report_sources = [
+            source
+            for source in sources
+            if source.get("result_type") == 5 and source.get("report_markdown")
+        ]
+        report_source_ids = {id(source) for source in report_sources}
+        matched_url_sources = [
+            source
+            for source in sources
+            if id(source) not in report_source_ids
+            and isinstance(source.get("url"), str)
+            and cls._normalize_url(source["url"]) in cited_urls
+        ]
+
+        if not matched_url_sources:
+            logger.warning(
+                "Cited-only research import requested, but none of the report URLs "
+                "matched research sources; falling back to all importable research sources"
+            )
+            return CitedSourceSelection(
+                sources=sources,
+                cited_url_count=len(cited_urls),
+                matched_url_source_count=0,
+                used_fallback=True,
+            )
+
+        return CitedSourceSelection(
+            sources=[*report_sources, *matched_url_sources],
+            cited_url_count=len(cited_urls),
+            matched_url_source_count=len(matched_url_sources),
+        )
 
     async def start(
         self,

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -23,7 +23,7 @@ _RESEARCH_RESULT_TYPE_ALIASES = {
 }
 
 _URL_PATTERN = re.compile(r"https?://[^\s<>\]\)\"']+")
-_MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]+\]\((https?://[^\s\)]+)")
+_MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\((https?://[^\s\)]+)")
 _MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+\]\((https?://[^\s\)]+)")
 _TRAILING_URL_PUNCTUATION = ".,;:!?"
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -13,9 +13,10 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 
 from ._core import ClientCore
+from ._env import get_base_url
 from ._url_utils import is_youtube_url
 from .exceptions import NetworkError, ValidationError
-from .rpc import UPLOAD_URL, RPCError, RPCMethod
+from .rpc import RPCError, RPCMethod, get_upload_url
 from .rpc.types import SourceStatus
 from .types import (
     Source,
@@ -987,13 +988,14 @@ class SourcesAPI:
         """Start a resumable upload session and get the upload URL."""
         import json
 
-        url = f"{UPLOAD_URL}?authuser=0"
+        base_url = get_base_url()
+        url = f"{get_upload_url()}?authuser=0"
 
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
             "x-goog-authuser": "0",
             "x-goog-upload-command": "start",
             "x-goog-upload-header-content-length": str(file_size),
@@ -1042,11 +1044,12 @@ class SourcesAPI:
             upload_url: The resumable upload URL from _start_resumable_upload.
             file_path: Path to the file to upload.
         """
+        base_url = get_base_url()
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
             "x-goog-authuser": "0",
             "x-goog-upload-command": "upload, finalize",
             "x-goog-upload-offset": "0",

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -50,6 +50,7 @@ from typing import Any, NamedTuple, TypeAlias
 
 import httpx
 
+from ._env import get_base_url
 from ._url_utils import contains_google_auth_redirect, is_google_auth_redirect
 from .paths import get_storage_path, resolve_profile
 
@@ -210,6 +211,8 @@ ALLOWED_COOKIE_DOMAINS = {
     # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
     ".notebooklm.google.com",
     "notebooklm.google.com",
+    ".notebooklm.cloud.google.com",
+    "notebooklm.cloud.google.com",
     ".googleusercontent.com",
     "accounts.google.com",  # Required for token refresh redirects
     ".accounts.google.com",  # http.cookiejar may normalize Domain=accounts.google.com
@@ -577,6 +580,10 @@ def _auth_domain_priority(domain: str) -> int:
     if domain == ".notebooklm.google.com":
         return 3
     if domain == "notebooklm.google.com":
+        return 2
+    if domain == ".notebooklm.cloud.google.com":
+        return 3
+    if domain == "notebooklm.cloud.google.com":
         return 2
     if _is_google_domain(domain):
         return 1
@@ -2312,7 +2319,7 @@ async def _fetch_tokens_with_jar(
         await _poke_session(client, storage_path)
 
         response = await client.get(
-            "https://notebooklm.google.com/",
+            f"{get_base_url()}/",
             follow_redirects=True,
             timeout=30.0,
         )

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -421,6 +421,7 @@ def generate_audio(
     type=click.Choice(
         [
             "auto",
+            "custom",
             "classic",
             "whiteboard",
             "kawaii",
@@ -433,6 +434,7 @@ def generate_audio(
     ),
     default="auto",
 )
+@click.option("--style-prompt", default=None, help="Custom visual style prompt")
 @click.option("--language", default=None, help="Output language (default: from config or 'en')")
 @click.option("--source", "-s", "source_ids", multiple=True, help="Limit to specific source IDs")
 @click.option("--wait/--no-wait", default=False, help="Wait for completion (default: no-wait)")
@@ -445,6 +447,7 @@ def generate_video(
     notebook_id,
     video_format,
     style,
+    style_prompt,
     language,
     source_ids,
     wait,
@@ -479,6 +482,7 @@ def generate_video(
     }
     style_map = {
         "auto": VideoStyle.AUTO_SELECT,
+        "custom": VideoStyle.CUSTOM,
         "classic": VideoStyle.CLASSIC,
         "whiteboard": VideoStyle.WHITEBOARD,
         "kawaii": VideoStyle.KAWAII,
@@ -489,6 +493,12 @@ def generate_video(
         "paper-craft": VideoStyle.PAPER_CRAFT,
     }
     is_cinematic = video_format == "cinematic"
+    if is_cinematic and style_prompt:
+        raise click.UsageError("--style-prompt cannot be used with cinematic video")
+    if not is_cinematic and style == "custom" and not style_prompt:
+        raise click.UsageError("--style custom requires --style-prompt")
+    if not is_cinematic and style_prompt and style != "custom":
+        raise click.UsageError("--style-prompt requires --style custom")
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
@@ -510,6 +520,7 @@ def generate_video(
                     instructions=description or None,
                     video_format=format_map[video_format],
                     video_style=style_map[style],
+                    style_prompt=style_prompt,
                 )
 
             timeout = 1800.0 if is_cinematic else 600.0

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import time
+from dataclasses import dataclass
 from functools import wraps
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit
@@ -22,6 +23,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from .._research import CitedSourceSelection, ResearchAPI
 from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
 from ..exceptions import NetworkError, NotebookLimitError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
@@ -38,6 +40,15 @@ logger = logging.getLogger(__name__)
 _CLI_ARTIFACT_ALIASES = {
     "flashcard": "flashcards",  # CLI uses singular, enum uses plural
 }
+
+
+@dataclass(frozen=True)
+class ResearchImportResult:
+    """Result of importing research sources from CLI commands."""
+
+    imported: list[dict[str, str]]
+    sources: list[dict]
+    cited_selection: CitedSourceSelection | None = None
 
 
 def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
@@ -323,6 +334,82 @@ async def import_with_retry(
             await asyncio.sleep(sleep_for)
             delay = min(delay * backoff_factor, max_delay)
             attempt += 1
+
+
+def _select_research_sources_for_import(
+    sources: list[dict], report: str, cited_only: bool
+) -> tuple[list[dict], CitedSourceSelection | None]:
+    if not cited_only or not sources:
+        return sources, None
+
+    cited_selection = ResearchAPI.select_cited_sources(sources, report)
+    return cited_selection.sources, cited_selection
+
+
+def _display_cited_import_selection(cited_selection: CitedSourceSelection | None) -> None:
+    if cited_selection is None:
+        return
+
+    if cited_selection.used_fallback:
+        console.print("[yellow]Could not resolve cited sources; importing all sources.[/yellow]")
+        return
+
+    console.print(
+        f"[dim]Importing {cited_selection.matched_url_source_count} cited source(s)[/dim]"
+    )
+
+
+async def import_research_sources(
+    client,
+    notebook_id: str,
+    task_id: str,
+    sources: list[dict],
+    *,
+    report: str = "",
+    cited_only: bool = False,
+    max_elapsed: float = 1800,
+    json_output: bool = False,
+    status_message: str | None = None,
+) -> ResearchImportResult:
+    """Select and import research sources using shared CLI policy."""
+    sources_to_import, cited_selection = _select_research_sources_for_import(
+        sources, report, cited_only
+    )
+    if not sources_to_import:
+        return ResearchImportResult([], sources_to_import, cited_selection)
+
+    if not json_output:
+        _display_cited_import_selection(cited_selection)
+
+    if status_message and not json_output:
+        with console.status(status_message):
+            imported = await import_with_retry(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                max_elapsed=max_elapsed,
+            )
+    else:
+        if json_output:
+            imported = await import_with_retry(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                max_elapsed=max_elapsed,
+                json_output=True,
+            )
+        else:
+            imported = await import_with_retry(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                max_elapsed=max_elapsed,
+            )
+
+    return ResearchImportResult(imported, sources_to_import, cited_selection)
 
 
 # =============================================================================

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -9,13 +9,12 @@ import asyncio
 
 import click
 
-from .._research import ResearchAPI
 from ..client import NotebookLMClient
 from .helpers import (
     console,
     display_report,
     display_research_sources,
-    import_with_retry,
+    import_research_sources,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
@@ -186,11 +185,6 @@ def research_wait(
             query = status.get("query", "")
 
             report = status.get("report", "")
-            sources_to_import = sources
-            cited_selection = None
-            if cited_only and sources:
-                cited_selection = ResearchAPI.select_cited_sources(sources, report)
-                sources_to_import = cited_selection.sources
 
             if json_output:
                 result = {
@@ -200,21 +194,23 @@ def research_wait(
                     "sources": sources,
                     "report": report,
                 }
-                if cited_selection is not None:
-                    result["cited_only"] = True
-                    result["cited_sources_selected"] = len(sources_to_import)
-                    result["cited_only_fallback"] = cited_selection.used_fallback
-                if import_all and sources_to_import and task_id:
-                    imported = await import_with_retry(
+                if import_all and sources and task_id:
+                    import_result = await import_research_sources(
                         client,
                         nb_id_resolved,
                         task_id,
-                        sources_to_import,
+                        sources,
+                        report=report,
+                        cited_only=cited_only,
                         max_elapsed=timeout,
                         json_output=True,
                     )
-                    result["imported"] = len(imported)
-                    result["imported_sources"] = imported
+                    if import_result.cited_selection is not None:
+                        result["cited_only"] = True
+                        result["cited_sources_selected"] = len(import_result.sources)
+                        result["cited_only_fallback"] = import_result.cited_selection.used_fallback
+                    result["imported"] = len(import_result.imported)
+                    result["imported_sources"] = import_result.imported
                 json_output_response(result)
             else:
                 console.print(f"[green]✓ Research completed:[/green] {query}")
@@ -222,26 +218,17 @@ def research_wait(
 
                 display_report(report)
 
-                if import_all and sources_to_import and task_id:
-                    if cited_selection is not None:
-                        if cited_selection.used_fallback:
-                            console.print(
-                                "[yellow]Could not resolve cited sources; "
-                                "importing all sources.[/yellow]"
-                            )
-                        else:
-                            console.print(
-                                f"[dim]Importing {cited_selection.matched_url_source_count} "
-                                "cited source(s)[/dim]"
-                            )
-                    with console.status("Importing sources..."):
-                        imported = await import_with_retry(
-                            client,
-                            nb_id_resolved,
-                            task_id,
-                            sources_to_import,
-                            max_elapsed=timeout,
-                        )
-                    console.print(f"[green]Imported {len(imported)} sources[/green]")
+                if import_all and sources and task_id:
+                    import_result = await import_research_sources(
+                        client,
+                        nb_id_resolved,
+                        task_id,
+                        sources,
+                        report=report,
+                        cited_only=cited_only,
+                        max_elapsed=timeout,
+                        status_message="Importing sources...",
+                    )
+                    console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
 
     return _run()

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -9,6 +9,7 @@ import asyncio
 
 import click
 
+from .._research import ResearchAPI
 from ..client import NotebookLMClient
 from .helpers import (
     console,
@@ -123,9 +124,12 @@ def research_status(ctx, notebook_id, json_output, client_auth):
     help="Seconds between status checks (default: 5)",
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources when done")
+@click.option("--cited-only", is_flag=True, help="With --import-all, import only cited sources")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
-def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, client_auth):
+def research_wait(
+    ctx, notebook_id, timeout, interval, import_all, cited_only, json_output, client_auth
+):
     """Wait for research to complete.
 
     Blocks until research is completed or timeout is reached.
@@ -135,8 +139,12 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
     Examples:
       notebooklm research wait
       notebooklm research wait --timeout 600 --import-all
+      notebooklm research wait --import-all --cited-only
       notebooklm research wait --json
     """
+    if cited_only and not import_all:
+        raise click.UsageError("--cited-only requires --import-all")
+
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -178,6 +186,11 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
             query = status.get("query", "")
 
             report = status.get("report", "")
+            sources_to_import = sources
+            cited_selection = None
+            if cited_only and sources:
+                cited_selection = ResearchAPI.select_cited_sources(sources, report)
+                sources_to_import = cited_selection.sources
 
             if json_output:
                 result = {
@@ -187,12 +200,16 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
                     "sources": sources,
                     "report": report,
                 }
-                if import_all and sources and task_id:
+                if cited_selection is not None:
+                    result["cited_only"] = True
+                    result["cited_sources_selected"] = len(sources_to_import)
+                    result["cited_only_fallback"] = cited_selection.used_fallback
+                if import_all and sources_to_import and task_id:
                     imported = await import_with_retry(
                         client,
                         nb_id_resolved,
                         task_id,
-                        sources,
+                        sources_to_import,
                         max_elapsed=timeout,
                         json_output=True,
                     )
@@ -205,13 +222,24 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
 
                 display_report(report)
 
-                if import_all and sources and task_id:
+                if import_all and sources_to_import and task_id:
+                    if cited_selection is not None:
+                        if cited_selection.used_fallback:
+                            console.print(
+                                "[yellow]Could not resolve cited sources; "
+                                "importing all sources.[/yellow]"
+                            )
+                        else:
+                            console.print(
+                                f"[dim]Importing {cited_selection.matched_url_source_count} "
+                                "cited source(s)[/dim]"
+                            )
                     with console.status("Importing sources..."):
                         imported = await import_with_retry(
                             client,
                             nb_id_resolved,
                             task_id,
-                            sources,
+                            sources_to_import,
                             max_elapsed=timeout,
                         )
                     console.print(f"[green]Imported {len(imported)} sources[/green]")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext, Page
     from rich.console import Console
 
+from .._env import get_base_host, get_base_url
 from ..auth import (
     ALLOWED_COOKIE_DOMAINS,
     GOOGLE_REGIONAL_CCTLDS,
@@ -57,8 +58,6 @@ from .language import set_language
 logger = logging.getLogger(__name__)
 
 GOOGLE_ACCOUNTS_URL = "https://accounts.google.com/"
-NOTEBOOKLM_URL = "https://notebooklm.google.com/"
-NOTEBOOKLM_HOST = "notebooklm.google.com"
 
 # Retryable Playwright connection errors
 RETRYABLE_CONNECTION_ERRORS = ("ERR_CONNECTION_CLOSED", "ERR_CONNECTION_RESET")
@@ -543,7 +542,7 @@ def register_session_commands(cli):
                 # Retry navigation on transient connection errors with backoff
                 for attempt in range(1, LOGIN_MAX_RETRIES + 1):
                     try:
-                        page.goto(NOTEBOOKLM_URL, timeout=30000)
+                        page.goto(f"{get_base_url()}/", timeout=30000)
                         break
                     except PlaywrightError as exc:
                         error_str = str(exc)
@@ -611,7 +610,7 @@ def register_session_commands(cli):
                 # .google.co.uk). Use "commit" to resolve once response headers
                 # (including Set-Cookie) are processed, before any client-side
                 # JS redirect can interrupt. See #214.
-                for url in [GOOGLE_ACCOUNTS_URL, NOTEBOOKLM_URL]:
+                for url in [GOOGLE_ACCOUNTS_URL, f"{get_base_url()}/"]:
                     try:
                         page.goto(url, wait_until="commit")
                     except PlaywrightError as exc:
@@ -632,7 +631,7 @@ def register_session_commands(cli):
                             raise
 
                 current_url = page.url
-                if NOTEBOOKLM_HOST not in current_url:
+                if get_base_host() not in current_url:
                     console.print(f"[yellow]Warning: Current URL is {current_url}[/yellow]")
                     if not click.confirm("Save authentication anyway?"):
                         raise SystemExit(1)

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import click
 from rich.table import Table
 
+from .._research import ResearchAPI
 from .._url_utils import is_youtube_url
 from ..client import NotebookLMClient
 from ..types import source_status_to_str
@@ -557,6 +558,7 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
     help="Search mode (default: fast)",
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources")
+@click.option("--cited-only", is_flag=True, help="With --import-all, import only cited sources")
 @click.option(
     "--no-wait",
     is_flag=True,
@@ -574,7 +576,16 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 )
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, no_wait, timeout, client_auth
+    ctx,
+    query,
+    notebook_id,
+    search_source,
+    mode,
+    import_all,
+    cited_only,
+    no_wait,
+    timeout,
+    client_auth,
 ):
     """Search web or drive and add sources from results.
 
@@ -584,8 +595,12 @@ def source_add_research(
       source add-research "project docs" --from drive     # Search Google Drive
       source add-research "AI papers" --mode deep         # Deep search
       source add-research "tutorials" --import-all        # Auto-import all results
+      source add-research "topic" --import-all --cited-only
       source add-research "topic" --mode deep --no-wait   # Non-blocking deep search
     """
+    if cited_only and not import_all:
+        raise click.UsageError("--cited-only requires --import-all")
+
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -628,11 +643,30 @@ def source_add_research(
                 display_report(status.get("report", ""), json_hint=False)
 
                 if import_all and sources and task_id:
+                    sources_to_import = sources
+                    cited_selection = None
+                    if cited_only:
+                        cited_selection = ResearchAPI.select_cited_sources(
+                            sources,
+                            status.get("report", ""),
+                        )
+                        sources_to_import = cited_selection.sources
+                    if cited_selection is not None:
+                        if cited_selection.used_fallback:
+                            console.print(
+                                "[yellow]Could not resolve cited sources; "
+                                "importing all sources.[/yellow]"
+                            )
+                        else:
+                            console.print(
+                                f"[dim]Importing {cited_selection.matched_url_source_count} "
+                                "cited source(s)[/dim]"
+                            )
                     imported = await import_with_retry(
                         client,
                         nb_id_resolved,
                         task_id,
-                        sources,
+                        sources_to_import,
                         max_elapsed=timeout,
                     )
                     console.print(f"[green]Imported {len(imported)} sources[/green]")

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -22,7 +22,6 @@ from pathlib import Path
 import click
 from rich.table import Table
 
-from .._research import ResearchAPI
 from .._url_utils import is_youtube_url
 from ..client import NotebookLMClient
 from ..types import source_status_to_str
@@ -31,7 +30,7 @@ from .helpers import (
     display_report,
     display_research_sources,
     get_source_type_display,
-    import_with_retry,
+    import_research_sources,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
@@ -643,33 +642,16 @@ def source_add_research(
                 display_report(status.get("report", ""), json_hint=False)
 
                 if import_all and sources and task_id:
-                    sources_to_import = sources
-                    cited_selection = None
-                    if cited_only:
-                        cited_selection = ResearchAPI.select_cited_sources(
-                            sources,
-                            status.get("report", ""),
-                        )
-                        sources_to_import = cited_selection.sources
-                    if cited_selection is not None:
-                        if cited_selection.used_fallback:
-                            console.print(
-                                "[yellow]Could not resolve cited sources; "
-                                "importing all sources.[/yellow]"
-                            )
-                        else:
-                            console.print(
-                                f"[dim]Importing {cited_selection.matched_url_source_count} "
-                                "cited source(s)[/dim]"
-                            )
-                    imported = await import_with_retry(
+                    import_result = await import_research_sources(
                         client,
                         nb_id_resolved,
                         task_id,
-                        sources_to_import,
+                        sources,
+                        report=status.get("report", ""),
+                        cited_only=cited_only,
                         max_elapsed=timeout,
                     )
-                    console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
             else:
                 console.print(f"[yellow]Status: {status.get('status', 'unknown')}[/yellow]")
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from ._artifacts import ArtifactsAPI
 from ._chat import ChatAPI
 from ._core import DEFAULT_KEEPALIVE_MIN_INTERVAL, DEFAULT_TIMEOUT, ClientCore
+from ._env import get_base_url
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
@@ -223,7 +224,7 @@ class NotebookLMClient:
             ValueError: If token extraction fails (page structure may have changed).
         """
         http_client = self._core.get_http_client()
-        response = await http_client.get("https://notebooklm.google.com/")
+        response = await http_client.get(f"{get_base_url()}/")
         response.raise_for_status()
 
         # Check for redirect to login page

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ._env import get_base_url
+
 __all__ = [
     # Base
     "NotebookLMError",
@@ -348,7 +350,7 @@ class NotebookLimitError(NotebookError):
         message = (
             "Cannot create notebook: account appears to be at or very near the "
             f"NotebookLM notebook limit ({count_text} owned notebooks reported). "
-            "Delete old notebooks at https://notebooklm.google.com and try again."
+            f"Delete old notebooks at {get_base_url()} and try again."
         )
         if known_limits:
             message += f" Known NotebookLM limits include: {known_text}."

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -42,6 +42,9 @@ from .types import (
     VideoFormat,
     VideoStyle,
     artifact_status_to_str,
+    get_batchexecute_url,
+    get_query_url,
+    get_upload_url,
 )
 
 __all__ = [
@@ -49,6 +52,9 @@ __all__ = [
     "BATCHEXECUTE_URL",
     "QUERY_URL",
     "UPLOAD_URL",
+    "get_batchexecute_url",
+    "get_query_url",
+    "get_upload_url",
     "ArtifactTypeCode",
     "StudioContentType",  # Deprecated alias
     "ArtifactStatus",

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -2,10 +2,36 @@
 
 from enum import Enum
 
-# NotebookLM API endpoints
-BATCHEXECUTE_URL = "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute"
-QUERY_URL = "https://notebooklm.google.com/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
-UPLOAD_URL = "https://notebooklm.google.com/upload/_/"
+from .._env import DEFAULT_BASE_URL, get_base_url
+
+# Backward-compatible default-host endpoint constants. Runtime code should use
+# the lazy get_* helpers below so NOTEBOOKLM_BASE_URL is honored after import.
+BATCHEXECUTE_URL = f"{DEFAULT_BASE_URL}/_/LabsTailwindUi/data/batchexecute"
+QUERY_URL = (
+    f"{DEFAULT_BASE_URL}/_/LabsTailwindUi/data/"
+    "google.internal.labs.tailwind.orchestration.v1."
+    "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
+)
+UPLOAD_URL = f"{DEFAULT_BASE_URL}/upload/_/"
+
+
+def get_batchexecute_url() -> str:
+    """Return the NotebookLM batchexecute endpoint for the configured host."""
+    return f"{get_base_url()}/_/LabsTailwindUi/data/batchexecute"
+
+
+def get_query_url() -> str:
+    """Return the NotebookLM streamed chat endpoint for the configured host."""
+    return (
+        f"{get_base_url()}/_/LabsTailwindUi/data/"
+        "google.internal.labs.tailwind.orchestration.v1."
+        "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
+    )
+
+
+def get_upload_url() -> str:
+    """Return the NotebookLM upload endpoint for the configured host."""
+    return f"{get_base_url()}/upload/_/"
 
 
 class RPCMethod(str, Enum):

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
+from ._env import get_base_url
+
 # Import exceptions from centralized module (re-export for backward compatibility)
 from .exceptions import (
     ArtifactDownloadError,
@@ -1409,7 +1411,7 @@ class ShareStatus:
         view_level = ShareViewLevel.FULL_NOTEBOOK
 
         # Construct share URL if public
-        share_url = f"https://notebooklm.google.com/notebook/{notebook_id}" if is_public else None
+        share_url = f"{get_base_url()}/notebook/{notebook_id}" if is_public else None
 
         return cls(
             notebook_id=notebook_id,

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -169,6 +169,69 @@ class TestGenerateVideo:
 
             assert result.exit_code == 0
 
+    def test_generate_video_with_custom_style_prompt(self, runner, mock_auth):
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_video = AsyncMock(
+                return_value={"artifact_id": "video_123", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "video",
+                        "--style",
+                        "custom",
+                        "--style-prompt",
+                        "Use hand-drawn diagrams",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            mock_client.artifacts.generate_video.assert_awaited_once()
+            kwargs = mock_client.artifacts.generate_video.await_args.kwargs
+            assert kwargs["video_style"].name == "CUSTOM"
+            assert kwargs["style_prompt"] == "Use hand-drawn diagrams"
+
+    def test_generate_video_custom_style_requires_prompt(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            ["generate", "video", "--style", "custom", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 1
+        assert "--style custom requires --style-prompt" in result.output
+
+    def test_generate_video_style_prompt_requires_custom_style(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "video",
+                "--style",
+                "anime",
+                "--style-prompt",
+                "Use hand-drawn diagrams",
+                "-n",
+                "nb_123",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--style-prompt requires --style custom" in result.output
+
 
 # =============================================================================
 # GENERATE CINEMATIC VIDEO TESTS
@@ -238,6 +301,24 @@ class TestGenerateCinematicVideo:
             assert result.exit_code == 0
             # Should call generate_cinematic_video (not generate_video) despite --style
             mock_client.artifacts.generate_cinematic_video.assert_called_once()
+
+    def test_generate_cinematic_video_rejects_style_prompt(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "cinematic-video",
+                "--style-prompt",
+                "Use hand-drawn diagrams",
+                "-n",
+                "nb_123",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--style-prompt cannot be used with cinematic video" in result.output
 
 
 # =============================================================================

--- a/tests/unit/cli/test_research.py
+++ b/tests/unit/cli/test_research.py
@@ -9,6 +9,7 @@ from notebooklm.notebooklm_cli import cli
 from .conftest import create_mock_client, patch_client_for_module
 
 research_module = importlib.import_module("notebooklm.cli.research")
+helpers_module = importlib.import_module("notebooklm.cli.helpers")
 
 # =============================================================================
 # RESEARCH STATUS TESTS
@@ -178,7 +179,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                research_module, "import_with_retry", new_callable=AsyncMock
+                helpers_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -209,7 +210,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                research_module, "import_with_retry", new_callable=AsyncMock
+                helpers_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -275,7 +276,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                research_module, "import_with_retry", new_callable=AsyncMock
+                helpers_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -312,7 +313,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                research_module, "import_with_retry", new_callable=AsyncMock
+                helpers_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()

--- a/tests/unit/cli/test_research.py
+++ b/tests/unit/cli/test_research.py
@@ -205,6 +205,50 @@ class TestResearchWait:
             max_elapsed=300,
         )
 
+    def test_wait_with_import_all_cited_only(self, runner, mock_auth, mock_fetch_tokens):
+        with (
+            patch_client_for_module("research") as mock_client_cls,
+            patch.object(
+                research_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "query": "AI research",
+                    "sources": [
+                        {"title": "Cited", "url": "https://example.com/cited"},
+                        {"title": "Uncited", "url": "https://example.com/uncited"},
+                    ],
+                    "report": "Report cites https://example.com/cited",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--import-all", "--cited-only"],
+            )
+
+        assert result.exit_code == 0
+        assert "Imported 1 sources" in result.output
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
+            max_elapsed=300,
+        )
+
+    def test_wait_cited_only_requires_import_all(self, runner, mock_auth, mock_fetch_tokens):
+        result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--cited-only"])
+
+        assert result.exit_code == 1
+        assert "--cited-only requires --import-all" in result.output
+
     def test_wait_json_output_completed(self, runner, mock_auth, mock_fetch_tokens):
         with patch_client_for_module("research") as mock_client_cls:
             mock_client = create_mock_client()
@@ -260,6 +304,48 @@ class TestResearchWait:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=300,
+            json_output=True,
+        )
+
+    def test_wait_json_output_with_import_cited_only(self, runner, mock_auth, mock_fetch_tokens):
+        with (
+            patch_client_for_module("research") as mock_client_cls,
+            patch.object(
+                research_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "query": "AI research",
+                    "sources": [
+                        {"title": "Cited", "url": "https://example.com/cited"},
+                        {"title": "Uncited", "url": "https://example.com/uncited"},
+                    ],
+                    "report": "Report cites https://example.com/cited",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--json", "--import-all", "--cited-only"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["cited_only"] is True
+        assert data["cited_sources_selected"] == 1
+        assert data["cited_only_fallback"] is False
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
             max_elapsed=300,
             json_output=True,
         )

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -770,6 +770,65 @@ class TestSourceAddResearch:
             max_elapsed=1800,
         )
 
+    def test_add_research_with_import_all_cited_only(self, runner, mock_auth):
+        with (
+            patch_client_for_module("source") as mock_client_cls,
+            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "sources": [
+                        {"title": "Cited", "url": "https://example.com/cited"},
+                        {"title": "Uncited", "url": "https://example.com/uncited"},
+                    ],
+                    "report": "Report cites https://example.com/cited",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add-research",
+                        "AI papers",
+                        "--import-all",
+                        "--cited-only",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert "Imported 1 sources" in result.output
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
+            max_elapsed=1800,
+        )
+
+    def test_add_research_cited_only_requires_import_all(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            ["source", "add-research", "AI papers", "--cited-only", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 1
+        assert "--cited-only requires --import-all" in result.output
+
     def test_add_research_timeout_flag_threaded_to_import_with_retry(self, runner, mock_auth):
         with (
             patch_client_for_module("source") as mock_client_cls,

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -20,6 +20,7 @@ from notebooklm.types import (
 from .conftest import create_mock_client, patch_client_for_module
 
 source_module = importlib.import_module("notebooklm.cli.source")
+helpers_module = importlib.import_module("notebooklm.cli.helpers")
 
 
 @pytest.fixture
@@ -727,7 +728,9 @@ class TestSourceAddResearch:
     def test_add_research_with_import_all_uses_retry_helper(self, runner, mock_auth):
         with (
             patch_client_for_module("source") as mock_client_cls,
-            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
         ):
             mock_client = create_mock_client()
             mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
@@ -773,7 +776,9 @@ class TestSourceAddResearch:
     def test_add_research_with_import_all_cited_only(self, runner, mock_auth):
         with (
             patch_client_for_module("source") as mock_client_cls,
-            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
         ):
             mock_client = create_mock_client()
             mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
@@ -832,7 +837,9 @@ class TestSourceAddResearch:
     def test_add_research_timeout_flag_threaded_to_import_with_retry(self, runner, mock_auth):
         with (
             patch_client_for_module("source") as mock_client_cls,
-            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
         ):
             mock_client = create_mock_client()
             mock_client.research.start = AsyncMock(return_value={"task_id": "task_t1"})

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1666,6 +1666,8 @@ class TestIsAllowedCookieDomain:
 
         assert _is_allowed_cookie_domain(".google.com") is True
         assert _is_allowed_cookie_domain("notebooklm.google.com") is True
+        assert _is_allowed_cookie_domain("notebooklm.cloud.google.com") is True
+        assert _is_allowed_cookie_domain(".notebooklm.cloud.google.com") is True
         assert _is_allowed_cookie_domain(".googleusercontent.com") is True
         assert _is_allowed_cookie_domain(".accounts.google.com") is True
 
@@ -2031,7 +2033,9 @@ class TestAuthDomainPriority:
         [
             (".google.com", 4),
             (".notebooklm.google.com", 3),
+            (".notebooklm.cloud.google.com", 3),
             ("notebooklm.google.com", 2),
+            ("notebooklm.cloud.google.com", 2),
             (".google.de", 1),
             (".google.com.sg", 1),
             (".google.co.uk", 1),

--- a/tests/unit/test_chat_error_payload.py
+++ b/tests/unit/test_chat_error_payload.py
@@ -1,0 +1,26 @@
+"""Tests for chat error-payload parsing fallbacks."""
+
+import logging
+from unittest.mock import MagicMock
+
+from notebooklm._chat import ChatAPI
+
+
+class MalformedErrorPayload(list):
+    def __len__(self):
+        raise TypeError("malformed payload")
+
+
+def test_rate_limit_payload_parse_failure_logs_debug(caplog):
+    api = ChatAPI(core=MagicMock())
+
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
+        api._raise_if_rate_limited(MalformedErrorPayload())
+
+    records = [
+        record
+        for record in caplog.records
+        if "Could not parse chat error payload" in record.message
+    ]
+    assert records
+    assert records[0].exc_info is not None

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -1,0 +1,134 @@
+"""Tests for NotebookLM runtime endpoint configuration."""
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm._env import get_base_host, get_base_url
+from notebooklm._sources import SourcesAPI
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
+from notebooklm.rpc import RPCMethod, get_batchexecute_url, get_query_url, get_upload_url
+from notebooklm.types import ShareStatus
+
+
+def test_default_base_url_is_personal(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+
+    assert get_base_url() == "https://notebooklm.google.com"
+    assert get_base_host() == "notebooklm.google.com"
+
+
+def test_enterprise_base_url_via_env(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com/")
+
+    assert get_base_url() == "https://notebooklm.cloud.google.com"
+    assert get_base_host() == "notebooklm.cloud.google.com"
+
+
+def test_base_url_normalizes_mixed_case_and_whitespace(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "  https://NotebookLM.Cloud.Google.com/  ")
+
+    assert get_base_url() == "https://notebooklm.cloud.google.com"
+
+
+def test_empty_base_url_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "")
+
+    assert get_base_url() == "https://notebooklm.google.com"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://notebooklm.google.com",
+        "https://evil.example.com",
+        "https://notebooklm.google.com:443",
+        "https://user:notsecret@notebooklm.google.com",
+        "https://notebooklm.google.com/path",
+        "https://notebooklm.google.com?x=1",
+        "https://notebooklm.google.com/#fragment",
+    ],
+)
+def test_base_url_validation_rejects_unsafe_values(monkeypatch, value):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", value)
+
+    with pytest.raises(ValueError, match="NOTEBOOKLM_BASE_URL"):
+        get_base_url()
+
+
+def test_rpc_endpoint_helpers_are_lazy(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+    assert (
+        get_batchexecute_url()
+        == "https://notebooklm.cloud.google.com/_/LabsTailwindUi/data/batchexecute"
+    )
+    assert get_query_url().startswith("https://notebooklm.cloud.google.com/_/")
+    assert get_upload_url() == "https://notebooklm.cloud.google.com/upload/_/"
+
+
+def test_core_build_url_uses_enterprise_base_url(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+    core = ClientCore(AuthTokens(cookies={}, csrf_token="csrf", session_id="sid"))
+
+    url = core._build_url(RPCMethod.LIST_NOTEBOOKS)
+
+    assert url.startswith("https://notebooklm.cloud.google.com/_/LabsTailwindUi/data/")
+
+
+@pytest.mark.asyncio
+async def test_upload_start_uses_enterprise_url_and_headers(monkeypatch, httpx_mock):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+    auth = AuthTokens(cookies={"SID": "test"}, csrf_token="csrf", session_id="sid")
+    upload_url = "https://notebooklm.cloud.google.com/upload/_/?upload_id=test"
+    httpx_mock.add_response(
+        method="POST",
+        url="https://notebooklm.cloud.google.com/upload/_/?authuser=0",
+        headers={"x-goog-upload-url": upload_url},
+    )
+
+    core = ClientCore(auth)
+    await core.open()
+    try:
+        result = await SourcesAPI(core)._start_resumable_upload(
+            "nb_123",
+            "file.txt",
+            12,
+            "src_123",
+        )
+    finally:
+        await core.close()
+
+    request = httpx_mock.get_request()
+    assert result == upload_url
+    assert request is not None
+    assert str(request.url) == "https://notebooklm.cloud.google.com/upload/_/?authuser=0"
+    assert request.headers["origin"] == "https://notebooklm.cloud.google.com"
+    assert request.headers["referer"] == "https://notebooklm.cloud.google.com/"
+
+
+@pytest.mark.asyncio
+async def test_client_refresh_auth_uses_enterprise_base_url(monkeypatch, httpx_mock, tmp_path):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+    httpx_mock.add_response(
+        url="https://notebooklm.cloud.google.com/",
+        text='{"SNlM0e":"fresh_csrf","FdrFJe":"fresh_sid"}',
+    )
+    auth = AuthTokens(cookies={"SID": "test"}, csrf_token="old", session_id="old_sid")
+
+    async with NotebookLMClient(auth, storage_path=tmp_path / "storage.json") as client:
+        refreshed = await client.refresh_auth()
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert str(request.url) == "https://notebooklm.cloud.google.com/"
+    assert refreshed.csrf_token == "fresh_csrf"
+    assert refreshed.session_id == "fresh_sid"
+
+
+def test_share_status_uses_enterprise_base_url(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+    status = ShareStatus.from_api_response([[["owner@example.com"]], [True], 1000], "nb_123")
+
+    assert status.share_url == "https://notebooklm.cloud.google.com/notebook/nb_123"

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -1,6 +1,7 @@
 """Tests for research functionality."""
 
 import json
+import logging
 from urllib.parse import parse_qs
 
 import pytest
@@ -72,6 +73,88 @@ class TestBuildImportEntries:
         assert entry[10] == 2
         assert entry[0] is None
         assert entry[1] is None
+
+
+class TestCitedSourceSelection:
+    def test_extract_report_urls_normalizes_markdown_and_bare_urls(self):
+        urls = ResearchAPI.extract_report_urls(
+            "See [Example](https://Example.com/a/) and https://example.com/b."
+        )
+
+        assert urls == {"https://example.com/a", "https://example.com/b"}
+
+    def test_extract_report_urls_ignores_markdown_images(self):
+        urls = ResearchAPI.extract_report_urls(
+            "![chart](https://example.com/chart.png) cites [Article](https://example.com/a)"
+        )
+
+        assert urls == {"https://example.com/a"}
+
+    def test_select_cited_sources_filters_urls_and_preserves_report_entry(self):
+        sources = [
+            {
+                "title": "Deep Research Report",
+                "result_type": 5,
+                "report_markdown": "# Report",
+            },
+            {"title": "Cited", "url": "https://example.com/cited/"},
+            {"title": "Uncited", "url": "https://example.com/uncited"},
+            {"title": "No URL"},
+        ]
+
+        selection = ResearchAPI.select_cited_sources(
+            sources,
+            "Final report cites [the source](https://example.com/cited).",
+        )
+
+        assert selection.used_fallback is False
+        assert selection.cited_url_count == 1
+        assert selection.matched_url_source_count == 1
+        assert [source["title"] for source in selection.sources] == [
+            "Deep Research Report",
+            "Cited",
+        ]
+
+    def test_select_cited_sources_deduplicates_report_entries_with_urls(self):
+        report_source = {
+            "title": "Deep Research Report",
+            "result_type": 5,
+            "report_markdown": "# Report",
+            "url": "https://example.com/report",
+        }
+
+        selection = ResearchAPI.select_cited_sources(
+            [report_source],
+            "Final report cites https://example.com/report",
+        )
+
+        assert selection.used_fallback is True
+        assert selection.sources == [report_source]
+
+    def test_select_cited_sources_falls_back_when_no_urls_found(self, caplog):
+        sources = [{"title": "Source", "url": "https://example.com/source"}]
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm._research"):
+            selection = ResearchAPI.select_cited_sources(sources, "# Report without links")
+
+        assert selection.used_fallback is True
+        assert selection.sources == sources
+        assert "falling back" in caplog.text
+
+    def test_select_cited_sources_falls_back_when_no_sources_match(self, caplog):
+        sources = [{"title": "Source", "url": "https://example.com/source"}]
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm._research"):
+            selection = ResearchAPI.select_cited_sources(
+                sources,
+                "Report cites https://example.com/other",
+            )
+
+        assert selection.used_fallback is True
+        assert selection.cited_url_count == 1
+        assert selection.matched_url_source_count == 0
+        assert selection.sources == sources
+        assert "none of the report URLs matched" in caplog.text
 
 
 class TestExtractLegacyReportChunks:

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -85,7 +85,8 @@ class TestCitedSourceSelection:
 
     def test_extract_report_urls_ignores_markdown_images(self):
         urls = ResearchAPI.extract_report_urls(
-            "![chart](https://example.com/chart.png) cites [Article](https://example.com/a)"
+            "![chart](https://example.com/chart.png) and ![](https://example.com/empty.png) "
+            "cite [Article](https://example.com/a)"
         )
 
         assert urls == {"https://example.com/a"}

--- a/tests/unit/test_rpc_types.py
+++ b/tests/unit/test_rpc_types.py
@@ -8,6 +8,8 @@ from notebooklm.rpc.types import (
     RPCMethod,
     SourceStatus,
     artifact_status_to_str,
+    get_batchexecute_url,
+    get_query_url,
     source_status_to_str,
 )
 
@@ -22,6 +24,13 @@ class TestRPCConstants:
     def test_query_url(self):
         """Test query URL for streaming chat."""
         assert "GenerateFreeFormStreamed" in QUERY_URL
+
+    def test_endpoint_helpers_honor_env_after_import(self, monkeypatch):
+        """Test lazy endpoint helpers are not locked to import-time env."""
+        monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+        assert get_batchexecute_url().startswith("https://notebooklm.cloud.google.com/")
+        assert get_query_url().startswith("https://notebooklm.cloud.google.com/")
 
 
 class TestRPCMethod:

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -17,7 +17,8 @@ import pytest
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._chat import ChatAPI
 from notebooklm.auth import AuthTokens
-from notebooklm.rpc import InfographicStyle
+from notebooklm.exceptions import ValidationError
+from notebooklm.rpc import InfographicStyle, VideoFormat, VideoStyle
 
 
 @pytest.fixture
@@ -280,6 +281,75 @@ class TestArtifactsSourceSelection:
 
         assert source_ids_triple == [[["src_a"]], [["src_b"]]]
         assert source_ids_double == [["src_a"], ["src_b"]]
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_prompt_encoding(self, mock_core, mock_notes_api):
+        """Test custom video style prompt is encoded after the style code."""
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+        mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
+
+        await api.generate_video(
+            notebook_id="nb_123",
+            source_ids=["src_a"],
+            video_style=VideoStyle.CUSTOM,
+            style_prompt="Use hand-drawn diagrams",
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        video_config = params[2][8][2]
+        assert video_config[5] == VideoStyle.CUSTOM.value
+        assert video_config[6] == "Use hand-drawn diagrams"
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_requires_prompt(self, mock_core, mock_notes_api):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt is required"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.CUSTOM,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_rejects_empty_prompt(
+        self, mock_core, mock_notes_api
+    ):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt is required"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.CUSTOM,
+                style_prompt="",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_style_prompt_requires_custom_style(
+        self, mock_core, mock_notes_api
+    ):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt requires"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.ANIME,
+                style_prompt="Use hand-drawn diagrams",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_cinematic_rejects_style_prompt(self, mock_core, mock_notes_api):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="cinematic"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_format=VideoFormat.CINEMATIC,
+                style_prompt="Use hand-drawn diagrams",
+            )
 
     @pytest.mark.asyncio
     async def test_generate_report_source_encoding(self, mock_core, mock_notes_api):


### PR DESCRIPTION
## Summary
- Add `NOTEBOOKLM_BASE_URL` with a strict allowlist for `notebooklm.google.com` and `notebooklm.cloud.google.com`, and route runtime RPC/chat/upload/auth/share URLs through lazy helpers.
- Add cited-only research import filtering for `research wait --import-all --cited-only` and `source add-research --import-all --cited-only` with safe fallback to import-all.
- Add custom video style prompt plumbing and validation for `VideoStyle.CUSTOM` / `--style custom --style-prompt`.
- Replace the remaining silent chat error-payload parse fallback with debug logging.

## Reproduction
- Before fix, `NOTEBOOKLM_BASE_URL=https://notebooklm.cloud.google.com` still built personal-host RPC/upload URLs; after fix the lazy helpers and `_core._build_url()` build cloud-host URLs.
- Before fix, `notebooklm research wait --import-all --cited-only` failed with `No such option`; after fix the option is present and covered by CLI tests.
- Before fix, `notebooklm generate video --style custom` failed at Click choice validation; after fix `custom` is accepted when paired with `--style-prompt`.
- Before fix, malformed chat error payload parsing logged nothing; after fix it emits debug logs with `exc_info`.

## Test plan
- `uv run ruff check src/ tests/`
- `uv run mypy src/notebooklm`
- `uv run pytest tests/unit/test_env_base_url.py tests/unit/test_chat_error_payload.py tests/unit/test_research.py tests/unit/test_source_selection.py tests/unit/test_rpc_types.py tests/unit/cli/test_generate.py tests/unit/cli/test_research.py tests/unit/cli/test_source.py tests/unit/test_auth.py -q`
- `uv run pre-commit run --all-files`
- `uv run pytest -q` (`2442 passed, 9 skipped`; existing warnings only)

## Polish
- Native Codex review: fixed cited-source duplicate edge case, URL canonicalization, markdown image filtering, and explicit mypy narrowing.
- Claude review: raised the duplicate cited-source edge case and several hardening nits; addressed the actionable findings.
- Gemini review: no blocking issues found.

## Notes
- The custom video style prompt payload is covered by local request-shape tests. I could not run a fresh authenticated NotebookLM UI capture in this environment, so live endpoint verification is still recommended before release.

Closes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: support for custom visual-style prompts for video generation (--style custom + --style-prompt).
  * CLI: new --cited-only option to import only sources cited by a research report.
  * Runtime: NotebookLM endpoints are configurable via NOTEBOOKLM_BASE_URL; share links and upload/redirect behavior follow the configured base URL.

* **Bug Fixes**
  * Improved debug logging when chat error-payload parsing fails.

* **Tests**
  * Added unit tests for new CLI flags, cited-only flows, custom video styles, and endpoint configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/398)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->