### PR TITLE
feat(_core): server_error_max_retries with exponential backoff (T3.A)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -160,6 +160,41 @@ class _TransportRateLimited(Exception):
         self.original = original
 
 
+class _TransportServerError(Exception):
+    """Raised by ``_perform_authed_post`` when the server-error retry budget
+    is exhausted.
+
+    Covers two retryable failure modes that share an exponential-backoff
+    schedule (synthesis C4 / T4):
+
+    - ``isinstance(original, httpx.HTTPStatusError)`` with a 5xx status —
+      the response is available via ``response`` / ``status_code``.
+    - ``isinstance(original, httpx.RequestError)`` — a network-layer failure
+      (timeout, connect error, ...). ``response`` and ``status_code`` are
+      ``None`` in this case.
+
+    Callers map this onto their own error domain:
+
+    - ``rpc_call`` translates this back into the historical :class:`ServerError`
+      / :class:`NetworkError` shapes the RPC API has always raised.
+    - ``query_post`` translates this into :class:`ChatError` /
+      :class:`NetworkError` to match the chat API contract.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        original: Exception,
+        response: httpx.Response | None = None,
+        status_code: int | None = None,
+    ):
+        super().__init__(message)
+        self.original = original
+        self.response = response
+        self.status_code = status_code
+
+
 # Build-request factory: receives a fresh ``_AuthSnapshot`` and returns the
 # triple (url, body, extra_headers) for one HTTP attempt. ``_perform_authed_post``
 # invokes this once per attempt so refreshed snapshots are picked up on retry.
@@ -246,6 +281,7 @@ class ClientCore:
         keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
         keepalive_storage_path: Path | None = None,
         rate_limit_max_retries: int = 0,
+        server_error_max_retries: int = 3,
     ):
         """Initialize the core client.
 
@@ -276,6 +312,14 @@ class ClientCore:
                 per-attempt value is capped at ``MAX_RETRY_AFTER_SECONDS``, but
                 the cumulative sleep across N retries is ``N * cap``, so pick
                 ``rate_limit_max_retries`` accordingly.
+            server_error_max_retries: Max automatic retries for retryable transient
+                transport failures: HTTP 5xx responses and network-layer
+                ``httpx.RequestError`` (timeouts, connect errors). Defaults to
+                ``3``. Uses exponential backoff ``min(2 ** attempt, 30)``
+                seconds — 5xx responses rarely carry ``Retry-After``, so the
+                429 model doesn't apply. Set to ``0`` to disable. Refresh-path
+                errors (400/401/403) are NOT covered here; those follow the
+                existing auth-refresh-and-retry flow.
 
         Raises:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a
@@ -289,6 +333,11 @@ class ClientCore:
         if rate_limit_max_retries < 0:
             raise ValueError(f"rate_limit_max_retries must be >= 0, got {rate_limit_max_retries}")
         self._rate_limit_max_retries = rate_limit_max_retries
+        if server_error_max_retries < 0:
+            raise ValueError(
+                f"server_error_max_retries must be >= 0, got {server_error_max_retries}"
+            )
+        self._server_error_max_retries = server_error_max_retries
         self._refresh_lock: asyncio.Lock | None = asyncio.Lock() if refresh_callback else None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
@@ -713,6 +762,13 @@ class ClientCore:
           after that, raises :class:`_TransportRateLimited` with the final
           response and parsed retry-after value. With no parseable header or
           ``rate_limit_max_retries == 0``, raises immediately.
+        - **Server-error path** — on HTTP 5xx, or any ``httpx.RequestError``
+          (network-layer failures: timeouts, connect errors), sleeps with
+          exponential backoff ``min(2 ** attempt, 30)`` seconds and retries
+          until ``server_error_max_retries`` is reached; after that, raises
+          :class:`_TransportServerError`. ``server_error_max_retries == 0``
+          short-circuits to an immediate raise. This path does NOT honor
+          ``Retry-After`` because 5xx rarely carries it.
         - All other errors propagate as :class:`httpx.HTTPStatusError` /
           :class:`httpx.RequestError` unchanged.
 
@@ -742,6 +798,7 @@ class ClientCore:
 
         refreshed_this_call = False
         rate_limit_retries = 0
+        server_error_retries = 0
         start = time.perf_counter()
 
         while True:
@@ -808,6 +865,49 @@ class ClientCore:
                         f"{log_label} rate-limited (HTTP 429)",
                         retry_after=retry_after,
                         response=exc.response,
+                        original=exc,
+                    ) from exc
+
+                # --- 5xx / network retry path -------------------------------
+                # Exponential backoff: 5xx responses rarely carry Retry-After
+                # so we don't use the 429 model. ``httpx.RequestError`` covers
+                # transient network-layer failures (timeouts, connect errors,
+                # remote-protocol blips) that are reasonable to retry.
+                is_server_error = (
+                    isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600
+                )
+                is_network_error = isinstance(exc, httpx.RequestError)
+                if is_server_error or is_network_error:
+                    if server_error_retries < self._server_error_max_retries:
+                        backoff = min(2**server_error_retries, 30)
+                        status_label = (
+                            f"HTTP {exc.response.status_code}"  # type: ignore[union-attr]
+                            if is_server_error
+                            else type(exc).__name__
+                        )
+                        logger.warning(
+                            "%s server/network error (%s); backing off %ds then retrying (%d/%d)",
+                            log_label,
+                            status_label,
+                            backoff,
+                            server_error_retries + 1,
+                            self._server_error_max_retries,
+                        )
+                        await asyncio.sleep(backoff)
+                        server_error_retries += 1
+                        continue
+                    if is_server_error:
+                        status_error = cast(httpx.HTTPStatusError, exc)
+                        raise _TransportServerError(
+                            f"{log_label} server error "
+                            f"(HTTP {status_error.response.status_code}) after "
+                            f"{server_error_retries} retries",
+                            original=status_error,
+                            response=status_error.response,
+                            status_code=status_error.response.status_code,
+                        ) from exc
+                    raise _TransportServerError(
+                        f"{log_label} network error after {server_error_retries} retries: {exc}",
                         original=exc,
                     ) from exc
 
@@ -889,6 +989,18 @@ class ClientCore:
                     if exc.retry_after is not None
                     else ""
                 )
+            ) from exc
+        except _TransportServerError as exc:
+            if isinstance(exc.original, httpx.HTTPStatusError):
+                raise ChatError(
+                    f"{parse_label} failed with HTTP {exc.original.response.status_code} "
+                    f"after retries: {exc.original}"
+                ) from exc
+            # Network-layer failure (RequestError / Timeout).
+            assert isinstance(exc.original, httpx.RequestError)
+            raise NetworkError(
+                f"{parse_label} network error after retries: {exc.original}",
+                original_error=exc.original,
             ) from exc
         except httpx.TimeoutException as exc:
             raise NetworkError(
@@ -1019,6 +1131,29 @@ class ClientCore:
                 method_id=method.value,
                 retry_after=exc.retry_after,
             ) from exc.original
+        except _TransportServerError as exc:
+            elapsed = time.perf_counter() - start
+            # Translate the budget-exhaustion signal back into the historical
+            # RPC error shape: 5xx → ServerError; network → NetworkError /
+            # RPCTimeoutError. ``_raise_rpc_error_from_*`` already does the
+            # right mapping for the underlying ``original`` exception.
+            if isinstance(exc.original, httpx.HTTPStatusError):
+                logger.error(
+                    "RPC %s failed after %.3fs: HTTP %s (server-error retries exhausted)",
+                    method.name,
+                    elapsed,
+                    exc.original.response.status_code,
+                )
+                self._raise_rpc_error_from_http_status(exc.original, method)
+            else:
+                assert isinstance(exc.original, httpx.RequestError)
+                logger.error(
+                    "RPC %s failed after %.3fs: %s (server-error retries exhausted)",
+                    method.name,
+                    elapsed,
+                    exc.original,
+                )
+                self._raise_rpc_error_from_request_error(exc.original, method)
         except httpx.HTTPStatusError as exc:
             elapsed = time.perf_counter() - start
             logger.error(

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -84,6 +84,8 @@ class NotebookLMClient:
         storage_path: Path | None = None,
         keepalive: float | None = None,
         keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
+        rate_limit_max_retries: int = 0,
+        server_error_max_retries: int = 3,
     ):
         """Initialize the NotebookLM client.
 
@@ -100,6 +102,15 @@ class NotebookLMClient:
             keepalive_min_interval: Lower bound for ``keepalive`` (defaults to
                 60 s) to avoid accidentally rate-limiting Google's identity
                 surface.
+            rate_limit_max_retries: Max automatic retries on HTTP 429 with a
+                parseable ``Retry-After``. ``0`` (default) preserves the
+                pre-Phase-3 contract of raising immediately. See
+                :class:`ClientCore` for the per-attempt sleep semantics.
+            server_error_max_retries: Max automatic retries for retryable
+                transient failures: HTTP 5xx and network-layer
+                ``httpx.RequestError`` (timeouts, connect errors). Defaults to
+                ``3``. Uses exponential backoff ``min(2 ** attempt, 30)``
+                seconds. Set to ``0`` to disable.
         """
         # Normalize the effective storage path onto the auth object so every
         # downstream code path (refresh_auth, ClientCore.close on-close save,
@@ -122,6 +133,8 @@ class NotebookLMClient:
             keepalive=keepalive,
             keepalive_min_interval=keepalive_min_interval,
             keepalive_storage_path=auth.storage_path,
+            rate_limit_max_retries=rate_limit_max_retries,
+            server_error_max_retries=server_error_max_retries,
         )
 
         # Initialize sub-client APIs
@@ -169,6 +182,8 @@ class NotebookLMClient:
         profile: str | None = None,
         keepalive: float | None = None,
         keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
+        rate_limit_max_retries: int = 0,
+        server_error_max_retries: int = 3,
     ) -> "NotebookLMClient":
         """Create a client from Playwright storage state file.
 
@@ -184,6 +199,10 @@ class NotebookLMClient:
                 rotation poke. ``None`` disables it (default). See
                 :class:`NotebookLMClient` for full semantics.
             keepalive_min_interval: Floor for ``keepalive`` (defaults to 60 s).
+            rate_limit_max_retries: Max automatic retries on HTTP 429. ``0``
+                (default) preserves pre-Phase-3 raise-immediately behavior.
+            server_error_max_retries: Max automatic retries for HTTP 5xx /
+                network errors with exponential backoff. Defaults to ``3``.
 
         Returns:
             NotebookLMClient instance (not yet connected).
@@ -215,6 +234,8 @@ class NotebookLMClient:
             storage_path=storage_path,
             keepalive=keepalive,
             keepalive_min_interval=keepalive_min_interval,
+            rate_limit_max_retries=rate_limit_max_retries,
+            server_error_max_retries=server_error_max_retries,
         )
 
     async def refresh_auth(self) -> AuthTokens:

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -953,10 +953,16 @@ class TestArtifactErrorPaths:
         auth_tokens,
         httpx_mock: HTTPXMock,
     ):
-        """Test RPC error handling for HTTP 500."""
+        """Test RPC error handling for HTTP 500.
+
+        Uses ``server_error_max_retries=0`` to exercise the immediate-raise
+        path; T3.A adds bounded exponential-backoff retries for 5xx by
+        default, but the error-shape contract on exhaustion is what this test
+        pins down.
+        """
         httpx_mock.add_response(status_code=500)
 
-        async with NotebookLMClient(auth_tokens) as client:
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             with pytest.raises(RPCError, match="Server error 500"):
                 await client.artifacts.list("nb_123")
 

--- a/tests/integration/test_chat.py
+++ b/tests/integration/test_chat.py
@@ -618,7 +618,9 @@ class TestChatAskErrorHandling:
             url=re.compile(r".*GenerateFreeFormStreamed.*"),
         )
 
-        async with NotebookLMClient(auth_tokens) as client:
+        # ``server_error_max_retries=0`` pins the original immediate-raise
+        # contract; T3.A's default retries 5xx + RequestError 3x.
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             with pytest.raises(NetworkError, match="timed out"):
                 await client.chat.ask(
                     "nb_123",
@@ -650,7 +652,7 @@ class TestChatAskErrorHandling:
             method="POST",
         )
 
-        async with NotebookLMClient(auth_tokens) as client:
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             with pytest.raises(ChatError, match="500"):
                 await client.chat.ask(
                     "nb_123",
@@ -676,7 +678,7 @@ class TestChatAskErrorHandling:
             url=re.compile(r".*GenerateFreeFormStreamed.*"),
         )
 
-        async with NotebookLMClient(auth_tokens) as client:
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             with pytest.raises(NetworkError, match="connection refused"):
                 await client.chat.ask(
                     "nb_123",

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -638,8 +638,13 @@ class TestRpcCallAutoRetry:
         assert call_count[0] == 2, "Should only retry once"
 
     @pytest.mark.asyncio
-    async def test_no_retry_on_non_auth_error(self):
-        """rpc_call should NOT retry on non-auth errors (HTTP 500)."""
+    async def test_no_auth_refresh_on_non_auth_error(self):
+        """rpc_call should NOT trigger auth refresh on non-auth errors (HTTP 500).
+
+        Note: ``server_error_max_retries=0`` opts out of the T3.A 5xx retry
+        path so this test stays focused on the original assertion — that 500
+        does not trigger an auth refresh, regardless of the retry policy.
+        """
         auth = AuthTokens(
             cookies={"SID": "test", "__Secure-1PSIDTS": "test_1psidts"},
             csrf_token="csrf",
@@ -652,7 +657,12 @@ class TestRpcCallAutoRetry:
             refresh_called.append(True)
             return auth
 
-        core = ClientCore(auth, refresh_callback=mock_refresh, refresh_retry_delay=0)
+        core = ClientCore(
+            auth,
+            refresh_callback=mock_refresh,
+            refresh_retry_delay=0,
+            server_error_max_retries=0,
+        )
 
         call_count = [0]
 

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -30,6 +30,7 @@ from notebooklm._core import (
     _AuthSnapshot,
     _TransportAuthExpired,
     _TransportRateLimited,
+    _TransportServerError,
 )
 from notebooklm._logging import get_request_id
 from notebooklm.auth import AuthTokens
@@ -40,6 +41,7 @@ def _make_core(
     *,
     refresh_callback: Callable[[], Any] | None = None,
     rate_limit_max_retries: int = 0,
+    server_error_max_retries: int = 0,
 ) -> ClientCore:
     auth = AuthTokens(
         csrf_token="CSRF_OLD",
@@ -51,6 +53,7 @@ def _make_core(
         refresh_callback=refresh_callback,
         refresh_retry_delay=0.0,
         rate_limit_max_retries=rate_limit_max_retries,
+        server_error_max_retries=server_error_max_retries,
     )
 
 
@@ -410,3 +413,419 @@ async def test_rpc_call_happy_path_url_and_body_unchanged(monkeypatch):
         assert "f.req=" in captured["content"]
     finally:
         await core.close()
+
+
+# ---------------------------------------------------------------------------
+# server_error_max_retries — 5xx + network with exponential backoff (T3.A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_5xx_retries_then_succeeds(monkeypatch):
+    """503 followed by 200: server_error_max_retries=3 lets us recover."""
+    core = _make_core(server_error_max_retries=3)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _status_error(503)
+            return _ok_response()
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        response = await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert call_count["n"] == 2
+        # First retry sleeps 2 ** 0 = 1 second.
+        assert sleeps == [1]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
+    """Persistent 502 with budget=3 → 4 total attempts, then _TransportServerError."""
+    core = _make_core(server_error_max_retries=3)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            raise _status_error(502)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportServerError) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        # Initial + 3 retries = 4 total attempts.
+        assert call_count["n"] == 4
+        # Exponential backoff: 1, 2, 4 seconds (capped at 30).
+        assert sleeps == [1, 2, 4]
+        assert exc_info.value.status_code == 502
+        assert isinstance(exc_info.value.original, httpx.HTTPStatusError)
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_network_error_retries_then_succeeds(monkeypatch):
+    """httpx.RequestError (network blip) follows the server-error retry path."""
+    core = _make_core(server_error_max_retries=3)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise httpx.ReadTimeout("connection blip")
+            return _ok_response()
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        response = await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert call_count["n"] == 2
+        assert sleeps == [1]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_network_error_exhausts_budget_raises_transport_server_error(monkeypatch):
+    """Repeated httpx.ConnectError → exhausts budget → _TransportServerError
+    wrapping the underlying RequestError (status_code/response are None)."""
+    core = _make_core(server_error_max_retries=2)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportServerError) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        # Initial + 2 retries = 3 attempts; 2 sleeps (1, 2).
+        assert sleeps == [1, 2]
+        assert exc_info.value.status_code is None
+        assert exc_info.value.response is None
+        assert isinstance(exc_info.value.original, httpx.ConnectError)
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_server_error_budget_zero_raises_immediately(monkeypatch):
+    """server_error_max_retries=0 short-circuits to immediate raise (no sleep)."""
+    core = _make_core(server_error_max_retries=0)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            raise _status_error(500)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportServerError) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        # Exactly one attempt, no sleep.
+        assert call_count["n"] == 1
+        assert sleeps == []
+        assert exc_info.value.status_code == 500
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
+    """Backoff schedule: 1, 2, 4, 8, 16, 30 — caps at 30 for high attempt counts."""
+    core = _make_core(server_error_max_retries=8)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(503)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportServerError):
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        # min(2 ** attempt, 30) for attempt in 0..7 → 1, 2, 4, 8, 16, 30, 30, 30.
+        assert sleeps == [1, 2, 4, 8, 16, 30, 30, 30]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_5xx_path_does_not_touch_429_path(monkeypatch):
+    """Sanity: a 429 should still hit the rate-limit path, not the 5xx path,
+    even when server_error_max_retries is configured."""
+    core = _make_core(rate_limit_max_retries=1, server_error_max_retries=3)
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(429, retry_after="5")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportRateLimited) as exc_info:
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        # 429-path sleep uses Retry-After (5), NOT exponential backoff.
+        assert sleeps == [5]
+        assert exc_info.value.retry_after == 5
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
+    """A 503 must not be misclassified as auth error → refresh path. Refresh
+    callback must never be called even when configured."""
+    refresh_calls: list[bool] = []
+    captured_core: dict[str, ClientCore] = {}
+
+    async def refresh() -> AuthTokens:
+        refresh_calls.append(True)
+        return captured_core["c"].auth
+
+    core = _make_core(refresh_callback=refresh, server_error_max_retries=1)
+    captured_core["c"] = core
+    await core.open()
+    try:
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(503)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(_TransportServerError):
+            await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert refresh_calls == []
+    finally:
+        await core.close()
+
+
+# ---------------------------------------------------------------------------
+# rpc_call + query_post wrappers for _TransportServerError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_maps_transport_server_error_to_server_error(monkeypatch):
+    """``RPCError`` family: 5xx after retries → :class:`ServerError`."""
+    from notebooklm.rpc import ServerError
+
+    core = _make_core(server_error_max_retries=1)
+    await core.open()
+    try:
+
+        async def fake_sleep(seconds: float) -> None:
+            pass
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(503)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(ServerError) as exc_info:
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+        assert exc_info.value.status_code == 503
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_maps_transport_server_error_network_to_network_error(monkeypatch):
+    """Network failure exhausting budget on rpc_call → NetworkError (not RPCError)."""
+    from notebooklm.rpc import NetworkError
+
+    core = _make_core(server_error_max_retries=1)
+    await core.open()
+    try:
+
+        async def fake_sleep(seconds: float) -> None:
+            pass
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        async def fake_post(*args, **kwargs):
+            raise httpx.ConnectError("nope")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(NetworkError):
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_query_post_maps_transport_server_error_to_chat_error(monkeypatch):
+    """``query_post`` (chat surface): 5xx after retries → ChatError."""
+    from notebooklm.exceptions import ChatError
+
+    core = _make_core(server_error_max_retries=1)
+    await core.open()
+    try:
+
+        async def fake_sleep(seconds: float) -> None:
+            pass
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise _status_error(500)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(ChatError) as exc_info:
+            await core.query_post(build_request=build, parse_label="chat.ask")
+
+        assert "HTTP 500" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, _TransportServerError)
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_query_post_maps_transport_server_error_network_to_network_error(monkeypatch):
+    """Network failure exhausting budget on query_post → NetworkError."""
+    from notebooklm.exceptions import NetworkError
+
+    core = _make_core(server_error_max_retries=1)
+    await core.open()
+    try:
+
+        async def fake_sleep(seconds: float) -> None:
+            pass
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise httpx.ConnectError("nope")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(NetworkError) as exc_info:
+            await core.query_post(build_request=build, parse_label="chat.ask")
+
+        assert isinstance(exc_info.value.original_error, httpx.ConnectError)
+    finally:
+        await core.close()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_server_error_max_retries_negative_raises():
+    """Symmetric with rate_limit_max_retries: negative values are rejected."""
+    auth = AuthTokens(
+        csrf_token="CSRF",
+        session_id="SID",
+        cookies={"SID": "x"},
+    )
+    with pytest.raises(ValueError, match="server_error_max_retries must be >= 0"):
+        ClientCore(auth=auth, server_error_max_retries=-1)


### PR DESCRIPTION
## Summary

Tier 3 PR-T3.A — addresses synthesis **C4 / T4**: `rate_limit_max_retries` exists but `server_error_max_retries` was missing. 5xx errors were flagged retryable in the decoder but the transport loop hard-failed. This PR adds a symmetric setting.

- New `server_error_max_retries: int = 3` on `ClientCore.__init__`, `NotebookLMClient.__init__`, and `NotebookLMClient.from_storage`.
- `_perform_authed_post` now retries on:
  - `httpx.HTTPStatusError` with status `500 <= code < 600`
  - `httpx.RequestError` (network-layer: timeouts, connect errors, remote-protocol blips)
- Backoff is **exponential** `min(2 ** attempt, 30)` seconds — 5xx rarely carries `Retry-After`, so the 429 model doesn't apply.
- New `_TransportServerError` mirrors `_TransportRateLimited` for budget exhaustion; mapped by:
  - `rpc_call` → historical `ServerError` / `NetworkError` / `RPCTimeoutError` shapes
  - `query_post` → `ChatError` / `NetworkError`

### Non-changes (intentional)
- Auth refresh path (400/401/403) untouched — `is_auth_error` still gates refresh.
- 429 path untouched — `Retry-After` semantics and `rate_limit_max_retries` preserved; the 429 branch sits *before* the new 5xx/network branch in the except handler.
- 530 unit tests + 596 integration tests pass.

## Test plan
- [x] 503 → retry, eventually succeeds (sleeps == [1])
- [x] Persistent 502 → exhausts budget=3 → `_TransportServerError`; 4 total attempts; sleeps == [1, 2, 4]
- [x] Network `ReadTimeout` → retry, eventually succeeds
- [x] Persistent `ConnectError` → exhausts budget → `_TransportServerError` with `status_code=None`
- [x] `server_error_max_retries=0` → immediate raise, no sleep
- [x] Exponential backoff caps at 30 s for high attempt counts
- [x] 429 path still works (still raises `_TransportRateLimited` with `Retry-After` sleep) even when both budgets are configured
- [x] 503 does not trigger auth refresh
- [x] `rpc_call` maps `_TransportServerError(5xx)` → `ServerError`; network variant → `NetworkError`
- [x] `query_post` maps `_TransportServerError(5xx)` → `ChatError`; network variant → `NetworkError`
- [x] `server_error_max_retries < 0` raises `ValueError`

Two integration tests (`test_rpc_error_http_500`, `test_ask_*_raises_*`) and one unit test (`test_no_retry_on_non_auth_error` → renamed to `test_no_auth_refresh_on_non_auth_error`) now pass `server_error_max_retries=0` to pin their original immediate-raise assertion; they remain accurate as the "no auth refresh on 500" contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry mechanism for transient server and network failures with exponential backoff
  * New `server_error_max_retries` parameter (default: 3) for both `NotebookLMClient` and `ClientCore` to control automatic retry behavior
  * Improved resilience for temporary service disruptions

* **Documentation**
  * Updated API documentation to describe new retry configuration parameters

* **Tests**
  * Extended test coverage for server error and network failure retry handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/464)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->