### PR TITLE
feat(cli): add --use flag to create for opt-in context switch

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -83,7 +83,8 @@ See [Configuration](configuration.md) for details on environment variables and C
 | Command | Description | Example |
 |---------|-------------|---------|
 | `list` | List all notebooks | `notebooklm list` |
-| `create <title>` | Create notebook | `notebooklm create "Research"` |
+| `create <title>` | Create notebook (does not change active context) | `notebooklm create "Research"` |
+| `create <title> --use` | Create notebook and make it the active context | `notebooklm create "Research" --use` |
 | `delete -n <id>` | Delete notebook (uses current notebook if `-n` omitted) | `notebooklm delete -n abc123` |
 | `rename <title>` | Rename current notebook | `notebooklm rename "New Title"` |
 | `summary` | Get AI summary | `notebooklm summary` |

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -22,6 +22,7 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
+    set_current_notebook,
     with_client,
 )
 
@@ -73,14 +74,30 @@ def register_notebook_commands(cli):
 
     @cli.command("create")
     @click.argument("title")
+    @click.option(
+        "--use",
+        "-u",
+        "switch_context",
+        is_flag=True,
+        help="Set the new notebook as the current context (like 'notebooklm use <id>').",
+    )
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @with_client
-    def create_cmd(ctx, title, json_output, client_auth):
-        """Create a new notebook."""
+    def create_cmd(ctx, title, switch_context, json_output, client_auth):
+        """Create a new notebook.
+
+        By default, creates the notebook without changing the active context.
+        Pass --use (or -u) to make the new notebook the current context, so
+        subsequent commands like 'source add' target it.
+        """
 
         async def _run():
             async with NotebookLMClient(client_auth) as client:
                 nb = await client.notebooks.create(title)
+
+                if switch_context:
+                    created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
+                    set_current_notebook(nb.id, nb.title, nb.is_owner, created_str)
 
                 if json_output:
                     data = {
@@ -94,6 +111,12 @@ def register_notebook_commands(cli):
                     return
 
                 console.print(f"[green]Created notebook:[/green] {nb.id} - {nb.title}")
+                if switch_context:
+                    console.print("[dim]Context set to new notebook[/dim]")
+                else:
+                    console.print(
+                        f"[dim]Tip: pass --use next time, or run 'notebooklm use {nb.id}'.[/dim]"
+                    )
 
         return _run()
 

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -120,7 +120,8 @@ class TestNotebookList:
 
 
 class TestNotebookCreate:
-    def test_notebook_create(self, runner, mock_auth):
+    def test_notebook_create(self, runner, mock_auth, mock_context_file):
+        """Default create stays pure — context file is not touched."""
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.create = AsyncMock(
@@ -138,8 +139,38 @@ class TestNotebookCreate:
 
             assert result.exit_code == 0
             assert "Created notebook" in result.output
+            assert "--use" in result.output  # hint shown when flag is omitted
+            assert not mock_context_file.exists()
 
-    def test_notebook_create_json_output(self, runner, mock_auth):
+    def test_notebook_create_does_not_overwrite_existing_context(
+        self, runner, mock_auth, mock_context_file
+    ):
+        """Default create must leave a previously active context untouched."""
+        mock_context_file.write_text(
+            json.dumps({"notebook_id": "old_nb", "title": "Previously Active"})
+        )
+
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(
+                return_value=Notebook(
+                    id="new_nb_id", title="Fresh", created_at=datetime(2024, 1, 1)
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Fresh"])
+
+            assert result.exit_code == 0
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "old_nb"
+
+    def test_notebook_create_json_output(self, runner, mock_auth, mock_context_file):
+        """JSON mode without --use is pure — no context mutation, no hint noise."""
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.create = AsyncMock(
@@ -158,6 +189,72 @@ class TestNotebookCreate:
             assert result.exit_code == 0
             data = json.loads(result.output)
             assert data["notebook"]["id"] == "new_nb_id"
+            assert not mock_context_file.exists()
+
+    def test_notebook_create_with_use_flag(self, runner, mock_auth, mock_context_file):
+        """`create --use` switches context (text mode)."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(
+                return_value=Notebook(
+                    id="new_nb_id", title="Test Notebook", created_at=datetime(2024, 1, 1)
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Test Notebook", "--use"])
+
+            assert result.exit_code == 0
+            assert "Context set to new notebook" in result.output
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "new_nb_id"
+            assert context["title"] == "Test Notebook"
+
+    def test_notebook_create_with_use_short_flag(self, runner, mock_auth, mock_context_file):
+        """`-u` shorthand works identically to `--use`."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(
+                return_value=Notebook(id="short_id", title="Short", created_at=datetime(2024, 1, 1))
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Short", "-u"])
+
+            assert result.exit_code == 0
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "short_id"
+
+    def test_notebook_create_with_use_json(self, runner, mock_auth, mock_context_file):
+        """`create --use --json` switches context AND emits JSON (consistent with text mode)."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.create = AsyncMock(
+                return_value=Notebook(
+                    id="new_nb_id", title="Test Notebook", created_at=datetime(2024, 1, 1)
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["create", "Test Notebook", "--use", "--json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data["notebook"]["id"] == "new_nb_id"
+            context = json.loads(mock_context_file.read_text())
+            assert context["notebook_id"] == "new_nb_id"
 
     def test_notebook_create_json_quota_error(self, runner, mock_auth):
         """Create emits structured JSON when notebook quota is detected."""


### PR DESCRIPTION
## Summary

Restores the one-command workflow from #220 — `notebooklm create "X"` immediately followed by `source add` working on the new notebook — but as an **opt-in** behavior instead of an implicit side effect.

```bash
# Default: pure create, no state mutation (either mode)
notebooklm create "Research"
notebooklm create "Research" --json | jq .notebook.id

# Opt-in: create AND switch to it
notebooklm create "Research" --use
notebooklm create "Research" -u
notebooklm create "Research" --use --json
```

## Design notes

- `create` stays consistent with the CLI's existing verb model: `use` is the dedicated context-mutation verb; non-mutation commands (`list`, `get`, `rename`) leave context alone; `delete` only touches context as cleanup.
- Both text and JSON modes are behaviorally symmetric — the flag is the contract, the output format is presentation. Avoids the format/state-coupling smell that killed the earlier asymmetric proposal.
- Text mode without `--use` prints a one-line dim hint pointing at the flag and at `notebooklm use <id>`. JSON mode stays silent so piped output is unchanged.
- Mass-create races on the context file become opt-in: `for i in {1..100}; do notebooklm create "n$i"; done` is safe by default; only the `--use` form touches the file.

## Test plan

- [x] `test_notebook_create` — default, text mode: hint shown, context file untouched
- [x] `test_notebook_create_does_not_overwrite_existing_context` — pre-existing context is preserved (regression for the earlier auto-mutation behavior)
- [x] `test_notebook_create_json_output` — default, JSON mode: pure
- [x] `test_notebook_create_with_use_flag` — `--use` in text mode: context written
- [x] `test_notebook_create_with_use_short_flag` — `-u` shorthand
- [x] `test_notebook_create_with_use_json` — `--use --json`: context written AND JSON emitted
- [x] `ruff format --check .` / `ruff check .` / `mypy` clean
- [x] Full suite: 2646 passed, 12 skipped
- [ ] CI matrix green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--use` (shorthand: `-u`) flag for notebook creation that sets the newly created notebook as the active context
  * Updated creation feedback to confirm context switching when the flag is used, or suggest the flag for future use

* **Documentation**
  * Updated CLI reference guide to document the new `--use` flag option for notebook creation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/413)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->