### PR TITLE
test: contract tests for public shim modules' __all__ (T1.D)

### DIFF
--- a/src/notebooklm/config.py
+++ b/src/notebooklm/config.py
@@ -12,8 +12,8 @@ from ._env import (
 __all__ = [
     "DEFAULT_BASE_URL",
     "ENTERPRISE_BASE_HOST",
-    "PERSONAL_BASE_HOST",
     "get_base_host",
     "get_base_url",
     "get_default_language",
+    "PERSONAL_BASE_HOST",
 ]

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -8,6 +8,11 @@ Plan: .sisyphus/plans/private-module-boundary.md
 
 from __future__ import annotations
 
+import importlib
+from types import ModuleType
+
+import pytest
+
 # ---------------------------------------------------------------------------
 # PR-A section: notebooklm.research public surface
 # ---------------------------------------------------------------------------
@@ -86,3 +91,96 @@ def test_log_shim_exposes_install_redaction():
     from notebooklm.log import install_redaction
 
     assert callable(install_redaction)
+
+
+# ---------------------------------------------------------------------------
+# PR-T1.D section: __all__ contract tests for the public shim modules.
+#
+# Enforces, for each shim, that:
+#   1. ``__all__`` exists.
+#   2. Every name in ``__all__`` resolves via ``getattr``.
+#   3. No name in ``__all__`` is private (leading underscore).
+#   4. ``__all__`` is sorted case-insensitively (drift catcher).
+#   5. ``__all__`` matches the actual re-exported public surface — no orphans,
+#      no missing entries.
+# ---------------------------------------------------------------------------
+
+
+# (shim_module_name, internal_module_name)
+_SHIM_PAIRS = [
+    ("notebooklm.config", "notebooklm._env"),
+    ("notebooklm.urls", "notebooklm._url_utils"),
+    ("notebooklm.log", "notebooklm._logging"),
+]
+
+
+def _actual_reexports(shim: ModuleType, internal: ModuleType) -> set[str]:
+    """Return public names on ``shim`` that point at the same object on ``internal``.
+
+    A name is considered "re-exported" when both modules expose an attribute
+    of the same identity. This catches accidental shadowing (a shim defining
+    its own value) as well as truly re-exported symbols.
+    """
+    sentinel = object()
+    names: set[str] = set()
+    for name in dir(shim):
+        if name.startswith("_"):
+            continue
+        shim_obj = getattr(shim, name, sentinel)
+        internal_obj = getattr(internal, name, sentinel)
+        if shim_obj is sentinel or internal_obj is sentinel:
+            continue
+        if shim_obj is internal_obj:
+            names.add(name)
+    return names
+
+
+@pytest.mark.parametrize(
+    ("shim_name", "internal_name"),
+    _SHIM_PAIRS,
+    ids=[shim for shim, _ in _SHIM_PAIRS],
+)
+def test_public_shim_all_contract(shim_name: str, internal_name: str) -> None:
+    shim = importlib.import_module(shim_name)
+    internal = importlib.import_module(internal_name)
+
+    # 1. __all__ exists.
+    assert hasattr(shim, "__all__"), f"{shim_name} is missing __all__"
+    all_list = shim.__all__
+    assert isinstance(all_list, list), (
+        f"{shim_name}.__all__ must be a list, got {type(all_list).__name__}"
+    )
+
+    # 2. Every name in __all__ is importable.
+    for name in all_list:
+        assert hasattr(shim, name), f"{shim_name}.__all__ references missing attribute {name!r}"
+
+    # 3. No private names in __all__.
+    private = [n for n in all_list if n.startswith("_")]
+    assert not private, f"{shim_name}.__all__ leaks private names: {private}"
+
+    # 4. __all__ sorted case-insensitively (drift catcher).
+    expected_order = sorted(all_list, key=str.lower)
+    assert list(all_list) == expected_order, (
+        f"{shim_name}.__all__ is not sorted case-insensitively.\n"
+        f"  actual:   {list(all_list)}\n"
+        f"  expected: {expected_order}"
+    )
+
+    # 5. __all__ matches the actual public surface of the shim.
+    declared = set(all_list)
+    reexported = _actual_reexports(shim, internal)
+    missing = reexported - declared
+    orphans = declared - reexported
+    assert not missing, (
+        f"{shim_name}.__all__ is missing names re-exported from {internal_name}: {sorted(missing)}"
+    )
+    assert not orphans, (
+        f"{shim_name}.__all__ contains orphans not re-exported from {internal_name}: "
+        f"{sorted(orphans)}"
+    )
+
+    # Length sanity: no duplicates in __all__.
+    assert len(all_list) == len(declared), (
+        f"{shim_name}.__all__ contains duplicates: {sorted(all_list)}"
+    )

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -103,10 +103,13 @@ def test_log_shim_exposes_install_redaction():
 #   4. ``__all__`` is sorted case-insensitively (drift catcher).
 #   5. ``__all__`` matches the actual re-exported public surface — no orphans,
 #      no missing entries.
+#   6. ``__all__`` contains no duplicate entries.
 # ---------------------------------------------------------------------------
 
 
 # (shim_module_name, internal_module_name)
+# Note: notebooklm.research has targeted smoke tests in the PR-A section above
+# and is intentionally excluded from this generic contract sweep.
 _SHIM_PAIRS = [
     ("notebooklm.config", "notebooklm._env"),
     ("notebooklm.urls", "notebooklm._url_utils"),
@@ -120,6 +123,10 @@ def _actual_reexports(shim: ModuleType, internal: ModuleType) -> set[str]:
     A name is considered "re-exported" when both modules expose an attribute
     of the same identity. This catches accidental shadowing (a shim defining
     its own value) as well as truly re-exported symbols.
+
+    Note: names imported under ``typing.TYPE_CHECKING`` are not visible to
+    ``dir()`` at runtime, so type-only re-exports won't be detected. None of
+    the current shims use TYPE_CHECKING re-exports.
     """
     sentinel = object()
     names: set[str] = set()
@@ -180,7 +187,7 @@ def test_public_shim_all_contract(shim_name: str, internal_name: str) -> None:
         f"{sorted(orphans)}"
     )
 
-    # Length sanity: no duplicates in __all__.
+    # 6. Length sanity: no duplicates in __all__.
     assert len(all_list) == len(declared), (
         f"{shim_name}.__all__ contains duplicates: {sorted(all_list)}"
     )


### PR DESCRIPTION
## Summary
- Adds `tests/unit/test_public_shims.py` enforcing `__all__` contract on the public shim modules added in #441
- Asserts `__all__` is sorted, all names importable, no leading underscores, no orphans

## Why
Synthesis §1 T4 / audit C5 boundary work: the shims define the public surface but have no contract test. Drift would silently break consumers.

## Test plan
- [x] All three shims pass the contract test
- [x] Test detects: missing name, orphan name, unsorted ordering, private leak

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced tests to validate and enforce consistency of public module exports across shims and their implementations.
* **Chores**
  * Minor reordering of public export declarations to improve internal consistency (no functional change).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/445)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->