### PR TITLE
fix(cli): route status prints to stderr in --json mode (T1.E)

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -87,7 +87,7 @@ def artifact_list(ctx, notebook_id, artifact_type, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             # artifacts.list() already includes mind maps from notes system
             artifacts = await client.artifacts.list(nb_id_resolved, artifact_type=type_filter)
 
@@ -353,8 +353,10 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            resolved_id = await resolve_artifact_id(client, nb_id_resolved, artifact_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            resolved_id = await resolve_artifact_id(
+                client, nb_id_resolved, artifact_id, json_output=json_output
+            )
 
             try:
                 status = await client.artifacts.wait_for_completion(
@@ -415,12 +417,8 @@ def artifact_suggestions(ctx, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             suggestions = await client.artifacts.suggest_reports(nb_id_resolved)
-
-            if not suggestions:
-                console.print("[yellow]No suggestions available[/yellow]")
-                return
 
             if json_output:
                 data = [
@@ -428,6 +426,10 @@ def artifact_suggestions(ctx, notebook_id, json_output, client_auth):
                     for s in suggestions
                 ]
                 json_output_response(data)
+                return
+
+            if not suggestions:
+                console.print("[yellow]No suggestions available[/yellow]")
                 return
 
             table = Table(title="Suggested Reports")

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -151,7 +151,7 @@ def register_chat_commands(cli):
 
         async def _run():
             async with NotebookLMClient(client_auth, **client_kwargs) as client:
-                nb_id_resolved = await resolve_notebook_id(client, nb_id)
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
                 effective_conv_id = _determine_conversation_id(
                     explicit_conversation_id=conversation_id,
                     explicit_notebook_id=notebook_id,
@@ -168,7 +168,9 @@ def register_chat_commands(cli):
                     if effective_conv_id:
                         resumed_from_server = True
 
-                sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+                sources = await resolve_source_ids(
+                    client, nb_id_resolved, source_ids, json_output=json_output
+                )
                 result = await client.chat.ask(
                     nb_id_resolved,
                     question,
@@ -358,7 +360,7 @@ def register_chat_commands(cli):
                     return
 
                 nb_id = require_notebook(notebook_id)
-                nb_id_resolved = await resolve_notebook_id(client, nb_id)
+                nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
                 conv_id = await client.chat.get_conversation_id(nb_id_resolved)
                 qa_pairs = await client.chat.get_history(
                     nb_id_resolved, limit=limit, conversation_id=conv_id

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -180,7 +180,7 @@ async def _download_artifacts_generic(
 
     async def _download() -> dict[str, Any]:
         async with NotebookLMClient(auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
             # Setup download method dispatch
             download_methods: dict[str, _DownloadFn] = {

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -404,8 +404,10 @@ def generate_audio(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_audio(
@@ -535,8 +537,10 @@ def generate_video(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 if is_cinematic:
@@ -651,8 +655,10 @@ def generate_slide_deck(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_slide_deck(
@@ -727,7 +733,7 @@ def generate_revise_slide(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
             async def _generate():
                 return await client.artifacts.revise_slide(
@@ -802,8 +808,10 @@ def generate_quiz(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_quiz(
@@ -877,8 +885,10 @@ def generate_flashcards(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_flashcards(
@@ -972,8 +982,10 @@ def generate_infographic(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_infographic(
@@ -1041,8 +1053,10 @@ def generate_data_table(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_data_table(
@@ -1089,8 +1103,10 @@ def generate_mind_map(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_mind_map(
@@ -1233,8 +1249,10 @@ def generate_report_cmd(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            sources = await resolve_source_ids(client, nb_id_resolved, source_ids)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            sources = await resolve_source_ids(
+                client, nb_id_resolved, source_ids, json_output=json_output
+            )
 
             async def _generate():
                 return await client.artifacts.generate_report(

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -257,6 +257,12 @@ async def import_with_retry(
                                 f"verified {len(requested_urls_norm)} requested "
                                 f"sources — skipping retry.[/yellow]"
                             )
+                        else:
+                            logger.debug(
+                                "Import RPC timed out, but server-side verified "
+                                "%d requested sources — skipping retry (json mode).",
+                                len(requested_urls_norm),
+                            )
                         # Return only new sources that match a requested URL.
                         # No-URL new sources (research reports, pasted text)
                         # are included only if the request itself had no-URL
@@ -307,6 +313,12 @@ async def import_with_retry(
                                     "requested sources are already present — "
                                     "skipping retry.[/yellow]"
                                 )
+                            else:
+                                logger.debug(
+                                    "Import RPC timed out, but all requested "
+                                    "sources are already present — skipping retry "
+                                    "(json mode)."
+                                )
                             return _merge_imported_sources(
                                 [], verified_imported, verified_imported_ids
                             )
@@ -354,6 +366,12 @@ async def import_with_retry(
                 console.print(
                     f"[yellow]Import timed out; retrying in {sleep_for:.0f}s "
                     f"(attempt {attempt + 1})[/yellow]"
+                )
+            else:
+                logger.debug(
+                    "Import timed out; retrying in %.0fs (attempt %d) (json mode).",
+                    sleep_for,
+                    attempt + 1,
                 )
             await asyncio.sleep(sleep_for)
             delay = min(delay * backoff_factor, max_delay)

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -35,7 +35,30 @@ if TYPE_CHECKING:
     from ..types import Artifact, Source
 
 console = Console()
+# stderr_console is used for diagnostic / status output when --json mode is
+# active so that stdout stays parseable JSON for automation. See ``emit_status``.
+stderr_console = Console(stderr=True)
 logger = logging.getLogger(__name__)
+
+
+def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
+    """Emit a status / diagnostic line.
+
+    When ``json_output`` is True, the message is written to stderr via a
+    dedicated Rich console so that stdout remains pure JSON for downstream
+    automation. Otherwise the message goes through the regular stdout console.
+
+    Args:
+        msg: The message text. Rich markup is honored by both consoles.
+        json_output: True when the current command is producing JSON on stdout.
+        style: Optional Rich style to apply (e.g., ``"yellow"``, ``"dim"``).
+    """
+    target = stderr_console if json_output else console
+    if style is not None:
+        target.print(msg, style=style)
+    else:
+        target.print(msg)
+
 
 # CLI artifact type name aliases
 _CLI_ARTIFACT_ALIASES = {
@@ -661,6 +684,8 @@ async def _resolve_partial_id(
     list_fn,
     entity_name: str,
     list_command: str,
+    *,
+    json_output: bool = False,
 ) -> str:
     """Generic partial ID resolver.
 
@@ -672,6 +697,8 @@ async def _resolve_partial_id(
         list_fn: Async function that returns list of items with id/title attributes
         entity_name: Name for error messages (e.g., "notebook", "source")
         list_command: CLI command to list items (e.g., "list", "source list")
+        json_output: When True, the "Matched..." diagnostic is routed to stderr
+            via ``emit_status`` so stdout stays parseable JSON.
 
     Returns:
         Full ID of the matched item
@@ -692,7 +719,10 @@ async def _resolve_partial_id(
     if len(matches) == 1:
         if matches[0].id != partial_id:
             title = matches[0].title or "(untitled)"
-            console.print(f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]")
+            emit_status(
+                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
+                json_output=json_output,
+            )
         return matches[0].id
     elif len(matches) == 0:
         raise click.ClickException(
@@ -710,48 +740,78 @@ async def _resolve_partial_id(
         raise click.ClickException("\n".join(lines))
 
 
-async def resolve_notebook_id(client, partial_id: str) -> str:
-    """Resolve partial notebook ID to full ID."""
+async def resolve_notebook_id(client, partial_id: str, *, json_output: bool = False) -> str:
+    """Resolve partial notebook ID to full ID.
+
+    When ``json_output`` is True, the "Matched..." diagnostic for a successful
+    partial match is routed to stderr so stdout stays parseable JSON.
+    """
     return await _resolve_partial_id(
         partial_id,
         list_fn=lambda: client.notebooks.list(),
         entity_name="notebook",
         list_command="list",
+        json_output=json_output,
     )
 
 
-async def resolve_source_id(client, notebook_id: str, partial_id: str) -> str:
-    """Resolve partial source ID to full ID."""
+async def resolve_source_id(
+    client, notebook_id: str, partial_id: str, *, json_output: bool = False
+) -> str:
+    """Resolve partial source ID to full ID.
+
+    When ``json_output`` is True, the "Matched..." diagnostic for a successful
+    partial match is routed to stderr so stdout stays parseable JSON.
+    """
     return await _resolve_partial_id(
         partial_id,
         list_fn=lambda: client.sources.list(notebook_id),
         entity_name="source",
         list_command="source list",
+        json_output=json_output,
     )
 
 
-async def resolve_artifact_id(client, notebook_id: str, partial_id: str) -> str:
-    """Resolve partial artifact ID to full ID."""
+async def resolve_artifact_id(
+    client, notebook_id: str, partial_id: str, *, json_output: bool = False
+) -> str:
+    """Resolve partial artifact ID to full ID.
+
+    When ``json_output`` is True, the "Matched..." diagnostic for a successful
+    partial match is routed to stderr so stdout stays parseable JSON.
+    """
     return await _resolve_partial_id(
         partial_id,
         list_fn=lambda: client.artifacts.list(notebook_id),
         entity_name="artifact",
         list_command="artifact list",
+        json_output=json_output,
     )
 
 
-async def resolve_note_id(client, notebook_id: str, partial_id: str) -> str:
-    """Resolve partial note ID to full ID."""
+async def resolve_note_id(
+    client, notebook_id: str, partial_id: str, *, json_output: bool = False
+) -> str:
+    """Resolve partial note ID to full ID.
+
+    When ``json_output`` is True, the "Matched..." diagnostic for a successful
+    partial match is routed to stderr so stdout stays parseable JSON.
+    """
     return await _resolve_partial_id(
         partial_id,
         list_fn=lambda: client.notes.list(notebook_id),
         entity_name="note",
         list_command="note list",
+        json_output=json_output,
     )
 
 
 async def resolve_source_ids(
-    client, notebook_id: str, source_ids: tuple[str, ...]
+    client,
+    notebook_id: str,
+    source_ids: tuple[str, ...],
+    *,
+    json_output: bool = False,
 ) -> list[str] | None:
     """Resolve multiple partial source IDs to full IDs.
 
@@ -759,6 +819,8 @@ async def resolve_source_ids(
         client: NotebookLM client
         notebook_id: Resolved notebook ID
         source_ids: Tuple of partial source IDs from CLI
+        json_output: When True, "Matched..." diagnostics for partial matches
+            are routed to stderr so stdout stays parseable JSON.
 
     Returns:
         List of resolved source IDs, or None if no source IDs provided
@@ -767,7 +829,7 @@ async def resolve_source_ids(
         return None
     resolved = []
     for sid in source_ids:
-        resolved.append(await resolve_source_id(client, notebook_id, sid))
+        resolved.append(await resolve_source_id(client, notebook_id, sid, json_output=json_output))
     return resolved
 
 

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -60,7 +60,7 @@ def note_list(ctx, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             notes = await client.notes.list(nb_id_resolved)
 
             if json_output:

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -260,7 +260,9 @@ def register_notebook_commands(cli):
         async def _run():
             async with NotebookLMClient(client_auth) as client:
                 # Resolve partial ID
-                resolved_id = await resolve_notebook_id(client, notebook_id)
+                resolved_id = await resolve_notebook_id(
+                    client, notebook_id, json_output=json_output
+                )
 
                 # Get metadata (use notebooks.get_metadata)
                 metadata = await client.notebooks.get_metadata(resolved_id)

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -68,7 +68,7 @@ def research_status(ctx, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             status = await client.research.poll(nb_id_resolved)
 
             if json_output:
@@ -148,19 +148,21 @@ def research_wait(
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             max_iterations = max(1, timeout // interval)
             status = None
             task_id = None
 
-            with console.status("Waiting for research to complete..."):
+            async def _poll_loop() -> bool:
+                """Poll until completion or terminal state; returns True on success."""
+                nonlocal status, task_id
                 for _ in range(max_iterations):
                     status = await client.research.poll(nb_id_resolved)
                     status_val = status.get("status", "unknown")
 
                     if status_val == "completed":
                         task_id = status.get("task_id")
-                        break
+                        return True
                     elif status_val == "no_research":
                         if json_output:
                             json_output_response(
@@ -171,16 +173,24 @@ def research_wait(
                         raise SystemExit(1)
 
                     await asyncio.sleep(interval)
-                else:
-                    if json_output:
-                        json_output_response(
-                            {"status": "timeout", "error": f"Timed out after {timeout}s"}
-                        )
-                    else:
-                        console.print(f"[yellow]Timed out after {timeout} seconds[/yellow]")
-                    raise SystemExit(1)
 
-            # Research completed
+                if json_output:
+                    json_output_response(
+                        {"status": "timeout", "error": f"Timed out after {timeout}s"}
+                    )
+                else:
+                    console.print(f"[yellow]Timed out after {timeout} seconds[/yellow]")
+                raise SystemExit(1)
+
+            if json_output:
+                await _poll_loop()
+            else:
+                with console.status("Waiting for research to complete..."):
+                    await _poll_loop()
+
+            # Research completed — _poll_loop either populated `status` or
+            # raised SystemExit, so a non-None status is guaranteed here.
+            assert status is not None
             sources = status.get("sources", [])
             query = status.get("query", "")
 

--- a/src/notebooklm/cli/share.py
+++ b/src/notebooklm/cli/share.py
@@ -89,7 +89,7 @@ def share_status(ctx, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id)
+            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
             status = await client.sharing.get_status(resolved_id)
 
             if json_output:
@@ -172,7 +172,7 @@ def share_public(ctx, notebook_id, enable, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id)
+            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
             status = await client.sharing.set_public(resolved_id, enable)
 
             if json_output:
@@ -225,7 +225,7 @@ def share_view_level(ctx, level, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id)
+            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
             status = await client.sharing.set_view_level(resolved_id, view_level)
 
             if json_output:
@@ -281,7 +281,7 @@ def share_add(ctx, email, notebook_id, permission, no_notify, message, json_outp
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id)
+            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
             await client.sharing.add_user(
                 resolved_id,
                 email,
@@ -340,7 +340,7 @@ def share_update(ctx, email, notebook_id, permission, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id)
+            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
             await client.sharing.update_user(resolved_id, email, perm)
 
             if json_output:
@@ -381,7 +381,7 @@ def share_remove(ctx, email, notebook_id, yes, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            resolved_id = await resolve_notebook_id(client, nb_id)
+            resolved_id = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
             # Confirm after resolution so user sees context
             if not yes and not json_output:

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -30,6 +30,7 @@ from .helpers import (
     console,
     display_report,
     display_research_sources,
+    emit_status,
     get_source_type_display,
     import_research_sources,
     json_output_response,
@@ -185,11 +186,16 @@ def _looks_like_full_source_id(source_id: str) -> bool:
     )
 
 
-async def _resolve_source_for_delete(client, notebook_id: str, source_id: str) -> str:
+async def _resolve_source_for_delete(
+    client, notebook_id: str, source_id: str, *, json_output: bool = False
+) -> str:
     """Resolve a source ID for delete, returning the full source ID string.
 
     Canonical UUIDs take a fast path and skip the live source list lookup.
     Partial IDs are resolved against the live list.
+
+    When ``json_output`` is True, the "Matched..." diagnostic for a successful
+    partial match is routed to stderr so stdout stays parseable JSON.
     """
     source_id = validate_id(source_id, "source")
     if _looks_like_full_source_id(source_id):
@@ -201,7 +207,10 @@ async def _resolve_source_for_delete(client, notebook_id: str, source_id: str) -
     if len(matches) == 1:
         if matches[0].id != source_id:
             title = matches[0].title or "(untitled)"
-            console.print(f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]")
+            emit_status(
+                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
+                json_output=json_output,
+            )
         return matches[0].id
 
     if len(matches) > 1:
@@ -264,7 +273,7 @@ def source_list(ctx, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             sources = await client.sources.list(nb_id_resolved)
             nb = None
             if json_output:
@@ -386,7 +395,7 @@ def source_add(
 
     async def _run():
         async with NotebookLMClient(client_auth, **client_kwargs) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
             if detected_type == "url" or detected_type == "youtube":
                 src = await client.sources.add_url(nb_id_resolved, content)
             elif detected_type == "text":
@@ -798,13 +807,21 @@ def source_fulltext(ctx, source_id, notebook_id, json_output, output, output_for
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            resolved_id = await resolve_source_id(client, nb_id_resolved, source_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            resolved_id = await resolve_source_id(
+                client, nb_id_resolved, source_id, json_output=json_output
+            )
 
-            with console.status("Fetching fulltext content..."):
-                fulltext = await client.sources.get_fulltext(
+            async def _fetch():
+                return await client.sources.get_fulltext(
                     nb_id_resolved, resolved_id, output_format=output_format
                 )
+
+            if json_output:
+                fulltext = await _fetch()
+            else:
+                with console.status("Fetching fulltext content..."):
+                    fulltext = await _fetch()
 
             if json_output:
                 from dataclasses import asdict
@@ -864,11 +881,19 @@ def source_guide(ctx, source_id, notebook_id, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            resolved_id = await resolve_source_id(client, nb_id_resolved, source_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            resolved_id = await resolve_source_id(
+                client, nb_id_resolved, source_id, json_output=json_output
+            )
 
-            with console.status("Generating source guide..."):
-                guide = await client.sources.get_guide(nb_id_resolved, resolved_id)
+            async def _fetch_guide():
+                return await client.sources.get_guide(nb_id_resolved, resolved_id)
+
+            if json_output:
+                guide = await _fetch_guide()
+            else:
+                with console.status("Generating source guide..."):
+                    guide = await _fetch_guide()
 
             if json_output:
                 data = {
@@ -989,8 +1014,10 @@ def source_wait(ctx, source_id, notebook_id, timeout, json_output, client_auth):
 
     async def _run():
         async with NotebookLMClient(client_auth) as client:
-            nb_id_resolved = await resolve_notebook_id(client, nb_id)
-            resolved_id = await resolve_source_id(client, nb_id_resolved, source_id)
+            nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
+            resolved_id = await resolve_source_id(
+                client, nb_id_resolved, source_id, json_output=json_output
+            )
 
             if not json_output:
                 console.print(f"[dim]Waiting for source {resolved_id}...[/dim]")

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -13,6 +13,7 @@ that exposes a ``--json`` flag so future regressions surface immediately.
 from __future__ import annotations
 
 import json
+from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -41,7 +42,7 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def mock_auth_env():
+def mock_auth_env() -> Generator[None, None, None]:
     """Stub auth loading + token fetch so --json paths run offline."""
     with (
         patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
@@ -228,9 +229,68 @@ def _customize_share_view_level(client: MagicMock) -> None:
     client.sharing.set_view_level = AsyncMock(return_value=_stub_share_status())
 
 
+def _customize_source_fulltext(client: MagicMock) -> None:
+    # source fulltext --json calls asdict() on the result, so return a real
+    # SourceFulltext dataclass instance (not a MagicMock).
+    from notebooklm.types import SourceFulltext
+
+    client.sources.get_fulltext = AsyncMock(
+        return_value=SourceFulltext(
+            source_id="src123def456ghi789jkl",
+            title="Source A",
+            content="some content",
+            url=None,
+            char_count=12,
+        )
+    )
+
+
+def _customize_source_guide(client: MagicMock) -> None:
+    client.sources.get_guide = AsyncMock(
+        return_value={"summary": "a summary", "keywords": ["k1", "k2"]}
+    )
+
+
+def _customize_research_wait(client: MagicMock) -> None:
+    # research wait polls until status == "completed". Return a completed
+    # payload immediately so the loop exits on the first iteration.
+    client.research.poll = AsyncMock(
+        return_value={
+            "status": "completed",
+            "sources": [],
+            "query": "",
+            "report": "",
+        }
+    )
+
+
 JSON_COMMANDS: list[tuple[str, list[str], object]] = [
     # source group
     ("source_list", ["source", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
+    (
+        "source_fulltext",
+        [
+            "source",
+            "fulltext",
+            "src123def456ghi789jkl",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--json",
+        ],
+        _customize_source_fulltext,
+    ),
+    (
+        "source_guide",
+        [
+            "source",
+            "guide",
+            "src123def456ghi789jkl",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--json",
+        ],
+        _customize_source_guide,
+    ),
     # artifact group
     ("artifact_list", ["artifact", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
     (
@@ -240,6 +300,11 @@ JSON_COMMANDS: list[tuple[str, list[str], object]] = [
     ),
     # research group
     ("research_status", ["research", "status", "-n", "abc123def456ghi789jkl", "--json"], None),
+    (
+        "research_wait",
+        ["research", "wait", "-n", "abc123def456ghi789jkl", "--json"],
+        _customize_research_wait,
+    ),
     # share group
     ("share_status", ["share", "status", "-n", "abc123def456ghi789jkl", "--json"], None),
     (

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -1,0 +1,344 @@
+"""Stdout-purity contract for ``--json`` mode.
+
+Any CLI command that supports ``--json`` MUST emit nothing on stdout except
+the JSON payload, so that ``json.loads(result.stdout)`` succeeds for downstream
+automation. Diagnostic prints (status text, partial-ID "Matched..." hints,
+Rich live status) belong on stderr.
+
+This test suite locks the contract for the two known violators called out in
+audit K2 / codex #4 — and adds a parametrized sweep across every CLI command
+that exposes a ``--json`` flag so future regressions surface immediately.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.rpc.types import ShareAccess, ShareViewLevel
+from notebooklm.types import (
+    Artifact,
+    AskResult,
+    Note,
+    Notebook,
+    ShareStatus,
+    Source,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal mocks needed to keep --json paths offline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth_env():
+    """Stub auth loading + token fetch so --json paths run offline."""
+    with (
+        patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_load.return_value = {
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        mock_fetch.return_value = ("csrf_token", "session_id")
+        yield
+
+
+def _stub_notebooks() -> list[Notebook]:
+    return [
+        Notebook(
+            id="abc123def456ghi789jkl",
+            title="First Notebook",
+            created_at=datetime(2024, 1, 1),
+            is_owner=True,
+        ),
+        Notebook(
+            id="xyz789uvw456rst123mno",
+            title="Second Notebook",
+            created_at=datetime(2024, 1, 2),
+            is_owner=False,
+        ),
+    ]
+
+
+def _stub_sources() -> list[Source]:
+    return [
+        Source(id="src123def456ghi789jkl", title="Source A"),
+        Source(id="src999zzz888yyy777uvw", title="Source B"),
+    ]
+
+
+def _stub_artifacts() -> list[Artifact]:
+    # _artifact_type=1 is AUDIO in rpc/types; full coverage isn't required —
+    # we just need objects that round-trip through to-dict.
+    return [
+        Artifact(
+            id="art123def456ghi789jkl",
+            title="Artifact A",
+            _artifact_type=1,
+            status=3,
+            created_at=datetime(2024, 1, 1),
+        ),
+    ]
+
+
+def _stub_notes() -> list[Note]:
+    return [
+        Note(
+            id="note123def456ghi789jkl",
+            notebook_id="abc123def456ghi789jkl",
+            title="Note A",
+            content="content",
+        ),
+    ]
+
+
+def _stub_share_status(notebook_id: str = "abc123def456ghi789jkl") -> ShareStatus:
+    return ShareStatus(
+        notebook_id=notebook_id,
+        is_public=False,
+        access=ShareAccess.RESTRICTED,
+        view_level=ShareViewLevel.FULL_NOTEBOOK,
+        share_url=None,
+        shared_users=[],
+    )
+
+
+def _make_client(extra_setup=None) -> MagicMock:
+    """Build a single mock client that satisfies every --json command path.
+
+    The same mock is used across patches in many CLI modules — each test only
+    exercises the methods relevant to that command, so over-mocking is harmless.
+    """
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+
+    # Namespaces
+    for ns in (
+        "notebooks",
+        "sources",
+        "artifacts",
+        "chat",
+        "research",
+        "notes",
+        "sharing",
+    ):
+        setattr(client, ns, MagicMock())
+
+    # Common list/lookup stubs (resolve_*_id walks these).
+    client.notebooks.list = AsyncMock(return_value=_stub_notebooks())
+    client.notebooks.get = AsyncMock(
+        return_value=_stub_notebooks()[0],
+    )
+    client.notebooks.get_metadata = AsyncMock(
+        return_value=MagicMock(to_dict=lambda: {"id": "abc123def456ghi789jkl"})
+    )
+    client.sources.list = AsyncMock(return_value=_stub_sources())
+    client.artifacts.list = AsyncMock(return_value=_stub_artifacts())
+    client.artifacts.suggest_reports = AsyncMock(return_value=[])
+    client.notes.list = AsyncMock(return_value=_stub_notes())
+    client.research.poll = AsyncMock(return_value={"status": "no_research"})
+    client.sharing.get_status = AsyncMock(return_value=_stub_share_status())
+    client.chat.get_conversation_id = AsyncMock(return_value=None)
+    client.chat.get_history = AsyncMock(return_value=[])
+
+    if extra_setup is not None:
+        extra_setup(client)
+    return client
+
+
+def _patch_modules() -> list:
+    """Return patch objects for every cli module that constructs NotebookLMClient.
+
+    Caller does the ``with`` dance themselves so they can swap in a fresh mock
+    instance for each command invocation.
+    """
+    import importlib
+
+    modules = [
+        "notebooklm.cli.notebook",
+        "notebooklm.cli.chat",
+        "notebooklm.cli.session",
+        "notebooklm.cli.share",
+        "notebooklm.cli.source",
+        "notebooklm.cli.artifact",
+        "notebooklm.cli.research",
+        "notebooklm.cli.note",
+        "notebooklm.cli.generate",
+        "notebooklm.cli.download",
+    ]
+    return [patch.object(importlib.import_module(name), "NotebookLMClient") for name in modules]
+
+
+def _run_with_mock_client(runner: CliRunner, args: list[str], client: MagicMock):
+    """Invoke the CLI with NotebookLMClient mocked in every relevant module."""
+    patches = _patch_modules()
+    try:
+        for p in patches:
+            cls = p.start()
+            cls.return_value = client
+        return runner.invoke(cli, args, catch_exceptions=False)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+# ---------------------------------------------------------------------------
+# Sweep: every --json-enabled command must emit valid JSON on stdout.
+# ---------------------------------------------------------------------------
+
+
+# Each entry: (case_id, argv, optional client customization).
+# We keep this list curated rather than fully auto-discovered because the
+# argv shape (positional args, required flags) differs per command. Adding
+# a new --json command should fail this sweep until it lands here.
+def _customize_chat_ask(client: MagicMock) -> None:
+    client.chat.ask = AsyncMock(
+        return_value=AskResult(
+            answer="answer text",
+            conversation_id="conv-123",
+            turn_number=1,
+            is_follow_up=False,
+            references=[],
+            raw_response="",
+        )
+    )
+
+
+def _customize_share_public(client: MagicMock) -> None:
+    client.sharing.set_public = AsyncMock(return_value=_stub_share_status())
+
+
+def _customize_share_view_level(client: MagicMock) -> None:
+    client.sharing.set_view_level = AsyncMock(return_value=_stub_share_status())
+
+
+JSON_COMMANDS: list[tuple[str, list[str], object]] = [
+    # source group
+    ("source_list", ["source", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
+    # artifact group
+    ("artifact_list", ["artifact", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
+    (
+        "artifact_suggestions",
+        ["artifact", "suggestions", "-n", "abc123def456ghi789jkl", "--json"],
+        None,
+    ),
+    # research group
+    ("research_status", ["research", "status", "-n", "abc123def456ghi789jkl", "--json"], None),
+    # share group
+    ("share_status", ["share", "status", "-n", "abc123def456ghi789jkl", "--json"], None),
+    (
+        "share_public",
+        ["share", "public", "-n", "abc123def456ghi789jkl", "--enable", "--json"],
+        _customize_share_public,
+    ),
+    (
+        "share_view_level",
+        ["share", "view-level", "full", "-n", "abc123def456ghi789jkl", "--json"],
+        _customize_share_view_level,
+    ),
+    # note group
+    ("note_list", ["note", "list", "-n", "abc123def456ghi789jkl", "--json"], None),
+    # notebook group (top-level via session/notebook modules)
+    ("notebook_list", ["list", "--json"], None),
+    ("notebook_metadata", ["metadata", "-n", "abc123def456ghi789jkl", "--json"], None),
+    # session group
+    ("status_cmd", ["status", "--json"], None),
+    # chat group
+    (
+        "ask_cmd",
+        ["ask", "hi", "-n", "abc123def456ghi789jkl", "--json"],
+        _customize_chat_ask,
+    ),
+    (
+        "history_cmd",
+        ["history", "-n", "abc123def456ghi789jkl", "--json"],
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id,argv,customize",
+    JSON_COMMANDS,
+    ids=[c[0] for c in JSON_COMMANDS],
+)
+def test_json_mode_stdout_is_parseable(
+    case_id: str,
+    argv: list[str],
+    customize,
+    runner: CliRunner,
+    mock_auth_env,
+) -> None:
+    """``--json`` stdout must be a single parseable JSON document."""
+    client = _make_client(customize)
+    result = _run_with_mock_client(runner, argv, client)
+
+    assert result.exit_code == 0, (
+        f"{case_id} failed (exit={result.exit_code})\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert result.stdout.strip(), f"{case_id}: empty stdout"
+
+    # The contract: stdout is pure JSON (one document).
+    try:
+        json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"{case_id}: stdout is not valid JSON ({exc})\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Spot-check: "Matched..." partial-ID print routes to stderr in --json mode.
+# ---------------------------------------------------------------------------
+
+
+def test_matched_partial_id_goes_to_stderr_in_json_mode(runner: CliRunner, mock_auth_env) -> None:
+    """Partial-ID resolution must not corrupt --json stdout."""
+    client = _make_client()
+    # Use a partial ID ("abc") that uniquely matches the first stub notebook,
+    # so resolve_notebook_id takes the "Matched..." branch.
+    result = _run_with_mock_client(runner, ["source", "list", "-n", "abc", "--json"], client)
+
+    assert result.exit_code == 0, result.output
+    # The diagnostic line must appear on stderr — never stdout.
+    assert "Matched" in result.stderr, (
+        f"Expected 'Matched' on stderr, got stderr={result.stderr!r}, stdout={result.stdout!r}"
+    )
+    assert "Matched" not in result.stdout, (
+        f"'Matched' leaked into stdout, breaking JSON contract: {result.stdout!r}"
+    )
+    # And stdout still parses.
+    json.loads(result.stdout)
+
+
+def test_matched_partial_id_still_goes_to_stdout_in_human_mode(
+    runner: CliRunner, mock_auth_env
+) -> None:
+    """Non-JSON mode keeps the diagnostic on stdout (unchanged UX)."""
+    client = _make_client()
+    result = _run_with_mock_client(runner, ["source", "list", "-n", "abc"], client)
+
+    assert result.exit_code == 0, result.output
+    # Without --json, the diagnostic continues to flow through the normal
+    # stdout console (user-facing message).
+    assert "Matched" in result.stdout

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -219,7 +219,7 @@ def _file_contains_best_effort_after_except(filepath: Path, except_line: int) ->
 _SILENT_SITES = [
     ("cli/_firefox_containers.py", 133),
     ("cli/_firefox_containers.py", 364),
-    ("cli/helpers.py", 577),
+    ("cli/helpers.py", 596),
     ("notebooklm_cli.py", 66),
 ]
 

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -219,7 +219,7 @@ def _file_contains_best_effort_after_except(filepath: Path, except_line: int) ->
 _SILENT_SITES = [
     ("cli/_firefox_containers.py", 133),
     ("cli/_firefox_containers.py", 364),
-    ("cli/helpers.py", 555),
+    ("cli/helpers.py", 577),
     ("notebooklm_cli.py", 66),
 ]
 


### PR DESCRIPTION
## Summary
- Adds `cli.helpers.emit_status(msg, json_output=...)` — routes diagnostic prints to stderr when JSON-mode (via a module-level `stderr_console = Console(stderr=True)`).
- Sweeps every `--json` command path to plumb `json_output` through partial-ID resolution: `_resolve_partial_id`, `resolve_notebook_id`, `resolve_source_id`, `resolve_artifact_id`, `resolve_note_id`, `resolve_source_ids`, and `source._resolve_source_for_delete` — all now accept `json_output=False` keyword arg, defaulted so behavior is unchanged for non-JSON callers.
- Gates the previously-unguarded `console.status(...)` Rich-live blocks in:
  - `research wait --json` (`cli/research.py:156`)
  - `source fulltext --json` (`cli/source.py:804`)
  - `source guide --json` (`cli/source.py:870`)
- Moves the "No suggestions available" stdout print in `artifact suggestions` so `--json` always emits a JSON document (empty list when no suggestions).
- Fixed sites for the "Matched..." partial-ID diagnostic (now routed via `emit_status`):
  - `cli/helpers.py:695` — `_resolve_partial_id`
  - `cli/source.py:204` — `_resolve_source_for_delete`
- Updated call sites to forward `json_output` through resolution helpers in: `artifact.py`, `chat.py` (`ask`, `history`), `download.py` (`_download_artifacts_generic`), `generate.py` (all 10 `generate.*` commands), `note.py` (`note list`), `notebook.py` (`metadata`), `research.py` (`status`, `wait`), `share.py` (all 6 share commands), `source.py` (`list`, `add`, `fulltext`, `guide`, `wait`).
- Adds `tests/unit/test_json_stdout_purity.py`: parametrized sweep verifying `json.loads(result.stdout)` succeeds for every CLI command with `--json` (13 cases at first commit), plus a spot-check asserting the "Matched..." partial-ID diagnostic lands on stderr (never stdout) in `--json` mode and remains on stdout in human mode.
- Bumps the line number in `tests/unit/test_swallow_observability.py` (helpers.py `# best-effort:` site shifted from 555 → 577 after the new helper/imports).

## Why
Audit K2 / codex #4: automation cannot reliably parse `--json` output today because the "Matched..." partial-ID hint and Rich `console.status(...)` live blocks both land on stdout, breaking the contract that `--json` stdout = a single parseable JSON document.

## Test plan
- [x] Sweep coverage: parametrized test covers 13 `--json` commands (source list, artifact list/suggestions, research status, share status/public/view-level, note list, notebook list/metadata, status, ask, history)
- [x] "Matched..." prints verified going to stderr under `--json`
- [x] No regression in interactive-mode UX (status still prints to stdout for users)
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest tests/unit` — all green (2275 passed, 5 skipped)

Part of Tier 1 (`.sisyphus/plans/tier-1-implementation.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured CLI JSON mode is clean and machine-parseable by routing diagnostics to stderr and making ID resolution respect JSON output mode across commands.
* **Refactor**
  * Polled research/wait flow improved for clearer completion and timeout handling.
* **Tests**
  * Added tests enforcing stdout purity for --json and validating diagnostic routing between stdout/stderr.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/450)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->