### PR TITLE
feat(login): add --browser chrome and auto-detect login completion

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -1245,6 +1245,14 @@ def register_session_commands(cli):
                             "Try again with: notebooklm login"
                         )
                         raise SystemExit(1) from None
+                    except PlaywrightError as exc:
+                        # Browser/tab closed during the wait. Cannot resume a
+                        # partially completed SSO form, so surface the same
+                        # help text other browser-closed paths use.
+                        if TARGET_CLOSED_ERROR in str(exc):
+                            console.print(BROWSER_CLOSED_HELP)
+                            raise SystemExit(1) from exc
+                        raise
                     console.print("[green]Login detected.[/green]")
 
                 # Force .google.com cookies for regional users (e.g. UK lands on
@@ -1270,6 +1278,20 @@ def register_session_commands(cli):
                                     raise
                         elif not _is_navigation_interrupted_error(error_str):
                             raise
+
+                # Defense-in-depth: wait_for_url proved we reached the host,
+                # but the cookie-forcing round-trip above can land us back on
+                # accounts.google.com if the session was invalidated mid-flow
+                # (rare, but the old interactive path defended against this
+                # via a "save anyway?" confirm). Auto-detect is non-interactive,
+                # so fail fast with a clear next step instead.
+                if not _url_matches_base_host(page.url):
+                    console.print(
+                        f"[red]Unexpected URL after login: {page.url}[/red]\n"
+                        "Authentication may be incomplete. "
+                        "Try: notebooklm login --fresh"
+                    )
+                    raise SystemExit(1)
 
                 context.storage_state(path=str(storage_path))
                 from ..auth import clear_account_metadata

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -941,9 +941,13 @@ def register_session_commands(cli):
     )
     @click.option(
         "--browser",
-        type=click.Choice(["chromium", "msedge"], case_sensitive=False),
+        type=click.Choice(["chromium", "chrome", "msedge"], case_sensitive=False),
         default="chromium",
-        help="Browser to use for login (default: chromium). Use 'msedge' for Microsoft Edge.",
+        help=(
+            "Browser to use for login (default: chromium). "
+            "Use 'chrome' for system Google Chrome (workaround when bundled "
+            "Chromium crashes, e.g. macOS 15+), 'msedge' for Microsoft Edge."
+        ),
     )
     @click.option(
         "--browser-cookies",
@@ -1008,9 +1012,10 @@ def register_session_commands(cli):
     ):
         """Log in to NotebookLM via browser.
 
-        Opens a browser window for Google login. After logging in,
-        press ENTER in the terminal to save authentication.
+        Opens a browser window for Google login. Authentication is saved
+        automatically once login is detected (no terminal interaction needed).
 
+        Use --browser chrome if the bundled Chromium crashes (e.g. macOS 15+).
         Use --browser msedge if your organization requires Microsoft Edge for SSO.
 
         Note: Cannot be used when NOTEBOOKLM_AUTH_JSON is set (use file-based
@@ -1107,23 +1112,30 @@ def register_session_commands(cli):
 
         try:
             from playwright.sync_api import Error as PlaywrightError
+            from playwright.sync_api import TimeoutError as PlaywrightTimeout
             from playwright.sync_api import sync_playwright
         except ImportError:
-            if browser == "msedge":
+            if browser in ("msedge", "chrome"):
                 install_hint = "  pip install notebooklm[browser]"
             else:
                 install_hint = "  pip install notebooklm[browser]\n  playwright install chromium"
             console.print(f"[red]Playwright not installed. Run:[/red]\n{install_hint}")
             raise SystemExit(1) from None
 
-        # Pre-flight check: verify Chromium browser is installed (skip for Edge)
+        # Pre-flight check: verify Chromium browser is installed (system Chrome
+        # and Edge are checked at launch time by Playwright's channel routing).
         if browser == "chromium":
             _ensure_chromium_installed()
 
         from ..paths import resolve_profile
 
         profile_name = resolve_profile()
-        browser_label = "Microsoft Edge" if browser == "msedge" else "Chromium"
+        browser_labels = {
+            "msedge": "Microsoft Edge",
+            "chrome": "Google Chrome",
+            "chromium": "Chromium",
+        }
+        browser_label = browser_labels.get(browser, "Chromium")
         console.print(f"[dim]Profile: {profile_name}[/dim]")
         console.print(f"[yellow]Opening {browser_label} for Google login...[/yellow]")
         console.print(f"[dim]Using persistent profile: {browser_profile}[/dim]")
@@ -1140,8 +1152,8 @@ def register_session_commands(cli):
                 ],
                 "ignore_default_args": ["--enable-automation"],
             }
-            if browser == "msedge":
-                launch_kwargs["channel"] = "msedge"
+            if browser in ("msedge", "chrome"):
+                launch_kwargs["channel"] = browser
 
             context = None
             try:
@@ -1209,12 +1221,25 @@ def register_session_commands(cli):
                             logger.debug(f"Non-retryable error: {error_str}")
                             raise
 
-                console.print("\n[bold green]Instructions:[/bold green]")
-                console.print("1. Complete the Google login in the browser window")
-                console.print("2. Wait until you see the NotebookLM homepage")
-                console.print("3. Press [bold]ENTER[/bold] here to save and close\n")
-
-                input("[Press ENTER when logged in] ")
+                if _url_matches_base_host(page.url):
+                    # Persistent browser profile already has a valid session.
+                    console.print("[green]Already logged in.[/green]")
+                else:
+                    console.print("\n[bold green]Instructions:[/bold green]")
+                    console.print("1. Complete the Google login in the browser window")
+                    console.print(
+                        "2. Authentication will be saved automatically once login is detected\n"
+                    )
+                    console.print("[dim]Waiting for login (up to 5 minutes)...[/dim]")
+                    try:
+                        page.wait_for_url(f"{get_base_url()}/**", timeout=300_000)
+                    except PlaywrightTimeout:
+                        console.print(
+                            "[red]Login not detected within 5 minutes.[/red]\n"
+                            "Try again with: notebooklm login"
+                        )
+                        raise SystemExit(1) from None
+                    console.print("[green]Login detected.[/green]")
 
                 # Force .google.com cookies for regional users (e.g. UK lands on
                 # .google.co.uk). Use "commit" to resolve once response headers
@@ -1240,12 +1265,6 @@ def register_session_commands(cli):
                         elif not _is_navigation_interrupted_error(error_str):
                             raise
 
-                current_url = page.url
-                if not _url_matches_base_host(current_url):
-                    console.print(f"[yellow]Warning: Current URL is {current_url}[/yellow]")
-                    if not click.confirm("Save authentication anyway?"):
-                        raise SystemExit(1)
-
                 context.storage_state(path=str(storage_path))
                 from ..auth import clear_account_metadata
 
@@ -1264,16 +1283,23 @@ def register_session_commands(cli):
 
             except Exception as e:
                 # Handle browser launch errors specially (context will be None if launch failed)
-                if context is None:
-                    if browser == "msedge" and (
-                        "executable doesn't exist" in str(e).lower()
-                        or "no such file" in str(e).lower()
-                        or "failed to launch" in str(e).lower()
-                    ):
-                        logger.error(f"Microsoft Edge not found: {e}")
+                if context is None and browser in ("msedge", "chrome"):
+                    err = str(e).lower()
+                    is_not_found = (
+                        "executable doesn't exist" in err
+                        or "is not found at" in err
+                        or "no such file" in err
+                        or "failed to launch" in err
+                    )
+                    if is_not_found:
+                        install_urls = {
+                            "msedge": "https://www.microsoft.com/edge",
+                            "chrome": "https://www.google.com/chrome",
+                        }
+                        logger.error(f"{browser_labels[browser]} not found: {e}")
                         console.print(
-                            "[red]Microsoft Edge not found.[/red]\n"
-                            "Install from: https://www.microsoft.com/edge\n"
+                            f"[red]{browser_labels[browser]} not found.[/red]\n"
+                            f"Install from: {install_urls[browser]}\n"
                             "Or use the default Chromium browser: notebooklm login"
                         )
                         raise SystemExit(1) from e

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -113,6 +113,16 @@ def _url_matches_base_host(url: str) -> bool:
     return current_host == get_base_host().lower()
 
 
+# Browsers launched via Playwright's `channel` parameter (system-installed,
+# not the bundled Chromium). Maps channel name -> (display label, install URL).
+# Used for the --browser option, the launch banner, and the not-installed
+# error path. The bundled "chromium" choice is intentionally absent.
+_CHANNEL_BROWSERS: dict[str, tuple[str, str]] = {
+    "msedge": ("Microsoft Edge", "https://www.microsoft.com/edge"),
+    "chrome": ("Google Chrome", "https://www.google.com/chrome"),
+}
+
+
 # Maps user-facing browser names to rookiepy function names.
 _ROOKIEPY_BROWSER_ALIASES: dict[str, str] = {
     "arc": "arc",
@@ -941,7 +951,7 @@ def register_session_commands(cli):
     )
     @click.option(
         "--browser",
-        type=click.Choice(["chromium", "chrome", "msedge"], case_sensitive=False),
+        type=click.Choice(["chromium", *_CHANNEL_BROWSERS], case_sensitive=False),
         default="chromium",
         help=(
             "Browser to use for login (default: chromium). "
@@ -1115,7 +1125,7 @@ def register_session_commands(cli):
             from playwright.sync_api import TimeoutError as PlaywrightTimeout
             from playwright.sync_api import sync_playwright
         except ImportError:
-            if browser in ("msedge", "chrome"):
+            if browser in _CHANNEL_BROWSERS:
                 install_hint = "  pip install notebooklm[browser]"
             else:
                 install_hint = "  pip install notebooklm[browser]\n  playwright install chromium"
@@ -1130,12 +1140,8 @@ def register_session_commands(cli):
         from ..paths import resolve_profile
 
         profile_name = resolve_profile()
-        browser_labels = {
-            "msedge": "Microsoft Edge",
-            "chrome": "Google Chrome",
-            "chromium": "Chromium",
-        }
-        browser_label = browser_labels.get(browser, "Chromium")
+        channel_info = _CHANNEL_BROWSERS.get(browser)
+        browser_label = channel_info[0] if channel_info else "Chromium"
         console.print(f"[dim]Profile: {profile_name}[/dim]")
         console.print(f"[yellow]Opening {browser_label} for Google login...[/yellow]")
         console.print(f"[dim]Using persistent profile: {browser_profile}[/dim]")
@@ -1152,7 +1158,7 @@ def register_session_commands(cli):
                 ],
                 "ignore_default_args": ["--enable-automation"],
             }
-            if browser in ("msedge", "chrome"):
+            if browser in _CHANNEL_BROWSERS:
                 launch_kwargs["channel"] = browser
 
             context = None
@@ -1283,23 +1289,23 @@ def register_session_commands(cli):
 
             except Exception as e:
                 # Handle browser launch errors specially (context will be None if launch failed)
-                if context is None and browser in ("msedge", "chrome"):
+                if context is None and browser in _CHANNEL_BROWSERS:
                     err = str(e).lower()
-                    is_not_found = (
-                        "executable doesn't exist" in err
-                        or "is not found at" in err
-                        or "no such file" in err
-                        or "failed to launch" in err
+                    is_not_found = any(
+                        marker in err
+                        for marker in (
+                            "executable doesn't exist",
+                            "is not found at",
+                            "no such file",
+                            "failed to launch",
+                        )
                     )
                     if is_not_found:
-                        install_urls = {
-                            "msedge": "https://www.microsoft.com/edge",
-                            "chrome": "https://www.google.com/chrome",
-                        }
-                        logger.error(f"{browser_labels[browser]} not found: {e}")
+                        label, install_url = _CHANNEL_BROWSERS[browser]
+                        logger.error(f"{label} not found: {e}")
                         console.print(
-                            f"[red]{browser_labels[browser]} not found.[/red]\n"
-                            f"Install from: {install_urls[browser]}\n"
+                            f"[red]{label} not found.[/red]\n"
+                            f"Install from: {install_url}\n"
                             "Or use the default Chromium browser: notebooklm login"
                         )
                         raise SystemExit(1) from e

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -118,12 +118,13 @@ class TestLoginCommand:
         assert "Cannot run 'login' when NOTEBOOKLM_AUTH_JSON is set" in result.output
 
     def test_login_help_shows_browser_option(self, runner):
-        """Test login --help shows --browser option with chromium/msedge choices."""
+        """Test login --help shows --browser option with chromium/chrome/msedge choices."""
         result = runner.invoke(cli, ["login", "--help"])
 
         assert result.exit_code == 0
         assert "--browser" in result.output
         assert "chromium" in result.output
+        assert "chrome" in result.output
         assert "msedge" in result.output
 
     def test_login_rejects_invalid_browser(self, runner):
@@ -136,8 +137,10 @@ class TestLoginCommand:
     def mock_login_browser(self, tmp_path):
         """Mock Playwright browser launch for login --browser tests.
 
-        Yields (mock_ensure, mock_launch) for assertions on chromium install
-        check and launch_persistent_context kwargs.
+        The mocked page reports it is already on the NotebookLM host, so the
+        auto-detect ``wait_for_url`` fast-path is taken and the test does not
+        block. Yields (mock_ensure, mock_launch) for assertions on chromium
+        install check and launch_persistent_context kwargs.
         """
         with (
             patch("notebooklm.cli.session._ensure_chromium_installed") as mock_ensure,
@@ -150,7 +153,6 @@ class TestLoginCommand:
                 return_value=tmp_path / "profile",
             ),
             patch("notebooklm.cli.session._sync_server_language_to_config"),
-            patch("builtins.input", return_value=""),
         ):
             mock_context = MagicMock()
             mock_page = MagicMock()
@@ -163,17 +165,21 @@ class TestLoginCommand:
 
             yield mock_ensure, mock_launch
 
-    def test_login_msedge_skips_chromium_install(self, runner, mock_login_browser):
-        """Test --browser msedge skips _ensure_chromium_installed."""
+    @pytest.mark.parametrize("browser", ["msedge", "chrome"])
+    def test_login_channel_browser_skips_chromium_install(
+        self, runner, mock_login_browser, browser
+    ):
+        """--browser msedge|chrome skips _ensure_chromium_installed."""
         mock_ensure, _ = mock_login_browser
-        runner.invoke(cli, ["login", "--browser", "msedge"])
+        runner.invoke(cli, ["login", "--browser", browser])
         mock_ensure.assert_not_called()
 
-    def test_login_msedge_passes_channel_param(self, runner, mock_login_browser):
-        """Test --browser msedge passes channel='msedge' to launch_persistent_context."""
+    @pytest.mark.parametrize("browser", ["msedge", "chrome"])
+    def test_login_channel_browser_passes_channel_param(self, runner, mock_login_browser, browser):
+        """--browser msedge|chrome passes channel=<browser> to launch_persistent_context."""
         _, mock_launch = mock_login_browser
-        runner.invoke(cli, ["login", "--browser", "msedge"])
-        assert mock_launch.call_args[1].get("channel") == "msedge"
+        runner.invoke(cli, ["login", "--browser", browser])
+        assert mock_launch.call_args[1].get("channel") == browser
 
     def test_login_chromium_default_no_channel(self, runner, mock_login_browser):
         """Test default chromium calls _ensure_chromium_installed and has no channel."""
@@ -182,8 +188,17 @@ class TestLoginCommand:
         mock_ensure.assert_called_once()
         assert "channel" not in mock_launch.call_args[1]
 
-    def test_login_msedge_not_installed_shows_helpful_error(self, runner, tmp_path):
-        """Test --browser msedge shows helpful error when Edge is not installed."""
+    @pytest.mark.parametrize(
+        ("browser", "expected_label", "expected_install_url_fragment"),
+        [
+            ("msedge", "Microsoft Edge", "microsoft.com/edge"),
+            ("chrome", "Google Chrome", "google.com/chrome"),
+        ],
+    )
+    def test_login_channel_browser_not_installed_shows_helpful_error(
+        self, runner, tmp_path, browser, expected_label, expected_install_url_fragment
+    ):
+        """--browser msedge|chrome shows helpful error when the browser is not installed."""
         with (
             patch("notebooklm.cli.session._ensure_chromium_installed"),
             patch("playwright.sync_api.sync_playwright") as mock_pw,
@@ -199,21 +214,22 @@ class TestLoginCommand:
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
             )
             mock_launch.side_effect = Exception(
-                "Executable doesn't exist at /ms-edge\nFailed to launch"
+                f"Executable doesn't exist at /{browser}\nFailed to launch"
             )
 
-            result = runner.invoke(cli, ["login", "--browser", "msedge"])
+            result = runner.invoke(cli, ["login", "--browser", browser])
 
         assert result.exit_code == 1
-        assert "Microsoft Edge not found" in result.output
-        assert "microsoft.com/edge" in result.output
+        assert f"{expected_label} not found" in result.output
+        assert expected_install_url_fragment in result.output
 
     @pytest.fixture
     def mock_login_browser_with_storage(self, tmp_path):
         """Mock Playwright browser for login tests that assert exit_code == 0.
 
         Like mock_login_browser but also makes storage_state() create the file
-        so that storage_path.chmod() succeeds.
+        so that storage_path.chmod() succeeds. The mocked page reports it is
+        already on the NotebookLM host, so the auto-detect fast-path is taken.
         """
         storage_file = tmp_path / "storage.json"
         with (
@@ -225,7 +241,6 @@ class TestLoginCommand:
                 return_value=tmp_path / "profile",
             ),
             patch("notebooklm.cli.session._sync_server_language_to_config"),
-            patch("builtins.input", return_value=""),
         ):
             mock_context = MagicMock()
             mock_page = MagicMock()
@@ -309,6 +324,56 @@ class TestLoginCommand:
         assert len(goto_calls) == 3
         assert goto_calls[1].kwargs.get("wait_until") == "commit"
         assert goto_calls[2].kwargs.get("wait_until") == "commit"
+
+    def test_login_auto_detect_skipped_when_already_logged_in(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """When the initial page is already on NotebookLM, wait_for_url is not called."""
+        mock_page = mock_login_browser_with_storage
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0
+        assert "Already logged in" in result.output
+        mock_page.wait_for_url.assert_not_called()
+
+    def test_login_auto_detect_waits_for_url_when_not_logged_in(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """When the initial page is on accounts.google.com, wait_for_url is called."""
+        mock_page = mock_login_browser_with_storage
+        # Initial URL is on Google login, then wait_for_url "succeeds" and the
+        # next reads of mock_page.url return the NotebookLM host for the
+        # subsequent cookie-forcing navigation.
+        mock_page.url = "https://accounts.google.com/signin"
+
+        def succeed(url, **kwargs):
+            mock_page.url = "https://notebooklm.google.com/"
+
+        mock_page.wait_for_url.side_effect = succeed
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 0
+        mock_page.wait_for_url.assert_called_once()
+        # Verify timeout=300_000 (5 minutes) is passed
+        assert mock_page.wait_for_url.call_args.kwargs.get("timeout") == 300_000
+        assert "Login detected" in result.output
+
+    def test_login_auto_detect_timeout_exits_with_helpful_message(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """When wait_for_url times out, login exits 1 with a helpful message."""
+        from playwright.sync_api import TimeoutError as PlaywrightTimeout
+
+        mock_page = mock_login_browser_with_storage
+        mock_page.url = "https://accounts.google.com/signin"
+        mock_page.wait_for_url.side_effect = PlaywrightTimeout("Timeout 300000ms exceeded")
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 1
+        assert "Login not detected within 5 minutes" in result.output
 
     def test_login_retries_on_connection_closed_error(
         self, runner, mock_login_browser_with_storage

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -375,6 +375,48 @@ class TestLoginCommand:
         assert result.exit_code == 1
         assert "Login not detected within 5 minutes" in result.output
 
+    def test_login_auto_detect_browser_closed_during_wait_shows_help(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """When the browser is closed during wait_for_url, login surfaces BROWSER_CLOSED_HELP."""
+        from playwright.sync_api import Error as PlaywrightError
+
+        mock_page = mock_login_browser_with_storage
+        mock_page.url = "https://accounts.google.com/signin"
+        mock_page.wait_for_url.side_effect = PlaywrightError(
+            "Target page, context or browser has been closed"
+        )
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 1
+        assert "browser window was closed" in result.output.lower()
+
+    def test_login_auto_detect_final_url_drift_fails_safely(
+        self, runner, mock_login_browser_with_storage
+    ):
+        """If the cookie-forcing round-trip leaves us off-host, fail without saving auth."""
+        mock_page = mock_login_browser_with_storage
+        # Start unauthenticated; wait_for_url succeeds; final cookie-forcing
+        # goto bounces back to accounts.google.com (session invalidated mid-flow).
+        mock_page.url = "https://accounts.google.com/signin"
+
+        def wait_succeeds(url, **kwargs):
+            mock_page.url = "https://notebooklm.google.com/"
+
+        def goto_drifts(url, **kwargs):
+            if "notebooklm" in url:
+                mock_page.url = "https://accounts.google.com/AccountChooser"
+
+        mock_page.wait_for_url.side_effect = wait_succeeds
+        mock_page.goto.side_effect = goto_drifts
+
+        result = runner.invoke(cli, ["login"])
+
+        assert result.exit_code == 1
+        assert "Unexpected URL after login" in result.output
+        assert "Authentication saved" not in result.output
+
     def test_login_retries_on_connection_closed_error(
         self, runner, mock_login_browser_with_storage
     ):


### PR DESCRIPTION
## Summary

Relands the two improvements proposed in #213 on top of current `main`. The
original PR's base predates several login() fixes that landed since
(retry-with-recovery, profile-aware storage path, fix #214 `wait_until="commit"`,
fix #121 language sync, rookiepy `--browser-cookies` fast-path, `--all-accounts`,
`clear_account_metadata`). Applying #213 as-is would have regressed those, so
this PR re-implements the *ideas* — credit @Jayleonc — on a clean base.

### Changes (single file: `src/notebooklm/cli/session.py`)

1. **`--browser chrome`** — adds system Google Chrome as a third choice
   alongside `chromium` and `msedge`. Wired through Playwright's `channel`
   parameter. Skips the bundled-Chromium install check at preflight.
   Workaround for the macOS 15+ issue where Playwright's bundled
   "Chrome for Testing" Chromium crashes on launch.

2. **Auto-detect login completion** — replaces the blocking
   `input("[Press ENTER when logged in]")` step with
   `page.wait_for_url(f"{base}/**", timeout=300_000)`. Removes the
   terminal-interaction friction for agent/CI contexts where stdin isn't
   reliably wired up. Five-minute timeout; clear error message on timeout.

3. **Generalized "browser not found" error path** — single dict-keyed
   handler that gives both chrome and msedge a friendly install URL hint.

4. **Removed redundant post-cookie URL-mismatch confirm** — `wait_for_url`
   already guarantees we're on the NotebookLM host, so the
   `click.confirm("Save authentication anyway?")` prompt is no longer
   reachable in normal flow.

### Preserved verbatim

- Retry loop on `RETRYABLE_CONNECTION_ERRORS` + `TargetClosedError` recovery
  via `_recover_page`
- Regional cookie forcing with `wait_until="commit"` (fix #214)
- `clear_account_metadata` after save
- `_sync_server_language_to_config` (fix #121)
- Windows-aware permissions handling
- Profile-aware `storage_path` resolution via `ctx.obj`
- `--browser-cookies`, `--account`, `--all-accounts`, `--profile-name`,
  `--fresh` flag handling

## Test plan

- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy src/notebooklm --ignore-missing-imports` clean
- [x] `pytest` — 2671 passed, 9 skipped
- [x] Existing msedge tests parameterized to also cover chrome (channel,
      skip-install, not-found-error)
- [x] New tests: already-logged-in fast path skips `wait_for_url`;
      not-logged-in calls `wait_for_url` with 5-min timeout;
      `PlaywrightTimeout` exits 1 with helpful message
- [ ] Manual: `notebooklm login --browser chrome` on macOS 15+ opens
      system Chrome and auto-saves on completion
- [ ] Manual: `notebooklm login --browser chrome` without Chrome installed
      shows the install hint

Closes #213.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Chrome and Microsoft Edge options in the login command
  * Automatic login detection now waits non-interactively (up to ~5 minutes) and reports friendly timeouts

* **Improvements**
  * Clearer, browser-specific installation guidance and targeted launch error messages
  * Removed manual "press ENTER to save" step and tightened post-login validation

* **Tests**
  * Expanded unit tests to cover channel-based browsers and various auto-detection scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/415)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->