### PR TITLE
feat(cli): notebooklm use fails closed (T3.D)

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from ._core import ClientCore
 from ._env import get_base_url
 from ._settings import build_get_user_settings_params, extract_account_limits
-from .exceptions import NotebookLimitError, RPCError
+from .exceptions import NotebookLimitError, NotebookNotFoundError, RPCError
 from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, SuggestedTopic
 
@@ -145,6 +145,12 @@ class NotebooksAPI:
 
         Returns:
             Notebook object with details.
+
+        Raises:
+            NotebookNotFoundError: If the notebook does not exist. The backend
+                returns an empty / degenerate payload (missing ``id`` and
+                ``title``) for unknown IDs rather than a proper RPC error, so
+                this method post-validates the parsed response.
         """
         params = [notebook_id, None, [2], None, 0]
         result = await self._core.rpc_call(
@@ -154,7 +160,16 @@ class NotebooksAPI:
         )
         # get_notebook returns [nb_info, ...] where nb_info contains the notebook data
         nb_info = result[0] if result and isinstance(result, list) and len(result) > 0 else []
-        return Notebook.from_api_response(nb_info)
+        notebook = Notebook.from_api_response(nb_info)
+        # Degenerate response: empty payload, or both id+title parsed to empty
+        # strings. Either condition reliably signals an unknown notebook_id —
+        # a valid notebook always has at least one of id/title populated.
+        if not nb_info or (not notebook.id and not notebook.title):
+            raise NotebookNotFoundError(
+                notebook_id,
+                method_id=RPCMethod.GET_NOTEBOOK.value,
+            )
+        return notebook
 
     async def delete(self, notebook_id: str) -> bool:
         """Delete a notebook.

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -160,11 +160,21 @@ class NotebooksAPI:
         )
         # get_notebook returns [nb_info, ...] where nb_info contains the notebook data
         nb_info = result[0] if result and isinstance(result, list) and len(result) > 0 else []
+        # Guard the empty-payload case BEFORE parsing. ``Notebook.from_api_response``
+        # currently tolerates ``[]`` but a future tightening could turn that into
+        # an ``IndexError`` that would surface as a confusing crash instead of
+        # the intended ``NotebookNotFoundError``. Raising here keeps the contract
+        # stable regardless of how the parser evolves.
+        if not nb_info:
+            raise NotebookNotFoundError(
+                notebook_id,
+                method_id=RPCMethod.GET_NOTEBOOK.value,
+            )
         notebook = Notebook.from_api_response(nb_info)
-        # Degenerate response: empty payload, or both id+title parsed to empty
-        # strings. Either condition reliably signals an unknown notebook_id —
-        # a valid notebook always has at least one of id/title populated.
-        if not nb_info or (not notebook.id and not notebook.title):
+        # Defense-in-depth: even when the outer list isn't empty, the server can
+        # return a payload whose id and title both parse to ``""``. A valid
+        # notebook always has at least one of the two populated.
+        if not notebook.id and not notebook.title:
             raise NotebookNotFoundError(
                 notebook_id,
                 method_id=RPCMethod.GET_NOTEBOOK.value,

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -40,6 +40,7 @@ from ..auth import (
 )
 from ..client import NotebookLMClient
 from ..config import get_base_host, get_base_url
+from ..exceptions import NotebookNotFoundError
 from ..io import atomic_write_json
 from ..paths import (
     get_browser_profile_dir,
@@ -1350,8 +1351,17 @@ def register_session_commands(cli):
 
     @cli.command("use")
     @click.argument("notebook_id")
+    @click.option(
+        "--force",
+        is_flag=True,
+        default=False,
+        help=(
+            "Skip the existence check and persist the notebook ID even if "
+            "verification fails. Use for offline work or debugging."
+        ),
+    )
     @click.pass_context
-    def use_notebook(ctx, notebook_id):
+    def use_notebook(ctx, notebook_id, force):
         """Set the current notebook context.
 
         Once set, all commands will use this notebook by default.
@@ -1359,14 +1369,42 @@ def register_session_commands(cli):
 
         Supports partial IDs - 'notebooklm use abc' matches 'abc123...'
 
+        By default, the notebook must exist on the server; a typo or
+        unreachable backend results in a non-zero exit and the saved
+        context is left untouched. Pass --force to bypass verification.
+
         \b
         Example:
           notebooklm use nb123
           notebooklm ask "what is this about?"   # Uses nb123
           notebooklm generate video "a fun explainer"  # Uses nb123
         """
+        # --force path: persist immediately without any RPC verification.
+        # Useful when the network is unavailable or for debugging.
+        if force:
+            set_current_notebook(notebook_id)
+            table = Table()
+            table.add_column("ID", style="cyan")
+            table.add_column("Title", style="green")
+            table.add_column("Owner")
+            table.add_column("Created", style="dim")
+            table.add_row(notebook_id, "(not verified — --force)", "-", "-")
+            console.print(table)
+            return
+
         try:
             auth = get_auth_tokens(ctx)
+        except FileNotFoundError as exc:
+            # No auth file on disk — surface a helpful error rather than
+            # poisoning the saved context with an unverified ID.
+            raise click.ClickException(
+                "Cannot verify notebook without authentication. "
+                "Run 'notebooklm login' first, or pass --force to skip verification."
+            ) from exc
+        except click.ClickException:
+            raise
+
+        try:
 
             async def _get():
                 async with NotebookLMClient(auth) as client:
@@ -1376,43 +1414,43 @@ def register_session_commands(cli):
                     return nb, resolved_id
 
             nb, resolved_id = run_async(_get())
-
-            created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
-            set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)
-
-            table = Table()
-            table.add_column("ID", style="cyan")
-            table.add_column("Title", style="green")
-            table.add_column("Owner")
-            table.add_column("Created", style="dim")
-
-            created = created_str or "-"
-            owner_status = "Owner" if nb.is_owner else "Shared"
-            table.add_row(nb.id, nb.title, owner_status, created)
-
-            console.print(table)
-
-        except FileNotFoundError:
-            set_current_notebook(notebook_id)
-            table = Table()
-            table.add_column("ID", style="cyan")
-            table.add_column("Title", style="green")
-            table.add_column("Owner")
-            table.add_column("Created", style="dim")
-            table.add_row(notebook_id, "-", "-", "-")
-            console.print(table)
         except click.ClickException:
-            # Re-raise click exceptions (from resolve_notebook_id)
+            # Re-raise click exceptions (from resolve_notebook_id — partial-id
+            # ambiguity or "no match"). These already exit non-zero with a
+            # clear message and never reach the persistence branch.
             raise
-        except Exception as e:
-            set_current_notebook(notebook_id)
-            table = Table()
-            table.add_column("ID", style="cyan")
-            table.add_column("Title", style="green")
-            table.add_column("Owner")
-            table.add_column("Created", style="dim")
-            table.add_row(notebook_id, f"Warning: {str(e)}", "-", "-")
-            console.print(table)
+        except NotebookNotFoundError as exc:
+            # Server confirmed the notebook does not exist. Fail closed: do
+            # not persist anything to context.json, and exit 1 with a clear
+            # error.
+            raise click.ClickException(
+                f"Notebook {notebook_id!r} not found. "
+                "Run 'notebooklm list' to see available notebooks, "
+                "or pass --force to bypass verification."
+            ) from exc
+        except Exception as exc:
+            # All other failures (network errors, RPC errors, auth expiry,
+            # etc.) also fail closed — we cannot confirm the notebook exists,
+            # so refuse to persist. --force is the documented escape hatch.
+            raise click.ClickException(
+                f"Could not verify notebook {notebook_id!r}: {exc}. "
+                "Pass --force to persist without verification."
+            ) from exc
+
+        created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
+        set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)
+
+        table = Table()
+        table.add_column("ID", style="cyan")
+        table.add_column("Title", style="green")
+        table.add_column("Owner")
+        table.add_column("Created", style="dim")
+
+        created = created_str or "-"
+        owner_status = "Owner" if nb.is_owner else "Shared"
+        table.add_row(nb.id, nb.title, owner_status, created)
+
+        console.print(table)
 
     @cli.command("status")
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -103,6 +103,15 @@ def _connection_error_help() -> str:
     )
 
 
+def _use_notebook_table() -> Table:
+    t = Table()
+    t.add_column("ID", style="cyan")
+    t.add_column("Title", style="green")
+    t.add_column("Owner")
+    t.add_column("Created", style="dim")
+    return t
+
+
 def _is_navigation_interrupted_error(error: str | Exception) -> bool:
     """Return True for Playwright navigation races that are safe to ignore."""
     error_str = str(error).lower()
@@ -1383,11 +1392,7 @@ def register_session_commands(cli):
         # Useful when the network is unavailable or for debugging.
         if force:
             set_current_notebook(notebook_id)
-            table = Table()
-            table.add_column("ID", style="cyan")
-            table.add_column("Title", style="green")
-            table.add_column("Owner")
-            table.add_column("Created", style="dim")
+            table = _use_notebook_table()
             table.add_row(notebook_id, "(not verified — --force)", "-", "-")
             console.print(table)
             return
@@ -1439,11 +1444,7 @@ def register_session_commands(cli):
         created_str = nb.created_at.strftime("%Y-%m-%d") if nb.created_at else None
         set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)
 
-        table = Table()
-        table.add_column("ID", style="cyan")
-        table.add_column("Title", style="green")
-        table.add_column("Owner")
-        table.add_column("Created", style="dim")
+        table = _use_notebook_table()
 
         created = created_str or "-"
         owner_status = "Owner" if nb.is_owner else "Shared"

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -1404,15 +1404,14 @@ def register_session_commands(cli):
         except click.ClickException:
             raise
 
+        async def _get():
+            async with NotebookLMClient(auth) as client:
+                # Resolve partial ID to full ID
+                resolved_id = await resolve_notebook_id(client, notebook_id)
+                nb = await client.notebooks.get(resolved_id)
+                return nb, resolved_id
+
         try:
-
-            async def _get():
-                async with NotebookLMClient(auth) as client:
-                    # Resolve partial ID to full ID
-                    resolved_id = await resolve_notebook_id(client, notebook_id)
-                    nb = await client.notebooks.get(resolved_id)
-                    return nb, resolved_id
-
             nb, resolved_id = run_async(_get())
         except click.ClickException:
             # Re-raise click exceptions (from resolve_notebook_id — partial-id

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -122,6 +122,16 @@ class NetworkError(NotebookLMError):
 class RPCError(NotebookLMError):
     """Base for RPC-specific failures after connection established.
 
+    Note:
+        A small number of domain-level exceptions also inherit from
+        :class:`RPCError` so that ``except RPCError`` keeps catching them at
+        transport-level call sites. Currently :class:`NotebookNotFoundError`
+        is one such case — the underlying RPC call succeeded but returned a
+        degenerate payload, and historic callers relied on ``except RPCError``
+        to handle it. When writing new ``except RPCError`` clauses, be aware
+        these domain errors may also flow through; catch the specific domain
+        type first if you want to handle it differently.
+
     Attributes:
         method_id: The RPC method ID (e.g., "abc123") for debugging.
         raw_response: First 500 chars of raw response for debugging.

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -442,16 +442,35 @@ class NotebookError(NotebookLMError):
     """Base for notebook operations."""
 
 
-class NotebookNotFoundError(NotebookError):
+class NotebookNotFoundError(RPCError, NotebookError):
     """Notebook not found.
+
+    Inherits from both :class:`RPCError` and :class:`NotebookError` so callers
+    can catch either base. The RPC base is what ``client.notebooks.get`` raises
+    when the server returns an empty / degenerate payload for a missing ID, so
+    ``except RPCError`` keeps working at call sites that handle transport-level
+    failures. ``except NotebookError`` continues to work at domain-level call
+    sites that don't care about the RPC layer.
 
     Attributes:
         notebook_id: The ID that was not found.
+        method_id: The RPC method ID (inherited from :class:`RPCError`).
+        raw_response: First 500 chars of the raw response, if any.
     """
 
-    def __init__(self, notebook_id: str):
+    def __init__(
+        self,
+        notebook_id: str,
+        *,
+        method_id: str | None = None,
+        raw_response: str | None = None,
+    ):
         self.notebook_id = notebook_id
-        super().__init__(f"Notebook not found: {notebook_id}")
+        super().__init__(
+            f"Notebook not found: {notebook_id}",
+            method_id=method_id,
+            raw_response=raw_response,
+        )
 
 
 class NotebookLimitError(NotebookError):

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1042,17 +1042,41 @@ class TestUseCommand:
         # Should show resolved full ID
         assert "nb_full_id_123" in result.output or "Resolved Notebook" in result.output
 
-    def test_use_without_auth_sets_id_anyway(self, runner, mock_context_file):
-        """Test 'use' command sets ID even without auth file."""
+    def test_use_without_auth_fails_closed(self, runner, mock_context_file):
+        """'use' fails closed (exit 1) when no auth is available — fix for T3.D.
+
+        Pre-T3.D behavior persisted unverified IDs after auth failure, poisoning
+        saved state for downstream commands. The new contract: refuse to write
+        context.json and emit a clear "run notebooklm login" message.
+        """
         with patch(
             "notebooklm.cli.helpers.load_auth_from_storage",
             side_effect=FileNotFoundError("No auth"),
         ):
             result = runner.invoke(cli, ["use", "nb_noauth"])
 
-        # Should still set the context (with warning)
+        # Refuses to persist; surfaces a remediation hint.
+        assert result.exit_code == 1
+        assert not mock_context_file.exists()
+        assert (
+            "notebooklm login" in result.output.lower()
+            or "authentication" in result.output.lower()
+            or "--force" in result.output
+        )
+
+    def test_use_without_auth_force_persists(self, runner, mock_context_file):
+        """`use --force` bypasses verification, mirrors offline/debug path."""
+        with patch(
+            "notebooklm.cli.helpers.load_auth_from_storage",
+            side_effect=FileNotFoundError("No auth"),
+        ):
+            result = runner.invoke(cli, ["use", "--force", "nb_forced"])
+
         assert result.exit_code == 0
-        assert "nb_noauth" in result.output
+        assert "nb_forced" in result.output
+        assert mock_context_file.exists()
+        data = json.loads(mock_context_file.read_text())
+        assert data["notebook_id"] == "nb_forced"
 
     def test_use_shows_owner_status(self, runner, mock_auth, mock_context_file):
         """Test 'use' command displays ownership status correctly."""
@@ -1665,8 +1689,13 @@ class TestLoginLanguageSync:
 
 
 class TestSessionEdgeCases:
-    def test_use_handles_api_error_gracefully(self, runner, mock_auth, mock_context_file):
-        """Test 'use' command handles API errors gracefully."""
+    def test_use_handles_api_error_fails_closed(self, runner, mock_auth, mock_context_file):
+        """'use' fails closed when the API errors — fix for T3.D.
+
+        Pre-T3.D: an exception during ``client.notebooks.get`` was swallowed
+        and the unverified ID was persisted with a "Warning" tag, poisoning
+        downstream commands. New contract: exit 1, leave context.json untouched.
+        """
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notebooks.get = AsyncMock(side_effect=Exception("API Error: Rate limited"))
@@ -1685,10 +1714,9 @@ class TestSessionEdgeCases:
 
                     result = runner.invoke(cli, ["use", "nb_error"])
 
-        # Should still set context with warning, not crash
-        assert result.exit_code == 0
-        # Error message should be shown
-        assert "Warning" in result.output or "Error" in result.output or "nb_error" in result.output
+        assert result.exit_code == 1
+        assert not mock_context_file.exists()
+        assert "API Error" in result.output or "Could not verify" in result.output
 
     def test_status_shows_shared_notebook_correctly(self, runner, mock_context_file):
         """Test status correctly shows shared (non-owner) notebooks."""

--- a/tests/unit/cli/test_use_fails_closed.py
+++ b/tests/unit/cli/test_use_fails_closed.py
@@ -1,0 +1,205 @@
+"""Tests for ``notebooklm use`` fail-closed verification (PR T3.D).
+
+Before PR T3.D, ``notebooklm use <id>`` persisted the supplied notebook ID to
+``context.json`` *even when the existence check failed* — either because the
+RPC errored, or because the server returned a degenerate "empty notebook"
+payload for an unknown ID. The result was poisoned saved state that broke
+downstream commands until the user manually cleared the context.
+
+This module pins the post-fix contract:
+
+* Successful ``client.notebooks.get`` → context is persisted, exit 0.
+* ``NotebookNotFoundError`` from ``client.notebooks.get`` → exit 1, context
+  file is NOT created.
+* ``--force`` flag → context is persisted regardless of verification.
+
+Each test mocks the entire client surface; nothing here hits the network.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.exceptions import NotebookNotFoundError, RPCError
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import Notebook
+
+from .conftest import create_mock_client, patch_main_cli_client
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth():
+    """Patch storage auth so the `use` command sees real-looking cookies."""
+    with patch("notebooklm.cli.helpers.load_auth_from_storage") as mock:
+        mock.return_value = {
+            "SID": "test",
+            "__Secure-1PSIDTS": "test_1psidts",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        yield mock
+
+
+@pytest.fixture
+def mock_context_file(tmp_path):
+    """Provide a temporary context path; both call sites are patched."""
+    context_file = tmp_path / "context.json"
+    with (
+        patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.session.get_context_path", return_value=context_file),
+    ):
+        yield context_file
+
+
+def _make_notebook(notebook_id: str = "nb_real", title: str = "Real Notebook") -> Notebook:
+    return Notebook(
+        id=notebook_id,
+        title=title,
+        created_at=datetime(2026, 1, 15),
+        is_owner=True,
+    )
+
+
+class TestNotebookNotFoundIsRPCError:
+    """``NotebookNotFoundError`` must still be catchable as ``RPCError``."""
+
+    def test_inherits_from_rpc_error(self):
+        # ``except RPCError`` at higher layers must still match — this is the
+        # whole point of widening the base class in T3.D.
+        assert issubclass(NotebookNotFoundError, RPCError)
+
+    def test_carries_notebook_id(self):
+        err = NotebookNotFoundError("nb_typo")
+        assert err.notebook_id == "nb_typo"
+        assert "nb_typo" in str(err)
+
+    def test_accepts_method_id(self):
+        # The CLI/_notebooks.get site forwards method_id for diagnostics.
+        err = NotebookNotFoundError("nb_x", method_id="rwIQyf")
+        assert err.method_id == "rwIQyf"
+
+
+class TestUseFailsClosedBadId:
+    """Bad notebook ID → no context write, exit 1."""
+
+    def test_notebook_not_found_does_not_persist(self, runner, mock_auth, mock_context_file):
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.get = AsyncMock(
+                side_effect=NotebookNotFoundError("nb_missing", method_id="rwIQyf"),
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                with patch(
+                    "notebooklm.cli.session.resolve_notebook_id", new_callable=AsyncMock
+                ) as mock_resolve:
+                    mock_resolve.return_value = "nb_missing"
+
+                    result = runner.invoke(cli, ["use", "nb_missing"])
+
+        # Exit non-zero, never touched context.json.
+        assert result.exit_code == 1
+        assert not mock_context_file.exists()
+        # Surface a clear "not found" message so the user can self-correct.
+        assert "nb_missing" in result.output
+        assert "not found" in result.output.lower() or "force" in result.output.lower()
+
+    def test_generic_rpc_error_does_not_persist(self, runner, mock_auth, mock_context_file):
+        """Network / RPC errors also fail closed — we can't confirm existence."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.get = AsyncMock(
+                side_effect=RPCError("server hung up", method_id="rwIQyf"),
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                with patch(
+                    "notebooklm.cli.session.resolve_notebook_id", new_callable=AsyncMock
+                ) as mock_resolve:
+                    mock_resolve.return_value = "nb_rpc_fail"
+
+                    result = runner.invoke(cli, ["use", "nb_rpc_fail"])
+
+        assert result.exit_code == 1
+        assert not mock_context_file.exists()
+
+
+class TestUseFailsClosedGoodId:
+    """Good notebook ID → context persisted, exit 0."""
+
+    def test_good_id_persists_context(self, runner, mock_auth, mock_context_file):
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.notebooks.get = AsyncMock(
+                return_value=_make_notebook("nb_real", "Real Notebook"),
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                with patch(
+                    "notebooklm.cli.session.resolve_notebook_id", new_callable=AsyncMock
+                ) as mock_resolve:
+                    mock_resolve.return_value = "nb_real"
+
+                    result = runner.invoke(cli, ["use", "nb_real"])
+
+        assert result.exit_code == 0
+        assert mock_context_file.exists()
+        data = json.loads(mock_context_file.read_text())
+        assert data["notebook_id"] == "nb_real"
+        assert data["title"] == "Real Notebook"
+
+
+class TestUseForceFlag:
+    """``--force`` bypasses the existence check entirely."""
+
+    def test_force_with_bad_id_still_persists(self, runner, mock_context_file):
+        """No client mocking needed — --force never calls the network."""
+        result = runner.invoke(cli, ["use", "--force", "nb_offline"])
+
+        assert result.exit_code == 0
+        assert mock_context_file.exists()
+        data = json.loads(mock_context_file.read_text())
+        assert data["notebook_id"] == "nb_offline"
+        # Banner clarifies the ID was not verified, so the user isn't misled.
+        assert "not verified" in result.output.lower() or "force" in result.output.lower()
+
+    def test_force_does_not_call_get(self, runner, mock_auth, mock_context_file):
+        """--force is offline-safe: even a guaranteed-raise ``get`` is bypassed."""
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            # If --force *did* call get, this mock would surface the error.
+            mock_client.notebooks.get = AsyncMock(
+                side_effect=NotebookNotFoundError("should-not-be-called"),
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["use", "--force", "nb_force_id"])
+
+        assert result.exit_code == 0
+        assert mock_context_file.exists()
+        # The get-mock side_effect would have surfaced if it had been invoked.
+        mock_client.notebooks.get.assert_not_called()

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._notebooks import NotebooksAPI
-from notebooklm.exceptions import NetworkError, NotebookLimitError, RPCError
+from notebooklm.exceptions import (
+    NetworkError,
+    NotebookLimitError,
+    NotebookNotFoundError,
+    RPCError,
+)
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import AccountLimits, Notebook
 
@@ -248,3 +253,91 @@ class TestCreateNotebookQuotaDetection:
             [None, [1, None, None, None, None, None, None, None, None, None, [1]]],
             source_path="/",
         )
+
+
+class TestGetNotebookFailsClosed:
+    """``NotebooksAPI.get`` raises ``NotebookNotFoundError`` on degenerate responses (T3.D).
+
+    The NotebookLM backend returns a *parseable but empty* payload for unknown
+    notebook IDs rather than a typed error. Pre-T3.D, ``get()`` happily returned
+    ``Notebook(id="", title="")`` and the CLI ``use`` command persisted that as
+    saved state. The post-fix contract: detect the degenerate shape and raise.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_returns_notebook_on_full_response(self):
+        api = _make_api()
+        # Realistic shape: [[title, ?, id, ?, ?, [None, False, ...]], ...]
+        api._core.rpc_call = AsyncMock(
+            return_value=[["My Notebook", None, "nb_real_123", None, None, [None, False]]]
+        )
+
+        notebook = await api.get("nb_real_123")
+
+        assert notebook.id == "nb_real_123"
+        assert notebook.title == "My Notebook"
+
+    @pytest.mark.asyncio
+    async def test_get_raises_on_empty_outer_list(self):
+        """Server returned ``[]`` — no notebook at all."""
+        api = _make_api()
+        api._core.rpc_call = AsyncMock(return_value=[])
+
+        with pytest.raises(NotebookNotFoundError) as exc_info:
+            await api.get("nb_missing")
+
+        assert exc_info.value.notebook_id == "nb_missing"
+        assert exc_info.value.method_id == RPCMethod.GET_NOTEBOOK.value
+
+    @pytest.mark.asyncio
+    async def test_get_raises_on_none_response(self):
+        api = _make_api()
+        api._core.rpc_call = AsyncMock(return_value=None)
+
+        with pytest.raises(NotebookNotFoundError):
+            await api.get("nb_missing")
+
+    @pytest.mark.asyncio
+    async def test_get_raises_on_degenerate_empty_inner(self):
+        """``[[]]`` — outer wrapper present but inner notebook payload empty."""
+        api = _make_api()
+        api._core.rpc_call = AsyncMock(return_value=[[]])
+
+        with pytest.raises(NotebookNotFoundError) as exc_info:
+            await api.get("nb_typo")
+
+        assert "nb_typo" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_get_raises_when_id_and_title_both_blank(self):
+        """Both id and title parsed to empty string → treat as not found."""
+        api = _make_api()
+        # Same shape as the happy path but with empty strings in both fields.
+        api._core.rpc_call = AsyncMock(return_value=[["", None, "", None, None, [None, False]]])
+
+        with pytest.raises(NotebookNotFoundError):
+            await api.get("nb_typo")
+
+    @pytest.mark.asyncio
+    async def test_get_succeeds_when_title_present_but_id_blank(self):
+        """Defensive: a present title alone is enough — not a degenerate payload.
+
+        We only treat the response as "not found" when BOTH id and title are
+        blank, so a parser-quirk that strips the id but keeps the title still
+        returns a Notebook rather than raising.
+        """
+        api = _make_api()
+        api._core.rpc_call = AsyncMock(
+            return_value=[["Title Only", None, "", None, None, [None, False]]]
+        )
+
+        notebook = await api.get("nb_partial")
+
+        assert notebook.title == "Title Only"
+
+    def test_notebook_not_found_error_is_rpc_error(self):
+        """``NotebookNotFoundError`` must be catchable as ``RPCError`` (T3.D contract)."""
+        assert issubclass(NotebookNotFoundError, RPCError)
+        err = NotebookNotFoundError("nb_x", method_id="rwIQyf")
+        assert err.notebook_id == "nb_x"
+        assert err.method_id == "rwIQyf"


### PR DESCRIPTION
## Summary

Closes synthesis gap K8 / Tier 3 plan item PR-T3.D.

- `notebooklm use <id>` now verifies the notebook exists on the server *before* persisting it to `context.json`. Pre-fix, a typo / network error / auth expiry left poisoned saved state that broke every downstream command.
- Hardens `NotebooksAPI.get`: the NotebookLM backend returns a parseable-but-empty payload for unknown IDs (no typed error), so `get()` previously returned `Notebook(id="", title="")`. It now raises `NotebookNotFoundError` when both id and title are blank, or the payload is empty/None.
- Widens `NotebookNotFoundError` to inherit from **both** `RPCError` and `NotebookError`, so existing `except RPCError` and `except NotebookError` call sites both keep working.
- Adds `--force` to `use` for offline / debugging.

### Behavior matrix

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| `use <valid>` | persist, exit 0 | persist, exit 0 |
| `use <typo>` (server returns empty) | persist `Notebook(id="")`, exit 0 | exit 1, no persist |
| `use <id>` with network/RPC error | persist with "Warning: ...", exit 0 | exit 1, no persist |
| `use <id>` with no auth | persist anyway, exit 0 | exit 1, no persist, "run notebooklm login" hint |
| `use --force <anything>` | n/a | persist, exit 0 |

## Test plan

- [x] `uv run pytest -q` — 3102 passed, 12 skipped
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success
- [x] New unit tests: `tests/unit/cli/test_use_fails_closed.py` (bad ID, good ID, --force)
- [x] New API tests: `tests/unit/test_notebook_api.py::TestGetNotebookFailsClosed`
- [x] Updated incompatible existing tests in `tests/unit/cli/test_session.py`
- [ ] Manual: typo a notebook ID → see exit 1, context.json untouched
- [ ] Manual: `use --force foo` offline → persists "foo" with "(not verified — --force)" banner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--force` to `notebooklm use` to persist a notebook ID without server verification and mark it as unverified.

* **Bug Fixes**
  * `use` now fails closed on auth or backend verification errors and instructs to login or use `--force`; no unverified context is saved unless forced.
  * Backend degenerate/empty notebook responses are treated as "not found".

* **Tests**
  * Added/expanded tests for fail-closed behavior, verification, and `--force` bypass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/468)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->