### PR TITLE
test: harden cookie-save race test against scheduler assumptions

### DIFF
--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -1433,7 +1433,6 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
         second worker observes the first's advance.
         """
         import asyncio
-        import threading
 
         from notebooklm import auth as auth_mod
         from notebooklm._core import ClientCore
@@ -1476,26 +1475,25 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
 
         monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", capture_save)
 
-        # Explicit barrier: each coroutine records its submission under a
-        # threading.Lock, and the second arrival sets ``both_submitted``.
-        # Until then, both coroutines spin on ``asyncio.sleep(0)``, which
-        # yields control to the event loop so the OTHER coroutine can be
-        # scheduled and reach the same point. This makes the synchronization
-        # point explicit and does NOT rely on the asyncio scheduler being
-        # FIFO — once ``both_submitted`` is set, both coroutines proceed
-        # regardless of resume order. Free-threaded CPython, uvloop, or any
-        # future loop implementation must honour this barrier.
-        submitted_lock = threading.Lock()
+        # Explicit barrier: each coroutine records its submission and the
+        # second arrival sets ``both_submitted``; both then ``await`` the
+        # event before running ``func``. Because asyncio coroutines on one
+        # loop don't preempt, the ``append``/``set`` pair is already atomic
+        # from each coroutine's POV — no extra lock needed. The barrier is
+        # an ``asyncio.Event`` (suspending wait) rather than ``threading.Event``
+        # (busy-poll) so the test doesn't depend on the loop preferring to
+        # resume a particular task. Once ``both_submitted`` is set, both
+        # coroutines proceed regardless of resume order — free-threaded
+        # CPython, uvloop, or any future loop implementation must honour
+        # this barrier.
         submitted: list[tuple] = []
-        both_submitted = threading.Event()
+        both_submitted = asyncio.Event()
 
         async def fake_to_thread(func, /, *args, **kwargs):
-            with submitted_lock:
-                submitted.append((func, args, kwargs))
-                if len(submitted) == 2:
-                    both_submitted.set()
-            while not both_submitted.is_set():
-                await asyncio.sleep(0)
+            submitted.append((func, args, kwargs))
+            if len(submitted) == 2:
+                both_submitted.set()
+            await both_submitted.wait()
             return func(*args, **kwargs)
 
         monkeypatch.setattr("notebooklm._core.asyncio.to_thread", fake_to_thread)

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -1433,6 +1433,7 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
         second worker observes the first's advance.
         """
         import asyncio
+        import threading
 
         from notebooklm import auth as auth_mod
         from notebooklm._core import ClientCore
@@ -1475,22 +1476,46 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
 
         monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", capture_save)
 
+        # Explicit barrier: each coroutine records its submission under a
+        # threading.Lock, and the second arrival sets ``both_submitted``.
+        # Until then, both coroutines spin on ``asyncio.sleep(0)``, which
+        # yields control to the event loop so the OTHER coroutine can be
+        # scheduled and reach the same point. This makes the synchronization
+        # point explicit and does NOT rely on the asyncio scheduler being
+        # FIFO — once ``both_submitted`` is set, both coroutines proceed
+        # regardless of resume order. Free-threaded CPython, uvloop, or any
+        # future loop implementation must honour this barrier.
+        submitted_lock = threading.Lock()
         submitted: list[tuple] = []
+        both_submitted = threading.Event()
 
         async def fake_to_thread(func, /, *args, **kwargs):
-            submitted.append((func, args, kwargs))
-            while len(submitted) < 2:
+            with submitted_lock:
+                submitted.append((func, args, kwargs))
+                if len(submitted) == 2:
+                    both_submitted.set()
+            while not both_submitted.is_set():
                 await asyncio.sleep(0)
             return func(*args, **kwargs)
 
         monkeypatch.setattr("notebooklm._core.asyncio.to_thread", fake_to_thread)
 
-        # Two jars representing distinct post-rotation states. First save
-        # rotates *PSIDTS to v1; second to v2. Built with fresh jar.set()
-        # calls so the Cookie objects are NOT aliased between jars (httpx's
-        # ``Cookies(other)`` copy-constructor re-uses Cookie object refs).
-        # Submitted via gather so both save_cookies() coroutines reach their
-        # asyncio.to_thread before either worker advances the baseline.
+        # Two jars representing distinct post-rotation states. The save that
+        # acquires ``_save_lock`` first rotates *PSIDTS away from v0; the
+        # second must then observe that rotation as its baseline. Built with
+        # fresh jar.set() calls so the Cookie objects are NOT aliased between
+        # jars (httpx's ``Cookies(other)`` copy-constructor re-uses Cookie
+        # object refs). Submitted via gather so both save_cookies()
+        # coroutines reach their asyncio.to_thread before either worker
+        # advances the baseline.
+        #
+        # Note on naming: ``jar_a`` / ``jar_b`` are intentionally
+        # call-order-agnostic. After the barrier releases, either jar may end
+        # up as ``captured_calls[0]`` depending on which coroutine the loop
+        # resumes first — that ordering is precisely what we DON'T want this
+        # test to depend on. The assertion below uses positional names
+        # (first/second by worker execution order, not by gather argument
+        # order) to stay robust across schedulers.
         assert core._http_client is not None
 
         def _fresh_jar(psidts_value: str) -> httpx.Cookies:
@@ -1499,13 +1524,13 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
             j.set("__Secure-1PSIDTS", psidts_value, domain=".google.com", path="/")
             return j
 
-        jar_v1 = _fresh_jar("v1")
-        jar_v2 = _fresh_jar("v2")
+        jar_a = _fresh_jar("v1")
+        jar_b = _fresh_jar("v2")
 
         try:
             await asyncio.gather(
-                core.save_cookies(jar_v1),
-                core.save_cookies(jar_v2),
+                core.save_cookies(jar_a),
+                core.save_cookies(jar_b),
             )
         finally:
             await core.close()
@@ -1521,9 +1546,10 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
         assert first_baseline == "v0" and second_baseline == first_jar, (
             "When two saves serialize through _save_lock, the second worker "
             "must observe the baseline advanced by the first. Observed "
-            f"(jar, baseline) pairs for *PSIDTS: {captured_pairs}. If both baselines "
-            "are v0, the snapshot was captured on the loop thread before "
-            "the lock — a stale-baseline race risking lost updates."
+            f"(jar, baseline) pairs for *PSIDTS: {captured_pairs}. "
+            "If both baselines are v0, the snapshot was captured on the "
+            "loop thread before the lock — a stale-baseline race risking "
+            "lost updates."
         )
 
 


### PR DESCRIPTION
## Summary

Hardens `tests/unit/test_auth_cookie_save_race.py::TestSaveCookiesSeesLatestBaselineUnderContention::test_concurrent_saves_each_see_latest_baseline` against the issues #386 flagged.

- Replace the `len(submitted) < 2` gate (which depended on CPython's FIFO asyncio scheduling) with an explicit `asyncio.Event` barrier. Both coroutines now suspend on `await both_submitted.wait()` until the second arrival sets the event — no busy-poll, no FIFO assumption. Works under free-threaded CPython, uvloop, or any future loop.
- Rename `jar_v1`/`jar_v2` → `jar_a`/`jar_b` (call-order-agnostic) and add a comment noting that `captured_calls[0]` reflects worker execution order, not gather argument order. Assertion already uses positional names (`first_jar`, `second_baseline`).
- Fix the f-string concat in the failure message so it reads cleanly.

After triple-model review (codex/gemini/claude), the initial `threading.Event` + busy-wait barrier was tightened further to `asyncio.Event` to remove the spin and the unneeded cross-thread lock.

Closes #386.

## Test plan

- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] Target test passes: `pytest tests/unit/test_auth_cookie_save_race.py -x` → 48 passed
- [x] Full unit suite passes: `pytest tests/unit/` → 1927 passed, 5 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced concurrency test reliability for cookie save operations with improved determinism.
  * Updated error messages to provide clearer diagnostics for test failure scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/403)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->