### PR TITLE
refactor(rpc): centralize source-ID nesting + ArtifactTypeCode literals (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 captured_rpcs/
 .worktrees/
 .worktree/
+worktrees/
 .sisyphus/
 .scratch/
 .claude/

--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -1,7 +1,7 @@
 # RPC Development Guide
 
 **Status:** Active
-**Last Updated:** 2026-01-20
+**Last Updated:** 2026-05-13
 
 This guide covers everything about NotebookLM's RPC protocol: capturing calls, debugging issues, and implementing new methods.
 

--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -476,3 +476,30 @@ async def validate_rpc_call(rpc_id: str, params: list, expected_action: str):
     assert result is not None, f"RPC {rpc_id} returned None"
     return {"rpc_id": rpc_id, "action": expected_action, "status": "verified"}
 ```
+
+## RPC Health Check Triage Policy
+
+The `rpc-health.yml` workflow runs daily (07:00 UTC) and opens an issue on any
+detected RPC ID mismatch or auth failure:
+
+- **RPC ID mismatch** issues: labeled `bug, rpc-breakage, automated`.
+- **Auth failure** issues: labeled `bug, automated` (no `rpc-breakage` label —
+  auth is an operational concern, not a protocol break).
+
+Routing:
+
+- **Maintainer assignment**: Issues land in the `teng-lin/notebooklm-py`
+  default issue inbox. The maintainer triages within 24 hours during business
+  days. (No auto-assignee — the project has a single maintainer and
+  auto-assignment adds noise.)
+- **Acknowledged-but-deferred**: If an upstream RPC change is observed but
+  the library still functions for the majority of users (e.g., one optional
+  field renamed), the maintainer closes the issue with the `acknowledged`
+  label and links the PR that resolves it.
+- **Notifying users**: If the breakage affects an RPC most users invoke
+  (e.g., `LIST_NOTEBOOKS`, `CREATE_NOTEBOOK`), the maintainer additionally
+  files a release-note draft + pins the issue.
+
+If you see an `rpc-breakage` issue sitting unattended for >7 days, ping the
+maintainer in a comment — it likely fell out of the inbox. The intent of this
+workflow is fast detection, not perpetual auto-noise.

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -42,6 +42,7 @@ from .rpc import (
     VideoFormat,
     VideoStyle,
     artifact_status_to_str,
+    nest_source_ids,
 )
 from .types import (
     Artifact,
@@ -412,8 +413,8 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
-        source_ids_double = [[sid] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
 
         format_code = audio_format.value if audio_format else None
         length_code = audio_length.value if audio_length else None
@@ -424,7 +425,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                1,  # ArtifactTypeCode.AUDIO
+                ArtifactTypeCode.AUDIO.value,
                 source_ids_triple,
                 None,
                 None,
@@ -483,8 +484,8 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
-        source_ids_double = [[sid] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
 
         format_code = video_format.value if video_format else None
         style_code = video_style.value if video_style else None
@@ -506,7 +507,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                3,  # ArtifactTypeCode.VIDEO
+                ArtifactTypeCode.VIDEO.value,
                 source_ids_triple,
                 None,
                 None,
@@ -557,8 +558,8 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
-        source_ids_double = [[sid] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
 
         params = [
             [2],
@@ -657,8 +658,8 @@ class ArtifactsAPI:
         config = format_configs[report_format]
         if extra_instructions and report_format != ReportFormat.CUSTOM:
             config = {**config, "prompt": f"{config['prompt']}\n\n{extra_instructions}"}
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
-        source_ids_double = [[sid] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
 
         params = [
             [2],
@@ -666,7 +667,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                2,  # ArtifactTypeCode.REPORT
+                ArtifactTypeCode.REPORT.value,
                 source_ids_triple,
                 None,
                 None,
@@ -742,7 +743,7 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
         quantity_code = quantity.value if quantity else None
         difficulty_code = difficulty.value if difficulty else None
 
@@ -752,7 +753,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                4,  # ArtifactTypeCode.QUIZ_FLASHCARD
+                ArtifactTypeCode.QUIZ_FLASHCARD.value,
                 source_ids_triple,
                 None,
                 None,
@@ -799,7 +800,7 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
         quantity_code = quantity.value if quantity else None
         difficulty_code = difficulty.value if difficulty else None
 
@@ -809,7 +810,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                4,  # ArtifactTypeCode.QUIZ_FLASHCARD
+                ArtifactTypeCode.QUIZ_FLASHCARD.value,
                 source_ids_triple,
                 None,
                 None,
@@ -862,7 +863,7 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
         orientation_code = orientation.value if orientation else None
         detail_code = detail_level.value if detail_level else None
         style_code = style.value if style else None
@@ -873,7 +874,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                7,  # ArtifactTypeCode.INFOGRAPHIC
+                ArtifactTypeCode.INFOGRAPHIC.value,
                 source_ids_triple,
                 None,
                 None,
@@ -918,7 +919,7 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
         format_code = slide_format.value if slide_format else None
         length_code = slide_length.value if slide_length else None
 
@@ -928,7 +929,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                8,  # ArtifactTypeCode.SLIDE_DECK
+                ArtifactTypeCode.SLIDE_DECK.value,
                 source_ids_triple,
                 None,
                 None,
@@ -1021,7 +1022,7 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_triple = [[[sid]] for sid in source_ids] if source_ids else []
+        source_ids_triple = nest_source_ids(source_ids, 2)
 
         params = [
             [2],
@@ -1029,7 +1030,7 @@ class ArtifactsAPI:
             [
                 None,
                 None,
-                9,  # ArtifactTypeCode.DATA_TABLE
+                ArtifactTypeCode.DATA_TABLE.value,
                 source_ids_triple,
                 None,
                 None,
@@ -1079,7 +1080,7 @@ class ArtifactsAPI:
         if source_ids is None:
             source_ids = await self._core.get_source_ids(notebook_id)
 
-        source_ids_nested = [[[sid]] for sid in source_ids] if source_ids else []
+        source_ids_nested = nest_source_ids(source_ids, 2)
 
         params = [
             source_ids_nested,

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -17,7 +17,7 @@ import httpx
 from ._core import ClientCore
 from ._env import get_default_language
 from .exceptions import ChatError, NetworkError, ValidationError
-from .rpc import RPCMethod, get_query_url
+from .rpc import RPCMethod, get_query_url, nest_source_ids
 from .types import AskResult, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ class ChatAPI:
             assert conversation_id is not None  # Type narrowing for mypy
             conversation_history = self._build_conversation_history(conversation_id)
 
-        sources_array = [[[sid]] for sid in source_ids] if source_ids else []
+        sources_array = nest_source_ids(source_ids, 2)
 
         params: list[Any] = [
             sources_array,

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -16,7 +16,7 @@ from .decoder import (
     parse_chunked_response,
     strip_anti_xssi,
 )
-from .encoder import build_request_body, encode_rpc_request
+from .encoder import build_request_body, encode_rpc_request, nest_source_ids
 from .types import (
     BATCHEXECUTE_URL,
     QUERY_URL,
@@ -77,6 +77,7 @@ __all__ = [
     "ExportType",
     "encode_rpc_request",
     "build_request_body",
+    "nest_source_ids",
     "strip_anti_xssi",
     "parse_chunked_response",
     "extract_rpc_result",

--- a/src/notebooklm/rpc/encoder.py
+++ b/src/notebooklm/rpc/encoder.py
@@ -35,6 +35,33 @@ def encode_rpc_request(method: RPCMethod, params: list[Any]) -> list:
     return [[inner]]
 
 
+def nest_source_ids(ids: list[str] | None, depth: int) -> list:
+    """Wrap each source ID in ``depth`` inner lists, then collect.
+
+    The outer list is always present; ``depth`` is the number of inner
+    wrapping levels per ID.
+
+    - depth=1: ``[[id1], [id2]]``
+    - depth=2: ``[[[id1]], [[id2]]]``
+    - depth=3: ``[[[[id1]]], [[[id2]]]]``
+
+    Args:
+        ids: Source IDs, or ``None`` (treated as empty).
+        depth: Inner wrap levels per ID. Must be ``>= 1``.
+
+    Returns:
+        Empty list when ``ids`` is ``None`` or empty.
+    """
+    if depth < 1:
+        raise ValueError(f"depth must be >= 1, got {depth}")
+    if not ids:
+        return []
+    result: list = list(ids)
+    for _ in range(depth):
+        result = [[item] for item in result]
+    return result
+
+
 def build_request_body(
     rpc_request: list,
     csrf_token: str | None = None,

--- a/tests/unit/test_artifact_type_code_consistency.py
+++ b/tests/unit/test_artifact_type_code_consistency.py
@@ -1,0 +1,28 @@
+"""Phase 2 P2.5 (slice) — pin ArtifactTypeCode usage consistency.
+
+After P2.2 replaced inline `N,  # ArtifactTypeCode.FOO` literals with
+`ArtifactTypeCode.FOO.value`, this test fails if anyone adds a new
+literal-with-comment pattern (suggesting the migration regressed).
+"""
+
+import re
+from pathlib import Path
+
+ARTIFACTS_PATH = Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "_artifacts.py"
+
+# Forbid `N,  # ArtifactTypeCode.NAME` (integer + comment naming the enum).
+# The replacement is `ArtifactTypeCode.NAME.value`.
+FORBIDDEN_PATTERN = re.compile(
+    r"^\s*\d+\s*,\s*#\s*ArtifactTypeCode\.[A-Z][A-Z0-9_]*\s*$",
+    re.M,
+)
+
+
+def test_no_inline_artifact_type_code_literals_in_artifacts_py():
+    text = ARTIFACTS_PATH.read_text(encoding="utf-8")
+    matches = FORBIDDEN_PATTERN.findall(text)
+    assert not matches, (
+        f"Found {len(matches)} inline ArtifactTypeCode literal(s) in "
+        f"_artifacts.py; replace with `ArtifactTypeCode.FOO.value`. "
+        f"Matches:\n" + "\n".join(matches)
+    )

--- a/tests/unit/test_encoder.py
+++ b/tests/unit/test_encoder.py
@@ -2,7 +2,9 @@
 
 import json
 
-from notebooklm.rpc.encoder import build_request_body, encode_rpc_request
+import pytest
+
+from notebooklm.rpc.encoder import build_request_body, encode_rpc_request, nest_source_ids
 from notebooklm.rpc.types import RPCMethod
 
 
@@ -116,3 +118,47 @@ class TestBuildRequestBody:
 
         assert "f.req=" in body
         assert "at=token" in body
+
+
+class TestNestSourceIds:
+    """Phase 2 P2.1 — `nest_source_ids` helper."""
+
+    def test_empty_returns_empty(self):
+        assert nest_source_ids([], 1) == []
+        assert nest_source_ids([], 5) == []
+        assert nest_source_ids(None, 1) == []
+        assert nest_source_ids(None, 2) == []
+
+    def test_depth_1(self):
+        """depth=1 → [[sid] for sid in ids]"""
+        assert nest_source_ids(["a"], 1) == [["a"]]
+        assert nest_source_ids(["a", "b"], 1) == [["a"], ["b"]]
+
+    def test_depth_2(self):
+        """depth=2 → [[[sid]] for sid in ids]"""
+        assert nest_source_ids(["a"], 2) == [[["a"]]]
+        assert nest_source_ids(["a", "b"], 2) == [[["a"]], [["b"]]]
+
+    def test_depth_3(self):
+        """depth=3 → [[[[sid]]] for sid in ids]"""
+        assert nest_source_ids(["a"], 3) == [[[["a"]]]]
+
+    def test_invalid_depth_raises(self):
+        with pytest.raises(ValueError, match="depth must be >= 1"):
+            nest_source_ids(["a"], 0)
+        with pytest.raises(ValueError, match="depth must be >= 1"):
+            nest_source_ids(["a"], -1)
+
+    def test_invalid_depth_raises_even_for_empty_input(self):
+        """Depth validation runs before empty short-circuit — contract is uniform."""
+        with pytest.raises(ValueError, match="depth must be >= 1"):
+            nest_source_ids([], 0)
+        with pytest.raises(ValueError, match="depth must be >= 1"):
+            nest_source_ids(None, 0)
+
+    def test_input_not_mutated(self):
+        """The helper must not mutate its input list."""
+        ids = ["a", "b", "c"]
+        original = list(ids)
+        nest_source_ids(ids, 2)
+        assert ids == original


### PR DESCRIPTION
## Summary

Phase 2 of the gaps-remediation effort. Mechanical refactor with regression test scaffolding; no behavior change.

## Changes

**P2.1 — `nest_source_ids` helper** added to `src/notebooklm/rpc/encoder.py`. Centralizes the position-sensitive `[[id]]` / `[[[id]]]` wrapping pattern that previously appeared inline at 15 call sites.

Migration:
- \`src/notebooklm/_artifacts.py\`: 14 inline comprehensions (10 depth-2 + 4 depth-1) → \`nest_source_ids(source_ids, depth)\`.
- \`src/notebooklm/_chat.py:107\`: 1 inline depth-2 comprehension migrated.

**P2.2 — `ArtifactTypeCode` literal cleanup.** 8 `N,  # ArtifactTypeCode.FOO` sites in `_artifacts.py` replaced with `ArtifactTypeCode.FOO.value`. Line 569 already used the canonical form and is unchanged.

**P2.5 (slice) — regression guard.** `tests/unit/test_artifact_type_code_consistency.py` prevents anyone re-introducing the literal-with-comment idiom.

**P2.6 — triage policy.** Section added to `docs/rpc-development.md` documenting how `rpc-health.yml` auto-opened issues are routed (correct labels: RPC mismatch → `bug, rpc-breakage, automated`; auth failure → `bug, automated`).

## Deferred (per master plan §6)

- **P2.3** (typed schema adapters): explicitly multi-PR. Will land as its own series.
- **P2.4** (`is_auth_error` → typed dispatch): requires new `AuthError` subclasses (`CSRFExpired`, `SessionInvalid`, `AccountMismatch`). Separate PR.
- **P2.5** (full RPC payload regression fixtures): needs PII-scrubbed payloads per method. Separate PR.

## MOMUS log

- Plan v1 REJECT by Codex (missing `_chat.py:107`, wrong count, wrong workflow labels). Claude SHIP. Gemini failed.
- Plan v2: addressed all Codex items; proceeded to execute.

## Polish review fixes applied inline

- Triple review (Claude + Codex + Gemini) caught: accidental `worktrees/` gitlinks staged → unstaged + `.gitignore` updated. Helper depth-validate-first ordering → fixed.

## Test plan

- [x] \`uv run pytest tests/unit/test_encoder.py tests/unit/test_artifact_type_code_consistency.py -v\` — 17 passed
- [x] \`uv run pytest\` — 2811 passed, 12 skipped
- [x] \`uv run ruff format . && uv run ruff check .\` — clean
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added RPC Health Check Triage Policy and updated docs' Last Updated metadata.

* **Refactor**
  * Improved internal source-ID handling and artifact-type code consistency across generation flows.

* **Tests**
  * Added tests for source-ID nesting behavior and artifact-type code enforcement.

* **Chore**
  * .gitignore updated to explicitly ignore worktrees/.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/433)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->