### PR TITLE
fix(auth): atomic storage_state.json writes (T1.H2)

### DIFF
--- a/src/notebooklm/_atomic_io.py
+++ b/src/notebooklm/_atomic_io.py
@@ -55,7 +55,7 @@ def atomic_write_json(path: Path, data: Any, *, mode: int = 0o600) -> None:
             # partial temp files would leak into the storage parent dir on
             # every failed save attempt.
             temp_path = Path(temp_file.name)
-            temp_file.write(json.dumps(data, indent=2, ensure_ascii=False))
+            json.dump(data, temp_file, indent=2, ensure_ascii=False)
         if sys.platform != "win32":
             # chmod is a no-op on Windows (and can confuse ACLs)
             os.chmod(temp_path, mode)

--- a/src/notebooklm/_atomic_io.py
+++ b/src/notebooklm/_atomic_io.py
@@ -1,0 +1,69 @@
+"""Atomic JSON write helpers.
+
+Shared by :mod:`notebooklm.auth` and :mod:`notebooklm.cli.session` so both
+write sites for ``storage_state.json`` use the same crash- and concurrency-safe
+pattern (NamedTemporaryFile in the same directory, ``chmod 0o600``, then
+``os.replace``).
+
+Default permission mode is ``0o600`` because the primary caller writes
+Playwright storage state containing session cookies, which are credential-
+equivalent secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def atomic_write_json(path: Path, data: Any, *, mode: int = 0o600) -> None:
+    """Write ``data`` as JSON to ``path`` atomically.
+
+    Steps:
+
+    1. Serialize ``data`` to a sibling :class:`tempfile.NamedTemporaryFile` in
+       the same directory as ``path`` (same-filesystem for ``os.replace``
+       atomicity).
+    2. ``chmod`` the temp file to ``mode`` (default ``0o600`` — cookies are
+       secrets). Skipped on Windows where POSIX permissions are a no-op and
+       can confuse ACLs.
+    3. ``os.replace`` the temp file onto ``path`` (atomic on POSIX and Windows).
+    4. On any failure: unlink the temp file and re-raise.
+
+    The caller decides whether to log/swallow the exception.
+    """
+
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            # Capture temp path BEFORE write so cleanup-on-failure can still
+            # unlink it if write() raises (e.g. ENOSPC, EROFS). Without this,
+            # partial temp files would leak into the storage parent dir on
+            # every failed save attempt.
+            temp_path = Path(temp_file.name)
+            temp_file.write(json.dumps(data, indent=2, ensure_ascii=False))
+        if sys.platform != "win32":
+            # chmod is a no-op on Windows (and can confuse ACLs)
+            os.chmod(temp_path, mode)
+        os.replace(temp_path, path)
+    except Exception:
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except Exception as cleanup_err:
+                logger.debug("Failed to clean up temp file %s: %s", temp_path, cleanup_err)
+        raise

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -37,7 +37,6 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import warnings
@@ -51,6 +50,7 @@ from urllib.parse import urlencode
 
 import httpx
 
+from ._atomic_io import atomic_write_json
 from ._env import get_base_url
 from ._url_utils import contains_google_auth_redirect, is_google_auth_redirect
 from .paths import get_storage_path, resolve_profile
@@ -1807,24 +1807,8 @@ def save_cookies_to_storage(
                 return_result=return_result,
             )
 
-        temp_path: Path | None = None
         try:
-            with tempfile.NamedTemporaryFile(
-                "w",
-                encoding="utf-8",
-                dir=path.parent,
-                prefix=f".{path.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as temp_file:
-                # Capture the temp path BEFORE the write so the cleanup-on-
-                # failure branch can still unlink it if write() raises (ENOSPC,
-                # EROFS). Without this, partial temp files leak into the
-                # storage parent dir on every save attempt.
-                temp_path = Path(temp_file.name)
-                temp_file.write(json.dumps(storage_data, indent=2, ensure_ascii=False))
-            os.chmod(temp_path, 0o600)
-            temp_path.replace(path)
+            atomic_write_json(path, storage_data)
             logger.debug("Successfully synced %d refreshed cookies to %s", updated_count, path)
             # Even on a successful disk write, if any CAS arm rejected work,
             # disk diverges from ``post`` for at least one key — caller must
@@ -1835,11 +1819,6 @@ def save_cookies_to_storage(
             )
         except Exception as e:
             logger.warning("Failed to write updated cookies to %s: %s", path, e)
-            if temp_path is not None:
-                try:
-                    temp_path.unlink(missing_ok=True)
-                except Exception as cleanup_err:
-                    logger.debug("Failed to clean up temp file %s: %s", temp_path, cleanup_err)
             return _cookie_save_return(CookieSaveResult(False), return_result=return_result)
 
 

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -393,12 +393,11 @@ def _write_extracted_cookies(
 
     try:
         storage_path.parent.mkdir(parents=True, exist_ok=True)
-        storage_path.write_text(
-            json.dumps(storage_state, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
+        # Atomic write with chmod 0o600 — avoids non-atomic + world-readable
+        # window from plain write_text + post-hoc chmod.
+        atomic_write_json(storage_path, storage_state)
         if sys.platform != "win32":
             storage_path.parent.chmod(0o700)
-            storage_path.chmod(0o600)
     except OSError as e:
         logger.error("Failed to save authentication to %s: %s", storage_path, e)
         console.print(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
@@ -742,13 +741,13 @@ def _login_with_browser_cookies(
     # Create parent directory (avoid mode= on Windows to prevent ACL issues)
     try:
         storage_path.parent.mkdir(parents=True, exist_ok=True)
-        storage_path.write_text(
-            json.dumps(storage_state, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
+        # Atomic write with chmod 0o600 — avoids non-atomic + world-readable
+        # window from plain write_text + post-hoc chmod.
+        atomic_write_json(storage_path, storage_state)
         if sys.platform != "win32":
-            # On Unix: ensure both directory and file have restrictive permissions
+            # On Unix: ensure directory has restrictive permissions
+            # (atomic_write_json handles the file mode).
             storage_path.parent.chmod(0o700)
-            storage_path.chmod(0o600)
     except OSError as e:
         logger.error("Failed to save authentication to %s: %s", storage_path, e)
         console.print(f"[red]Failed to save authentication to {storage_path}.[/red]\nDetails: {e}")
@@ -1300,8 +1299,7 @@ def register_session_commands(cli):
                     raise SystemExit(1)
 
                 # Atomic write with chmod 0o600 — Playwright's path= argument
-                # writes directly (non-atomic + world-readable window). See
-                # PR-T1.H2 / audit X1 #1.
+                # writes directly (non-atomic + world-readable window).
                 state = context.storage_state()
                 atomic_write_json(storage_path, state)
                 from ..auth import clear_account_metadata

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -40,6 +40,7 @@ from ..auth import (
 )
 from ..client import NotebookLMClient
 from ..config import get_base_host, get_base_url
+from ..io import atomic_write_json
 from ..paths import (
     get_browser_profile_dir,
     get_context_path,
@@ -1298,7 +1299,11 @@ def register_session_commands(cli):
                     )
                     raise SystemExit(1)
 
-                context.storage_state(path=str(storage_path))
+                # Atomic write with chmod 0o600 — Playwright's path= argument
+                # writes directly (non-atomic + world-readable window). See
+                # PR-T1.H2 / audit X1 #1.
+                state = context.storage_state()
+                atomic_write_json(storage_path, state)
                 from ..auth import clear_account_metadata
 
                 try:
@@ -1309,10 +1314,6 @@ def register_session_commands(cli):
                         storage_path,
                         exc,
                     )
-                # Restrict permissions to owner only (contains sensitive cookies)
-                if sys.platform != "win32":
-                    # chmod is a no-op on Windows (and can confuse ACLs)
-                    storage_path.chmod(0o600)
 
             except Exception as e:
                 # Handle browser launch errors specially (context will be None if launch failed)

--- a/src/notebooklm/io.py
+++ b/src/notebooklm/io.py
@@ -1,0 +1,10 @@
+"""Public I/O helpers (re-exports from internal _atomic_io).
+
+Exists so :mod:`notebooklm.cli` can import :func:`atomic_write_json` without
+violating the ``cli/`` boundary rule (no ``notebooklm._*`` imports). See
+``tests/unit/test_cli_boundary.py``.
+"""
+
+from ._atomic_io import atomic_write_json
+
+__all__ = ["atomic_write_json"]

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -259,9 +259,10 @@ class TestLoginCommand:
     def mock_login_browser_with_storage(self, tmp_path):
         """Mock Playwright browser for login tests that assert exit_code == 0.
 
-        Like mock_login_browser but also makes storage_state() create the file
-        so that storage_path.chmod() succeeds. The mocked page reports it is
-        already on the NotebookLM host, so the auto-detect fast-path is taken.
+        Like mock_login_browser but also makes storage_state() return a dict
+        that the login flow can write via atomic_write_json. The mocked page
+        reports it is already on the NotebookLM host, so the auto-detect
+        fast-path is taken.
         """
         storage_file = tmp_path / "storage.json"
         with (
@@ -278,8 +279,8 @@ class TestLoginCommand:
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
             mock_context.pages = [mock_page]
-            # Make storage_state create the file so chmod succeeds
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            # storage_state() now returns a dict; atomic_write_json writes it.
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
             )
@@ -597,7 +598,7 @@ class TestLoginCommand:
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
             mock_context.pages = [mock_page]
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
             )
@@ -632,7 +633,7 @@ class TestLoginCommand:
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
             mock_context.pages = [mock_page]
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
             )
@@ -673,7 +674,7 @@ class TestLoginCommand:
             mock_page = MagicMock()
             mock_page.url = "https://notebooklm.google.com/"
             mock_context.pages = [mock_page]
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
             )
@@ -749,7 +750,7 @@ class TestLoginCommand:
             mock_context.pages = [mock_page_stale]
             # new_page() returns a working fresh page
             mock_context.new_page.return_value = mock_page_fresh
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
 
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
@@ -809,7 +810,7 @@ class TestLoginCommand:
             mock_page_stale.url = "https://notebooklm.google.com/"
             mock_context.pages = [mock_page_stale]
             mock_context.new_page.return_value = mock_page_fresh
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
 
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
@@ -863,7 +864,7 @@ class TestLoginCommand:
             )
             mock_context.pages = [mock_page_stale]
             mock_context.new_page.return_value = mock_page_recovered
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
 
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
@@ -902,7 +903,7 @@ class TestLoginCommand:
             )
             mock_context.pages = [mock_page]
             mock_context.new_page.return_value = mock_page  # new pages also fail
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
 
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context
@@ -961,7 +962,7 @@ class TestLoginCommand:
             )
             mock_context.pages = [mock_page_stale]
             mock_context.new_page.return_value = mock_page_recovered
-            mock_context.storage_state.side_effect = lambda path: Path(path).write_text("{}")
+            mock_context.storage_state.return_value = {"cookies": [], "origins": []}
 
             mock_launch = (
                 mock_pw.return_value.__enter__.return_value.chromium.launch_persistent_context

--- a/tests/unit/test_atomic_io.py
+++ b/tests/unit/test_atomic_io.py
@@ -110,7 +110,7 @@ def test_concurrent_writers_never_corrupt(tmp_path: Path) -> None:
 
 
 def test_crash_midwrite_preserves_original(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """If json.dumps raises mid-write, the pre-existing file is untouched
+    """If json.dump raises mid-write, the pre-existing file is untouched
     and no temp file is left behind in the parent dir.
     """
     target = tmp_path / "state.json"
@@ -126,7 +126,7 @@ def test_crash_midwrite_preserves_original(tmp_path: Path, monkeypatch: pytest.M
     def explode(*args, **kwargs):  # noqa: ANN002, ANN003
         raise Boom("disk full")
 
-    monkeypatch.setattr(mod.json, "dumps", explode)
+    monkeypatch.setattr(mod.json, "dump", explode)
 
     with pytest.raises(Boom):
         atomic_write_json(target, {"new": "value"})

--- a/tests/unit/test_atomic_io.py
+++ b/tests/unit/test_atomic_io.py
@@ -1,0 +1,177 @@
+"""Unit tests for :mod:`notebooklm._atomic_io` / :mod:`notebooklm.io`.
+
+Covers the contract required by both write sites (auth.py cookie sync and
+cli/session.py initial login save):
+
+- Round-trip: data written can be read back unchanged.
+- Permissions: file mode is ``0o600`` on POSIX (sensitive cookies).
+- Concurrency: simultaneous writers never produce a partial/corrupt file —
+  every observable state is valid JSON matching exactly one writer's payload.
+- Crash safety: if the write fails mid-flight, the original file is untouched
+  and no temp files leak into the parent dir.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from notebooklm._atomic_io import atomic_write_json as atomic_write_json_private
+from notebooklm.io import atomic_write_json
+
+
+def test_public_shim_is_same_callable() -> None:
+    """`notebooklm.io.atomic_write_json` must re-export the private symbol."""
+    assert atomic_write_json is atomic_write_json_private
+
+
+def test_roundtrip_dict(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    payload = {"cookies": [{"name": "SID", "value": "abc"}], "origins": []}
+    atomic_write_json(target, payload)
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_roundtrip_list(tmp_path: Path) -> None:
+    target = tmp_path / "list.json"
+    payload = [1, 2, {"x": "y"}]
+    atomic_write_json(target, payload)
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_roundtrip_unicode_preserved(tmp_path: Path) -> None:
+    target = tmp_path / "u.json"
+    payload = {"city": "Zürich", "emoji": "naïve"}
+    atomic_write_json(target, payload)
+    # ensure_ascii=False is part of the contract (matches auth.py legacy)
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission semantics")
+def test_chmod_0o600(tmp_path: Path) -> None:
+    target = tmp_path / "secret.json"
+    atomic_write_json(target, {"k": "v"})
+    assert target.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission semantics")
+def test_chmod_override(tmp_path: Path) -> None:
+    target = tmp_path / "rw.json"
+    atomic_write_json(target, {"k": "v"}, mode=0o644)
+    assert target.stat().st_mode & 0o777 == 0o644
+
+
+def test_overwrites_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    target.write_text(json.dumps({"old": True}), encoding="utf-8")
+    atomic_write_json(target, {"new": True})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"new": True}
+
+
+def test_concurrent_writers_never_corrupt(tmp_path: Path) -> None:
+    """Two threads racing on the same path must always leave a valid JSON
+    file matching one of the writers' payloads (no partial / interleaved bytes).
+    """
+    target = tmp_path / "race.json"
+    payload_a = {"who": "A", "filler": "a" * 256}
+    payload_b = {"who": "B", "filler": "b" * 256}
+
+    barrier = threading.Barrier(2)
+
+    def write(payload: dict) -> None:
+        barrier.wait()
+        for _ in range(50):
+            atomic_write_json(target, payload)
+
+    threads = [
+        threading.Thread(target=write, args=(payload_a,)),
+        threading.Thread(target=write, args=(payload_b,)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Final state: file exists, parses as JSON, matches one of the payloads.
+    raw = target.read_text(encoding="utf-8")
+    parsed = json.loads(raw)
+    assert parsed in (payload_a, payload_b)
+
+    # No leftover temp files in the parent dir (NamedTemporaryFile uses
+    # ".<name>.*.tmp" prefix). os.replace is atomic, so a successful run
+    # cleans up after itself; a leak here would mean a temp file survived.
+    leaked = list(tmp_path.glob(f".{target.name}.*.tmp"))
+    assert not leaked, f"leaked temp files: {leaked}"
+
+
+def test_crash_midwrite_preserves_original(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If json.dumps raises mid-write, the pre-existing file is untouched
+    and no temp file is left behind in the parent dir.
+    """
+    target = tmp_path / "state.json"
+    original = {"original": True, "value": 42}
+    target.write_text(json.dumps(original), encoding="utf-8")
+    original_bytes = target.read_bytes()
+
+    class Boom(RuntimeError):
+        pass
+
+    import notebooklm._atomic_io as mod
+
+    def explode(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise Boom("disk full")
+
+    monkeypatch.setattr(mod.json, "dumps", explode)
+
+    with pytest.raises(Boom):
+        atomic_write_json(target, {"new": "value"})
+
+    # Original file untouched
+    assert target.read_bytes() == original_bytes
+    # No temp file leaked
+    leaked = list(tmp_path.glob(f".{target.name}.*.tmp"))
+    assert not leaked, f"leaked temp files: {leaked}"
+
+
+def test_crash_during_replace_preserves_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If os.replace itself fails, the original file stays intact and the
+    temp file is cleaned up (otherwise repeated failures leak files).
+    """
+    target = tmp_path / "state.json"
+    original = {"original": True}
+    target.write_text(json.dumps(original), encoding="utf-8")
+    original_bytes = target.read_bytes()
+
+    import notebooklm._atomic_io as mod
+
+    def boom(src, dst):  # noqa: ANN001
+        raise OSError("EXDEV-like cross-fs replace failure")
+
+    monkeypatch.setattr(mod.os, "replace", boom)
+
+    with pytest.raises(OSError, match="EXDEV-like"):
+        atomic_write_json(target, {"new": "value"})
+
+    assert target.read_bytes() == original_bytes
+    leaked = list(tmp_path.glob(f".{target.name}.*.tmp"))
+    assert not leaked, f"leaked temp files: {leaked}"
+
+
+def test_temp_file_uses_target_directory(tmp_path: Path) -> None:
+    """Temp file must live next to target so os.replace is same-filesystem
+    (atomic). Verified indirectly: a write into a sub-dir succeeds.
+    """
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    target = sub / "state.json"
+    atomic_write_json(target, {"k": "v"})
+    assert target.exists()
+    # Parent dir is the one we asked for
+    assert target.parent == sub

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -720,7 +720,7 @@ class TestSaveReturnsBoolSuccess:
             return handle
 
         monkeypatch.setattr(tempfile, "NamedTemporaryFile", boom_namedtemp)
-        monkeypatch.setattr("notebooklm.auth.tempfile.NamedTemporaryFile", boom_namedtemp)
+        monkeypatch.setattr("notebooklm._atomic_io.tempfile.NamedTemporaryFile", boom_namedtemp)
 
         assert save_cookies_to_storage(jar, storage, original_snapshot=snapshot) is False
         # And the original on-disk value must still be intact.
@@ -1211,7 +1211,7 @@ class TestNoTempFileLeakOnWriteFailure:
             handle.write = lambda *a, **k: (_ for _ in ()).throw(OSError("simulated ENOSPC"))
             return handle
 
-        monkeypatch.setattr("notebooklm.auth.tempfile.NamedTemporaryFile", boom_namedtemp)
+        monkeypatch.setattr("notebooklm._atomic_io.tempfile.NamedTemporaryFile", boom_namedtemp)
 
         save_cookies_to_storage(jar, storage, original_snapshot=snapshot)
 


### PR DESCRIPTION
## Summary
- Adds `notebooklm.io.atomic_write_json` (NamedTemporaryFile + chmod + os.replace)
- Routes both write sites through it: `auth.py:1812-1827` (existing pattern, now shared) and `cli/session.py:1301` (was non-atomic)
- Concurrency test: two threads writing simultaneously produce valid JSON every time

## Why
Audit X1 / codex #1 / synthesis T5: initial Playwright save was non-atomic, leaving cookies briefly world-readable or risking partial writes under concurrent CLI invocations.

## Test plan
- [x] chmod 0o600 verified after write
- [x] Concurrent two-thread test
- [x] Crash-mid-write does not corrupt original file
- [x] `test_cli_boundary.py` still passes (no new private-module imports in cli/)

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of authentication state persistence through atomic file operations, preventing data corruption during writes.
  * Enhanced security with restrictive file permissions on authentication storage files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/449)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->