### PR TITLE
feat(cli): with_client -> handle_errors() integration (T1.G)

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -25,7 +25,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
-from ..exceptions import NetworkError, NotebookLimitError, RPCError, RPCTimeoutError
+from ..exceptions import NetworkError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
 from ..research import select_cited_sources
 from ..types import ArtifactType, CitedSourceSelection
@@ -989,11 +989,20 @@ def with_client(f):
     @wraps(f)
     @click.pass_context
     def wrapper(ctx, *args, **kwargs):
+        from .error_handler import handle_errors
+
         cmd_name = f.__name__
         start = time.monotonic()
         logger.debug("CLI command starting: %s", cmd_name)
 
         json_output = kwargs.get("json_output", False)
+        # Verbose is captured on the root group via Click ``--verbose`` count.
+        # Use ``find_root`` so nested subcommand contexts still see it.
+        try:
+            verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
+        except Exception:
+            verbose_count = 0
+        verbose = verbose_count >= 1
 
         def log_result(status: str, detail: str = "") -> float:
             elapsed = time.monotonic() - start
@@ -1003,30 +1012,27 @@ def with_client(f):
                 logger.debug("CLI command %s: %s (%.3fs)", status, cmd_name, elapsed)
             return elapsed
 
+        # Auth bootstrap: FileNotFoundError here means the storage file is
+        # missing, which has a dedicated rich UX via ``handle_auth_error``.
+        # We deliberately handle this BEFORE entering ``handle_errors`` so a
+        # FileNotFoundError raised *inside* the command body (e.g., a missing
+        # ``--source-file`` argument) is not misclassified as an auth error.
         try:
+            auth = get_auth_tokens(ctx)
+        except FileNotFoundError:
+            log_result("failed", "not authenticated")
+            handle_auth_error(json_output)
+            return  # unreachable — handle_auth_error raises SystemExit
+
+        with handle_errors(verbose=verbose, json_output=json_output):
             try:
-                auth = get_auth_tokens(ctx)
-            except FileNotFoundError:
-                log_result("failed", "not authenticated")
-                handle_auth_error(json_output)
-                return  # unreachable (handle_auth_error raises SystemExit), but keeps mypy happy
-            coro = f(ctx, *args, client_auth=auth, **kwargs)
-            result = run_async(coro)
+                coro = f(ctx, *args, client_auth=auth, **kwargs)
+                result = run_async(coro)
+            except Exception as e:
+                log_result("failed", str(e))
+                raise
             log_result("completed")
             return result
-        except Exception as e:
-            log_result("failed", str(e))
-            if json_output:
-                if isinstance(e, NotebookLimitError):
-                    json_error_response(
-                        "NOTEBOOK_LIMIT",
-                        str(e),
-                        extra=e.to_error_response_extra(),
-                    )
-                    return
-                json_error_response("ERROR", str(e))
-            else:
-                handle_error(e)
 
     return wrapper
 

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -209,7 +209,8 @@ class TestGenerateVideo:
             ["generate", "video", "--style", "custom", "-n", "nb_123"],
         )
 
-        assert result.exit_code == 1
+        # ``click.UsageError`` exits 2 — Click's standard convention.
+        assert result.exit_code == 2
         assert "--style custom requires --style-prompt" in result.output
 
     def test_generate_video_custom_style_rejects_blank_prompt(
@@ -229,7 +230,7 @@ class TestGenerateVideo:
             ],
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "--style custom requires --style-prompt" in result.output
 
     def test_generate_video_style_prompt_requires_custom_style(
@@ -249,7 +250,7 @@ class TestGenerateVideo:
             ],
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "--style-prompt requires --style custom" in result.output
 
 
@@ -337,7 +338,7 @@ class TestGenerateCinematicVideo:
             ],
         )
 
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "--style-prompt cannot be used with cinematic video" in result.output
 
 

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -630,6 +630,10 @@ class TestWithClientDecorator:
         Regression test for GitHub issue #153: `source add --type file` with a
         missing file was incorrectly showing 'Not logged in' because the
         with_client decorator caught all FileNotFoundError as auth errors.
+
+        After T1.G, ``with_client`` routes body errors through ``handle_errors``,
+        so an unexpected FileNotFoundError surfaces as an UNEXPECTED_ERROR
+        (exit 2) — still NOT an auth error.
         """
         import click
         from click.testing import CliRunner
@@ -651,13 +655,14 @@ class TestWithClientDecorator:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(test_cmd)
 
-        assert result.exit_code == 1
-        # Should show the actual file error, NOT an auth error
-        assert "File not found" in result.output
-        assert "login" not in result.output.lower()
+        # Must not exit 0; the operation failed.
+        assert result.exit_code != 0
+        # The crucial property: this is NOT misclassified as an auth error.
+        combined = (result.output or "") + " " + (getattr(result, "stderr", "") or "")
+        assert "login" not in combined.lower()
 
     def test_decorator_handles_exception_non_json(self):
-        """Test error handling in non-JSON mode"""
+        """Unhandled body exceptions surface via ``handle_errors`` (exit 2)."""
         import click
         from click.testing import CliRunner
 
@@ -678,11 +683,13 @@ class TestWithClientDecorator:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(test_cmd)
 
-        assert result.exit_code == 1
-        assert "Test error" in result.output
+        # UNEXPECTED_ERROR → exit 2 (system/bug bucket).
+        assert result.exit_code == 2
+        combined = (result.output or "") + " " + (getattr(result, "stderr", "") or "")
+        assert "Test error" in combined
 
     def test_decorator_handles_exception_json_mode(self):
-        """Test error handling in JSON mode"""
+        """``--json`` mode emits parseable JSON with nonzero exit."""
         import click
         from click.testing import CliRunner
 
@@ -704,8 +711,8 @@ class TestWithClientDecorator:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(test_cmd, ["--json"])
 
-        assert result.exit_code == 1
-        data = json.loads(result.output)
+        assert result.exit_code != 0
+        data = json.loads(result.stdout)
         assert data["error"] is True
         assert "Test error" in data["message"]
 

--- a/tests/unit/cli/test_research.py
+++ b/tests/unit/cli/test_research.py
@@ -247,7 +247,8 @@ class TestResearchWait:
     def test_wait_cited_only_requires_import_all(self, runner, mock_auth, mock_fetch_tokens):
         result = runner.invoke(cli, ["research", "wait", "-n", "nb_123", "--cited-only"])
 
-        assert result.exit_code == 1
+        # ``click.UsageError`` exits 2 — Click's standard convention.
+        assert result.exit_code == 2
         assert "--cited-only requires --import-all" in result.output
 
     def test_wait_json_output_completed(self, runner, mock_auth, mock_fetch_tokens):

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -833,7 +833,8 @@ class TestSourceAddResearch:
             ["source", "add-research", "AI papers", "--cited-only", "-n", "nb_123"],
         )
 
-        assert result.exit_code == 1
+        # ``click.UsageError`` exits 2 — Click's standard convention.
+        assert result.exit_code == 2
         assert "--cited-only requires --import-all" in result.output
 
     def test_add_research_timeout_flag_threaded_to_import_with_retry(self, runner, mock_auth):

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -1,0 +1,240 @@
+"""``with_client`` routes errors through ``handle_errors`` (T1.G).
+
+Before T1.G, ``@with_client`` ran its own ad-hoc ``try/except FileNotFoundError``
++ broad ``except Exception``, so typed library exceptions got squashed into a
+generic ``"ERROR"`` payload (or a plain "Error: ..." stderr line) with no
+actionable hint.
+
+After T1.G:
+
+* ``AuthError`` → "Run 'notebooklm login' to re-authenticate." hint, exit 1
+* ``RateLimitError`` → "Retry after Ns" hint, exit 1
+* ``FileNotFoundError`` (missing storage file) → same AUTH_REQUIRED UX, exit 1
+* JSON variants emit parseable JSON with the appropriate ``code`` + nonzero exit
+* Happy path is unchanged (exit 0, normal output)
+
+The tests use a throwaway Click command registered onto a fresh ``click.Group``
+so they exercise the decorator in isolation from the production CLI surface.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.cli.helpers import with_client
+from notebooklm.exceptions import AuthError, RateLimitError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    # Click 8.2+ separates stdout/stderr in ``CliRunner`` by default, which is
+    # what we need to assert hints went to stderr and JSON to stdout.
+    return CliRunner()
+
+
+@pytest.fixture
+def stubbed_auth(monkeypatch) -> Generator[None, None, None]:
+    """Replace ``get_auth_tokens`` with a no-op so the body runs.
+
+    Tests that want to force a ``FileNotFoundError`` from the auth bootstrap
+    will override this fixture's behavior locally.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    fake_auth = MagicMock(name="AuthTokens-stub")
+    with patch("notebooklm.cli.helpers.get_auth_tokens", return_value=fake_auth):
+        yield
+
+
+def _build_cli(body):
+    """Wrap ``body`` (a coroutine factory) in a minimal ``with_client`` command.
+
+    The resulting ``Group`` exposes a single ``run`` subcommand with optional
+    ``--json`` flag, matching the calling convention every production CLI
+    command uses.
+    """
+
+    @click.group()
+    @click.option("-v", "--verbose", count=True)
+    @click.pass_context
+    def cli(ctx, verbose):
+        ctx.ensure_object(dict)
+
+    @cli.command("run")
+    @click.option("--json", "json_output", is_flag=True)
+    @with_client
+    def run(ctx, json_output, client_auth):
+        return body(client_auth)
+
+    return cli
+
+
+# ---------------------------------------------------------------------------
+# Text-mode failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_auth_error_surfaces_login_hint(runner: CliRunner, stubbed_auth) -> None:
+    """``AuthError`` → "run notebooklm login" hint, exit code 1."""
+
+    async def _raise(_auth):
+        raise AuthError("Token expired")
+
+    cli = _build_cli(_raise)
+    result = runner.invoke(cli, ["run"], catch_exceptions=False)
+
+    assert result.exit_code == 1, result.stderr
+    assert "Authentication error" in result.stderr
+    assert "notebooklm login" in result.stderr
+
+
+def test_rate_limit_error_surfaces_retry_hint(runner: CliRunner, stubbed_auth) -> None:
+    """``RateLimitError`` → "Retry after Ns" hint, exit code 1."""
+
+    async def _raise(_auth):
+        raise RateLimitError("Too many requests", retry_after=42)
+
+    cli = _build_cli(_raise)
+    result = runner.invoke(cli, ["run"], catch_exceptions=False)
+
+    assert result.exit_code == 1, result.stderr
+    assert "Rate limited" in result.stderr
+    assert "42" in result.stderr
+
+
+def test_file_not_found_routes_to_auth_hint(runner: CliRunner, monkeypatch) -> None:
+    """Missing storage file → AUTH_REQUIRED UX (same as no-login path)."""
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    with patch(
+        "notebooklm.cli.helpers.get_auth_tokens",
+        side_effect=FileNotFoundError("missing storage"),
+    ):
+        cli = _build_cli(_never_called)
+        result = runner.invoke(cli, ["run"], catch_exceptions=False)
+
+    assert result.exit_code == 1, result.stderr
+    # ``handle_auth_error`` prints rich console output; we just need the
+    # actionable hint to be reachable somewhere across stdout/stderr/output.
+    combined = (result.stdout or "") + (result.stderr or "") + (result.output or "")
+    assert "notebooklm login" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# JSON-mode failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_auth_error_json_payload(runner: CliRunner, stubbed_auth) -> None:
+    """JSON mode: AuthError → parseable JSON with AUTH_ERROR code, nonzero exit."""
+
+    async def _raise(_auth):
+        raise AuthError("Token expired")
+
+    cli = _build_cli(_raise)
+    result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code != 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "AUTH_ERROR"
+    assert "Token expired" in payload["message"]
+
+
+def test_rate_limit_error_json_payload(runner: CliRunner, stubbed_auth) -> None:
+    """JSON mode: RateLimitError → parseable JSON with RATE_LIMITED code, retry_after."""
+
+    async def _raise(_auth):
+        raise RateLimitError("Too many requests", retry_after=30)
+
+    cli = _build_cli(_raise)
+    result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code != 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "RATE_LIMITED"
+    assert payload["retry_after"] == 30
+
+
+def test_file_not_found_json_payload(runner: CliRunner, monkeypatch) -> None:
+    """JSON mode: missing storage → AUTH_REQUIRED JSON, nonzero exit."""
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    with patch(
+        "notebooklm.cli.helpers.get_auth_tokens",
+        side_effect=FileNotFoundError("missing storage"),
+    ):
+        cli = _build_cli(_never_called)
+        result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code != 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "AUTH_REQUIRED"
+
+
+def test_unexpected_error_json_payload_exits_2(runner: CliRunner, stubbed_auth) -> None:
+    """JSON mode: unknown ``RuntimeError`` → UNEXPECTED_ERROR + exit 2 (system error)."""
+
+    async def _raise(_auth):
+        raise RuntimeError("something went sideways")
+
+    cli = _build_cli(_raise)
+    result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 2, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: happy path still works
+# ---------------------------------------------------------------------------
+
+
+def test_successful_command_exits_zero(runner: CliRunner, stubbed_auth) -> None:
+    """A command that runs cleanly should still exit 0 with no errors."""
+    sentinel: dict = {}
+
+    async def _ok(auth):
+        sentinel["called"] = True
+        click.echo("ok")
+        return None
+
+    cli = _build_cli(_ok)
+    result = runner.invoke(cli, ["run"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stderr
+    assert sentinel.get("called") is True
+    assert "ok" in result.stdout
+
+
+def test_successful_command_json_mode_exits_zero(runner: CliRunner, stubbed_auth) -> None:
+    """``--json`` happy path also exits 0."""
+
+    async def _ok(auth):
+        click.echo(json.dumps({"ok": True}))
+
+    cli = _build_cli(_ok)
+    result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload == {"ok": True}


### PR DESCRIPTION
## Summary
- `@with_client` decorator now wraps the command body in `cli.error_handler.handle_errors(verbose=..., json_output=...)`.
- Auth-bootstrap `FileNotFoundError` (missing storage file) is still handled BEFORE entering `handle_errors` so a `FileNotFoundError` raised inside a command body (issue #153: `source add --type file`) is not misclassified as an auth error.
- AuthError -> "Run 'notebooklm login' to re-authenticate." hint (exit 1).
- RateLimitError -> "Retry after Ns" hint + `retry_after` in JSON (exit 1).
- ValidationError / ConfigError / NetworkError / NotebookLimitError -> typed codes (exit 1).
- Broad `Exception` -> `UNEXPECTED_ERROR` + bug-report hint (exit 2).
- Verbose flag is read off `ctx.find_root().params` so `RPCError`/`RateLimitError` diagnostics include `method_id` when `-v` is passed.
- JSON-mode variants emit parseable JSON + nonzero exit (regression coverage for T1.F).

## Why
Audit X3 / synthesis section 1 T4 / codex #11: `handle_errors` existed with all the actionable hints, but `with_client` ran its own ad-hoc `try/except` so users saw generic "ERROR" instead of "run notebooklm login". This is the protective-layer wiring that closes Tier 1.

## Behavioral notes
- `click.UsageError`/`click.BadParameter` raised inside command bodies now exit with Click's standard exit code 2 (was 1 because the old broad `except Exception` swallowed them). Updated four existing tests to reflect the standard convention.
- An unexpected `FileNotFoundError` from inside a body (not the auth bootstrap) now exits 2 with `UNEXPECTED_ERROR` instead of being silently caught as a generic `ERROR`. The original issue #153 invariant — "this is NOT an auth error" — is preserved and tested.
- A bare `ValueError` from a body is now `UNEXPECTED_ERROR` (exit 2) rather than `ERROR` (exit 1).

## Follow-ups (NOT in this PR)
- `cli/download.py:169` and `cli/download.py:813` call `AuthTokens.from_storage()` directly (bypassing `with_client`) — their own try/except for `FileNotFoundError` could be replaced with a shared helper.
- `cli/download.py:676,862,894` invoke `handle_error(e)` directly inside synchronous code paths — could route through `handle_errors` once those paths are refactored to use the decorator.
- `cli/session.py`, `cli/profile.py`, `cli/skill.py` have multiple `except ValueError/OSError` blocks that surface `click.ClickException`; these are pre-`with_client` modules that could benefit from `handle_errors` once converted.

## Test plan
- [x] AuthError, RateLimitError, FileNotFoundError surface actionable hints + exit 1
- [x] JSON mode of each emits parseable JSON + nonzero exit
- [x] Happy path unchanged (exit 0)
- [x] Regression guard: FileNotFoundError inside body is NOT classified as auth error (issue #153)
- [x] Full unit suite green (2386 passed, 5 skipped)

Part of Tier 1 (`.sisyphus/plans/tier-1-implementation.md`). Closes the protective-layer wiring.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CLI error handling with clearer, more actionable error messages for authentication failures, rate limiting, and validation errors.
  * Standardized exit codes to match CLI conventions for better automation and script integration.

* **Tests**
  * Added comprehensive error handling test coverage and validation of exit code behavior across various failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->