### PR TITLE
feat: add notebooklm.{config,urls,log} public shim modules

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext, Page
     from rich.console import Console
 
-from .._env import get_base_host, get_base_url
 from ..auth import (
     ALLOWED_COOKIE_DOMAINS,
     GOOGLE_REGIONAL_CCTLDS,
@@ -40,6 +39,7 @@ from ..auth import (
     read_account_metadata,
 )
 from ..client import NotebookLMClient
+from ..config import get_base_host, get_base_url
 from ..paths import (
     get_browser_profile_dir,
     get_context_path,

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -23,9 +23,9 @@ from urllib.parse import urlparse, urlunparse
 import click
 from rich.table import Table
 
-from .._url_utils import is_youtube_url
 from ..client import NotebookLMClient
 from ..types import source_status_to_str
+from ..urls import is_youtube_url
 from .helpers import (
     console,
     display_report,

--- a/src/notebooklm/config.py
+++ b/src/notebooklm/config.py
@@ -1,0 +1,19 @@
+"""Public runtime configuration surface (re-exports from internal _env)."""
+
+from ._env import (
+    DEFAULT_BASE_URL,
+    ENTERPRISE_BASE_HOST,
+    PERSONAL_BASE_HOST,
+    get_base_host,
+    get_base_url,
+    get_default_language,
+)
+
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "ENTERPRISE_BASE_HOST",
+    "PERSONAL_BASE_HOST",
+    "get_base_host",
+    "get_base_url",
+    "get_default_language",
+]

--- a/src/notebooklm/log.py
+++ b/src/notebooklm/log.py
@@ -1,0 +1,9 @@
+"""Public logging helpers (re-exports from internal _logging).
+
+Named ``log`` (not ``logging``) to avoid shadowing the stdlib ``logging`` module
+for users doing ``from notebooklm import logging``.
+"""
+
+from ._logging import install_redaction
+
+__all__ = ["install_redaction"]

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -160,7 +160,7 @@ def cli(ctx, storage, profile, verbose):
         logging.getLogger("notebooklm").setLevel(logging.DEBUG)
         # DEBUG logging on httpx/urllib3 emits full URLs and headers — install
         # redaction so credentials don't leak via third-party loggers.
-        from ._logging import install_redaction
+        from .log import install_redaction
 
         install_redaction("httpx", "urllib3")
     elif verbose == 1:

--- a/src/notebooklm/urls.py
+++ b/src/notebooklm/urls.py
@@ -1,0 +1,13 @@
+"""Public URL helpers (re-exports from internal _url_utils)."""
+
+from ._url_utils import (
+    contains_google_auth_redirect,
+    is_google_auth_redirect,
+    is_youtube_url,
+)
+
+__all__ = [
+    "contains_google_auth_redirect",
+    "is_google_auth_redirect",
+    "is_youtube_url",
+]

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -63,5 +63,26 @@ def test_research_api_reexports_cited_source_selection_for_back_compat():
 
 # ---------------------------------------------------------------------------
 # PR-D section: notebooklm.config / notebooklm.urls / notebooklm.log public shims
-# (intentionally left blank; PR-D appends below this marker)
 # ---------------------------------------------------------------------------
+
+
+def test_config_shim_exposes_documented_names(monkeypatch):
+    # Guard against a NOTEBOOKLM_BASE_URL override leaking from the env,
+    # so the assertion stays valid on developer machines and overridden CI.
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+    from notebooklm import config
+
+    assert config.get_base_url() == config.DEFAULT_BASE_URL
+    assert config.DEFAULT_BASE_URL == "https://notebooklm.google.com"
+
+
+def test_urls_shim_exposes_documented_names():
+    from notebooklm.urls import is_youtube_url
+
+    assert is_youtube_url("https://www.youtube.com/watch?v=x") is True
+
+
+def test_log_shim_exposes_install_redaction():
+    from notebooklm.log import install_redaction
+
+    assert callable(install_redaction)


### PR DESCRIPTION
## Summary
Implements PR-D of the private-module boundary plan (`.sisyphus/plans/private-module-boundary.md`).

Adds three thin public modules so the CLI can stop reaching into `_env`, `_url_utils`, `_logging`:

- `notebooklm.config` — `get_base_url`, `get_base_host`, `get_default_language`, `DEFAULT_BASE_URL`, host constants
- `notebooklm.urls` — `is_youtube_url`, `is_google_auth_redirect`, `contains_google_auth_redirect`
- `notebooklm.log` — `install_redaction` (named `log` deliberately to avoid shadowing stdlib `logging`)

Each is 5-10 lines: pure re-exports with explicit `__all__`. `notebooklm.__init__` is intentionally **not** modified — these are accessed via explicit `from notebooklm.config import …`.

Resolves violations V2, V4, V5 from the audit.

## Test plan
- [x] `pytest tests/unit/test_public_shims.py` green
- [x] Full suite green
- [x] mypy clean
- [x] `grep -rnE "from \.\._(env |url_utils|logging)" src/notebooklm/cli/ src/notebooklm/notebooklm_cli.py` returns zero

@claude please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added public modules that expose runtime configuration, logging, and URL helper APIs and updated the CLI to use these public helpers.
* **Tests**
  * Added unit smoke tests verifying the new public shims for configuration, logging, and URL helpers work as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/441)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->