### PR TITLE
fix(chat): log malformed error payloads

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -617,7 +617,10 @@ class ChatAPI:
         except ChatError:
             raise
         except Exception:
-            pass  # Ignore parse failures; let normal empty-answer handling proceed
+            logger.debug(
+                "Could not parse chat error payload; continuing with empty-answer handling",
+                exc_info=True,
+            )
 
     def _parse_citations(self, first: list) -> list[ChatReference]:
         """Parse citation details from response structure.

--- a/tests/unit/test_chat_error_payload.py
+++ b/tests/unit/test_chat_error_payload.py
@@ -1,0 +1,26 @@
+"""Tests for chat error-payload parsing fallbacks."""
+
+import logging
+from unittest.mock import MagicMock
+
+from notebooklm._chat import ChatAPI
+
+
+class MalformedErrorPayload(list):
+    def __len__(self):
+        raise TypeError("malformed payload")
+
+
+def test_rate_limit_payload_parse_failure_logs_debug(caplog):
+    api = ChatAPI(core=MagicMock())
+
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
+        api._raise_if_rate_limited(MalformedErrorPayload())
+
+    records = [
+        record
+        for record in caplog.records
+        if "Could not parse chat error payload" in record.message
+    ]
+    assert records
+    assert records[0].exc_info is not None


### PR DESCRIPTION
## Summary
- log DEBUG details when chat error-payload parsing fails instead of swallowing the exception silently
- add regression coverage for malformed rate-limit/error payloads

## Test plan
- `uv run pytest tests/unit/test_chat_error_payload.py -q`
- `uv run ruff check src/ tests/`
- `uv run pre-commit run --all-files`
- `uv run mypy src/notebooklm` attempted; fails on existing main baseline issue at `src/notebooklm/_core.py:290`

Refs #389.
Supersedes the item-9 slice of #398.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and debugging information when rate limit scenarios occur.

* **Tests**
  * Added unit test coverage for error payload parsing fallbacks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/400)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->