### PR TITLE
chore(audit): address deferred PR-review nits

### DIFF
--- a/docs/auth-keepalive.md
+++ b/docs/auth-keepalive.md
@@ -1436,7 +1436,7 @@ A `ContextVar` (`_REFRESH_ATTEMPTED_CONTEXT`) gates same-task retries in
 the parent process, and a per-loop / per-resolved-storage-path asyncio
 lock registry (`_get_refresh_lock`, mirroring the keepalive
 `_get_poke_lock` pattern) combined with `_REFRESH_GENERATIONS` guarded
-by `_REFRESH_STATE_LOCK` (a sync `threading.Lock`) ensure that a fan-out
+by `_REFRESH_STATE_LOCK` (a sync `threading.Lock`) ensures that a fan-out
 of N concurrent failing requests — even across event loops or worker
 threads sharing the same storage path — triggers exactly one refresh,
 not N.

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -1028,6 +1028,12 @@ def with_client(f):
                 log_result("failed", "not authenticated")
                 handle_auth_error(json_output)
                 return  # unreachable — handle_auth_error raises SystemExit
+            except Exception as e:
+                # Non-FileNotFoundError bootstrap failures (AuthError, malformed
+                # storage JSON, etc.) still need the structured debug-log entry;
+                # ``handle_errors`` will translate the exception to a typed hint.
+                log_result("failed", str(e))
+                raise
             try:
                 coro = f(ctx, *args, client_auth=auth, **kwargs)
                 result = run_async(coro)

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -185,6 +185,44 @@ def test_auth_bootstrap_malformed_json_routes_through_handle_errors(
     assert payload["code"] == "UNEXPECTED_ERROR"
 
 
+def test_auth_bootstrap_non_filenotfound_logs_failed_result(
+    runner: CliRunner, monkeypatch, caplog
+) -> None:
+    """Bootstrap exceptions other than FileNotFoundError emit ``log_result('failed', ...)``.
+
+    Regression guard for Gemini feedback on PR #455 (helpers.py:1030): previously
+    only ``FileNotFoundError`` produced the structured debug log entry, so an
+    ``AuthError`` during bootstrap would be handled by ``handle_errors`` but the
+    timing/cmd-name pair never reached the debug log — an observability gap when
+    triaging auth failures via ``NOTEBOOKLM_DEBUG=1``.
+    """
+    import logging
+
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="notebooklm.cli"),
+        patch(
+            "notebooklm.cli.helpers.get_auth_tokens",
+            side_effect=AuthError("token refresh failed"),
+        ),
+    ):
+        cli = _build_cli(_never_called)
+        result = runner.invoke(cli, ["run"], catch_exceptions=False)
+
+    assert result.exit_code == 1, result.stderr
+    failed_records = [
+        r for r in caplog.records if "failed" in r.getMessage() and "run" in r.getMessage()
+    ]
+    assert failed_records, (
+        f"Expected at least one log_result('failed', ...) record, got: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # JSON-mode failure paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two small follow-ups from the post-merge PR audit of #445–#457:

- **`cli/helpers.py`** — close observability gap flagged by `@gemini-code-assist` on [PR #455 (thread 3239194271)](https://github.com/teng-lin/notebooklm-py/pull/455#discussion_r3239194271). Non-`FileNotFoundError` auth-bootstrap exceptions (e.g., `AuthError`, `ValueError` from malformed JSON) were typed by `handle_errors` but skipped the `log_result("failed", ...)` debug log. Adds an `except Exception` that emits the structured log line and re-raises.
- **`docs/auth-keepalive.md`** — fix subject-verb agreement flagged by `@coderabbitai` on [PR #457 (thread 3239263423)](https://github.com/teng-lin/notebooklm-py/pull/457#discussion_r3239263423). "ensure" → "ensures" (singular subject).

Adds one regression test (`test_auth_bootstrap_non_filenotfound_logs_failed_result`) pinning the new debug-log path.

## Audit non-action summary

Other comments from the audit were closed as non-actionable on their original threads:

- **CodeRabbit S106/S108 warnings** on `tests/unit/test_core_reqid*.py` and `tests/unit/test_refresh_lock_registry.py` — false positives; this project's `tool.ruff.lint.select` does not include the `S` bandit rules, and `uv run ruff check` passes on main.
- **Gemini JSON/non-JSON exit-code asymmetry** on `cli/artifact.py` and `cli/session.py` (`auth check`) — deliberate per the inline comment in `artifact.py:377-381`: JSON path is intentionally stricter (any non-completed → exit 1) for automation; Rich path stays looser for interactive use.
- **Gemini threading concern on `_core.next_reqid`** — `ClientCore` is intended to be single-loop; cross-thread sharing is not a supported pattern (documented as a scope boundary, not a follow-up).

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest` — 3006 passed, 9 skipped
- [x] New regression test (`test_auth_bootstrap_non_filenotfound_logs_failed_result`) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in authentication documentation.

* **Bug Fixes**
  * Enhanced error logging during authentication bootstrap failures.

* **Tests**
  * Added test coverage for authentication failure scenarios and debug logging verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/460)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->