### PR TITLE
deps: bump pygments 2.19.2 -> 2.20.0 (GHSA-5239-wwwm-4pmq)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,11 @@ pre-commit install
 
 For full prerequisites, headless setup, optional extras (`[cookies]`, `[markdown]`), and platform notes, see [docs/installation.md#e-contributor](docs/installation.md#e-contributor).
 
+The `browser` extra is part of the contributor install because the default unit
+suite imports and patches `playwright.sync_api`. The command
+`uv sync --frozen --extra dev` is only the test/lint toolchain; it is not enough
+for `uv run pytest`.
+
 ### Code Quality
 
 This project uses **ruff** for linting and formatting:

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,6 +112,10 @@ src/notebooklm/
    uv run pre-commit install
    ```
 
+   The `browser` extra is required for the default `uv run pytest` suite because
+   several unit tests import and patch `playwright.sync_api`. The command
+   `uv sync --frozen --extra dev` installs the test tools, but not Playwright.
+
    CI runs the same lint gate with `uv run pre-commit run --all-files`, so local hook results should match the `quality` job.
 
 2. **Authenticate:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -220,6 +220,8 @@ pre-commit install
 
 **Why three extras and not `[all]`:** `[all]` is `pip` extras semantics. `uv sync --extra X` is the `uv` equivalent. The three extras here mirror the contents of `[all]` = `[browser, dev, markdown]`. `cookies` is intentionally excluded (`rookiepy` build issues on Python 3.13+); opt in via `--extra cookies` if needed.
 
+**Why `browser` is part of the contributor install:** the default local test suite includes unit tests that import and patch `playwright.sync_api`, even though they do not launch a real browser. `uv sync --frozen --extra dev` installs pytest/ruff/mypy but not Playwright, so `uv run pytest` will fail with `ModuleNotFoundError: No module named 'playwright'`. Use the full contributor command above before running the default test suite.
+
 **Linux only:** `uv run playwright install-deps chromium` (scoped form, matches `test.yml`).
 
 **Pre-commit checklist (run before every commit):**
@@ -261,7 +263,7 @@ Source of truth: `pyproject.toml` `[project.optional-dependencies]`.
 | `browser` | `playwright>=1.40.0` | `notebooklm login` (interactive). | `pip install "notebooklm-py[browser]"` | `uv add "notebooklm-py[browser]"` |
 | `cookies` | `rookiepy>=0.1.0` | `notebooklm login --browser-cookies <browser>`, `notebooklm auth inspect`. | `pip install "notebooklm-py[cookies]"` | `uv add "notebooklm-py[cookies]"` |
 | `markdown` | `markdownify>=0.14.1` | `notebooklm source fulltext -f markdown`. | `pip install "notebooklm-py[markdown]"` | `uv add "notebooklm-py[markdown]"` |
-| `dev` | pytest stack, mypy, ruff (`==0.15.12` exact pin), pre-commit (`>=4.5.1`), vcrpy | Contributors only. | `pip install "notebooklm-py[dev]"` | `uv add "notebooklm-py[dev]"` (in your project) — but contributors *to this repo* use the [Persona E](#e-contributor) `uv sync` flow instead |
+| `dev` | pytest stack, mypy, ruff (`==0.15.12` exact pin), pre-commit (`>=4.5.1`), vcrpy | Contributor tooling only. Not sufficient for this repo's default `uv run pytest`; add `browser` too because some unit tests import Playwright. | `pip install "notebooklm-py[dev]"` | `uv add "notebooklm-py[dev]"` (in your project) — but contributors *to this repo* use the [Persona E](#e-contributor) `uv sync` flow instead |
 | `all` | Resolves to `browser` + `dev` + `markdown` (**not `cookies`**) | Contributors who do not need `rookiepy`. | `pip install "notebooklm-py[all]"` | `uv add "notebooklm-py[all]"` (in your project) — see [All vs All-Extras](#all-vs-all-extras) |
 
 > **Note on `uv` columns:** the `uv (in your project)` column is for users adding `notebooklm-py` as a dependency in **their own** project (requires a `pyproject.toml` in that project). Contributors working inside *this* repo use the Persona E flow (`uv sync --frozen --extra ...`), governed by this repo's `uv.lock`. Do not run `uv sync` outside a project — it errors with `No pyproject.toml found`.

--- a/uv.lock
+++ b/uv.lock
@@ -661,11 +661,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Security fix** (primary): Bumps `pygments` 2.19.2 -> 2.20.0 in `uv.lock` to resolve [Dependabot alert #2](https://github.com/teng-lin/notebooklm-py/security/dependabot/2). Advisory [GHSA-5239-wwwm-4pmq](https://github.com/advisories/GHSA-5239-wwwm-4pmq) / CVE-2026-4539 — low-severity ReDoS in `AdlLexer` (local access, CVSS 3.3). Transitive dep via `pytest` and `rich`; lockfile-only change.
- **Docs**: Carried a pre-existing local commit clarifying that the `browser` extra is required for tests (`CONTRIBUTING.md`, `docs/development.md`, `docs/installation.md`).

## Test plan
- [ ] CI passes (ruff format/check, mypy, pytest)
- [ ] Dependabot alert #2 auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)