### PR TITLE
test(cli): cover doctor diagnostics

### DIFF
--- a/src/notebooklm/cli/doctor.py
+++ b/src/notebooklm/cli/doctor.py
@@ -88,6 +88,8 @@ def register_doctor_command(cli):
         if storage_path.exists():
             try:
                 data = json.loads(storage_path.read_text(encoding="utf-8"))
+                if not isinstance(data, dict):
+                    raise ValueError("storage root is not an object")
                 cookies = data.get("cookies", [])
                 if not isinstance(cookies, list):
                     raise ValueError("cookies is not a list")
@@ -95,14 +97,14 @@ def register_doctor_command(cli):
                 if "SID" in cookie_names:
                     checks["auth"] = {
                         "status": "pass",
-                        "detail": f"authenticated (SID cookie present, {len(cookie_names)} cookies)",
+                        "detail": f"local SID cookie present ({len(cookie_names)} cookies)",
                     }
                 else:
                     checks["auth"] = {
                         "status": "fail",
                         "detail": "SID cookie missing",
                     }
-            except (json.JSONDecodeError, OSError) as e:
+            except (json.JSONDecodeError, OSError, ValueError) as e:
                 checks["auth"] = {"status": "fail", "detail": f"invalid storage file: {e}"}
         else:
             checks["auth"] = {"status": "fail", "detail": "not authenticated"}
@@ -112,6 +114,8 @@ def register_doctor_command(cli):
         if config_path.exists():
             try:
                 config_data = json.loads(config_path.read_text(encoding="utf-8"))
+                if not isinstance(config_data, dict):
+                    raise ValueError("config root is not an object")
                 default_profile = config_data.get("default_profile")
                 if default_profile and isinstance(default_profile, str):
                     try:
@@ -133,7 +137,7 @@ def register_doctor_command(cli):
                         "status": "pass",
                         "detail": "valid (no default_profile set)",
                     }
-            except (json.JSONDecodeError, OSError) as e:
+            except (json.JSONDecodeError, OSError, ValueError) as e:
                 checks["config"] = {"status": "fail", "detail": f"invalid: {e}"}
         else:
             checks["config"] = {"status": "pass", "detail": "not present (using defaults)"}

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -145,6 +145,10 @@ def _read_default_profile() -> str | None:
             return _cached_default_profile  # type: ignore[return-value]
 
         data = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            _cached_default_profile = None
+            _config_mtime = mtime
+            return None
         value = data.get("default_profile")
         # Guard against non-string values (e.g., {"default_profile": 123})
         _cached_default_profile = value if isinstance(value, str) else None

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -57,12 +57,21 @@ def test_doctor_reports_clean_profile_layout(runner, isolated_notebooklm_home):
 
     assert data["profile"] == "default"
     assert data["profile_source"] == "config.json"
-    assert data["checks"] == {
-        "migration": {"status": "pass", "detail": "complete"},
-        "profile_dir": {"status": "pass", "detail": str(profile_dir)},
-        "auth": {"status": "pass", "detail": "local SID cookie present (1 cookies)"},
-        "config": {"status": "pass", "detail": "valid (default_profile: default)"},
+    assert data["checks"]["migration"] == {"status": "pass", "detail": "complete"}
+    assert data["checks"]["auth"] == {
+        "status": "pass",
+        "detail": "local SID cookie present (1 cookies)",
     }
+    assert data["checks"]["config"] == {
+        "status": "pass",
+        "detail": "valid (default_profile: default)",
+    }
+    if sys.platform == "win32":
+        assert data["checks"]["profile_dir"]["status"] == "warn"
+        assert str(profile_dir) in data["checks"]["profile_dir"]["detail"]
+        assert "permissions:" in data["checks"]["profile_dir"]["detail"]
+    else:
+        assert data["checks"]["profile_dir"] == {"status": "pass", "detail": str(profile_dir)}
 
 
 def test_doctor_reports_legacy_layout_without_startup_migration(runner, isolated_notebooklm_home):

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -1,7 +1,6 @@
 """Unit tests for the ``notebooklm doctor`` diagnostics command."""
 
 import json
-import os
 import sys
 from pathlib import Path
 
@@ -189,7 +188,7 @@ def test_doctor_fix_creates_missing_profile_dir(runner, isolated_notebooklm_home
     data = json.loads(result.output)
     profile_dir = home / "profiles" / "default"
     assert profile_dir.is_dir()
-    if os.name != "nt":
+    if sys.platform != "win32":
         assert profile_dir.stat().st_mode & 0o777 == 0o700
     assert data["checks"]["profile_dir"] == {"status": "pass", "detail": str(profile_dir)}
     assert data["fixes_applied"] == [f"Created profile directory: {profile_dir}"]
@@ -197,8 +196,10 @@ def test_doctor_fix_creates_missing_profile_dir(runner, isolated_notebooklm_home
 
 def test_doctor_fix_migrates_legacy_layout(runner, isolated_notebooklm_home):
     home = isolated_notebooklm_home
-    _write_json(home / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
-    _write_json(home / "context.json", {"current_notebook": "nb_123"})
+    storage_payload = _storage([{"name": "SID", "value": "x"}])
+    context_payload = {"current_notebook": "nb_123"}
+    _write_json(home / "storage_state.json", storage_payload)
+    _write_json(home / "context.json", context_payload)
 
     result = runner.invoke(
         cli,
@@ -211,6 +212,12 @@ def test_doctor_fix_migrates_legacy_layout(runner, isolated_notebooklm_home):
     assert not (home / "storage_state.json").exists()
     assert (profile_dir / "storage_state.json").exists()
     assert (profile_dir / "context.json").exists()
+    assert json.loads((profile_dir / "storage_state.json").read_text(encoding="utf-8")) == (
+        storage_payload
+    )
+    assert json.loads((profile_dir / "context.json").read_text(encoding="utf-8")) == (
+        context_payload
+    )
     assert data["checks"]["migration"] == {
         "status": "pass",
         "detail": "complete (just migrated)",

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -1,0 +1,222 @@
+"""Unit tests for the ``notebooklm doctor`` diagnostics command."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from notebooklm import paths
+from notebooklm.notebooklm_cli import cli
+
+
+@pytest.fixture(autouse=True)
+def isolated_notebooklm_home(tmp_path, monkeypatch):
+    """Keep doctor tests away from the real profile home and cached profile state."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+    yield tmp_path
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _make_profile(home: Path, name: str = "default") -> Path:
+    profile_dir = home / "profiles" / name
+    profile_dir.mkdir(parents=True)
+    if sys.platform != "win32":
+        profile_dir.chmod(0o700)
+    return profile_dir
+
+
+def _storage(cookies: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    return {"cookies": cookies}
+
+
+def _invoke_json(runner, args: list[str]) -> dict:
+    result = runner.invoke(cli, [*args, "doctor", "--json"])
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+def test_doctor_reports_clean_profile_layout(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+    profile_dir = _make_profile(home)
+    _write_json(profile_dir / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
+    _write_json(home / "config.json", {"default_profile": "default"})
+
+    data = _invoke_json(runner, [])
+
+    assert data["profile"] == "default"
+    assert data["profile_source"] == "config.json"
+    assert data["checks"] == {
+        "migration": {"status": "pass", "detail": "complete"},
+        "profile_dir": {"status": "pass", "detail": str(profile_dir)},
+        "auth": {"status": "pass", "detail": "local SID cookie present (1 cookies)"},
+        "config": {"status": "pass", "detail": "valid (default_profile: default)"},
+    }
+
+
+def test_doctor_reports_legacy_layout_without_startup_migration(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+    _write_json(home / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
+
+    data = _invoke_json(runner, ["--storage", str(home / "unused.json")])
+
+    assert data["checks"]["migration"] == {
+        "status": "fail",
+        "detail": "legacy layout detected",
+    }
+    assert data["checks"]["profile_dir"]["status"] == "fail"
+    assert data["checks"]["auth"] == {
+        "status": "pass",
+        "detail": "local SID cookie present (1 cookies)",
+    }
+
+
+def test_doctor_reports_missing_profile_dir(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+
+    data = _invoke_json(runner, ["--storage", str(home / "unused.json")])
+
+    assert data["checks"]["migration"] == {
+        "status": "pass",
+        "detail": "clean (no legacy files)",
+    }
+    assert data["checks"]["profile_dir"] == {
+        "status": "fail",
+        "detail": f"{home / 'profiles' / 'default'} not found",
+    }
+    assert data["checks"]["auth"] == {"status": "fail", "detail": "not authenticated"}
+
+
+def test_doctor_reports_invalid_storage_json(runner, isolated_notebooklm_home):
+    profile_dir = _make_profile(isolated_notebooklm_home)
+    profile_dir.joinpath("storage_state.json").write_text("{not json", encoding="utf-8")
+
+    data = _invoke_json(runner, [])
+
+    assert data["checks"]["auth"]["status"] == "fail"
+    assert data["checks"]["auth"]["detail"].startswith("invalid storage file:")
+
+
+def test_doctor_reports_invalid_storage_root_shape(runner, isolated_notebooklm_home):
+    profile_dir = _make_profile(isolated_notebooklm_home)
+    _write_json(profile_dir / "storage_state.json", [])
+
+    data = _invoke_json(runner, [])
+
+    assert data["checks"]["auth"] == {
+        "status": "fail",
+        "detail": "invalid storage file: storage root is not an object",
+    }
+
+
+def test_doctor_reports_invalid_storage_cookie_shape(runner, isolated_notebooklm_home):
+    profile_dir = _make_profile(isolated_notebooklm_home)
+    _write_json(profile_dir / "storage_state.json", {"cookies": {"name": "SID"}})
+
+    data = _invoke_json(runner, [])
+
+    assert data["checks"]["auth"] == {
+        "status": "fail",
+        "detail": "invalid storage file: cookies is not a list",
+    }
+
+
+def test_doctor_reports_cookies_missing_sid(runner, isolated_notebooklm_home):
+    profile_dir = _make_profile(isolated_notebooklm_home)
+    _write_json(profile_dir / "storage_state.json", _storage([{"name": "HSID", "value": "x"}]))
+
+    data = _invoke_json(runner, [])
+
+    assert data["checks"]["auth"] == {"status": "fail", "detail": "SID cookie missing"}
+
+
+def test_doctor_warns_when_config_default_profile_is_missing(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+    _make_profile(home)
+    _write_json(home / "profiles" / "default" / "storage_state.json", _storage([]))
+    _write_json(home / "config.json", {"default_profile": "missing"})
+
+    data = _invoke_json(runner, [])
+
+    assert data["profile"] == "missing"
+    assert data["profile_source"] == "config.json"
+    assert data["checks"]["profile_dir"]["status"] == "fail"
+    assert data["checks"]["config"] == {
+        "status": "warn",
+        "detail": "default_profile 'missing' does not exist",
+    }
+
+
+def test_doctor_reports_invalid_config_root_shape(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+    _make_profile(home)
+    _write_json(home / "config.json", [])
+
+    data = _invoke_json(runner, [])
+
+    assert data["checks"]["config"] == {
+        "status": "fail",
+        "detail": "invalid: config root is not an object",
+    }
+
+
+def test_doctor_fix_creates_missing_profile_dir(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+
+    result = runner.invoke(cli, ["doctor", "--fix", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    profile_dir = home / "profiles" / "default"
+    assert profile_dir.is_dir()
+    if os.name != "nt":
+        assert profile_dir.stat().st_mode & 0o777 == 0o700
+    assert data["checks"]["profile_dir"] == {"status": "pass", "detail": str(profile_dir)}
+    assert data["fixes_applied"] == [f"Created profile directory: {profile_dir}"]
+
+
+def test_doctor_fix_migrates_legacy_layout(runner, isolated_notebooklm_home):
+    home = isolated_notebooklm_home
+    _write_json(home / "storage_state.json", _storage([{"name": "SID", "value": "x"}]))
+    _write_json(home / "context.json", {"current_notebook": "nb_123"})
+
+    result = runner.invoke(
+        cli,
+        ["--storage", str(home / "unused.json"), "doctor", "--fix", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    profile_dir = home / "profiles" / "default"
+    assert not (home / "storage_state.json").exists()
+    assert (profile_dir / "storage_state.json").exists()
+    assert (profile_dir / "context.json").exists()
+    assert data["checks"]["migration"] == {
+        "status": "pass",
+        "detail": "complete (just migrated)",
+    }
+    assert data["fixes_applied"] == ["Migrated legacy layout to profiles/default/"]
+
+
+def test_doctor_json_output_shape(runner, isolated_notebooklm_home):
+    _make_profile(isolated_notebooklm_home)
+
+    data = _invoke_json(runner, [])
+
+    assert set(data) == {"profile", "profile_source", "checks"}
+    assert set(data["checks"]) == {"migration", "profile_dir", "auth", "config"}
+    for check in data["checks"].values():
+        assert set(check) == {"status", "detail"}
+        assert check["status"] in {"pass", "warn", "fail"}
+        assert isinstance(check["detail"], str)


### PR DESCRIPTION
## Summary
- add focused unit coverage for doctor diagnostics across profile, migration, auth, config, fix, and JSON paths
- clarify auth diagnostics as local SID-cookie presence rather than verified live authentication
- handle non-object storage/config JSON shapes cleanly

Fixes #420

## Test plan
- `uv run pytest tests/unit/cli/test_doctor.py -q`
- `uv run pytest tests/unit/cli/test_doctor.py tests/unit/test_paths.py tests/unit/test_migration.py -q`
- `uv run ruff check src/notebooklm/cli/doctor.py src/notebooklm/paths.py tests/unit/cli/test_doctor.py`
- `uv run mypy src/notebooklm/cli/doctor.py src/notebooklm/paths.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for the `notebooklm doctor` command: stricter validation of config/storage JSON shapes (object/list expectations), clearer success/failure details (including local SID cookie detection), and better handling/classification of malformed or invalid JSON.
  * Enhanced fix/migration behavior to correctly create missing profile layout and migrate legacy storage into the expected profile structure.

* **Tests**
  * Added comprehensive unit tests for `notebooklm doctor`, covering diagnostics output, JSON schema validation, and migration/--fix scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/428)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->