### PR TITLE
fix(_core): preserve timeout error message + remove prod assert (PR #464 followup)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -1027,9 +1027,10 @@ class ClientCore:
                 f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
             ) from exc
         # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
-        # handlers were removed after T3.A — ``_perform_authed_post`` now
-        # always either retries those or wraps them in ``_TransportServerError``
-        # (handled above), so they cannot reach this scope.
+        # handlers were removed here because ``_perform_authed_post`` always
+        # either retries those errors or wraps them in
+        # ``_TransportServerError`` (handled above), so they cannot reach
+        # this scope.
 
     async def rpc_call(
         self,
@@ -1184,8 +1185,8 @@ class ClientCore:
                 exc.response.status_code,
             )
             self._raise_rpc_error_from_http_status(exc, method)
-        # NOTE: bare ``httpx.RequestError`` handler was removed after T3.A —
-        # ``_perform_authed_post`` now always either retries network-layer
+        # NOTE: bare ``httpx.RequestError`` handler was removed here because
+        # ``_perform_authed_post`` always either retries network-layer
         # errors or wraps them in ``_TransportServerError`` (handled above),
         # so they cannot reach this scope.
 

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -997,25 +997,39 @@ class ClientCore:
                     f"after retries: {exc.original}"
                 ) from exc
             # Network-layer failure (RequestError / Timeout).
-            assert isinstance(exc.original, httpx.RequestError)
+            # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
+            # ``_TransportServerError`` on the network path; this guard keeps
+            # the contract enforced under ``python -O`` (where ``assert``
+            # would be stripped) and gives a clear diagnostic if the
+            # invariant ever drifts.
+            if not isinstance(exc.original, httpx.RequestError):
+                raise TypeError(
+                    f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                ) from exc
+            # Preserve the timeout-specific message: TimeoutException is a
+            # subclass of RequestError, so without this branch read/connect
+            # timeouts would surface as a generic "network error after
+            # retries" line and lose the "timed out" signal callers rely on.
+            if isinstance(exc.original, httpx.TimeoutException):
+                raise NetworkError(
+                    f"{parse_label} timed out after retries: {exc.original}",
+                    original_error=exc.original,
+                ) from exc
             raise NetworkError(
                 f"{parse_label} network error after retries: {exc.original}",
                 original_error=exc.original,
             ) from exc
-        except httpx.TimeoutException as exc:
-            raise NetworkError(
-                f"{parse_label} timed out: {exc}",
-                original_error=exc,
-            ) from exc
         except httpx.HTTPStatusError as exc:
+            # Non-5xx / non-401 / non-429 status errors fall through
+            # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
+            # or unhandled 4xx).
             raise ChatError(
                 f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
             ) from exc
-        except httpx.RequestError as exc:
-            raise NetworkError(
-                f"{parse_label} request failed: {exc}",
-                original_error=exc,
-            ) from exc
+        # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
+        # handlers were removed after T3.A — ``_perform_authed_post`` now
+        # always either retries those or wraps them in ``_TransportServerError``
+        # (handled above), so they cannot reach this scope.
 
     async def rpc_call(
         self,
@@ -1146,7 +1160,14 @@ class ClientCore:
                 )
                 self._raise_rpc_error_from_http_status(exc.original, method)
             else:
-                assert isinstance(exc.original, httpx.RequestError)
+                # ``_perform_authed_post`` only wraps ``httpx.RequestError``
+                # into ``_TransportServerError`` on the network path; this
+                # guard keeps the contract enforced under ``python -O``
+                # (where ``assert`` would be stripped).
+                if not isinstance(exc.original, httpx.RequestError):
+                    raise TypeError(
+                        f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                    ) from exc
                 logger.error(
                     "RPC %s failed after %.3fs: %s (server-error retries exhausted)",
                     method.name,
@@ -1163,10 +1184,10 @@ class ClientCore:
                 exc.response.status_code,
             )
             self._raise_rpc_error_from_http_status(exc, method)
-        except httpx.RequestError as exc:
-            elapsed = time.perf_counter() - start
-            logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, exc)
-            self._raise_rpc_error_from_request_error(exc, method)
+        # NOTE: bare ``httpx.RequestError`` handler was removed after T3.A —
+        # ``_perform_authed_post`` now always either retries network-layer
+        # errors or wraps them in ``_TransportServerError`` (handled above),
+        # so they cannot reach this scope.
 
         # ---------- Decode -------------------------------------------------
         # Decode-time auth retry stays RPC-specific: Google sometimes

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -391,8 +391,9 @@ async def test_query_post_timeout_after_budget_keeps_timeout_message(monkeypatch
     """Timeout that exhausts the retry budget still surfaces ``timed out`` —
     explicit regression for the dead-handler bug: prior to the fix, the only
     code path that could produce a ``timed out`` message was the bare
-    ``except httpx.TimeoutException`` handler, which became unreachable after
-    T3.A wrapped all ``httpx.RequestError`` into ``_TransportServerError``."""
+    ``except httpx.TimeoutException`` handler, which became unreachable once
+    ``_perform_authed_post`` started wrapping every ``httpx.RequestError``
+    into ``_TransportServerError`` (PR #464)."""
     from notebooklm.exceptions import NetworkError
 
     core = _make_core(server_error_max_retries=2)
@@ -419,6 +420,9 @@ async def test_query_post_timeout_after_budget_keeps_timeout_message(monkeypatch
         assert "timed out" in msg
         assert "network error after retries" not in msg
         assert isinstance(exc_info.value.original_error, httpx.ReadTimeout)
+        # Chain: NetworkError -> _TransportServerError -> ReadTimeout (symmetry
+        # with the budget=0 test above).
+        assert isinstance(exc_info.value.__cause__, _TransportServerError)
     finally:
         await core.close()
 

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -355,6 +355,10 @@ async def test_query_post_wraps_auth_expired_as_chat_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_query_post_wraps_timeout_as_network_error(monkeypatch):
+    """Timeout with budget=0: ``_TransportServerError`` path must still produce a
+    ``NetworkError`` whose message preserves the ``timed out`` signal (regression
+    against PR #464 follow-up — without the timeout-specific branch, the message
+    collapses to a generic ``network error after retries``)."""
     from notebooklm.exceptions import NetworkError
 
     core = _make_core()
@@ -372,6 +376,48 @@ async def test_query_post_wraps_timeout_as_network_error(monkeypatch):
         with pytest.raises(NetworkError) as exc_info:
             await core.query_post(build_request=build, parse_label="chat.ask")
 
+        assert isinstance(exc_info.value.original_error, httpx.ReadTimeout)
+        msg = str(exc_info.value)
+        assert "timed out" in msg
+        assert "network error after retries" not in msg
+        # Chain: NetworkError -> _TransportServerError -> ReadTimeout
+        assert isinstance(exc_info.value.__cause__, _TransportServerError)
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_query_post_timeout_after_budget_keeps_timeout_message(monkeypatch):
+    """Timeout that exhausts the retry budget still surfaces ``timed out`` —
+    explicit regression for the dead-handler bug: prior to the fix, the only
+    code path that could produce a ``timed out`` message was the bare
+    ``except httpx.TimeoutException`` handler, which became unreachable after
+    T3.A wrapped all ``httpx.RequestError`` into ``_TransportServerError``."""
+    from notebooklm.exceptions import NetworkError
+
+    core = _make_core(server_error_max_retries=2)
+    await core.open()
+    try:
+
+        async def fake_sleep(seconds: float) -> None:
+            pass
+
+        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        async def fake_post(*args, **kwargs):
+            raise httpx.ReadTimeout("read timeout")
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with pytest.raises(NetworkError) as exc_info:
+            await core.query_post(build_request=build, parse_label="chat.ask")
+
+        msg = str(exc_info.value)
+        assert "timed out" in msg
+        assert "network error after retries" not in msg
         assert isinstance(exc_info.value.original_error, httpx.ReadTimeout)
     finally:
         await core.close()


### PR DESCRIPTION
## Summary

Two follow-up fixes from the **delayed Claude review on merged PR #464** (server_error_max_retries with exponential backoff). PR #464 landed before Claude finished reviewing; this PR addresses the findings.

### Issue 1 — Dead exception handlers (medium)

After PR #464, `_perform_authed_post` either retries every `httpx.RequestError` (including `TimeoutException`) or wraps it in `_TransportServerError`. That left three handlers in callers unreachable:

- `query_post`: `except httpx.TimeoutException` and `except httpx.RequestError` (never fire).
- `rpc_call`: `except httpx.RequestError` (never fires).

**Observable bug:** read/connect timeouts in `query_post` now surface as a generic `"chat.ask network error after retries: ..."` `NetworkError` instead of the historical `"chat.ask timed out: ..."` message — losing a signal callers rely on.

**Fix:** branch on `isinstance(exc.original, httpx.TimeoutException)` inside `query_post`'s `_TransportServerError` handler before falling back to the generic network message; drop the dead clauses below. `rpc_call` already routes through `_raise_rpc_error_from_request_error`, which preserves the Timeout / ConnectTimeout / ConnectError / generic distinction — only the dead clause needed removal there.

### Issue 2 — `assert isinstance(...)` in production (minor)

Two sites used `assert isinstance(exc.original, httpx.RequestError)` purely for mypy narrowing. `assert` is stripped under `python -O`, so the invariant goes silent in optimized builds. Replaced with explicit `if not isinstance(...): raise TypeError(...) from exc` guards.

### Constraints honored

- No change to `_TransportServerError`'s public contract (shape, fields, chaining).
- No change to retry semantics (budget, backoff, which exception classes are retried).
- Drops only provably unreachable code paths.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest tests/unit` — 2491 passed, 5 skipped
- [x] `uv run pytest tests/integration` — 599 passed, 4 skipped
- [x] New regression test `test_query_post_timeout_after_budget_keeps_timeout_message` exercises the previously-broken path (`ReadTimeout` exhausting `server_error_max_retries=2`) and asserts the surfaced `NetworkError` contains `"timed out"` and **not** `"network error after retries"`.
- [x] Existing `test_query_post_wraps_timeout_as_network_error` (budget=0 path) tightened with the same wording check.

Refs: PR #464 (delayed Claude review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Timeout errors now show clear timeout-specific messages instead of a generic network error.
  * Network error handling made more consistent, improving diagnostic details and preserving original timeout information for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/466)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->