### PR TITLE
fix(review): address outstanding Phase 0–4 reviewer feedback

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2335,11 +2335,14 @@ class ArtifactsAPI:
                     total_bytes = 0
                     with open(temp_file, "wb") as f:
                         async for chunk in response.aiter_bytes(chunk_size=65536):
-                            write_task = asyncio.ensure_future(asyncio.to_thread(f.write, chunk))
+                            write_task = asyncio.create_task(asyncio.to_thread(f.write, chunk))
                             try:
                                 await asyncio.shield(write_task)
                             except asyncio.CancelledError:
-                                with contextlib.suppress(BaseException):
+                                # Narrow to (CancelledError, Exception) so genuine
+                                # process-level signals (KeyboardInterrupt, SystemExit)
+                                # still propagate during cleanup.
+                                with contextlib.suppress(asyncio.CancelledError, Exception):
                                     await write_task
                                 raise
                             total_bytes += len(chunk)

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -7,6 +7,7 @@ Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 
 import asyncio
 import builtins
+import contextlib
 import csv
 import html
 import json
@@ -2322,17 +2323,25 @@ class ArtifactsAPI:
 
                     # Stream to file in chunks to handle large files efficiently.
                     # Each per-chunk write is dispatched to a worker thread so the
-                    # event loop isn't blocked on disk I/O; the loop body still
-                    # awaits each write before reading the next chunk, so the
-                    # shared file handle is never accessed concurrently in normal
-                    # execution. On task cancellation the worker thread may briefly
-                    # outlive the `with` block, but the temp file is unconditionally
-                    # unlinked in the outer `except` handler so the partial state
-                    # is discarded either way.
+                    # event loop isn't blocked on disk I/O; the loop body awaits
+                    # each write before reading the next chunk so the shared file
+                    # handle is never accessed concurrently in normal execution.
+                    #
+                    # Cancellation: ``asyncio.shield`` keeps the in-flight write
+                    # alive across a CancelledError; the except block awaits the
+                    # shielded task to completion BEFORE letting the with-block
+                    # close the file. Without this, the worker thread could touch
+                    # ``f`` after the with-block has started closing it.
                     total_bytes = 0
                     with open(temp_file, "wb") as f:
                         async for chunk in response.aiter_bytes(chunk_size=65536):
-                            await asyncio.to_thread(f.write, chunk)
+                            write_task = asyncio.ensure_future(asyncio.to_thread(f.write, chunk))
+                            try:
+                                await asyncio.shield(write_task)
+                            except asyncio.CancelledError:
+                                with contextlib.suppress(BaseException):
+                                    await write_task
+                                raise
                             total_bytes += len(chunk)
 
                     if total_bytes == 0:

--- a/tests/unit/test_ci_audit_scripts.py
+++ b/tests/unit/test_ci_audit_scripts.py
@@ -23,6 +23,7 @@ def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
         text=True,
         cwd=REPO_ROOT,
         check=False,
+        timeout=30,
     )
 
 

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -82,10 +82,12 @@ def test_rpc_call_impl_has_no_await_before_post():
 
     outer_nodes = list(_walk_outer(func))
     # ast.iter_child_nodes does not guarantee source order across all node
-    # types, so pick the earliest post-await by line number.
-    post_await_linenos = [n.lineno for n in outer_nodes if is_post_await(n)]
-    post_await_lineno = min(post_await_linenos, default=None)
-    assert post_await_lineno is not None, (
+    # types, so pick the earliest post-await by (lineno, col_offset). Using
+    # the tuple — not just lineno — catches same-line earlier awaits like
+    # ``await build_body(); await post(...)`` written on one line.
+    post_await_positions = [(n.lineno, n.col_offset) for n in outer_nodes if is_post_await(n)]
+    post_await_position = min(post_await_positions, default=None)
+    assert post_await_position is not None, (
         "Could not locate `await ...post(...)` in _rpc_call_impl. If you "
         "refactored the call site (e.g., to `self._http_client.request(...)`), "
         "update this guard to match — the invariant is 'no await before the "
@@ -93,10 +95,12 @@ def test_rpc_call_impl_has_no_await_before_post():
     )
 
     earlier_awaits = [
-        n for n in outer_nodes if isinstance(n, ast.Await) and n.lineno < post_await_lineno
+        n
+        for n in outer_nodes
+        if isinstance(n, ast.Await) and (n.lineno, n.col_offset) < post_await_position
     ]
     assert not earlier_awaits, (
-        f"_rpc_call_impl gained an await before the POST at line {post_await_lineno}: "
+        f"_rpc_call_impl gained an await before the POST at {post_await_position}: "
         f"{[(n.lineno, ast.dump(n)) for n in earlier_awaits]}. "
         "This breaks the snapshot-invariant — auth state could be mutated between "
         "the read and the actual send."
@@ -193,9 +197,11 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
             for t in pending:
                 t.cancel()
             # Bounded join so cancelled tasks actually settle before the
-            # ``async with make_core(...)`` block exits.
+            # ``async with make_core(...)`` block exits. Narrow to
+            # ``(CancelledError, Exception)`` so KeyboardInterrupt / SystemExit
+            # during the test still propagate.
             if pending:
-                with contextlib.suppress(BaseException):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await asyncio.wait_for(
                         asyncio.gather(*pending, return_exceptions=True),
                         EVENT_TIMEOUT_S,

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import contextlib
 import inspect
 import json
 import textwrap
@@ -64,9 +65,25 @@ def test_rpc_call_impl_has_no_await_before_post():
         attr = call.func
         return isinstance(attr, ast.Attribute) and attr.attr == "post"
 
-    # ast.walk does not guarantee source order, so pick the earliest match by
-    # line number — robust to future code that contains multiple post() calls.
-    post_await_linenos = [n.lineno for n in ast.walk(func) if is_post_await(n)]
+    def _walk_outer(parent):
+        """Yield nodes that belong to ``parent`` itself (skip nested defs).
+
+        ``ast.walk`` descends into nested ``FunctionDef`` / ``AsyncFunctionDef``
+        / ``Lambda`` bodies — that would let a future helper coroutine inside
+        ``_rpc_call_impl`` smuggle the matching ``await ...post(...)`` past
+        this guard. We only want statements lexically at the outer level.
+        """
+        boundaries = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+        for child in ast.iter_child_nodes(parent):
+            if isinstance(child, boundaries):
+                continue  # don't descend into nested callables
+            yield child
+            yield from _walk_outer(child)
+
+    outer_nodes = list(_walk_outer(func))
+    # ast.iter_child_nodes does not guarantee source order across all node
+    # types, so pick the earliest post-await by line number.
+    post_await_linenos = [n.lineno for n in outer_nodes if is_post_await(n)]
     post_await_lineno = min(post_await_linenos, default=None)
     assert post_await_lineno is not None, (
         "Could not locate `await ...post(...)` in _rpc_call_impl. If you "
@@ -76,7 +93,7 @@ def test_rpc_call_impl_has_no_await_before_post():
     )
 
     earlier_awaits = [
-        n for n in ast.walk(func) if isinstance(n, ast.Await) and n.lineno < post_await_lineno
+        n for n in outer_nodes if isinstance(n, ast.Await) and n.lineno < post_await_lineno
     ]
     assert not earlier_awaits, (
         f"_rpc_call_impl gained an await before the POST at line {post_await_lineno}: "
@@ -143,24 +160,46 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
         client = NotebookLMClient.__new__(NotebookLMClient)
         client._core = core
 
-        if rpc_first:
-            rpc_task = asyncio.create_task(core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []))
-            await asyncio.wait_for(rpc_send_entered.wait(), EVENT_TIMEOUT_S)
-            refresh_task = asyncio.create_task(client.refresh_auth())
-            await asyncio.wait_for(get_entered.wait(), EVENT_TIMEOUT_S)
+        # try/finally ensures the mock-transport handlers are unblocked even
+        # if a wait_for times out — otherwise pending tasks dangle in the
+        # event loop and the test hangs until pytest's own timeout fires.
+        rpc_task: asyncio.Task | None = None
+        refresh_task: asyncio.Task | None = None
+        try:
+            if rpc_first:
+                rpc_task = asyncio.create_task(core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []))
+                await asyncio.wait_for(rpc_send_entered.wait(), EVENT_TIMEOUT_S)
+                refresh_task = asyncio.create_task(client.refresh_auth())
+                await asyncio.wait_for(get_entered.wait(), EVENT_TIMEOUT_S)
+                let_get_complete.set()
+                await asyncio.wait_for(refresh_task, EVENT_TIMEOUT_S)
+                let_rpc_send_complete.set()
+                await asyncio.wait_for(rpc_task, EVENT_TIMEOUT_S)
+            else:
+                refresh_task = asyncio.create_task(client.refresh_auth())
+                await asyncio.wait_for(get_entered.wait(), EVENT_TIMEOUT_S)
+                rpc_task = asyncio.create_task(core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []))
+                await asyncio.wait_for(rpc_send_entered.wait(), EVENT_TIMEOUT_S)
+                let_get_complete.set()
+                await asyncio.wait_for(refresh_task, EVENT_TIMEOUT_S)
+                let_rpc_send_complete.set()
+                await asyncio.wait_for(rpc_task, EVENT_TIMEOUT_S)
+        finally:
+            # Always release the mock-transport gates so any in-flight handlers
+            # can return — even if the test errored above.
             let_get_complete.set()
-            await refresh_task
             let_rpc_send_complete.set()
-            await rpc_task
-        else:
-            refresh_task = asyncio.create_task(client.refresh_auth())
-            await asyncio.wait_for(get_entered.wait(), EVENT_TIMEOUT_S)
-            rpc_task = asyncio.create_task(core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []))
-            await asyncio.wait_for(rpc_send_entered.wait(), EVENT_TIMEOUT_S)
-            let_get_complete.set()
-            await refresh_task
-            let_rpc_send_complete.set()
-            await rpc_task
+            pending = [t for t in (rpc_task, refresh_task) if t is not None and not t.done()]
+            for t in pending:
+                t.cancel()
+            # Bounded join so cancelled tasks actually settle before the
+            # ``async with make_core(...)`` block exits.
+            if pending:
+                with contextlib.suppress(BaseException):
+                    await asyncio.wait_for(
+                        asyncio.gather(*pending, return_exceptions=True),
+                        EVENT_TIMEOUT_S,
+                    )
 
     assert len(captured_post) == 1, (
         f"Expected exactly one POST on the wire, got {len(captured_post)}: {captured_post!r}"

--- a/tests/unit/test_rate_limit_retry.py
+++ b/tests/unit/test_rate_limit_retry.py
@@ -8,13 +8,14 @@ budget enables bounded automatic retries that sleep for the (clamped)
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from notebooklm._core import ClientCore
-from notebooklm.rpc import RateLimitError, RPCMethod
+from notebooklm.rpc import RateLimitError, RPCError, RPCMethod
 
 
 @pytest.fixture
@@ -54,14 +55,12 @@ async def test_rate_limit_retry_success_with_budget(auth_tokens):
     core = ClientCore(auth_tokens, rate_limit_max_retries=2)
     core._http_client = mock_client
 
-    with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
-        # Decode may fail on the synthetic 200 — that's fine, what we care about
-        # is the post counts and sleep budget. We expect either success or a
-        # decode-level failure, but the retry MUST have fired.
-        try:
-            await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
-        except Exception:
-            pass
+    # Decode may fail on the synthetic 200 — that's fine, what we care about
+    # is the post counts and sleep budget. We expect either success or an
+    # RPCError-tree decode failure, but the retry MUST have fired. Narrowed
+    # from `except Exception` to keep unrelated programming errors visible.
+    with patch("asyncio.sleep", AsyncMock()) as mock_sleep, contextlib.suppress(RPCError):
+        await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb1"])
 
     assert mock_client.post.call_count == 2, (
         f"Expected initial 429 then 1 retry, got {mock_client.post.call_count}"

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -123,23 +123,12 @@ async def test_summary_warns_on_indexerror_drift(caplog):
 # ---------------------------------------------------------------------------
 
 
-def test_retry_after_non_integer_logs_debug(caplog):
-    """_core.py:545 — Retry-After non-integer should DEBUG log, not WARNING."""
-    import notebooklm._core as core_mod
-
-    with caplog.at_level(logging.DEBUG, logger="notebooklm"):
-        # Drive the parse directly via a small helper inline; the production
-        # call site is buried in an HTTP error path. Simulate by invoking the
-        # same code shape.
-        try:
-            int("not-an-int")
-        except ValueError as e:
-            core_mod.logger.debug("Retry-After header not an integer: %r", "not-an-int")
-            assert e is not None
-    debug_records = [
-        r for r in caplog.records if r.levelno == logging.DEBUG and "Retry-After" in r.message
-    ]
-    assert debug_records
+# Removed: ``test_retry_after_non_integer_logs_debug`` was self-fulfilling — it
+# called ``core_mod.logger.debug(...)`` inline rather than exercising production
+# code. Phase 3 replaced the original "Retry-After header not an integer" log
+# site with the ``_parse_retry_after`` helper, which returns ``None`` silently
+# for unparseable input. Parse semantics are covered by
+# ``tests/unit/test_retry_after.py``.
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up PR closing **six unaddressed bot-reviewer comments** from PRs #430–#435 that landed too close to merge or fell through the cracks during the autonomous plan→MOMUS→polish pipeline. Audited systematically via the \`/pulls/{N}/comments\` and \`/pulls/{N}/reviews\` endpoints across the phase PRs.

## Substantive fixes

### From PR #431 (Phase 1)
- **\`tests/unit/test_swallow_observability.py\`** — delete \`test_retry_after_non_integer_logs_debug\`. Self-fulfilling test (called \`core_mod.logger.debug\` inline); the production log site was replaced in Phase 3 by \`_parse_retry_after\` which returns \`None\` silently. Real coverage is in \`tests/unit/test_retry_after.py\`. [coderabbitai review #4285662570]
- **\`tests/unit/test_ci_audit_scripts.py\`** — add \`timeout=30\` to \`subprocess.run\`. [coderabbitai review #4285760453]

### From PR #432 (Phase 1.5)
- **\`tests/unit/test_concurrency_refresh_race.py\`** — try/finally that always releases mock-transport events, \`asyncio.wait_for\` on task joins, bounded gather-cleanup. [coderabbitai review #4285938492 #1]
- **\`tests/unit/test_concurrency_refresh_race.py::_walk_outer\`** — scope AST guard to outer function body. Skips \`FunctionDef\`/\`AsyncFunctionDef\`/\`Lambda\`/\`ClassDef\` so nested helper code can't smuggle the post() match past the guard. [coderabbitai review #4285938492 #2]

### From PR #434 (Phase 3)
- **\`src/notebooklm/_artifacts.py\` streaming download** — \`asyncio.shield\` per-chunk write + \`except CancelledError: with suppress(BaseException): await write_task; raise\`. Prevents the worker thread racing with \`with open(...)\` \`__exit__\` closing the file handle on cancellation. The earlier \`BaseException\` widening helped temp-file unlink but did NOT close the race on \`f\`. [coderabbitai inline #3238178206]
- **\`tests/unit/test_rate_limit_retry.py\`** — narrow \`except Exception: pass\` → \`contextlib.suppress(RPCError)\`. Real programming errors now surface. [coderabbitai review #4286187249]

## Polish triple-review

Claude / Codex / Gemini all SHIP. Two consensus micro-improvements applied inline:
- \`ClassDef\` added to \`_walk_outer\` boundaries (Claude — future-proof against inline class defs).
- Bounded \`gather(*pending, return_exceptions=True)\` in race-test \`finally\` (Codex — ensures cancelled tasks settle).

## Ultrathink on the shield/cancel pattern

Trace under double-cancellation (\`CancelledError\` arrives during cleanup):
1. \`await shield(write_task)\` — outer cancels; inner task keeps running.
2. \`except CancelledError\` block: \`with suppress(BaseException): await write_task\` — if a *second* cancel arrives, \`BaseException\` suppress swallows it; cleanup completes.
3. \`raise\` — propagates the *first* CancelledError up; \`with open(...)\` closes \`f\` *after* the thread is guaranteed done.

The recursive-shield alternative (\`await asyncio.shield(write_task)\` inside the except) would defer indefinitely under repeated cancels. The \`suppress(BaseException) + raise\` is the canonical asyncio cleanup idiom.

## Test plan
- [x] \`uv run pytest\` — 2822 passed, 12 skipped (–1 from the deleted obsolete test)
- [x] \`uv run ruff format . && uv run ruff check .\` — clean
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` — clean

@claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of file downloads so in-progress writes complete reliably during async cancellations.

* **Tests**
  * Hardened concurrency and race-condition tests for in-flight RPC requests.
  * Added execution timeouts to prevent test hangs.
  * Narrowed exception handling in retry tests and consolidated retry-after parsing coverage.
  * Removed an obsolete observability test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/436)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->