### PR TITLE
fix(ci): enforce ninety percent coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,4 +88,4 @@ jobs:
         fi
 
     - name: Run tests with coverage
-      run: pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=70
+      run: pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ pre-commit install
 uv run ruff format --check . && \
     uv run ruff check . && \
     uv run mypy src/notebooklm --ignore-missing-imports && \
-    uv run pytest
+    uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90
 ```
 
 **No uv?** Plain pip works as a fallback (won't enforce the lockfile, so you may resolve newer dep versions than CI):

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -227,7 +227,10 @@ pre-commit install
 **Pre-commit checklist (run before every commit):**
 
 ```bash
-uv run ruff format --check . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest
+uv run ruff format --check . && \
+    uv run ruff check . && \
+    uv run mypy src/notebooklm --ignore-missing-imports && \
+    uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90
 ```
 
 **Verify:**


### PR DESCRIPTION
## Summary
- align the CI coverage gate with the repo's 90% coverage policy
- update contributor docs to use the same explicit coverage command

Fixes #421

## Test plan
- `uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration and documentation to enforce a higher code coverage threshold of 90%.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/425)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->