### PR TITLE
ci(claude): guard fork PRs + pin action to commit SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,11 +15,9 @@ permissions:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip fork-origin PRs — repository secrets (CLAUDE_CODE_OAUTH_TOKEN) are
+    # not exposed to workflows triggered from forks, so the job would fail.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'


### PR DESCRIPTION
## Summary

Follow-up to #438 — applies the two CodeRabbit comments that landed after the squash-merge.

## Changes

`.github/workflows/claude-code-review.yml`:

1. **Fork-PR guard.** Added `if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}` to the `claude-review` job. Repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`) are not exposed to workflows triggered from forks, so the job would fail on every external contributor PR. Used `full_name == github.repository` rather than `!head.repo.fork` because `.repo.fork` reflects whether the head repo *itself* is a fork of something (coincidentally true for fork-PR head repos but not a reliable check).

2. **SHA-pinned action.** `anthropics/claude-code-action@v1` → `@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1`. The `v1` tag is mutable (last moved 2026-05-13, the same day the install ran) and grants `id-token: write` + access to the Claude OAuth token; a tag rewrite could silently swap the executed code. SHA was resolved via `gh api repos/anthropics/claude-code-action/git/ref/tags/v1` and the annotated tag dereferenced to its commit.

`claude.yml`'s action ref is intentionally **not** changed in this PR — CodeRabbit only flagged `claude-code-review.yml`, and keeping scope tight makes the fix reviewable. Happy to extend in a follow-up if desired.

## Test plan

- [x] `python scripts/check_workflow_permissions.py` passes locally
- [ ] CI green (Test / Code Quality, claude-review, CodeQL)
- [ ] No regressions to the Claude Code Review run on this PR itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code review workflow failures when pull requests originate from forked repositories.

* **Chores**
  * Updated automated code review action to use a specific version reference for improved stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/439)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->