### PR TITLE
feat(client): support enterprise base url

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -16,7 +16,7 @@ import httpx
 
 from ._core import ClientCore
 from .exceptions import ChatError, NetworkError, ValidationError
-from .rpc import QUERY_URL, RPCMethod
+from .rpc import RPCMethod, get_query_url
 from .types import AskResult, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class ChatAPI:
             url_params["f.sid"] = self._core.auth.session_id
 
         query_string = urlencode(url_params)
-        url = f"{QUERY_URL}?{query_string}"
+        url = f"{get_query_url()}?{query_string}"
 
         http_client = self._core.get_http_client()
         try:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -24,7 +24,6 @@ from .auth import (
     snapshot_cookie_jar,
 )
 from .rpc import (
-    BATCHEXECUTE_URL,
     AuthError,
     ClientError,
     NetworkError,
@@ -36,6 +35,7 @@ from .rpc import (
     build_request_body,
     decode_response,
     encode_rpc_request,
+    get_batchexecute_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -278,6 +278,7 @@ class ClientCore:
         effective_path = path if path is not None else self._keepalive_storage_path
         if effective_path is None:
             return
+        save_path: Path = effective_path
 
         jar_copy = httpx.Cookies(jar)
         # Computed on the loop thread off ``jar_copy`` so the worker can refresh
@@ -287,7 +288,7 @@ class ClientCore:
 
         def _save(
             s: httpx.Cookies = jar_copy,
-            p: Path = effective_path,
+            p: Path = save_path,
             lock: threading.Lock = self._save_lock,
             post: CookieSnapshot = post_save_snapshot,
             client: ClientCore = self,
@@ -453,7 +454,7 @@ class ClientCore:
             "f.sid": self.auth.session_id,
             "rt": "c",
         }
-        return f"{BATCHEXECUTE_URL}?{urlencode(params)}"
+        return f"{get_batchexecute_url()}?{urlencode(params)}"
 
     async def rpc_call(
         self,

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -31,6 +31,7 @@ def get_base_url() -> str:
     host = parsed.hostname
     if (
         parsed.scheme != "https"
+        or host is None
         or host not in _ALLOWED_BASE_HOSTS
         or port is not None
         or parsed.username is not None

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -1,0 +1,50 @@
+"""Runtime environment helpers for NotebookLM endpoints."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+DEFAULT_BASE_URL = "https://notebooklm.google.com"
+PERSONAL_BASE_HOST = "notebooklm.google.com"
+ENTERPRISE_BASE_HOST = "notebooklm.cloud.google.com"
+
+_ALLOWED_BASE_HOSTS = frozenset({PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST})
+
+
+def get_base_url() -> str:
+    """Return the configured NotebookLM base URL.
+
+    ``NOTEBOOKLM_BASE_URL`` is constrained to known Google-owned NotebookLM hosts
+    because the value is used for authenticated requests.
+    """
+    configured = os.environ.get("NOTEBOOKLM_BASE_URL")
+    raw = (configured.strip() if configured is not None else DEFAULT_BASE_URL).rstrip("/")
+    if not raw:
+        raw = DEFAULT_BASE_URL
+    parsed = urlparse(raw)
+    path = parsed.path.rstrip("/")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("NOTEBOOKLM_BASE_URL has an invalid port") from exc
+    host = parsed.hostname
+    if (
+        parsed.scheme != "https"
+        or host not in _ALLOWED_BASE_HOSTS
+        or port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or path
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+    ):
+        allowed = ", ".join(sorted(_ALLOWED_BASE_HOSTS))
+        raise ValueError(f"NOTEBOOKLM_BASE_URL must use https and one of: {allowed}")
+    return f"https://{host}"
+
+
+def get_base_host() -> str:
+    """Return the configured NotebookLM host."""
+    return urlparse(get_base_url()).hostname or PERSONAL_BASE_HOST

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from ._core import ClientCore
+from ._env import get_base_url
 from ._settings import build_get_user_settings_params, extract_account_limits
 from .exceptions import NotebookLimitError, RPCError
 from .rpc import RPCMethod
@@ -343,7 +344,7 @@ class NotebooksAPI:
         )
 
         # Build share URL
-        base_url = f"https://notebooklm.google.com/notebook/{notebook_id}"
+        base_url = f"{get_base_url()}/notebook/{notebook_id}"
         if public and artifact_id:
             url = f"{base_url}?artifactId={artifact_id}"
         elif public:
@@ -370,7 +371,7 @@ class NotebooksAPI:
         Returns:
             The share URL string.
         """
-        base_url = f"https://notebooklm.google.com/notebook/{notebook_id}"
+        base_url = f"{get_base_url()}/notebook/{notebook_id}"
         if artifact_id:
             return f"{base_url}?artifactId={artifact_id}"
         return base_url

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -13,9 +13,10 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 
 from ._core import ClientCore
+from ._env import get_base_url
 from ._url_utils import is_youtube_url
 from .exceptions import NetworkError, ValidationError
-from .rpc import UPLOAD_URL, RPCError, RPCMethod
+from .rpc import RPCError, RPCMethod, get_upload_url
 from .rpc.types import SourceStatus
 from .types import (
     Source,
@@ -987,13 +988,14 @@ class SourcesAPI:
         """Start a resumable upload session and get the upload URL."""
         import json
 
-        url = f"{UPLOAD_URL}?authuser=0"
+        base_url = get_base_url()
+        url = f"{get_upload_url()}?authuser=0"
 
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
             "x-goog-authuser": "0",
             "x-goog-upload-command": "start",
             "x-goog-upload-header-content-length": str(file_size),
@@ -1042,11 +1044,12 @@ class SourcesAPI:
             upload_url: The resumable upload URL from _start_resumable_upload.
             file_path: Path to the file to upload.
         """
+        base_url = get_base_url()
         headers = {
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-            "Origin": "https://notebooklm.google.com",
-            "Referer": "https://notebooklm.google.com/",
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
             "x-goog-authuser": "0",
             "x-goog-upload-command": "upload, finalize",
             "x-goog-upload-offset": "0",

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -50,6 +50,7 @@ from typing import Any, NamedTuple, TypeAlias
 
 import httpx
 
+from ._env import get_base_url
 from ._url_utils import contains_google_auth_redirect, is_google_auth_redirect
 from .paths import get_storage_path, resolve_profile
 
@@ -210,6 +211,8 @@ ALLOWED_COOKIE_DOMAINS = {
     # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
     ".notebooklm.google.com",
     "notebooklm.google.com",
+    ".notebooklm.cloud.google.com",
+    "notebooklm.cloud.google.com",
     ".googleusercontent.com",
     "accounts.google.com",  # Required for token refresh redirects
     ".accounts.google.com",  # http.cookiejar may normalize Domain=accounts.google.com
@@ -577,6 +580,10 @@ def _auth_domain_priority(domain: str) -> int:
     if domain == ".notebooklm.google.com":
         return 3
     if domain == "notebooklm.google.com":
+        return 2
+    if domain == ".notebooklm.cloud.google.com":
+        return 3
+    if domain == "notebooklm.cloud.google.com":
         return 2
     if _is_google_domain(domain):
         return 1
@@ -2312,7 +2319,7 @@ async def _fetch_tokens_with_jar(
         await _poke_session(client, storage_path)
 
         response = await client.get(
-            "https://notebooklm.google.com/",
+            f"{get_base_url()}/",
             follow_redirects=True,
             timeout=30.0,
         )

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext, Page
     from rich.console import Console
 
+from .._env import get_base_host, get_base_url
 from ..auth import (
     ALLOWED_COOKIE_DOMAINS,
     GOOGLE_REGIONAL_CCTLDS,
@@ -57,8 +58,6 @@ from .language import set_language
 logger = logging.getLogger(__name__)
 
 GOOGLE_ACCOUNTS_URL = "https://accounts.google.com/"
-NOTEBOOKLM_URL = "https://notebooklm.google.com/"
-NOTEBOOKLM_HOST = "notebooklm.google.com"
 
 # Retryable Playwright connection errors
 RETRYABLE_CONNECTION_ERRORS = ("ERR_CONNECTION_CLOSED", "ERR_CONNECTION_RESET")
@@ -543,7 +542,7 @@ def register_session_commands(cli):
                 # Retry navigation on transient connection errors with backoff
                 for attempt in range(1, LOGIN_MAX_RETRIES + 1):
                     try:
-                        page.goto(NOTEBOOKLM_URL, timeout=30000)
+                        page.goto(f"{get_base_url()}/", timeout=30000)
                         break
                     except PlaywrightError as exc:
                         error_str = str(exc)
@@ -611,7 +610,7 @@ def register_session_commands(cli):
                 # .google.co.uk). Use "commit" to resolve once response headers
                 # (including Set-Cookie) are processed, before any client-side
                 # JS redirect can interrupt. See #214.
-                for url in [GOOGLE_ACCOUNTS_URL, NOTEBOOKLM_URL]:
+                for url in [GOOGLE_ACCOUNTS_URL, f"{get_base_url()}/"]:
                     try:
                         page.goto(url, wait_until="commit")
                     except PlaywrightError as exc:
@@ -632,7 +631,7 @@ def register_session_commands(cli):
                             raise
 
                 current_url = page.url
-                if NOTEBOOKLM_HOST not in current_url:
+                if get_base_host() not in current_url:
                     console.print(f"[yellow]Warning: Current URL is {current_url}[/yellow]")
                     if not click.confirm("Save authentication anyway?"):
                         raise SystemExit(1)

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -19,6 +19,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import click
 import httpx
@@ -96,6 +97,12 @@ def _is_navigation_interrupted_error(error: str | Exception) -> bool:
     """Return True for Playwright navigation races that are safe to ignore."""
     error_str = str(error).lower()
     return any(marker in error_str for marker in _NAVIGATION_INTERRUPTED_MARKERS)
+
+
+def _url_matches_base_host(url: str) -> bool:
+    """Return True when ``url`` is on the configured NotebookLM host."""
+    current_host = (urlparse(url).hostname or "").lower()
+    return current_host == get_base_host().lower()
 
 
 # Maps user-facing browser names to rookiepy function names.
@@ -631,7 +638,7 @@ def register_session_commands(cli):
                             raise
 
                 current_url = page.url
-                if get_base_host() not in current_url:
+                if not _url_matches_base_host(current_url):
                     console.print(f"[yellow]Warning: Current URL is {current_url}[/yellow]")
                     if not click.confirm("Save authentication anyway?"):
                         raise SystemExit(1)

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -78,19 +78,24 @@ BROWSER_CLOSED_HELP = (
     "  1. Run: notebooklm login --fresh\n"
     "  2. Or run: notebooklm auth logout && notebooklm login"
 )
-CONNECTION_ERROR_HELP = (
-    "[red]Failed to connect to NotebookLM after multiple retries.[/red]\n"
-    "This may be caused by:\n"
-    "  • Network connectivity issues\n"
-    "  • Firewall or VPN blocking notebooklm.google.com\n"
-    "  • Corporate proxy interfering with the connection\n"
-    "  • Google rate limiting (too many login attempts)\n\n"
-    "Try:\n"
-    "  1. Check your internet connection\n"
-    "  2. Disable VPN/proxy temporarily\n"
-    "  3. Wait a few minutes before retrying\n"
-    "  4. Check if notebooklm.google.com is accessible in your browser"
-)
+
+
+def _connection_error_help() -> str:
+    """Return login connection troubleshooting text for the configured host."""
+    base_host = get_base_host()
+    return (
+        "[red]Failed to connect to NotebookLM after multiple retries.[/red]\n"
+        "This may be caused by:\n"
+        "  • Network connectivity issues\n"
+        f"  • Firewall or VPN blocking {base_host}\n"
+        "  • Corporate proxy interfering with the connection\n"
+        "  • Google rate limiting (too many login attempts)\n\n"
+        "Try:\n"
+        "  1. Check your internet connection\n"
+        "  2. Disable VPN/proxy temporarily\n"
+        "  3. Wait a few minutes before retrying\n"
+        f"  4. Check if {base_host} is accessible in your browser"
+    )
 
 
 def _is_navigation_interrupted_error(error: str | Exception) -> bool:
@@ -599,7 +604,7 @@ def register_session_commands(cli):
                                 f"Failed to connect to NotebookLM after {LOGIN_MAX_RETRIES} attempts. "
                                 f"Last error: {error_str}"
                             )
-                            console.print(CONNECTION_ERROR_HELP)
+                            console.print(_connection_error_help())
                             raise SystemExit(1) from exc
                         else:
                             # Non-retryable error - re-raise immediately

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from ._artifacts import ArtifactsAPI
 from ._chat import ChatAPI
 from ._core import DEFAULT_KEEPALIVE_MIN_INTERVAL, DEFAULT_TIMEOUT, ClientCore
+from ._env import get_base_url
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
@@ -223,7 +224,7 @@ class NotebookLMClient:
             ValueError: If token extraction fails (page structure may have changed).
         """
         http_client = self._core.get_http_client()
-        response = await http_client.get("https://notebooklm.google.com/")
+        response = await http_client.get(f"{get_base_url()}/")
         response.raise_for_status()
 
         # Check for redirect to login page

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ._env import get_base_url
+from ._env import DEFAULT_BASE_URL, get_base_url
 
 __all__ = [
     # Base
@@ -347,10 +347,14 @@ class NotebookLimitError(NotebookError):
             count_text = f"{current_count}/{limit}"
 
         known_text = ", ".join(str(value) for value in known_limits)
+        try:
+            base_url = get_base_url()
+        except ValueError:
+            base_url = DEFAULT_BASE_URL
         message = (
             "Cannot create notebook: account appears to be at or very near the "
             f"NotebookLM notebook limit ({count_text} owned notebooks reported). "
-            f"Delete old notebooks at {get_base_url()} and try again."
+            f"Delete old notebooks at {base_url} and try again."
         )
         if known_limits:
             message += f" Known NotebookLM limits include: {known_text}."

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ._env import get_base_url
+
 __all__ = [
     # Base
     "NotebookLMError",
@@ -348,7 +350,7 @@ class NotebookLimitError(NotebookError):
         message = (
             "Cannot create notebook: account appears to be at or very near the "
             f"NotebookLM notebook limit ({count_text} owned notebooks reported). "
-            "Delete old notebooks at https://notebooklm.google.com and try again."
+            f"Delete old notebooks at {get_base_url()} and try again."
         )
         if known_limits:
             message += f" Known NotebookLM limits include: {known_text}."

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -42,6 +42,9 @@ from .types import (
     VideoFormat,
     VideoStyle,
     artifact_status_to_str,
+    get_batchexecute_url,
+    get_query_url,
+    get_upload_url,
 )
 
 __all__ = [
@@ -49,6 +52,9 @@ __all__ = [
     "BATCHEXECUTE_URL",
     "QUERY_URL",
     "UPLOAD_URL",
+    "get_batchexecute_url",
+    "get_query_url",
+    "get_upload_url",
     "ArtifactTypeCode",
     "StudioContentType",  # Deprecated alias
     "ArtifactStatus",

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -2,10 +2,36 @@
 
 from enum import Enum
 
-# NotebookLM API endpoints
-BATCHEXECUTE_URL = "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute"
-QUERY_URL = "https://notebooklm.google.com/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
-UPLOAD_URL = "https://notebooklm.google.com/upload/_/"
+from .._env import DEFAULT_BASE_URL, get_base_url
+
+# Backward-compatible default-host endpoint constants. Runtime code should use
+# the lazy get_* helpers below so NOTEBOOKLM_BASE_URL is honored after import.
+BATCHEXECUTE_URL = f"{DEFAULT_BASE_URL}/_/LabsTailwindUi/data/batchexecute"
+QUERY_URL = (
+    f"{DEFAULT_BASE_URL}/_/LabsTailwindUi/data/"
+    "google.internal.labs.tailwind.orchestration.v1."
+    "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
+)
+UPLOAD_URL = f"{DEFAULT_BASE_URL}/upload/_/"
+
+
+def get_batchexecute_url() -> str:
+    """Return the NotebookLM batchexecute endpoint for the configured host."""
+    return f"{get_base_url()}/_/LabsTailwindUi/data/batchexecute"
+
+
+def get_query_url() -> str:
+    """Return the NotebookLM streamed chat endpoint for the configured host."""
+    return (
+        f"{get_base_url()}/_/LabsTailwindUi/data/"
+        "google.internal.labs.tailwind.orchestration.v1."
+        "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
+    )
+
+
+def get_upload_url() -> str:
+    """Return the NotebookLM upload endpoint for the configured host."""
+    return f"{get_base_url()}/upload/_/"
 
 
 class RPCMethod(str, Enum):

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -15,6 +15,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
+from ._env import get_base_url
+
 # Import exceptions from centralized module (re-export for backward compatibility)
 from .exceptions import (
     ArtifactDownloadError,
@@ -1409,7 +1411,7 @@ class ShareStatus:
         view_level = ShareViewLevel.FULL_NOTEBOOK
 
         # Construct share URL if public
-        share_url = f"https://notebooklm.google.com/notebook/{notebook_id}" if is_public else None
+        share_url = f"{get_base_url()}/notebook/{notebook_id}" if is_public else None
 
         return cls(
             notebook_id=notebook_id,

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -71,6 +71,13 @@ class TestLoginUrlValidation:
         assert _url_matches_base_host("https://notebooklm.cloud.google.com/notebook/abc")
         assert not _url_matches_base_host("https://notebooklm.google.com/notebook/abc")
 
+    def test_connection_error_help_uses_enterprise_base_host(self, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+        from notebooklm.cli.session import _connection_error_help
+
+        assert "notebooklm.cloud.google.com" in _connection_error_help()
+
 
 class TestLoginCommand:
     def test_login_playwright_import_error_handling(self, runner):

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -52,6 +52,26 @@ def mock_context_file(tmp_path):
 # =============================================================================
 
 
+class TestLoginUrlValidation:
+    def test_url_matches_default_base_host(self, monkeypatch):
+        monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+
+        from notebooklm.cli.session import _url_matches_base_host
+
+        assert _url_matches_base_host("https://notebooklm.google.com/notebook/abc")
+        assert not _url_matches_base_host(
+            "https://example.com/path?next=https://notebooklm.google.com/"
+        )
+
+    def test_url_matches_enterprise_base_host(self, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+        from notebooklm.cli.session import _url_matches_base_host
+
+        assert _url_matches_base_host("https://notebooklm.cloud.google.com/notebook/abc")
+        assert not _url_matches_base_host("https://notebooklm.google.com/notebook/abc")
+
+
 class TestLoginCommand:
     def test_login_playwright_import_error_handling(self, runner):
         """Test that ImportError for playwright is handled gracefully."""

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -76,7 +76,10 @@ class TestLoginUrlValidation:
 
         from notebooklm.cli.session import _connection_error_help
 
-        assert "notebooklm.cloud.google.com" in _connection_error_help()
+        blocked_host = (
+            _connection_error_help().split("Firewall or VPN blocking ", 1)[1].split("\n", 1)[0]
+        )
+        assert blocked_host == "notebooklm.cloud.google.com"
 
 
 class TestLoginCommand:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1666,6 +1666,8 @@ class TestIsAllowedCookieDomain:
 
         assert _is_allowed_cookie_domain(".google.com") is True
         assert _is_allowed_cookie_domain("notebooklm.google.com") is True
+        assert _is_allowed_cookie_domain("notebooklm.cloud.google.com") is True
+        assert _is_allowed_cookie_domain(".notebooklm.cloud.google.com") is True
         assert _is_allowed_cookie_domain(".googleusercontent.com") is True
         assert _is_allowed_cookie_domain(".accounts.google.com") is True
 
@@ -2031,7 +2033,9 @@ class TestAuthDomainPriority:
         [
             (".google.com", 4),
             (".notebooklm.google.com", 3),
+            (".notebooklm.cloud.google.com", 3),
             ("notebooklm.google.com", 2),
+            ("notebooklm.cloud.google.com", 2),
             (".google.de", 1),
             (".google.com.sg", 1),
             (".google.co.uk", 1),

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -1,0 +1,134 @@
+"""Tests for NotebookLM runtime endpoint configuration."""
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm._env import get_base_host, get_base_url
+from notebooklm._sources import SourcesAPI
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
+from notebooklm.rpc import RPCMethod, get_batchexecute_url, get_query_url, get_upload_url
+from notebooklm.types import ShareStatus
+
+
+def test_default_base_url_is_personal(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+
+    assert get_base_url() == "https://notebooklm.google.com"
+    assert get_base_host() == "notebooklm.google.com"
+
+
+def test_enterprise_base_url_via_env(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com/")
+
+    assert get_base_url() == "https://notebooklm.cloud.google.com"
+    assert get_base_host() == "notebooklm.cloud.google.com"
+
+
+def test_base_url_normalizes_mixed_case_and_whitespace(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "  https://NotebookLM.Cloud.Google.com/  ")
+
+    assert get_base_url() == "https://notebooklm.cloud.google.com"
+
+
+def test_empty_base_url_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "")
+
+    assert get_base_url() == "https://notebooklm.google.com"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://notebooklm.google.com",
+        "https://evil.example.com",
+        "https://notebooklm.google.com:443",
+        "https://user:notsecret@notebooklm.google.com",
+        "https://notebooklm.google.com/path",
+        "https://notebooklm.google.com?x=1",
+        "https://notebooklm.google.com/#fragment",
+    ],
+)
+def test_base_url_validation_rejects_unsafe_values(monkeypatch, value):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", value)
+
+    with pytest.raises(ValueError, match="NOTEBOOKLM_BASE_URL"):
+        get_base_url()
+
+
+def test_rpc_endpoint_helpers_are_lazy(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+    assert (
+        get_batchexecute_url()
+        == "https://notebooklm.cloud.google.com/_/LabsTailwindUi/data/batchexecute"
+    )
+    assert get_query_url().startswith("https://notebooklm.cloud.google.com/_/")
+    assert get_upload_url() == "https://notebooklm.cloud.google.com/upload/_/"
+
+
+def test_core_build_url_uses_enterprise_base_url(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+    core = ClientCore(AuthTokens(cookies={}, csrf_token="csrf", session_id="sid"))
+
+    url = core._build_url(RPCMethod.LIST_NOTEBOOKS)
+
+    assert url.startswith("https://notebooklm.cloud.google.com/_/LabsTailwindUi/data/")
+
+
+@pytest.mark.asyncio
+async def test_upload_start_uses_enterprise_url_and_headers(monkeypatch, httpx_mock):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+    auth = AuthTokens(cookies={"SID": "test"}, csrf_token="csrf", session_id="sid")
+    upload_url = "https://notebooklm.cloud.google.com/upload/_/?upload_id=test"
+    httpx_mock.add_response(
+        method="POST",
+        url="https://notebooklm.cloud.google.com/upload/_/?authuser=0",
+        headers={"x-goog-upload-url": upload_url},
+    )
+
+    core = ClientCore(auth)
+    await core.open()
+    try:
+        result = await SourcesAPI(core)._start_resumable_upload(
+            "nb_123",
+            "file.txt",
+            12,
+            "src_123",
+        )
+    finally:
+        await core.close()
+
+    request = httpx_mock.get_request()
+    assert result == upload_url
+    assert request is not None
+    assert str(request.url) == "https://notebooklm.cloud.google.com/upload/_/?authuser=0"
+    assert request.headers["origin"] == "https://notebooklm.cloud.google.com"
+    assert request.headers["referer"] == "https://notebooklm.cloud.google.com/"
+
+
+@pytest.mark.asyncio
+async def test_client_refresh_auth_uses_enterprise_base_url(monkeypatch, httpx_mock, tmp_path):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+    httpx_mock.add_response(
+        url="https://notebooklm.cloud.google.com/",
+        text='{"SNlM0e":"fresh_csrf","FdrFJe":"fresh_sid"}',
+    )
+    auth = AuthTokens(cookies={"SID": "test"}, csrf_token="old", session_id="old_sid")
+
+    async with NotebookLMClient(auth, storage_path=tmp_path / "storage.json") as client:
+        refreshed = await client.refresh_auth()
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert str(request.url) == "https://notebooklm.cloud.google.com/"
+    assert refreshed.csrf_token == "fresh_csrf"
+    assert refreshed.session_id == "fresh_sid"
+
+
+def test_share_status_uses_enterprise_base_url(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+    status = ShareStatus.from_api_response([[["owner@example.com"]], [True], 1000], "nb_123")
+
+    assert status.share_url == "https://notebooklm.cloud.google.com/notebook/nb_123"

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -271,6 +271,15 @@ class TestDomainExceptions:
         assert "Known NotebookLM limits include: 100, 500" in str(e)
         assert e.to_error_response_extra()["known_limits"] == [100, 500]
 
+    def test_notebook_limit_error_tolerates_invalid_base_url_env(self, monkeypatch):
+        """NotebookLimitError should preserve quota context even if env config is invalid."""
+        monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://evil.example.com")
+
+        e = NotebookLimitError(499, limit=500)
+
+        assert "499/500" in str(e)
+        assert "https://notebooklm.google.com" in str(e)
+
     def test_source_not_found_has_source_id(self):
         """SourceNotFoundError stores source_id."""
         e = SourceNotFoundError("src_456")

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -3,6 +3,7 @@
 import pytest
 
 import notebooklm
+from notebooklm._env import DEFAULT_BASE_URL
 from notebooklm.exceptions import (
     ArtifactDownloadError,
     ArtifactError,
@@ -278,7 +279,15 @@ class TestDomainExceptions:
         e = NotebookLimitError(499, limit=500)
 
         assert "499/500" in str(e)
-        assert "https://notebooklm.google.com" in str(e)
+        base_url = (
+            str(e)
+            .split("Delete old notebooks at ", 1)[1]
+            .split(
+                " and try again.",
+                1,
+            )[0]
+        )
+        assert base_url == DEFAULT_BASE_URL
 
     def test_source_not_found_has_source_id(self):
         """SourceNotFoundError stores source_id."""

--- a/tests/unit/test_rpc_types.py
+++ b/tests/unit/test_rpc_types.py
@@ -8,6 +8,8 @@ from notebooklm.rpc.types import (
     RPCMethod,
     SourceStatus,
     artifact_status_to_str,
+    get_batchexecute_url,
+    get_query_url,
     source_status_to_str,
 )
 
@@ -22,6 +24,13 @@ class TestRPCConstants:
     def test_query_url(self):
         """Test query URL for streaming chat."""
         assert "GenerateFreeFormStreamed" in QUERY_URL
+
+    def test_endpoint_helpers_honor_env_after_import(self, monkeypatch):
+        """Test lazy endpoint helpers are not locked to import-time env."""
+        monkeypatch.setenv("NOTEBOOKLM_BASE_URL", "https://notebooklm.cloud.google.com")
+
+        assert get_batchexecute_url().startswith("https://notebooklm.cloud.google.com/")
+        assert get_query_url().startswith("https://notebooklm.cloud.google.com/")
 
 
 class TestRPCMethod:


### PR DESCRIPTION
## Summary
- add validated NOTEBOOKLM_BASE_URL support for personal and enterprise NotebookLM hosts
- route RPC, chat, upload, auth refresh, login, and share URL construction through the configured host
- allow enterprise NotebookLM cookie domains and cover lazy endpoint behavior in unit tests

Supersedes the item-6 slice of #398.

Refs #389

## Tests
- uv run pytest tests/unit/test_env_base_url.py tests/unit/test_rpc_types.py tests/unit/test_auth.py -q
- uv run ruff check src/ tests/
- uv run mypy src/notebooklm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable NotebookLM base URL via environment, applied across auth, client refresh, chat, uploads, sharing, RPC helpers, and CLI flows.
  * Public URL helper functions exported for dynamic endpoints.

* **Bug Fixes**
  * Login, token retrieval, sharing, and upload requests now work with alternative NotebookLM hosts and set correct origin/referer and cookie handling.

* **Tests**
  * Added unit tests for base-URL handling, endpoint helpers, cookie domain rules, and login URL validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/402)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->