### PR TITLE
feat(reliability): per-poll retry + async writes + HTTP-date Retry-After + bounded 429 retry (Phase 3)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2318,7 +2318,11 @@ class ArtifactsAPI:
                     # Each per-chunk write is dispatched to a worker thread so the
                     # event loop isn't blocked on disk I/O; the loop body still
                     # awaits each write before reading the next chunk, so the
-                    # shared file handle is never accessed concurrently.
+                    # shared file handle is never accessed concurrently in normal
+                    # execution. On task cancellation the worker thread may briefly
+                    # outlive the `with` block, but the temp file is unconditionally
+                    # unlinked in the outer `except` handler so the partial state
+                    # is discarded either way.
                     total_bytes = 0
                     with open(temp_file, "wb") as f:
                         async for chunk in response.aiter_bytes(chunk_size=65536):
@@ -2335,8 +2339,9 @@ class ArtifactsAPI:
                     temp_file.rename(output_file)
                     logger.debug("Downloaded %s (%d bytes)", url[:60], total_bytes)
                     return output_path
-        except Exception:
-            # Clean up partial temp file on any failure
+        except BaseException:
+            # Clean up partial temp file on any failure, including asyncio.CancelledError
+            # (which is a BaseException, not an Exception, in Python 3.8+).
             temp_file.unlink(missing_ok=True)
             raise
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1855,11 +1855,17 @@ class ArtifactsAPI:
             try:
                 status = await self.poll_status(notebook_id, task_id)
             except (NetworkError, RPCTimeoutError, ServerError) as e:
-                # Transient — retry up to POLL_MAX_RETRIES times with exponential backoff
+                # Transient — retry up to POLL_MAX_RETRIES times with exponential
+                # backoff capped at 8s. Also clamp by remaining timeout budget so
+                # the retry path never extends wall-clock past the caller's
+                # `timeout` parameter; raise if there's no headroom left.
                 if poll_retry_count >= POLL_MAX_RETRIES:
                     raise
+                remaining = timeout - (asyncio.get_running_loop().time() - start_time)
+                if remaining <= 0:
+                    raise
                 poll_retry_count += 1
-                backoff = min(2**poll_retry_count, 8.0)  # cap at 8s
+                backoff = min(2**poll_retry_count, 8.0, remaining)
                 logger.warning(
                     "wait_for_completion: transient %s on poll #%d, retrying in %.1fs",
                     e.__class__.__name__,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -32,11 +32,14 @@ from .rpc import (
     InfographicDetail,
     InfographicOrientation,
     InfographicStyle,
+    NetworkError,
     QuizDifficulty,
     QuizQuantity,
     ReportFormat,
     RPCError,
     RPCMethod,
+    RPCTimeoutError,
+    ServerError,
     SlideDeckFormat,
     SlideDeckLength,
     VideoFormat,
@@ -57,6 +60,9 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Maximum number of retries for transient errors during artifact polling
+POLL_MAX_RETRIES = 3
 
 # Media artifact types that require URL availability before reporting completion
 _MEDIA_ARTIFACT_TYPES = frozenset(
@@ -1622,10 +1628,13 @@ class ArtifactsAPI:
             output = Path(output_path)
             output.parent.mkdir(parents=True, exist_ok=True)
 
-            with output.open("w", newline="", encoding="utf-8-sig") as f:
-                writer = csv.writer(f)
-                writer.writerow(headers)
-                writer.writerows(rows)
+            def _write_csv() -> None:
+                with output.open("w", newline="", encoding="utf-8-sig") as f:
+                    writer = csv.writer(f)
+                    writer.writerow(headers)
+                    writer.writerows(rows)
+
+            await asyncio.to_thread(_write_csv)
 
             return str(output)
 
@@ -1838,11 +1847,29 @@ class ArtifactsAPI:
         current_interval = initial_interval
         consecutive_not_found = 0
         total_not_found = 0
+        poll_retry_count = 0
         first_not_found_time: float | None = None
         last_status: str | None = None
 
         while True:
-            status = await self.poll_status(notebook_id, task_id)
+            try:
+                status = await self.poll_status(notebook_id, task_id)
+            except (NetworkError, RPCTimeoutError, ServerError) as e:
+                # Transient — retry up to POLL_MAX_RETRIES times with exponential backoff
+                if poll_retry_count >= POLL_MAX_RETRIES:
+                    raise
+                poll_retry_count += 1
+                backoff = min(2**poll_retry_count, 8.0)  # cap at 8s
+                logger.warning(
+                    "wait_for_completion: transient %s on poll #%d, retrying in %.1fs",
+                    e.__class__.__name__,
+                    poll_retry_count,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            poll_retry_count = 0  # reset on success
             last_status = status.status
 
             if status.is_complete or status.is_failed:
@@ -2195,7 +2222,7 @@ class ArtifactsAPI:
 
                     output_file = Path(output_path)
                     output_file.parent.mkdir(parents=True, exist_ok=True)
-                    output_file.write_bytes(response.content)
+                    await asyncio.to_thread(output_file.write_bytes, response.content)
                     result.succeeded.append(output_path)
                     # Log host+path only; download URLs may carry capability
                     # tokens in query params that aren't covered by the
@@ -2287,11 +2314,15 @@ class ArtifactsAPI:
                             "Authentication may have expired. Run 'notebooklm login'.",
                         )
 
-                    # Stream to file in chunks to handle large files efficiently
+                    # Stream to file in chunks to handle large files efficiently.
+                    # Each per-chunk write is dispatched to a worker thread so the
+                    # event loop isn't blocked on disk I/O; the loop body still
+                    # awaits each write before reading the next chunk, so the
+                    # shared file handle is never accessed concurrently.
                     total_bytes = 0
                     with open(temp_file, "wb") as f:
                         async for chunk in response.aiter_bytes(chunk_size=65536):
-                            f.write(chunk)
+                            await asyncio.to_thread(f.write, chunk)
                             total_bytes += len(chunk)
 
                     if total_bytes == 0:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -7,6 +7,8 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import urlencode
@@ -54,6 +56,38 @@ DEFAULT_CONNECT_TIMEOUT = 10.0  # Connection establishment timeout
 DEFAULT_KEEPALIVE_MIN_INTERVAL = 60.0
 
 # Auth error detection patterns (case-insensitive)
+# Upper bound on Retry-After wait. Caps both integer-seconds and HTTP-date forms
+# so a malicious or buggy server can't force a multi-hour pause.
+MAX_RETRY_AFTER_SECONDS = 300
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    """Parse RFC 7231 Retry-After: integer-seconds OR HTTP-date.
+
+    Returns seconds-until-retry as a non-negative int, clamped to
+    ``MAX_RETRY_AFTER_SECONDS``. Returns ``None`` for empty or unparseable input.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    # Integer-seconds form (most common)
+    try:
+        return min(MAX_RETRY_AFTER_SECONDS, max(0, int(value)))
+    except ValueError:
+        pass
+    # HTTP-date form (RFC 7231 §7.1.1.1)
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = (dt - datetime.now(timezone.utc)).total_seconds()
+    return min(MAX_RETRY_AFTER_SECONDS, max(0, int(delta)))
+
+
 AUTH_ERROR_PATTERNS = (
     "authentication",
     "expired",
@@ -142,6 +176,7 @@ class ClientCore:
         keepalive: float | None = None,
         keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
         keepalive_storage_path: Path | None = None,
+        rate_limit_max_retries: int = 0,
     ):
         """Initialize the core client.
 
@@ -164,6 +199,10 @@ class ClientCore:
                 Must be a positive finite number.
             keepalive_storage_path: Optional storage path to persist rotated cookies
                 to from the keepalive loop. Falls back to ``auth.storage_path``.
+            rate_limit_max_retries: Max automatic retries when a 429 response carries
+                a parseable ``Retry-After`` header. Defaults to ``2``. Each
+                retry sleeps for the (clamped) ``Retry-After`` value; ``Retry-After``
+                is capped at ``MAX_RETRY_AFTER_SECONDS``. Set to ``0`` to disable.
 
         Raises:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a
@@ -174,6 +213,9 @@ class ClientCore:
         self._connect_timeout = connect_timeout
         self._refresh_callback = refresh_callback
         self._refresh_retry_delay = refresh_retry_delay
+        if rate_limit_max_retries < 0:
+            raise ValueError(f"rate_limit_max_retries must be >= 0, got {rate_limit_max_retries}")
+        self._rate_limit_max_retries = rate_limit_max_retries
         self._refresh_lock: asyncio.Lock | None = asyncio.Lock() if refresh_callback else None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
@@ -481,6 +523,7 @@ class ClientCore:
         source_path: str = "/",
         allow_null: bool = False,
         _is_retry: bool = False,
+        _rate_limit_retries: int = 0,
     ) -> Any:
         """Make an RPC call to the NotebookLM API.
 
@@ -493,6 +536,7 @@ class ClientCore:
             source_path: The source path parameter (usually /notebook/{id}).
             allow_null: If True, don't raise error when response is null.
             _is_retry: Internal flag to prevent infinite retries.
+            _rate_limit_retries: Internal counter for rate limit retries.
 
         Returns:
             Decoded response data.
@@ -506,14 +550,19 @@ class ClientCore:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
 
         # Only the outer rpc_call mints a request id; the recursive retry path
-        # (_is_retry=True) inherits the parent's id so a single failure→refresh
-        # →retry sequence appears under one [req=<id>] in the logs.
-        if _is_retry:
-            return await self._rpc_call_impl(method, params, source_path, allow_null, _is_retry)
+        # (_is_retry=True or rate limit retry) inherits the parent's id so a
+        # single failure→refresh→retry sequence appears under one [req=<id>]
+        # in the logs.
+        if _is_retry or _rate_limit_retries > 0:
+            return await self._rpc_call_impl(
+                method, params, source_path, allow_null, _is_retry, _rate_limit_retries
+            )
 
         _reqid_token = set_request_id()
         try:
-            return await self._rpc_call_impl(method, params, source_path, allow_null, _is_retry)
+            return await self._rpc_call_impl(
+                method, params, source_path, allow_null, _is_retry, _rate_limit_retries
+            )
         finally:
             reset_request_id(_reqid_token)
 
@@ -524,6 +573,7 @@ class ClientCore:
         source_path: str,
         allow_null: bool,
         _is_retry: bool,
+        _rate_limit_retries: int = 0,
     ) -> Any:
         # Caller (rpc_call) has already verified self._http_client is not None;
         # re-assert for mypy narrowing through this helper.
@@ -560,17 +610,32 @@ class ClientCore:
 
                 # Map HTTP status codes to appropriate exception types
                 if status == 429:
-                    # Rate limiting - extract retry-after if available
-                    retry_after = None
-                    retry_after_header = e.response.headers.get("retry-after")
-                    if retry_after_header:
-                        try:
-                            retry_after = int(retry_after_header)
-                        except ValueError:
-                            logger.debug(
-                                "Retry-After header not an integer: %r",
-                                retry_after_header,
-                            )
+                    # Rate limiting - parse retry-after (integer or HTTP-date).
+                    retry_after = _parse_retry_after(e.response.headers.get("retry-after"))
+                    # Opt-in automatic retry: if the caller enabled the budget and
+                    # the server gave us a parseable Retry-After, sleep and retry.
+                    # _is_retry stays at its incoming value so the post-sleep call
+                    # can still escalate via the auth-refresh path on 401/403.
+                    if (
+                        retry_after is not None
+                        and _rate_limit_retries < self._rate_limit_max_retries
+                    ):
+                        logger.warning(
+                            "RPC %s rate-limited (HTTP 429); sleeping %ds then retrying (%d/%d)",
+                            method.name,
+                            retry_after,
+                            _rate_limit_retries + 1,
+                            self._rate_limit_max_retries,
+                        )
+                        await asyncio.sleep(retry_after)
+                        return await self.rpc_call(
+                            method,
+                            params,
+                            source_path,
+                            allow_null,
+                            _is_retry=_is_retry,
+                            _rate_limit_retries=_rate_limit_retries + 1,
+                        )
                     msg = f"API rate limit exceeded calling {method.name}"
                     if retry_after:
                         msg += f". Retry after {retry_after} seconds"

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -200,9 +200,13 @@ class ClientCore:
             keepalive_storage_path: Optional storage path to persist rotated cookies
                 to from the keepalive loop. Falls back to ``auth.storage_path``.
             rate_limit_max_retries: Max automatic retries when a 429 response carries
-                a parseable ``Retry-After`` header. Defaults to ``2``. Each
-                retry sleeps for the (clamped) ``Retry-After`` value; ``Retry-After``
-                is capped at ``MAX_RETRY_AFTER_SECONDS``. Set to ``0`` to disable.
+                a parseable ``Retry-After`` header. ``0`` (default) preserves the
+                pre-Phase-3 contract of raising ``RateLimitError`` immediately —
+                opt in to a positive value to enable bounded sleep-and-retry.
+                Each retry sleeps for the (clamped) ``Retry-After`` value; that
+                per-attempt value is capped at ``MAX_RETRY_AFTER_SECONDS``, but
+                the cumulative sleep across N retries is ``N * cap``, so pick
+                ``rate_limit_max_retries`` accordingly.
 
         Raises:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -1,0 +1,64 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from notebooklm._artifacts import ArtifactsAPI, GenerationStatus
+from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
+
+
+@pytest.fixture
+def api():
+    core = MagicMock()
+    notes_api = MagicMock()
+    return ArtifactsAPI(core, notes_api)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_retry_success(api):
+    # Mock poll_status to fail twice then succeed
+    status_ready = GenerationStatus(task_id="task1", status="completed")
+
+    api.poll_status = AsyncMock()
+    api.poll_status.side_effect = [
+        NetworkError("transient net"),
+        RPCTimeoutError("transient timeout"),
+        status_ready,
+    ]
+
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
+        # Also need to patch asyncio.get_running_loop().time() to avoid timeout
+        # but here we just test the retry logic
+        result = await api.wait_for_completion("nb1", "task1", timeout=60.0)
+
+        assert result == status_ready
+        assert api.poll_status.call_count == 3
+        assert mock_sleep.call_count == 2
+        # Backoff: 2^1=2, 2^2=4
+        mock_sleep.assert_any_call(2.0)
+        mock_sleep.assert_any_call(4.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_retry_exhausted(api):
+    api.poll_status = AsyncMock()
+    api.poll_status.side_effect = NetworkError("persistent fail")
+
+    with patch("asyncio.sleep", AsyncMock()):
+        with pytest.raises(NetworkError, match="persistent fail"):
+            await api.wait_for_completion("nb1", "task1", timeout=60.0)
+
+        # Initial call + 3 retries = 4 total calls
+        assert api.poll_status.call_count == 4
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_no_retry_on_auth_error(api):
+    api.poll_status = AsyncMock()
+    api.poll_status.side_effect = AuthError("auth fail")
+
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
+        with pytest.raises(AuthError, match="auth fail"):
+            await api.wait_for_completion("nb1", "task1", timeout=60.0)
+
+        assert api.poll_status.call_count == 1
+        assert mock_sleep.call_count == 0

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -242,7 +242,7 @@ async def test_retry_inherits_parent_request_id():
 
     captured_ids: list[str | None] = []
 
-    async def fake_impl(method, params, source_path, allow_null, is_retry):
+    async def fake_impl(method, params, source_path, allow_null, is_retry, rate_limit_retries=0):
         captured_ids.append(get_request_id())
         # First call: raise to trigger retry path; second call: succeed.
         if not is_retry:

--- a/tests/unit/test_rate_limit_retry.py
+++ b/tests/unit/test_rate_limit_retry.py
@@ -1,0 +1,131 @@
+"""Phase 3 P3.5 — opt-in 429 retry budget on `ClientCore.rpc_call`.
+
+Default behavior (`rate_limit_max_retries=0`) preserves the pre-Phase-3
+contract: raise ``RateLimitError`` on the first 429. Opting in to a positive
+budget enables bounded automatic retries that sleep for the (clamped)
+``Retry-After`` value.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm.rpc import RateLimitError, RPCMethod
+
+
+@pytest.fixture
+def auth_tokens():
+    auth = MagicMock()
+    auth.csrf_token = "fake_csrf"
+    return auth
+
+
+def _build_429(retry_after: str | None = "1") -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 429
+    resp.headers = {"retry-after": retry_after} if retry_after is not None else {}
+    resp.reason_phrase = "Too Many Requests"
+
+    def raise_429():
+        raise httpx.HTTPStatusError("Rate Limit", request=MagicMock(), response=resp)
+
+    resp.raise_for_status.side_effect = raise_429
+    return resp
+
+
+def _build_200(payload: list) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.text = ")]}'\n[null,[" + str(payload).replace("'", '"') + "]]"
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_retry_success_with_budget(auth_tokens):
+    """With budget>0 and a parseable Retry-After, the second call succeeds."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.side_effect = [_build_429("1"), _build_200([["result"]])]
+
+    core = ClientCore(auth_tokens, rate_limit_max_retries=2)
+    core._http_client = mock_client
+
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
+        # Decode may fail on the synthetic 200 — that's fine, what we care about
+        # is the post counts and sleep budget. We expect either success or a
+        # decode-level failure, but the retry MUST have fired.
+        try:
+            await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
+        except Exception:
+            pass
+
+    assert mock_client.post.call_count == 2, (
+        f"Expected initial 429 then 1 retry, got {mock_client.post.call_count}"
+    )
+    mock_sleep.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_retry_exhausted_with_budget(auth_tokens):
+    """Budget=2 means: initial + 2 retries = 3 total posts before RateLimitError."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.return_value = _build_429("1")
+
+    core = ClientCore(auth_tokens, rate_limit_max_retries=2)
+    core._http_client = mock_client
+
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
+        await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
+
+    assert mock_client.post.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_no_retry_if_disabled(auth_tokens):
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+    resp_429 = MagicMock(spec=httpx.Response)
+    resp_429.status_code = 429
+    resp_429.headers = {"retry-after": "1"}
+
+    def raise_429():
+        raise httpx.HTTPStatusError("Rate Limit", request=MagicMock(), response=resp_429)
+
+    resp_429.raise_for_status.side_effect = raise_429
+
+    mock_client.post.return_value = resp_429
+
+    # Explicitly disable retries
+    core = ClientCore(auth_tokens, rate_limit_max_retries=0)
+    core._http_client = mock_client
+
+    with pytest.raises(RateLimitError):
+        await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
+
+    assert mock_client.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_no_retry_without_header(auth_tokens):
+    """No Retry-After header → raise immediately even with budget>0."""
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.post.return_value = _build_429(retry_after=None)
+
+    core = ClientCore(auth_tokens, rate_limit_max_retries=2)
+    core._http_client = mock_client
+
+    with pytest.raises(RateLimitError):
+        await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
+
+    assert mock_client.post.call_count == 1
+
+
+def test_rate_limit_max_retries_negative_raises(auth_tokens):
+    """Negative budget is rejected at construction."""
+    with pytest.raises(ValueError, match="rate_limit_max_retries must be >= 0"):
+        ClientCore(auth_tokens, rate_limit_max_retries=-1)

--- a/tests/unit/test_retry_after.py
+++ b/tests/unit/test_retry_after.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta, timezone
+
+from notebooklm._core import _parse_retry_after
+
+
+def test_parse_retry_after_integer():
+    assert _parse_retry_after("30") == 30
+    assert _parse_retry_after(" 120 ") == 120
+    assert _parse_retry_after("0") == 0
+    assert _parse_retry_after("-5") == 0
+
+
+def test_parse_retry_after_http_date():
+    # Future date: now + 60 seconds
+    future = datetime.now(timezone.utc) + timedelta(seconds=60)
+    # Format as RFC 7231: Wed, 21 Oct 2015 07:28:00 GMT
+    date_str = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    # Allow some slack (1-2 seconds) for test execution time
+    result = _parse_retry_after(date_str)
+    assert result is not None
+    assert 58 <= result <= 60
+
+
+def test_parse_retry_after_past_date():
+    past = datetime.now(timezone.utc) - timedelta(seconds=60)
+    date_str = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+    assert _parse_retry_after(date_str) == 0
+
+
+def test_parse_retry_after_invalid():
+    assert _parse_retry_after("not a date") is None
+    assert _parse_retry_after("") is None
+    assert _parse_retry_after("   ") is None
+    # Partially valid but not what we want
+    assert _parse_retry_after("2026-05-13") is None


### PR DESCRIPTION
## Summary

Phase 3 of the gaps-remediation effort. Hardens the client against transient failures without breaking backward compatibility.

## Changes

### P3.1 — Per-poll retry in `wait_for_completion`
\`_artifacts.py:wait_for_completion\` wraps each \`poll_status\` call in a bounded exponential-backoff retry (\`POLL_MAX_RETRIES=3\`, backoff 2/4/8s). Catches \`NetworkError\`, \`RPCTimeoutError\`, \`ServerError\`. \`AuthError\` propagates immediately.

### P3.2 — Async file writes for downloads
Three sync I/O sites in \`_artifacts.py\` wrapped with \`asyncio.to_thread\`:
- \`output_file.write_bytes(response.content)\` in \`_download_urls_batch\`.
- \`f.write(chunk)\` inside \`async for\` streaming-download loop.
- \`csv.writer(...).writerow/writerows\` in \`download_data_table\`.

No new dependency (\`aiofiles\` rejected per master plan v2.1).

### P3.3 — \`Retry-After\` HTTP-date parsing
New \`_parse_retry_after(value)\` helper in \`_core.py\` handles both integer-seconds and HTTP-date forms (RFC 7231). Result is clamped to \`MAX_RETRY_AFTER_SECONDS=300\` so a malicious/buggy server can't force a multi-hour pause.

### P3.5 — Opt-in 429 retry budget
New \`rate_limit_max_retries\` ctor arg on \`ClientCore\` (default \`0\` — preserves existing behavior). Positive values enable bounded automatic retry that sleeps for the (clamped) \`Retry-After\` value. The 429-retry state is a new \`_rate_limit_retries: int\` parameter, distinct from \`_is_retry\` (auth-refresh path); 401/403 after a 429 sleep can still trigger auth refresh.

## Deferred (per master plan)

- **P3.4** (circuit breaker on RPCSchemaError) — depends on RPCSchemaError which doesn't exist yet (Phase 2 P2.3 deliverable). Defer.
- **P3.6** (storage-state schema versioning) — needs migration-policy design + storage audit. Standalone PR before any Phase 5 file moves.

## MOMUS R1 fixes applied

Triple review (Claude + Codex + Gemini) caught:
- \`_artifacts.py:1453\` was already async-wrapped — drop from list, add 1633 CSV instead.
- P3.5 \`_is_retry\` overload bug — needs distinct \`_rate_limit_retries\` counter.
- Default kept at \`0\` for backward compat.
- P3.1 catch must include \`ServerError\` for typed 5xx mapping.
- P3.3 should cap to prevent multi-hour pauses.

## Tests

- \`tests/unit/test_retry_after.py\` (4 tests).
- \`tests/unit/test_rate_limit_retry.py\` (5 tests).
- \`tests/unit/test_artifacts_polling_retries.py\` (3 tests).
- Updated \`tests/unit/test_logging_correlation.py::fake_impl\` signature.

## Test plan
- [x] \`uv run pytest\` — 2823 passed, 12 skipped (+12 new)
- [x] \`uv run ruff format . && uv run ruff check .\` — clean
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in rate-limit retry support that respects server Retry-After hints with a configurable retry budget.

* **Improvements**
  * Polling for artifact completion now performs limited exponential backoff retries for transient failures.
  * Downloads and CSV exports offload disk I/O to avoid blocking async event loops.

* **Bug Fixes**
  * Temporary files are reliably cleaned up on cancellations and non-standard failures.

* **Tests**
  * Added unit tests covering polling retries, Retry-After parsing, and rate-limit retry behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/434)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->