### PR TITLE
docs: from_storage() example needs await (T1.H1)

### DIFF
--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -3,7 +3,7 @@
 Example usage:
     from notebooklm import NotebookLMClient
 
-    async with NotebookLMClient.from_storage() as client:
+    async with await NotebookLMClient.from_storage() as client:
         notebooks = await client.notebooks.list()
         await client.sources.add_url(notebook_id, "https://example.com")
         result = await client.chat.ask(notebook_id, "What is this about?")

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -246,7 +246,7 @@ class ArtifactsAPI:
     Reports, Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             # Generate
             status = await client.artifacts.generate_audio(notebook_id)
             await client.artifacts.wait_for_completion(notebook_id, status.task_id)

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -38,7 +38,7 @@ class ChatAPI:
     conversation history with follow-up support.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             # Ask a question
             result = await client.chat.ask(notebook_id, "What is X?")
             print(result.answer)

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -26,7 +26,7 @@ class NotebooksAPI:
     notebooks, as well as getting AI-generated descriptions.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             notebooks = await client.notebooks.list()
             new_nb = await client.notebooks.create("My Research")
             await client.notebooks.rename(new_nb.id, "Better Title")

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -23,7 +23,7 @@ class NotesAPI:
     Notes support operations like export to Docs/Sheets and conversion to sources.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             # Create and update notes
             note = await client.notes.create(notebook_id, "My Note", "Content here")
             await client.notes.update(notebook_id, note.id, "Updated content", "New Title")

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -31,7 +31,7 @@ class ResearchAPI:
     importing discovered sources into notebooks.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             # Start research
             task = await client.research.start(notebook_id, "quantum computing")
 

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -131,7 +131,7 @@ class SettingsAPI:
     Provides methods for managing global user settings like output language.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             lang = await client.settings.get_output_language()
             await client.settings.set_output_language("zh_Hans")
     """

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -17,7 +17,7 @@ class SharingAPI:
     including public link access and user-specific sharing.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             # Get current status
             status = await client.sharing.get_status(notebook_id)
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -49,7 +49,7 @@ class SourcesAPI:
     and refreshing sources in notebooks.
 
     Usage:
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             sources = await client.sources.list(notebook_id)
             new_src = await client.sources.add_url(notebook_id, "https://example.com")
             await client.sources.rename(notebook_id, new_src.id, "Better Title")

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -4,7 +4,7 @@ This module provides the NotebookLMClient class, a modern async client
 for interacting with Google NotebookLM using undocumented RPC APIs.
 
 Example:
-    async with NotebookLMClient.from_storage() as client:
+    async with await NotebookLMClient.from_storage() as client:
         # List notebooks
         notebooks = await client.notebooks.list()
 
@@ -57,7 +57,7 @@ class NotebookLMClient:
 
     Usage:
         # Create from saved authentication
-        async with NotebookLMClient.from_storage() as client:
+        async with await NotebookLMClient.from_storage() as client:
             notebooks = await client.notebooks.list()
 
         # Create from AuthTokens directly

--- a/tests/unit/test_docstrings.py
+++ b/tests/unit/test_docstrings.py
@@ -1,0 +1,150 @@
+"""Guards against `from_storage` docstring drift.
+
+`NotebookLMClient.from_storage` is an async classmethod, so a correct
+example must use ``async with await NotebookLMClient.from_storage(...)``.
+A bare ``async with NotebookLMClient.from_storage(...)`` raises
+``TypeError`` at runtime because the coroutine itself is not an async
+context manager. This test parses the module/class docstrings in the
+public package and asserts every example snippet stays well-formed.
+
+Audit X4 / codex #21 / C6: module docstrings in ``client.py`` and
+``__init__.py`` historically had this bug; this test exists so the bug
+cannot re-enter via copy-paste.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from notebooklm.client import NotebookLMClient
+
+# Files whose docstrings should not contain the broken example. We parse
+# each file's AST and walk every docstring (module + class + function).
+DOCSTRING_TARGETS = [
+    "src/notebooklm/__init__.py",
+    "src/notebooklm/client.py",
+    "src/notebooklm/_notebooks.py",
+    "src/notebooklm/_sources.py",
+    "src/notebooklm/_artifacts.py",
+    "src/notebooklm/_chat.py",
+    "src/notebooklm/_research.py",
+    "src/notebooklm/_notes.py",
+    "src/notebooklm/_settings.py",
+    "src/notebooklm/_sharing.py",
+]
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _iter_docstrings(tree: ast.AST):
+    """Yield every docstring found in the AST."""
+    for node in ast.walk(tree):
+        if isinstance(
+            node,
+            (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+        ):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                yield node, doc
+
+
+@pytest.mark.parametrize("relpath", DOCSTRING_TARGETS)
+def test_from_storage_examples_use_await(relpath: str) -> None:
+    """No docstring example may show `async with` + `from_storage()` without `await`.
+
+    The whole point of the audit: ``from_storage`` is async, so anything
+    that opens it as an async context manager must await it first.
+    """
+    path = _repo_root() / relpath
+    tree = ast.parse(path.read_text())
+
+    offenders: list[tuple[str, int, str]] = []
+    for node, doc in _iter_docstrings(tree):
+        # ``node.lineno`` for a module is 1; for class/function it's the
+        # def line. Either is good enough to point a human at the bug.
+        for idx, line in enumerate(doc.splitlines(), start=1):
+            if "from_storage(" in line and "async with" in line and "await" not in line:
+                offenders.append((getattr(node, "name", "<module>"), idx, line.strip()))
+
+    assert not offenders, (
+        f"{relpath}: found `async with ...from_storage(...)` example(s) "
+        f"missing `await`: {offenders}"
+    )
+
+
+@pytest.mark.parametrize("relpath", DOCSTRING_TARGETS)
+def test_docstring_example_lines_parse(relpath: str) -> None:
+    """Every example line that mentions `from_storage()` must be valid Python.
+
+    We don't execute the snippets — we only parse them. This catches
+    typos / unterminated strings / etc. so future drift breaks a test
+    instead of silently shipping a broken example.
+    """
+    path = _repo_root() / relpath
+    tree = ast.parse(path.read_text())
+
+    for _node, doc in _iter_docstrings(tree):
+        for raw in doc.splitlines():
+            line = raw.strip()
+            if "from_storage(" not in line:
+                continue
+            # Strip trailing ``as client:`` so the example fragment is a
+            # statement we can parse standalone. ``async with X as y:``
+            # is only valid inside an async function; wrap accordingly.
+            wrapped = f"async def _():\n    {line}\n        pass\n"
+            try:
+                ast.parse(wrapped)
+            except SyntaxError as exc:  # pragma: no cover - failure path
+                pytest.fail(f"{relpath}: example line {line!r} failed to parse: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_from_storage_smoke_constructs_client(tmp_path: Path, httpx_mock: HTTPXMock) -> None:
+    """Smoke test: the documented example shape actually returns a client.
+
+    Mirrors what the module/class docstrings advertise:
+
+        async with await NotebookLMClient.from_storage(path=...) as client:
+            ...
+
+    We stop short of entering the context manager — we just assert that
+    awaiting ``from_storage`` returns a ``NotebookLMClient`` instance.
+    That is enough to prove the example shape compiles and runs.
+    """
+    storage_file = tmp_path / "storage_state.json"
+    storage_state = {
+        "cookies": [
+            {"name": "SID", "value": "smoke_sid", "domain": ".google.com"},
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "smoke_1psidts",
+                "domain": ".google.com",
+            },
+            {"name": "HSID", "value": "smoke_hsid", "domain": ".google.com"},
+        ],
+        "origins": [],
+    }
+    storage_file.write_text(json.dumps(storage_state))
+
+    # ``from_storage`` performs a token fetch against notebooklm.google.com
+    # during construction; serve a minimal stub so the call resolves
+    # without touching the network.
+    html = '"SNlM0e":"smoke_csrf" "FdrFJe":"smoke_session"'
+    httpx_mock.add_response(
+        url="https://notebooklm.google.com/",
+        content=html.encode(),
+    )
+
+    client = await NotebookLMClient.from_storage(path=str(storage_file))
+
+    assert isinstance(client, NotebookLMClient)
+    # Sanity: the client should not be connected yet — from_storage just
+    # constructs it. Entering the async-with would call __aenter__.
+    assert client.is_connected is False

--- a/tests/unit/test_docstrings.py
+++ b/tests/unit/test_docstrings.py
@@ -95,17 +95,21 @@ def test_docstring_example_lines_parse(relpath: str) -> None:
             line = raw.strip()
             if "from_storage(" not in line:
                 continue
-            # Strip trailing ``as client:`` so the example fragment is a
-            # statement we can parse standalone. ``async with X as y:``
-            # is only valid inside an async function; wrap accordingly.
-            wrapped = f"async def _():\n    {line}\n        pass\n"
+            # Wrap the line inside an ``async def`` so constructs like
+            # ``async with X as y:`` (only legal inside an async function)
+            # parse. If the line is itself a compound-statement header
+            # (ends with ``:``), give it a ``pass`` body so the wrapper
+            # stays syntactically valid.
+            if line.rstrip().endswith(":"):
+                wrapped = f"async def _():\n    {line}\n        pass\n"
+            else:
+                wrapped = f"async def _():\n    {line}\n"
             try:
                 ast.parse(wrapped)
             except SyntaxError as exc:  # pragma: no cover - failure path
                 pytest.fail(f"{relpath}: example line {line!r} failed to parse: {exc}")
 
 
-@pytest.mark.asyncio
 async def test_from_storage_smoke_constructs_client(tmp_path: Path, httpx_mock: HTTPXMock) -> None:
     """Smoke test: the documented example shape actually returns a client.
 


### PR DESCRIPTION
## Summary
- Module docstrings in `client.py` and `__init__.py` now show `async with await NotebookLMClient.from_storage()` — matches the runtime contract (from_storage is async)
- Adds `tests/unit/test_docstrings.py` to lint future docstring drift via `ast.parse` + a smoke test that constructs the client from a fake storage file

## Why
Audit X4 / codex #21: docstring example raised `TypeError` at runtime because `await` was missing. Both module-level snippets had the issue. Tests catch future drift.

## Test plan
- [x] `ast.parse` succeeds on all `from_storage()` example lines
- [x] Smoke test constructs client from tmp_path storage file

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples across API docs to correctly show awaiting the client when using async context managers (use "async with await NotebookLMClient.from_storage()").

* **Tests**
  * Added tests that validate docstring examples and enforce correct async/await patterns for from_storage() usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/447)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->