### PR TITLE
feat(artifacts): strict-migrate _parse_generation_result (T1.B1)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -993,9 +993,6 @@ class ArtifactsAPI:
                 source_path=f"/notebook/{notebook_id}",
                 allow_null=True,
             )
-            if result is None:
-                logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
-            return self._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
         except RPCError as e:
             if e.rpc_code == "USER_DISPLAYABLE_ERROR":
                 return GenerationStatus(
@@ -1005,6 +1002,13 @@ class ArtifactsAPI:
                     error_code=str(e.rpc_code) if e.rpc_code is not None else None,
                 )
             raise
+        if result is None:
+            logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
+        # Parse outside the try/except so a strict-mode UnknownRPCMethodError
+        # (DecodingError -> RPCError) is not swallowed by the rpc_code guard
+        # above. Schema drift is a separate signal from quota/displayable
+        # errors and must surface to callers under strict decoding.
+        return self._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
 
     async def generate_data_table(
         self,
@@ -2103,7 +2107,6 @@ class ArtifactsAPI:
                 source_path=f"/notebook/{notebook_id}",
                 allow_null=True,
             )
-            return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
         except RPCError as e:
             if e.rpc_code == "USER_DISPLAYABLE_ERROR":
                 return GenerationStatus(
@@ -2113,6 +2116,11 @@ class ArtifactsAPI:
                     error_code=str(e.rpc_code) if e.rpc_code is not None else None,
                 )
             raise
+        # Parse outside the try/except so a strict-mode UnknownRPCMethodError
+        # (DecodingError -> RPCError) is not swallowed by the rpc_code guard
+        # above. Schema drift is a separate signal from quota/displayable
+        # errors and must surface to callers under strict decoding.
+        return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
 
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw artifact list data."""
@@ -2390,12 +2398,20 @@ class ArtifactsAPI:
             source: Caller label included in drift logs / exceptions.
         """
         artifact_id = safe_index(result, 0, 0, method_id=method_id, source=source)
-        # status_code is optional: it may legitimately be absent from a real
-        # response. Under strict mode, missing this leaf still raises — that
-        # is intentional: we want to learn if Google starts omitting it.
-        status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
 
         if artifact_id:
+            # In every captured CREATE_ARTIFACT / REVISE_SLIDE response we have
+            # observed, ``status_code`` sits at ``result[0][4]``. We treat it
+            # as required: under strict mode, a missing leaf raises
+            # ``UnknownRPCMethodError`` so we learn early if Google starts
+            # omitting it. The ``is not None`` fallback to ``"pending"`` only
+            # exists for soft-mode drift, where ``safe_index`` returns
+            # ``None`` instead of raising.
+            #
+            # Fetching ``status_code`` here (after the ``artifact_id`` check)
+            # avoids emitting a duplicate drift warning when the outer
+            # descent already failed at ``result[0][0]``.
+            status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
             status = artifact_status_to_str(status_code) if status_code is not None else "pending"
             return GenerationStatus(task_id=artifact_id, status=status)
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -47,6 +47,7 @@ from .rpc import (
     VideoStyle,
     artifact_status_to_str,
     nest_source_ids,
+    safe_index,
 )
 from .types import (
     Artifact,
@@ -994,7 +995,7 @@ class ArtifactsAPI:
             )
             if result is None:
                 logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
-            return self._parse_generation_result(result)
+            return self._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
         except RPCError as e:
             if e.rpc_code == "USER_DISPLAYABLE_ERROR":
                 return GenerationStatus(
@@ -2102,7 +2103,7 @@ class ArtifactsAPI:
                 source_path=f"/notebook/{notebook_id}",
                 allow_null=True,
             )
-            return self._parse_generation_result(result)
+            return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
         except RPCError as e:
             if e.rpc_code == "USER_DISPLAYABLE_ERROR":
                 return GenerationStatus(
@@ -2363,31 +2364,40 @@ class ArtifactsAPI:
             temp_file.unlink(missing_ok=True)
             raise
 
-    def _parse_generation_result(self, result: Any) -> GenerationStatus:
+    def _parse_generation_result(
+        self,
+        result: Any,
+        *,
+        method_id: str,
+        source: str = "_parse_generation_result",
+    ) -> GenerationStatus:
         """Parse generation API result into GenerationStatus.
 
         The API returns a single ID that serves as both the task_id (for polling
         during generation) and the artifact_id (once complete). This ID is at
         position [0][0] in the response and becomes Artifact.id in the list.
-        """
-        if result and isinstance(result, list) and len(result) > 0:
-            artifact_data = result[0]
-            artifact_id = (
-                artifact_data[0]
-                if isinstance(artifact_data, list) and len(artifact_data) > 0
-                else None
-            )
-            status_code = (
-                artifact_data[4]
-                if isinstance(artifact_data, list) and len(artifact_data) > 4
-                else None
-            )
 
-            if artifact_id:
-                status = (
-                    artifact_status_to_str(status_code) if status_code is not None else "pending"
-                )
-                return GenerationStatus(task_id=artifact_id, status=status)
+        Schema-drift handling is delegated to ``safe_index``: under the default
+        soft-strict mode (``NOTEBOOKLM_STRICT_DECODE=0``) drift returns ``None``
+        and falls through to the legacy "failed" path; under strict mode
+        (``=1``) ``safe_index`` raises ``UnknownRPCMethodError`` so callers can
+        surface schema changes early.
+
+        Args:
+            result: Decoded RPC payload.
+            method_id: Calling RPC method ID (``CREATE_ARTIFACT`` or
+                ``REVISE_SLIDE``) — threaded through to error diagnostics.
+            source: Caller label included in drift logs / exceptions.
+        """
+        artifact_id = safe_index(result, 0, 0, method_id=method_id, source=source)
+        # status_code is optional: it may legitimately be absent from a real
+        # response. Under strict mode, missing this leaf still raises — that
+        # is intentional: we want to learn if Google starts omitting it.
+        status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
+
+        if artifact_id:
+            status = artifact_status_to_str(status_code) if status_code is not None else "pending"
+            return GenerationStatus(task_id=artifact_id, status=status)
 
         return GenerationStatus(
             task_id="", status="failed", error="Generation failed - no artifact_id returned"

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -2003,8 +2003,13 @@ class TestParseGenerationResult:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch,
     ):
         """_parse_generation_result returns failed status when result has no artifact_id."""
+        # These tests pin down soft-strict behavior; guard against CI flipping
+        # NOTEBOOKLM_STRICT_DECODE on in the future. Strict-mode coverage of
+        # the same inputs lives in test_artifacts_drift.py.
+        monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
         notebook_response = build_rpc_response(
             RPCMethod.GET_NOTEBOOK,
             [
@@ -2035,8 +2040,10 @@ class TestParseGenerationResult:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch,
     ):
         """_parse_generation_result returns failed status when result is None."""
+        monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
         notebook_response = build_rpc_response(
             RPCMethod.GET_NOTEBOOK,
             [
@@ -2066,8 +2073,10 @@ class TestParseGenerationResult:
         auth_tokens,
         httpx_mock: HTTPXMock,
         build_rpc_response,
+        monkeypatch,
     ):
         """_parse_generation_result reads status_code from artifact_data[4]."""
+        monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
         notebook_response = build_rpc_response(
             RPCMethod.GET_NOTEBOOK,
             [

--- a/tests/integration/test_artifacts_drift.py
+++ b/tests/integration/test_artifacts_drift.py
@@ -171,3 +171,26 @@ class TestParseGenerationResultStrictDrift:
         assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
         # We descended into result[0], then failed on result[0][0].
         assert err.path == (0,)
+
+    def test_status_code_missing_raises_in_strict_mode(self, artifacts_api, monkeypatch):
+        """task_id present but status_code position absent must raise in strict mode.
+
+        ``status_code`` is treated as a required leaf: in every captured real
+        response it sits at ``result[0][4]``. If Google starts shipping a
+        truncated shape like ``[["task_short"]]`` (task_id only, no
+        status_code), we want to learn about it via a typed drift exception
+        rather than silently falling back to ``"pending"``.
+        """
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            artifacts_api._parse_generation_result(
+                [["task_short"]], method_id=RPCMethod.CREATE_ARTIFACT.value
+            )
+
+        err = exc_info.value
+        assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
+        assert err.source == "_parse_generation_result"
+        # We descended into result[0] (a list of length 1), then failed on
+        # result[0][4] — so the failing path stops at (0,).
+        assert err.path == (0,)

--- a/tests/integration/test_artifacts_drift.py
+++ b/tests/integration/test_artifacts_drift.py
@@ -1,0 +1,173 @@
+"""Schema-drift tests for ``_parse_generation_result`` (PR T1.B1).
+
+These tests pin down the contract that PR T1.B1 establishes:
+
+* ``_parse_generation_result`` accepts ``method_id`` as a keyword argument and
+  threads it through ``safe_index`` so drift diagnostics know which RPC failed.
+* Under the default soft-strict mode (``NOTEBOOKLM_STRICT_DECODE=0``) drift
+  returns the legacy ``GenerationStatus(status="failed", task_id="")`` shape,
+  preserving backward compatibility with callers that handle that sentinel.
+* Under strict mode (``NOTEBOOKLM_STRICT_DECODE=1``) drift raises
+  ``UnknownRPCMethodError`` carrying the supplied ``method_id`` so operators
+  can detect that Google's response shape moved out from under us.
+
+Real-shape happy-path coverage for the wire-level flow already exists in
+``tests/integration/test_artifacts.py::TestParseGenerationResult`` (CREATE_ARTIFACT)
+and elsewhere. Here we exercise the parser directly with constructed dicts
+because the soft/strict mode toggle is a runtime concern that doesn't depend on
+HTTP plumbing — a VCR cassette would only add ceremony without exercising the
+new branch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm.exceptions import UnknownRPCMethodError
+from notebooklm.rpc import RPCMethod
+
+
+@pytest.fixture
+def artifacts_api():
+    """Build a minimal ArtifactsAPI for direct parser invocation."""
+    mock_core = MagicMock()
+    mock_core.rpc_call = AsyncMock()
+    mock_notes = MagicMock()
+    return ArtifactsAPI(mock_core, notes_api=mock_notes)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: real response shape parses correctly for both call sites.
+# ---------------------------------------------------------------------------
+
+
+class TestParseGenerationResultHappyPath:
+    """Real response shape parses successfully when ``method_id`` is supplied."""
+
+    def test_create_artifact_real_shape(self, artifacts_api):
+        """CREATE_ARTIFACT response: [[task_id, title, type_code, None, status]]."""
+        result = [["task_abc", "Audio Overview", 1, None, 1]]
+
+        status = artifacts_api._parse_generation_result(
+            result, method_id=RPCMethod.CREATE_ARTIFACT.value
+        )
+
+        assert status.task_id == "task_abc"
+        assert status.status == "in_progress"
+        assert status.error is None
+
+    def test_revise_slide_real_shape(self, artifacts_api):
+        """REVISE_SLIDE shares the response shape with CREATE_ARTIFACT."""
+        result = [["revised_xyz", "Slide Deck", 8, None, 3]]
+
+        status = artifacts_api._parse_generation_result(
+            result, method_id=RPCMethod.REVISE_SLIDE.value
+        )
+
+        assert status.task_id == "revised_xyz"
+        assert status.status == "completed"
+        assert status.error is None
+
+
+# ---------------------------------------------------------------------------
+# Drift: soft mode (default) preserves legacy "failed" sentinel.
+# ---------------------------------------------------------------------------
+
+
+class TestParseGenerationResultSoftDrift:
+    """Soft mode (``NOTEBOOKLM_STRICT_DECODE`` unset) returns legacy failure."""
+
+    def test_none_result_returns_failed(self, artifacts_api, monkeypatch):
+        monkeypatch.delenv("NOTEBOOKLM_STRICT_DECODE", raising=False)
+
+        status = artifacts_api._parse_generation_result(
+            None, method_id=RPCMethod.CREATE_ARTIFACT.value
+        )
+
+        assert status.status == "failed"
+        assert status.task_id == ""
+        assert status.error and "no artifact_id" in status.error.lower()
+
+    def test_empty_list_returns_failed(self, artifacts_api, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+
+        status = artifacts_api._parse_generation_result(
+            [], method_id=RPCMethod.CREATE_ARTIFACT.value
+        )
+
+        assert status.status == "failed"
+        assert status.task_id == ""
+
+    def test_missing_inner_leaf_returns_failed(self, artifacts_api, monkeypatch):
+        """Inner list is too short to expose [0][0] / [0][4] — soft mode swallows."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+
+        # Inner list missing both task_id and status_code positions.
+        status = artifacts_api._parse_generation_result(
+            [[]], method_id=RPCMethod.REVISE_SLIDE.value
+        )
+
+        assert status.status == "failed"
+        assert status.task_id == ""
+
+    def test_status_code_missing_still_returns_pending(self, artifacts_api, monkeypatch):
+        """Drift on the optional status_code leaf must NOT break a valid task_id.
+
+        Under soft mode, ``safe_index`` returns ``None`` for the missing leaf,
+        which the parser already handles by defaulting to ``"pending"``.
+        """
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "0")
+
+        # task_id present, status_code position absent.
+        status = artifacts_api._parse_generation_result(
+            [["task_short"]], method_id=RPCMethod.CREATE_ARTIFACT.value
+        )
+
+        assert status.task_id == "task_short"
+        assert status.status == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Drift: strict mode raises typed UnknownRPCMethodError.
+# ---------------------------------------------------------------------------
+
+
+class TestParseGenerationResultStrictDrift:
+    """Strict mode (``NOTEBOOKLM_STRICT_DECODE=1``) raises typed errors."""
+
+    def test_none_result_raises(self, artifacts_api, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            artifacts_api._parse_generation_result(None, method_id=RPCMethod.CREATE_ARTIFACT.value)
+
+        err = exc_info.value
+        assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
+        assert err.source == "_parse_generation_result"
+        # Top-level descent: failing path is empty (we failed at the first index).
+        assert err.path == ()
+
+    def test_empty_list_raises_for_revise_slide(self, artifacts_api, monkeypatch):
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            artifacts_api._parse_generation_result([], method_id=RPCMethod.REVISE_SLIDE.value)
+
+        err = exc_info.value
+        assert err.method_id == RPCMethod.REVISE_SLIDE.value
+        assert err.source == "_parse_generation_result"
+
+    def test_inner_leaf_missing_raises(self, artifacts_api, monkeypatch):
+        """Drift on the inner leaf reports a non-empty failing path."""
+        monkeypatch.setenv("NOTEBOOKLM_STRICT_DECODE", "1")
+
+        with pytest.raises(UnknownRPCMethodError) as exc_info:
+            artifacts_api._parse_generation_result([[]], method_id=RPCMethod.CREATE_ARTIFACT.value)
+
+        err = exc_info.value
+        assert err.method_id == RPCMethod.CREATE_ARTIFACT.value
+        # We descended into result[0], then failed on result[0][0].
+        assert err.path == (0,)

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -298,7 +298,7 @@ class TestParseGenerationResult:
         """Test parsing None result returns failed status."""
         api, _ = mock_artifacts_api
 
-        result = api._parse_generation_result(None)
+        result = api._parse_generation_result(None, method_id="R7cb6c")
 
         assert result.status == "failed"
         assert result.task_id == ""
@@ -308,7 +308,7 @@ class TestParseGenerationResult:
         """Test parsing empty list returns failed status."""
         api, _ = mock_artifacts_api
 
-        result = api._parse_generation_result([])
+        result = api._parse_generation_result([], method_id="R7cb6c")
 
         assert result.status == "failed"
         assert result.task_id == ""
@@ -319,7 +319,9 @@ class TestParseGenerationResult:
         api, _ = mock_artifacts_api
 
         # Valid result with status code 1 (in_progress)
-        result = api._parse_generation_result([["artifact_001", "Title", 1, None, 1]])
+        result = api._parse_generation_result(
+            [["artifact_001", "Title", 1, None, 1]], method_id="R7cb6c"
+        )
 
         assert result.task_id == "artifact_001"
         assert result.status == "in_progress"
@@ -328,7 +330,9 @@ class TestParseGenerationResult:
         """Test parsing valid completed status (code 3)."""
         api, _ = mock_artifacts_api
 
-        result = api._parse_generation_result([["artifact_002", "Title", 1, None, 3]])
+        result = api._parse_generation_result(
+            [["artifact_002", "Title", 1, None, 3]], method_id="R7cb6c"
+        )
 
         assert result.task_id == "artifact_002"
         assert result.status == "completed"
@@ -337,7 +341,9 @@ class TestParseGenerationResult:
         """Test parsing unknown status code returns unknown."""
         api, _ = mock_artifacts_api
 
-        result = api._parse_generation_result([["artifact_003", "Title", 1, None, 99]])
+        result = api._parse_generation_result(
+            [["artifact_003", "Title", 1, None, 99]], method_id="R7cb6c"
+        )
 
         assert result.task_id == "artifact_003"
         assert result.status == "unknown"  # Unknown codes return "unknown"


### PR DESCRIPTION
## Summary
- Migrates `_parse_generation_result` to use `safe_index` (added in T1.A).
- Signature now takes `method_id` keyword arg; call sites pass `RPCMethod.CREATE_ARTIFACT.value` (`_call_generate`) and `RPCMethod.REVISE_SLIDE.value` (`revise_slide`).
- Soft mode (`NOTEBOOKLM_STRICT_DECODE=0`, default) preserves the legacy `GenerationStatus(status="failed", task_id="")` sentinel; strict mode (`=1`) raises typed `UnknownRPCMethodError` with `method_id`, `source`, and the failing `path` populated.
- Removes the previous `isinstance`/`len` defensive guards inside the parser — `safe_index` now handles `IndexError`/`TypeError`/`KeyError` uniformly.

## History scan
Ran `git log -p --follow src/notebooklm/_artifacts.py` and `git log -S "_parse_generation_result"`. The function was introduced in `b57147a` (namespaced-client refactor, Jan 2026) with the same defensive `isinstance`/`len` pattern present at HEAD. `c8a77c4` (UserDisplayableError) only changed the *callers* (introduced `_call_generate`). `7cc0ba1` added the second call site (`revise_slide`) without modifying the parser body.

**Conclusion**: no historical variation in the parser. The defensive guards were speculative — the soft-rollout (`NOTEBOOKLM_STRICT_DECODE=0` returning `None` and falling through to the legacy "failed" sentinel) provides the safety net the guards used to.

## Test design choice
New `tests/integration/test_artifacts_drift.py` exercises the parser directly with constructed payloads rather than routing through VCR cassettes. Rationale: the soft/strict mode toggle is a runtime concern decoupled from HTTP plumbing — a cassette would add ceremony without exercising the new branch. Real-shape wire-level coverage already exists in `tests/integration/test_artifacts.py::TestParseGenerationResult` (CREATE_ARTIFACT happy/null/failed paths), which continues to pass with the new signature (callers updated to thread `method_id`).

## Test plan
- [x] Happy path for `CREATE_ARTIFACT` real shape (`[[task_id, ..., status_code]]`) → `GenerationStatus` populated.
- [x] Happy path for `REVISE_SLIDE` real shape → same.
- [x] Drift under soft mode (`None`, `[]`, `[[]]`, `[[task_id]]`) → returns legacy `failed`/`pending` as appropriate.
- [x] Drift under strict mode → raises `UnknownRPCMethodError` carrying `method_id=R7cb6c`/`KmcKPe`, `source="_parse_generation_result"`, and the failing `path`.
- [x] Existing `tests/unit/test_artifacts_coverage.py::TestParseGenerationResult` updated to pass `method_id` and still passes.
- [x] Full suite (`uv run pytest`) green: 2934 passed, 9 skipped.
- [x] `ruff format`, `ruff check`, `mypy src/notebooklm` clean.

Part of Tier 1 (`.sisyphus/plans/tier-1-implementation.md`). Synthesis #1 T1 + #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of artifact generation result parsing for enhanced error handling.
  * Enhanced error diagnostics when artifact generation encounters schema variations.

* **Tests**
  * Added comprehensive integration tests for schema-drift scenarios.
  * Updated existing tests to verify strict and lenient error modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/452)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->