### PR TITLE
feat(rpc): safe_index helper + UnknownRPCMethodError routing (T1.A)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,7 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_HL` | Default interface/output language code (e.g. `en`, `ja`, `zh_Hans`) | `en` |
 | `NOTEBOOKLM_LOG_LEVEL` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` | `WARNING` |
 | `NOTEBOOKLM_DEBUG_RPC` | Legacy: Enable RPC debug logging (use `LOG_LEVEL=DEBUG` instead) | `false` |
+| `NOTEBOOKLM_STRICT_DECODE` | Raise `UnknownRPCMethodError` on schema drift instead of warn-and-fallback | `0` |
 
 ### NOTEBOOKLM_HOME
 
@@ -166,6 +167,28 @@ back to `en`. For the generate commands, the resolution order is:
 2. `NOTEBOOKLM_HL` environment variable
 3. `language` value from the active profile's config
 4. `en` (built-in default)
+
+### Decoder strictness
+
+NotebookLM's batchexecute responses are obfuscated, undocumented, and reshaped
+by Google without notice. The decoder uses a shared `safe_index` helper to walk
+nested response payloads. When it can't descend (an index is out of range, or
+the value at a step isn't indexable), behavior depends on
+`NOTEBOOKLM_STRICT_DECODE`:
+
+| Value | Behavior |
+|-------|----------|
+| `0` (default) | Log a warning with the failing path, `method_id`, `source` label, and a truncated repr of the data. Return `None` so legacy callers keep working. |
+| `1` / `true` / `True` | Raise `UnknownRPCMethodError` (a subclass of `DecodingError` / `RPCError`) with structured `method_id`, `path`, `source`, and `data_at_failure` attributes. |
+
+The default of `0` is a soft-rollout safeguard for this release while
+call sites migrate to defensive indexing. A future release will flip the
+default to `1` — set `NOTEBOOKLM_STRICT_DECODE=1` in your CI/staging
+environments now to catch drift early.
+
+The same `UnknownRPCMethodError` is also raised by `decode_response()` when the
+batchexecute response contains RPC IDs but not the one the call requested
+(typically a sign that Google rotated the method ID).
 
 ## CLI Options
 

--- a/src/notebooklm/_env.py
+++ b/src/notebooklm/_env.py
@@ -16,6 +16,19 @@ ENTERPRISE_BASE_HOST = "notebooklm.cloud.google.com"
 
 _ALLOWED_BASE_HOSTS = frozenset({PERSONAL_BASE_HOST, ENTERPRISE_BASE_HOST})
 
+STRICT_DECODE_ENV = "NOTEBOOKLM_STRICT_DECODE"
+
+
+def is_strict_decode_enabled() -> bool:
+    """Return True if the strict-decode mode is enabled.
+
+    During the Tier-1 soft-rollout, schema-drift helpers (e.g. ``safe_index``)
+    fall back to warn-and-return-None by default. Setting
+    ``NOTEBOOKLM_STRICT_DECODE=1`` (or ``true``/``True``) flips them to raise
+    ``UnknownRPCMethodError`` instead, surfacing drift early.
+    """
+    return os.environ.get(STRICT_DECODE_ENV, "0") in ("1", "true", "True")
+
 
 def get_base_url() -> str:
     """Return the configured NotebookLM base URL.

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -179,7 +179,88 @@ class UnknownRPCMethodError(DecodingError):
     """RPC response structure doesn't match expectations.
 
     This often indicates Google has changed the API. Check for library updates.
+
+    Carries structured context to help diagnose schema drift:
+
+    Attributes:
+        method_id: The RPC method ID that was requested (or that drifted).
+        path: Index path inside the decoded payload at which descent failed
+            (empty tuple for top-level drift, ``(0, 2)`` for nested, etc.).
+        source: Caller-provided label identifying which decoder/helper raised
+            this error (e.g. ``"_notebooks.list"``).
+        found_ids: When raised by the response-level decoder, the list of RPC
+            IDs actually present in the response.
+        raw_response: First 500 chars of the raw response, when available.
+        data_at_failure: Truncated repr (~200 chars) of the data the helper
+            was attempting to index into when descent failed.
     """
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        method_id: str | int | None = None,
+        path: tuple[int, ...] | None = None,
+        source: str | None = None,
+        found_ids: list[int | str] | None = None,
+        raw_response: Any | None = None,
+        data_at_failure: Any | None = None,
+        rpc_code: str | int | None = None,
+    ):
+        # Coerce method_id to str for the base RPCError contract while
+        # preserving the original (possibly int) value on this subclass.
+        base_method_id = str(method_id) if method_id is not None else None
+        # Normalize found_ids to list[str] for the base contract while
+        # keeping the typed list[int | str] on this subclass.
+        base_found_ids: list[str] | None = (
+            None if found_ids is None else [str(item) for item in found_ids]
+        )
+        # raw_response on RPCError is str | None; only forward when stringy.
+        base_raw_response = raw_response if isinstance(raw_response, str) else None
+        super().__init__(
+            message,
+            method_id=base_method_id,
+            raw_response=base_raw_response,
+            rpc_code=rpc_code,
+            found_ids=base_found_ids,
+        )
+        # Preserve original typed values on this subclass.
+        self.method_id = method_id  # type: ignore[assignment]
+        self.path = path
+        self.source = source
+        # Override base found_ids with the typed list (may contain ints).
+        if found_ids is not None:
+            self.found_ids = found_ids  # type: ignore[assignment]
+        self.raw_response = raw_response
+        self.data_at_failure = data_at_failure
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        extras: list[str] = []
+        if self.method_id is not None:
+            extras.append(f"method_id={self.method_id!r}")
+        if self.path is not None:
+            extras.append(f"path={self.path!r}")
+        if self.source is not None:
+            extras.append(f"source={self.source!r}")
+        if self.found_ids:
+            extras.append(f"found_ids={self.found_ids!r}")
+        if self.data_at_failure is not None:
+            extras.append(f"data_at_failure={self.data_at_failure!r}")
+        if not extras:
+            return base
+        return f"{base} [{', '.join(extras)}]" if base else ", ".join(extras)
+
+    def __repr__(self) -> str:
+        return (
+            f"UnknownRPCMethodError("
+            f"message={super().__str__()!r}, "
+            f"method_id={self.method_id!r}, "
+            f"path={self.path!r}, "
+            f"source={self.source!r}, "
+            f"found_ids={self.found_ids!r}, "
+            f"data_at_failure={self.data_at_failure!r})"
+        )
 
 
 class AuthError(RPCError):

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -231,7 +231,10 @@ class UnknownRPCMethodError(DecodingError):
         # Override base found_ids with the typed list (may contain ints).
         if found_ids is not None:
             self.found_ids = found_ids  # type: ignore[assignment]
-        self.raw_response = raw_response
+        # Honor RPCError's 500-char truncation contract for stringy
+        # raw_response while preserving non-string payloads (dict/list/etc)
+        # supported by this subclass's widened ``Any`` type.
+        self.raw_response = raw_response[:500] if isinstance(raw_response, str) else raw_response
         self.data_at_failure = data_at_failure
 
     def __str__(self) -> str:

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -9,11 +9,13 @@ from .decoder import (
     RPCErrorCode,
     RPCTimeoutError,
     ServerError,
+    UnknownRPCMethodError,
     collect_rpc_ids,
     decode_response,
     extract_rpc_result,
     get_error_message_for_code,
     parse_chunked_response,
+    safe_index,
     strip_anti_xssi,
 )
 from .encoder import build_request_body, encode_rpc_request, nest_source_ids
@@ -83,6 +85,7 @@ __all__ = [
     "extract_rpc_result",
     "collect_rpc_ids",
     "decode_response",
+    "safe_index",
     # Exceptions
     "RPCError",
     "AuthError",
@@ -91,6 +94,7 @@ __all__ = [
     "RateLimitError",
     "ServerError",
     "ClientError",
+    "UnknownRPCMethodError",
     # Error handling utilities
     "RPCErrorCode",
     "get_error_message_for_code",

--- a/src/notebooklm/rpc/_safe_index.py
+++ b/src/notebooklm/rpc/_safe_index.py
@@ -14,6 +14,7 @@ hand-rolling ``try/except IndexError`` blocks.
 from __future__ import annotations
 
 import logging
+import reprlib
 from typing import Any
 
 from .._env import is_strict_decode_enabled
@@ -25,10 +26,29 @@ logger = logging.getLogger(__name__)
 
 _REPR_TRUNCATE = 200
 
+# Use reprlib so we never materialize a huge repr just to slice it. Tune the
+# knobs so the resulting representation stays close to ``repr(value)[:200]``
+# semantics without recursing into giant inner structures.
+_REPR = reprlib.Repr()
+_REPR.maxstring = _REPR_TRUNCATE
+_REPR.maxother = _REPR_TRUNCATE
+_REPR.maxlist = 10
+_REPR.maxtuple = 10
+_REPR.maxdict = 10
+_REPR.maxarray = 10
+_REPR.maxset = 10
+_REPR.maxfrozenset = 10
+_REPR.maxdeque = 10
+_REPR.maxlevel = 4
+
 
 def _truncate(value: Any) -> str:
-    """Return a length-bounded repr suitable for logs/exception attributes."""
-    text = repr(value)
+    """Return a length-bounded repr suitable for logs/exception attributes.
+
+    Uses ``reprlib`` to avoid materialising the full repr of pathologically
+    large/deep payloads before slicing.
+    """
+    text = _REPR.repr(value)
     if len(text) <= _REPR_TRUNCATE:
         return text
     return text[:_REPR_TRUNCATE] + "..."
@@ -68,9 +88,11 @@ def safe_index(
             failing_path = tuple(path[:i])
             data_repr = _truncate(current)
             if is_strict_decode_enabled():
+                # method_id/source are appended by UnknownRPCMethodError.__str__
+                # via its structured fields — don't duplicate them in the
+                # message text.
                 raise UnknownRPCMethodError(
-                    f"safe_index drift at path {failing_path}[{key}] "
-                    f"(method_id={method_id!r}, source={source!r})",
+                    f"safe_index drift at path {failing_path}[{key}]",
                     method_id=method_id,
                     path=failing_path,
                     source=source,

--- a/src/notebooklm/rpc/_safe_index.py
+++ b/src/notebooklm/rpc/_safe_index.py
@@ -1,0 +1,88 @@
+"""Shared schema-drift helper for indexing into decoded RPC payloads.
+
+``safe_index`` walks a nested list/tuple by integer keys with soft-strict
+semantics. In the default soft-rollout mode it logs a warning and returns
+``None`` on drift; setting ``NOTEBOOKLM_STRICT_DECODE=1`` flips it to raise
+``UnknownRPCMethodError`` so callers fail fast when Google's response shape
+moves out from under us.
+
+This is the single shared point of policy for "the payload didn't look like
+we expected" — call sites should migrate to ``safe_index`` rather than
+hand-rolling ``try/except IndexError`` blocks.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .._env import is_strict_decode_enabled
+from ..exceptions import UnknownRPCMethodError
+
+__all__ = ["safe_index"]
+
+logger = logging.getLogger(__name__)
+
+_REPR_TRUNCATE = 200
+
+
+def _truncate(value: Any) -> str:
+    """Return a length-bounded repr suitable for logs/exception attributes."""
+    text = repr(value)
+    if len(text) <= _REPR_TRUNCATE:
+        return text
+    return text[:_REPR_TRUNCATE] + "..."
+
+
+def safe_index(
+    data: Any,
+    *path: int,
+    method_id: str | int | None,
+    source: str,
+) -> Any:
+    """Walk ``data`` by ``path`` indices with soft-strict drift handling.
+
+    Args:
+        data: Nested list/tuple structure (typically a decoded RPC payload).
+        *path: Sequence of integer indices to descend.
+        method_id: RPC method ID (for diagnostics on drift).
+        source: Caller label identifying where the drift was observed
+            (e.g. ``"_notebooks.list"``); included in logs and the raised
+            exception's ``source`` attribute.
+
+    Returns:
+        The value at ``data[path[0]][path[1]]...`` on success, or ``None`` in
+        soft mode when descent fails.
+
+    Raises:
+        UnknownRPCMethodError: When ``NOTEBOOKLM_STRICT_DECODE`` is truthy and
+            descent fails. The exception carries ``method_id``, ``source``,
+            ``path`` (truncated to where descent stopped), and a truncated
+            ``data_at_failure`` repr.
+    """
+    current: Any = data
+    for i, key in enumerate(path):
+        try:
+            current = current[key]
+        except (IndexError, TypeError, KeyError) as exc:
+            failing_path = tuple(path[:i])
+            data_repr = _truncate(current)
+            if is_strict_decode_enabled():
+                raise UnknownRPCMethodError(
+                    f"safe_index drift at path {failing_path}[{key}] "
+                    f"(method_id={method_id!r}, source={source!r})",
+                    method_id=method_id,
+                    path=failing_path,
+                    source=source,
+                    data_at_failure=data_repr,
+                ) from exc
+            logger.warning(
+                "safe_index drift at %r[%d] (method_id=%r, source=%r): %s",
+                failing_path,
+                key,
+                method_id,
+                source,
+                data_repr,
+            )
+            return None
+    return current

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -15,7 +15,9 @@ from ..exceptions import (
     RPCError,
     RPCTimeoutError,
     ServerError,
+    UnknownRPCMethodError,
 )
+from ._safe_index import safe_index
 
 # Re-export for backward compatibility (imports from notebooklm.rpc.decoder still work)
 __all__ = [
@@ -26,6 +28,7 @@ __all__ = [
     "RateLimitError",
     "ServerError",
     "ClientError",
+    "UnknownRPCMethodError",
     "RPCErrorCode",
     "get_error_message_for_code",
     "strip_anti_xssi",
@@ -33,6 +36,7 @@ __all__ = [
     "collect_rpc_ids",
     "extract_rpc_result",
     "decode_response",
+    "safe_index",
 ]
 
 logger = logging.getLogger(__name__)
@@ -485,12 +489,12 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
     if result is None and not allow_null:
         if found_ids and rpc_id not in found_ids:
             # Method ID likely changed - provide actionable error
-            raise RPCError(
+            raise UnknownRPCMethodError(
                 f"No result found for RPC ID '{rpc_id}'. "
                 f"Response contains IDs: {found_ids}. "
                 f"The RPC method ID may have changed.",
                 method_id=rpc_id,
-                found_ids=found_ids,
+                found_ids=list(found_ids),
                 raw_response=response_preview,
             )
 

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -4,11 +4,13 @@ import json
 
 import pytest
 
+from notebooklm.exceptions import DecodingError
 from notebooklm.rpc.decoder import (
     AuthError,
     ClientError,
     RateLimitError,
     RPCError,
+    UnknownRPCMethodError,
     collect_rpc_ids,
     decode_response,
     extract_rpc_result,
@@ -719,3 +721,87 @@ class TestAuthError:
         error = AuthError("Token expired", method_id="abc123")
         assert str(error) == "Token expired"
         assert error.method_id == "abc123"
+
+
+class TestUnknownRPCMethodErrorRouting:
+    """The 'requested rpc_id missing but other IDs found' branch routes to
+    ``UnknownRPCMethodError`` (a ``DecodingError`` subclass), not plain
+    ``RPCError``. Other null-result branches must keep raising ``RPCError``.
+    """
+
+    def _build_raw_missing(self) -> tuple[str, str, list[str]]:
+        """Build a response where requested ID is missing but another is present."""
+        requested = "OldMethodId"
+        actual = "NewMethodId"
+        inner = json.dumps([])
+        chunk = json.dumps(["wrb.fr", actual, inner, None, None])
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+        return raw, requested, [actual]
+
+    def test_missing_id_raises_unknown_rpc_method_error(self):
+        raw, requested, found = self._build_raw_missing()
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            decode_response(raw, requested)
+        err = exc_info.value
+        assert err.method_id == requested
+        assert err.found_ids == found
+        # raw_response must match the legacy RPCError preview semantics.
+        assert err.raw_response is not None
+        assert isinstance(err.raw_response, str)
+        # Message text unchanged.
+        assert "may have changed" in str(err)
+        assert requested in str(err)
+
+    def test_unknown_method_error_catchable_as_rpc_error(self):
+        raw, requested, _ = self._build_raw_missing()
+        with pytest.raises(RPCError):
+            decode_response(raw, requested)
+
+    def test_unknown_method_error_catchable_as_decoding_error(self):
+        raw, requested, _ = self._build_raw_missing()
+        with pytest.raises(DecodingError):
+            decode_response(raw, requested)
+
+    def test_unknown_method_error_catchable_as_specific_type(self):
+        raw, requested, _ = self._build_raw_missing()
+        with pytest.raises(UnknownRPCMethodError):
+            decode_response(raw, requested)
+
+    def test_status_code_branch_still_plain_rpc_error(self):
+        """Negative test: status-code [13] branch must NOT reroute."""
+        rpc_id = RPCMethod.GET_NOTEBOOK.value
+        chunk = json.dumps(["wrb.fr", rpc_id, None, None, None, [13], "generic"])
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, rpc_id)
+        # Must be plain RPCError (or ClientError for 5/7), but NEVER UnknownRPCMethodError.
+        assert not isinstance(exc_info.value, UnknownRPCMethodError)
+
+    def test_null_result_branch_still_plain_rpc_error(self):
+        """Negative test: null-result-no-status branch must NOT reroute."""
+        rpc_id = RPCMethod.GET_NOTEBOOK.value
+        chunk = json.dumps(["wrb.fr", rpc_id, None, None, None, None])
+        raw = f")]}}'\n{len(chunk)}\n{chunk}\n"
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, rpc_id)
+        assert not isinstance(exc_info.value, UnknownRPCMethodError)
+
+    def test_no_rpc_data_branch_still_plain_rpc_error(self):
+        """Negative test: empty-chunks branch must NOT reroute."""
+        raw = ")]}'\n"
+        with pytest.raises(RPCError) as exc_info:
+            decode_response(raw, "AnyId")
+        assert not isinstance(exc_info.value, UnknownRPCMethodError)
+
+    def test_preserves_byte_for_byte_payload_of_legacy_branch(self):
+        """raw_response, method_id, and found_ids match legacy RPCError shape."""
+        raw, requested, found = self._build_raw_missing()
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            decode_response(raw, requested)
+        err = exc_info.value
+        # Same fields legacy RPCError populated.
+        assert err.method_id == requested
+        assert err.found_ids == found
+        assert err.raw_response is not None
+        # raw_response preview cap (500 chars) preserved by the base RPCError contract.
+        assert len(err.raw_response) <= 500

--- a/tests/unit/test_safe_index.py
+++ b/tests/unit/test_safe_index.py
@@ -11,6 +11,7 @@ import logging
 
 import pytest
 
+import notebooklm.rpc as rpc_pkg
 from notebooklm.exceptions import (
     DecodingError,
     RPCError,
@@ -23,6 +24,9 @@ from notebooklm.rpc.decoder import safe_index as safe_index_via_decoder
 def test_safe_index_helper_is_reexported_via_decoder():
     """Helper is importable from both _safe_index and decoder modules."""
     assert safe_index is safe_index_via_decoder
+    # Also pinned through the rpc package namespace so all three import paths
+    # resolve to the same object.
+    assert rpc_pkg.safe_index is safe_index
 
 
 def test_happy_three_level_descent_returns_leaf():
@@ -136,3 +140,27 @@ def test_data_at_failure_is_truncated(monkeypatch):
         safe_index(huge, 0, 99, method_id="abc", source="test")
     assert exc_info.value.data_at_failure is not None
     assert len(exc_info.value.data_at_failure) <= 210  # 200 + ellipsis margin
+
+
+def test_unknown_rpc_method_error_truncates_string_raw_response():
+    """Regression: ``UnknownRPCMethodError`` must honor RPCError's 500-char cap.
+
+    Previously the subclass unconditionally reassigned ``self.raw_response``
+    after the base class truncated, bypassing the contract.
+    """
+    huge = "x" * 5000
+    err = UnknownRPCMethodError("boom", raw_response=huge)
+    assert err.raw_response is not None
+    assert isinstance(err.raw_response, str)
+    assert len(err.raw_response) == 500
+
+
+def test_unknown_rpc_method_error_preserves_non_string_raw_response():
+    """Non-string raw_response (dict/list) is preserved as-is.
+
+    The subclass widens the type to ``Any`` to support structured payloads;
+    truncation only applies to strings.
+    """
+    payload = {"chunk": ["a", "b"], "meta": {"k": "v"}}
+    err = UnknownRPCMethodError("boom", raw_response=payload)
+    assert err.raw_response is payload

--- a/tests/unit/test_safe_index.py
+++ b/tests/unit/test_safe_index.py
@@ -1,0 +1,138 @@
+"""Tests for ``notebooklm.rpc._safe_index.safe_index``.
+
+Covers happy descent, soft-mode warn-and-fallback, strict-mode raise, and
+backward-compat exception hierarchy (``except RPCError`` catches strict-mode
+errors).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from notebooklm.exceptions import (
+    DecodingError,
+    RPCError,
+    UnknownRPCMethodError,
+)
+from notebooklm.rpc._safe_index import safe_index
+from notebooklm.rpc.decoder import safe_index as safe_index_via_decoder
+
+
+def test_safe_index_helper_is_reexported_via_decoder():
+    """Helper is importable from both _safe_index and decoder modules."""
+    assert safe_index is safe_index_via_decoder
+
+
+def test_happy_three_level_descent_returns_leaf():
+    data = [[["leaf"]]]
+    result = safe_index(data, 0, 0, 0, method_id="abc", source="test")
+    assert result == "leaf"
+
+
+def test_descent_with_no_path_returns_root():
+    data = ["root"]
+    result = safe_index(data, method_id="abc", source="test")
+    assert result == ["root"]
+
+
+def test_drift_outer_index_soft_mode_returns_none_with_warning(monkeypatch, caplog):
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    data = ["only-one"]
+    with caplog.at_level(logging.WARNING, logger="notebooklm.rpc._safe_index"):
+        result = safe_index(data, 5, method_id="abc", source="test.outer")
+    assert result is None
+    assert any(
+        "safe_index drift" in record.message and record.levelno == logging.WARNING
+        for record in caplog.records
+    )
+
+
+def test_drift_inner_index_soft_mode_returns_none(monkeypatch):
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    data = [[["leaf"]]]
+    # Outer ok, inner index out of range.
+    result = safe_index(data, 0, 0, 9, method_id="abc", source="test.inner")
+    assert result is None
+
+
+def test_drift_outer_strict_mode_raises_with_attributes(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    data = ["only-one"]
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(data, 5, method_id="abc-method", source="test.outer")
+    err = exc_info.value
+    assert err.method_id == "abc-method"
+    assert err.source == "test.outer"
+    assert err.path == ()
+    assert err.data_at_failure is not None
+    assert "only-one" in err.data_at_failure
+
+
+def test_drift_strict_mode_chains_original_exception(monkeypatch):
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    data = ["only-one"]
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(data, 5, method_id="abc", source="test")
+    assert isinstance(exc_info.value.__cause__, IndexError)
+
+
+def test_descending_into_none_is_caught_and_rerouted(monkeypatch):
+    """``data[0]`` returning None then descending again triggers TypeError."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    data = [None]
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(data, 0, 0, method_id="abc", source="test.none")
+    err = exc_info.value
+    assert err.path == (0,)
+    assert isinstance(err.__cause__, TypeError)
+
+
+def test_descending_into_int_is_caught_and_rerouted(monkeypatch):
+    """Indexing an int raises TypeError, which safe_index catches."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    data = [42]
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(data, 0, 0, method_id="abc", source="test.int")
+    assert isinstance(exc_info.value.__cause__, TypeError)
+
+
+def test_strict_mode_exception_is_catchable_as_rpc_error(monkeypatch):
+    """Backward compat: ``except RPCError`` still catches strict-mode raise."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    data = []
+    try:
+        safe_index(data, 0, method_id="abc", source="test")
+    except RPCError as e:
+        assert isinstance(e, UnknownRPCMethodError)
+        assert isinstance(e, DecodingError)
+    else:
+        pytest.fail("Expected RPCError to be raised")
+
+
+def test_strict_mode_truthy_values(monkeypatch):
+    """``true`` and ``True`` should also enable strict mode."""
+    for value in ("1", "true", "True"):
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", value)
+        with pytest.raises(UnknownRPCMethodError):
+            safe_index([], 0, method_id="abc", source="test")
+
+
+def test_strict_mode_falsy_values(monkeypatch, caplog):
+    """``0``, unset, and arbitrary strings should keep soft mode."""
+    for value in ("0", "no", "false", ""):
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", value)
+        with caplog.at_level(logging.WARNING, logger="notebooklm.rpc._safe_index"):
+            result = safe_index([], 0, method_id="abc", source="test")
+        assert result is None
+
+
+def test_data_at_failure_is_truncated(monkeypatch):
+    """Repr is truncated to ~200 chars to avoid blowing up logs/exceptions."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    huge = [["x" * 5000]]
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        safe_index(huge, 0, 99, method_id="abc", source="test")
+    assert exc_info.value.data_at_failure is not None
+    assert len(exc_info.value.data_at_failure) <= 210  # 200 + ellipsis margin


### PR DESCRIPTION
## Summary
- Adds `safe_index(data, *path, method_id, source)` shared helper for typed schema-drift handling
- Reroutes `decoder.py:486-494` "requested rpc_id missing" branch from `RPCError` to typed `UnknownRPCMethodError`
- Extends `UnknownRPCMethodError` with structured attributes (`method_id`, `path`, `source`, `found_ids`, `raw_response`, `data_at_failure`)
- Introduces `NOTEBOOKLM_STRICT_DECODE` env-var for soft-rollout (default `0` = warn-and-fallback this release; flip to `1` next release)

## Why
Foundation for Tier 1 strictness migrations (PR-T1.B1/B2). Synthesis §1 T1 + T6: schema drift currently swallowed silently. `UnknownRPCMethodError` was defined but never raised. Soft-rollout knob protects against undocumented Google response wobble (§8).

## Test plan
- [x] `safe_index` happy/drift paths under both env-var modes
- [x] Decoder reroute preserves `found_ids`/`raw_response` exactly
- [x] Backward compat: `except RPCError` still catches
- [x] Status-code branches still raise plain `RPCError` (no over-broad reroute)

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NOTEBOOKLM_STRICT_DECODE to control decoder strictness: default warns and returns None on schema drift; strict (`1`/`true`) raises a detailed decode error with contextual fields.

* **Documentation**
  * Added docs describing decoder strictness and the environment variable.

* **Tests**
  * Added comprehensive tests for error routing and safe indexing behavior in both soft and strict modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/448)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->