### PR TITLE
test(rpc): specify malformed chunk parsing

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -180,18 +180,22 @@ def parse_chunked_response(response: str) -> list[Any]:
         List of parsed JSON chunks
 
     Raises:
-        RPCError: If more than 10% of chunks are malformed, indicating API issues.
+        RPCError: If more than 10% of response records are malformed, indicating API issues.
 
     Note:
-        Malformed chunks are skipped with a warning logged. If the error rate
-        exceeds 10%, raises RPCError as this likely indicates API changes.
+        Malformed chunks are skipped with a warning logged. A byte-count line
+        without a following payload, or with a payload whose UTF-8 byte length
+        does not match the declared count, is treated as malformed and skipped.
+        If the error rate exceeds 10%, raises RPCError as this likely indicates
+        API changes.
     """
     if not response or not response.strip():
         return []
 
     chunks = []
     skipped_count = 0
-    lines = response.strip().split("\n")
+    total_records = 0
+    lines = [line.removesuffix("\r") for line in response.strip().split("\n")]
 
     i = 0
     while i < len(lines):
@@ -204,27 +208,47 @@ def parse_chunked_response(response: str) -> list[Any]:
 
         # Try to parse as byte count
         try:
-            int(line)  # Validate it's a byte count (we don't need the value)
+            byte_count = int(line)
+            total_records += 1
             i += 1
 
             # Next line should be JSON payload
-            if i < len(lines):
-                json_str = lines[i]
-                try:
-                    chunk = json.loads(json_str)
-                    chunks.append(chunk)
-                except json.JSONDecodeError as e:
-                    # Skip malformed chunks but warn
-                    skipped_count += 1
-                    logger.warning(
-                        "Skipping malformed chunk at line %d: %s. Preview: %s",
-                        i + 1,
-                        e,
-                        json_str[:100],
-                    )
+            if i >= len(lines):
+                skipped_count += 1
+                logger.warning("Skipping byte-count line %d without payload", i)
+                continue
+
+            json_str = lines[i]
+            actual_byte_count = len(json_str.encode("utf-8"))
+            if actual_byte_count != byte_count:
+                skipped_count += 1
+                logger.warning(
+                    "Skipping chunk at line %d: declared %d bytes but payload is %d bytes. "
+                    "Preview: %s",
+                    i + 1,
+                    byte_count,
+                    actual_byte_count,
+                    json_str[:100],
+                )
+                i += 1
+                continue
+
+            try:
+                chunk = json.loads(json_str)
+                chunks.append(chunk)
+            except json.JSONDecodeError as e:
+                # Skip malformed chunks but warn
+                skipped_count += 1
+                logger.warning(
+                    "Skipping malformed chunk at line %d: %s. Preview: %s",
+                    i + 1,
+                    e,
+                    json_str[:100],
+                )
             i += 1
         except ValueError:
             # Not a byte count, try to parse as JSON directly
+            total_records += 1
             try:
                 chunk = json.loads(line)
                 chunks.append(chunk)
@@ -241,10 +265,11 @@ def parse_chunked_response(response: str) -> list[Any]:
 
     # Fail if error rate is too high (indicates API problems)
     if skipped_count > 0:
-        error_rate = skipped_count / len(lines) if lines else 0
+        error_rate = skipped_count / total_records if total_records else 0
         if error_rate > 0.1:  # More than 10% malformed
             raise RPCError(
-                f"Response parsing failed: {skipped_count} of {len(lines)} chunks malformed. "
+                f"Response parsing failed: {skipped_count} of {total_records} response records "
+                f"malformed. "
                 f"This may indicate API changes or data corruption.",
                 raw_response=response[:500],
             )

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -184,10 +184,11 @@ def parse_chunked_response(response: str) -> list[Any]:
 
     Note:
         Malformed chunks are skipped with a warning logged. A byte-count line
-        without a following payload, or with a payload whose UTF-8 byte length
-        does not match the declared count, is treated as malformed and skipped.
-        If the error rate exceeds 10%, raises RPCError as this likely indicates
-        API changes.
+        without a following payload is malformed. A byte-count mismatch is
+        logged but tolerated when the following payload is still valid JSON,
+        because recorded and proxy-transformed streams may not preserve Google's
+        original byte count. If the malformed-record rate exceeds 10%, raises
+        RPCError as this likely indicates API changes.
     """
     if not response or not response.strip():
         return []
@@ -221,17 +222,14 @@ def parse_chunked_response(response: str) -> list[Any]:
             json_str = lines[i]
             actual_byte_count = len(json_str.encode("utf-8"))
             if actual_byte_count != byte_count:
-                skipped_count += 1
                 logger.warning(
-                    "Skipping chunk at line %d: declared %d bytes but payload is %d bytes. "
-                    "Preview: %s",
+                    "Chunk at line %d declares %d bytes but payload is %d bytes; "
+                    "parsing valid JSON payload anyway. Preview: %s",
                     i + 1,
                     byte_count,
                     actual_byte_count,
                     json_str[:100],
                 )
-                i += 1
-                continue
 
             try:
                 chunk = json.loads(json_str)

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -48,7 +48,7 @@ class TestParseChunkedResponse:
     @staticmethod
     def _chunk_record(data):
         chunk_json = json.dumps(data)
-        return f"{len(chunk_json)}\n{chunk_json}"
+        return f"{len(chunk_json.encode('utf-8'))}\n{chunk_json}"
 
     def test_parses_single_chunk(self):
         """Test parsing response with single chunk."""

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -45,6 +45,11 @@ class TestStripAntiXSSI:
 
 
 class TestParseChunkedResponse:
+    @staticmethod
+    def _chunk_record(data):
+        chunk_json = json.dumps(data)
+        return f"{len(chunk_json)}\n{chunk_json}"
+
     def test_parses_single_chunk(self):
         """Test parsing response with single chunk."""
         chunk_data = ["chunk", "data"]
@@ -93,7 +98,8 @@ class TestParseChunkedResponse:
 
     def test_ignores_malformed_chunks(self):
         """Test malformed chunks are ignored when below 10% threshold."""
-        # Add 10 valid chunks and 1 malformed = 9% error rate (below 10% threshold)
+        # Add 10 valid chunk records and 1 malformed record, keeping the record-based
+        # error rate below the 10% threshold.
         valid_chunks = [json.dumps([f"valid{i}"]) for i in range(10)]
         valid_parts = "\n".join([f"{len(c)}\n{c}" for c in valid_chunks])
         response = f"{valid_parts}\n99\nnot-json\n"
@@ -103,6 +109,65 @@ class TestParseChunkedResponse:
         assert len(chunks) == 10
         assert chunks[0] == ["valid0"]
         assert chunks[9] == ["valid9"]
+
+    def test_skips_mismatched_byte_count_below_threshold(self, caplog):
+        """Mismatched byte counts are malformed chunks, not valid JSON fallbacks."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
+        payload = json.dumps(["wrong-size"])
+        response = f"{valid_parts}\n{len(payload) + 1}\n{payload}\n"
+
+        chunks = parse_chunked_response(response)
+
+        assert chunks == [[f"valid{i}"] for i in range(10)]
+        assert "declared" in caplog.text
+        assert "payload is" in caplog.text
+
+    def test_skips_byte_count_without_payload_below_threshold(self, caplog):
+        """A trailing byte-count line without a payload is malformed and skipped."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
+        response = f"{valid_parts}\n42\n"
+
+        chunks = parse_chunked_response(response)
+
+        assert chunks == [[f"valid{i}"] for i in range(10)]
+        assert "without payload" in caplog.text
+
+    def test_skips_payload_split_across_lines_below_threshold(self):
+        """A payload split across lines is treated as truncated malformed input."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(20))
+        payload = json.dumps(["split"])
+        first_part, second_part = payload[:4], payload[4:]
+        response = f"{valid_parts}\n{len(payload)}\n{first_part}\n{second_part}\n"
+
+        chunks = parse_chunked_response(response)
+
+        assert chunks == [[f"valid{i}"] for i in range(20)]
+
+    def test_skips_extra_non_json_lines_before_and_after_valid_chunk(self):
+        """Standalone non-JSON lines are skipped while valid chunks are preserved."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(20))
+        response = f"noise-before\n{valid_parts}\nnoise-after\n"
+
+        chunks = parse_chunked_response(response)
+
+        assert chunks == [[f"valid{i}"] for i in range(20)]
+
+    def test_error_rate_exactly_ten_percent_is_tolerated(self):
+        """The malformed-record threshold is exclusive: exactly 10% does not raise."""
+        valid_lines = "\n".join(json.dumps([f"valid{i}"]) for i in range(9))
+        response = f"{valid_lines}\nnot-json\n"
+
+        chunks = parse_chunked_response(response)
+
+        assert chunks == [[f"valid{i}"] for i in range(9)]
+
+    def test_error_rate_just_above_ten_percent_raises(self):
+        """The parser raises once malformed records exceed 10%."""
+        valid_lines = "\n".join(json.dumps([f"valid{i}"]) for i in range(8))
+        response = f"{valid_lines}\nnot-json\n"
+
+        with pytest.raises(RPCError, match="Response parsing failed"):
+            parse_chunked_response(response)
 
 
 class TestExtractRPCResult:

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -110,16 +110,16 @@ class TestParseChunkedResponse:
         assert chunks[0] == ["valid0"]
         assert chunks[9] == ["valid9"]
 
-    def test_skips_mismatched_byte_count_below_threshold(self, caplog):
-        """Mismatched byte counts are malformed chunks, not valid JSON fallbacks."""
+    def test_warns_but_parses_mismatched_byte_count_with_valid_json(self, caplog):
+        """Mismatched byte counts are tolerated when the payload is valid JSON."""
         valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
         payload = json.dumps(["wrong-size"])
         response = f"{valid_parts}\n{len(payload) + 1}\n{payload}\n"
 
         chunks = parse_chunked_response(response)
 
-        assert chunks == [[f"valid{i}"] for i in range(10)]
-        assert "declared" in caplog.text
+        assert chunks == [[f"valid{i}"] for i in range(10)] + [["wrong-size"]]
+        assert "declares" in caplog.text
         assert "payload is" in caplog.text
 
     def test_skips_byte_count_without_payload_below_threshold(self, caplog):


### PR DESCRIPTION
## Summary
- validate declared byte counts against JSON payload byte lengths in chunked RPC responses
- document malformed record tolerance and the exclusive 10% failure threshold in tests
- cover mismatched, missing, split, noisy, and threshold-boundary chunk streams

Fixes #423

## Test plan
- `uv run pytest tests/unit/test_decoder.py -q`
- `uv run ruff check src/notebooklm/rpc/decoder.py tests/unit/test_decoder.py`
- `uv run ruff format --check src/notebooklm/rpc/decoder.py tests/unit/test_decoder.py`
- `uv run mypy src/notebooklm/rpc/decoder.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunked-response parsing: normalizes input lines, validates declared byte counts vs actual UTF-8 payload size, better detection/logging/skipping of malformed records, and computes malformed-rate using record counts.

* **Tests**
  * Expanded unit coverage for malformed-chunk scenarios, log assertions for detected issues, and boundary tests for the malformed-rate threshold.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/424)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->