### PR TITLE
feat(_core): _perform_authed_post + query_post transport helpers (T2.C)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 from urllib.parse import urlencode
 
 import httpx
@@ -119,10 +119,11 @@ class _TransportAuthExpired(Exception):
     """Raised by ``_perform_authed_post`` when the refresh callback itself
     failed during an auth recovery attempt.
 
-    ``original`` is the transport-layer exception that triggered the refresh
-    attempt (``httpx.HTTPStatusError`` for an HTTP-mapped auth failure, or
-    ``httpx.RequestError`` for a network-level one). The refresh callback's
-    error is attached via ``__cause__``.
+    ``original`` is the transport-layer ``httpx.HTTPStatusError`` that
+    triggered the refresh attempt — :func:`is_auth_error` only flags
+    ``HTTPStatusError`` responses, so network-level ``RequestError``s never
+    reach this path. The refresh callback's error is attached via
+    ``__cause__``.
 
     Callers map this onto their own error domain:
 
@@ -911,7 +912,6 @@ class ClientCore:
         source_path: str = "/",
         allow_null: bool = False,
         _is_retry: bool = False,
-        _rate_limit_retries: int = 0,
     ) -> Any:
         """Make an RPC call to the NotebookLM API.
 
@@ -923,8 +923,7 @@ class ClientCore:
             params: Parameters for the RPC call (nested list structure).
             source_path: The source path parameter (usually /notebook/{id}).
             allow_null: If True, don't raise error when response is null.
-            _is_retry: Internal flag to prevent infinite retries.
-            _rate_limit_retries: Internal counter for rate limit retries.
+            _is_retry: Internal flag to prevent infinite decode-time retries.
 
         Returns:
             Decoded response data.
@@ -937,20 +936,18 @@ class ClientCore:
         if not self._http_client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
 
-        # Only the outer rpc_call mints a request id; the recursive retry path
-        # (_is_retry=True or rate limit retry) inherits the parent's id so a
-        # single failure→refresh→retry sequence appears under one [req=<id>]
-        # in the logs.
-        if _is_retry or _rate_limit_retries > 0:
-            return await self._rpc_call_impl(
-                method, params, source_path, allow_null, _is_retry, _rate_limit_retries
-            )
+        # Only the outer rpc_call mints a request id; the decode-time retry
+        # path (``_is_retry=True``) inherits the parent's id so a single
+        # decode-error → refresh → retry sequence appears under one
+        # ``[req=<id>]`` in the logs. HTTP-status retries (auth + 429) happen
+        # inside ``_perform_authed_post`` without recursion, so they don't
+        # need this guard.
+        if _is_retry:
+            return await self._rpc_call_impl(method, params, source_path, allow_null, _is_retry)
 
         _reqid_token = set_request_id()
         try:
-            return await self._rpc_call_impl(
-                method, params, source_path, allow_null, _is_retry, _rate_limit_retries
-            )
+            return await self._rpc_call_impl(method, params, source_path, allow_null, _is_retry)
         finally:
             reset_request_id(_reqid_token)
 
@@ -961,7 +958,6 @@ class ClientCore:
         source_path: str,
         allow_null: bool,
         _is_retry: bool,
-        _rate_limit_retries: int = 0,
     ) -> Any:
         # Caller (rpc_call) has already verified self._http_client is not None;
         # re-assert for mypy narrowing through this helper.
@@ -974,14 +970,24 @@ class ClientCore:
         # refreshed CSRF and the URL with the refreshed session id /
         # authuser. Capturing ``self.auth.csrf_token`` here directly would
         # snapshot at outer-call time and replay a stale token on retry.
+        rpc_request = encode_rpc_request(method, params)
+
         def _build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
-            # _build_url reads ``self.auth.session_id`` / ``self.auth.authuser``
-            # / ``self.auth.account_email`` directly; those mirror the snapshot
-            # because the refresh callback mutates ``self.auth`` in place
-            # before we loop. We pass the snapshot's csrf_token into
-            # ``build_request_body`` to keep the body internally consistent.
+            # Deliberate divergence: the body uses the snapshot's csrf_token
+            # (a frozen point-in-time copy) while ``_build_url`` reads
+            # ``self.auth.session_id`` / ``self.auth.authuser`` /
+            # ``self.auth.account_email`` LIVE off ``self.auth``. The two
+            # stay consistent only because the no-await invariant between
+            # ``_snapshot()`` and the ``client.post(...)`` call inside
+            # ``_perform_authed_post`` guarantees no coroutine can mutate
+            # ``self.auth`` between snapshot capture and request build (see
+            # the AST guard in ``tests/unit/test_concurrency_refresh_race.py``
+            # — adding an ``await`` anywhere in this factory or in
+            # ``_build_url`` would silently desync URL from body across a
+            # refresh). The snapshot's session_id/authuser/account_email
+            # fields are carried for symmetry / future-proofing but are not
+            # the source of truth on this code path.
             url = self._build_url(method, source_path)
-            rpc_request = encode_rpc_request(method, params)
             body = build_request_body(rpc_request, snapshot.csrf_token)
             return url, body, {}
 
@@ -1021,9 +1027,7 @@ class ClientCore:
                 elapsed,
                 exc.response.status_code,
             )
-            return self._raise_rpc_error_from_http_status(
-                exc, method, _rate_limit_retries=_rate_limit_retries
-            )
+            self._raise_rpc_error_from_http_status(exc, method)
         except httpx.RequestError as exc:
             elapsed = time.perf_counter() - start
             logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, exc)
@@ -1065,15 +1069,12 @@ class ClientCore:
         self,
         exc: httpx.HTTPStatusError,
         method: RPCMethod,
-        *,
-        _rate_limit_retries: int = 0,
-    ) -> Any:
+    ) -> NoReturn:
         """Map an HTTP-status failure onto the RPC error hierarchy.
 
         Centralizes the status-to-exception mapping that historically lived
-        inline in ``_rpc_call_impl``. Returns ``NoReturn`` semantically (it
-        always raises), but is typed ``Any`` so callers can ``return`` it
-        from ``async`` functions for mypy.
+        inline in ``_rpc_call_impl``. Always raises — typed ``NoReturn`` so
+        mypy sees the caller's control flow terminates here.
         """
         status = exc.response.status_code
 
@@ -1112,8 +1113,13 @@ class ClientCore:
         self,
         exc: httpx.RequestError,
         method: RPCMethod,
-    ) -> None:
-        """Map a non-HTTPStatus transport failure onto NetworkError/RPCTimeoutError."""
+    ) -> NoReturn:
+        """Map a non-HTTPStatus transport failure onto NetworkError/RPCTimeoutError.
+
+        Always raises — typed ``NoReturn`` so mypy treats the caller's
+        control flow as terminating here, preventing an unbound-``response``
+        warning in the decode block of ``_rpc_call_impl``.
+        """
         # Check ConnectTimeout first (more specific than general TimeoutException)
         if isinstance(exc, httpx.ConnectTimeout):
             raise NetworkError(
@@ -1175,30 +1181,14 @@ class ClientCore:
             method.name,
         )
 
-        # This function is only called when _refresh_callback is set
-        assert self._refresh_callback is not None
-
-        # Use lock to coordinate refresh task creation
-        # Note: refresh_callback is expected to update auth headers internally
-        # Lock is always created when callback is set (see __init__)
-        assert self._refresh_lock is not None
-
-        # Determine which task to await (existing or new)
-        async with self._refresh_lock:
-            if self._refresh_task is not None and not self._refresh_task.done():
-                # Another refresh is in progress, wait on it
-                refresh_task = self._refresh_task
-                logger.debug("Waiting on existing refresh task for RPC %s", method.name)
-            else:
-                # Start a new refresh task
-                # Cast needed: Awaitable → Coroutine for create_task (async funcs return coroutines)
-                coro = cast(Coroutine[Any, Any, AuthTokens], self._refresh_callback())
-                self._refresh_task = asyncio.create_task(coro)
-                refresh_task = self._refresh_task
-
-        # Await refresh outside the lock so other callers can join
+        # Delegate the shared-task + lock dance to ``_await_refresh`` so this
+        # decode-time retry path stays in lockstep with the transport-time
+        # path inside ``_perform_authed_post``. On refresh failure, surface
+        # the *original* RPC decode error (not the refresh error) so callers
+        # see the symptom they originally hit — refresh failure is attached
+        # as ``__cause__``.
         try:
-            await refresh_task
+            await self._await_refresh()
         except Exception as refresh_error:
             logger.warning("Token refresh failed: %s", refresh_error)
             raise original_error from refresh_error

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -8,6 +8,7 @@ import time
 import warnings
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -96,6 +97,72 @@ AUTH_ERROR_PATTERNS = (
     "login",
     "re-authenticate",
 )
+
+
+@dataclass(frozen=True)
+class _AuthSnapshot:
+    """Point-in-time view of auth headers used to build a single request.
+
+    Captured once per HTTP attempt by ``_perform_authed_post`` and passed
+    into the caller-supplied ``build_request`` factory so the URL/body are
+    consistent for that attempt. On retry, a *new* snapshot is taken so
+    refreshed credentials are picked up before the rebuild.
+    """
+
+    csrf_token: str
+    session_id: str
+    authuser: int
+    account_email: str | None
+
+
+class _TransportAuthExpired(Exception):
+    """Raised by ``_perform_authed_post`` when the refresh callback itself
+    failed during an auth recovery attempt.
+
+    ``original`` is the transport-layer exception that triggered the refresh
+    attempt (``httpx.HTTPStatusError`` for an HTTP-mapped auth failure, or
+    ``httpx.RequestError`` for a network-level one). The refresh callback's
+    error is attached via ``__cause__``.
+
+    Callers map this onto their own error domain:
+
+    - ``rpc_call`` re-raises ``original`` so legacy callers that catch
+      :class:`httpx.HTTPStatusError` keep working byte-for-byte.
+    - ``query_post`` translates this into :class:`ChatError`.
+    """
+
+    def __init__(self, message: str, *, original: Exception):
+        super().__init__(message)
+        self.original = original
+
+
+class _TransportRateLimited(Exception):
+    """Raised by ``_perform_authed_post`` when the 429 retry budget is
+    exhausted (or no retries are configured).
+
+    ``retry_after`` carries the parsed (clamped) Retry-After value when the
+    server provided one; ``response`` is the final httpx response so callers
+    can read status / reason for their own error message.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        retry_after: int | None,
+        response: httpx.Response,
+        original: httpx.HTTPStatusError,
+    ):
+        super().__init__(message)
+        self.retry_after = retry_after
+        self.response = response
+        self.original = original
+
+
+# Build-request factory: receives a fresh ``_AuthSnapshot`` and returns the
+# triple (url, body, extra_headers) for one HTTP attempt. ``_perform_authed_post``
+# invokes this once per attempt so refreshed snapshots are picked up on retry.
+_BuildRequest = Callable[[_AuthSnapshot], tuple[str, str, dict[str, str]]]
 
 
 def _resolve_keepalive_interval(keepalive: float | None, min_interval: float) -> float | None:
@@ -566,6 +633,20 @@ class ClientCore:
 
         self.auth.cookie_jar = self._http_client.cookies
 
+    def _snapshot(self) -> _AuthSnapshot:
+        """Capture the current auth headers as a frozen snapshot.
+
+        Used by ``_perform_authed_post`` to make a single HTTP attempt's
+        URL/body consistent (no mid-attempt mutation from refresh /
+        keepalive). A fresh snapshot is taken on each retry.
+        """
+        return _AuthSnapshot(
+            csrf_token=self.auth.csrf_token,
+            session_id=self.auth.session_id,
+            authuser=self.auth.authuser,
+            account_email=self.auth.account_email,
+        )
+
     def _build_url(self, rpc_method: RPCMethod, source_path: str = "/") -> str:
         """Build the batchexecute URL for an RPC call.
 
@@ -593,6 +674,235 @@ class ClientCore:
                 self.auth.account_email,
             )
         return f"{get_batchexecute_url()}?{urlencode(params)}"
+
+    async def _perform_authed_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        log_label: str,
+    ) -> httpx.Response:
+        """Run an authed POST through the shared retry/refresh pipeline.
+
+        The pipeline is the transport-level core that both ``rpc_call`` and
+        ``query_post`` share. Per-attempt behavior:
+
+        1. Take a fresh ``_AuthSnapshot`` via :meth:`_snapshot`.
+        2. Invoke ``build_request(snapshot)`` to assemble ``(url, body,
+           extra_headers)``. The factory is called *once per attempt* so that
+           retries pick up refreshed credentials instead of replaying a stale
+           pre-refresh URL/body — see synthesis §6 Tier-2 item 4.
+        3. POST via the underlying ``httpx.AsyncClient`` and call
+           ``raise_for_status()``.
+
+        Error-boundary contract (callers must wrap into their own typed
+        exceptions):
+
+        - **Auth refresh path** — when a refresh callback is configured and
+          the failure looks like an auth error (HTTP 400/401/403, see
+          :func:`is_auth_error`), the helper awaits a shared refresh task and
+          retries once with a fresh snapshot. If the refresh callback itself
+          raises, the original transport exception is wrapped in
+          :class:`_TransportAuthExpired` (refresh error chained via
+          ``__cause__``) so callers can re-raise the original unchanged
+          (``rpc_call``) or translate to their own typed error
+          (``query_post``). If the post-refresh retry's POST fails for a
+          non-auth reason, that exception propagates as-is.
+        - **Rate-limit path** — on HTTP 429 with a parseable Retry-After,
+          sleeps and retries until ``rate_limit_max_retries`` is reached;
+          after that, raises :class:`_TransportRateLimited` with the final
+          response and parsed retry-after value. With no parseable header or
+          ``rate_limit_max_retries == 0``, raises immediately.
+        - All other errors propagate as :class:`httpx.HTTPStatusError` /
+          :class:`httpx.RequestError` unchanged.
+
+        Caller responsibilities:
+
+        - Manage the ``set_request_id`` context (so retries within a single
+          logical call share one ``[req=<id>]`` tag).
+        - Decode the response (this helper does no parsing).
+        - Wrap transport exceptions into the caller's error domain:
+          ``rpc_call`` maps into :class:`RPCError`-family exceptions;
+          ``query_post`` maps into :class:`ChatError` / :class:`NetworkError`.
+
+        Args:
+            build_request: Factory invoked once per attempt with a fresh
+                ``_AuthSnapshot``. Must return ``(url, body, extra_headers)``.
+                ``extra_headers`` is merged onto the httpx client's defaults
+                for this attempt only.
+            log_label: Caller-friendly label embedded in log lines (e.g. an
+                RPC method name or ``"chat.ask"``).
+
+        Returns:
+            The raw ``httpx.Response`` from the successful attempt. The
+            caller owns decoding.
+        """
+        assert self._http_client is not None
+        client = self._http_client
+
+        refreshed_this_call = False
+        rate_limit_retries = 0
+        start = time.perf_counter()
+
+        while True:
+            snapshot = self._snapshot()
+            url, body, headers = build_request(snapshot)
+
+            try:
+                if headers:
+                    response = await client.post(url, content=body, headers=headers)
+                else:
+                    response = await client.post(url, content=body)
+                response.raise_for_status()
+            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+                # --- Auth refresh path ---------------------------------
+                if (
+                    not refreshed_this_call
+                    and self._refresh_callback is not None
+                    and is_auth_error(exc)
+                ):
+                    logger.info(
+                        "%s auth error detected, attempting token refresh",
+                        log_label,
+                    )
+                    try:
+                        await self._await_refresh()
+                    except Exception as refresh_error:
+                        logger.warning("Token refresh failed: %s", refresh_error)
+                        # Signal "refresh failed" to the caller via a typed
+                        # transport exception so the RPC mapper can re-raise
+                        # the *original* HTTPStatusError unchanged (matches
+                        # the historical ``_try_refresh_and_retry`` contract
+                        # — see ``test_no_retry_on_cookie_expiration``).
+                        raise _TransportAuthExpired(
+                            f"auth refresh failed for {log_label}",
+                            original=exc,
+                        ) from refresh_error
+                    if self._refresh_retry_delay > 0:
+                        await asyncio.sleep(self._refresh_retry_delay)
+                    logger.info("Token refresh successful, retrying %s", log_label)
+                    refreshed_this_call = True
+                    # Loop around: next iteration takes a FRESH snapshot,
+                    # rebuilds the request body with the new csrf/sid, and
+                    # re-POSTs.
+                    continue
+
+                # --- 429 rate-limit path --------------------------------
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
+                    retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+                    if (
+                        retry_after is not None
+                        and rate_limit_retries < self._rate_limit_max_retries
+                    ):
+                        logger.warning(
+                            "%s rate-limited (HTTP 429); sleeping %ds then retrying (%d/%d)",
+                            log_label,
+                            retry_after,
+                            rate_limit_retries + 1,
+                            self._rate_limit_max_retries,
+                        )
+                        await asyncio.sleep(retry_after)
+                        rate_limit_retries += 1
+                        continue
+                    raise _TransportRateLimited(
+                        f"{log_label} rate-limited (HTTP 429)",
+                        retry_after=retry_after,
+                        response=exc.response,
+                        original=exc,
+                    ) from exc
+
+                # --- Anything else: propagate the raw transport error ----
+                elapsed = time.perf_counter() - start
+                logger.debug(
+                    "%s transport error after %.3fs: %s",
+                    log_label,
+                    elapsed,
+                    exc,
+                )
+                raise
+
+            # Success
+            return response
+
+    async def _await_refresh(self) -> None:
+        """Run / join the shared refresh task.
+
+        Concurrent callers share one refresh task so a thundering herd of
+        401s on the same client triggers exactly one token refresh. The lock
+        protects task-creation only; the await on the task itself happens
+        outside the lock so other callers can join.
+        """
+        assert self._refresh_callback is not None
+        assert self._refresh_lock is not None
+
+        async with self._refresh_lock:
+            if self._refresh_task is not None and not self._refresh_task.done():
+                refresh_task = self._refresh_task
+                logger.debug("Joining existing refresh task")
+            else:
+                coro = cast(Coroutine[Any, Any, AuthTokens], self._refresh_callback())
+                self._refresh_task = asyncio.create_task(coro)
+                refresh_task = self._refresh_task
+
+        await refresh_task
+
+    async def query_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        parse_label: str,
+    ) -> httpx.Response:
+        """Chat-side semantic owner around :meth:`_perform_authed_post`.
+
+        Wraps the shared transport pipeline with chat-flavored exception
+        mapping: transport-layer auth failures become
+        :class:`~notebooklm.exceptions.ChatError`, and transport-layer
+        network/rate-limit failures become
+        :class:`~notebooklm.exceptions.NetworkError` /
+        :class:`~notebooklm.exceptions.ChatError` respectively. This keeps
+        ChatAPI free of HTTP-status branching and matches the historical
+        contract of ``ChatAPI.ask`` (T2.D will migrate that caller).
+
+        Args:
+            build_request: See :meth:`_perform_authed_post`.
+            parse_label: Caller-friendly label used in log lines and error
+                messages (e.g. ``"chat.ask"``).
+        """
+        # Import here to avoid a circular import: exceptions imports from
+        # this module's siblings.
+        from .exceptions import ChatError, NetworkError
+
+        try:
+            return await self._perform_authed_post(
+                build_request=build_request,
+                log_label=parse_label,
+            )
+        except _TransportAuthExpired as exc:
+            raise ChatError(
+                f"{parse_label} failed: authentication expired and refresh did not recover"
+            ) from exc
+        except _TransportRateLimited as exc:
+            raise ChatError(
+                f"{parse_label} rate-limited (HTTP 429)."
+                + (
+                    f" Retry after {exc.retry_after} seconds."
+                    if exc.retry_after is not None
+                    else ""
+                )
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise NetworkError(
+                f"{parse_label} timed out: {exc}",
+                original_error=exc,
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise ChatError(
+                f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise NetworkError(
+                f"{parse_label} request failed: {exc}",
+                original_error=exc,
+            ) from exc
 
     async def rpc_call(
         self,
@@ -659,124 +969,72 @@ class ClientCore:
         start = time.perf_counter()
         logger.debug("RPC %s starting", method.name)
 
-        url = self._build_url(method, source_path)
-        rpc_request = encode_rpc_request(method, params)
-        body = build_request_body(rpc_request, self.auth.csrf_token)
+        # ``_perform_authed_post`` calls this factory once per HTTP attempt;
+        # on retry it passes a fresh snapshot so the body is rebuilt with the
+        # refreshed CSRF and the URL with the refreshed session id /
+        # authuser. Capturing ``self.auth.csrf_token`` here directly would
+        # snapshot at outer-call time and replay a stale token on retry.
+        def _build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            # _build_url reads ``self.auth.session_id`` / ``self.auth.authuser``
+            # / ``self.auth.account_email`` directly; those mirror the snapshot
+            # because the refresh callback mutates ``self.auth`` in place
+            # before we loop. We pass the snapshot's csrf_token into
+            # ``build_request_body`` to keep the body internally consistent.
+            url = self._build_url(method, source_path)
+            rpc_request = encode_rpc_request(method, params)
+            body = build_request_body(rpc_request, snapshot.csrf_token)
+            return url, body, {}
 
         try:
-            response = await self._http_client.post(url, content=body)
-            response.raise_for_status()
-        except (httpx.HTTPStatusError, httpx.RequestError) as e:
+            response = await self._perform_authed_post(
+                build_request=_build,
+                log_label=f"RPC {method.name}",
+            )
+        except _TransportAuthExpired as exc:
+            # Refresh callback raised. Historical contract:
+            # the *original* transport exception escapes with the refresh
+            # error attached via ``__cause__`` (already chained inside
+            # ``_perform_authed_post``). No status-code mapping happens for
+            # this path — callers that catch :class:`httpx.HTTPStatusError`
+            # see exactly what they used to see pre-extraction.
+            raise exc.original from exc.__cause__
+        except _TransportRateLimited as exc:
             elapsed = time.perf_counter() - start
+            logger.error(
+                "RPC %s failed after %.3fs: HTTP 429",
+                method.name,
+                elapsed,
+            )
+            msg = f"API rate limit exceeded calling {method.name}"
+            if exc.retry_after:
+                msg += f". Retry after {exc.retry_after} seconds"
+            raise RateLimitError(
+                msg,
+                method_id=method.value,
+                retry_after=exc.retry_after,
+            ) from exc.original
+        except httpx.HTTPStatusError as exc:
+            elapsed = time.perf_counter() - start
+            logger.error(
+                "RPC %s failed after %.3fs: HTTP %s",
+                method.name,
+                elapsed,
+                exc.response.status_code,
+            )
+            return self._raise_rpc_error_from_http_status(
+                exc, method, _rate_limit_retries=_rate_limit_retries
+            )
+        except httpx.RequestError as exc:
+            elapsed = time.perf_counter() - start
+            logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, exc)
+            self._raise_rpc_error_from_request_error(exc, method)
 
-            # Check if this is an auth error and we can retry
-            if not _is_retry and self._refresh_callback and is_auth_error(e):
-                refreshed = await self._try_refresh_and_retry(
-                    method, params, source_path, allow_null, e
-                )
-                if refreshed is not None:
-                    return refreshed
-
-            if isinstance(e, httpx.HTTPStatusError):
-                status = e.response.status_code
-                logger.error(
-                    "RPC %s failed after %.3fs: HTTP %s",
-                    method.name,
-                    elapsed,
-                    status,
-                )
-
-                # Map HTTP status codes to appropriate exception types
-                if status == 429:
-                    # Rate limiting - parse retry-after (integer or HTTP-date).
-                    retry_after = _parse_retry_after(e.response.headers.get("retry-after"))
-                    # Opt-in automatic retry: if the caller enabled the budget and
-                    # the server gave us a parseable Retry-After, sleep and retry.
-                    # _is_retry stays at its incoming value so the post-sleep call
-                    # can still escalate via the auth-refresh path on 401/403.
-                    if (
-                        retry_after is not None
-                        and _rate_limit_retries < self._rate_limit_max_retries
-                    ):
-                        logger.warning(
-                            "RPC %s rate-limited (HTTP 429); sleeping %ds then retrying (%d/%d)",
-                            method.name,
-                            retry_after,
-                            _rate_limit_retries + 1,
-                            self._rate_limit_max_retries,
-                        )
-                        await asyncio.sleep(retry_after)
-                        return await self.rpc_call(
-                            method,
-                            params,
-                            source_path,
-                            allow_null,
-                            _is_retry=_is_retry,
-                            _rate_limit_retries=_rate_limit_retries + 1,
-                        )
-                    msg = f"API rate limit exceeded calling {method.name}"
-                    if retry_after:
-                        msg += f". Retry after {retry_after} seconds"
-                    raise RateLimitError(
-                        msg, method_id=method.value, retry_after=retry_after
-                    ) from e
-
-                if 500 <= status < 600:
-                    raise ServerError(
-                        f"Server error {status} calling {method.name}: {e.response.reason_phrase}",
-                        method_id=method.value,
-                        status_code=status,
-                    ) from e
-
-                if 400 <= status < 500 and status not in (401, 403):
-                    raise ClientError(
-                        f"Client error {status} calling {method.name}: {e.response.reason_phrase}",
-                        method_id=method.value,
-                        status_code=status,
-                    ) from e
-
-                # 401/403 or other: Generic RPCError (handled by auth retry above)
-                raise RPCError(
-                    f"HTTP {status} calling {method.name}: {e.response.reason_phrase}",
-                    method_id=method.value,
-                ) from e
-
-            # Network/connection errors
-            else:
-                logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, e)
-
-                # Check ConnectTimeout first (more specific than general TimeoutException)
-                if isinstance(e, httpx.ConnectTimeout):
-                    raise NetworkError(
-                        f"Connection timed out calling {method.name}: {e}",
-                        method_id=method.value,
-                        original_error=e,
-                    ) from e
-
-                # Timeout errors (general timeouts, not connection timeouts)
-                if isinstance(e, httpx.TimeoutException):
-                    raise RPCTimeoutError(
-                        f"Request timed out calling {method.name}",
-                        method_id=method.value,
-                        timeout_seconds=self._timeout,
-                        original_error=e,
-                    ) from e
-
-                # Connection errors (DNS, network unavailable, etc., excluding ConnectTimeout)
-                if isinstance(e, httpx.ConnectError):
-                    raise NetworkError(
-                        f"Connection failed calling {method.name}: {e}",
-                        method_id=method.value,
-                        original_error=e,
-                    ) from e
-
-                # Other request errors
-                raise NetworkError(
-                    f"Request failed calling {method.name}: {e}",
-                    method_id=method.value,
-                    original_error=e,
-                ) from e
-
+        # ---------- Decode -------------------------------------------------
+        # Decode-time auth retry stays RPC-specific: Google sometimes
+        # returns a 200 with an auth-shaped RPCError payload (the body says
+        # "authentication expired" instead of a 401 status code). The chat
+        # streaming format doesn't have this pattern, so the retry lives
+        # here, not in ``_perform_authed_post``.
         try:
             result = decode_response(response.text, method.value, allow_null=allow_null)
             elapsed = time.perf_counter() - start
@@ -802,6 +1060,88 @@ class ClientCore:
                 f"Failed to decode response for {method.name}: {e}",
                 method_id=method.value,
             ) from e
+
+    def _raise_rpc_error_from_http_status(
+        self,
+        exc: httpx.HTTPStatusError,
+        method: RPCMethod,
+        *,
+        _rate_limit_retries: int = 0,
+    ) -> Any:
+        """Map an HTTP-status failure onto the RPC error hierarchy.
+
+        Centralizes the status-to-exception mapping that historically lived
+        inline in ``_rpc_call_impl``. Returns ``NoReturn`` semantically (it
+        always raises), but is typed ``Any`` so callers can ``return`` it
+        from ``async`` functions for mypy.
+        """
+        status = exc.response.status_code
+
+        if status == 429:
+            # _perform_authed_post normally raises ``_TransportRateLimited``
+            # before reaching here. This branch covers callers that bypass
+            # the helper or a 429 surfacing after an auth retry.
+            retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+            msg = f"API rate limit exceeded calling {method.name}"
+            if retry_after:
+                msg += f". Retry after {retry_after} seconds"
+            raise RateLimitError(msg, method_id=method.value, retry_after=retry_after) from exc
+
+        if 500 <= status < 600:
+            raise ServerError(
+                f"Server error {status} calling {method.name}: {exc.response.reason_phrase}",
+                method_id=method.value,
+                status_code=status,
+            ) from exc
+
+        if 400 <= status < 500 and status not in (401, 403):
+            raise ClientError(
+                f"Client error {status} calling {method.name}: {exc.response.reason_phrase}",
+                method_id=method.value,
+                status_code=status,
+            ) from exc
+
+        # 401/403 or other: Generic RPCError (auth retry already attempted by
+        # _perform_authed_post when a refresh callback was configured).
+        raise RPCError(
+            f"HTTP {status} calling {method.name}: {exc.response.reason_phrase}",
+            method_id=method.value,
+        ) from exc
+
+    def _raise_rpc_error_from_request_error(
+        self,
+        exc: httpx.RequestError,
+        method: RPCMethod,
+    ) -> None:
+        """Map a non-HTTPStatus transport failure onto NetworkError/RPCTimeoutError."""
+        # Check ConnectTimeout first (more specific than general TimeoutException)
+        if isinstance(exc, httpx.ConnectTimeout):
+            raise NetworkError(
+                f"Connection timed out calling {method.name}: {exc}",
+                method_id=method.value,
+                original_error=exc,
+            ) from exc
+
+        if isinstance(exc, httpx.TimeoutException):
+            raise RPCTimeoutError(
+                f"Request timed out calling {method.name}",
+                method_id=method.value,
+                timeout_seconds=self._timeout,
+                original_error=exc,
+            ) from exc
+
+        if isinstance(exc, httpx.ConnectError):
+            raise NetworkError(
+                f"Connection failed calling {method.name}: {exc}",
+                method_id=method.value,
+                original_error=exc,
+            ) from exc
+
+        raise NetworkError(
+            f"Request failed calling {method.name}: {exc}",
+            method_id=method.value,
+            original_error=exc,
+        ) from exc
 
     async def _try_refresh_and_retry(
         self,

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -1,23 +1,30 @@
-"""Phase 1.5 P1.5.1 — snapshot-invariant for `_rpc_call_impl`.
+"""Phase 1.5 P1.5.1 — snapshot-invariant for the shared POST helper.
 
 httpx merges the cookie jar into the outgoing ``httpx.Request`` synchronously
-in ``build_request()``, before any ``await``. ``_rpc_call_impl`` reads
-``auth.csrf_token`` and ``auth.session_id`` synchronously before
-``await self._http_client.post(url, content=body)``. Therefore, the entire
-``(csrf, session_id, cookies)`` snapshot is atomic from a concurrent-coroutine
-standpoint: no other task can mutate state between read and the wire.
+in ``build_request()``, before any ``await``. ``_perform_authed_post`` reads
+the auth snapshot (via ``self._snapshot()``) and assembles ``(url, body,
+headers)`` via ``build_request(snapshot)`` synchronously before
+``await client.post(...)``. Therefore, within a single retry iteration the
+entire ``(csrf, session_id, cookies)`` snapshot is atomic from a concurrent
+coroutine standpoint: no other task can mutate state between read and the
+wire.
+
+T2.C moved the POST out of ``_rpc_call_impl`` into ``_perform_authed_post``
+so chat (T2.D) can share the same transport pipeline. The AST guard below
+follows the POST; the invariant still belongs at the shared site.
 
 This file *locks* that invariant in two ways:
 
-1. ``test_rpc_call_impl_has_no_await_before_post`` — static AST guard that
-   fails the moment someone adds an ``await`` to the currently-synchronous
-   prologue of ``_rpc_call_impl``. Conservative: any await before ``post()``
-   is rejected, even if it precedes the auth reads.
+1. ``test_perform_authed_post_has_no_await_before_post_per_iteration`` —
+   static AST guard against an ``await`` inside the retry loop of
+   ``_perform_authed_post`` that precedes the iteration's ``client.post(...)``
+   call.
 
-2. ``test_concurrent_refresh_does_not_corrupt_inflight_rpc_request`` — runtime
-   self-consistency. Drives concurrent ``refresh_auth`` against an in-flight
-   ``rpc_call`` (both orderings) and asserts the captured ``httpx.Request``
-   is never observed with mixed-generation (csrf, session_id, cookies) state.
+2. ``test_concurrent_refresh_does_not_corrupt_inflight_rpc_request`` —
+   runtime self-consistency. Drives concurrent ``refresh_auth`` against an
+   in-flight ``rpc_call`` (both orderings) and asserts the captured
+   ``httpx.Request`` is never observed with mixed-generation (csrf,
+   session_id, cookies) state.
 """
 
 from __future__ import annotations
@@ -42,19 +49,35 @@ from notebooklm.rpc import RPCMethod
 EVENT_TIMEOUT_S = 5.0
 
 
-def test_rpc_call_impl_has_no_await_before_post():
-    """``_rpc_call_impl`` must not contain any ``await`` before its ``post()``.
+def test_perform_authed_post_has_no_await_before_post_per_iteration():
+    """Within a single retry iteration of ``_perform_authed_post``, no
+    ``await`` may sit lexically before the ``client.post(...)`` call.
 
-    If anyone adds an ``await`` to the prologue of ``_rpc_call_impl``, a
+    Each retry iteration starts with a synchronous ``self._snapshot()`` and
+    a synchronous ``build_request(snapshot)`` — both are reads / assembly,
+    no awaits. The very next statement is the actual POST. If anyone
+    introduces an ``await`` between the snapshot read and the POST, a
     concurrent ``refresh_auth`` could mutate ``auth.csrf_token`` /
     ``auth.session_id`` / the cookie jar between the read and the wire,
-    producing a mismatched-generation request. The rule is conservative:
-    any earlier ``await`` is rejected, not just ones that fall between the
-    auth reads and the ``post()`` call.
+    producing a mismatched-generation request.
+
+    The check is per-iteration: awaits *between* iterations (e.g.
+    ``await self._await_refresh()`` followed by ``continue``) are fine
+    because each iteration takes a fresh snapshot.
     """
-    src = textwrap.dedent(inspect.getsource(ClientCore._rpc_call_impl))
+    src = textwrap.dedent(inspect.getsource(ClientCore._perform_authed_post))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
+
+    # Locate the retry loop (the outermost ``while`` in the body).
+    while_loop = next(
+        (n for n in ast.iter_child_nodes(func) if isinstance(n, ast.While)),
+        None,
+    )
+    assert while_loop is not None, (
+        "Could not locate the retry-loop ``while`` in _perform_authed_post. "
+        "If the loop was restructured, update this guard to match."
+    )
 
     def is_post_await(node):
         if not isinstance(node, ast.Await):
@@ -66,44 +89,63 @@ def test_rpc_call_impl_has_no_await_before_post():
         return isinstance(attr, ast.Attribute) and attr.attr == "post"
 
     def _walk_outer(parent):
-        """Yield nodes that belong to ``parent`` itself (skip nested defs).
+        """Yield nodes lexically inside ``parent`` itself (skip nested defs).
 
         ``ast.walk`` descends into nested ``FunctionDef`` / ``AsyncFunctionDef``
-        / ``Lambda`` bodies — that would let a future helper coroutine inside
-        ``_rpc_call_impl`` smuggle the matching ``await ...post(...)`` past
-        this guard. We only want statements lexically at the outer level.
+        / ``Lambda`` bodies — that would let a future helper coroutine
+        smuggle the matching ``await ...post(...)`` past this guard. We only
+        want statements at this lexical level. We DO descend into the loop's
+        own ``try`` / ``except`` / ``if`` blocks so awaits in retry-branch
+        bookkeeping (post-error handlers) remain visible to the guard.
         """
         boundaries = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
         for child in ast.iter_child_nodes(parent):
             if isinstance(child, boundaries):
-                continue  # don't descend into nested callables
+                continue
             yield child
             yield from _walk_outer(child)
 
-    outer_nodes = list(_walk_outer(func))
-    # ast.iter_child_nodes does not guarantee source order across all node
-    # types, so pick the earliest post-await by (lineno, col_offset). Using
-    # the tuple — not just lineno — catches same-line earlier awaits like
-    # ``await build_body(); await post(...)`` written on one line.
-    post_await_positions = [(n.lineno, n.col_offset) for n in outer_nodes if is_post_await(n)]
+    # Walk only the ``try`` block at the top of the while body — that's the
+    # critical prologue → POST window. Awaits in ``except`` handlers are by
+    # definition AFTER the POST (post-error path) and don't violate the
+    # invariant. ``self._snapshot()`` and ``build_request(snapshot)`` are
+    # synchronous assignments inside the while body before the try, so
+    # they're irrelevant to this guard.
+    try_node = next(
+        (n for n in ast.iter_child_nodes(while_loop) if isinstance(n, ast.Try)),
+        None,
+    )
+    assert try_node is not None, (
+        "Could not locate the ``try:`` block guarding the POST in "
+        "_perform_authed_post. Update this guard if the structure changed."
+    )
+    # We only walk the try body, NOT its handlers.
+    try_body_nodes: list[ast.AST] = []
+    for stmt in try_node.body:
+        try_body_nodes.append(stmt)
+        try_body_nodes.extend(_walk_outer(stmt))
+
+    post_await_positions = [(n.lineno, n.col_offset) for n in try_body_nodes if is_post_await(n)]
     post_await_position = min(post_await_positions, default=None)
     assert post_await_position is not None, (
-        "Could not locate `await ...post(...)` in _rpc_call_impl. If you "
-        "refactored the call site (e.g., to `self._http_client.request(...)`), "
-        "update this guard to match — the invariant is 'no await before the "
-        "RPC send', not specifically the `.post` attribute."
+        "Could not locate `await ...post(...)` in the try body of "
+        "_perform_authed_post. If the call site was refactored (e.g. to "
+        "``client.request(...)``), update this guard to match — the "
+        "invariant is 'no await between snapshot read and the POST per "
+        "iteration', not specifically the `.post` attribute."
     )
 
     earlier_awaits = [
         n
-        for n in outer_nodes
+        for n in try_body_nodes
         if isinstance(n, ast.Await) and (n.lineno, n.col_offset) < post_await_position
     ]
     assert not earlier_awaits, (
-        f"_rpc_call_impl gained an await before the POST at {post_await_position}: "
+        f"_perform_authed_post gained an await before the per-iteration POST "
+        f"at {post_await_position}: "
         f"{[(n.lineno, ast.dump(n)) for n in earlier_awaits]}. "
-        "This breaks the snapshot-invariant — auth state could be mutated between "
-        "the read and the actual send."
+        "This breaks the snapshot-invariant — auth state could be mutated "
+        "between the snapshot read and the actual send."
     )
 
 

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -1,0 +1,412 @@
+"""Parity tests for the shared transport pipeline (T2.C).
+
+Pins down the behavior of :meth:`ClientCore._perform_authed_post` (and the
+chat-side :meth:`ClientCore.query_post`) extracted from ``_rpc_call_impl``:
+
+- ``build_request`` factory is called once per HTTP attempt.
+- On a single auth-error retry, the factory is called TWICE, and the second
+  invocation observes a fresh ``_AuthSnapshot`` capturing whatever the
+  refresh callback mutated.
+- The request-id correlation tag (``[req=<id>]``) is stable across the retry
+  chain.
+- ``rate_limit_max_retries`` bounds 429 retries; exhausting the budget
+  raises ``_TransportRateLimited``.
+- The historical ``rpc_call`` happy path is unchanged byte-for-byte
+  (URL + body identical to pre-extraction).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._core import (
+    ClientCore,
+    _AuthSnapshot,
+    _TransportAuthExpired,
+    _TransportRateLimited,
+)
+from notebooklm._logging import get_request_id
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import RPCMethod
+
+
+def _make_core(
+    *,
+    refresh_callback: Callable[[], Any] | None = None,
+    rate_limit_max_retries: int = 0,
+) -> ClientCore:
+    auth = AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "sid_cookie"},
+    )
+    return ClientCore(
+        auth=auth,
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=0.0,
+        rate_limit_max_retries=rate_limit_max_retries,
+    )
+
+
+def _ok_response(text: str = "OK") -> httpx.Response:
+    return httpx.Response(
+        200,
+        text=text,
+        request=httpx.Request("POST", "https://example.test/x"),
+    )
+
+
+def _status_error(code: int, *, retry_after: str | None = None) -> httpx.HTTPStatusError:
+    headers = {"retry-after": retry_after} if retry_after else {}
+    request = httpx.Request("POST", "https://example.test/x")
+    response = httpx.Response(code, request=request, headers=headers)
+    return httpx.HTTPStatusError(f"HTTP {code}", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# _perform_authed_post
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_request_called_once_on_happy_path(monkeypatch):
+    core = _make_core()
+    await core.open()
+    try:
+        calls: list[_AuthSnapshot] = []
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            calls.append(snapshot)
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(url, *, content, **kwargs):
+            assert url == "https://example.test/x"
+            assert content == "payload"
+            return _ok_response()
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        response = await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert len(calls) == 1
+        assert calls[0].csrf_token == "CSRF_OLD"
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch):
+    """On a 401 + successful refresh, the factory is invoked twice — and the
+    second call sees the refreshed CSRF / session-id, not the stale ones."""
+    refresh_calls = []
+
+    async def refresh() -> AuthTokens:
+        refresh_calls.append(True)
+        # Mutate auth state so the second snapshot picks up new values.
+        core.auth.csrf_token = "CSRF_NEW"
+        core.auth.session_id = "SID_NEW"
+        return core.auth
+
+    core = _make_core(refresh_callback=refresh)
+    await core.open()
+    try:
+        snapshots: list[_AuthSnapshot] = []
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            snapshots.append(snapshot)
+            return "https://example.test/x", f"body-{snapshot.csrf_token}", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(url, *, content, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _status_error(401)
+            # Second attempt succeeds — confirm it carries the refreshed body.
+            assert content == "body-CSRF_NEW"
+            return _ok_response()
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        response = await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert len(refresh_calls) == 1
+        assert call_count["n"] == 2
+        assert len(snapshots) == 2
+        # First snapshot pre-refresh; second snapshot post-refresh.
+        assert snapshots[0].csrf_token == "CSRF_OLD"
+        assert snapshots[0].session_id == "SID_OLD"
+        assert snapshots[1].csrf_token == "CSRF_NEW"
+        assert snapshots[1].session_id == "SID_NEW"
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_auth_expired_when_refresh_fails(monkeypatch):
+    refresh_error = RuntimeError("re-authenticate")
+
+    async def refresh() -> AuthTokens:
+        raise refresh_error
+
+    core = _make_core(refresh_callback=refresh)
+    await core.open()
+    try:
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        original = _status_error(401)
+
+        async def fake_post(*args, **kwargs):
+            raise original
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportAuthExpired) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert exc_info.value.original is original
+        assert exc_info.value.__cause__ is refresh_error
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_429_retries_exhaust_to_transport_rate_limited(monkeypatch):
+    core = _make_core(rate_limit_max_retries=2)
+    await core.open()
+    try:
+        # Avoid actually sleeping during the retry budget.
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            raise _status_error(429, retry_after="1")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportRateLimited) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        # Initial attempt + 2 retries = 3 total POSTs.
+        assert call_count["n"] == 3
+        assert sleeps == [1, 1]
+        assert exc_info.value.retry_after == 1
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_429_without_retry_budget_raises_immediately(monkeypatch):
+    core = _make_core(rate_limit_max_retries=0)
+    await core.open()
+    try:
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(429, retry_after="60")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportRateLimited) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert exc_info.value.retry_after == 60
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_request_id_constant_across_retry_chain(monkeypatch):
+    """The correlation id set by ``rpc_call`` must be visible inside every
+    retry attempt — both pre- and post-refresh.
+    """
+
+    async def refresh() -> AuthTokens:
+        core.auth.csrf_token = "CSRF_NEW"
+        return core.auth
+
+    core = _make_core(refresh_callback=refresh)
+    await core.open()
+    try:
+        observed_request_ids: list[str | None] = []
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            observed_request_ids.append(get_request_id())
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _status_error(401)
+            return _ok_response()
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        # Drive through rpc_call so set_request_id is in scope (rpc_call is
+        # the caller boundary that owns the request-id context).
+        async def fake_decode(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(
+            "notebooklm._core.decode_response",
+            lambda *args, **kwargs: [],
+        )
+
+        # Use _perform_authed_post directly inside set_request_id to verify
+        # the helper itself doesn't reset the id.
+        from notebooklm._logging import reset_request_id, set_request_id
+
+        token = set_request_id("REQ-stable-1234")
+        try:
+            await core._perform_authed_post(build_request=build, log_label="test")
+        finally:
+            reset_request_id(token)
+
+        assert call_count["n"] == 2
+        assert observed_request_ids == ["REQ-stable-1234", "REQ-stable-1234"]
+    finally:
+        await core.close()
+
+
+# ---------------------------------------------------------------------------
+# query_post (chat-side wrapper)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_post_wraps_rate_limit_as_chat_error(monkeypatch):
+    from notebooklm.exceptions import ChatError
+
+    core = _make_core(rate_limit_max_retries=0)
+    await core.open()
+    try:
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(429, retry_after="42")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(ChatError) as exc_info:
+            await core.query_post(build_request=build, parse_label="chat.ask")
+
+        assert "Retry after 42 seconds" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, _TransportRateLimited)
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_query_post_wraps_auth_expired_as_chat_error(monkeypatch):
+    from notebooklm.exceptions import ChatError
+
+    async def refresh() -> AuthTokens:
+        raise RuntimeError("login needed")
+
+    core = _make_core(refresh_callback=refresh)
+    await core.open()
+    try:
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(401)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(ChatError) as exc_info:
+            await core.query_post(build_request=build, parse_label="chat.ask")
+
+        assert "authentication expired" in str(exc_info.value).lower()
+        assert isinstance(exc_info.value.__cause__, _TransportAuthExpired)
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_query_post_wraps_timeout_as_network_error(monkeypatch):
+    from notebooklm.exceptions import NetworkError
+
+    core = _make_core()
+    await core.open()
+    try:
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise httpx.ReadTimeout("read timeout")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(NetworkError) as exc_info:
+            await core.query_post(build_request=build, parse_label="chat.ask")
+
+        assert isinstance(exc_info.value.original_error, httpx.ReadTimeout)
+    finally:
+        await core.close()
+
+
+# ---------------------------------------------------------------------------
+# rpc_call happy-path parity (URL + body byte-for-byte)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_happy_path_url_and_body_unchanged(monkeypatch):
+    """After the T2.C extraction, ``rpc_call`` must produce the same outgoing
+    ``(url, body)`` as pre-extraction for the happy path."""
+    core = _make_core()
+    await core.open()
+    try:
+        captured: dict[str, Any] = {}
+
+        async def fake_post(url, *, content, **kwargs):
+            captured["url"] = url
+            captured["content"] = content
+            # Minimal valid batchexecute response.
+            rpc_id = RPCMethod.LIST_NOTEBOOKS.value
+            inner = json.dumps([])
+            chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+            text = f")]}}'\n{len(chunk)}\n{chunk}\n"
+            return _ok_response(text)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+        # The URL must carry the standard batchexecute query string.
+        assert "rpcids=" + RPCMethod.LIST_NOTEBOOKS.value in captured["url"]
+        assert "f.sid=SID_OLD" in captured["url"]
+        # The body must include the CSRF token under the historical ``at=`` param.
+        assert "at=CSRF_OLD" in captured["content"]
+        assert "f.req=" in captured["content"]
+    finally:
+        await core.close()


### PR DESCRIPTION
## Summary
- Adds `_AuthSnapshot` frozen dataclass capturing (csrf_token, session_id, authuser, account_email)
- Extracts `_perform_authed_post(build_request, log_label)` from `_rpc_call_impl` — shared HTTP transport with auth refresh, 429 retry, snapshot-per-attempt
- Adds `core.query_post(build_request, parse_label)` wrapper for chat semantic ownership (maps transport exceptions to `ChatError` / `NetworkError`)
- `build_request` factory callback is invoked **once per attempt** — receives a fresh `_AuthSnapshot` on retry (fixes the snapshot-staleness hazard 3 momus reviewers flagged)
- `_rpc_call_impl` refactored to delegate transport to `_perform_authed_post`; decode + decode-time auth retry stay RPC-specific (chat doesn't return 200 + auth-shaped payloads)

## Why
Synthesis §6 Tier 2 items 1 + 4 + 5: unify the transport pipeline so ChatAPI (T2.D) can reuse the auth-refresh/429/request-id machinery without bypassing `_core`.

## Error-boundary contract
- `_perform_authed_post` raises typed transport exceptions: `_TransportAuthExpired` (refresh callback failed), `_TransportRateLimited` (429 budget exhausted). All other transport failures propagate as `httpx.HTTPStatusError` / `httpx.RequestError` unchanged.
- `rpc_call` re-raises the original `httpx.HTTPStatusError` on `_TransportAuthExpired` (preserves the historical `_try_refresh_and_retry` contract — `test_no_retry_on_cookie_expiration` still passes). Maps `_TransportRateLimited` → `RateLimitError`. Maps everything else through the existing status→exception mapper.
- `query_post` wraps `_TransportAuthExpired` / `_TransportRateLimited` → `ChatError`. Timeouts / network errors → `NetworkError`. Other HTTP status errors → `ChatError`.

## Snapshot freshness (load-bearing)
The AST guard in `tests/unit/test_concurrency_refresh_race.py` follows the POST: it now asserts that within a single iteration of `_perform_authed_post`'s retry loop, no `await` sits between `self._snapshot()` / `build_request(snapshot)` and `client.post(...)`. The runtime concurrent-refresh race test still drives both orderings and asserts no mixed-generation (csrf, session_id, cookies) requests.

## Test plan
- [x] `build_request` called once on happy path
- [x] `build_request` called TWICE with fresh snapshot on 401 (second invocation observes refreshed CSRF)
- [x] Request-id stable across retry chain
- [x] 429 backoff respects `rate_limit_max_retries`, raises `_TransportRateLimited` on exhaustion
- [x] `query_post` maps transport exceptions to `ChatError` / `NetworkError`
- [x] `rpc_call` happy-path URL+body byte-for-byte unchanged
- [x] Existing 596 integration tests + 1628 unit tests pass with no behavior change
- [x] `_rpc_call_impl` still owns decode-time auth retry (RPC-specific)

Part of Tier 2 (.sisyphus/plans/tier-2-implementation.md).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust auth-refresh handling with a single-retry recovery path and clearer failure reporting.
  * Bounded rate-limit retries honoring Retry-After and surfacing retry details when exhausted.
  * Transport and HTTP errors now map consistently to user-facing network/chat errors.

* **Refactor**
  * Shared, snapshot-aware transport pipeline to rebuild requests per retry for consistent auth state.

* **Tests**
  * Expanded tests for concurrent refresh races and transport/retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/458)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->