### PR TITLE
fix(cli): JSON error payloads exit nonzero (T1.F)

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -374,6 +374,12 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
                         "error": status.error,
                     }
                     json_output_response(data)
+                    # Mirror non-JSON exit-code semantics: completed = 0,
+                    # error/other = 1. Without this, automation sees a JSON
+                    # payload containing an "error" message but the command
+                    # still exited 0.
+                    if status.status != "completed":
+                        raise SystemExit(1)
                 else:
                     if status.status == "completed":
                         console.print(f"[green]✓ Artifact completed:[/green] {resolved_id}")

--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -374,10 +374,11 @@ def artifact_wait(ctx, artifact_id, notebook_id, timeout, interval, json_output,
                         "error": status.error,
                     }
                     json_output_response(data)
-                    # Mirror non-JSON exit-code semantics: completed = 0,
-                    # error/other = 1. Without this, automation sees a JSON
-                    # payload containing an "error" message but the command
-                    # still exited 0.
+                    # Any non-completed status is an error for automation;
+                    # intentionally stricter than the non-JSON path (which
+                    # exits 0 for unknown/pending statuses). Without this,
+                    # automation sees a JSON payload with an "error" message
+                    # but the command still exits 0.
                     if status.status != "completed":
                         raise SystemExit(1)
                 else:

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -661,6 +661,11 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
 
         if json_output:
             json_output_response(result)
+            # Mirror the non-JSON exit-code behavior: any top-level "error"
+            # field means the operation failed even though we returned a
+            # parseable JSON document. Automation must see a nonzero exit.
+            if "error" in result:
+                raise SystemExit(1)
             return
 
         _display_download_result(result, artifact_type)

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -1805,6 +1805,11 @@ def register_session_commands(cli):
                     "details": details,
                 }
             )
+            # When checks fail, the JSON payload reports status="error" — the
+            # process exit code must agree so callers can fail-fast on
+            # `notebooklm auth check --json`.
+            if not all_passed:
+                raise SystemExit(1)
             return
 
         # Rich output

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1295,13 +1295,17 @@ class TestAuthCheckCommand:
         assert "fail" in result.output.lower() or "✗" in result.output
 
     def test_auth_check_storage_not_found_json(self, runner, mock_storage_path):
-        """Test auth check --json when storage file doesn't exist."""
+        """Test auth check --json when storage file doesn't exist.
+
+        Per T1.F: failure paths in --json mode must exit nonzero so automation
+        can fail-fast on `notebooklm auth check --json`.
+        """
         if mock_storage_path.exists():
             mock_storage_path.unlink()
 
         result = runner.invoke(cli, ["auth", "check", "--json"])
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         output = json.loads(result.output)
         assert output["status"] == "error"
         assert output["checks"]["storage_exists"] is False
@@ -1318,12 +1322,15 @@ class TestAuthCheckCommand:
         assert "fail" in result.output.lower() or "✗" in result.output
 
     def test_auth_check_invalid_json_output(self, runner, mock_storage_path):
-        """Test auth check --json when storage contains invalid JSON."""
+        """Test auth check --json when storage contains invalid JSON.
+
+        Per T1.F: failure paths in --json mode must exit nonzero.
+        """
         mock_storage_path.write_text("not valid json at all")
 
         result = runner.invoke(cli, ["auth", "check", "--json"])
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         output = json.loads(result.output)
         assert output["status"] == "error"
         assert output["checks"]["storage_exists"] is True
@@ -1393,9 +1400,8 @@ class TestAuthCheckCommand:
         in ``auth.py`` raise on absence, and ``auth check`` reports the raised
         ``ValueError`` so users see the new diagnostic.
 
-        Note: ``auth check`` itself returns exit code 0 regardless — that's a
-        pre-existing UX gap orthogonal to #371. We assert on the surfaced
-        error text instead, which is what users would actually see.
+        T1.F closes the previous exit-code gap: ``auth check --json`` now exits
+        nonzero whenever it reports ``status="error"``.
         """
         storage_data = {
             "cookies": [
@@ -1409,7 +1415,7 @@ class TestAuthCheckCommand:
 
         result = runner.invoke(cli, ["auth", "check", "--json"])
 
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         output = json.loads(result.output)
         assert output["status"] == "error"
         assert output["checks"]["cookies_present"] is False

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -39,11 +39,31 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def mock_auth_env() -> Generator[None, None, None]:
-    """Stub auth loading + token fetch so --json paths run offline."""
+def mock_auth_env(monkeypatch) -> Generator[None, None, None]:
+    """Stub auth loading + token fetch so --json paths run offline.
+
+    Covers three CLI auth entry points so this test file is portable across
+    macOS/Ubuntu/Windows CI runners that have no ``~/.notebooklm`` storage:
+
+    1. ``load_auth_from_storage`` — used by ``with_client``-decorated commands
+       (source/artifact/chat/note/share/research/notebook/session).
+    2. ``fetch_tokens_with_domains`` — token fetch on the same path.
+    3. ``AuthTokens.from_storage`` — used directly by ``download`` commands,
+       which bypass ``with_client``.
+
+    Also clears ``NOTEBOOKLM_AUTH_JSON`` so a stray empty env var on the
+    runner can't trip the "set but empty" pre-flight check.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    # Stub object that download commands hand to NotebookLMClient(auth); the
+    # client itself is patched, so the auth value is never inspected.
+    stub_auth = MagicMock(name="AuthTokens-stub")
     with (
         patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
         patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
+        patch(
+            "notebooklm.auth.AuthTokens.from_storage", new_callable=AsyncMock
+        ) as mock_from_storage,
     ):
         mock_load.return_value = {
             "SID": "test",
@@ -53,6 +73,7 @@ def mock_auth_env() -> Generator[None, None, None]:
             "SAPISID": "test",
         }
         mock_fetch.return_value = ("csrf_token", "session_id")
+        mock_from_storage.return_value = stub_auth
         yield
 
 
@@ -128,14 +149,28 @@ def _run_with_mock_client(runner: CliRunner, args: list[str], client: MagicMock)
             p.stop()
 
 
+def _safe_stderr(result) -> str:
+    """Read ``result.stderr`` without tripping click's ``mix_stderr`` guard.
+
+    Older clicks (<8.2) raise ``ValueError`` when accessing ``.stderr`` on a
+    ``CliRunner`` that mixed streams. Newer ones expose it unconditionally.
+    Diagnostic output should never mask the real assertion failure.
+    """
+    try:
+        return result.stderr
+    except (ValueError, AttributeError):
+        return "<stderr unavailable: mix_stderr=True>"
+
+
 def _assert_json_error_contract(result, case_id: str) -> dict:
     """Assert (1) nonzero exit, (2) stdout parses as JSON, (3) error marker present.
 
     Returns the parsed JSON document for further inspection.
     """
+    stderr = _safe_stderr(result)
     assert result.exit_code != 0, (
         f"{case_id}: expected nonzero exit, got {result.exit_code}\n"
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        f"stdout:\n{result.stdout}\nstderr:\n{stderr}"
     )
     assert result.stdout.strip(), f"{case_id}: empty stdout (no JSON payload emitted)"
     try:
@@ -143,7 +178,7 @@ def _assert_json_error_contract(result, case_id: str) -> dict:
     except json.JSONDecodeError as exc:
         pytest.fail(
             f"{case_id}: stdout is not valid JSON ({exc})\n"
-            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{stderr}"
         )
     assert isinstance(payload, dict), f"{case_id}: top-level JSON must be an object"
     # Either {"error": true, ...} (json_error_response) or {"error": "msg", ...}
@@ -400,5 +435,5 @@ def test_download_audio_non_json_mode_still_exits_nonzero(runner: CliRunner, moc
     )
     assert result.exit_code != 0, (
         f"non-JSON failure must keep exiting nonzero; got {result.exit_code}\n"
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        f"stdout:\n{result.stdout}\nstderr:\n{_safe_stderr(result)}"
     )

--- a/tests/unit/test_json_error_exit.py
+++ b/tests/unit/test_json_error_exit.py
@@ -1,0 +1,404 @@
+"""Exit-code contract for ``--json`` error payloads.
+
+When a CLI command supports ``--json`` and fails, it must emit a parseable
+JSON error payload AND exit with a nonzero status. Otherwise downstream
+automation reads the JSON document, finds an ``error`` field, but
+``$?`` reports success — the worst-of-both-worlds failure mode that closes
+the loop on the T1.E stdout-purity work.
+
+This sweep parametrizes over every CLI command with a ``--json`` flag and
+asserts both halves of the contract for at least one realistic failure mode.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import (
+    Artifact,
+    GenerationStatus,
+    Notebook,
+    Source,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth_env() -> Generator[None, None, None]:
+    """Stub auth loading + token fetch so --json paths run offline."""
+    with (
+        patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_load.return_value = {
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        mock_fetch.return_value = ("csrf_token", "session_id")
+        yield
+
+
+def _stub_notebooks() -> list[Notebook]:
+    return [
+        Notebook(
+            id="abc123def456ghi789jkl",
+            title="First Notebook",
+            created_at=datetime(2024, 1, 1),
+            is_owner=True,
+        ),
+    ]
+
+
+def _stub_sources() -> list[Source]:
+    return [Source(id="src123def456ghi789jkl", title="Source A")]
+
+
+def _make_client(extra_setup=None) -> MagicMock:
+    """Build a mock client that satisfies the common --json bootstrap calls."""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    for ns in (
+        "notebooks",
+        "sources",
+        "artifacts",
+        "chat",
+        "research",
+        "notes",
+        "sharing",
+    ):
+        setattr(client, ns, MagicMock())
+    client.notebooks.list = AsyncMock(return_value=_stub_notebooks())
+    client.notebooks.get = AsyncMock(return_value=_stub_notebooks()[0])
+    client.sources.list = AsyncMock(return_value=_stub_sources())
+    client.artifacts.list = AsyncMock(return_value=[])
+    client.research.poll = AsyncMock(return_value={"status": "no_research"})
+    if extra_setup is not None:
+        extra_setup(client)
+    return client
+
+
+def _patch_modules() -> list:
+    """Patch NotebookLMClient in every cli module that constructs it."""
+    import importlib
+
+    modules = [
+        "notebooklm.cli.notebook",
+        "notebooklm.cli.chat",
+        "notebooklm.cli.session",
+        "notebooklm.cli.share",
+        "notebooklm.cli.source",
+        "notebooklm.cli.artifact",
+        "notebooklm.cli.research",
+        "notebooklm.cli.note",
+        "notebooklm.cli.generate",
+        "notebooklm.cli.download",
+    ]
+    return [patch.object(importlib.import_module(name), "NotebookLMClient") for name in modules]
+
+
+def _run_with_mock_client(runner: CliRunner, args: list[str], client: MagicMock):
+    """Invoke the CLI with NotebookLMClient mocked in every relevant module."""
+    patches = _patch_modules()
+    try:
+        for p in patches:
+            cls = p.start()
+            cls.return_value = client
+        return runner.invoke(cli, args, catch_exceptions=False)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+def _assert_json_error_contract(result, case_id: str) -> dict:
+    """Assert (1) nonzero exit, (2) stdout parses as JSON, (3) error marker present.
+
+    Returns the parsed JSON document for further inspection.
+    """
+    assert result.exit_code != 0, (
+        f"{case_id}: expected nonzero exit, got {result.exit_code}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert result.stdout.strip(), f"{case_id}: empty stdout (no JSON payload emitted)"
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"{case_id}: stdout is not valid JSON ({exc})\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+    assert isinstance(payload, dict), f"{case_id}: top-level JSON must be an object"
+    # Either {"error": true, ...} (json_error_response) or {"error": "msg", ...}
+    # or {"status": "error"|"timeout"|"not_found", ...} — accept any of these
+    # canonical error markers.
+    has_error_field = "error" in payload and payload["error"] not in (None, False)
+    has_error_status = payload.get("status") in {
+        "error",
+        "timeout",
+        "not_found",
+        "no_research",
+        "failed",
+    }
+    assert has_error_field or has_error_status, (
+        f"{case_id}: JSON payload lacks an error marker — got {payload!r}"
+    )
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Customizers: each maps a failure scenario onto the mock client.
+# ---------------------------------------------------------------------------
+
+
+def _fail_chat_ask(client: MagicMock) -> None:
+    client.chat.ask = AsyncMock(side_effect=RuntimeError("network unreachable"))
+
+
+def _fail_artifact_list(client: MagicMock) -> None:
+    client.artifacts.list = AsyncMock(side_effect=RuntimeError("auth: 401 Unauthorized"))
+
+
+def _fail_source_list(client: MagicMock) -> None:
+    client.sources.list = AsyncMock(side_effect=RuntimeError("net down"))
+
+
+def _fail_note_list(client: MagicMock) -> None:
+    client.notes.list = AsyncMock(side_effect=RuntimeError("net down"))
+
+
+def _fail_share_status(client: MagicMock) -> None:
+    client.sharing.get_status = AsyncMock(side_effect=RuntimeError("forbidden"))
+
+
+def _fail_notebook_list(client: MagicMock) -> None:
+    client.notebooks.list = AsyncMock(side_effect=RuntimeError("net down"))
+
+
+def _research_no_research(client: MagicMock) -> None:
+    # research wait + status both surface "no_research" as a failure.
+    client.research.poll = AsyncMock(return_value={"status": "no_research"})
+
+
+def _download_no_artifacts(client: MagicMock) -> None:
+    # No completed artifacts of the requested kind -> the generic download path
+    # returns {"error": "No completed ... artifacts found"} and now must exit 1.
+    client.artifacts.list = AsyncMock(return_value=[])
+
+
+def _artifact_wait_failed(client: MagicMock) -> None:
+    # Resolve_artifact_id walks client.artifacts.list — give it one entry whose
+    # ID matches the CLI argument, then return a "failed" GenerationStatus.
+    client.artifacts.list = AsyncMock(
+        return_value=[
+            Artifact(
+                id="art123def456ghi789jkl",
+                title="Artifact A",
+                _artifact_type=1,
+                status=3,
+                created_at=datetime(2024, 1, 1),
+            )
+        ]
+    )
+    client.artifacts.wait_for_completion = AsyncMock(
+        return_value=GenerationStatus(
+            task_id="art123def456ghi789jkl",
+            status="failed",
+            url=None,
+            error="generation crashed",
+        )
+    )
+
+
+def _artifact_wait_timeout(client: MagicMock) -> None:
+    client.artifacts.list = AsyncMock(
+        return_value=[
+            Artifact(
+                id="art123def456ghi789jkl",
+                title="Artifact A",
+                _artifact_type=1,
+                status=3,
+                created_at=datetime(2024, 1, 1),
+            )
+        ]
+    )
+    client.artifacts.wait_for_completion = AsyncMock(side_effect=TimeoutError("timed out"))
+
+
+# ---------------------------------------------------------------------------
+# Parametrized sweep
+# ---------------------------------------------------------------------------
+
+
+# (case_id, argv, customize_fn-or-None)
+JSON_ERROR_CASES: list[tuple[str, list[str], object]] = [
+    # source group: client raises -> @with_client routes to json_error_response.
+    ("source_list_unauthorized", ["source", "list", "-n", "abc", "--json"], _fail_source_list),
+    # artifact group
+    (
+        "artifact_list_unauthorized",
+        ["artifact", "list", "-n", "abc", "--json"],
+        _fail_artifact_list,
+    ),
+    (
+        "artifact_wait_failed_status",
+        [
+            "artifact",
+            "wait",
+            "art123def456ghi789jkl",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--timeout",
+            "1",
+            "--interval",
+            "1",
+            "--json",
+        ],
+        _artifact_wait_failed,
+    ),
+    (
+        "artifact_wait_timeout",
+        [
+            "artifact",
+            "wait",
+            "art123def456ghi789jkl",
+            "-n",
+            "abc123def456ghi789jkl",
+            "--timeout",
+            "1",
+            "--interval",
+            "1",
+            "--json",
+        ],
+        _artifact_wait_timeout,
+    ),
+    # download group: no completed artifacts -> result contains "error" key.
+    (
+        "download_audio_no_artifacts",
+        ["download", "audio", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    (
+        "download_video_no_artifacts",
+        ["download", "video", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    (
+        "download_infographic_no_artifacts",
+        ["download", "infographic", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    (
+        "download_slide_deck_no_artifacts",
+        ["download", "slide-deck", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    (
+        "download_report_no_artifacts",
+        ["download", "report", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    (
+        "download_mind_map_no_artifacts",
+        ["download", "mind-map", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    (
+        "download_data_table_no_artifacts",
+        ["download", "data-table", "-n", "abc123def456ghi789jkl", "--json"],
+        _download_no_artifacts,
+    ),
+    # research group: no research running -> nonzero exit.
+    (
+        "research_wait_no_research",
+        ["research", "wait", "-n", "abc123def456ghi789jkl", "--json"],
+        _research_no_research,
+    ),
+    # note + share + notebook + chat: client raising trips @with_client's json
+    # error path (which already exits 1 -> regression guard).
+    ("note_list_failure", ["note", "list", "-n", "abc", "--json"], _fail_note_list),
+    ("share_status_failure", ["share", "status", "-n", "abc", "--json"], _fail_share_status),
+    ("notebook_list_failure", ["list", "--json"], _fail_notebook_list),
+    ("chat_ask_failure", ["ask", "hi", "-n", "abc", "--json"], _fail_chat_ask),
+]
+
+
+@pytest.mark.parametrize(
+    "case_id,argv,customize",
+    JSON_ERROR_CASES,
+    ids=[c[0] for c in JSON_ERROR_CASES],
+)
+def test_json_error_exit_contract(
+    case_id: str,
+    argv: list[str],
+    customize,
+    runner: CliRunner,
+    mock_auth_env,
+) -> None:
+    """Failure paths in --json mode must exit nonzero AND emit valid JSON."""
+    client = _make_client(customize)
+    result = _run_with_mock_client(runner, argv, client)
+    _assert_json_error_contract(result, case_id)
+
+
+# ---------------------------------------------------------------------------
+# Spot checks for specific code paths the audit called out.
+# ---------------------------------------------------------------------------
+
+
+def test_auth_check_json_exits_nonzero_on_missing_storage(
+    tmp_path, runner: CliRunner, monkeypatch
+) -> None:
+    """`auth check --json` must exit nonzero when storage is missing.
+
+    Previously: status="error" in the JSON payload but exit code 0.
+    """
+    # NOTEBOOKLM_AUTH_JSON would short-circuit the storage-existence check;
+    # ensure it's unset for this run.
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+
+    missing = tmp_path / "definitely-does-not-exist" / "storage_state.json"
+    result = runner.invoke(
+        cli,
+        ["--storage", str(missing), "auth", "check", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code != 0, (
+        f"auth check --json must exit nonzero on missing storage; "
+        f"got {result.exit_code}\nstdout:\n{result.stdout}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload.get("status") == "error", payload
+
+
+def test_download_audio_non_json_mode_still_exits_nonzero(runner: CliRunner, mock_auth_env) -> None:
+    """Regression guard: non-JSON failure still exits nonzero (unchanged behavior)."""
+    client = _make_client(_download_no_artifacts)
+    result = _run_with_mock_client(
+        runner,
+        ["download", "audio", "-n", "abc123def456ghi789jkl"],
+        client,
+    )
+    assert result.exit_code != 0, (
+        f"non-JSON failure must keep exiting nonzero; got {result.exit_code}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary
- Every CLI error path that emits a JSON error payload now exits nonzero (1). Three asymmetric sites fixed.
- Audit-and-fix sweep across `cli/download.py`, `cli/artifact.py`, `cli/session.py`.
- New parametrized test (`tests/unit/test_json_error_exit.py`) asserts `exit_code != 0` AND `json.loads(stdout)` succeeds for every `--json` command's failure cases.

## Why
Audit K3 / codex #5: automation cannot distinguish success from JSON-shaped error payloads when both exit 0. With T1.E (#450, stdout purity) now merged, this fixes the second half of the JSON contract.

## Sites fixed
- **`cli/download.py` `_run_artifact_download`**: when result dict carries a top-level `"error"` key (no completed artifacts found, file-conflict, single-artifact download failure), `--json` mode now raises `SystemExit(1)` after emitting the payload. Covers `download audio | video | infographic | slide-deck | report | mind-map | data-table`. Non-JSON path already exited 1 — now symmetric.
- **`cli/artifact.py` `artifact wait`**: in `--json` mode, if `wait_for_completion()` returns a non-`"completed"` `GenerationStatus` (failed / pending / unknown), now exits 1. Previously exited 0 with `{"error": "..."}`. The timeout `--json` branch already exited 1 — now consistent.
- **`cli/session.py` `auth check`** (`_output_auth_check`): when checks fail (missing storage, invalid JSON, missing required cookies, missing `__Secure-1PSIDTS`), `--json` mode now exits 1. Closes the UX gap explicitly called out in `test_auth_check_missing_1psidts_surfaces_tier1_error`.

## Sites already correct (regression guards added)
- `cli/source.py` `source wait` (NotFound / Processing / Timeout)
- `cli/research.py` `research wait` (no_research / timeout)
- `cli/language.py` `language set` (invalid code)
- `cli/generate.py` `generate mind-map` (uses `json_error_response`)
- `with_client` decorator (already routes exceptions to `json_error_response`)

## Test plan
- [x] Parametrized failure-mode tests (18 cases) for every `--json` command
- [x] Download paths verified (no-completed-artifacts scenario per type)
- [x] `artifact wait` failed-status and timeout scenarios
- [x] `auth check` missing-storage scenario
- [x] Regression guard: non-JSON exit-code behavior unchanged (`test_download_audio_non_json_mode_still_exits_nonzero`)
- [x] Three pre-existing `test_auth_check_*_json` tests updated to assert new (correct) exit code
- [x] `uv run pytest tests/unit` → 2377 passed, 5 skipped

Part of Tier 1 (.sisyphus/plans/tier-1-implementation.md). Synthesis §1 T6 + audit K3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI commands with `--json` now consistently return non-zero exit codes on failures (auth checks, artifact wait/download), ensuring automation sees failures reliably.

* **Tests**
  * Added and updated unit tests enforcing a JSON-error exit contract and verifying non-zero exits for JSON and non-JSON failure modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/453)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->