### PR TITLE
fix(scripts): rpc-health emits exit 3 for non-transient ERROR (T1.C)

### DIFF
--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -84,8 +84,6 @@ jobs:
         if [ -z "$affected" ]; then
           affected="(see report)"
         fi
-        echo "affected=${affected}" >> "$GITHUB_OUTPUT"
-        echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
         {
           echo "## Non-transient ERROR detected"
           echo ""

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -73,6 +73,43 @@ jobs:
         content-filepath: health-report.txt
         labels: bug, automated
 
+    - name: Extract failing methods for ERROR issue
+      if: steps.health.outputs.exit_code == '3'
+      id: error_details
+      shell: bash
+      run: |
+        # Pull the affected-methods list out of the RESULT line emitted by the script.
+        affected=$(grep -m1 "non-transient ERROR detected in methods:" health-report.txt \
+          | sed -E 's/.*methods: //' || true)
+        if [ -z "$affected" ]; then
+          affected="(see report)"
+        fi
+        echo "affected=${affected}" >> "$GITHUB_OUTPUT"
+        echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+        {
+          echo "## Non-transient ERROR detected"
+          echo ""
+          echo "**Affected methods:** ${affected}"
+          echo ""
+          echo "**Commit:** ${GITHUB_SHA}"
+          echo ""
+          echo "Full report attached below (rate-limit / \`RESOURCE_EXHAUSTED\` errors"
+          echo "are filtered out — anything listed here is a real failure that needs"
+          echo "investigation: timeouts, parse failures, unexpected HTTP errors)."
+          echo ""
+          echo "---"
+          echo ""
+          cat health-report.txt
+        } > error-issue-body.md
+
+    - name: Create Issue on Non-transient ERROR
+      if: steps.health.outputs.exit_code == '3'
+      uses: peter-evans/create-issue-from-file@v6
+      with:
+        title: "RPC Health Check: Non-transient ERROR detected"
+        content-filepath: error-issue-body.md
+        labels: rpc-error, bug, automated
+
     - name: Upload Report
       if: always()
       uses: actions/upload-artifact@v7

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -5,9 +5,18 @@ This script makes minimal API calls to exercise RPC methods and verify
 that the method IDs in rpc/types.py still match what the API returns.
 
 Exit codes:
-    0 - All RPC methods OK (or transient errors only)
+    0 - All RPC methods OK (or only transient rate-limit errors)
     1 - One or more RPC methods have mismatched IDs
     2 - Authentication or infrastructure failure (not an RPC problem)
+    3 - One or more RPC methods returned a non-transient ERROR
+        (timeouts, parse failures, unexpected HTTP errors)
+
+Priority order when multiple statuses are present:
+    MISMATCH (1) > AUTH (2) > non-transient ERROR (3) > OK (0)
+
+Transient errors that still exit 0 are limited to rate-limit signals
+(HTTP 429 and gRPC ``RESOURCE_EXHAUSTED``). Everything else is treated
+as a real failure so the nightly canary can flag silent breakage.
 
 Environment variables:
     NOTEBOOKLM_AUTH_JSON - Playwright storage state JSON (required)
@@ -945,6 +954,65 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
     return results
 
 
+# Substrings that mark an ERROR as a transient rate-limit signal.
+# These are the ONLY errors that count as transient — everything else
+# (timeouts, parse failures, unexpected HTTP errors) is treated as a real
+# failure so the nightly canary can flag silent breakage. Keep this list
+# narrow on purpose: broadening it would mask real RPC drift.
+TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
+    "HTTP 429",
+    "RESOURCE_EXHAUSTED",
+)
+
+
+def is_transient_error(error_message: str | None) -> bool:
+    """Return True if an ERROR result is a transient rate-limit signal.
+
+    Rate-limit responses (HTTP 429, gRPC ``RESOURCE_EXHAUSTED``) are the
+    only errors classified as transient. They are expected on throttled
+    days and should not trip the canary. Anything else — timeouts, parse
+    failures, unexpected HTTP errors — is treated as a real failure.
+    """
+    if not error_message:
+        return False
+    return any(marker in error_message for marker in TRANSIENT_ERROR_MARKERS)
+
+
+def partition_errors(
+    results: list[CheckResult],
+) -> tuple[list[CheckResult], list[CheckResult]]:
+    """Split ERROR results into (non-transient, transient) lists."""
+    non_transient: list[CheckResult] = []
+    transient: list[CheckResult] = []
+    for r in results:
+        if r.status != CheckStatus.ERROR:
+            continue
+        if is_transient_error(r.error):
+            transient.append(r)
+        else:
+            non_transient.append(r)
+    return non_transient, transient
+
+
+def compute_exit_code(
+    counts: Counter[CheckStatus],
+    non_transient_errors: list[CheckResult],
+) -> int:
+    """Compute the script exit code from result counts.
+
+    Priority order (highest wins):
+        1. MISMATCH  -> 1
+        2. AUTH      -> 2 (signaled by the caller via sys.exit, never reached here)
+        3. non-transient ERROR -> 3
+        4. OK        -> 0
+    """
+    if counts[CheckStatus.MISMATCH] > 0:
+        return 1
+    if non_transient_errors:
+        return 3
+    return 0
+
+
 def print_summary(results: list[CheckResult]) -> int:
     """Print summary and return exit code."""
     print()
@@ -956,10 +1024,17 @@ def print_summary(results: list[CheckResult]) -> int:
     total = len(results)
     tested = total - counts[CheckStatus.SKIPPED]
 
+    error_results = [r for r in results if r.status == CheckStatus.ERROR]
+    transient_count = sum(1 for r in error_results if is_transient_error(r.error))
+    non_transient_count = len(error_results) - transient_count
+
     print(f"TESTED:   {tested}/{total} methods")
     print(f"OK:       {counts[CheckStatus.OK]}/{tested}")
     print(f"MISMATCH: {counts[CheckStatus.MISMATCH]}/{tested}")
-    print(f"ERROR:    {counts[CheckStatus.ERROR]}/{tested}")
+    print(
+        f"ERROR:    {counts[CheckStatus.ERROR]}/{tested} "
+        f"(non-transient: {non_transient_count}, transient: {transient_count})"
+    )
 
     # Print details for mismatches
     mismatches = [r for r in results if r.status == CheckStatus.MISMATCH]
@@ -974,26 +1049,36 @@ def print_summary(results: list[CheckResult]) -> int:
             print(f"    Action:   Update RPCMethod.{r.method.name} in src/notebooklm/rpc/types.py")
             print()
 
-    # Print details for errors
-    errors = [r for r in results if r.status == CheckStatus.ERROR]
-    if errors:
+    # Print details for errors, split into non-transient (real failures)
+    # and transient (rate-limit) buckets so the cron output is actionable.
+    non_transient_errors, transient_errors = partition_errors(results)
+    if non_transient_errors or transient_errors:
         print()
         print("ERROR DETAILS:")
         print("-" * 40)
-        for r in errors:
-            print(f"  {r.method.name} ({r.expected_id}): {r.error}")
+        for r in non_transient_errors:
+            print(f"  [non-transient] {r.method.name} ({r.expected_id}): {r.error}")
+        for r in transient_errors:
+            print(f"  [transient]     {r.method.name} ({r.expected_id}): {r.error}")
         print()
 
-    # Return exit code
-    # Only fail on MISMATCH (RPC ID changed) - this is what we care about
-    # ERROR could be transient (rate limiting, network issues) - don't fail on these
-    if counts[CheckStatus.MISMATCH] > 0:
+    # Return exit code.
+    # Priority: MISMATCH (1) > non-transient ERROR (3) > OK (0).
+    # AUTH (2) is signaled earlier via sys.exit(2) and never reaches here.
+    exit_code = compute_exit_code(counts, non_transient_errors)
+
+    if exit_code == 1:
         print("RESULT: FAIL - RPC ID mismatches detected")
         return 1
-    if counts[CheckStatus.ERROR] > 0:
-        print("RESULT: WARN - Some methods had errors (may be transient)")
-        print("       Review ERROR DETAILS above for potential issues")
-        return 0  # Don't fail - could be rate limiting or network issues
+    if exit_code == 3:
+        affected = ", ".join(r.method.name for r in non_transient_errors)
+        print(f"RESULT: FAIL - non-transient ERROR detected in methods: {affected}")
+        print("       These are real failures (not rate-limit transients).")
+        return 3
+    if transient_errors:
+        print("RESULT: PASS - Only transient rate-limit errors observed")
+        print("       Review ERROR DETAILS above for affected methods.")
+        return 0
     print("RESULT: PASS - All tested RPC methods OK")
     return 0
 

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -1024,9 +1024,9 @@ def print_summary(results: list[CheckResult]) -> int:
     total = len(results)
     tested = total - counts[CheckStatus.SKIPPED]
 
-    error_results = [r for r in results if r.status == CheckStatus.ERROR]
-    transient_count = sum(1 for r in error_results if is_transient_error(r.error))
-    non_transient_count = len(error_results) - transient_count
+    non_transient_errors, transient_errors = partition_errors(results)
+    non_transient_count = len(non_transient_errors)
+    transient_count = len(transient_errors)
 
     print(f"TESTED:   {tested}/{total} methods")
     print(f"OK:       {counts[CheckStatus.OK]}/{tested}")
@@ -1051,7 +1051,6 @@ def print_summary(results: list[CheckResult]) -> int:
 
     # Print details for errors, split into non-transient (real failures)
     # and transient (rate-limit) buckets so the cron output is actionable.
-    non_transient_errors, transient_errors = partition_errors(results)
     if non_transient_errors or transient_errors:
         print()
         print("ERROR DETAILS:")

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -228,10 +228,17 @@ def test_print_summary_lists_affected_methods_on_exit_three(
     ]
     assert print_summary(results) == 3
     out = capsys.readouterr().out
+    # Extract the "affected methods" header line so we only inspect the list
+    # of method names (the surrounding explanatory text legitimately mentions
+    # "rate-limit transients").
+    header_line = next(
+        line for line in out.splitlines() if "non-transient ERROR detected in methods:" in line
+    )
+    affected = header_line.split("methods:", 1)[1]
     # Both non-transient methods appear in the affected list…
-    assert "timeout" in out and "parse" in out
-    # …and the transient one does NOT trip the failure header.
-    assert "rate-limit" not in out.split("RESULT:")[1].lower() or True
+    assert "timeout" in affected and "parse" in affected
+    # …and the transient one is NOT listed as an affected method.
+    assert "rate" not in affected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -1,0 +1,259 @@
+"""Tests for ``scripts/check_rpc_health.py`` exit-code policy (PR-T1.C).
+
+The nightly canary previously exited ``0`` on every ``ERROR`` status by
+labelling them "transient". That meant a silently-broken canary stayed
+green in CI while the Tier-1 drift detector was effectively offline.
+
+These tests pin down the new policy:
+
+    * MISMATCH                   -> exit 1   (RPC ID drift)
+    * Non-transient ERROR        -> exit 3   (timeouts, parse errors, etc.)
+    * Transient rate-limit ERROR -> exit 0   (HTTP 429 / RESOURCE_EXHAUSTED)
+    * All OK                     -> exit 0
+
+Priority when statuses collide: MISMATCH (1) > non-transient ERROR (3) > OK (0).
+AUTH (2) is signalled earlier via ``sys.exit(2)`` and is exercised in the
+auth-failure test by invoking ``main()`` with a missing storage env var.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Load scripts/check_rpc_health.py as a module. The ``scripts`` directory
+# is not a package, so we go through importlib rather than a normal import.
+# Registering the module in ``sys.modules`` before executing it is required
+# so that ``@dataclass`` can resolve forward references back to this module
+# during class construction.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_rpc_health.py"
+_spec = importlib.util.spec_from_file_location("check_rpc_health", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+check_rpc_health = importlib.util.module_from_spec(_spec)
+sys.modules["check_rpc_health"] = check_rpc_health
+_spec.loader.exec_module(check_rpc_health)
+
+
+CheckStatus = check_rpc_health.CheckStatus
+CheckResult = check_rpc_health.CheckResult
+compute_exit_code = check_rpc_health.compute_exit_code
+is_transient_error = check_rpc_health.is_transient_error
+partition_errors = check_rpc_health.partition_errors
+print_summary = check_rpc_health.print_summary
+
+
+def _result(
+    name: str,
+    status: CheckStatus,
+    *,
+    error: str | None = None,
+) -> CheckResult:
+    """Build a CheckResult with a stub RPCMethod-like object.
+
+    ``print_summary`` accesses ``result.method.name`` and
+    ``result.expected_id``, so we use a small ducktype rather than
+    importing the real ``RPCMethod`` enum (which would add a heavy
+    dependency for what is purely a logic test).
+    """
+
+    class _Method:
+        def __init__(self, n: str) -> None:
+            self.name = n
+
+    return CheckResult(  # type: ignore[no-any-return]
+        method=_Method(name),  # type: ignore[arg-type]
+        status=status,
+        expected_id=f"id_{name}",
+        found_ids=[],
+        error=error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_transient_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "HTTP 429",
+        "HTTP 429: Too Many Requests",
+        "rpc error: code = RESOURCE_EXHAUSTED desc = quota exceeded",
+        "RESOURCE_EXHAUSTED",
+    ],
+)
+def test_transient_markers_match(message: str) -> None:
+    assert is_transient_error(message) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        None,
+        "",
+        "HTTP 500",
+        "HTTP 503",
+        "Parse error: unexpected token",
+        "Connection timeout",
+        "RPC ID not found in response",
+    ],
+)
+def test_non_transient_markers_do_not_match(message: str | None) -> None:
+    assert is_transient_error(message) is False
+
+
+# ---------------------------------------------------------------------------
+# partition_errors
+# ---------------------------------------------------------------------------
+
+
+def test_partition_errors_separates_transient_from_real() -> None:
+    results = [
+        _result("ok", CheckStatus.OK),
+        _result("rate", CheckStatus.ERROR, error="HTTP 429"),
+        _result("timeout", CheckStatus.ERROR, error="Connection timeout"),
+        _result("parse", CheckStatus.ERROR, error="Parse error: bad JSON"),
+        _result("quota", CheckStatus.ERROR, error="RESOURCE_EXHAUSTED on RPC"),
+        _result("mismatch", CheckStatus.MISMATCH),
+    ]
+    non_transient, transient = partition_errors(results)
+    assert [r.method.name for r in non_transient] == ["timeout", "parse"]
+    assert [r.method.name for r in transient] == ["rate", "quota"]
+
+
+# ---------------------------------------------------------------------------
+# compute_exit_code priority
+# ---------------------------------------------------------------------------
+
+
+def _counts(**overrides: int) -> Counter[Any]:
+    """Build a Counter with all statuses defaulted to 0."""
+    base: dict[Any, int] = dict.fromkeys(CheckStatus, 0)
+    base.update({getattr(CheckStatus, k.upper()): v for k, v in overrides.items()})
+    return Counter(base)
+
+
+def test_exit_code_all_ok() -> None:
+    assert compute_exit_code(_counts(ok=10), []) == 0
+
+
+def test_exit_code_only_transient_errors() -> None:
+    # Counts include the ERROR, but the non_transient list is empty.
+    counts = _counts(ok=9, error=1)
+    assert compute_exit_code(counts, []) == 0
+
+
+def test_exit_code_non_transient_error() -> None:
+    counts = _counts(ok=9, error=1)
+    non_transient = [_result("timeout", CheckStatus.ERROR, error="Connection timeout")]
+    assert compute_exit_code(counts, non_transient) == 3
+
+
+def test_exit_code_mismatch_alone() -> None:
+    counts = _counts(ok=9, mismatch=1)
+    assert compute_exit_code(counts, []) == 1
+
+
+def test_exit_code_mismatch_beats_non_transient_error() -> None:
+    """Priority: MISMATCH (1) wins over non-transient ERROR (3)."""
+    counts = _counts(ok=8, mismatch=1, error=1)
+    non_transient = [_result("timeout", CheckStatus.ERROR, error="Connection timeout")]
+    assert compute_exit_code(counts, non_transient) == 1
+
+
+# ---------------------------------------------------------------------------
+# print_summary (integration over the helpers)
+# ---------------------------------------------------------------------------
+
+
+def test_print_summary_all_match_returns_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [_result(f"m{i}", CheckStatus.OK) for i in range(3)]
+    assert print_summary(results) == 0
+    out = capsys.readouterr().out
+    assert "RESULT: PASS" in out
+
+
+def test_print_summary_only_rate_limit_returns_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [
+        _result("ok", CheckStatus.OK),
+        _result("rate", CheckStatus.ERROR, error="HTTP 429"),
+    ]
+    assert print_summary(results) == 0
+    out = capsys.readouterr().out
+    assert "transient" in out.lower()
+    assert "RESULT: PASS" in out
+
+
+def test_print_summary_non_transient_error_returns_three(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [
+        _result("ok", CheckStatus.OK),
+        _result("timeout", CheckStatus.ERROR, error="Connection timeout"),
+    ]
+    assert print_summary(results) == 3
+    out = capsys.readouterr().out
+    assert "non-transient ERROR detected in methods: timeout" in out
+
+
+def test_print_summary_mismatch_plus_error_returns_one(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [
+        _result("drift", CheckStatus.MISMATCH),
+        _result("timeout", CheckStatus.ERROR, error="Connection timeout"),
+    ]
+    assert print_summary(results) == 1
+    out = capsys.readouterr().out
+    assert "RESULT: FAIL - RPC ID mismatches detected" in out
+
+
+def test_print_summary_lists_affected_methods_on_exit_three(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [
+        _result("timeout", CheckStatus.ERROR, error="Connection timeout"),
+        _result("parse", CheckStatus.ERROR, error="Parse error: bad JSON"),
+        _result("rate", CheckStatus.ERROR, error="HTTP 429"),
+    ]
+    assert print_summary(results) == 3
+    out = capsys.readouterr().out
+    # Both non-transient methods appear in the affected list…
+    assert "timeout" in out and "parse" in out
+    # …and the transient one does NOT trip the failure header.
+    assert "rate-limit" not in out.split("RESULT:")[1].lower() or True
+
+
+# ---------------------------------------------------------------------------
+# main() auth-failure path -> exit 2
+# ---------------------------------------------------------------------------
+
+
+def test_main_exits_two_when_auth_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing ``NOTEBOOKLM_AUTH_JSON`` must surface as exit code 2.
+
+    Even if the developer running the test happens to have a local
+    ``~/.notebooklm/storage_state.json``, we patch the loader to simulate
+    a fresh CI environment with no credentials available.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    monkeypatch.setattr("sys.argv", ["check_rpc_health.py"])
+
+    def _missing() -> dict[str, str]:
+        raise FileNotFoundError("simulated missing storage_state.json")
+
+    monkeypatch.setattr(check_rpc_health, "load_auth_from_storage", _missing)
+
+    with pytest.raises(SystemExit) as excinfo:
+        check_rpc_health.main()
+    assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary
- `scripts/check_rpc_health.py` now returns exit 3 when any RPC method returns non-transient ERROR (timeouts, deserialization failures); rate-limit ERROR still exits 0 with warning
- `.github/workflows/rpc-health.yml` opens a new issue (label `rpc-error`) on exit 3 in addition to the existing exit-1/2 branches
- Priority: MISMATCH (1) > AUTH (2) > non-transient ERROR (3) > OK (0)

## Why
Audit K4 / synthesis Sec 1 T6: the canary that defends Tier-1 schema-drift work currently exits 0 on ERROR -- CI stays green while the drift detector is silently broken. Without this, the protective layer has holes.

## Test plan
- [x] Exit-code mapping unit-tested with all classes of input
- [x] Rate-limit ERROR still treated as transient (no issue spam on throttled days)
- [x] Existing exit-1 / exit-2 branches unchanged

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now files a GitHub issue for non-transient RPC health errors, including affected methods, commit SHA, and a filtered report.

* **Behavior Changes**
  * Health checks now distinguish transient (rate-limit) vs non-transient errors and apply a stricter exit-code policy (distinct codes for mismatches vs non-transient errors).

* **Tests**
  * Added thorough tests covering transient detection, error partitioning, exit-code rules, summary output, and auth-failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/446)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->