### PR TITLE
feat(sources): markdown output format for get_fulltext (closes #222, takes over #223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Source fulltext markdown format** - Retrieve source content as structured Markdown with headings, tables, links, and emphasis preserved (closes #222)
+  - New `output_format` parameter on `client.sources.get_fulltext()` (`"text"` default, `"markdown"`)
+  - New `-f`/`--format` CLI option on `source fulltext` command
+  - Requires optional `markdownify` dependency (`pip install notebooklm-py[markdown]`)
+
 ### Changed
 - **Cookie identity widened to `(name, domain, path)` per RFC 6265 §5.3** - `CookieKey`, `DomainCookieMap`, `AuthTokens.cookies`, `extract_cookies_with_domains`, and `normalize_cookie_map` now key on the path-aware triple instead of the legacy `(name, domain)` pair. PR #363 already made the snapshot/delta save path path-aware; #406 closes the corresponding load-side and legacy-merge gaps so two cookies sharing `(name, domain)` at distinct paths (e.g. `OSID@/` and `OSID@/u/0/`) coexist end-to-end. **Writes remain fully backward compatible** — `AuthTokens(cookies={"SID": "..."})` (flat) and `AuthTokens(cookies={("SID", ".google.com"): "..."})` (legacy 2-tuple) both still work; `normalize_cookie_map` widens missing paths to `/` and `_update_cookie_input` collapses path-siblings back when the caller's target uses the legacy 2-tuple shape. **Reads of `auth.cookies` with the old 2-tuple key shape now raise `KeyError`** — callers that subscript the dict directly should update from `auth.cookies[("SID", ".google.com")]` to `auth.cookies[("SID", ".google.com", "/")]`, or use `auth.flat_cookies["SID"]` / `auth.cookie_header` when path doesn't matter. The same migration applies to the return value of `extract_cookies_with_domains`. Empirically, every Set-Cookie observed in captured Google traffic uses `path=/`, so this is correctness/headroom rather than a live bug fix (#369, #406).
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,7 +115,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
 | `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait`, `--timeout` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
-| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` |
+| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` (`-f markdown` requires the `markdown` extra: `pip install notebooklm-py[markdown]`) |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
 | `rename <id> <title>` | Source ID, new title | - | `source rename src123 "New Name"` |
 | `refresh <id>` | Source ID | - | `source refresh src123` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,7 +115,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
 | `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait`, `--timeout` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
-| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` (`-f markdown` requires the `markdown` extra: `pip install notebooklm-py[markdown]`) |
+| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` (`-f markdown` requires the `markdown` extra: `pip install "notebooklm-py[markdown]"`) |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
 | `rename <id> <title>` | Source ID, new title | - | `source rename src123 "New Name"` |
 | `refresh <id>` | Source ID | - | `source refresh src123` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,7 +115,7 @@ Supported source types: URLs, YouTube videos, files (PDF, text, Markdown, Word, 
 | `add-drive <id> <title>` | Drive file ID | - | `source add-drive abc123 "Doc"` |
 | `add-research <query>` | Search query | `--mode [fast|deep]`, `--from [web|drive]`, `--import-all`, `--no-wait`, `--timeout` | `source add-research "AI" --mode deep --no-wait` |
 | `get <id>` | Source ID | - | `source get src123` |
-| `fulltext <id>` | Source ID | `--json`, `-o FILE` | `source fulltext src123 -o content.txt` |
+| `fulltext <id>` | Source ID | `--json`, `-o FILE`, `-f [text\|markdown]` | `source fulltext src123 -f markdown -o out.md` |
 | `guide <id>` | Source ID | `--json` | `source guide src123` |
 | `rename <id> <title>` | Source ID, new title | - | `source rename src123 "New Name"` |
 | `refresh <id>` | Source ID | - | `source refresh src123` |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -294,7 +294,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, *, format: str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
+| `get_fulltext(notebook_id, source_id, *, output_format)` | `str, str, *, output_format: str` | `SourceFulltext` | Get full content (output_format: `"text"` or `"markdown"`) |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -294,7 +294,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id)` | `str, str` | `SourceFulltext` | Get full indexed text content |
+| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -294,7 +294,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id, *, output_format)` | `str, str, *, output_format: str` | `SourceFulltext` | Get full content (output_format: `"text"` or `"markdown"`) |
+| `get_fulltext(notebook_id, source_id, *, output_format="text")` | `str, str, *, output_format: Literal["text", "markdown"]` | `SourceFulltext` | Get full content; `"markdown"` requires the optional `markdownify` extra |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -294,7 +294,7 @@ print(url)
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `notebook_id: str` | `list[Source]` | List sources |
 | `get(notebook_id, source_id)` | `str, str` | `Source` | Get source details |
-| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
+| `get_fulltext(notebook_id, source_id, *, format)` | `str, str, *, format: str` | `SourceFulltext` | Get full content (format: `"text"` or `"markdown"`) |
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url)` | `str, str` | `Source` | Add URL source |
 | `add_youtube(notebook_id, url)` | `str, str` | `Source` | Add YouTube video |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "ruff==0.8.6",
     "vcrpy>=6.0.0",
 ]
-all = ["notebooklm-py[browser,dev]"]
+all = ["notebooklm-py[browser,dev,markdown]"]
 
 [project.scripts]
 notebooklm = "notebooklm.notebooklm_cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Documentation = "https://github.com/teng-lin/notebooklm-py#readme"
 Issues = "https://github.com/teng-lin/notebooklm-py/issues"
 
 [project.optional-dependencies]
+markdown = ["markdownify>=0.14.1"]
 browser = ["playwright>=1.40.0"]
 cookies = ["rookiepy>=0.1.0"]
 dev = [

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -874,6 +874,17 @@ class SourcesAPI:
         if output_format not in ("text", "markdown"):
             raise ValueError(f"Invalid format: '{output_format}'. Must be 'text' or 'markdown'.")
 
+        # Fail fast on missing optional dep so CLI users don't pay for an RPC
+        # round-trip before seeing the install hint.
+        if output_format == "markdown":
+            try:
+                from markdownify import markdownify as md
+            except ImportError:
+                raise ImportError(
+                    "The 'markdown' format requires the 'markdownify' package. "
+                    "Install it with: pip install 'notebooklm-py[markdown]'"
+                ) from None
+
         # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
         params = [[source_id], [3], [3]] if output_format == "markdown" else [[source_id], [2], [2]]
 
@@ -908,19 +919,22 @@ class SourcesAPI:
                     url = _extract_source_url(metadata, allow_bare_http=False)
 
             if output_format == "markdown":
-                # HTML content at result[4][1]
+                # HTML content at result[4][1]; may be absent for source types
+                # without an HTML rendition (e.g. youtube, pasted_text).
+                html_content = None
                 if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
-                    html_content = result[4][1]
-                    if isinstance(html_content, str):
-                        try:
-                            from markdownify import markdownify as md
-                        except ImportError:
-                            raise ImportError(
-                                "The 'markdown' format requires the 'markdownify' package. "
-                                "Please install it with: pip install 'notebooklm-py[markdown]'"
-                            ) from None
-
-                        content = md(html_content, heading_style="ATX")
+                    candidate = result[4][1]
+                    if isinstance(candidate, str):
+                        html_content = candidate
+                if html_content is not None:
+                    content = md(html_content, heading_style="ATX")
+                else:
+                    logger.warning(
+                        "Source %s (type=%s) has no HTML rendition for output_format='markdown'; "
+                        "returning empty content. Retry with output_format='text'.",
+                        source_id,
+                        source_type,
+                    )
             else:
                 # Plaintext content blocks at result[3][0]
                 # Each block may be nested arrays with text strings

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -849,9 +849,9 @@ class SourcesAPI:
             source_id: The source ID to get fulltext for.
             format: Content format - ``"text"`` (default) returns flattened
                 plaintext, ``"markdown"`` returns the source with headings,
-                tables, links, and emphasis preserved.  The markdown path
+                tables, links, and emphasis preserved. The markdown format
                 requires the ``markdownify`` package (``pip install
-                markdownify``).
+                'notebooklm-py[markdown]'``).
 
         Returns:
             SourceFulltext object with content, title, source_type, url, and char_count.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -867,6 +867,9 @@ class SourcesAPI:
             from the API (params ``[3],[3]`` instead of ``[2],[2]``) and
             converting it via *markdownify*.
         """
+        if format not in ("text", "markdown"):
+            raise ValueError(f"Invalid format: '{format}'. Must be 'text' or 'markdown'.")
+
         # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
         params = [[source_id], [3], [3]] if format == "markdown" else [[source_id], [2], [2]]
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -905,7 +905,13 @@ class SourcesAPI:
                 if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
                     html_content = result[4][1]
                     if isinstance(html_content, str):
-                        from markdownify import markdownify as md
+                        try:
+                            from markdownify import markdownify as md
+                        except ImportError:
+                            raise ImportError(
+                                "The 'markdown' format requires the 'markdownify' package. "
+                                "Please install it with: pip install 'notebooklm-py[markdown]'"
+                            ) from None
 
                         content = md(html_content, heading_style="ATX")
             else:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import replace
 from pathlib import Path
 from time import monotonic
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qs, urlparse
 
 import httpx
@@ -840,14 +840,18 @@ class SourcesAPI:
         return {"summary": summary, "keywords": keywords}
 
     async def get_fulltext(
-        self, notebook_id: str, source_id: str, *, format: str = "text"
+        self,
+        notebook_id: str,
+        source_id: str,
+        *,
+        output_format: Literal["text", "markdown"] = "text",
     ) -> SourceFulltext:
         """Get the full content of a source.
 
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to get fulltext for.
-            format: Content format - ``"text"`` (default) returns flattened
+            output_format: Content format - ``"text"`` (default) returns flattened
                 plaintext, ``"markdown"`` returns the source with headings,
                 tables, links, and emphasis preserved. The markdown format
                 requires the ``markdownify`` package (``pip install
@@ -867,11 +871,11 @@ class SourcesAPI:
             from the API (params ``[3],[3]`` instead of ``[2],[2]``) and
             converting it via *markdownify*.
         """
-        if format not in ("text", "markdown"):
-            raise ValueError(f"Invalid format: '{format}'. Must be 'text' or 'markdown'.")
+        if output_format not in ("text", "markdown"):
+            raise ValueError(f"Invalid format: '{output_format}'. Must be 'text' or 'markdown'.")
 
         # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
-        params = [[source_id], [3], [3]] if format == "markdown" else [[source_id], [2], [2]]
+        params = [[source_id], [3], [3]] if output_format == "markdown" else [[source_id], [2], [2]]
 
         result = await self._core.rpc_call(
             RPCMethod.GET_SOURCE,
@@ -903,7 +907,7 @@ class SourcesAPI:
                         source_type = metadata[4]
                     url = _extract_source_url(metadata, allow_bare_http=False)
 
-            if format == "markdown":
+            if output_format == "markdown":
                 # HTML content at result[4][1]
                 if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
                     html_content = result[4][1]

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -839,15 +839,19 @@ class SourcesAPI:
 
         return {"summary": summary, "keywords": keywords}
 
-    async def get_fulltext(self, notebook_id: str, source_id: str) -> SourceFulltext:
-        """Get the full indexed text content of a source.
-
-        Returns the raw text content that was extracted and indexed from the source,
-        along with metadata. This is what NotebookLM uses for chat and artifact generation.
+    async def get_fulltext(
+        self, notebook_id: str, source_id: str, *, format: str = "text"
+    ) -> SourceFulltext:
+        """Get the full content of a source.
 
         Args:
             notebook_id: The notebook ID.
             source_id: The source ID to get fulltext for.
+            format: Content format - ``"text"`` (default) returns flattened
+                plaintext, ``"markdown"`` returns the source with headings,
+                tables, links, and emphasis preserved.  The markdown path
+                requires the ``markdownify`` package (``pip install
+                markdownify``).
 
         Returns:
             SourceFulltext object with content, title, source_type, url, and char_count.
@@ -858,9 +862,14 @@ class SourcesAPI:
         Note:
             Source type codes: 1=google_docs, 2=google_other, 3=pdf, 4=pasted_text,
             5=web_page, 8=generated_text, 9=youtube
+
+            The ``"markdown"`` format works by requesting the HTML rendition
+            from the API (params ``[3],[3]`` instead of ``[2],[2]``) and
+            converting it via *markdownify*.
         """
-        # GET_SOURCE RPC with params: [[source_id], [2], [2]]
-        params = [[source_id], [2], [2]]
+        # [3],[3] returns HTML at result[4][1]; [2],[2] returns plaintext at result[3][0]
+        params = [[source_id], [3], [3]] if format == "markdown" else [[source_id], [2], [2]]
+
         result = await self._core.rpc_call(
             RPCMethod.GET_SOURCE,
             params,
@@ -891,13 +900,22 @@ class SourcesAPI:
                         source_type = metadata[4]
                     url = _extract_source_url(metadata, allow_bare_http=False)
 
-            # Content blocks at result[3][0]
-            # Each block may be nested arrays with text strings
-            if len(result) > 3 and isinstance(result[3], list) and len(result[3]) > 0:
-                content_blocks = result[3][0]
-                if isinstance(content_blocks, list):
-                    texts = self._extract_all_text(content_blocks)
-                    content = "\n".join(texts)
+            if format == "markdown":
+                # HTML content at result[4][1]
+                if len(result) > 4 and isinstance(result[4], list) and len(result[4]) > 1:
+                    html_content = result[4][1]
+                    if isinstance(html_content, str):
+                        from markdownify import markdownify as md
+
+                        content = md(html_content, heading_style="ATX")
+            else:
+                # Plaintext content blocks at result[3][0]
+                # Each block may be nested arrays with text strings
+                if len(result) > 3 and isinstance(result[3], list) and len(result[3]) > 0:
+                    content_blocks = result[3][0]
+                    if isinstance(content_blocks, list):
+                        texts = self._extract_all_text(content_blocks)
+                        content = "\n".join(texts)
 
         # Log warning if content is empty but source exists
         if not content:

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -672,13 +672,13 @@ def source_add_research(
 @click.option(
     "--format",
     "-f",
-    "content_format",
+    "output_format",
     type=click.Choice(["text", "markdown"]),
     default="text",
     help="Content format: text (default) or markdown",
 )
 @with_client
-def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_format, client_auth):
+def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_format, client_auth):
     """Get full content of a source.
 
     Retrieves the complete content from NotebookLM. Use --format markdown to get
@@ -701,7 +701,7 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_fo
 
             with console.status("Fetching fulltext content..."):
                 fulltext = await client.sources.get_fulltext(
-                    nb_id_resolved, resolved_id, output_format=content_format
+                    nb_id_resolved, resolved_id, output_format=output_format
                 )
 
             if json_output:
@@ -722,14 +722,14 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_fo
                 console.print(f"[bold]URL:[/bold] {fulltext.url}")
             console.print()
             console.print("[bold cyan]Content:[/bold cyan]")
-            # Show first 2000 chars with truncation notice
+            # markup=False so markdown links like `[text](url)` are not eaten by Rich's tag parser
             if len(fulltext.content) > 2000:
-                console.print(fulltext.content[:2000])
+                console.print(fulltext.content[:2000], markup=False, highlight=False)
                 console.print(
                     f"\n[dim]... ({fulltext.char_count - 2000:,} more chars, use -o to save full content)[/dim]"
                 )
             else:
-                console.print(fulltext.content)
+                console.print(fulltext.content, markup=False, highlight=False)
 
     return _run()
 

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -669,20 +669,28 @@ def source_add_research(
 )
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.option("--output", "-o", type=click.Path(), help="Write content to file")
+@click.option(
+    "--format",
+    "-f",
+    "content_format",
+    type=click.Choice(["text", "markdown"]),
+    default="text",
+    help="Content format: text (default) or markdown",
+)
 @with_client
-def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_auth):
-    """Get full indexed text content of a source.
+def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_format, client_auth):
+    """Get full content of a source.
 
-    Retrieves the complete text content as indexed by NotebookLM. This is the
-    actual text that NotebookLM uses when answering questions about this source.
+    Retrieves the complete content from NotebookLM. Use --format markdown to get
+    a rich version with headings, tables, links, and emphasis preserved.
 
     SOURCE_ID can be a full UUID or a partial prefix (e.g., 'abc' matches 'abc123...').
 
     \b
     Examples:
-      source fulltext abc123                    # Show fulltext in terminal
-      source fulltext abc123 --json             # Output as JSON
-      source fulltext abc123 -o content.txt     # Save to file
+      source fulltext abc123                        # Show plaintext in terminal
+      source fulltext abc123 -f markdown -o out.md  # Save markdown to file
+      source fulltext abc123 --json                 # Output as JSON
     """
     nb_id = require_notebook(notebook_id)
 
@@ -692,7 +700,9 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, client_aut
             resolved_id = await resolve_source_id(client, nb_id_resolved, source_id)
 
             with console.status("Fetching fulltext content..."):
-                fulltext = await client.sources.get_fulltext(nb_id_resolved, resolved_id)
+                fulltext = await client.sources.get_fulltext(
+                    nb_id_resolved, resolved_id, format=content_format
+                )
 
             if json_output:
                 from dataclasses import asdict

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -701,7 +701,7 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, content_fo
 
             with console.status("Fetching fulltext content..."):
                 fulltext = await client.sources.get_fulltext(
-                    nb_id_resolved, resolved_id, format=content_format
+                    nb_id_resolved, resolved_id, output_format=content_format
                 )
 
             if json_output:

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -1026,7 +1026,7 @@ class TestGetFulltext:
     async def test_get_fulltext_invalid_format_raises(self, auth_tokens):
         """Unknown output_format must fail fast before any RPC call."""
         async with NotebookLMClient(auth_tokens) as client:
-            with pytest.raises(ValueError, match="text.*markdown"):
+            with pytest.raises(ValueError, match=r"text.*markdown"):
                 await client.sources.get_fulltext(
                     "nb_123",
                     "src_x",

--- a/tests/integration/test_sources.py
+++ b/tests/integration/test_sources.py
@@ -970,6 +970,112 @@ class TestGetFulltext:
         assert fulltext.content == ""
         assert fulltext.char_count == 0
 
+    @pytest.mark.asyncio
+    async def test_get_fulltext_markdown_basic(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Markdown mode converts HTML at result[4][1] via markdownify."""
+        pytest.importorskip("markdownify")
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [
+                ["source_md", "MD Article", []],
+                None,
+                None,
+                None,
+                [None, "<h1>Title</h1><p>Hello <strong>world</strong>.</p>"],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            fulltext = await client.sources.get_fulltext(
+                "nb_123", "source_md", output_format="markdown"
+            )
+
+        assert fulltext.source_id == "source_md"
+        assert "# Title" in fulltext.content
+        assert "**world**" in fulltext.content
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_markdown_sends_params_3_3(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Markdown mode requests HTML rendition via params [3],[3]."""
+        pytest.importorskip("markdownify")
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [["src_x", "T", []], None, None, None, [None, "<p>x</p>"]],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            await client.sources.get_fulltext("nb_123", "src_x", output_format="markdown")
+
+        body = urllib.parse.unquote(httpx_mock.get_request().content.decode())
+        assert "[3]" in body
+        assert "[2]" not in body or body.count("[3]") >= 2
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_invalid_format_raises(self, auth_tokens):
+        """Unknown output_format must fail fast before any RPC call."""
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ValueError, match="text.*markdown"):
+                await client.sources.get_fulltext(
+                    "nb_123",
+                    "src_x",
+                    output_format="html",  # type: ignore[arg-type]
+                )
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_markdown_missing_dep_raises(self, monkeypatch, auth_tokens):
+        """When markdownify is unavailable, ImportError surfaces before the RPC."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "markdownify":
+                raise ImportError("No module named 'markdownify'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with pytest.raises(ImportError, match="markdownify"):
+                await client.sources.get_fulltext("nb_123", "src_x", output_format="markdown")
+
+    @pytest.mark.asyncio
+    async def test_get_fulltext_markdown_no_html_returns_empty(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+        caplog,
+    ):
+        """Source with no HTML rendition logs a warning and returns empty content."""
+        pytest.importorskip("markdownify")
+        response = build_rpc_response(
+            RPCMethod.GET_SOURCE,
+            [["src_yt", "YouTube vid", []], None, None, None],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        async with NotebookLMClient(auth_tokens) as client:
+            with caplog.at_level("WARNING"):
+                fulltext = await client.sources.get_fulltext(
+                    "nb_123", "src_yt", output_format="markdown"
+                )
+
+        assert fulltext.content == ""
+        assert any("no HTML rendition" in r.message for r in caplog.records)
+
 
 class TestListSourcesMalformedResponse:
     """Tests for list() warning paths when API response is malformed (lines 71-95)."""

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -1351,6 +1351,39 @@ class TestSourceFulltext:
             assert data["content"] == "Some content"
             assert data["char_count"] == 12
 
+    def test_source_fulltext_format_markdown_propagates(self, runner, mock_auth):
+        """`-f markdown` propagates output_format='markdown' to the API."""
+        with patch_client_for_module("source") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.sources.list = AsyncMock(
+                return_value=[Source(id="src_123", title="MD Source")]
+            )
+            mock_client.sources.get_fulltext = AsyncMock(
+                return_value=SourceFulltext(
+                    source_id="src_123",
+                    title="MD Source",
+                    content="# Heading\n\n[link](https://example.com)",
+                    char_count=39,
+                    url=None,
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["source", "fulltext", "src_123", "-n", "nb_123", "-f", "markdown"]
+                )
+
+            assert result.exit_code == 0
+            mock_client.sources.get_fulltext.assert_awaited_once()
+            _, kwargs = mock_client.sources.get_fulltext.call_args
+            assert kwargs["output_format"] == "markdown"
+            # Markdown link should round-trip verbatim, not be eaten by Rich markup
+            assert "[link](https://example.com)" in result.output
+
     def test_source_fulltext_with_url(self, runner, mock_auth):
         """Shows URL field when present in fulltext."""
         with patch_client_for_module("source") as mock_client_cls:


### PR DESCRIPTION
Adds an `output_format` kwarg to `client.sources.get_fulltext()` and a `-f/--format` CLI flag on `source fulltext`. Builds on @jaytxng's work in #223 — rebased onto current `main`, merge conflicts resolved, polish pass applied.

Closes #222. Supersedes #223.

## Summary

- New `output_format: Literal["text", "markdown"]` kwarg on `client.sources.get_fulltext()` (default `"text"` — fully backward compatible).
- New `-f`/`--format` CLI option on `source fulltext`.
- Markdown format preserves headings, tables, links, and emphasis from the source by requesting the API's HTML rendition (params `[3],[3]`) and converting it via `markdownify`.
- `markdownify` is gated behind a new `[markdown]` extra (also pulled into `[all]`): `pip install 'notebooklm-py[markdown]'`.

## Polish pass (on top of @jaytxng's commits)

After rebasing, ran a three-reviewer pass (Claude / Codex / Gemini) and applied consensus fixes:

- **Fail-fast on missing optional dep.** `markdownify` is checked at the top of the `markdown` branch, before the RPC call, so CLI users see the install hint without paying a network round-trip first.
- **Surface missing-HTML-rendition explicitly.** For source types without an HTML rendition (e.g. youtube, pasted_text), markdown mode now logs a clear warning naming `output_format='markdown'` and suggesting `'text'`, instead of silently returning empty content.
- **Rich markup escape.** CLI output uses `markup=False, highlight=False` so markdown link syntax like `[link](url)` round-trips verbatim instead of being eaten by Rich's tag parser.
- **Naming consistency.** Click destination renamed `content_format` → `output_format` to match the API kwarg at the call site.
- **Docs.** `python-api.md` signature updated to show `Literal["text", "markdown"]` and the `markdownify` requirement.
- **Tests.** Added integration + CLI unit tests covering: markdown happy path, `[3],[3]` params on the wire, invalid `output_format` rejection, missing `markdownify` dependency, missing HTML rendition, and CLI `-f markdown` propagation (incl. asserting Rich markup is not eaten).

## Test plan

- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] Full test suite: **2615 passed, 9 skipped, 0 failed**
- [x] New tests added: 4 integration + 1 CLI unit (see `tests/integration/test_sources.py::TestGetFulltext::test_get_fulltext_markdown_*` and `tests/unit/cli/test_source.py::TestSourceFulltext::test_source_fulltext_format_markdown_propagates`)
- [ ] Manual smoke against a real notebook (deferred; covered by CI cassettes — no shape change to `[2],[2]` path)

## Author attribution

Original work by @jaytxng across 9 commits (preserved with their authorship). Polish commit is mine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added markdown output format for source fulltext: available via CLI `-f markdown` and Python API `output_format="markdown"`.
  * CLI output formatting updated to render markdown appropriately.

* **Documentation**
  * Updated CLI reference and Python API docs with examples and notes about the markdown option and optional dependency.

* **Dependencies**
  * Optional markdown conversion extra added (install to enable markdown output).

* **Tests**
  * Added tests covering markdown output behavior and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/410)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->