### PR TITLE
refactor(research): public research surface

### DIFF
--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -97,6 +97,7 @@ from .types import (
     ChatMode,
     ChatReference,
     ChatResponseLength,
+    CitedSourceSelection,
     ConversationTurn,
     DriveMimeType,
     ExportType,
@@ -156,6 +157,7 @@ __all__ = [
     "ChatReference",
     "AskResult",
     "ChatMode",
+    "CitedSourceSelection",
     "SharedUser",
     "ShareStatus",
     # Base Exceptions

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -5,14 +5,15 @@ and importing discovered sources into notebooks.
 """
 
 import logging
-import re
-from dataclasses import dataclass
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
 
+from . import research as _research_pub
 from ._core import ClientCore
 from .exceptions import ValidationError
 from .rpc import RPCMethod
+from .types import CitedSourceSelection
+
+__all__ = ["CitedSourceSelection", "ResearchAPI"]
 
 logger = logging.getLogger(__name__)
 
@@ -21,22 +22,6 @@ _RESEARCH_RESULT_TYPE_ALIASES = {
     "drive": 2,
     "report": 5,
 }
-
-_URL_RE = r"https?://(?:[^\s<>\]\(\)\"']+|\([^\s<>\]\(\)\"']*\))+"
-_URL_PATTERN = re.compile(_URL_RE)
-_MARKDOWN_IMAGE_PATTERN = re.compile(rf"!\[[^\]]*\]\(({_URL_RE})(?:\s+[^\)]*)?\)")
-_MARKDOWN_LINK_PATTERN = re.compile(rf"(?<!!)\[[^\]]+\]\(({_URL_RE})\)")
-_TRAILING_URL_PUNCTUATION = ".,;:!?"
-
-
-@dataclass(frozen=True)
-class CitedSourceSelection:
-    """Result of applying cited-only filtering to research sources."""
-
-    sources: list[dict[str, Any]]
-    cited_url_count: int
-    matched_url_source_count: int
-    used_fallback: bool = False
 
 
 class ResearchAPI:
@@ -102,35 +87,21 @@ class ResearchAPI:
 
     @staticmethod
     def _normalize_url(url: str) -> str:
-        """Normalize source/report URLs for citation matching."""
-        parsed = urlsplit(url.rstrip(_TRAILING_URL_PUNCTUATION))
-        return urlunsplit(
-            (
-                parsed.scheme.lower(),
-                parsed.netloc.lower(),
-                parsed.path.rstrip("/"),
-                parsed.query,
-                parsed.fragment,
-            )
-        )
+        """Normalize source/report URLs for citation matching.
+
+        Thin wrapper retained for backward compatibility. Delegates to
+        :func:`notebooklm.research.normalize_url`.
+        """
+        return _research_pub.normalize_url(url)
 
     @classmethod
     def extract_report_urls(cls, report: str) -> set[str]:
-        """Extract normalized URLs from research report markdown/text."""
-        if not report:
-            return set()
+        """Extract normalized URLs from research report markdown/text.
 
-        # Collect URL-like references from both markdown links and bare text,
-        # then subtract markdown images because embedded assets are not citations.
-        urls = {
-            cls._normalize_url(match.group(1)) for match in _MARKDOWN_LINK_PATTERN.finditer(report)
-        }
-        urls.update(cls._normalize_url(match.group(0)) for match in _URL_PATTERN.finditer(report))
-        image_urls = {
-            cls._normalize_url(match.group(1)) for match in _MARKDOWN_IMAGE_PATTERN.finditer(report)
-        }
-        urls.difference_update(image_urls)
-        return {url for url in urls if url.startswith(("http://", "https://"))}
+        Thin wrapper retained for backward compatibility. Delegates to
+        :func:`notebooklm.research.extract_report_urls`.
+        """
+        return _research_pub.extract_report_urls(report)
 
     @classmethod
     def select_cited_sources(
@@ -140,55 +111,10 @@ class ResearchAPI:
     ) -> CitedSourceSelection:
         """Return research sources cited by the completed report.
 
-        Report entries are preserved so deep-research import still brings in the
-        generated report itself. If no cited URL subset can be resolved, falls
-        back to the original source list to avoid an empty import surprise.
+        Thin wrapper retained for backward compatibility. Delegates to
+        :func:`notebooklm.research.select_cited_sources`.
         """
-        cited_urls = cls.extract_report_urls(report)
-        if not cited_urls:
-            logger.warning(
-                "Cited-only research import requested, but no cited URLs were found; "
-                "falling back to all importable research sources"
-            )
-            return CitedSourceSelection(
-                sources=sources,
-                cited_url_count=0,
-                matched_url_source_count=0,
-                used_fallback=True,
-            )
-
-        report_sources = [
-            source
-            for source in sources
-            if source.get("result_type") == _RESEARCH_RESULT_TYPE_ALIASES["report"]
-            and source.get("report_markdown")
-        ]
-        report_source_ids = {id(source) for source in report_sources}
-        matched_url_sources = [
-            source
-            for source in sources
-            if id(source) not in report_source_ids
-            and isinstance(source.get("url"), str)
-            and cls._normalize_url(source["url"]) in cited_urls
-        ]
-
-        if not matched_url_sources:
-            logger.warning(
-                "Cited-only research import requested, but none of the report URLs "
-                "matched research sources; falling back to all importable research sources"
-            )
-            return CitedSourceSelection(
-                sources=sources,
-                cited_url_count=len(cited_urls),
-                matched_url_source_count=0,
-                used_fallback=True,
-            )
-
-        return CitedSourceSelection(
-            sources=[*report_sources, *matched_url_sources],
-            cited_url_count=len(cited_urls),
-            matched_url_source_count=len(matched_url_sources),
-        )
+        return _research_pub.select_cited_sources(sources, report)
 
     async def start(
         self,

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -24,11 +24,11 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from .._research import CitedSourceSelection, ResearchAPI
 from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
 from ..exceptions import NetworkError, NotebookLimitError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
-from ..types import ArtifactType
+from ..research import select_cited_sources
+from ..types import ArtifactType, CitedSourceSelection
 from ._encoding import safe_echo
 
 if TYPE_CHECKING:
@@ -343,7 +343,7 @@ def _select_research_sources_for_import(
     if not cited_only or not sources:
         return sources, None
 
-    cited_selection = ResearchAPI.select_cited_sources(sources, report)
+    cited_selection = select_cited_sources(sources, report)
     return cited_selection.sources, cited_selection
 
 

--- a/src/notebooklm/research.py
+++ b/src/notebooklm/research.py
@@ -1,0 +1,118 @@
+"""Public research utilities (free functions; no client instance required).
+
+Note: this is the *library* research helper module. The CLI command group lives
+at ``notebooklm.cli.research`` — different file, different concern.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from .types import CitedSourceSelection
+
+logger = logging.getLogger(__name__)
+
+_RESEARCH_RESULT_TYPE_ALIASES = {
+    "web": 1,
+    "drive": 2,
+    "report": 5,
+}
+
+_URL_RE = r"https?://(?:[^\s<>\]\(\)\"']+|\([^\s<>\]\(\)\"']*\))+"
+_URL_PATTERN = re.compile(_URL_RE)
+_MARKDOWN_IMAGE_PATTERN = re.compile(rf"!\[[^\]]*\]\(({_URL_RE})(?:\s+[^\)]*)?\)")
+_MARKDOWN_LINK_PATTERN = re.compile(rf"(?<!!)\[[^\]]+\]\(({_URL_RE})\)")
+_TRAILING_URL_PUNCTUATION = ".,;:!?"
+
+
+def normalize_url(url: str) -> str:
+    """Normalize source/report URLs for citation matching."""
+    parsed = urlsplit(url.rstrip(_TRAILING_URL_PUNCTUATION))
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/"),
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def extract_report_urls(report: str) -> set[str]:
+    """Extract normalized URLs from research report markdown/text."""
+    if not report:
+        return set()
+
+    # Collect URL-like references from both markdown links and bare text,
+    # then subtract markdown images because embedded assets are not citations.
+    urls = {normalize_url(match.group(1)) for match in _MARKDOWN_LINK_PATTERN.finditer(report)}
+    urls.update(normalize_url(match.group(0)) for match in _URL_PATTERN.finditer(report))
+    image_urls = {
+        normalize_url(match.group(1)) for match in _MARKDOWN_IMAGE_PATTERN.finditer(report)
+    }
+    urls.difference_update(image_urls)
+    return {url for url in urls if url.startswith(("http://", "https://"))}
+
+
+def select_cited_sources(
+    sources: list[dict[str, Any]],
+    report: str,
+) -> CitedSourceSelection:
+    """Return research sources cited by the completed report.
+
+    Report entries are preserved so deep-research import still brings in the
+    generated report itself. If no cited URL subset can be resolved, falls
+    back to the original source list to avoid an empty import surprise.
+    """
+    cited_urls = extract_report_urls(report)
+    if not cited_urls:
+        logger.warning(
+            "Cited-only research import requested, but no cited URLs were found; "
+            "falling back to all importable research sources"
+        )
+        return CitedSourceSelection(
+            sources=sources,
+            cited_url_count=0,
+            matched_url_source_count=0,
+            used_fallback=True,
+        )
+
+    report_sources = [
+        source
+        for source in sources
+        if source.get("result_type") == _RESEARCH_RESULT_TYPE_ALIASES["report"]
+        and source.get("report_markdown")
+    ]
+    report_source_ids = {id(source) for source in report_sources}
+    matched_url_sources = [
+        source
+        for source in sources
+        if id(source) not in report_source_ids
+        and isinstance(source.get("url"), str)
+        and normalize_url(source["url"]) in cited_urls
+    ]
+
+    if not matched_url_sources:
+        logger.warning(
+            "Cited-only research import requested, but none of the report URLs "
+            "matched research sources; falling back to all importable research sources"
+        )
+        return CitedSourceSelection(
+            sources=sources,
+            cited_url_count=len(cited_urls),
+            matched_url_source_count=0,
+            used_fallback=True,
+        )
+
+    return CitedSourceSelection(
+        sources=[*report_sources, *matched_url_sources],
+        cited_url_count=len(cited_urls),
+        matched_url_source_count=len(matched_url_sources),
+    )
+
+
+__all__ = ["extract_report_urls", "normalize_url", "select_cited_sources"]

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -91,6 +91,16 @@ class AccountTier:
     plan_name: str | None = None
 
 
+@dataclass(frozen=True)
+class CitedSourceSelection:
+    """Result of applying cited-only filtering to research sources."""
+
+    sources: list[dict[str, Any]]
+    cited_url_count: int
+    matched_url_source_count: int
+    used_fallback: bool = False
+
+
 class SourceType(str, Enum):
     """User-facing source types.
 
@@ -411,6 +421,7 @@ def _extract_artifact_url(data: list[Any], artifact_type: int | None) -> str | N
 
 __all__ = [
     # Dataclasses
+    "CitedSourceSelection",
     "Notebook",
     "NotebookDescription",
     "NotebookMetadata",

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1,0 +1,67 @@
+"""Tests for the public shim modules introduced by the private-module boundary plan.
+
+Each section is owned by a different PR; please keep the markers below intact when
+appending so concurrent PRs can merge cleanly.
+
+Plan: .sisyphus/plans/private-module-boundary.md
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# PR-A section: notebooklm.research public surface
+# ---------------------------------------------------------------------------
+
+
+def test_research_module_exposes_documented_helpers():
+    """notebooklm.research re-exports the three free helpers used by the CLI."""
+    from notebooklm.research import (
+        extract_report_urls,
+        normalize_url,
+        select_cited_sources,
+    )
+
+    assert callable(extract_report_urls)
+    assert callable(normalize_url)
+    assert callable(select_cited_sources)
+
+
+def test_cited_source_selection_is_on_public_surface():
+    """CitedSourceSelection lives in notebooklm.types and on the top-level package."""
+    from notebooklm import CitedSourceSelection as TopLevel
+    from notebooklm.types import CitedSourceSelection
+
+    assert TopLevel is CitedSourceSelection
+
+
+def test_research_select_cited_sources_returns_public_dataclass():
+    """select_cited_sources returns the public CitedSourceSelection dataclass."""
+    from notebooklm.research import select_cited_sources
+    from notebooklm.types import CitedSourceSelection
+
+    result = select_cited_sources([], "")
+    assert isinstance(result, CitedSourceSelection)
+    assert result.used_fallback is True
+
+
+def test_research_api_backward_compat_classmethod_delegates():
+    """notebooklm._research.ResearchAPI.select_cited_sources still works."""
+    from notebooklm._research import ResearchAPI
+    from notebooklm.types import CitedSourceSelection
+
+    result = ResearchAPI.select_cited_sources([], "")
+    assert isinstance(result, CitedSourceSelection)
+
+
+def test_research_api_reexports_cited_source_selection_for_back_compat():
+    """notebooklm._research.CitedSourceSelection continues to resolve."""
+    from notebooklm._research import CitedSourceSelection as Legacy
+    from notebooklm.types import CitedSourceSelection
+
+    assert Legacy is CitedSourceSelection
+
+
+# ---------------------------------------------------------------------------
+# PR-D section: notebooklm.config / notebooklm.urls / notebooklm.log public shims
+# (intentionally left blank; PR-D appends below this marker)
+# ---------------------------------------------------------------------------

--- a/tests/unit/test_research.py
+++ b/tests/unit/test_research.py
@@ -148,7 +148,7 @@ class TestCitedSourceSelection:
     def test_select_cited_sources_falls_back_when_no_urls_found(self, caplog):
         sources = [{"title": "Source", "url": "https://example.com/source"}]
 
-        with caplog.at_level(logging.WARNING, logger="notebooklm._research"):
+        with caplog.at_level(logging.WARNING, logger="notebooklm.research"):
             selection = ResearchAPI.select_cited_sources(sources, "# Report without links")
 
         assert selection.used_fallback is True
@@ -158,7 +158,7 @@ class TestCitedSourceSelection:
     def test_select_cited_sources_falls_back_when_no_sources_match(self, caplog):
         sources = [{"title": "Source", "url": "https://example.com/source"}]
 
-        with caplog.at_level(logging.WARNING, logger="notebooklm._research"):
+        with caplog.at_level(logging.WARNING, logger="notebooklm.research"):
             selection = ResearchAPI.select_cited_sources(
                 sources,
                 "Report cites https://example.com/other",


### PR DESCRIPTION
## Summary
Implements PR-A of the private-module boundary plan (`.sisyphus/plans/private-module-boundary.md`).

- Moves `CitedSourceSelection` dataclass to `notebooklm.types` (public surface)
- New `notebooklm.research` module exposes free functions: `select_cited_sources`, `extract_report_urls`, `normalize_url`
- `_research.ResearchAPI.select_cited_sources` / `extract_report_urls` preserved as delegating classmethods for backward compatibility
- `cli/helpers.py` migrated from `from .._research import …` to `from ..research import …` + `from ..types import CitedSourceSelection`

Resolves violation V1 from the audit.

## Test plan
- [x] `pytest tests/unit/test_research.py` green (caplog logger names updated to `notebooklm.research`)
- [x] `pytest tests/unit/test_public_shims.py` green (new)
- [x] Full suite green
- [x] mypy clean

@claude please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Research citation utilities are now available in the public API, enabling direct access to URL normalization and source selection for cited references.

* **Tests**
  * Added comprehensive tests to validate public API surface and backward-compatibility paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/443)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->