### PR TITLE
fix(_artifacts): _download_url wraps httpx in ArtifactDownloadError (T3.F)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2283,7 +2283,14 @@ class ArtifactsAPI:
             The output path on success.
 
         Raises:
-            ArtifactDownloadError: If download fails or authentication expired.
+            ArtifactDownloadError: On any HTTP or network failure. For 401/403
+                responses the message indicates that re-authentication is
+                needed (``try `notebooklm login```), and the exception's
+                ``status_code`` attribute carries the HTTP status. For other
+                HTTP errors ``status_code`` is set to the response code; for
+                transport failures (timeouts, DNS, connection resets) the
+                ``status_code`` is ``None``. Callers no longer see raw
+                ``httpx.HTTPError`` subclasses from this method.
         """
         # Validate URL scheme and domain before sending auth cookies.
         # httpx sends cookies to every request made by the client regardless of
@@ -2312,60 +2319,92 @@ class ArtifactsAPI:
         timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
 
         try:
-            # Nested context managers required: client.stream() returns an async
-            # context manager that must run within the client's scope
-            async with httpx.AsyncClient(  # noqa: SIM117
-                cookies=cookies,
-                follow_redirects=True,
-                timeout=timeout,
-            ) as client:
-                async with client.stream("GET", url) as response:
-                    response.raise_for_status()
+            try:
+                # Nested context managers required: client.stream() returns an
+                # async context manager that must run within the client's scope
+                async with httpx.AsyncClient(  # noqa: SIM117
+                    cookies=cookies,
+                    follow_redirects=True,
+                    timeout=timeout,
+                ) as client:
+                    async with client.stream("GET", url) as response:
+                        response.raise_for_status()
 
-                    content_type = response.headers.get("content-type", "")
-                    if "text/html" in content_type:
-                        raise ArtifactDownloadError(
-                            "media",
-                            details="Download failed: received HTML instead of media file. "
-                            "Authentication may have expired. Run 'notebooklm login'.",
-                        )
+                        content_type = response.headers.get("content-type", "")
+                        if "text/html" in content_type:
+                            raise ArtifactDownloadError(
+                                "media",
+                                details="Download failed: received HTML instead of media file. "
+                                "Authentication may have expired. Run 'notebooklm login'.",
+                            )
 
-                    # Stream to file in chunks to handle large files efficiently.
-                    # Each per-chunk write is dispatched to a worker thread so the
-                    # event loop isn't blocked on disk I/O; the loop body awaits
-                    # each write before reading the next chunk so the shared file
-                    # handle is never accessed concurrently in normal execution.
-                    #
-                    # Cancellation: ``asyncio.shield`` keeps the in-flight write
-                    # alive across a CancelledError; the except block awaits the
-                    # shielded task to completion BEFORE letting the with-block
-                    # close the file. Without this, the worker thread could touch
-                    # ``f`` after the with-block has started closing it.
-                    total_bytes = 0
-                    with open(temp_file, "wb") as f:
-                        async for chunk in response.aiter_bytes(chunk_size=65536):
-                            write_task = asyncio.create_task(asyncio.to_thread(f.write, chunk))
-                            try:
-                                await asyncio.shield(write_task)
-                            except asyncio.CancelledError:
-                                # Narrow to (CancelledError, Exception) so genuine
-                                # process-level signals (KeyboardInterrupt, SystemExit)
-                                # still propagate during cleanup.
-                                with contextlib.suppress(asyncio.CancelledError, Exception):
-                                    await write_task
-                                raise
-                            total_bytes += len(chunk)
+                        # Stream to file in chunks to handle large files efficiently.
+                        # Each per-chunk write is dispatched to a worker thread so the
+                        # event loop isn't blocked on disk I/O; the loop body awaits
+                        # each write before reading the next chunk so the shared file
+                        # handle is never accessed concurrently in normal execution.
+                        #
+                        # Cancellation: ``asyncio.shield`` keeps the in-flight write
+                        # alive across a CancelledError; the except block awaits the
+                        # shielded task to completion BEFORE letting the with-block
+                        # close the file. Without this, the worker thread could touch
+                        # ``f`` after the with-block has started closing it.
+                        total_bytes = 0
+                        with open(temp_file, "wb") as f:
+                            async for chunk in response.aiter_bytes(chunk_size=65536):
+                                write_task = asyncio.create_task(asyncio.to_thread(f.write, chunk))
+                                try:
+                                    await asyncio.shield(write_task)
+                                except asyncio.CancelledError:
+                                    # Narrow to (CancelledError, Exception) so genuine
+                                    # process-level signals (KeyboardInterrupt, SystemExit)
+                                    # still propagate during cleanup.
+                                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                                        await write_task
+                                    raise
+                                total_bytes += len(chunk)
 
-                    if total_bytes == 0:
-                        raise ArtifactDownloadError(
-                            "media",
-                            details="Download produced 0 bytes -- the remote file may be missing or empty",
-                        )
+                        if total_bytes == 0:
+                            raise ArtifactDownloadError(
+                                "media",
+                                details=(
+                                    "Download produced 0 bytes -- the remote file may "
+                                    "be missing or empty"
+                                ),
+                            )
 
-                    # Only move to final location on success
-                    temp_file.rename(output_file)
-                    logger.debug("Downloaded %s (%d bytes)", url[:60], total_bytes)
-                    return output_path
+                        # Only move to final location on success
+                        temp_file.rename(output_file)
+                        logger.debug("Downloaded %s (%d bytes)", url[:60], total_bytes)
+                        return output_path
+            except httpx.HTTPStatusError as e:
+                # HTTP-level failure (4xx/5xx). Translate to ArtifactDownloadError
+                # so callers see a consistent exception type instead of a raw
+                # httpx subclass. 401/403 get an explicit "re-login" hint,
+                # mirroring the message style used by _download_urls_batch.
+                if e.response.status_code in (401, 403):
+                    raise ArtifactDownloadError(
+                        "media",
+                        details=(
+                            f"Authentication required for {url[:80]}... -- try `notebooklm login`"
+                        ),
+                        cause=e,
+                        status_code=e.response.status_code,
+                    ) from e
+                raise ArtifactDownloadError(
+                    "media",
+                    details=f"HTTP {e.response.status_code} downloading {url[:80]}...",
+                    cause=e,
+                    status_code=e.response.status_code,
+                ) from e
+            except httpx.RequestError as e:
+                # Transport-level failure: timeouts, DNS, TLS, connection
+                # resets, etc. No HTTP response was received, so no status_code.
+                raise ArtifactDownloadError(
+                    "media",
+                    details=f"Network error downloading {url[:80]}...: {e}",
+                    cause=e,
+                ) from e
         except BaseException:
             # Clean up partial temp file on any failure, including asyncio.CancelledError
             # (which is a BaseException, not an Exception, in Python 3.8+).

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -644,6 +644,10 @@ class ArtifactDownloadError(ArtifactError):
         artifact_id: The ID (if known).
         details: Additional error details.
         cause: The underlying exception.
+        status_code: HTTP status code from the failed response, when the
+            failure was an HTTP-level error (e.g. 401, 403, 500). ``None`` for
+            transport-level failures (timeouts, DNS, connection resets) where
+            no response was received.
     """
 
     def __init__(
@@ -652,11 +656,13 @@ class ArtifactDownloadError(ArtifactError):
         details: str | None = None,
         artifact_id: str | None = None,
         cause: Exception | None = None,
+        status_code: int | None = None,
     ):
         self.artifact_type = artifact_type
         self.artifact_id = artifact_id
         self.details = details
         self.cause = cause
+        self.status_code = status_code
         msg = f"Failed to download {artifact_type} artifact"
         if artifact_id:
             msg += f" {artifact_id}"

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -1,0 +1,239 @@
+"""Unit tests for ``ArtifactsAPI._download_url`` httpx-error wrapping.
+
+These tests pin the T3.F contract: every httpx failure (auth, generic HTTP,
+timeout, connection error) is surfaced as :class:`ArtifactDownloadError`,
+never as a raw ``httpx`` subclass. 401/403 carry an explicit
+``Authentication required ... try `notebooklm login``` hint plus the
+``status_code`` attribute on the exception; other HTTP errors keep their
+``status_code``; transport errors leave ``status_code`` ``None``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm.types import ArtifactDownloadError
+
+
+@pytest.fixture
+def mock_artifacts_api():
+    """ArtifactsAPI wired to MagicMocks -- no real I/O."""
+    mock_core = MagicMock()
+    mock_core.rpc_call = AsyncMock()
+    mock_core.get_source_ids = AsyncMock(return_value=[])
+    mock_notes = MagicMock()
+    mock_notes.list_mind_maps = AsyncMock(return_value=[])
+    api = ArtifactsAPI(mock_core, notes_api=mock_notes)
+    return api
+
+
+def _build_mock_response(
+    *,
+    raise_for_status_exc: Exception | None = None,
+    content: bytes = b"",
+    content_type: str = "video/mp4",
+) -> MagicMock:
+    """Build a mock streaming response for ``client.stream()``.
+
+    If ``raise_for_status_exc`` is provided, ``raise_for_status`` raises it.
+    Otherwise the response streams ``content`` in a single chunk.
+    """
+
+    async def mock_aiter_bytes(chunk_size: int = 8192):
+        if content:
+            yield content
+
+    mock_response = MagicMock()
+    mock_response.headers = {"content-type": content_type}
+    if raise_for_status_exc is not None:
+        mock_response.raise_for_status = MagicMock(side_effect=raise_for_status_exc)
+    else:
+        mock_response.raise_for_status = MagicMock()
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+    return mock_response
+
+
+def _patch_httpx_client(
+    mock_response: MagicMock | None = None, *, stream_exc: Exception | None = None
+):
+    """Return ctx managers patching httpx.AsyncClient and load_httpx_cookies.
+
+    ``stream_exc``: if set, ``client.stream(...)`` raises this exception when
+    entered (covers httpx.ConnectError / TimeoutException raised during
+    connection establishment, before any response arrives).
+    """
+    mock_client = AsyncMock()
+    if stream_exc is not None:
+        # Make ``async with client.stream(...) as response`` raise on enter.
+        failing_cm = MagicMock()
+        failing_cm.__aenter__ = AsyncMock(side_effect=stream_exc)
+        failing_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client.stream = MagicMock(return_value=failing_cm)
+    else:
+        assert mock_response is not None
+        mock_client.stream = MagicMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    return (
+        patch.object(httpx, "AsyncClient", return_value=mock_client),
+        patch("notebooklm._artifacts.load_httpx_cookies", return_value=MagicMock()),
+    )
+
+
+def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build a real httpx.HTTPStatusError carrying ``status_code``."""
+    request = httpx.Request("GET", "https://storage.googleapis.com/file.mp4")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}",
+        request=request,
+        response=response,
+    )
+
+
+class TestDownloadUrlErrorWrapping:
+    """Pin T3.F: httpx errors become ArtifactDownloadError."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_output_path(self, mock_artifacts_api):
+        """200 OK with body -> returns output_path, file written."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            content = b"binary media payload"
+            response = _build_mock_response(content=content)
+            client_patch, cookies_patch = _patch_httpx_client(response)
+
+            with client_patch, cookies_patch:
+                result = await api._download_url(
+                    "https://storage.googleapis.com/file.mp4", output_path
+                )
+
+            assert result == output_path
+            with open(output_path, "rb") as f:
+                assert f.read() == content
+
+    @pytest.mark.asyncio
+    async def test_401_raises_artifact_download_error_with_auth_hint(self, mock_artifacts_api):
+        """401 -> ArtifactDownloadError mentioning re-auth, status_code=401."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            err = _make_http_status_error(401)
+            response = _build_mock_response(raise_for_status_exc=err)
+            client_patch, cookies_patch = _patch_httpx_client(response)
+
+            with (
+                client_patch,
+                cookies_patch,
+                pytest.raises(ArtifactDownloadError) as exc_info,
+            ):
+                await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
+
+            assert exc_info.value.status_code == 401
+            assert "Authentication required" in str(exc_info.value)
+            assert "notebooklm login" in str(exc_info.value)
+            # Cause preserved for diagnostics.
+            assert isinstance(exc_info.value.__cause__, httpx.HTTPStatusError)
+            # Partial temp file cleaned up.
+            assert not os.path.exists(output_path)
+            assert not os.path.exists(output_path + ".tmp")
+
+    @pytest.mark.asyncio
+    async def test_403_raises_artifact_download_error_with_auth_hint(self, mock_artifacts_api):
+        """403 follows the same auth-hint path as 401, with status_code=403."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            err = _make_http_status_error(403)
+            response = _build_mock_response(raise_for_status_exc=err)
+            client_patch, cookies_patch = _patch_httpx_client(response)
+
+            with (
+                client_patch,
+                cookies_patch,
+                pytest.raises(ArtifactDownloadError) as exc_info,
+            ):
+                await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
+
+            assert exc_info.value.status_code == 403
+            assert "Authentication required" in str(exc_info.value)
+            assert "notebooklm login" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_500_raises_artifact_download_error_generic_http(self, mock_artifacts_api):
+        """500 -> ArtifactDownloadError without auth hint, status_code=500."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            err = _make_http_status_error(500)
+            response = _build_mock_response(raise_for_status_exc=err)
+            client_patch, cookies_patch = _patch_httpx_client(response)
+
+            with (
+                client_patch,
+                cookies_patch,
+                pytest.raises(ArtifactDownloadError) as exc_info,
+            ):
+                await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
+
+            assert exc_info.value.status_code == 500
+            assert "HTTP 500" in str(exc_info.value)
+            assert "Authentication required" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_artifact_download_error_no_status(self, mock_artifacts_api):
+        """httpx.TimeoutException -> ArtifactDownloadError, status_code=None."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            client_patch, cookies_patch = _patch_httpx_client(
+                stream_exc=httpx.ReadTimeout("read timed out"),
+            )
+
+            with (
+                client_patch,
+                cookies_patch,
+                pytest.raises(ArtifactDownloadError) as exc_info,
+            ):
+                await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
+
+            assert exc_info.value.status_code is None
+            assert "Network error" in str(exc_info.value)
+            assert isinstance(exc_info.value.__cause__, httpx.ReadTimeout)
+
+    @pytest.mark.asyncio
+    async def test_connect_error_raises_artifact_download_error(self, mock_artifacts_api):
+        """httpx.ConnectError -> ArtifactDownloadError, status_code=None."""
+        api = mock_artifacts_api
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "file.mp4")
+            client_patch, cookies_patch = _patch_httpx_client(
+                stream_exc=httpx.ConnectError("dns resolution failed"),
+            )
+
+            with (
+                client_patch,
+                cookies_patch,
+                pytest.raises(ArtifactDownloadError) as exc_info,
+            ):
+                await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
+
+            assert exc_info.value.status_code is None
+            assert "Network error" in str(exc_info.value)
+            assert isinstance(exc_info.value.__cause__, httpx.ConnectError)


### PR DESCRIPTION
## Summary

`_download_url` in `src/notebooklm/_artifacts.py` previously leaked raw `httpx.HTTPError` subclasses to callers, contradicting its docstring which promised `ArtifactDownloadError`. T3.F makes truth match the docstring:

- 401/403 -> `ArtifactDownloadError` with `"Authentication required for {url}... -- try `notebooklm login`"` and `status_code` attribute set. Mirrors the auth-hint style used by `_download_urls_batch`.
- Other HTTP errors (e.g. 500) -> `ArtifactDownloadError` with `"HTTP {code} downloading {url}..."` and `status_code` set.
- Transport failures (timeouts, DNS, connection resets) -> `ArtifactDownloadError` with `"Network error downloading {url}..."` and `status_code=None`.
- 200 happy path is unchanged; partial `.tmp` cleanup on failure is preserved.
- Existing in-function raises (HTML response, 0 bytes, untrusted domain, non-HTTPS) flow through unchanged.

`ArtifactDownloadError` gains an optional `status_code` kwarg so callers can branch on HTTP vs transport failures programmatically.

Public signature and happy-path return value of `_download_url` are unchanged. No changes to other download paths.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit` (2440 passed, 5 skipped)
- [x] `uv run pytest tests/integration` (599 passed, 4 skipped)
- [x] New `tests/unit/test_download_url.py` covers six paths: 200, 401, 403, 500, `ReadTimeout`, `ConnectError`.

Refs parent plan: `.sisyphus/plans/tier-3-implementation.md` PR-T3.F.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Download failures now include HTTP status codes in error messages for improved diagnostics.
  * Authentication failures (401/403) now display helpful guidance to re-authenticate.
  * Network timeouts and connection errors are better reported with meaningful error context.

* **Tests**
  * Added comprehensive test coverage for download error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/462)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->