### PR TITLE
feat(cli): import cited research sources

### DIFF
--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -24,7 +24,7 @@ _RESEARCH_RESULT_TYPE_ALIASES = {
 
 _URL_RE = r"https?://(?:[^\s<>\]\(\)\"']+|\([^\s<>\]\(\)\"']*\))+"
 _URL_PATTERN = re.compile(_URL_RE)
-_MARKDOWN_IMAGE_PATTERN = re.compile(rf"!\[[^\]]*\]\(({_URL_RE})\)")
+_MARKDOWN_IMAGE_PATTERN = re.compile(rf"!\[[^\]]*\]\(({_URL_RE})(?:\s+[^\)]*)?\)")
 _MARKDOWN_LINK_PATTERN = re.compile(rf"(?<!!)\[[^\]]+\]\(({_URL_RE})\)")
 _TRAILING_URL_PUNCTUATION = ".,;:!?"
 

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -120,6 +120,8 @@ class ResearchAPI:
         if not report:
             return set()
 
+        # Collect URL-like references from both markdown links and bare text,
+        # then subtract markdown images because embedded assets are not citations.
         urls = {
             cls._normalize_url(match.group(1)) for match in _MARKDOWN_LINK_PATTERN.finditer(report)
         }

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -5,7 +5,10 @@ and importing discovered sources into notebooks.
 """
 
 import logging
+import re
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from ._core import ClientCore
 from .exceptions import ValidationError
@@ -18,6 +21,21 @@ _RESEARCH_RESULT_TYPE_ALIASES = {
     "drive": 2,
     "report": 5,
 }
+
+_URL_PATTERN = re.compile(r"https?://[^\s<>\]\)\"']+")
+_MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\((https?://[^\s\)]+)")
+_MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+\]\((https?://[^\s\)]+)")
+_TRAILING_URL_PUNCTUATION = ".,;:!?"
+
+
+@dataclass(frozen=True)
+class CitedSourceSelection:
+    """Result of applying cited-only filtering to research sources."""
+
+    sources: list[dict[str, Any]]
+    cited_url_count: int
+    matched_url_source_count: int
+    used_fallback: bool = False
 
 
 class ResearchAPI:
@@ -80,6 +98,93 @@ class ResearchAPI:
             return ""
         chunks = [chunk for chunk in src[6] if isinstance(chunk, str) and chunk]
         return "\n\n".join(chunks)
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        """Normalize source/report URLs for citation matching."""
+        parsed = urlsplit(url.rstrip(_TRAILING_URL_PUNCTUATION))
+        return urlunsplit(
+            (
+                parsed.scheme.lower(),
+                parsed.netloc.lower(),
+                parsed.path.rstrip("/"),
+                parsed.query,
+                parsed.fragment,
+            )
+        )
+
+    @classmethod
+    def extract_report_urls(cls, report: str) -> set[str]:
+        """Extract normalized URLs from research report markdown/text."""
+        if not report:
+            return set()
+
+        urls = {
+            cls._normalize_url(match.group(1)) for match in _MARKDOWN_LINK_PATTERN.finditer(report)
+        }
+        urls.update(cls._normalize_url(match.group(0)) for match in _URL_PATTERN.finditer(report))
+        image_urls = {
+            cls._normalize_url(match.group(1)) for match in _MARKDOWN_IMAGE_PATTERN.finditer(report)
+        }
+        urls.difference_update(image_urls)
+        return {url for url in urls if url.startswith(("http://", "https://"))}
+
+    @classmethod
+    def select_cited_sources(
+        cls,
+        sources: list[dict[str, Any]],
+        report: str,
+    ) -> CitedSourceSelection:
+        """Return research sources cited by the completed report.
+
+        Report entries are preserved so deep-research import still brings in the
+        generated report itself. If no cited URL subset can be resolved, falls
+        back to the original source list to avoid an empty import surprise.
+        """
+        cited_urls = cls.extract_report_urls(report)
+        if not cited_urls:
+            logger.warning(
+                "Cited-only research import requested, but no cited URLs were found; "
+                "falling back to all importable research sources"
+            )
+            return CitedSourceSelection(
+                sources=sources,
+                cited_url_count=0,
+                matched_url_source_count=0,
+                used_fallback=True,
+            )
+
+        report_sources = [
+            source
+            for source in sources
+            if source.get("result_type") == 5 and source.get("report_markdown")
+        ]
+        report_source_ids = {id(source) for source in report_sources}
+        matched_url_sources = [
+            source
+            for source in sources
+            if id(source) not in report_source_ids
+            and isinstance(source.get("url"), str)
+            and cls._normalize_url(source["url"]) in cited_urls
+        ]
+
+        if not matched_url_sources:
+            logger.warning(
+                "Cited-only research import requested, but none of the report URLs "
+                "matched research sources; falling back to all importable research sources"
+            )
+            return CitedSourceSelection(
+                sources=sources,
+                cited_url_count=len(cited_urls),
+                matched_url_source_count=0,
+                used_fallback=True,
+            )
+
+        return CitedSourceSelection(
+            sources=[*report_sources, *matched_url_sources],
+            cited_url_count=len(cited_urls),
+            matched_url_source_count=len(matched_url_sources),
+        )
 
     async def start(
         self,

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -160,7 +160,8 @@ class ResearchAPI:
         report_sources = [
             source
             for source in sources
-            if source.get("result_type") == 5 and source.get("report_markdown")
+            if source.get("result_type") == _RESEARCH_RESULT_TYPE_ALIASES["report"]
+            and source.get("report_markdown")
         ]
         report_source_ids = {id(source) for source in report_sources}
         matched_url_sources = [

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -22,9 +22,10 @@ _RESEARCH_RESULT_TYPE_ALIASES = {
     "report": 5,
 }
 
-_URL_PATTERN = re.compile(r"https?://[^\s<>\]\)\"']+")
-_MARKDOWN_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\((https?://[^\s\)]+)")
-_MARKDOWN_LINK_PATTERN = re.compile(r"(?<!!)\[[^\]]+\]\((https?://[^\s\)]+)")
+_URL_RE = r"https?://(?:[^\s<>\]\(\)\"']+|\([^\s<>\]\(\)\"']*\))+"
+_URL_PATTERN = re.compile(_URL_RE)
+_MARKDOWN_IMAGE_PATTERN = re.compile(rf"!\[[^\]]*\]\(({_URL_RE})\)")
+_MARKDOWN_LINK_PATTERN = re.compile(rf"(?<!!)\[[^\]]+\]\(({_URL_RE})\)")
 _TRAILING_URL_PUNCTUATION = ".,;:!?"
 
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import time
+from dataclasses import dataclass
 from functools import wraps
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit, urlunsplit
@@ -22,6 +23,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from .._research import CitedSourceSelection, ResearchAPI
 from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
 from ..exceptions import NetworkError, NotebookLimitError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
@@ -38,6 +40,15 @@ logger = logging.getLogger(__name__)
 _CLI_ARTIFACT_ALIASES = {
     "flashcard": "flashcards",  # CLI uses singular, enum uses plural
 }
+
+
+@dataclass(frozen=True)
+class ResearchImportResult:
+    """Result of importing research sources from CLI commands."""
+
+    imported: list[dict[str, str]]
+    sources: list[dict]
+    cited_selection: CitedSourceSelection | None = None
 
 
 def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
@@ -323,6 +334,82 @@ async def import_with_retry(
             await asyncio.sleep(sleep_for)
             delay = min(delay * backoff_factor, max_delay)
             attempt += 1
+
+
+def _select_research_sources_for_import(
+    sources: list[dict], report: str, cited_only: bool
+) -> tuple[list[dict], CitedSourceSelection | None]:
+    if not cited_only or not sources:
+        return sources, None
+
+    cited_selection = ResearchAPI.select_cited_sources(sources, report)
+    return cited_selection.sources, cited_selection
+
+
+def _display_cited_import_selection(cited_selection: CitedSourceSelection | None) -> None:
+    if cited_selection is None:
+        return
+
+    if cited_selection.used_fallback:
+        console.print("[yellow]Could not resolve cited sources; importing all sources.[/yellow]")
+        return
+
+    console.print(
+        f"[dim]Importing {cited_selection.matched_url_source_count} cited source(s)[/dim]"
+    )
+
+
+async def import_research_sources(
+    client,
+    notebook_id: str,
+    task_id: str,
+    sources: list[dict],
+    *,
+    report: str = "",
+    cited_only: bool = False,
+    max_elapsed: float = 1800,
+    json_output: bool = False,
+    status_message: str | None = None,
+) -> ResearchImportResult:
+    """Select and import research sources using shared CLI policy."""
+    sources_to_import, cited_selection = _select_research_sources_for_import(
+        sources, report, cited_only
+    )
+    if not sources_to_import:
+        return ResearchImportResult([], sources_to_import, cited_selection)
+
+    if not json_output:
+        _display_cited_import_selection(cited_selection)
+
+    if status_message and not json_output:
+        with console.status(status_message):
+            imported = await import_with_retry(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                max_elapsed=max_elapsed,
+            )
+    else:
+        if json_output:
+            imported = await import_with_retry(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                max_elapsed=max_elapsed,
+                json_output=True,
+            )
+        else:
+            imported = await import_with_retry(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                max_elapsed=max_elapsed,
+            )
+
+    return ResearchImportResult(imported, sources_to_import, cited_selection)
 
 
 # =============================================================================

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -16,7 +16,7 @@ import os
 import time
 from dataclasses import dataclass
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
 import click
@@ -381,33 +381,24 @@ async def import_research_sources(
     if not json_output:
         _display_cited_import_selection(cited_selection)
 
+    retry_kwargs: dict[str, Any] = {"max_elapsed": max_elapsed}
+    if json_output:
+        retry_kwargs["json_output"] = True
+
+    async def _import_selected() -> list[dict[str, str]]:
+        return await import_with_retry(
+            client,
+            notebook_id,
+            task_id,
+            sources_to_import,
+            **retry_kwargs,
+        )
+
     if status_message and not json_output:
         with console.status(status_message):
-            imported = await import_with_retry(
-                client,
-                notebook_id,
-                task_id,
-                sources_to_import,
-                max_elapsed=max_elapsed,
-            )
+            imported = await _import_selected()
     else:
-        if json_output:
-            imported = await import_with_retry(
-                client,
-                notebook_id,
-                task_id,
-                sources_to_import,
-                max_elapsed=max_elapsed,
-                json_output=True,
-            )
-        else:
-            imported = await import_with_retry(
-                client,
-                notebook_id,
-                task_id,
-                sources_to_import,
-                max_elapsed=max_elapsed,
-            )
+        imported = await _import_selected()
 
     return ResearchImportResult(imported, sources_to_import, cited_selection)
 

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -14,7 +14,7 @@ from .helpers import (
     console,
     display_report,
     display_research_sources,
-    import_with_retry,
+    import_research_sources,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
@@ -123,9 +123,12 @@ def research_status(ctx, notebook_id, json_output, client_auth):
     help="Seconds between status checks (default: 5)",
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources when done")
+@click.option("--cited-only", is_flag=True, help="With --import-all, import only cited sources")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
-def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, client_auth):
+def research_wait(
+    ctx, notebook_id, timeout, interval, import_all, cited_only, json_output, client_auth
+):
     """Wait for research to complete.
 
     Blocks until research is completed or timeout is reached.
@@ -135,8 +138,12 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
     Examples:
       notebooklm research wait
       notebooklm research wait --timeout 600 --import-all
+      notebooklm research wait --import-all --cited-only
       notebooklm research wait --json
     """
+    if cited_only and not import_all:
+        raise click.UsageError("--cited-only requires --import-all")
+
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -188,16 +195,22 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
                     "report": report,
                 }
                 if import_all and sources and task_id:
-                    imported = await import_with_retry(
+                    import_result = await import_research_sources(
                         client,
                         nb_id_resolved,
                         task_id,
                         sources,
+                        report=report,
+                        cited_only=cited_only,
                         max_elapsed=timeout,
                         json_output=True,
                     )
-                    result["imported"] = len(imported)
-                    result["imported_sources"] = imported
+                    if import_result.cited_selection is not None:
+                        result["cited_only"] = True
+                        result["cited_sources_selected"] = len(import_result.sources)
+                        result["cited_only_fallback"] = import_result.cited_selection.used_fallback
+                    result["imported"] = len(import_result.imported)
+                    result["imported_sources"] = import_result.imported
                 json_output_response(result)
             else:
                 console.print(f"[green]✓ Research completed:[/green] {query}")
@@ -206,14 +219,16 @@ def research_wait(ctx, notebook_id, timeout, interval, import_all, json_output, 
                 display_report(report)
 
                 if import_all and sources and task_id:
-                    with console.status("Importing sources..."):
-                        imported = await import_with_retry(
-                            client,
-                            nb_id_resolved,
-                            task_id,
-                            sources,
-                            max_elapsed=timeout,
-                        )
-                    console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    import_result = await import_research_sources(
+                        client,
+                        nb_id_resolved,
+                        task_id,
+                        sources,
+                        report=report,
+                        cited_only=cited_only,
+                        max_elapsed=timeout,
+                        status_message="Importing sources...",
+                    )
+                    console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
 
     return _run()

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -30,7 +30,7 @@ from .helpers import (
     display_report,
     display_research_sources,
     get_source_type_display,
-    import_with_retry,
+    import_research_sources,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
@@ -557,6 +557,7 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
     help="Search mode (default: fast)",
 )
 @click.option("--import-all", is_flag=True, help="Import all found sources")
+@click.option("--cited-only", is_flag=True, help="With --import-all, import only cited sources")
 @click.option(
     "--no-wait",
     is_flag=True,
@@ -574,7 +575,16 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
 )
 @with_client
 def source_add_research(
-    ctx, query, notebook_id, search_source, mode, import_all, no_wait, timeout, client_auth
+    ctx,
+    query,
+    notebook_id,
+    search_source,
+    mode,
+    import_all,
+    cited_only,
+    no_wait,
+    timeout,
+    client_auth,
 ):
     """Search web or drive and add sources from results.
 
@@ -584,8 +594,12 @@ def source_add_research(
       source add-research "project docs" --from drive     # Search Google Drive
       source add-research "AI papers" --mode deep         # Deep search
       source add-research "tutorials" --import-all        # Auto-import all results
+      source add-research "topic" --import-all --cited-only
       source add-research "topic" --mode deep --no-wait   # Non-blocking deep search
     """
+    if cited_only and not import_all:
+        raise click.UsageError("--cited-only requires --import-all")
+
     nb_id = require_notebook(notebook_id)
 
     async def _run():
@@ -628,14 +642,16 @@ def source_add_research(
                 display_report(status.get("report", ""), json_hint=False)
 
                 if import_all and sources and task_id:
-                    imported = await import_with_retry(
+                    import_result = await import_research_sources(
                         client,
                         nb_id_resolved,
                         task_id,
                         sources,
+                        report=status.get("report", ""),
+                        cited_only=cited_only,
                         max_elapsed=timeout,
                     )
-                    console.print(f"[green]Imported {len(imported)} sources[/green]")
+                    console.print(f"[green]Imported {len(import_result.imported)} sources[/green]")
             else:
                 console.print(f"[yellow]Status: {status.get('status', 'unknown')}[/yellow]")
 

--- a/tests/unit/cli/test_research.py
+++ b/tests/unit/cli/test_research.py
@@ -9,6 +9,7 @@ from notebooklm.notebooklm_cli import cli
 from .conftest import create_mock_client, patch_client_for_module
 
 research_module = importlib.import_module("notebooklm.cli.research")
+helpers_module = importlib.import_module("notebooklm.cli.helpers")
 
 # =============================================================================
 # RESEARCH STATUS TESTS
@@ -178,7 +179,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                research_module, "import_with_retry", new_callable=AsyncMock
+                helpers_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -204,6 +205,50 @@ class TestResearchWait:
             [{"title": "Source 1", "url": "http://example.com"}],
             max_elapsed=300,
         )
+
+    def test_wait_with_import_all_cited_only(self, runner, mock_auth, mock_fetch_tokens):
+        with (
+            patch_client_for_module("research") as mock_client_cls,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "query": "AI research",
+                    "sources": [
+                        {"title": "Cited", "url": "https://example.com/cited"},
+                        {"title": "Uncited", "url": "https://example.com/uncited"},
+                    ],
+                    "report": "Report cites https://example.com/cited",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--import-all", "--cited-only"],
+            )
+
+        assert result.exit_code == 0
+        assert "Imported 1 sources" in result.output
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
+            max_elapsed=300,
+        )
+
+    def test_wait_cited_only_requires_import_all(self, runner, mock_auth, mock_fetch_tokens):
+        result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--cited-only"])
+
+        assert result.exit_code == 1
+        assert "--cited-only requires --import-all" in result.output
 
     def test_wait_json_output_completed(self, runner, mock_auth, mock_fetch_tokens):
         with patch_client_for_module("research") as mock_client_cls:
@@ -231,7 +276,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                research_module, "import_with_retry", new_callable=AsyncMock
+                helpers_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -260,6 +305,48 @@ class TestResearchWait:
             "nb_123",
             "task_123",
             [{"title": "Source 1", "url": "http://example.com"}],
+            max_elapsed=300,
+            json_output=True,
+        )
+
+    def test_wait_json_output_with_import_cited_only(self, runner, mock_auth, mock_fetch_tokens):
+        with (
+            patch_client_for_module("research") as mock_client_cls,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "query": "AI research",
+                    "sources": [
+                        {"title": "Cited", "url": "https://example.com/cited"},
+                        {"title": "Uncited", "url": "https://example.com/uncited"},
+                    ],
+                    "report": "Report cites https://example.com/cited",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                ["research", "wait", "-n", "nb_123", "--json", "--import-all", "--cited-only"],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["cited_only"] is True
+        assert data["cited_sources_selected"] == 1
+        assert data["cited_only_fallback"] is False
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
             max_elapsed=300,
             json_output=True,
         )

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -20,6 +20,7 @@ from notebooklm.types import (
 from .conftest import create_mock_client, patch_client_for_module
 
 source_module = importlib.import_module("notebooklm.cli.source")
+helpers_module = importlib.import_module("notebooklm.cli.helpers")
 
 
 @pytest.fixture
@@ -727,7 +728,9 @@ class TestSourceAddResearch:
     def test_add_research_with_import_all_uses_retry_helper(self, runner, mock_auth):
         with (
             patch_client_for_module("source") as mock_client_cls,
-            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
         ):
             mock_client = create_mock_client()
             mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
@@ -770,10 +773,73 @@ class TestSourceAddResearch:
             max_elapsed=1800,
         )
 
+    def test_add_research_with_import_all_cited_only(self, runner, mock_auth):
+        with (
+            patch_client_for_module("source") as mock_client_cls,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
+        ):
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_123"})
+            mock_client.research.poll = AsyncMock(
+                return_value={
+                    "status": "completed",
+                    "task_id": "task_123",
+                    "sources": [
+                        {"title": "Cited", "url": "https://example.com/cited"},
+                        {"title": "Uncited", "url": "https://example.com/uncited"},
+                    ],
+                    "report": "Report cites https://example.com/cited",
+                }
+            )
+            mock_import.return_value = [{"id": "src_1", "title": "Cited"}]
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    [
+                        "source",
+                        "add-research",
+                        "AI papers",
+                        "--import-all",
+                        "--cited-only",
+                        "-n",
+                        "nb_123",
+                    ],
+                )
+
+        assert result.exit_code == 0
+        assert "Imported 1 sources" in result.output
+        mock_import.assert_awaited_once_with(
+            mock_client,
+            "nb_123",
+            "task_123",
+            [{"title": "Cited", "url": "https://example.com/cited"}],
+            max_elapsed=1800,
+        )
+
+    def test_add_research_cited_only_requires_import_all(
+        self, runner, mock_auth, mock_fetch_tokens
+    ):
+        result = runner.invoke(
+            cli,
+            ["source", "add-research", "AI papers", "--cited-only", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 1
+        assert "--cited-only requires --import-all" in result.output
+
     def test_add_research_timeout_flag_threaded_to_import_with_retry(self, runner, mock_auth):
         with (
             patch_client_for_module("source") as mock_client_cls,
-            patch.object(source_module, "import_with_retry", new_callable=AsyncMock) as mock_import,
+            patch.object(
+                helpers_module, "import_with_retry", new_callable=AsyncMock
+            ) as mock_import,
         ):
             mock_client = create_mock_client()
             mock_client.research.start = AsyncMock(return_value={"task_id": "task_t1"})

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -83,9 +83,21 @@ class TestCitedSourceSelection:
 
         assert urls == {"https://example.com/a", "https://example.com/b"}
 
+    def test_extract_report_urls_keeps_balanced_parentheses(self):
+        urls = ResearchAPI.extract_report_urls(
+            "See [Function](https://en.wikipedia.org/wiki/Function_(mathematics)) "
+            "and https://example.com/Topic_(research)."
+        )
+
+        assert urls == {
+            "https://en.wikipedia.org/wiki/Function_(mathematics)",
+            "https://example.com/Topic_(research)",
+        }
+
     def test_extract_report_urls_ignores_markdown_images(self):
         urls = ResearchAPI.extract_report_urls(
-            "![chart](https://example.com/chart.png) and ![](https://example.com/empty.png) "
+            "![chart](https://example.com/chart_(v2).png) and "
+            "![](https://example.com/empty.png) "
             "cite [Article](https://example.com/a)"
         )
 

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -1,6 +1,7 @@
 """Tests for research functionality."""
 
 import json
+import logging
 from urllib.parse import parse_qs
 
 import pytest
@@ -72,6 +73,89 @@ class TestBuildImportEntries:
         assert entry[10] == 2
         assert entry[0] is None
         assert entry[1] is None
+
+
+class TestCitedSourceSelection:
+    def test_extract_report_urls_normalizes_markdown_and_bare_urls(self):
+        urls = ResearchAPI.extract_report_urls(
+            "See [Example](https://Example.com/a/) and https://example.com/b."
+        )
+
+        assert urls == {"https://example.com/a", "https://example.com/b"}
+
+    def test_extract_report_urls_ignores_markdown_images(self):
+        urls = ResearchAPI.extract_report_urls(
+            "![chart](https://example.com/chart.png) and ![](https://example.com/empty.png) "
+            "cite [Article](https://example.com/a)"
+        )
+
+        assert urls == {"https://example.com/a"}
+
+    def test_select_cited_sources_filters_urls_and_preserves_report_entry(self):
+        sources = [
+            {
+                "title": "Deep Research Report",
+                "result_type": 5,
+                "report_markdown": "# Report",
+            },
+            {"title": "Cited", "url": "https://example.com/cited/"},
+            {"title": "Uncited", "url": "https://example.com/uncited"},
+            {"title": "No URL"},
+        ]
+
+        selection = ResearchAPI.select_cited_sources(
+            sources,
+            "Final report cites [the source](https://example.com/cited).",
+        )
+
+        assert selection.used_fallback is False
+        assert selection.cited_url_count == 1
+        assert selection.matched_url_source_count == 1
+        assert [source["title"] for source in selection.sources] == [
+            "Deep Research Report",
+            "Cited",
+        ]
+
+    def test_select_cited_sources_deduplicates_report_entries_with_urls(self):
+        report_source = {
+            "title": "Deep Research Report",
+            "result_type": 5,
+            "report_markdown": "# Report",
+            "url": "https://example.com/report",
+        }
+
+        selection = ResearchAPI.select_cited_sources(
+            [report_source],
+            "Final report cites https://example.com/report",
+        )
+
+        assert selection.used_fallback is True
+        assert selection.sources == [report_source]
+
+    def test_select_cited_sources_falls_back_when_no_urls_found(self, caplog):
+        sources = [{"title": "Source", "url": "https://example.com/source"}]
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm._research"):
+            selection = ResearchAPI.select_cited_sources(sources, "# Report without links")
+
+        assert selection.used_fallback is True
+        assert selection.sources == sources
+        assert "falling back" in caplog.text
+
+    def test_select_cited_sources_falls_back_when_no_sources_match(self, caplog):
+        sources = [{"title": "Source", "url": "https://example.com/source"}]
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm._research"):
+            selection = ResearchAPI.select_cited_sources(
+                sources,
+                "Report cites https://example.com/other",
+            )
+
+        assert selection.used_fallback is True
+        assert selection.cited_url_count == 1
+        assert selection.matched_url_source_count == 0
+        assert selection.sources == sources
+        assert "none of the report URLs matched" in caplog.text
 
 
 class TestExtractLegacyReportChunks:

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -97,6 +97,7 @@ class TestCitedSourceSelection:
     def test_extract_report_urls_ignores_markdown_images(self):
         urls = ResearchAPI.extract_report_urls(
             "![chart](https://example.com/chart_(v2).png) and "
+            '![titled](https://example.com/titled.png "Chart title") '
             "![](https://example.com/empty.png) "
             "cite [Article](https://example.com/a)"
         )


### PR DESCRIPTION
## Summary
- add cited-only research source selection based on URLs cited in the completed report
- expose `--cited-only` for `research wait --import-all` and `source add-research --import-all`
- share CLI research import handling and cover empty-alt markdown image URL extraction

Refs #389

Supersedes the item-7 slice of #398.

## Tests
- `uv run pytest tests/unit/test_research.py tests/unit/cli/test_research.py tests/unit/cli/test_source.py -q`
- `uv run ruff check src/ tests/`
- `uv run mypy src/notebooklm` *(fails on existing `src/notebooklm/_core.py:290` Path default type mismatch outside this slice)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --cited-only option for research import (requires --import-all); imports only sources cited in a report and preserves report entries.
  * JSON output includes cited-selection metadata; non-JSON mode prints cited counts and fallback notices.
  * Improved URL extraction and normalization for matching cited links; markdown image links are ignored.

* **Tests**
  * Added unit tests for URL extraction, cited-source selection, deduplication, fallback behavior, and CLI flag validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/401)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->