### PR TITLE
revert(cli): restore pure-create contract from PR-220

### DIFF
--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -22,7 +22,6 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
-    set_current_notebook,
     with_client,
 )
 
@@ -83,9 +82,6 @@ def register_notebook_commands(cli):
             async with NotebookLMClient(client_auth) as client:
                 nb = await client.notebooks.create(title)
 
-                created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
-                set_current_notebook(nb.id, nb.title, nb.is_owner, created_str)
-
                 if json_output:
                     data = {
                         "notebook": {
@@ -98,7 +94,6 @@ def register_notebook_commands(cli):
                     return
 
                 console.print(f"[green]Created notebook:[/green] {nb.id} - {nb.title}")
-                console.print("[dim]Context set to new notebook[/dim]")
 
         return _run()
 

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -120,7 +120,7 @@ class TestNotebookList:
 
 
 class TestNotebookCreate:
-    def test_notebook_create(self, runner, mock_auth, mock_context_file):
+    def test_notebook_create(self, runner, mock_auth):
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.create = AsyncMock(
@@ -138,12 +138,8 @@ class TestNotebookCreate:
 
             assert result.exit_code == 0
             assert "Created notebook" in result.output
-            assert "Context set to new notebook" in result.output
-            context = json.loads(mock_context_file.read_text())
-            assert context["notebook_id"] == "new_nb_id"
-            assert context["title"] == "Test Notebook"
 
-    def test_notebook_create_json_output(self, runner, mock_auth, mock_context_file):
+    def test_notebook_create_json_output(self, runner, mock_auth):
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.create = AsyncMock(
@@ -162,54 +158,6 @@ class TestNotebookCreate:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["notebook"]["id"] == "new_nb_id"
-            context = json.loads(mock_context_file.read_text())
-            assert context["notebook_id"] == "new_nb_id"
-
-    def test_notebook_create_replaces_existing_context(self, runner, mock_auth, mock_context_file):
-        """Reproduces #220: create must overwrite a previously active context."""
-        mock_context_file.write_text(
-            json.dumps({"notebook_id": "old_nb", "title": "Previously Active"})
-        )
-
-        with patch_main_cli_client() as mock_client_cls:
-            mock_client = create_mock_client()
-            mock_client.notebooks.create = AsyncMock(
-                return_value=Notebook(
-                    id="brand_new", title="Fresh", created_at=datetime(2024, 1, 1)
-                )
-            )
-            mock_client_cls.return_value = mock_client
-
-            with patch(
-                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
-                result = runner.invoke(cli, ["create", "Fresh"])
-
-            assert result.exit_code == 0
-            context = json.loads(mock_context_file.read_text())
-            assert context["notebook_id"] == "brand_new"
-            assert context["title"] == "Fresh"
-
-    def test_notebook_create_without_created_at(self, runner, mock_auth, mock_context_file):
-        """Guard the `if nb.created_at else None` branch so a future refactor can't regress it."""
-        with patch_main_cli_client() as mock_client_cls:
-            mock_client = create_mock_client()
-            mock_client.notebooks.create = AsyncMock(
-                return_value=Notebook(id="nb_no_date", title="Undated", created_at=None)
-            )
-            mock_client_cls.return_value = mock_client
-
-            with patch(
-                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
-            ) as mock_fetch:
-                mock_fetch.return_value = ("csrf", "session")
-                result = runner.invoke(cli, ["create", "Undated"])
-
-            assert result.exit_code == 0
-            context = json.loads(mock_context_file.read_text())
-            assert context["notebook_id"] == "nb_no_date"
-            assert "created_at" not in context
 
     def test_notebook_create_json_quota_error(self, runner, mock_auth):
         """Create emits structured JSON when notebook quota is detected."""


### PR DESCRIPTION
## Summary

Revert #220 (`fix(cli): auto-set context to newly created notebook`).

PR-220 fixed a real workflow pain — after `notebooklm create`, subsequent commands like `source add` targeted the previously-active notebook instead of the new one — but it did so by coupling a write command with **implicit context mutation** in both text and `--json` modes.

That breaks a pre-existing rule in this CLI:

| Command | Touches context? |
|---|---|
| `use` | yes — dedicated context-mutation verb |
| `list`, `get`, `rename` | no |
| `delete` | only as cleanup (clears stale ref) |
| `create` (after #220) | **yes — implicit, both modes** |

Two specific concerns:

1. **`--json` script trap.** Scripts and LLM agents that previously used `notebooklm create "X" --json | jq .notebook.id` as a stateless "give me an ID" call now get a hidden state mutation as a side effect. That violates the usual contract that `--json` output ≠ out-of-band state change.

2. **Mass-create races.** `set_current_notebook` does a non-atomic read-modify-write with no file lock. 100 concurrent `notebooklm create` invocations can race on the context file, and the `data["account"]` preservation block can drop fresh account updates. Was always going to be a footgun, but PR-220 made it the default path.

The asymmetric mitigation — keep mutation in text mode, strip it from `--json` — was rejected because coupling output format with side-effect semantics is a stronger smell than the bug PR-220 was trying to fix.

Reverting now, before any release ships this behavior. The bug reporter's one-command workflow will be restored in a follow-up that adds `--use` (with `-u` shorthand) as an opt-in flag — default stays pure, both modes consistent.

## Test plan

- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] `pytest` — 2642 passed, 12 skipped (PR-220's tests removed by the revert)
- [ ] CI matrix green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook creation command behavior has changed: newly created notebooks no longer automatically become your current notebook in the CLI. The "Context set to new notebook" confirmation message has been removed. All other notebook operations, including JSON output and success notifications, remain fully functional.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/412)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->