### PR TITLE
feat(cli): support custom video styles

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -447,11 +447,12 @@ class ArtifactsAPI:
         """
         if language is None:
             language = get_default_language()
-        if video_format == VideoFormat.CINEMATIC and style_prompt:
+        normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
+        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
             raise ValidationError("style_prompt is not supported for cinematic videos")
-        if video_style == VideoStyle.CUSTOM and not style_prompt:
+        if video_style == VideoStyle.CUSTOM and not normalized_style_prompt:
             raise ValidationError("style_prompt is required when video_style is CUSTOM")
-        if style_prompt and video_style != VideoStyle.CUSTOM:
+        if normalized_style_prompt and video_style != VideoStyle.CUSTOM:
             raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
 
         if source_ids is None:
@@ -471,8 +472,8 @@ class ArtifactsAPI:
             format_code,
             style_code,
         ]
-        if style_prompt:
-            video_config.append(style_prompt)
+        if normalized_style_prompt:
+            video_config.append(normalized_style_prompt)
 
         params = [
             [2],

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -427,6 +427,7 @@ class ArtifactsAPI:
         instructions: str | None = None,
         video_format: VideoFormat | None = None,
         video_style: VideoStyle | None = None,
+        style_prompt: str | None = None,
     ) -> GenerationStatus:
         """Generate a Video Overview.
 
@@ -438,12 +439,21 @@ class ArtifactsAPI:
             instructions: Custom instructions for video generation.
             video_format: EXPLAINER or BRIEF.
             video_style: AUTO_SELECT, CLASSIC, WHITEBOARD, etc.
+            style_prompt: Custom visual style instructions. Requires
+                ``video_style=VideoStyle.CUSTOM``.
 
         Returns:
             GenerationStatus with task_id for polling.
         """
         if language is None:
             language = get_default_language()
+        if video_format == VideoFormat.CINEMATIC and style_prompt:
+            raise ValidationError("style_prompt is not supported for cinematic videos")
+        if video_style == VideoStyle.CUSTOM and not style_prompt:
+            raise ValidationError("style_prompt is required when video_style is CUSTOM")
+        if style_prompt and video_style != VideoStyle.CUSTOM:
+            raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
+
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
@@ -452,6 +462,17 @@ class ArtifactsAPI:
 
         format_code = video_format.value if video_format else None
         style_code = video_style.value if video_style else None
+
+        video_config = [
+            source_ids_double,
+            language,
+            instructions,
+            None,
+            format_code,
+            style_code,
+        ]
+        if style_prompt:
+            video_config.append(style_prompt)
 
         params = [
             [2],
@@ -468,14 +489,7 @@ class ArtifactsAPI:
                 [
                     None,
                     None,
-                    [
-                        source_ids_double,
-                        language,
-                        instructions,
-                        None,
-                        format_code,
-                        style_code,
-                    ],
+                    video_config,
                 ],
             ],
         ]

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -517,11 +517,12 @@ def generate_video(
         "paper-craft": VideoStyle.PAPER_CRAFT,
     }
     is_cinematic = video_format == "cinematic"
-    if is_cinematic and style_prompt:
+    normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
+    if is_cinematic and normalized_style_prompt:
         raise click.UsageError("--style-prompt cannot be used with cinematic video")
-    if not is_cinematic and style == "custom" and not style_prompt:
+    if not is_cinematic and style == "custom" and not normalized_style_prompt:
         raise click.UsageError("--style custom requires --style-prompt")
-    if not is_cinematic and style_prompt and style != "custom":
+    if not is_cinematic and normalized_style_prompt and style != "custom":
         raise click.UsageError("--style-prompt requires --style custom")
 
     async def _run():
@@ -544,7 +545,7 @@ def generate_video(
                     instructions=description or None,
                     video_format=format_map[video_format],
                     video_style=style_map[style],
-                    style_prompt=style_prompt,
+                    style_prompt=normalized_style_prompt,
                 )
 
             timeout = 1800.0 if is_cinematic else 600.0

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -491,6 +491,7 @@ def generate_video(
     Example:
       notebooklm generate video "a funny explainer for kids age 5"
       notebooklm generate video "professional presentation" --style classic
+      notebooklm generate video --style custom --style-prompt "hand-drawn diagrams"
       notebooklm generate video --format cinematic "documentary overview"
       notebooklm generate video -s src_001 "from specific source"
     """

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -441,6 +441,7 @@ def generate_audio(
     type=click.Choice(
         [
             "auto",
+            "custom",
             "classic",
             "whiteboard",
             "kawaii",
@@ -453,6 +454,7 @@ def generate_audio(
     ),
     default="auto",
 )
+@click.option("--style-prompt", default=None, help="Custom visual style prompt")
 @click.option(
     "--language",
     default=None,
@@ -469,6 +471,7 @@ def generate_video(
     notebook_id,
     video_format,
     style,
+    style_prompt,
     language,
     source_ids,
     wait,
@@ -503,6 +506,7 @@ def generate_video(
     }
     style_map = {
         "auto": VideoStyle.AUTO_SELECT,
+        "custom": VideoStyle.CUSTOM,
         "classic": VideoStyle.CLASSIC,
         "whiteboard": VideoStyle.WHITEBOARD,
         "kawaii": VideoStyle.KAWAII,
@@ -513,6 +517,12 @@ def generate_video(
         "paper-craft": VideoStyle.PAPER_CRAFT,
     }
     is_cinematic = video_format == "cinematic"
+    if is_cinematic and style_prompt:
+        raise click.UsageError("--style-prompt cannot be used with cinematic video")
+    if not is_cinematic and style == "custom" and not style_prompt:
+        raise click.UsageError("--style custom requires --style-prompt")
+    if not is_cinematic and style_prompt and style != "custom":
+        raise click.UsageError("--style-prompt requires --style custom")
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
@@ -534,6 +544,7 @@ def generate_video(
                     instructions=description or None,
                     video_format=format_map[video_format],
                     video_style=style_map[style],
+                    style_prompt=style_prompt,
                 )
 
             timeout = 1800.0 if is_cinematic else 600.0

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -169,6 +169,69 @@ class TestGenerateVideo:
 
             assert result.exit_code == 0
 
+    def test_generate_video_with_custom_style_prompt(self, runner, mock_auth):
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_video = AsyncMock(
+                return_value={"artifact_id": "video_123", "status": "processing"}
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "generate",
+                        "video",
+                        "--style",
+                        "custom",
+                        "--style-prompt",
+                        "Use hand-drawn diagrams",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+            assert result.exit_code == 0
+            mock_client.artifacts.generate_video.assert_awaited_once()
+            kwargs = mock_client.artifacts.generate_video.await_args.kwargs
+            assert kwargs["video_style"].name == "CUSTOM"
+            assert kwargs["style_prompt"] == "Use hand-drawn diagrams"
+
+    def test_generate_video_custom_style_requires_prompt(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            ["generate", "video", "--style", "custom", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 1
+        assert "--style custom requires --style-prompt" in result.output
+
+    def test_generate_video_style_prompt_requires_custom_style(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "video",
+                "--style",
+                "anime",
+                "--style-prompt",
+                "Use hand-drawn diagrams",
+                "-n",
+                "nb_123",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--style-prompt requires --style custom" in result.output
+
 
 # =============================================================================
 # GENERATE CINEMATIC VIDEO TESTS
@@ -238,6 +301,24 @@ class TestGenerateCinematicVideo:
             assert result.exit_code == 0
             # Should call generate_cinematic_video (not generate_video) despite --style
             mock_client.artifacts.generate_cinematic_video.assert_called_once()
+
+    def test_generate_cinematic_video_rejects_style_prompt(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "cinematic-video",
+                "--style-prompt",
+                "Use hand-drawn diagrams",
+                "-n",
+                "nb_123",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--style-prompt cannot be used with cinematic video" in result.output
 
 
 # =============================================================================

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -189,7 +189,7 @@ class TestGenerateVideo:
                         "--style",
                         "custom",
                         "--style-prompt",
-                        "Use hand-drawn diagrams",
+                        "  Use hand-drawn diagrams  ",
                         "-n",
                         "nb_123",
                     ],
@@ -207,6 +207,26 @@ class TestGenerateVideo:
         result = runner.invoke(
             cli,
             ["generate", "video", "--style", "custom", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 1
+        assert "--style custom requires --style-prompt" in result.output
+
+    def test_generate_video_custom_style_rejects_blank_prompt(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "generate",
+                "video",
+                "--style",
+                "custom",
+                "--style-prompt",
+                "   ",
+                "-n",
+                "nb_123",
+            ],
         )
 
         assert result.exit_code == 1

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -17,7 +17,8 @@ import pytest
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._chat import ChatAPI
 from notebooklm.auth import AuthTokens
-from notebooklm.rpc import InfographicStyle
+from notebooklm.exceptions import ValidationError
+from notebooklm.rpc import InfographicStyle, VideoFormat, VideoStyle
 
 
 @pytest.fixture
@@ -280,6 +281,75 @@ class TestArtifactsSourceSelection:
 
         assert source_ids_triple == [[["src_a"]], [["src_b"]]]
         assert source_ids_double == [["src_a"], ["src_b"]]
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_prompt_encoding(self, mock_core, mock_notes_api):
+        """Test custom video style prompt is encoded after the style code."""
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+        mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
+
+        await api.generate_video(
+            notebook_id="nb_123",
+            source_ids=["src_a"],
+            video_style=VideoStyle.CUSTOM,
+            style_prompt="Use hand-drawn diagrams",
+        )
+
+        params = mock_core.rpc_call.call_args.args[1]
+        video_config = params[2][8][2]
+        assert video_config[5] == VideoStyle.CUSTOM.value
+        assert video_config[6] == "Use hand-drawn diagrams"
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_requires_prompt(self, mock_core, mock_notes_api):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt is required"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.CUSTOM,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_rejects_empty_prompt(
+        self, mock_core, mock_notes_api
+    ):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt is required"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.CUSTOM,
+                style_prompt="",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_style_prompt_requires_custom_style(
+        self, mock_core, mock_notes_api
+    ):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt requires"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.ANIME,
+                style_prompt="Use hand-drawn diagrams",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_cinematic_rejects_style_prompt(self, mock_core, mock_notes_api):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="cinematic"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_format=VideoFormat.CINEMATIC,
+                style_prompt="Use hand-drawn diagrams",
+            )
 
     @pytest.mark.asyncio
     async def test_generate_report_source_encoding(self, mock_core, mock_notes_api):

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -292,7 +292,7 @@ class TestArtifactsSourceSelection:
             notebook_id="nb_123",
             source_ids=["src_a"],
             video_style=VideoStyle.CUSTOM,
-            style_prompt="Use hand-drawn diagrams",
+            style_prompt="  Use hand-drawn diagrams  ",
         )
 
         params = mock_core.rpc_call.call_args.args[1]
@@ -323,6 +323,20 @@ class TestArtifactsSourceSelection:
                 source_ids=["src_a"],
                 video_style=VideoStyle.CUSTOM,
                 style_prompt="",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_video_custom_style_rejects_blank_prompt(
+        self, mock_core, mock_notes_api
+    ):
+        api = ArtifactsAPI(mock_core, mock_notes_api)
+
+        with pytest.raises(ValidationError, match="style_prompt is required"):
+            await api.generate_video(
+                notebook_id="nb_123",
+                source_ids=["src_a"],
+                video_style=VideoStyle.CUSTOM,
+                style_prompt="   ",
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add custom video style prompt support to the artifacts API payload
- expose `generate video --style custom --style-prompt ...` in the CLI
- cover CLI validation and RPC payload encoding for custom video style prompts

Refs #389

Supersedes the item-8 slice of #398.

## Tests
- `uv run pytest tests/unit/cli/test_generate.py tests/unit/test_source_selection.py -q`
- `uv run ruff check src/ tests/`
- `uv run mypy src/notebooklm` *(fails: existing `src/notebooklm/_core.py:290` incompatible default for argument `p`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video generation supports custom visual styling via an optional style prompt; CLI adds a `--style-prompt` option and a `custom` style.

* **Validation**
  * Enforced: `--style-prompt` required when style is `custom`; disallowed for `cinematic` or any non-`custom` style; blank/whitespace prompts rejected and prompts are trimmed.

* **Tests**
  * Added unit tests for successful and failing style-prompt scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/399)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->