### PR TITLE
Fix auth cookie paths and source markdown handling

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -839,7 +839,9 @@ class SourcesAPI:
 
         return {"summary": summary, "keywords": keywords}
 
-    async def get_fulltext(self, notebook_id: str, source_id: str) -> SourceFulltext:
+    async def get_fulltext(
+        self, notebook_id: str, source_id: str, *, preserve_markdown: bool = False
+    ) -> SourceFulltext:
         """Get the full indexed text content of a source.
 
         Returns the raw text content that was extracted and indexed from the source,
@@ -848,6 +850,9 @@ class SourcesAPI:
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to get fulltext for.
+            preserve_markdown: For markdown sources, prefer the raw markdown
+                body when the response includes it, instead of NotebookLM's
+                indexed plain-text blocks.
 
         Returns:
             SourceFulltext object with content, title, source_type, url, and char_count.
@@ -899,6 +904,11 @@ class SourcesAPI:
                     texts = self._extract_all_text(content_blocks)
                     content = "\n".join(texts)
 
+            if preserve_markdown and source_type == 8:
+                markdown_content = self._extract_markdown_content(result)
+                if markdown_content:
+                    content = markdown_content
+
         # Log warning if content is empty but source exists
         if not content:
             logger.warning(
@@ -920,6 +930,52 @@ class SourcesAPI:
     # =========================================================================
     # Private helper methods
     # =========================================================================
+
+    def _extract_markdown_content(self, data: Any) -> str:
+        """Best-effort extraction of raw markdown embedded in a source response.
+
+        Markdown report sources can include both indexed text blocks (already
+        flattened for search) and the original markdown body. The default
+        fulltext path keeps returning the indexed text for backward
+        compatibility; callers that opt in can use this helper to preserve
+        tables, headings, and other markdown formatting when the raw body is
+        present in the response.
+        """
+        candidates: builtins.list[str] = []
+
+        def walk(value: Any, depth: int = 100) -> None:
+            if depth <= 0:
+                return
+            if isinstance(value, str):
+                if self._looks_like_markdown_document(value):
+                    candidates.append(value)
+                return
+            if isinstance(value, builtins.list):
+                for item in value:
+                    walk(item, depth - 1)
+            elif isinstance(value, dict):
+                for item in value.values():
+                    walk(item, depth - 1)
+
+        walk(data)
+        return max(candidates, key=len, default="")
+
+    @staticmethod
+    def _looks_like_markdown_document(value: str) -> bool:
+        """Return true for strings likely to be raw markdown documents."""
+        text = value.strip()
+        if len(text) < 3:
+            return False
+        markdown_markers = (
+            text.startswith("#"),
+            "\n#" in text,
+            "\n|" in text and "|" in text,
+            "```" in text,
+            "\n- " in text,
+            "\n* " in text,
+            re.search(r"\[[^\]]+\]\([^\)]+\)", text) is not None,
+        )
+        return any(markdown_markers)
 
     def _extract_all_text(self, data: builtins.list, max_depth: int = 100) -> builtins.list[str]:
         """Recursively extract all text strings from nested arrays.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -42,11 +42,11 @@ import threading
 import time
 import warnings
 import weakref
-from collections.abc import Iterator
+from collections.abc import Iterator, MutableMapping
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NamedTuple, TypeAlias
+from typing import Any, NamedTuple, TypeAlias, cast
 from urllib.parse import urlencode
 
 import httpx
@@ -57,10 +57,11 @@ from .paths import get_storage_path, resolve_profile
 
 logger = logging.getLogger(__name__)
 
-CookieKey: TypeAlias = tuple[str, str]
+CookieKey: TypeAlias = tuple[str, str, str]
+LegacyCookieKey: TypeAlias = tuple[str, str]
 DomainCookieMap: TypeAlias = dict[CookieKey, str]
 FlatCookieMap: TypeAlias = dict[str, str]
-CookieInput: TypeAlias = DomainCookieMap | FlatCookieMap
+CookieInput: TypeAlias = DomainCookieMap | dict[LegacyCookieKey, str] | FlatCookieMap
 
 
 class CookieSnapshotKey(NamedTuple):
@@ -68,10 +69,9 @@ class CookieSnapshotKey(NamedTuple):
 
     RFC 6265 treats ``path`` as part of cookie identity: two cookies with the
     same ``(name, domain)`` but different paths are distinct entries. The
-    snapshot/delta path widens the legacy ``(name, domain)`` key (still used
-    elsewhere for back-compat — see ``CookieKey``) to ``(name, domain, path)``
-    so that path-scoped cookies (e.g. ``OSID`` on a per-product path) survive
-    a load → save round trip and so that a sibling-process write to a
+    cookie helpers use the same ``(name, domain, path)`` identity so that
+    path-scoped cookies (e.g. ``OSID`` on a per-product path) survive a
+    load → save round trip and so that a sibling-process write to a
     different-path variant of the same name is not silently overwritten.
     """
 
@@ -487,18 +487,26 @@ class AuthTokens:
 
 
 def normalize_cookie_map(cookies: CookieInput | None) -> DomainCookieMap:
-    """Normalize flat or domain-aware cookie maps into (name, domain) keys."""
+    """Normalize flat/domain-aware cookie maps into (name, domain, path) keys.
+
+    Two-element ``(name, domain)`` keys remain accepted for public API
+    compatibility and are treated as path ``/``.
+    """
     normalized: DomainCookieMap = {}
     if not cookies:
         return normalized
 
     for key, value in cookies.items():
         if isinstance(key, tuple):
-            name, domain = key
+            if len(key) == 2:
+                name, domain = key
+                path = "/"
+            else:
+                name, domain, path = key
         else:
-            name, domain = key, ".google.com"
+            name, domain, path = key, ".google.com", "/"
         if name:
-            normalized[(name, domain or ".google.com")] = value
+            normalized[(name, domain or ".google.com", path or "/")] = value
     return normalized
 
 
@@ -517,7 +525,7 @@ def flatten_cookie_map(cookies: CookieInput | None) -> FlatCookieMap:
     flat: FlatCookieMap = {}
     priorities: dict[str, int] = {}
 
-    for (name, domain), value in normalize_cookie_map(cookies).items():
+    for (name, domain, _path), value in normalize_cookie_map(cookies).items():
         priority = _auth_domain_priority(domain)
         if name not in flat or priority > priorities[name]:
             flat[name] = value
@@ -1333,7 +1341,7 @@ def extract_cookies_with_domains(
     """Extract Google cookies from storage state preserving original domains.
 
     Unlike extract_cookies_from_storage() which returns a simple dict of
-    name->value, this function returns a dict of (name, domain)->value tuples
+    name->value, this function returns a dict of (name, domain, path)->value tuples
     to preserve the original cookie domains. This is required for building
     proper httpx.Cookies jars that handle cross-domain redirects correctly.
 
@@ -1341,8 +1349,8 @@ def extract_cookies_with_domains(
         storage_state: Parsed JSON from Playwright's storage state file.
 
     Returns:
-        Dict mapping (cookie_name, domain) tuples to values.
-        Example: {("SID", ".google.com"): "abc123", ("HSID", ".google.com"): "def456"}
+        Dict mapping (cookie_name, domain, path) tuples to values.
+        Example: {("SID", ".google.com", "/"): "abc123"}
 
     Raises:
         ValueError: If required cookies (SID) are missing from storage state.
@@ -1357,12 +1365,12 @@ def extract_cookies_with_domains(
         if not _is_allowed_auth_domain(domain) or not name or not value:
             continue
 
-        key = (name, domain)
+        key = (name, domain, cookie.get("path") or "/")
         if key not in cookie_map:
             cookie_map[key] = value
 
     # Validate required cookies exist (any domain)
-    _validate_required_cookies({name for name, _ in cookie_map})
+    _validate_required_cookies({name for name, _domain, _path in cookie_map})
     return cookie_map
 
 
@@ -1419,7 +1427,7 @@ def build_cookie_jar(
     Priority:
     1. If storage_path exists, load from storage with original domains
     2. Otherwise, use provided cookies while preserving domain keys. Legacy
-       flat mappings are assigned to .google.com for backward compatibility.
+       flat mappings are assigned to .google.com path / for backward compatibility.
 
     Args:
         cookies: Domain-aware (name, domain) cookie dict, or legacy flat
@@ -1434,8 +1442,8 @@ def build_cookie_jar(
         return build_httpx_cookies_from_storage(storage_path)
 
     jar = httpx.Cookies()
-    for (name, domain), value in normalize_cookie_map(cookies).items():
-        jar.set(name, value, domain=domain)
+    for (name, domain, path), value in normalize_cookie_map(cookies).items():
+        jar.set(name, value, domain=domain, path=path)
     return jar
 
 
@@ -1811,7 +1819,7 @@ def _merge_cookies_legacy(cookie_jar: httpx.Cookies, storage_data: dict[str, Any
         Number of cookie entries added or modified in ``storage_data``.
     """
     cookies_by_key = {
-        (cookie.name, cookie.domain): cookie
+        (cookie.name, cookie.domain, cookie.path or "/"): cookie
         for cookie in cookie_jar.jar
         if cookie.name and cookie.domain and _is_allowed_cookie_domain(cookie.domain)
     }
@@ -1824,7 +1832,7 @@ def _merge_cookies_legacy(cookie_jar: httpx.Cookies, storage_data: dict[str, Any
         if not name or not domain:
             continue
 
-        key = (name, domain)
+        key = (name, domain, stored_cookie.get("path") or "/")
         stored_keys.update(_cookie_key_variants(key))
         refreshed_cookie = _find_cookie_for_storage(cookies_by_key, key, stored_cookie.get("value"))
         if refreshed_cookie is None:
@@ -2123,13 +2131,13 @@ def _storage_entry_to_cookie(entry: dict[str, Any]) -> http.cookiejar.Cookie:
 
 
 def _cookie_key_variants(key: CookieKey) -> set[CookieKey]:
-    """Return equivalent host/domain cookie keys for leading-dot domains."""
-    name, domain = key
+    """Return equivalent host/domain cookie keys, preserving path identity."""
+    name, domain, path = key
     variants = {key}
     if domain.startswith("."):
-        variants.add((name, domain[1:]))
+        variants.add((name, domain[1:], path))
     else:
-        variants.add((name, f".{domain}"))
+        variants.add((name, f".{domain}", path))
     return variants
 
 
@@ -2298,7 +2306,7 @@ async def _fetch_tokens_with_refresh(
 def _cookie_map_from_jar(cookie_jar: httpx.Cookies) -> DomainCookieMap:
     """Extract a domain-aware auth cookie map from an httpx cookie jar."""
     return {
-        (cookie.name, cookie.domain): cookie.value
+        (cookie.name, cookie.domain, cookie.path or "/"): cookie.value
         for cookie in cookie_jar.jar
         if cookie.name
         and cookie.domain
@@ -2310,11 +2318,12 @@ def _cookie_map_from_jar(cookie_jar: httpx.Cookies) -> DomainCookieMap:
 def _update_cookie_input(target: CookieInput, fresh: DomainCookieMap) -> None:
     """Update caller-provided cookies in place while preserving key style."""
     use_domain_keys = any(isinstance(key, tuple) for key in target)
-    target.clear()
+    mutable_target = cast(MutableMapping[Any, str], target)
+    mutable_target.clear()
     if use_domain_keys:
-        target.update(fresh)
+        mutable_target.update(fresh)
     else:
-        target.update(flatten_cookie_map(fresh))  # type: ignore[arg-type]
+        mutable_target.update(flatten_cookie_map(fresh))
 
 
 # --- Keepalive poke ----------------------------------------------------------

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -568,9 +568,8 @@ def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
     default=1800,
     type=int,
     help=(
-        "Retry budget in seconds for --import-all when the IMPORT_RESEARCH RPC "
-        "times out (default: 1800). Mirrors 'research wait --timeout'. "
-        "Has no effect without --import-all."
+        "Wait/retry budget in seconds for research completion and --import-all "
+        "IMPORT_RESEARCH retries (default: 1800). Mirrors 'research wait --timeout'."
     ),
 )
 @with_client
@@ -623,16 +622,19 @@ def source_add_research(
                 return
 
             status = None
-            for _ in range(60):
+            deadline = asyncio.get_running_loop().time() + timeout
+            while True:
                 status = await client.research.poll(nb_id_resolved)
                 if status.get("status") == "completed":
                     break
                 elif status.get("status") == "no_research":
                     console.print("[red]Research failed to start[/red]")
                     raise SystemExit(1)
-                await asyncio.sleep(5)
-            else:
-                status = {"status": "timeout"}
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    status = {"status": "timeout"}
+                    break
+                await asyncio.sleep(min(5, remaining))
 
             if status.get("status") == "completed":
                 sources = status.get("sources", [])
@@ -669,8 +671,14 @@ def source_add_research(
 )
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.option("--output", "-o", type=click.Path(), help="Write content to file")
+@click.option(
+    "--markdown",
+    "preserve_markdown",
+    is_flag=True,
+    help="For markdown sources, preserve raw markdown formatting when available.",
+)
 @with_client
-def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_auth):
+def source_fulltext(ctx, source_id, notebook_id, json_output, output, preserve_markdown, client_auth):
     """Get full indexed text content of a source.
 
     Retrieves the complete text content as indexed by NotebookLM. This is the
@@ -682,6 +690,7 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_aut
     Examples:
       source fulltext abc123                    # Show fulltext in terminal
       source fulltext abc123 --json             # Output as JSON
+      source fulltext abc123 --markdown         # Preserve markdown tables/headings
       source fulltext abc123 -o content.txt     # Save to file
     """
     nb_id = require_notebook(notebook_id)
@@ -692,7 +701,9 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_aut
             resolved_id = await resolve_source_id(client, nb_id_resolved, source_id)
 
             with console.status("Fetching fulltext content..."):
-                fulltext = await client.sources.get_fulltext(nb_id_resolved, resolved_id)
+                fulltext = await client.sources.get_fulltext(
+                    nb_id_resolved, resolved_id, preserve_markdown=preserve_markdown
+                )
 
             if json_output:
                 from dataclasses import asdict

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -949,6 +949,35 @@ class TestGetFulltext:
         assert "[2]" in body
 
     @pytest.mark.asyncio
+    async def test_get_fulltext_preserve_markdown_prefers_raw_markdown(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Markdown sources can return raw markdown instead of indexed text blocks."""
+        markdown = "# Report\n\n| A | B |\n|---|---|\n| 1 | 2 |"
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                ["src_md", "Report", [None, None, None, None, 8]],
+                [markdown],
+                None,
+                [[["Report", "A", "B", "1", "2"]]],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext(
+                "nb_123", "src_md", preserve_markdown=True
+            )
+
+        assert fulltext.kind == SourceType.MARKDOWN
+        assert fulltext.content == markdown
+        assert "| A | B |" in fulltext.content
+
+    @pytest.mark.asyncio
     async def test_get_fulltext_empty_content(
         self,
         auth_tokens,

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -875,6 +875,39 @@ class TestSourceAddResearch:
         assert result.exit_code == 0
         assert mock_import.await_args.kwargs["max_elapsed"] == 600
 
+    def test_add_research_timeout_bounds_polling_wait(self, runner, mock_auth, monkeypatch):
+        """--timeout also bounds the research polling wait, not only import retries."""
+        times = iter([0.0, 0.0, 1.0])
+
+        class FakeLoop:
+            def time(self):
+                return next(times)
+
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.research.start = AsyncMock(return_value={"task_id": "task_t1"})
+            mock_client.research.poll = AsyncMock(return_value={"status": "in_progress"})
+            mock_client_cls.return_value = mock_client
+            monkeypatch.setattr(source_module.asyncio, "get_running_loop", lambda: FakeLoop())
+
+            async def no_sleep(_delay):
+                return None
+
+            monkeypatch.setattr(source_module.asyncio, "sleep", no_sleep)
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli,
+                    ["source", "add-research", "topic", "--timeout", "1", "-n", "nb_123"],
+                )
+
+        assert result.exit_code == 0
+        assert "Status: timeout" in result.output
+        assert mock_client.research.poll.await_count == 2
+
 
 # =============================================================================
 # COMMAND EXISTENCE TESTS
@@ -1317,6 +1350,39 @@ class TestSourceFulltext:
             assert result.exit_code == 0
             assert "Saved" in result.output
             assert output_file.read_text(encoding="utf-8") == content
+
+    def test_source_fulltext_markdown_flag_threads_to_api(self, runner, mock_auth):
+        """--markdown requests raw markdown preservation from the API layer."""
+        markdown = "# Report\n\n| A | B |\n|---|---|\n| 1 | 2 |"
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="Markdown Report")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="Markdown Report",
+                    content=markdown,
+                    _type_code=8,
+                    char_count=len(markdown),
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["source", "fulltext", "src_123", "-n", "nb_123", "--markdown"]
+                )
+
+            assert result.exit_code == 0
+            assert "| A | B |" in result.output
+            mock_client.sources.get_fulltext.assert_awaited_once_with(
+                "nb_123", "src_123", preserve_markdown=True
+            )
 
     def test_source_fulltext_json_output(self, runner, mock_auth):
         """--json outputs JSON with fulltext fields."""

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -45,9 +45,9 @@ class TestAuthTokens:
             session_id="sess456",
         )
         assert tokens.cookies == {
-            ("SID", ".google.com"): "abc",
-            ("__Secure-1PSIDTS", ".google.com"): "test_1psidts",
-            ("HSID", ".google.com"): "def",
+            ("SID", ".google.com", "/"): "abc",
+            ("__Secure-1PSIDTS", ".google.com", "/"): "test_1psidts",
+            ("HSID", ".google.com", "/"): "def",
         }
         assert tokens.flat_cookies == {
             "SID": "abc",
@@ -690,6 +690,108 @@ class TestCookieAttributePreservation:
         assert gaps.secure is True
         assert gaps.has_nonstandard_attr("HttpOnly")
 
+    def test_build_httpx_cookies_from_storage_keeps_path_siblings(self, tmp_path):
+        """Cookies with same name/domain but different paths coexist on load."""
+        storage_file = tmp_path / "storage_state.json"
+        state = {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "root-sid",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": -1,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+                {
+                    "name": "SID",
+                    "value": "user-sid",
+                    "domain": ".google.com",
+                    "path": "/u/0/",
+                    "expires": -1,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "test_1psidts",
+                    "domain": ".google.com",
+                    "path": "/",
+                },
+            ]
+        }
+        storage_file.write_text(json.dumps(state))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+
+        assert self._find_cookie(jar, "SID", ".google.com", "/").value == "root-sid"
+        assert self._find_cookie(jar, "SID", ".google.com", "/u/0/").value == "user-sid"
+
+    def test_path_sibling_round_trip_preserves_both_cookies(self, tmp_path):
+        """Load → save → reload keeps same-name/domain cookies on distinct paths."""
+        storage_file = tmp_path / "storage_state.json"
+        state = {
+            "cookies": [
+                {
+                    "name": "SID",
+                    "value": "root-sid",
+                    "domain": ".google.com",
+                    "path": "/",
+                    "expires": -1,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+                {
+                    "name": "SID",
+                    "value": "user-sid",
+                    "domain": ".google.com",
+                    "path": "/u/0/",
+                    "expires": -1,
+                    "httpOnly": True,
+                    "secure": True,
+                },
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "test_1psidts",
+                    "domain": ".google.com",
+                    "path": "/",
+                },
+            ]
+        }
+        storage_file.write_text(json.dumps(state))
+
+        jar = build_httpx_cookies_from_storage(storage_file)
+        snapshot = snapshot_cookie_jar(jar)
+        self._find_cookie(jar, "SID", ".google.com", "/u/0/").value = "rotated-user-sid"
+        save_cookies_to_storage(jar, storage_file, original_snapshot=snapshot)
+        reloaded = build_httpx_cookies_from_storage(storage_file)
+
+        assert self._find_cookie(reloaded, "SID", ".google.com", "/").value == "root-sid"
+        assert (
+            self._find_cookie(reloaded, "SID", ".google.com", "/u/0/").value
+            == "rotated-user-sid"
+        )
+
+    def test_find_cookie_for_storage_uses_path_when_siblings_exist(self):
+        """Legacy save lookup chooses the cookie matching name/domain/path."""
+        import httpx
+
+        from notebooklm.auth import _find_cookie_for_storage
+
+        jar = httpx.Cookies()
+        jar.set("SID", "root-sid", domain=".google.com", path="/")
+        jar.set("SID", "user-sid", domain=".google.com", path="/u/0/")
+        cookies_by_key = {
+            (cookie.name, cookie.domain, cookie.path or "/"): cookie for cookie in jar.jar
+        }
+
+        found = _find_cookie_for_storage(cookies_by_key, ("SID", ".google.com", "/u/0/"), None)
+
+        assert found is not None
+        assert found.value == "user-sid"
+        assert found.path == "/u/0/"
+
     def test_round_trip_with_value_change_preserves_attributes(self, tmp_path):
         """Load → bump value → save → reload preserves path/secure/httpOnly.
 
@@ -1057,6 +1159,7 @@ class TestFetchTokens:
         assert (
             "ACCOUNT_REFRESH",
             ".accounts.google.com",
+            "/",
         ) in extract_cookies_with_domains(storage_state)
 
     def test_save_cookies_to_storage_preserves_secure_permissions(self, tmp_path):
@@ -1514,7 +1617,7 @@ class TestAuthTokensFromStorage:
 
         tokens = await AuthTokens.from_storage(storage_file)
 
-        assert tokens.cookies[("SID", ".google.com")] == "sid"
+        assert tokens.cookies[("SID", ".google.com", "/")] == "sid"
         assert tokens.flat_cookies["SID"] == "sid"
         assert tokens.csrf_token == "csrf_token"
         assert tokens.session_id == "session_id"
@@ -2368,8 +2471,8 @@ class TestSiblingGoogleProductExtraction:
             ]
         }
         cookie_map = extract_cookies_with_domains(storage_state)
-        assert ("PRODUCT_TOKEN", domain) in cookie_map
-        assert cookie_map[("PRODUCT_TOKEN", domain)] == "sibling"
+        assert ("PRODUCT_TOKEN", domain, "/") in cookie_map
+        assert cookie_map[("PRODUCT_TOKEN", domain, "/")] == "sibling"
 
     @pytest.mark.parametrize("domain", SIBLING_DOMAINS)
     def test_load_httpx_cookies_keeps_sibling_cookies(self, tmp_path, domain):
@@ -2424,13 +2527,13 @@ class TestSiblingGoogleProductExtraction:
             ]
         }
         cookie_map = extract_cookies_with_domains(storage_state)
-        assert ("SID", ".google.com") in cookie_map
-        assert ("HSID", ".google.com") in cookie_map
-        assert ("OSID", "notebooklm.google.com") in cookie_map
-        assert ("OSID2", ".notebooklm.google.com") in cookie_map
-        assert ("ACC", "accounts.google.com") in cookie_map
-        assert ("ACC2", ".accounts.google.com") in cookie_map
-        assert ("MEDIA", ".googleusercontent.com") in cookie_map
+        assert ("SID", ".google.com", "/") in cookie_map
+        assert ("HSID", ".google.com", "/") in cookie_map
+        assert ("OSID", "notebooklm.google.com", "/") in cookie_map
+        assert ("OSID2", ".notebooklm.google.com", "/") in cookie_map
+        assert ("ACC", "accounts.google.com", "/") in cookie_map
+        assert ("ACC2", ".accounts.google.com", "/") in cookie_map
+        assert ("MEDIA", ".googleusercontent.com", "/") in cookie_map
 
     def test_unified_filter_rejects_unrelated_domains(self):
         """Regression: cookies from unrelated domains are still rejected."""
@@ -2445,7 +2548,7 @@ class TestSiblingGoogleProductExtraction:
             ]
         }
         cookie_map = extract_cookies_with_domains(storage_state)
-        kept_names = {name for name, _ in cookie_map}
+        kept_names = {name for name, _domain, _path in cookie_map}
         assert kept_names == {"SID", "__Secure-1PSIDTS"}
 
 


### PR DESCRIPTION
## Summary
- make cookie identity path-aware as `(name, domain, path)` across load/save helpers
- add `source fulltext --markdown` to preserve raw markdown for markdown report sources when the response includes it
- make `source add-research --timeout` bound research polling as well as import retries

Fixes #369.
Fixes #315.
Fixes #222.

## Verification
- `uv run pytest tests/unit/test_auth.py tests/unit/cli/test_source.py tests/integration/test_sources.py -q` (441 passed, 2 skipped)
- `uv run mypy src/notebooklm/auth.py src/notebooklm/_sources.py src/notebooklm/cli/source.py`
- `uv run ruff check src/notebooklm/auth.py src/notebooklm/_sources.py src/notebooklm/cli/source.py tests/unit/test_auth.py tests/unit/cli/test_source.py tests/integration/test_sources.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--markdown` flag to `source fulltext` command to preserve original markdown formatting from sources.

* **Improvements**
  * Enhanced timeout handling in `source add-research` command with improved time-based deadline logic.
  * Improved authentication session reliability through refined cookie management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->