### PR TITLE
feat(notebooks): strict-migrate get_summary (T1.B2)

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -8,7 +8,7 @@ from ._core import ClientCore
 from ._env import get_base_url
 from ._settings import build_get_user_settings_params, extract_account_limits
 from .exceptions import NotebookLimitError, RPCError
-from .rpc import RPCMethod
+from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, SuggestedTopic
 
 if TYPE_CHECKING:
@@ -211,21 +211,19 @@ class NotebooksAPI:
             source_path=f"/notebook/{notebook_id}",
         )
         # Response structure: [[[summary_string, ...], topics, ...]]
-        # Summary is at result[0][0][0]
-        try:
-            if result and isinstance(result, list):
-                summary = result[0][0][0]
-                return str(summary) if summary else ""
-        except (IndexError, TypeError) as e:
-            # result[0][0][0] is unguarded — except IS reachable when the
-            # summary payload shape drifts.
-            logger.warning(
-                "Summary extraction failed for notebook %s (schema drift?): %s",
-                notebook_id,
-                e,
-                exc_info=True,
-            )
-        return ""
+        # Summary is at result[0][0][0]. ``safe_index`` enforces shape under
+        # ``NOTEBOOKLM_STRICT_DECODE=1`` (raising ``UnknownRPCMethodError`` on
+        # drift) and falls back to warn-and-return-None in the default soft
+        # rollout — preserving the legacy ``""`` return.
+        summary = safe_index(
+            result,
+            0,
+            0,
+            0,
+            method_id=RPCMethod.SUMMARIZE.value,
+            source="_notebooks.get_summary",
+        )
+        return str(summary) if summary else ""
 
     async def get_description(self, notebook_id: str) -> NotebookDescription:
         """Get AI-generated summary and suggested topics for a notebook.

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -211,10 +211,6 @@ class NotebooksAPI:
             source_path=f"/notebook/{notebook_id}",
         )
         # Response structure: [[[summary_string, ...], topics, ...]]
-        # Summary is at result[0][0][0]. ``safe_index`` enforces shape under
-        # ``NOTEBOOKLM_STRICT_DECODE=1`` (raising ``UnknownRPCMethodError`` on
-        # drift) and falls back to warn-and-return-None in the default soft
-        # rollout — preserving the legacy ``""`` return.
         summary = safe_index(
             result,
             0,

--- a/tests/integration/test_get_summary_drift.py
+++ b/tests/integration/test_get_summary_drift.py
@@ -1,0 +1,115 @@
+"""Tier-1 T1.B2 — strict-mode coverage for ``NotebooksAPI.get_summary``.
+
+The site at ``_notebooks.py:get_summary`` used to swallow ``IndexError`` /
+``TypeError`` from an unguarded ``result[0][0][0]`` descent. T1.B2 migrates
+it to ``safe_index`` so:
+
+* In the default soft rollout (``NOTEBOOKLM_STRICT_DECODE`` unset), drift
+  warn-logs and the method still returns ``""`` — preserving legacy semantics
+  for the single caller at ``cli/notebook.py``.
+* With ``NOTEBOOKLM_STRICT_DECODE=1``, drift raises
+  ``UnknownRPCMethodError`` carrying ``method_id=RPCMethod.SUMMARIZE.value``
+  and ``source='_notebooks.get_summary'`` for debuggability.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._notebooks import NotebooksAPI
+from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm.rpc import RPCMethod
+
+
+def _make_api(rpc_return):
+    api = NotebooksAPI.__new__(NotebooksAPI)
+    core = MagicMock()
+    core.rpc_call = AsyncMock(return_value=rpc_return)
+    api._core = core
+    return api
+
+
+@pytest.mark.asyncio
+async def test_get_summary_happy_path_returns_string(monkeypatch):
+    """Well-formed response shape extracts the summary string."""
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    # Real shape: [[[summary_string, ...], topics, ...]]
+    api = _make_api([[["the summary text"]]])
+
+    summary = await api.get_summary("nb_happy")
+
+    assert summary == "the summary text"
+
+
+@pytest.mark.asyncio
+async def test_get_summary_happy_path_also_holds_under_strict(monkeypatch):
+    """Strict mode must not penalize valid payloads."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    api = _make_api([[["the summary text"]]])
+
+    summary = await api.get_summary("nb_happy_strict")
+
+    assert summary == "the summary text"
+
+
+@pytest.mark.asyncio
+async def test_get_summary_drift_soft_mode_returns_empty_with_warning(monkeypatch, caplog):
+    """Default soft mode: drift returns ``""`` and emits a warn-level log.
+
+    Preserves legacy CLI behavior — ``description.summary`` truthiness check
+    at ``cli/notebook.py:213`` continues to work without spurious errors.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    # result[0] is an empty list → result[0][0] raises IndexError.
+    api = _make_api([[]])
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm"):
+        summary = await api.get_summary("nb_drift_soft")
+
+    assert summary == ""
+    drift_warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "safe_index drift" in r.message
+    ]
+    assert drift_warnings, (
+        f"expected safe_index drift warning, got: {[r.message for r in caplog.records]}"
+    )
+    # The warning carries the call-site label so log readers can locate the
+    # offending decoder without a stack trace.
+    assert any("_notebooks.get_summary" in r.message for r in drift_warnings)
+
+
+@pytest.mark.asyncio
+async def test_get_summary_drift_strict_mode_raises_typed_error(monkeypatch):
+    """Strict mode: drift raises ``UnknownRPCMethodError`` with context."""
+    monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+    api = _make_api([[]])
+
+    with pytest.raises(UnknownRPCMethodError) as exc_info:
+        await api.get_summary("nb_drift_strict")
+
+    err = exc_info.value
+    assert err.method_id == RPCMethod.SUMMARIZE.value
+    assert err.source == "_notebooks.get_summary"
+    # Descent succeeded for result[0]; failure landed at the next hop.
+    assert err.path == (0,)
+    assert err.data_at_failure is not None
+
+
+@pytest.mark.asyncio
+async def test_get_summary_falsy_summary_returns_empty(monkeypatch):
+    """A None/empty summary at the expected path returns ``""``.
+
+    Distinguishes "drift" (shape mismatch) from "empty value" (valid shape,
+    nothing to surface) — both produce ``""`` but only the former logs.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+    api = _make_api([[[None]]])
+
+    summary = await api.get_summary("nb_empty_value")
+
+    assert summary == ""

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -86,7 +86,7 @@ class TestNotebooksAPI:
         """Get notebook summary."""
         async with vcr_client() as client:
             summary = await client.notebooks.get_summary(READONLY_NOTEBOOK_ID)
-        assert summary is not None
+        assert isinstance(summary, str)
 
     @pytest.mark.vcr
     @pytest.mark.asyncio

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -99,9 +99,17 @@ def test_qa_pairs_warns_on_unguarded_shape(caplog):
 
 
 @pytest.mark.asyncio
-async def test_summary_warns_on_indexerror_drift(caplog):
-    """_notebooks.py: summary extraction warns when result[0][0][0] raises."""
+async def test_summary_warns_on_indexerror_drift(caplog, monkeypatch):
+    """_notebooks.py: summary extraction warns when result[0][0][0] raises.
+
+    Tier-1 T1.B2 migrated this site to ``safe_index``; the warning message
+    now comes from ``notebooklm.rpc._safe_index`` and carries the call-site
+    label ``source='_notebooks.get_summary'`` instead of the notebook id.
+    """
     from notebooklm._notebooks import NotebooksAPI
+
+    # Pin soft mode so safe_index warns instead of raising.
+    monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
 
     api = NotebooksAPI.__new__(NotebooksAPI)
     mock_core = MagicMock()
@@ -115,7 +123,10 @@ async def test_summary_warns_on_indexerror_drift(caplog):
         summary = await api.get_summary("nb_summary")
 
     assert summary == ""
-    assert any("schema drift" in r.message and "nb_summary" in r.message for r in caplog.records)
+    assert any(
+        "safe_index drift" in r.message and "_notebooks.get_summary" in r.message
+        for r in caplog.records
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Migrates `NotebooksAPI.get_summary` to use `safe_index` (added in T1.A).
- Soft-strict mode (default) preserves the legacy `""` return on drift; strict mode (`NOTEBOOKLM_STRICT_DECODE=1`) raises typed `UnknownRPCMethodError` with `method_id=RPCMethod.SUMMARIZE.value` and `source='_notebooks.get_summary'`.
- Removes the ad-hoc `try/except (IndexError, TypeError)` + "schema drift?" warning — `safe_index` provides equivalent logging on the soft path.

## Caller audit
- `src/notebooklm/cli/notebook.py:213-215` — `if description and description.summary: console.print(description.summary)`. Truthiness check tolerates `""` (soft mode) and surfaces strict-mode errors via the CLI's standard `UnknownRPCMethodError` handler.
- No background tasks. No `asyncio.gather`. Safe to migrate without coordinator work.
- Tests touching this site (`test_swallow_observability.py:115`, `test_vcr_comprehensive.py:84`, `test_types.py`) updated where needed; `test_types.py` was unaffected (tests `NotebookDescription.from_api_response` directly).

## History scan
`git log -S "summary = result" -- src/notebooklm/_notebooks.py` surfaces two relevant commits:
- `6a6e1a9` (#150, 2 months ago — "fix(notebooks): correct SUMMARIZE response parsing"): introduced the unguarded `result[0][0][0]` access wrapped in a silent `try/except (IndexError, TypeError): pass`.
- `90d1b3c` (#431, Phase 1 observability): replaced the silent `pass` with `logger.warning("Summary extraction failed ... schema drift?")` but kept the swallowing behavior.

T1.B2 is the third and final iteration on this site: same swallowing semantics under soft default, but now with a typed-strict path and a single shared helper.

## Test plan
- [x] Happy path returns string (soft and strict modes).
- [x] Drift under soft mode → returns `""` + `safe_index drift` warning logged with `source='_notebooks.get_summary'`.
- [x] Drift under strict mode → raises `UnknownRPCMethodError` with `method_id=RPCMethod.SUMMARIZE.value`, `source='_notebooks.get_summary'`, `path=(0,)`.
- [x] Falsy summary at valid path still returns `""` (no warning).
- [x] Existing `notebooks_get_summary.yaml` VCR happy path passes under both modes.
- [x] `ruff format`, `ruff check`, `mypy src/notebooklm`, `pytest tests/unit` (2,341 passed), `pytest tests/integration` (589 passed) all clean.

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md). Synthesis §1 T1 + §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of notebook summary extraction to better handle malformed responses and edge cases.

* **Tests**
  * Added integration tests covering various summary handling scenarios and error conditions.
  * Updated unit tests to validate improved error handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/451)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->