### PR TITLE
fix(cli): close language sync coroutines

### DIFF
--- a/src/notebooklm/cli/language.py
+++ b/src/notebooklm/cli/language.py
@@ -141,6 +141,14 @@ def set_language(code: str) -> None:
     save_config(config)
 
 
+def _run_language_rpc(coro):
+    """Run a language RPC coroutine and close it if the sync runner does not."""
+    try:
+        return run_async(coro)
+    finally:
+        coro.close()
+
+
 def _sync_language_to_server(code: str, ctx: click.Context) -> str | None:
     """Sync language setting to server via RPC.
 
@@ -158,7 +166,7 @@ def _sync_language_to_server(code: str, ctx: click.Context) -> str | None:
             async with NotebookLMClient(auth) as client:
                 return await client.settings.set_output_language(code)
 
-        return run_async(_set())
+        return _run_language_rpc(_set())
     except Exception as e:
         logger.debug("Failed to sync language to server: %s", e)
         return None
@@ -180,7 +188,7 @@ def _get_language_from_server(ctx: click.Context) -> str | None:
             async with NotebookLMClient(auth) as client:
                 return await client.settings.get_output_language()
 
-        return run_async(_get())
+        return _run_language_rpc(_get())
     except Exception as e:
         logger.debug("Failed to get language from server: %s", e)
         return None

--- a/tests/unit/cli/test_language.py
+++ b/tests/unit/cli/test_language.py
@@ -1,7 +1,9 @@
 """Tests for language CLI commands (list, get, set)."""
 
+import gc
 import importlib
 import json
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,6 +31,15 @@ def mock_config_file(tmp_path):
         patch.object(language_module, "get_home_dir", return_value=home_dir),
     ):
         yield config_file
+
+
+def unawaited_coroutine_warnings(caught_warnings):
+    return [
+        warning
+        for warning in caught_warnings
+        if issubclass(warning.category, RuntimeWarning)
+        and "was never awaited" in str(warning.message)
+    ]
 
 
 # =============================================================================
@@ -258,6 +269,24 @@ class TestSyncLanguageToServer:
 
         assert result is None
 
+    def test_sync_language_to_server_closes_coroutine_when_run_async_raises(self):
+        """Test run_async failures do not leak an unawaited coroutine warning."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+
+        with (
+            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
+            patch.object(language_module, "run_async", side_effect=Exception("connection error")),
+            warnings.catch_warnings(record=True) as caught_warnings,
+        ):
+            warnings.simplefilter("always", RuntimeWarning)
+
+            result = language_module._sync_language_to_server("en", mock_ctx)
+            gc.collect()
+
+        assert result is None
+        assert unawaited_coroutine_warnings(caught_warnings) == []
+
 
 class TestGetLanguageFromServer:
     def test_get_language_from_server_success(self):
@@ -296,6 +325,24 @@ class TestGetLanguageFromServer:
             result = language_module._get_language_from_server(mock_ctx)
 
         assert result is None
+
+    def test_get_language_from_server_closes_coroutine_when_run_async_raises(self):
+        """Test run_async failures do not leak an unawaited coroutine warning."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {}
+
+        with (
+            patch.object(language_module, "get_auth_tokens", return_value={"SID": "test"}),
+            patch.object(language_module, "run_async", side_effect=Exception("rpc error")),
+            warnings.catch_warnings(record=True) as caught_warnings,
+        ):
+            warnings.simplefilter("always", RuntimeWarning)
+
+            result = language_module._get_language_from_server(mock_ctx)
+            gc.collect()
+
+        assert result is None
+        assert unawaited_coroutine_warnings(caught_warnings) == []
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- close language sync RPC coroutines when `run_async` raises before awaiting them
- add regression coverage that asserts mocked runner failures do not emit unawaited coroutine warnings

Fixes #419

## Test plan
- `uv run pytest tests/unit/cli/test_language.py -q`
- `uv run pytest`
- `uv run ruff check .`
- `uv run mypy src/notebooklm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced error handling for language operations to ensure proper cleanup of resources in failure scenarios, improving overall stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/426)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->