### PR TITLE
chore(audit): address deferred Tier-3 PR-review nits

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2375,34 +2375,52 @@ class ArtifactsAPI:
 
                         # Only move to final location on success
                         temp_file.rename(output_file)
-                        logger.debug("Downloaded %s (%d bytes)", url[:60], total_bytes)
+                        # Log host+path only; full URLs may carry capability
+                        # tokens in query params (see _download_urls_batch for
+                        # the same redaction pattern).
+                        logger.debug(
+                            "Downloaded %s%s (%d bytes)",
+                            parsed.netloc,
+                            parsed.path,
+                            total_bytes,
+                        )
                         return output_path
             except httpx.HTTPStatusError as e:
                 # HTTP-level failure (4xx/5xx). Translate to ArtifactDownloadError
                 # so callers see a consistent exception type instead of a raw
                 # httpx subclass. 401/403 get an explicit "re-login" hint,
                 # mirroring the message style used by _download_urls_batch.
+                #
+                # Error details use ``parsed.netloc + parsed.path`` rather than
+                # ``url[:N]`` so capability tokens in query params can't leak
+                # into log lines or wrapped exception messages. ``status_code``
+                # rides on the exception attribute, so the message text doesn't
+                # repeat it.
                 if e.response.status_code in (401, 403):
                     raise ArtifactDownloadError(
                         "media",
                         details=(
-                            f"Authentication required for {url[:80]}... -- try `notebooklm login`"
+                            f"Authentication required for {parsed.netloc}{parsed.path}"
+                            " -- try `notebooklm login`"
                         ),
                         cause=e,
                         status_code=e.response.status_code,
                     ) from e
                 raise ArtifactDownloadError(
                     "media",
-                    details=f"HTTP {e.response.status_code} downloading {url[:80]}...",
+                    details=f"HTTP error downloading {parsed.netloc}{parsed.path}",
                     cause=e,
                     status_code=e.response.status_code,
                 ) from e
             except httpx.RequestError as e:
                 # Transport-level failure: timeouts, DNS, TLS, connection
                 # resets, etc. No HTTP response was received, so no status_code.
+                # ``str(e)`` for httpx errors can include the full request URL
+                # (with capability tokens in query params); rely on ``cause=e``
+                # to carry the original exception and keep the message redacted.
                 raise ArtifactDownloadError(
                     "media",
-                    details=f"Network error downloading {url[:80]}...: {e}",
+                    details=f"Network error downloading {parsed.netloc}{parsed.path}",
                     cause=e,
                 ) from e
         except BaseException:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import math
+import random
 import threading
 import time
 import warnings
@@ -879,14 +880,23 @@ class ClientCore:
                 is_network_error = isinstance(exc, httpx.RequestError)
                 if is_server_error or is_network_error:
                     if server_error_retries < self._server_error_max_retries:
+                        # Exponential backoff capped at 30s. The cap blunts
+                        # thundering-herd well past the first few retries
+                        # (every retry beyond ~5 attempts waits exactly 30s),
+                        # but the early retries (1s, 2s, 4s, ...) can still
+                        # synchronize across clients that all failed on the
+                        # same transient backend blip. Add a small ±20% jitter
+                        # so concurrent retries are spread out.
                         backoff = min(2**server_error_retries, 30)
+                        backoff += random.uniform(-0.2 * backoff, 0.2 * backoff)  # noqa: S311  # nosec B311 — jitter, not crypto
+                        backoff = max(0.1, backoff)
                         status_label = (
                             f"HTTP {exc.response.status_code}"  # type: ignore[union-attr]
                             if is_server_error
                             else type(exc).__name__
                         )
                         logger.warning(
-                            "%s server/network error (%s); backing off %ds then retrying (%d/%d)",
+                            "%s server/network error (%s); backing off %.1fs then retrying (%d/%d)",
                             log_label,
                             status_label,
                             backoff,

--- a/tests/unit/cli/test_storage_context_isolation.py
+++ b/tests/unit/cli/test_storage_context_isolation.py
@@ -123,7 +123,7 @@ class TestUseWritesSiblingContext:
     def test_use_writes_sibling_not_default(self, runner, tmp_path, isolated_home):
         storage_a = tmp_path / "A.json"
         # Pre-populate a fake storage file so existence checks pass; the CLI's
-        # `use` command in unverified form just persists the ID locally.
+        # `use --force` path persists the ID locally without an RPC round-trip.
         storage_a.write_text(json.dumps({"cookies": [], "origins": []}))
 
         # Place a default-profile context file so we can detect accidental writes.
@@ -133,13 +133,15 @@ class TestUseWritesSiblingContext:
         sibling_context = tmp_path / "A.json.context.json"
         assert not sibling_context.exists()
 
-        # `notebooklm use` falls through to a degraded "save-anyway" path on RPC
-        # failure (see session.py around line 1396-1414). With no auth mocked
-        # for the RPC, the fallback runs and writes context locally.
-        result = runner.invoke(cli, ["--storage", str(storage_a), "use", "nb_abc123def456"])
+        # ``use --force`` skips the existence-check RPC and writes context
+        # immediately — that's the right primitive for an isolation test that
+        # doesn't care whether the notebook exists, only WHERE the write lands.
+        # Post-T3.D, the unverified-but-saved fallback no longer exists; we
+        # use ``--force`` to express the same intent explicitly.
+        result = runner.invoke(
+            cli, ["--storage", str(storage_a), "use", "--force", "nb_abc123def456"]
+        )
 
-        # Even on auth/RPC failure, the persistence-on-failure path writes the
-        # notebook_id to the *sibling* context, not the default profile one.
         assert sibling_context.exists(), (
             f"sibling context not written: stdout={result.output} exit={result.exit_code}"
         )
@@ -210,9 +212,13 @@ class TestDefaultBehaviorUnchanged:
         profile_context.parent.mkdir(parents=True, exist_ok=True)
         profile_context.write_text(json.dumps({}))
 
-        result = runner.invoke(cli, ["use", "nb_default_path"])
-        # Best-effort: even if RPC fails, the fallback writes locally.
-        del result  # ignore exit code — focus on side effect
+        # ``--force`` keeps this test focused on *where* the write lands
+        # (default profile vs. sibling) rather than dragging in a full
+        # auth/RPC mock. Post-T3.D, ``use`` without ``--force`` fails closed
+        # on RPC errors, so the prior "best-effort fallback" wording no
+        # longer applies.
+        result = runner.invoke(cli, ["use", "--force", "nb_default_path"])
+        assert result.exit_code == 0, result.output
 
         data = json.loads(profile_context.read_text())
         assert data.get("notebook_id") == "nb_default_path"

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -37,6 +37,20 @@ from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
 
 
+@pytest.fixture(autouse=True)
+def _no_backoff_jitter(monkeypatch):
+    """Pin the 5xx/network backoff jitter to 0 for deterministic sleep assertions.
+
+    Production code adds a small ±20% jitter to the exponential backoff to
+    reduce thundering-herd effects across clients. These transport tests
+    assert exact sleep schedules (``[1, 2, 4, ...]``), so we patch
+    ``random.uniform`` inside ``notebooklm._core`` to return 0. The 429 path
+    uses ``Retry-After`` instead of jitter, so this fixture has no effect on
+    those tests.
+    """
+    monkeypatch.setattr("notebooklm._core.random.uniform", lambda a, b: 0.0)
+
+
 def _make_core(
     *,
     refresh_callback: Callable[[], Any] | None = None,

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -190,8 +190,13 @@ class TestDownloadUrlErrorWrapping:
             ):
                 await api._download_url("https://storage.googleapis.com/file.mp4", output_path)
 
+            # ``status_code`` rides on the exception attribute, so the
+            # message text no longer repeats it. The message uses
+            # ``parsed.netloc + parsed.path`` so capability tokens in query
+            # params can't leak into log lines.
             assert exc_info.value.status_code == 500
-            assert "HTTP 500" in str(exc_info.value)
+            assert "HTTP error downloading" in str(exc_info.value)
+            assert "storage.googleapis.com/file.mp4" in str(exc_info.value)
             assert "Authentication required" not in str(exc_info.value)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Sweep of three low-priority review nits left open after the merged Tier-3 PRs. Each item below references an unreplied `gemini-code-assist` suggestion that was tracked as a follow-up rather than addressed in the original PR.

### PR #462 — `_artifacts.py` `_download_url`
- Switched `url[:60]` / `url[:80]` in log + error messages to `parsed.netloc + parsed.path`, matching the redaction pattern already used in `_download_urls_batch`. Capability tokens that can appear in download-URL query params can no longer leak into debug logs or wrapped `ArtifactDownloadError` messages.
- Dropped the redundant `HTTP {status}` text from the generic-HTTP branch (status is already on `exc.status_code`) and the inline `{e}` from the network-error branch (httpx error messages can embed the full request URL).

### PR #464 — `_core.py` `_perform_authed_post`
- Added a small ±20% jitter to the 5xx/network exponential backoff so concurrent clients failing on the same transient backend blip don't synchronize their early retries (1s, 2s, 4s, ...). Floor is 0.1s so jitter can't drive the sleep to zero. The 30s cap is untouched, and 429s continue to honor `Retry-After` rather than going through this path.
- An autouse fixture in `test_core_transport.py` pins `random.uniform` to 0 so the existing exact-sleep assertions remain deterministic.

### Items intentionally excluded
- **PR #465 (2 CodeRabbit threads)** — both fixes were already merged in commit `1a45ce9`; the threads were acknowledgement-only replies.
- **PR #468 (1 gemini thread)** — the table-helper duplication concern is already factored via `_use_notebook_table()` in `cli/session.py`; explained in the PR-thread reply.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest` — 3119 passed, 9 skipped (full suite with `browser+dev+markdown` extras)
- [ ] CI green on PR
- [ ] `@claude review` completes without flagging new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for artifact download failures; authentication errors now direct users to `notebooklm login`.

* **Improvements**
  * Enhanced transient error handling with jittered exponential backoff for improved reliability.
  * More secure logging by redacting sensitive URL information from debug output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/470)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->