### PR TITLE
refactor(cli): move with_client auth bootstrap inside handle_errors (T1.G follow-up)

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -1012,19 +1012,22 @@ def with_client(f):
                 logger.debug("CLI command %s: %s (%.3fs)", status, cmd_name, elapsed)
             return elapsed
 
-        # Auth bootstrap: FileNotFoundError here means the storage file is
-        # missing, which has a dedicated rich UX via ``handle_auth_error``.
-        # We deliberately handle this BEFORE entering ``handle_errors`` so a
-        # FileNotFoundError raised *inside* the command body (e.g., a missing
-        # ``--source-file`` argument) is not misclassified as an auth error.
-        try:
-            auth = get_auth_tokens(ctx)
-        except FileNotFoundError:
-            log_result("failed", "not authenticated")
-            handle_auth_error(json_output)
-            return  # unreachable — handle_auth_error raises SystemExit
-
         with handle_errors(verbose=verbose, json_output=json_output):
+            # Auth bootstrap: FileNotFoundError here means the storage file is
+            # missing — it has a dedicated rich UX via ``handle_auth_error``.
+            # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
+            # raised *inside* the command body (e.g., a missing ``--source-file``
+            # argument; see issue #153) is NOT misclassified as an auth error —
+            # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
+            # Any OTHER exception from the auth bootstrap (malformed storage JSON,
+            # AuthError during token extraction, etc.) also reaches ``handle_errors``
+            # so users get typed hints rather than a raw traceback.
+            try:
+                auth = get_auth_tokens(ctx)
+            except FileNotFoundError:
+                log_result("failed", "not authenticated")
+                handle_auth_error(json_output)
+                return  # unreachable — handle_auth_error raises SystemExit
             try:
                 coro = f(ctx, *args, client_auth=auth, **kwargs)
                 result = run_async(coro)

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -132,6 +132,59 @@ def test_file_not_found_routes_to_auth_hint(runner: CliRunner, monkeypatch) -> N
     assert "notebooklm login" in combined.lower()
 
 
+def test_auth_bootstrap_non_filenotfound_routes_through_handle_errors(
+    runner: CliRunner, monkeypatch
+) -> None:
+    """Non-FileNotFoundError exceptions during auth bootstrap reach ``handle_errors``.
+
+    Regression guard for Gemini feedback on PR #454: previously the auth
+    bootstrap lived OUTSIDE ``handle_errors``, so a ``ValueError`` from
+    malformed storage JSON or an ``AuthError`` during token extraction would
+    bubble unhandled instead of getting the centralized hint + typed code.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    # AuthError surfaces with the actionable "run notebooklm login" hint and exit 1.
+    with patch(
+        "notebooklm.cli.helpers.get_auth_tokens",
+        side_effect=AuthError("token refresh failed"),
+    ):
+        cli = _build_cli(_never_called)
+        result = runner.invoke(cli, ["run"], catch_exceptions=False)
+
+    assert result.exit_code == 1, result.stderr
+    assert "notebooklm login" in result.stderr
+
+
+def test_auth_bootstrap_malformed_json_routes_through_handle_errors(
+    runner: CliRunner, monkeypatch
+) -> None:
+    """``ValueError`` (e.g., malformed storage JSON) during auth bootstrap exits 2.
+
+    Without ``handle_errors`` wrapping the bootstrap this would bubble as an
+    uncaught traceback.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    with patch(
+        "notebooklm.cli.helpers.get_auth_tokens",
+        side_effect=ValueError("malformed storage JSON"),
+    ):
+        cli = _build_cli(_never_called)
+        result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 2, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+
+
 # ---------------------------------------------------------------------------
 # JSON-mode failure paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Addresses [gemini-code-assist feedback on #454](https://github.com/teng-lin/notebooklm-py/pull/454#discussion_r): the auth bootstrap (`get_auth_tokens(ctx)`) lived OUTSIDE `handle_errors`, so a non-`FileNotFoundError` raised during token extraction (malformed storage JSON -> `ValueError`, `AuthError` during refresh, etc.) would bubble as a raw traceback instead of getting the centralized hint + typed exit code.

After this PR:
- `FileNotFoundError` still routes to `handle_auth_error` (rich UX preserved, issue #153 coverage intact).
- Any other auth-bootstrap exception falls through to `handle_errors` and surfaces the right hint per exception type:
  - `AuthError` -> "Run 'notebooklm login' to re-authenticate." (exit 1)
  - `ValueError` (malformed JSON, etc.) -> `UNEXPECTED_ERROR` with bug-report hint (exit 2)
  - `RateLimitError` during a token-refresh roundtrip -> "Retry after Ns" (exit 1)

## Why
Without this, `notebooklm <command>` would print a raw Python traceback if `~/.notebooklm/storage_state.json` was corrupted or if the token refresh round-trip hit an auth/rate-limit error — the worst-of-both-worlds UX that T1.G was supposed to close.

## Test plan
- [x] Two new regression tests in `tests/unit/test_with_client_handle_errors.py`:
  - `test_auth_bootstrap_non_filenotfound_routes_through_handle_errors` — `AuthError` during bootstrap surfaces login hint, exit 1.
  - `test_auth_bootstrap_malformed_json_routes_through_handle_errors` — `ValueError` during bootstrap emits parseable JSON with `UNEXPECTED_ERROR` code, exit 2.
- [x] All existing tests still pass (2388 passed).
- [x] Issue #153 invariant preserved: body-raised `FileNotFoundError` is still NOT misclassified as an auth error.

Follow-up to #454.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for authentication token issues, ensuring consistent error reporting across different scenarios and output modes.
  * Enhanced authentication error messages to provide actionable guidance for users.

* **Tests**
  * Added test coverage for authentication error handling paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/455)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->