### PR TITLE
test(cli): cover profile state mutations

### DIFF
--- a/src/notebooklm/cli/profile.py
+++ b/src/notebooklm/cli/profile.py
@@ -12,6 +12,8 @@ import json
 import os
 import re
 import shutil
+import sys
+from pathlib import Path
 
 import click
 from rich.table import Table
@@ -73,7 +75,7 @@ def email_to_profile_name(email: str, *, fallback: str = "account") -> str:
     return sanitized
 
 
-def _read_config(config_path, *, suppress_errors: bool = True) -> dict:
+def _read_config(config_path: Path, *, suppress_errors: bool = True) -> dict:
     """Read global config, optionally tolerating unreadable/corrupt files."""
     if not config_path.exists():
         return {}
@@ -86,14 +88,19 @@ def _read_config(config_path, *, suppress_errors: bool = True) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def _write_config(config_path, data: dict) -> None:
+def _write_config(config_path: Path, data: dict) -> None:
     """Write global config with private permissions."""
-    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if sys.platform == "win32":
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        config_path.parent.chmod(0o700)
     config_path.write_text(
-        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        json.dumps(data, indent=2, ensure_ascii=False, default=str) + "\n",
         encoding="utf-8",
     )
-    config_path.chmod(0o600)
+    if sys.platform != "win32":
+        config_path.chmod(0o600)
 
 
 @click.group("profile")

--- a/src/notebooklm/cli/profile.py
+++ b/src/notebooklm/cli/profile.py
@@ -73,6 +73,29 @@ def email_to_profile_name(email: str, *, fallback: str = "account") -> str:
     return sanitized
 
 
+def _read_config(config_path, *, suppress_errors: bool = True) -> dict:
+    """Read global config, optionally tolerating unreadable/corrupt files."""
+    if not config_path.exists():
+        return {}
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        if not suppress_errors:
+            raise
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_config(config_path, data: dict) -> None:
+    """Write global config with private permissions."""
+    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    config_path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    config_path.chmod(0o600)
+
+
 @click.group("profile")
 def profile():
     """Manage authentication profiles for multiple accounts."""
@@ -178,21 +201,14 @@ def switch_cmd(name):
         raise click.ClickException(f"Profile '{name}' not found.{hint}")
 
     config_path = get_config_path()
-    data: dict = {}
-    if config_path.exists():
-        try:
-            data = json.loads(config_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            pass
+    data = _read_config(config_path)
 
     old_profile = data.get("default_profile", "default")
     data["default_profile"] = name
-    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    config_path.write_text(
-        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    config_path.chmod(0o600)
+    try:
+        _write_config(config_path, data)
+    except OSError as e:
+        raise click.ClickException(f"Failed to update config.json: {e}") from None
 
     console.print(f"[green]Switched default profile: {old_profile} → {name}[/green]")
 
@@ -268,18 +284,11 @@ def rename_cmd(old_name, new_name):
     # AND config.json doesn't exist (implicit "default" fallback).
     config_path = get_config_path()
     try:
-        data: dict = {}
-        if config_path.exists():
-            data = json.loads(config_path.read_text(encoding="utf-8"))
+        data = _read_config(config_path, suppress_errors=False)
         configured_default = data.get("default_profile") or "default"
         if configured_default == old_name:
             data["default_profile"] = new_name
-            config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-            config_path.write_text(
-                json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
-            )
-            config_path.chmod(0o600)
+            _write_config(config_path, data)
             console.print(f"[dim]Updated default profile in config: {old_name} → {new_name}[/dim]")
     except (json.JSONDecodeError, OSError) as e:
         console.print(

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -190,7 +190,7 @@ class TestProfileSwitchCommand:
 
         profile_module._write_config(config_path, {"profile_path": Path("profiles/work")})
 
-        assert read_config(tmp_path) == {"profile_path": "profiles/work"}
+        assert read_config(tmp_path) == {"profile_path": str(Path("profiles/work"))}
 
     def test_switch_recovers_from_corrupt_config(self, runner, tmp_path):
         make_profile(tmp_path, "work")

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -2,6 +2,9 @@
 
 import importlib
 import json
+import os
+import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,8 +12,48 @@ from click.testing import CliRunner
 
 from notebooklm.cli.profile import _PROFILE_NAME_RE, email_to_profile_name
 from notebooklm.notebooklm_cli import cli
+from notebooklm.paths import _reset_config_cache, set_active_profile
 
 profile_module = importlib.import_module("notebooklm.cli.profile")
+
+
+@pytest.fixture(autouse=True)
+def reset_profile_state():
+    set_active_profile(None)
+    _reset_config_cache()
+    yield
+    set_active_profile(None)
+    _reset_config_cache()
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def notebooklm_env(home: Path, **extra: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["NOTEBOOKLM_HOME"] = str(home)
+    env.pop("NOTEBOOKLM_PROFILE", None)
+    env.update(extra)
+    return env
+
+
+def make_profile(home: Path, name: str) -> Path:
+    profile_dir = home / "profiles" / name
+    profile_dir.mkdir(parents=True)
+    return profile_dir
+
+
+def read_config(home: Path) -> dict:
+    return json.loads((home / "config.json").read_text(encoding="utf-8"))
+
+
+def profile_names(home: Path) -> list[str]:
+    profiles_dir = home / "profiles"
+    if not profiles_dir.exists():
+        return []
+    return sorted(path.name for path in profiles_dir.iterdir() if path.is_dir())
 
 
 class TestEmailToProfileName:
@@ -84,3 +127,183 @@ class TestProfileListAccountMetadata:
                 "account": "bob@gmail.com",
             }
         ]
+
+
+class TestProfileCreateCommand:
+    @pytest.mark.parametrize("name", [".", "-work", "_work", "work/team", "../work"])
+    def test_rejects_invalid_profile_names(self, runner, tmp_path, name):
+        result = runner.invoke(cli, ["profile", "create", "--", name], env=notebooklm_env(tmp_path))
+
+        assert result.exit_code == 1
+        assert "Invalid profile name" in result.output
+        assert profile_names(tmp_path) == []
+
+    def test_create_existing_profile_fails(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+
+        result = runner.invoke(cli, ["profile", "create", "work"], env=notebooklm_env(tmp_path))
+
+        assert result.exit_code == 1
+        assert "Profile 'work' already exists." in result.output
+
+
+class TestProfileSwitchCommand:
+    def test_switch_missing_profile_shows_available_profiles(self, runner, tmp_path):
+        make_profile(tmp_path, "personal")
+        make_profile(tmp_path, "work")
+
+        result = runner.invoke(
+            cli,
+            ["profile", "switch", "missing"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 1
+        assert "Profile 'missing' not found." in result.output
+        assert "Available: personal, work" in result.output
+
+    def test_switch_writes_default_profile_with_secure_permissions(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        (tmp_path / "config.json").write_text(json.dumps({"language": "ja"}), encoding="utf-8")
+
+        result = runner.invoke(cli, ["profile", "switch", "work"], env=notebooklm_env(tmp_path))
+
+        assert result.exit_code == 0, result.output
+        assert read_config(tmp_path) == {"language": "ja", "default_profile": "work"}
+        if sys.platform != "win32":
+            assert ((tmp_path / "config.json").stat().st_mode & 0o777) == 0o600
+
+    def test_switch_recovers_from_corrupt_config(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        (tmp_path / "config.json").write_text("{not json", encoding="utf-8")
+
+        result = runner.invoke(cli, ["profile", "switch", "work"], env=notebooklm_env(tmp_path))
+
+        assert result.exit_code == 0, result.output
+        assert read_config(tmp_path) == {"default_profile": "work"}
+
+    def test_switch_reports_config_write_failure(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        config_path = tmp_path / "config.json"
+
+        with patch.object(
+            profile_module, "_write_config", side_effect=OSError("permission denied")
+        ):
+            result = runner.invoke(
+                cli,
+                ["profile", "switch", "work"],
+                env=notebooklm_env(tmp_path),
+            )
+
+        assert result.exit_code == 1
+        assert "Failed to update config.json: permission denied" in result.output
+        assert not config_path.exists()
+
+
+class TestProfileDeleteCommand:
+    def test_delete_blocks_configured_default_profile(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        (tmp_path / "config.json").write_text(
+            json.dumps({"default_profile": "work"}),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli,
+            ["profile", "delete", "work", "--confirm"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 1
+        assert "Cannot delete active/default profile 'work'." in result.output
+        assert (tmp_path / "profiles" / "work").exists()
+
+    def test_delete_blocks_active_profile_from_cli_flag(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+
+        result = runner.invoke(
+            cli,
+            ["--profile", "work", "profile", "delete", "work", "--confirm"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 1
+        assert "Cannot delete active/default profile 'work'." in result.output
+        assert (tmp_path / "profiles" / "work").exists()
+
+    def test_delete_cancel_leaves_profile(self, runner, tmp_path):
+        make_profile(tmp_path, "old")
+
+        result = runner.invoke(
+            cli,
+            ["profile", "delete", "old"],
+            input="n\n",
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Cancelled." in result.output
+        assert (tmp_path / "profiles" / "old").exists()
+
+    def test_delete_confirm_removes_profile(self, runner, tmp_path):
+        make_profile(tmp_path, "old")
+
+        result = runner.invoke(
+            cli,
+            ["profile", "delete", "old", "--confirm"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Profile 'old' deleted." in result.output
+        assert not (tmp_path / "profiles" / "old").exists()
+
+
+class TestProfileRenameCommand:
+    def test_rename_profile_success(self, runner, tmp_path):
+        old_dir = make_profile(tmp_path, "work")
+        (old_dir / "context.json").write_text("{}", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            ["profile", "rename", "work", "client"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Profile renamed: work" in result.output
+        assert not (tmp_path / "profiles" / "work").exists()
+        assert (tmp_path / "profiles" / "client" / "context.json").exists()
+
+    def test_rename_updates_configured_default_profile(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        (tmp_path / "config.json").write_text(
+            json.dumps({"default_profile": "work", "language": "en"}),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli,
+            ["profile", "rename", "work", "client"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert read_config(tmp_path) == {"default_profile": "client", "language": "en"}
+        if sys.platform != "win32":
+            assert ((tmp_path / "config.json").stat().st_mode & 0o777) == 0o600
+
+    def test_rename_warns_when_config_read_fails_after_profile_move(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        (tmp_path / "config.json").write_text("{not json", encoding="utf-8")
+
+        result = runner.invoke(
+            cli,
+            ["profile", "rename", "work", "client"],
+            env=notebooklm_env(tmp_path),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Warning: profile renamed but config.json update failed" in result.output
+        assert not (tmp_path / "profiles" / "work").exists()
+        assert (tmp_path / "profiles" / "client").exists()

--- a/tests/unit/cli/test_profile.py
+++ b/tests/unit/cli/test_profile.py
@@ -172,6 +172,25 @@ class TestProfileSwitchCommand:
         assert read_config(tmp_path) == {"language": "ja", "default_profile": "work"}
         if sys.platform != "win32":
             assert ((tmp_path / "config.json").stat().st_mode & 0o777) == 0o600
+            assert (tmp_path.stat().st_mode & 0o777) == 0o700
+
+    def test_switch_secures_existing_config_directory(self, runner, tmp_path):
+        make_profile(tmp_path, "work")
+        if sys.platform != "win32":
+            tmp_path.chmod(0o777)
+
+        result = runner.invoke(cli, ["profile", "switch", "work"], env=notebooklm_env(tmp_path))
+
+        assert result.exit_code == 0, result.output
+        if sys.platform != "win32":
+            assert (tmp_path.stat().st_mode & 0o777) == 0o700
+
+    def test_write_config_serializes_path_values(self, tmp_path):
+        config_path = tmp_path / "config.json"
+
+        profile_module._write_config(config_path, {"profile_path": Path("profiles/work")})
+
+        assert read_config(tmp_path) == {"profile_path": "profiles/work"}
 
     def test_switch_recovers_from_corrupt_config(self, runner, tmp_path):
         make_profile(tmp_path, "work")


### PR DESCRIPTION
## Summary
- add isolated CLI coverage for profile create, switch, delete, and rename state mutations
- factor profile config read/write helpers and preserve secure config permissions
- surface clean config write failures from `profile switch`

Fixes #422

## Test plan
- `uv run pytest tests/unit/cli/test_profile.py tests/unit/test_paths.py -q`
- `uv run pytest tests/unit/cli -q`
- `uv run ruff check src/notebooklm/cli/profile.py tests/unit/cli/test_profile.py`
- `uv run mypy src/notebooklm/cli/profile.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Profile commands now robustly handle missing, unreadable, or corrupt config data and show clearer errors when saving fails.
  * Config and profile directories/files are created with stricter permissions on supported platforms.

* **Bug Fixes**
  * Switching, renaming, and deleting profiles more reliably update and validate the configured default, with safer recovery and warning behavior on partial failures.

* **Tests**
  * Added integration tests covering create/switch/delete/rename flows and related edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/427)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->