### PR TITLE
test(concurrency): snapshot + cache + refresh state-machine regression tests (Phase 1.5)

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures and helpers for tests/unit/.
+
+The ``make_core`` async context manager is imported directly by sibling
+test modules (e.g. ``from conftest import make_core``) — pytest adds the
+test directory to ``sys.path`` so the sibling import works.
+"""
+
+from contextlib import asynccontextmanager
+
+import httpx
+
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+
+
+@asynccontextmanager
+async def make_core(refresh_callback=None, transport=None, refresh_retry_delay=0.0):
+    """Yield an opened ClientCore with optional mock transport; close cleanly.
+
+    Args:
+        refresh_callback: async callable returning ``AuthTokens`` (or raising)
+            for use by ``_try_refresh_and_retry``. ``None`` skips refresh setup.
+        transport: optional ``httpx.MockTransport`` so tests can observe the
+            real ``httpx.Request`` after cookie merge.
+        refresh_retry_delay: shortened in tests (default 0.0) to keep the
+            suite fast — production default is 0.2s.
+    """
+    auth = AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "old_sid_cookie"},
+    )
+    core = ClientCore(
+        auth=auth,
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=refresh_retry_delay,
+    )
+    await core.open()
+    if transport is not None:
+        # Replace the auto-built client with one that uses our transport so we
+        # can observe real httpx.Request construction (cookie merge, headers).
+        # Capture the cookie jar BEFORE aclose() — reading attributes off a
+        # closed AsyncClient is brittle across httpx versions.
+        prior_cookies = core._http_client.cookies
+        await core._http_client.aclose()
+        core._http_client = httpx.AsyncClient(
+            cookies=prior_cookies,
+            transport=transport,
+            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        )
+    try:
+        yield core
+    finally:
+        await core.close()

--- a/tests/unit/test_concurrency_cache_race.py
+++ b/tests/unit/test_concurrency_cache_race.py
@@ -54,14 +54,10 @@ def test_cache_conversation_turn_remains_synchronous():
 
 
 @pytest.mark.asyncio
-async def test_cache_eviction_preserves_invariant_size():
+async def test_cache_eviction_preserves_invariant_size(monkeypatch):
+    monkeypatch.setattr(_core, "MAX_CONVERSATION_CACHE_SIZE", 3)
     async with make_core() as core:
-        original_max = _core.MAX_CONVERSATION_CACHE_SIZE
-        try:
-            _core.MAX_CONVERSATION_CACHE_SIZE = 3
-            for i in range(10):
-                core.cache_conversation_turn(f"conv-{i}", "q", "a", 0)
-            assert len(core._conversation_cache) == 3
-            assert list(core._conversation_cache.keys()) == ["conv-7", "conv-8", "conv-9"]
-        finally:
-            _core.MAX_CONVERSATION_CACHE_SIZE = original_max
+        for i in range(10):
+            core.cache_conversation_turn(f"conv-{i}", "q", "a", 0)
+        assert len(core._conversation_cache) == 3
+        assert list(core._conversation_cache.keys()) == ["conv-7", "conv-8", "conv-9"]

--- a/tests/unit/test_concurrency_cache_race.py
+++ b/tests/unit/test_concurrency_cache_race.py
@@ -1,0 +1,67 @@
+"""Phase 1.5 P1.5.2 — conversation cache atomicity guarantee.
+
+``cache_conversation_turn`` is synchronous: under cooperative asyncio
+scheduling it runs to completion before any other coroutine resumes. This
+file pins that guarantee with a concurrent-appends test, an AST guard
+against future ``await`` additions, and an eviction-correctness test.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import textwrap
+
+import pytest
+
+from conftest import make_core  # type: ignore[import-not-found]
+from notebooklm import _core
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cache_appends_to_same_conversation_preserve_all_turns():
+    async with make_core() as core:
+        n = 100
+
+        async def append(i):
+            core.cache_conversation_turn("conv-1", f"q{i}", f"a{i}", i)
+
+        await asyncio.gather(*(append(i) for i in range(n)))
+
+        cache = core.get_cached_conversation("conv-1")
+        assert len(cache) == n, f"Lost appends under gather: got {len(cache)}/{n}"
+        seen = {(t["query"], t["answer"], t["turn_number"]) for t in cache}
+        assert seen == {(f"q{i}", f"a{i}", i) for i in range(n)}
+
+
+def test_cache_conversation_turn_remains_synchronous():
+    """If anyone adds ``await`` to ``cache_conversation_turn``, this fails.
+
+    The cache's atomicity guarantee depends on the function having no yield
+    points.
+    """
+    src = inspect.getsource(_core.ClientCore.cache_conversation_turn)
+    tree = ast.parse(textwrap.dedent(src))
+    awaits = [n for n in ast.walk(tree) if isinstance(n, ast.Await)]
+    is_async = any(isinstance(n, ast.AsyncFunctionDef) for n in ast.walk(tree))
+    assert not awaits, (
+        "cache_conversation_turn must not contain `await` (breaks atomicity guarantee)"
+    )
+    assert not is_async, (
+        "cache_conversation_turn must not be `async def` (breaks atomicity guarantee)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_eviction_preserves_invariant_size():
+    async with make_core() as core:
+        original_max = _core.MAX_CONVERSATION_CACHE_SIZE
+        try:
+            _core.MAX_CONVERSATION_CACHE_SIZE = 3
+            for i in range(10):
+                core.cache_conversation_turn(f"conv-{i}", "q", "a", 0)
+            assert len(core._conversation_cache) == 3
+            assert list(core._conversation_cache.keys()) == ["conv-7", "conv-8", "conv-9"]
+        finally:
+            _core.MAX_CONVERSATION_CACHE_SIZE = original_max

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -64,11 +64,10 @@ def test_rpc_call_impl_has_no_await_before_post():
         attr = call.func
         return isinstance(attr, ast.Attribute) and attr.attr == "post"
 
-    post_await_lineno = None
-    for node in ast.walk(func):
-        if is_post_await(node):
-            post_await_lineno = node.lineno
-            break
+    # ast.walk does not guarantee source order, so pick the earliest match by
+    # line number — robust to future code that contains multiple post() calls.
+    post_await_linenos = [n.lineno for n in ast.walk(func) if is_post_await(n)]
+    post_await_lineno = min(post_await_linenos, default=None)
     assert post_await_lineno is not None, (
         "Could not locate `await ...post(...)` in _rpc_call_impl. If you "
         "refactored the call site (e.g., to `self._http_client.request(...)`), "

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -1,0 +1,198 @@
+"""Phase 1.5 P1.5.1 — snapshot-invariant for `_rpc_call_impl`.
+
+httpx merges the cookie jar into the outgoing ``httpx.Request`` synchronously
+in ``build_request()``, before any ``await``. ``_rpc_call_impl`` reads
+``auth.csrf_token`` and ``auth.session_id`` synchronously before
+``await self._http_client.post(url, content=body)``. Therefore, the entire
+``(csrf, session_id, cookies)`` snapshot is atomic from a concurrent-coroutine
+standpoint: no other task can mutate state between read and the wire.
+
+This file *locks* that invariant in two ways:
+
+1. ``test_rpc_call_impl_has_no_await_before_post`` — static AST guard that
+   fails the moment someone adds an ``await`` to the currently-synchronous
+   prologue of ``_rpc_call_impl``. Conservative: any await before ``post()``
+   is rejected, even if it precedes the auth reads.
+
+2. ``test_concurrent_refresh_does_not_corrupt_inflight_rpc_request`` — runtime
+   self-consistency. Drives concurrent ``refresh_auth`` against an in-flight
+   ``rpc_call`` (both orderings) and asserts the captured ``httpx.Request``
+   is never observed with mixed-generation (csrf, session_id, cookies) state.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import json
+import textwrap
+
+import httpx
+import pytest
+
+from conftest import make_core  # type: ignore[import-not-found]
+from notebooklm._core import ClientCore
+from notebooklm.rpc import RPCMethod
+
+# Test-side deadline for any single asyncio.Event in the race scaffolding.
+# Generous enough not to flake on slow CI, tight enough that a regression
+# (e.g., POST never reached the transport) fails fast instead of hanging.
+EVENT_TIMEOUT_S = 5.0
+
+
+def test_rpc_call_impl_has_no_await_before_post():
+    """``_rpc_call_impl`` must not contain any ``await`` before its ``post()``.
+
+    If anyone adds an ``await`` to the prologue of ``_rpc_call_impl``, a
+    concurrent ``refresh_auth`` could mutate ``auth.csrf_token`` /
+    ``auth.session_id`` / the cookie jar between the read and the wire,
+    producing a mismatched-generation request. The rule is conservative:
+    any earlier ``await`` is rejected, not just ones that fall between the
+    auth reads and the ``post()`` call.
+    """
+    src = textwrap.dedent(inspect.getsource(ClientCore._rpc_call_impl))
+    tree = ast.parse(src)
+    func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+
+    def is_post_await(node):
+        if not isinstance(node, ast.Await):
+            return False
+        call = node.value
+        if not isinstance(call, ast.Call):
+            return False
+        attr = call.func
+        return isinstance(attr, ast.Attribute) and attr.attr == "post"
+
+    post_await_lineno = None
+    for node in ast.walk(func):
+        if is_post_await(node):
+            post_await_lineno = node.lineno
+            break
+    assert post_await_lineno is not None, (
+        "Could not locate `await ...post(...)` in _rpc_call_impl. If you "
+        "refactored the call site (e.g., to `self._http_client.request(...)`), "
+        "update this guard to match — the invariant is 'no await before the "
+        "RPC send', not specifically the `.post` attribute."
+    )
+
+    earlier_awaits = [
+        n for n in ast.walk(func) if isinstance(n, ast.Await) and n.lineno < post_await_lineno
+    ]
+    assert not earlier_awaits, (
+        f"_rpc_call_impl gained an await before the POST at line {post_await_lineno}: "
+        f"{[(n.lineno, ast.dump(n)) for n in earlier_awaits]}. "
+        "This breaks the snapshot-invariant — auth state could be mutated between "
+        "the read and the actual send."
+    )
+
+
+def _synthetic_rpc_response_text(rpc_id: str) -> str:
+    """Build a minimal valid batchexecute response that decodes to []."""
+    inner = json.dumps([])
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+@pytest.mark.parametrize("rpc_first", [True, False], ids=["rpc-first", "refresh-first"])
+async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_first):
+    """Every outgoing RPC must carry a coherent (csrf, session_id, cookies) tuple.
+
+    On current code both parameterizations observe OLD/OLD/OLD: the RPC's
+    request is fully built (synchronously) while refresh is still suspended
+    in its GET, so all three values are captured from the pre-rotation state.
+    The assertion below catches the broken case where a future refactor
+    introduces a yield point between auth read and ``post()`` — letting
+    refresh complete in between would produce mixed generations.
+    """
+    captured_post: list[dict] = []
+    rpc_send_entered = asyncio.Event()
+    let_rpc_send_complete = asyncio.Event()
+    get_entered = asyncio.Event()
+    let_get_complete = asyncio.Event()
+
+    rpc_method_id = RPCMethod.LIST_NOTEBOOKS.value
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            captured_post.append(
+                {
+                    "url": str(request.url),
+                    "cookie": request.headers.get("cookie", ""),
+                    "body": bytes(request.content),
+                }
+            )
+            rpc_send_entered.set()
+            await let_rpc_send_complete.wait()
+            return httpx.Response(200, text=_synthetic_rpc_response_text(rpc_method_id))
+        get_entered.set()
+        await let_get_complete.wait()
+        body = '<script>"SNlM0e":"CSRF_NEW","FdrFJe":"SID_NEW"</script>'
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"set-cookie": "SID=new_sid_cookie; Path=/; Domain=.google.com"},
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    async with make_core(transport=transport) as core:
+        # NotebookLMClient.__new__ skips __init__ side effects — we only need a
+        # shell whose .auth property routes to our test core.
+        from notebooklm.client import NotebookLMClient
+
+        client = NotebookLMClient.__new__(NotebookLMClient)
+        client._core = core
+
+        if rpc_first:
+            rpc_task = asyncio.create_task(core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []))
+            await asyncio.wait_for(rpc_send_entered.wait(), EVENT_TIMEOUT_S)
+            refresh_task = asyncio.create_task(client.refresh_auth())
+            await asyncio.wait_for(get_entered.wait(), EVENT_TIMEOUT_S)
+            let_get_complete.set()
+            await refresh_task
+            let_rpc_send_complete.set()
+            await rpc_task
+        else:
+            refresh_task = asyncio.create_task(client.refresh_auth())
+            await asyncio.wait_for(get_entered.wait(), EVENT_TIMEOUT_S)
+            rpc_task = asyncio.create_task(core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []))
+            await asyncio.wait_for(rpc_send_entered.wait(), EVENT_TIMEOUT_S)
+            let_get_complete.set()
+            await refresh_task
+            let_rpc_send_complete.set()
+            await rpc_task
+
+    assert len(captured_post) == 1, (
+        f"Expected exactly one POST on the wire, got {len(captured_post)}: {captured_post!r}"
+    )
+    seen = captured_post[0]
+    cookie_is_new = "new_sid_cookie" in seen["cookie"]
+    cookie_is_old = "old_sid_cookie" in seen["cookie"]
+    csrf_is_new = b"CSRF_NEW" in seen["body"]
+    csrf_is_old = b"CSRF_OLD" in seen["body"]
+    sid_is_new = "SID_NEW" in seen["url"]
+    sid_is_old = "SID_OLD" in seen["url"]
+
+    # Sanity: each indicator is unambiguous (exactly one of old/new per axis).
+    # Without this, the coherence check below could false-pass when both
+    # "is_new" indicators are False simply because the markers weren't injected.
+    assert cookie_is_old ^ cookie_is_new, (
+        f"Cookie axis ambiguous (old={cookie_is_old}, new={cookie_is_new}): {seen['cookie']!r}"
+    )
+    assert csrf_is_old ^ csrf_is_new, (
+        f"CSRF axis ambiguous (old={csrf_is_old}, new={csrf_is_new}): body did not contain "
+        f"a recognizable CSRF marker"
+    )
+    assert sid_is_old ^ sid_is_new, (
+        f"Session-ID axis ambiguous (old={sid_is_old}, new={sid_is_new}): {seen['url']!r}"
+    )
+
+    # The invariant: all three axes must agree (all-OLD or all-NEW). Any mix
+    # indicates an unexpected yield in the prologue.
+    assert cookie_is_new == csrf_is_new == sid_is_new, (
+        f"Mixed-generation request observed (cookie_new={cookie_is_new}, "
+        f"csrf_new={csrf_is_new}, sid_new={sid_is_new}). A yield point was "
+        f"introduced between auth read and post() in _rpc_call_impl — re-run "
+        f"the AST guard above to find the offending await."
+    )

--- a/tests/unit/test_refresh_state_machine.py
+++ b/tests/unit/test_refresh_state_machine.py
@@ -1,0 +1,175 @@
+"""Phase 1.5 P1.5.4 — refresh state-machine regression tests.
+
+Pins three behaviors of ``ClientCore._try_refresh_and_retry``:
+
+1. Concurrent callers share the same in-flight refresh task (single-flight).
+2. Refresh failures propagate to all waiters with chained ``__cause__``.
+3. A second wave after the first task completes creates a *new* task
+   (the slot is not silently reused).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from conftest import make_core  # type: ignore[import-not-found]
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import AuthError, RPCMethod
+
+# Tight enough to fail fast if a regression hangs the suite, generous enough
+# not to flake on a slow CI runner. Each event-wait should resolve in <100ms;
+# 5s is two orders of magnitude of headroom.
+EVENT_TIMEOUT_S = 5.0
+
+
+async def _trigger_refresh(core):
+    """Drive ``_try_refresh_and_retry`` with throwaway args."""
+    return await core._try_refresh_and_retry(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        AuthError("simulated"),
+    )
+
+
+async def _wait_for_inflight_refresh_task(core, ticks: int = 20) -> bool:
+    """Yield up to ``ticks`` times for the shared refresh task to appear."""
+    for _ in range(ticks):
+        await asyncio.sleep(0)
+        if core._refresh_task is not None and not core._refresh_task.done():
+            return True
+    return False
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_share_single_refresh():
+    callback_entered = asyncio.Event()
+    release_refresh = asyncio.Event()
+    call_count = 0
+    core_box: list = []
+
+    async def cb():
+        nonlocal call_count
+        call_count += 1
+        callback_entered.set()
+        await release_refresh.wait()
+        tokens = AuthTokens(
+            csrf_token="CSRF_REFRESHED",
+            session_id="SID_REFRESHED",
+            cookies={"SID": "post_refresh"},
+        )
+        # Mirror real-world callback behavior: update core.auth in place.
+        core_box[0].auth.csrf_token = tokens.csrf_token
+        core_box[0].auth.session_id = tokens.session_id
+        return tokens
+
+    async with make_core(refresh_callback=cb) as core:
+        core_box.append(core)
+
+        async def fake_retry(*args, **kwargs):
+            return "ok"
+
+        core.rpc_call = fake_retry  # instance shadow over the bound method
+
+        tasks = [asyncio.create_task(_trigger_refresh(core)) for _ in range(3)]
+
+        await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
+        assert call_count == 1, f"FIRST entry should have call_count=1, got {call_count}"
+
+        # Give tasks 2 and 3 a chance to reach `await refresh_task`. The real
+        # single-flight invariant is proven by the post-release assertion below;
+        # this loop just lets the scheduler tick.
+        if not await _wait_for_inflight_refresh_task(core):
+            pytest.fail("Refresh task did not appear in 20 ticks")
+
+        assert call_count == 1, f"Multiple refreshes fired before release: {call_count}"
+
+        release_refresh.set()
+        results = await asyncio.gather(*tasks)
+
+        assert all(r == "ok" for r in results)
+        assert call_count == 1, f"Post-release call_count drifted to {call_count}"
+        assert core.auth.csrf_token == "CSRF_REFRESHED"
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_propagates_to_all_waiters():
+    """All waiters on the shared refresh task observe the same failure.
+
+    Uses a gated failing callback so all three triggers must join the in-flight
+    task before it raises — without the gate, the first task could complete
+    immediately and let the others spin up their own failed tasks, which would
+    pass the per-task assertions but not prove shared-task propagation.
+    """
+    boom = RuntimeError("refresh boom")
+    enter = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def cb():
+        nonlocal call_count
+        call_count += 1
+        enter.set()
+        await release.wait()
+        raise boom
+
+    async with make_core(refresh_callback=cb) as core:
+        tasks = [asyncio.create_task(_trigger_refresh(core)) for _ in range(3)]
+
+        await asyncio.wait_for(enter.wait(), EVENT_TIMEOUT_S)
+        if not await _wait_for_inflight_refresh_task(core):
+            pytest.fail("Refresh task did not appear in 20 ticks")
+
+        assert call_count == 1, (
+            f"Failure propagation test invalid: {call_count} callbacks fired "
+            "before release. Single-flight broken — each waiter spun its own."
+        )
+
+        release.set()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert call_count == 1, f"Refresh re-fired after failure: {call_count}"
+        # Identity check: every waiter must observe the SAME RuntimeError as
+        # __cause__. This proves shared-task propagation — a per-waiter retry
+        # would produce distinct RuntimeError instances even with the same msg.
+        for r in results:
+            assert isinstance(r, AuthError)
+            assert r.__cause__ is boom, (
+                f"Expected shared-task propagation (cause is boom), got "
+                f"{r.__cause__!r} (id={id(r.__cause__)}, boom id={id(boom)})"
+            )
+
+
+@pytest.mark.asyncio
+async def test_second_wave_creates_distinct_refresh_task():
+    call_count = 0
+
+    async def cb():
+        nonlocal call_count
+        call_count += 1
+        return AuthTokens(
+            csrf_token=f"R{call_count}",
+            session_id="S",
+            cookies={"SID": f"sid{call_count}"},
+        )
+
+    async with make_core(refresh_callback=cb) as core:
+
+        async def fake_retry(*args, **kwargs):
+            return "ok"
+
+        core.rpc_call = fake_retry
+
+        await _trigger_refresh(core)
+        first_task = core._refresh_task
+        assert first_task is not None and first_task.done()
+
+        await _trigger_refresh(core)
+        second_task = core._refresh_task
+        assert second_task is not None and second_task.done()
+
+        assert first_task is not second_task, "Second wave reused completed task"
+        assert call_count == 2


### PR DESCRIPTION
## Summary

Phase 1.5 of the gaps-remediation effort. Per the master plan §5: **prove first, then lock**.

After MOMUS triple-review across three rounds (Claude / Gemini / Codex), the suspected race in `_rpc_call_impl` was found to be structurally unreachable on current code: httpx merges the cookie jar into the outgoing `Request` *synchronously* in `build_request()` before any `await`, and `_rpc_call_impl` reads `csrf` / `session_id` synchronously before `await post()`. The `(csrf, session_id, cookies)` snapshot is therefore atomic from a concurrent-coroutine standpoint.

Rather than add speculative locks (forbidden by v2.1 of the master plan), this PR **locks the invariant with regression tests**. Future refactors that break it will fail loudly.

## What's in this PR

| File | Purpose |
|---|---|
| `tests/unit/conftest.py` | `make_core` async ctx mgr (opens `ClientCore`, optional `MockTransport`, shortened `refresh_retry_delay`). |
| `tests/unit/test_concurrency_refresh_race.py` (P1.5.1) | AST guard that any `await` added to `_rpc_call_impl`'s prologue fails the test; parameterized runtime self-consistency test driving concurrent `refresh_auth` vs in-flight `rpc_call` (both orderings). |
| `tests/unit/test_concurrency_cache_race.py` (P1.5.2) | Concurrent appends preserve all turns; AST guard against future `await` in `cache_conversation_turn`; eviction correctness. |
| `tests/unit/test_refresh_state_machine.py` (P1.5.4) | Single-flight refresh; failure propagation via shared task (gated callback + `__cause__ is boom` identity); second wave creates distinct task. |

**No production code changes.** P1.5.3 (snapshot + lock + perf gate) intentionally deferred — no proven race, no speculative production change. The AST guards regression-lock the invariants so P1.5.3 can land later, with a real failure to prove against.

## MOMUS convergence log

- v1: REJECT (all 3) — vague race premise.
- v2: REJECT (Claude + Codex; Gemini rate-limited) — `MockTransport` approach correct boundary but wrong scheduling; `client.auth = core.auth` would crash (property has no setter); `_refresh_lock` reuse would break single-flight.
- v3: SHIP (Claude + Gemini), fixable REJECT (Codex) — Codex's three substantive items (no event timeouts, weak XOR assertion that false-passes when both indicators are False, AST message inaccurate) applied inline before commit.
- Polish review applied: 5-second `asyncio.wait_for` deadlines on all event waits; assertion strengthened to check all three axes (csrf, session_id, cookies) explicitly with old/new sanity guards; `__cause__ is boom` identity check; `monkeypatch`-free cookie handoff in conftest.

## Test plan

- [x] `uv run pytest tests/unit/test_concurrency_refresh_race.py tests/unit/test_concurrency_cache_race.py tests/unit/test_refresh_state_machine.py -v` — 9 passed
- [x] `uv run pytest` — 2803 passed, 12 skipped
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive concurrency and atomicity tests to ensure cache consistency when many turns are appended concurrently, and to verify eviction invariants.
  * Added concurrency tests to ensure in-flight RPC requests remain self-consistent across auth rotations and AST guards preventing unintended awaits.
  * Added regression tests and fixtures to validate single-flight refresh behavior, error propagation, and shared refresh-task semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/432)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->