### PR TITLE
feat(cli): --storage isolates context per file (T3.C)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,6 +284,13 @@ notebooklm login
 notebooklm --storage /path/to/storage_state.json list
 ```
 
+When `--storage <path>` is set, notebook/conversation context is isolated to a
+sibling file `<path>.context.json` next to the storage file. This means two
+`--storage` invocations against different files cannot see each other's
+selected notebook, and neither pollutes the default profile context. Run
+`notebooklm --storage <path> status --paths` to see exactly which sibling
+context file is being used.
+
 ## CI/CD Configuration
 
 ### GitHub Actions (Recommended)

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -532,19 +532,26 @@ def _current_storage_override() -> Path | None:
     """Resolve the active ``--storage`` override from the current Click context.
 
     Returns the explicit storage path stored in ``ctx.obj["storage_path"]`` by
-    the root CLI group (see ``notebooklm_cli.cli``). When no Click context is
-    active (e.g., library usage) or no override was passed, returns ``None``.
-    Context-touching helpers thread this through ``get_context_path`` so that
-    ``--storage <path>`` isolates context into a sibling ``<path>.context.json``.
+    the root CLI group (see ``notebooklm_cli.cli``), canonicalized via
+    ``expanduser().resolve()`` so two representations of the same file (e.g.,
+    ``~/foo.json`` and ``/home/user/foo.json``) share one sibling-context
+    namespace. When no Click context is active (library usage) or no override
+    was passed, returns ``None``.
+
+    ``click.get_current_context(silent=True)`` already returns ``None`` outside
+    of a Click invocation, so no try/except is needed.
     """
-    try:
-        ctx = click.get_current_context(silent=True)
-    except RuntimeError:
-        return None
+    ctx = click.get_current_context(silent=True)
     if ctx is None or not ctx.obj:
         return None
     storage = ctx.obj.get("storage_path")
-    return storage if isinstance(storage, Path) else None
+    if storage is None:
+        return None
+    # Defensive normalization: ``notebooklm_cli`` already wraps strings via
+    # ``Path(storage)``, but accept either form so future callers (tests,
+    # library wrappers populating ``ctx.obj`` directly) don't get a
+    # string-vs-``Path`` mismatch crash inside ``get_context_path``.
+    return Path(storage).expanduser().resolve()
 
 
 def _get_context_value(key: str) -> str | None:

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -528,9 +528,28 @@ def get_auth_tokens(ctx) -> AuthTokens:
 # =============================================================================
 
 
+def _current_storage_override() -> Path | None:
+    """Resolve the active ``--storage`` override from the current Click context.
+
+    Returns the explicit storage path stored in ``ctx.obj["storage_path"]`` by
+    the root CLI group (see ``notebooklm_cli.cli``). When no Click context is
+    active (e.g., library usage) or no override was passed, returns ``None``.
+    Context-touching helpers thread this through ``get_context_path`` so that
+    ``--storage <path>`` isolates context into a sibling ``<path>.context.json``.
+    """
+    try:
+        ctx = click.get_current_context(silent=True)
+    except RuntimeError:
+        return None
+    if ctx is None or not ctx.obj:
+        return None
+    storage = ctx.obj.get("storage_path")
+    return storage if isinstance(storage, Path) else None
+
+
 def _get_context_value(key: str) -> str | None:
     """Read a single value from context.json."""
-    context_file = get_context_path()
+    context_file = get_context_path(storage_path=_current_storage_override())
     if not context_file.exists():
         return None
     try:
@@ -560,7 +579,7 @@ def _set_context_value(key: str, value: str | None) -> None:
     not data loss. We accept the minor inefficiency to keep the early-return
     fast path: most invocations have no context file at all.
     """
-    context_file = get_context_path()
+    context_file = get_context_path(storage_path=_current_storage_override())
     if not context_file.exists():
         return
 
@@ -602,7 +621,7 @@ def set_current_notebook(
     Uses ``atomic_update_json`` so the account-metadata preservation and the
     notebook-context overwrite happen as one lock-protected critical section.
     """
-    context_file = get_context_path()
+    context_file = get_context_path(storage_path=_current_storage_override())
 
     def _mutate(existing: dict[str, Any]) -> dict[str, Any]:
         data: dict[str, Any] = {}
@@ -637,7 +656,7 @@ def clear_context(*, clear_account: bool = False) -> bool:
 
     Returns True if a context file was changed or removed, False if none existed.
     """
-    context_file = get_context_path()
+    context_file = get_context_path(storage_path=_current_storage_override())
     if not context_file.exists():
         return False
     lock_path = context_file.with_suffix(context_file.suffix + ".lock")
@@ -945,8 +964,9 @@ def handle_auth_error(json_output: bool = False):
     """Handle authentication errors with helpful context."""
     from ..paths import get_path_info, get_storage_path
 
-    path_info = get_path_info()
-    storage_path = get_storage_path()
+    storage_override = _current_storage_override()
+    path_info = get_path_info(storage_path=storage_override)
+    storage_path = storage_override if storage_override is not None else get_storage_path()
     has_env_var = bool(os.environ.get("NOTEBOOKLM_AUTH_JSON"))
     has_home_env = bool(os.environ.get("NOTEBOOKLM_HOME"))
     storage_source = path_info["home_source"]

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -48,6 +48,7 @@ from ..paths import (
     get_storage_path,
 )
 from .helpers import (
+    _current_storage_override,
     clear_context,
     console,
     get_auth_tokens,
@@ -1417,14 +1418,18 @@ def register_session_commands(cli):
     @cli.command("status")
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @click.option("--paths", "show_paths", is_flag=True, help="Show resolved file paths")
-    @click.pass_context
-    def status(ctx, json_output, show_paths):
+    def status(json_output, show_paths):
         """Show current context (active notebook and conversation).
 
         Use --paths to see where configuration files are located
         (useful for debugging NOTEBOOKLM_HOME).
         """
-        storage_override = ctx.obj.get("storage_path") if ctx.obj else None
+        # Reuse the shared helper so the same ``--storage`` resolution + path
+        # canonicalization runs here as in ``_get_context_value`` and friends.
+        # Keeps a single source of truth for "which context file does
+        # ``--storage`` map to?" and avoids duplicating the normalization
+        # logic (string→Path, expanduser, resolve) at every call site.
+        storage_override = _current_storage_override()
         context_file = get_context_path(storage_path=storage_override)
         notebook_id = get_current_notebook()
 
@@ -1544,8 +1549,7 @@ def register_session_commands(cli):
         pass
 
     @auth_group.command("logout")
-    @click.pass_context
-    def auth_logout(ctx):
+    def auth_logout():
         """Log out by clearing saved authentication.
 
         Removes both the saved cookie file (storage_state.json) and the
@@ -1554,8 +1558,9 @@ def register_session_commands(cli):
 
         \b
         Examples:
-          notebooklm auth logout           # Clear auth for active profile
-          notebooklm -p work auth logout   # Clear auth for 'work' profile
+          notebooklm auth logout                       # Clear auth for active profile
+          notebooklm -p work auth logout               # Clear auth for 'work' profile
+          notebooklm --storage A.json auth logout      # Clear the override auth file
         """
         # Warn if env-based auth will remain active after logout
         if os.environ.get("NOTEBOOKLM_AUTH_JSON"):
@@ -1564,7 +1569,11 @@ def register_session_commands(cli):
                 "remain active after logout. Unset it to fully log out.[/yellow]"
             )
 
-        storage_path = get_storage_path()
+        # When ``--storage <path>`` is active, that path IS the auth file. Using
+        # the profile's storage_state.json instead would silently leave the
+        # actual session credentials in place — see coderabbit feedback on #467.
+        storage_override = _current_storage_override()
+        storage_path = storage_override if storage_override is not None else get_storage_path()
         browser_profile = get_browser_profile_dir()
 
         removed_any = False
@@ -1614,7 +1623,9 @@ def register_session_commands(cli):
             if clear_context(clear_account=True):
                 removed_any = True
         except OSError as exc:
-            storage_override = ctx.obj.get("storage_path") if ctx.obj else None
+            # Reuse the storage_override computed above so the diagnostic line
+            # points at the actual sibling-context file when ``--storage`` is
+            # active (matches the path that ``clear_context`` just tried).
             context_file = get_context_path(storage_path=storage_override)
             logger.error("Failed to remove context file %s: %s", context_file, exc)
             console.print(

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -1417,18 +1417,20 @@ def register_session_commands(cli):
     @cli.command("status")
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
     @click.option("--paths", "show_paths", is_flag=True, help="Show resolved file paths")
-    def status(json_output, show_paths):
+    @click.pass_context
+    def status(ctx, json_output, show_paths):
         """Show current context (active notebook and conversation).
 
         Use --paths to see where configuration files are located
         (useful for debugging NOTEBOOKLM_HOME).
         """
-        context_file = get_context_path()
+        storage_override = ctx.obj.get("storage_path") if ctx.obj else None
+        context_file = get_context_path(storage_path=storage_override)
         notebook_id = get_current_notebook()
 
         # Handle --paths flag
         if show_paths:
-            path_info = get_path_info()
+            path_info = get_path_info(storage_path=storage_override)
             if json_output:
                 json_output_response({"paths": path_info})
                 return
@@ -1542,7 +1544,8 @@ def register_session_commands(cli):
         pass
 
     @auth_group.command("logout")
-    def auth_logout():
+    @click.pass_context
+    def auth_logout(ctx):
         """Log out by clearing saved authentication.
 
         Removes both the saved cookie file (storage_state.json) and the
@@ -1611,7 +1614,8 @@ def register_session_commands(cli):
             if clear_context(clear_account=True):
                 removed_any = True
         except OSError as exc:
-            context_file = get_context_path()
+            storage_override = ctx.obj.get("storage_path") if ctx.obj else None
+            context_file = get_context_path(storage_path=storage_override)
             logger.error("Failed to remove context file %s: %s", context_file, exc)
             console.print(
                 f"[red]Cannot remove context file: {exc}[/red]\n"

--- a/src/notebooklm/notebooklm_cli.py
+++ b/src/notebooklm/notebooklm_cli.py
@@ -187,7 +187,10 @@ def cli(ctx, storage, profile, verbose):
             raise _click.ClickException(str(e)) from None
 
     ctx.ensure_object(dict)
-    ctx.obj["storage_path"] = Path(storage) if storage else None
+    # Canonicalize once at the boundary: ``--storage ~/foo.json`` and
+    # ``--storage /Users/x/foo.json`` must map to the same sibling-context
+    # namespace (see ``cli.helpers._current_storage_override``).
+    ctx.obj["storage_path"] = Path(storage).expanduser().resolve() if storage else None
     ctx.obj["profile"] = profile
 
 

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -274,18 +274,32 @@ def get_storage_path(profile: str | None = None) -> Path:
     return _legacy_fallback(profile_path, "storage_state.json", resolved)
 
 
-def get_context_path(profile: str | None = None) -> Path:
-    """Get context.json path for a profile.
+def get_context_path(
+    profile: str | None = None,
+    *,
+    storage_path: Path | None = None,
+) -> Path:
+    """Get context.json path for a profile or storage file.
 
-    Falls back to legacy home-root path for the "default" profile if the
-    profile-based path doesn't exist (pre-migration compatibility).
+    Precedence:
+        1. ``storage_path`` (explicit ``--storage <path>`` CLI flag) →
+           returns a sibling ``<storage_path>.context.json``. This isolates
+           context per storage file so two ``--storage`` invocations cannot
+           see each other's notebook selection.
+        2. Profile-based path (``profiles/<name>/context.json``).
+        3. Legacy home-root fallback (``~/.notebooklm/context.json`` for the
+           "default" profile when the profile path doesn't exist).
 
     Args:
         profile: Profile name. If None, uses the active profile.
+        storage_path: Explicit storage_state.json path from --storage flag.
+            When set, returns a sibling context file and skips profile lookup.
 
     Returns:
         Path to context.json.
     """
+    if storage_path is not None:
+        return storage_path.with_suffix(storage_path.suffix + ".context.json")
     resolved = resolve_profile(profile)
     profile_path = get_profile_dir(resolved) / "context.json"
     return _legacy_fallback(profile_path, "context.json", resolved)
@@ -317,13 +331,20 @@ def get_config_path() -> Path:
     return get_home_dir() / "config.json"
 
 
-def get_path_info(profile: str | None = None) -> dict[str, str]:
+def get_path_info(
+    profile: str | None = None,
+    *,
+    storage_path: Path | None = None,
+) -> dict[str, str]:
     """Get diagnostic info about resolved paths.
 
     Useful for debugging and the ``status`` / ``doctor`` commands.
 
     Args:
         profile: Profile name. If None, uses the active profile.
+        storage_path: Explicit ``--storage`` override. When set, ``storage_path``
+            and ``context_path`` in the result reflect the sibling-context
+            layout rather than the profile path.
 
     Returns:
         Dict with path information and sources.
@@ -332,7 +353,9 @@ def get_path_info(profile: str | None = None) -> dict[str, str]:
     resolved = resolve_profile(profile)
 
     # Determine profile source
-    if profile:
+    if storage_path is not None:
+        profile_source = "CLI flag (--storage)"
+    elif profile:
         profile_source = "CLI flag"
     elif _active_profile:
         profile_source = "CLI flag (--profile)"
@@ -343,14 +366,19 @@ def get_path_info(profile: str | None = None) -> dict[str, str]:
     else:
         profile_source = "default"
 
+    resolved_storage = (
+        str(storage_path) if storage_path is not None else str(get_storage_path(resolved))
+    )
+    resolved_context = str(get_context_path(resolved, storage_path=storage_path))
+
     return {
         "home_dir": str(get_home_dir()),
         "home_source": "NOTEBOOKLM_HOME" if home_from_env else "default (~/.notebooklm)",
         "profile": resolved,
         "profile_source": profile_source,
         "profile_dir": str(get_profile_dir(resolved)),
-        "storage_path": str(get_storage_path(resolved)),
-        "context_path": str(get_context_path(resolved)),
+        "storage_path": resolved_storage,
+        "context_path": resolved_context,
         "config_path": str(get_config_path()),
         "browser_profile_dir": str(get_browser_profile_dir(resolved)),
     }

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -352,9 +352,21 @@ def get_path_info(
     home_from_env = os.environ.get("NOTEBOOKLM_HOME")
     resolved = resolve_profile(profile)
 
-    # Determine profile source
+    # Determine profile source. When --storage is set, profile resolution is
+    # effectively bypassed for the auth + context paths — but we still resolve
+    # ``profile`` because consumers may want to know what profile *would* be
+    # active otherwise. Make the override clear in the label so ``status
+    # --paths`` doesn't claim "CLI flag (--storage)" set the profile.
+    other_profile_set = (
+        profile
+        or _active_profile
+        or os.environ.get("NOTEBOOKLM_PROFILE")
+        or _read_default_profile()
+    )
     if storage_path is not None:
-        profile_source = "CLI flag (--storage)"
+        profile_source = (
+            "CLI flag (--storage, profile ignored)" if other_profile_set else "CLI flag (--storage)"
+        )
     elif profile:
         profile_source = "CLI flag"
     elif _active_profile:

--- a/tests/unit/cli/test_storage_context_isolation.py
+++ b/tests/unit/cli/test_storage_context_isolation.py
@@ -102,6 +102,15 @@ class TestGetPathInfoStorageOverride:
         # No --storage means we don't claim "CLI flag (--storage)" as source.
         assert info["profile_source"] != "CLI flag (--storage)"
 
+    def test_storage_with_profile_marks_profile_ignored(self, tmp_path, isolated_home):
+        """When --storage and --profile both set, label is explicit."""
+        storage = tmp_path / "explicit.json"
+        info = get_path_info(profile="work", storage_path=storage)
+        # ``--profile work`` is shadowed by ``--storage`` for auth/context, so
+        # the source label must communicate that to avoid confusion in
+        # ``status --paths``.
+        assert info["profile_source"] == "CLI flag (--storage, profile ignored)"
+
 
 # =============================================================================
 # CLI-level isolation tests

--- a/tests/unit/cli/test_storage_context_isolation.py
+++ b/tests/unit/cli/test_storage_context_isolation.py
@@ -1,0 +1,216 @@
+"""Tests for ``--storage`` context isolation (PR-T3.C).
+
+The ``--storage <path>`` flag pins both auth state AND notebook context to
+sibling files (``<path>`` and ``<path>.context.json``). Without isolation,
+``--storage A use nb1`` would write to the DEFAULT profile context, then
+``--storage B ask`` would silently reuse A's notebook ID — see synthesis K1.
+
+These tests pin the contract:
+
+- ``--storage A use nb1`` writes to ``A.context.json`` (NOT the default profile).
+- ``--storage B status`` shows no context (B has its own sibling file).
+- ``--storage A status --paths`` reports the sibling path so users can
+  discover where context lives.
+- Default (no ``--storage``) behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.paths import get_context_path, get_path_info
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Pin NOTEBOOKLM_HOME to tmp so default-profile context lives in tmp.
+
+    Also resets the module-level active profile and config cache so test order
+    is irrelevant.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(home))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+
+    from notebooklm.paths import _reset_config_cache, set_active_profile
+
+    set_active_profile(None)
+    _reset_config_cache()
+    yield home
+    set_active_profile(None)
+    _reset_config_cache()
+
+
+# =============================================================================
+# Pure get_context_path() unit tests
+# =============================================================================
+
+
+class TestGetContextPathStorageOverride:
+    def test_sibling_path_when_storage_set(self, tmp_path):
+        """``storage_path`` returns sibling ``<path>.context.json``."""
+        storage = tmp_path / "accountA.json"
+        result = get_context_path(storage_path=storage)
+        assert result == tmp_path / "accountA.json.context.json"
+
+    def test_sibling_preserves_directory(self, tmp_path):
+        """Sibling path lives next to the storage file, not in HOME."""
+        nested = tmp_path / "deep" / "nest" / "creds.json"
+        result = get_context_path(storage_path=nested)
+        assert result.parent == nested.parent
+        assert result.name == "creds.json.context.json"
+
+    def test_storage_takes_precedence_over_profile(self, tmp_path, isolated_home):
+        """Explicit storage beats both profile + legacy fallback."""
+        storage = tmp_path / "explicit.json"
+        result = get_context_path(profile="work", storage_path=storage)
+        assert result == tmp_path / "explicit.json.context.json"
+
+    def test_none_storage_falls_back_to_profile(self, isolated_home):
+        """When ``storage_path`` is None, falls back to profile-based path."""
+        result = get_context_path(storage_path=None)
+        # Default profile, legacy fallback to home root (profile dir not created).
+        assert "context.json" in str(result)
+        assert str(isolated_home) in str(result.resolve())
+
+
+class TestGetPathInfoStorageOverride:
+    def test_storage_override_in_info(self, tmp_path, isolated_home):
+        """``get_path_info(storage_path=...)`` reflects sibling layout."""
+        storage = tmp_path / "explicit.json"
+        info = get_path_info(storage_path=storage)
+        assert info["storage_path"] == str(storage)
+        assert info["context_path"] == str(tmp_path / "explicit.json.context.json")
+        assert info["profile_source"] == "CLI flag (--storage)"
+
+    def test_no_override_unchanged(self, isolated_home):
+        """Default invocation (no override) keeps prior behavior."""
+        info = get_path_info()
+        assert "context.json" in info["context_path"]
+        assert "storage_state.json" in info["storage_path"]
+        # No --storage means we don't claim "CLI flag (--storage)" as source.
+        assert info["profile_source"] != "CLI flag (--storage)"
+
+
+# =============================================================================
+# CLI-level isolation tests
+# =============================================================================
+
+
+class TestUseWritesSiblingContext:
+    """``--storage A use nb1`` must write to ``A.context.json``, not default."""
+
+    def test_use_writes_sibling_not_default(self, runner, tmp_path, isolated_home):
+        storage_a = tmp_path / "A.json"
+        # Pre-populate a fake storage file so existence checks pass; the CLI's
+        # `use` command in unverified form just persists the ID locally.
+        storage_a.write_text(json.dumps({"cookies": [], "origins": []}))
+
+        # Place a default-profile context file so we can detect accidental writes.
+        default_context = isolated_home / "context.json"
+        default_context.write_text(json.dumps({}))
+
+        sibling_context = tmp_path / "A.json.context.json"
+        assert not sibling_context.exists()
+
+        # `notebooklm use` falls through to a degraded "save-anyway" path on RPC
+        # failure (see session.py around line 1396-1414). With no auth mocked
+        # for the RPC, the fallback runs and writes context locally.
+        result = runner.invoke(cli, ["--storage", str(storage_a), "use", "nb_abc123def456"])
+
+        # Even on auth/RPC failure, the persistence-on-failure path writes the
+        # notebook_id to the *sibling* context, not the default profile one.
+        assert sibling_context.exists(), (
+            f"sibling context not written: stdout={result.output} exit={result.exit_code}"
+        )
+        data = json.loads(sibling_context.read_text())
+        assert data["notebook_id"] == "nb_abc123def456"
+
+        # Default profile context must be untouched.
+        assert json.loads(default_context.read_text()) == {}
+
+
+class TestStorageIsolationBetweenFiles:
+    """``--storage A`` and ``--storage B`` must not see each other's context."""
+
+    def test_b_status_does_not_see_a_notebook(self, runner, tmp_path, isolated_home):
+        storage_b = tmp_path / "B.json"
+        # A's context says nb_aaa is selected; B has no context file at all.
+        (tmp_path / "A.json.context.json").write_text(
+            json.dumps({"notebook_id": "nb_aaa", "title": "A"})
+        )
+        # B's sibling context intentionally absent.
+
+        # `status` reads context only; doesn't need auth.
+        result_b = runner.invoke(cli, ["--storage", str(storage_b), "status"])
+        assert result_b.exit_code == 0
+        assert "nb_aaa" not in result_b.output
+        # The "No notebook selected" hint confirms B saw an empty context.
+        assert "No notebook selected" in result_b.output
+
+    def test_a_status_sees_only_a_notebook(self, runner, tmp_path, isolated_home):
+        storage_a = tmp_path / "A.json"
+        (tmp_path / "A.json.context.json").write_text(
+            json.dumps({"notebook_id": "nb_aaa", "title": "Notebook A"})
+        )
+
+        # Also put a different ID in the default profile context; A must NOT
+        # see it.
+        (isolated_home / "context.json").write_text(
+            json.dumps({"notebook_id": "nb_default", "title": "Default"})
+        )
+
+        result_a = runner.invoke(cli, ["--storage", str(storage_a), "status"])
+        assert result_a.exit_code == 0
+        assert "nb_aaa" in result_a.output
+        assert "nb_default" not in result_a.output
+
+
+class TestStatusPathsReflectsStorageOverride:
+    def test_paths_json_shows_sibling(self, runner, tmp_path, isolated_home):
+        storage_a = tmp_path / "A.json"
+        result = runner.invoke(cli, ["--storage", str(storage_a), "status", "--paths", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        paths = data["paths"]
+        assert paths["storage_path"] == str(storage_a)
+        assert paths["context_path"] == str(tmp_path / "A.json.context.json")
+        assert paths["profile_source"] == "CLI flag (--storage)"
+
+
+class TestDefaultBehaviorUnchanged:
+    """Without ``--storage``, context resolution must match prior behavior."""
+
+    def test_use_writes_default_profile_context(self, runner, isolated_home):
+        # Pre-create the default *profile* context (migration on first CLI
+        # invocation creates ``profiles/default/`` and moves legacy files
+        # there; we mirror that layout up front so the helpers' exists() gate
+        # opens).
+        profile_context = isolated_home / "profiles" / "default" / "context.json"
+        profile_context.parent.mkdir(parents=True, exist_ok=True)
+        profile_context.write_text(json.dumps({}))
+
+        result = runner.invoke(cli, ["use", "nb_default_path"])
+        # Best-effort: even if RPC fails, the fallback writes locally.
+        del result  # ignore exit code — focus on side effect
+
+        data = json.loads(profile_context.read_text())
+        assert data.get("notebook_id") == "nb_default_path"
+
+    def test_status_paths_no_storage_flag(self, runner, isolated_home):
+        result = runner.invoke(cli, ["status", "--paths", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # profile_source should NOT be the --storage label when flag absent.
+        assert data["paths"]["profile_source"] != "CLI flag (--storage)"


### PR DESCRIPTION
## Summary

- `--storage <path>` now derives a sibling context file `<path>.context.json` instead of writing to the default profile's `context.json`. Two `--storage` invocations against different files no longer leak notebook state between them.
- New `storage_path` keyword in `paths.get_context_path()` / `paths.get_path_info()` with precedence: explicit storage > profile > legacy home-root.
- CLI helpers (`_get_context_value`, `_set_context_value`, `set_current_notebook`, `clear_context`, `handle_auth_error`) thread the `--storage` override from `click.get_current_context().obj` through `get_context_path`. `status` and `auth logout` use `@click.pass_context` to read it directly.

Closes synthesis K1 from the Tier 3 plan (`.sisyphus/plans/tier-3-implementation.md` PR-T3.C). Depends on T3.E (#465) which is already merged.

## Test plan

- [x] `tests/unit/cli/test_storage_context_isolation.py` — 12 new tests covering:
  - `get_context_path(storage_path=...)` returns sibling path + preserves directory + takes precedence over profile.
  - `get_path_info(storage_path=...)` reports sibling layout and `"CLI flag (--storage)"` source.
  - `--storage A use nb_xyz` writes to `A.json.context.json`, NOT to default profile.
  - `--storage B status` shows no context when A has selected a notebook.
  - `--storage A status --paths --json` reports the sibling path.
  - Default (no `--storage`) behavior unchanged.
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports` — all clean.
- [x] `uv run pytest tests/unit` — 2499 passed, 5 skipped.
- [x] `uv run pytest tests/integration` — 596 passed, 7 skipped.
- [x] `uv run pytest tests/unit/cli` — 793 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--storage <path>` now isolates notebook context to a sibling context file and `status --paths` reports the active context file.

* **Bug Fixes**
  * Commands (including logout) now honor `--storage` overrides so operations target the intended storage/context.
  * `--storage` values are canonicalized so equivalent paths map to the same context.

* **Documentation**
  * Clarified storage-context isolation and how to verify active paths.

* **Tests**
  * Added tests covering storage/context isolation and CLI reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/467)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->