### PR TITLE
chore(types): tighten public-surface typing + rpc.* strict mode (Phase 4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,12 @@ module = "notebooklm.cli.*"
 warn_return_any = false
 strict_optional = true
 
+[[tool.mypy.overrides]]
+module = "notebooklm.rpc.*"
+disallow_untyped_defs = true
+warn_return_any = true
+strict_optional = true
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -17,8 +17,8 @@ import httpx
 from ._core import ClientCore
 from ._env import get_default_language
 from .exceptions import ChatError, NetworkError, ValidationError
-from .rpc import RPCMethod, get_query_url, nest_source_ids
-from .types import AskResult, ChatReference, ConversationTurn
+from .rpc import ChatGoal, ChatResponseLength, RPCMethod, get_query_url, nest_source_ids
+from .types import AskResult, ChatMode, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
 
@@ -363,8 +363,8 @@ class ChatAPI:
     async def configure(
         self,
         notebook_id: str,
-        goal: Any | None = None,
-        response_length: Any | None = None,
+        goal: ChatGoal | None = None,
+        response_length: ChatResponseLength | None = None,
         custom_prompt: str | None = None,
     ) -> None:
         """Configure chat persona and response settings for a notebook.
@@ -379,7 +379,6 @@ class ChatAPI:
             ValidationError: If goal is CUSTOM but custom_prompt is not provided.
         """
         logger.debug("Configuring chat for notebook %s", notebook_id)
-        from .rpc import ChatGoal, ChatResponseLength
 
         if goal is None:
             goal = ChatGoal.DEFAULT
@@ -404,15 +403,13 @@ class ChatAPI:
             allow_null=True,
         )
 
-    async def set_mode(self, notebook_id: str, mode: Any) -> None:
+    async def set_mode(self, notebook_id: str, mode: ChatMode) -> None:
         """Set chat mode using predefined configurations.
 
         Args:
             notebook_id: The notebook ID.
             mode: Predefined ChatMode (DEFAULT, LEARNING_GUIDE, CONCISE, DETAILED).
         """
-        from .rpc import ChatGoal, ChatResponseLength
-        from .types import ChatMode
 
         mode_configs = {
             ChatMode.DEFAULT: (ChatGoal.DEFAULT, ChatResponseLength.DEFAULT, None),

--- a/src/notebooklm/cli/options.py
+++ b/src/notebooklm/cli/options.py
@@ -4,9 +4,10 @@ Provides reusable option decorators to reduce boilerplate in commands.
 """
 
 import click
+from click.decorators import FC
 
 
-def notebook_option(f):
+def notebook_option(f: FC) -> FC:
     """Add --notebook/-n option for notebook ID.
 
     The option defaults to None, allowing context-based resolution.
@@ -21,7 +22,7 @@ def notebook_option(f):
     )(f)
 
 
-def json_option(f):
+def json_option(f: FC) -> FC:
     """Add --json output flag."""
     return click.option(
         "--json",
@@ -31,7 +32,7 @@ def json_option(f):
     )(f)
 
 
-def wait_option(f):
+def wait_option(f: FC) -> FC:
     """Add --wait/--no-wait flag for generation commands."""
     return click.option(
         "--wait/--no-wait",
@@ -40,7 +41,7 @@ def wait_option(f):
     )(f)
 
 
-def source_option(f):
+def source_option(f: FC) -> FC:
     """Add --source/-s option for source ID.
 
     Supports partial ID matching (e.g., 'abc' matches 'abc123...').
@@ -54,7 +55,7 @@ def source_option(f):
     )(f)
 
 
-def artifact_option(f):
+def artifact_option(f: FC) -> FC:
     """Add --artifact/-a option for artifact ID.
 
     Supports partial ID matching (e.g., 'abc' matches 'abc123...').
@@ -68,7 +69,7 @@ def artifact_option(f):
     )(f)
 
 
-def output_option(f):
+def output_option(f: FC) -> FC:
     """Add --output/-o option for output file path."""
     return click.option(
         "-o",
@@ -80,7 +81,7 @@ def output_option(f):
     )(f)
 
 
-def prompt_file_option(f):
+def prompt_file_option(f: FC) -> FC:
     """Add --prompt-file option for reading prompt/query text from a file."""
     return click.option(
         "--prompt-file",
@@ -91,7 +92,7 @@ def prompt_file_option(f):
     )(f)
 
 
-def retry_option(f):
+def retry_option(f: FC) -> FC:
     """Add --retry option for rate limit retry with exponential backoff."""
     return click.option(
         "--retry",
@@ -105,11 +106,11 @@ def retry_option(f):
 # Composite decorators for common patterns
 
 
-def standard_options(f):
+def standard_options(f: FC) -> FC:
     """Apply notebook + json options (most common pattern)."""
     return notebook_option(json_option(f))
 
 
-def generate_options(f):
+def generate_options(f: FC) -> FC:
     """Apply notebook + json + wait + retry options for generation commands."""
     return notebook_option(json_option(wait_option(retry_option(f))))

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 from pathlib import Path
+from types import TracebackType
 
 from ._artifacts import ArtifactsAPI
 from ._chat import ChatAPI
@@ -145,7 +146,12 @@ class NotebookLMClient:
         await self._core.open()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Close the client connection."""
         logger.debug("Closing NotebookLM client")
         await self._core.close()


### PR DESCRIPTION
## Summary

Phase 4 of the gaps-remediation effort. Pure type annotations; **no runtime behavior changes**.

## Changes

**P4.1** — \`pyproject.toml\`: add per-package mypy override for \`notebooklm.rpc.*\` with \`disallow_untyped_defs=true\`, \`warn_return_any=true\`, \`strict_optional=true\`. Protects the protocol seam from future drift.

**P4.2** — \`src/notebooklm/_chat.py\`: hoist \`ChatGoal\`, \`ChatResponseLength\` imports from \`.rpc\` to module top; hoist \`ChatMode\` from \`.types\`. Type:
- \`configure(goal: ChatGoal | None, response_length: ChatResponseLength | None)\` (was \`Any | None\`)
- \`set_mode(mode: ChatMode)\` (was \`Any\`)

**P4.3** — \`src/notebooklm/client.py\`: type \`__aexit__\` fully — \`(type[BaseException] | None, BaseException | None, TracebackType | None) -> None\`.

**P4.4** — \`src/notebooklm/cli/options.py\`: type all 10 decorator helpers with \`FC\` TypeVar from \`click.decorators\`. Pattern: \`def foo(f: FC) -> FC\`. Click 8.x types \`option()\` as \`Callable[[FC], FC]\` so no \`type: ignore\` needed.

## Deferred

- Strict typing for \`notebooklm._*\` — gradual rollout, follow-up PRs.
- Tighter input type for \`_chat.py::_parse_turns_to_qa_pairs(turns_data: Any)\` — depends on the P2.3 \`RPCResponseAdapter\` (also deferred).

## MOMUS log

R1 (Claude + Gemini): SHIP. Codex polish (read-only): no critical issues. No required fixes.

## Test plan
- [x] \`uv run pytest\` — 2823 passed, 12 skipped (no regression)
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` — clean
- [x] \`uv run ruff format . && uv run ruff check .\` — clean

## Note on signature narrowing

\`configure\` and \`set_mode\` narrow from \`Any\` to typed enums. All in-tree callers already pass the right enum value; external callers passing wrong-typed values will now get static-type errors (intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced type checking configuration for stricter module validation.
  * Added comprehensive type annotations to improve code quality and IDE support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/435)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->