### PR TITLE
test: AST guard against notebooklm._* imports in cli/

### DIFF
--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -24,10 +24,22 @@ def _violations(tree: ast.AST) -> list[str]:
                 parts = mod.split(".")
                 if len(parts) >= 2 and parts[0] == "notebooklm" and parts[1].startswith("_"):
                     bad.append(f"from {mod} import ...")
+                # `from notebooklm import _foo` — private module via imported names.
+                # Dunders like `__version__` are public package attrs by convention.
+                if mod == "notebooklm":
+                    for alias in node.names:
+                        if alias.name.startswith("_") and not alias.name.startswith("__"):
+                            bad.append(f"from notebooklm import {alias.name}")
             elif node.level >= 2:
                 # `from .._foo import ...` (parent-package private)
                 if mod.startswith("_"):
                     bad.append(f"from {'.' * node.level}{mod} import ...")
+                # `from .. import _foo` — private parent module via imported names.
+                # Dunders like `__version__` are public package attrs by convention.
+                if mod == "":
+                    for alias in node.names:
+                        if alias.name.startswith("_") and not alias.name.startswith("__"):
+                            bad.append(f"from {'.' * node.level} import {alias.name}")
             # level == 1 is intra-cli; underscore there is fine (cli's own private modules)
         # `import X` / `import X as Y`
         elif isinstance(node, ast.Import):

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -1,0 +1,52 @@
+"""Lint: cli/ files must not import notebooklm._* (private modules).
+
+Allowed:
+- intra-cli imports like `from ._encoding import ...` or `from ._firefox_containers import ...`
+- imports of non-underscored siblings/parents (e.g., `from ..types import ...`, `from ..research import ...`)
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
+
+
+def _violations(tree: ast.AST) -> list[str]:
+    bad: list[str] = []
+    for node in ast.walk(tree):
+        # `from X import …`
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level == 0:
+                # `from notebooklm._foo import ...`
+                parts = mod.split(".")
+                if len(parts) >= 2 and parts[0] == "notebooklm" and parts[1].startswith("_"):
+                    bad.append(f"from {mod} import ...")
+            elif node.level >= 2:
+                # `from .._foo import ...` (parent-package private)
+                if mod.startswith("_"):
+                    bad.append(f"from {'.' * node.level}{mod} import ...")
+            # level == 1 is intra-cli; underscore there is fine (cli's own private modules)
+        # `import X` / `import X as Y`
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                parts = alias.name.split(".")
+                if len(parts) >= 2 and parts[0] == "notebooklm" and parts[1].startswith("_"):
+                    bad.append(f"import {alias.name}")
+    return bad
+
+
+def test_no_private_module_imports_in_cli():
+    offenders: list[tuple[str, list[str]]] = []
+    for path in sorted(CLI_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        bad = _violations(tree)
+        if bad:
+            offenders.append((str(path.relative_to(CLI_ROOT.parent)), bad))
+    assert not offenders, (
+        "CLI must not import notebooklm._* (private). "
+        "Promote needed symbols to a public module (config/urls/log/research) "
+        f"and import from there.\nOffenders: {offenders}"
+    )


### PR DESCRIPTION
## Summary
Final piece of the private-module boundary plan (`.sisyphus/plans/private-module-boundary.md`).

Adds `tests/unit/test_cli_boundary.py` — a single AST walk that fails if any file under `src/notebooklm/cli/` imports a `notebooklm._<private>` module. Catches both `from notebooklm._foo import …` (level=0), `from .._foo import …` (level≥2), and `import notebooklm._foo` (plain Import).

Allowed: intra-cli underscored imports (`from ._encoding import …`) and any public sibling/parent (`..types`, `..research`, `..config`, `..urls`, `..log`).

Builds on:
- PR #443 (research surface) — `notebooklm.research`, `CitedSourceSelection` in `notebooklm.types`
- PR #442 (firefox CLI move) — `_firefox_containers` now lives under `cli/`
- PR #441 (public shims) — `notebooklm.{config,urls,log}`

## Test plan
- [x] `pytest tests/unit/test_cli_boundary.py` green on current main (post-Wave-1)
- [x] Verified guard rejects regression: temporarily adding `from .._env import …` to a cli file makes the test fail with a clear offenders message
- [x] Full suite green
- [x] mypy clean

@claude please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test that validates the CLI only depends on public modules. It scans CLI sources and fails with a clear list of offending imports when private/internal modules are referenced, helping prevent accidental reliance on private APIs and maintain clean, stable public interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/444)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->