### PR TITLE
refactor(cli): import RPC enums via public types module (T4.2)

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -15,7 +15,7 @@ import click
 from rich.table import Table
 
 from ..client import NotebookLMClient
-from ..rpc import ExportType
+from ..types import ExportType
 from .helpers import (
     cli_name_to_artifact_type,
     console,

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -261,7 +261,7 @@ def register_chat_commands(cli):
         nb_id = require_notebook(notebook_id)
 
         async def _run():
-            from ..rpc import ChatGoal, ChatResponseLength
+            from ..types import ChatGoal, ChatResponseLength
 
             async with NotebookLMClient(client_auth) as client:
                 nb_id_resolved = await resolve_notebook_id(client, nb_id)

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -618,7 +618,7 @@ def source_refresh(ctx, source_id, notebook_id, client_auth):
 @with_client
 def source_add_drive(ctx, file_id, title, notebook_id, mime_type, client_auth):
     """Add a Google Drive document as a source."""
-    from ..rpc import DriveMimeType
+    from ..types import DriveMimeType
 
     nb_id = require_notebook(notebook_id)
     mime_map = {

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -74,13 +74,42 @@ def test_research_api_reexports_cited_source_selection_for_back_compat():
 # the exact same objects as the canonical definitions in ``notebooklm.rpc.types``
 # (identity, not just equality), so isinstance checks and equality both work
 # regardless of which import path callers use.
+#
+# The explicit list below covers every public RPC enum re-exported by
+# ``notebooklm.types`` (see ``notebooklm.types.__all__``). Keep this list in
+# sync with the re-exports so any accidental shadowing in ``types.py`` —
+# redefining instead of re-exporting — is caught immediately. ``ArtifactTypeCode``
+# is intentionally excluded because it is imported by ``types.py`` for internal
+# use but not part of the public ``__all__``.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "enum_name",
-    ["ChatGoal", "ChatResponseLength", "DriveMimeType", "ExportType"],
-)
+_REEXPORTED_RPC_ENUMS = [
+    "ArtifactStatus",
+    "AudioFormat",
+    "AudioLength",
+    "ChatGoal",
+    "ChatResponseLength",
+    "DriveMimeType",
+    "ExportType",
+    "InfographicDetail",
+    "InfographicOrientation",
+    "InfographicStyle",
+    "QuizDifficulty",
+    "QuizQuantity",
+    "ReportFormat",
+    "ShareAccess",
+    "SharePermission",
+    "ShareViewLevel",
+    "SlideDeckFormat",
+    "SlideDeckLength",
+    "SourceStatus",
+    "VideoFormat",
+    "VideoStyle",
+]
+
+
+@pytest.mark.parametrize("enum_name", _REEXPORTED_RPC_ENUMS)
 def test_rpc_enum_reexports_are_identical(enum_name: str) -> None:
     """notebooklm.types.<Enum> is the same object as notebooklm.rpc.types.<Enum>."""
     import notebooklm.rpc.types as rpc_types
@@ -91,6 +120,34 @@ def test_rpc_enum_reexports_are_identical(enum_name: str) -> None:
     assert public_enum is canonical_enum, (
         f"notebooklm.types.{enum_name} must be the same object as "
         f"notebooklm.rpc.types.{enum_name} (identity, not equality)"
+    )
+
+
+def test_rpc_enum_reexport_list_matches_public_all() -> None:
+    """The _REEXPORTED_RPC_ENUMS guard list must stay aligned with notebooklm.types.__all__.
+
+    If a new enum is re-exported in ``types.py``'s ``__all__`` but not added
+    here, this test fails — preventing silent gaps in the identity coverage.
+    """
+    import notebooklm.rpc.types as rpc_types
+    import notebooklm.types as public_types
+
+    # Names that appear in both __all__ and rpc.types — i.e. the actual
+    # re-exported RPC enums.
+    declared = set(public_types.__all__)
+    rpc_names = {name for name in dir(rpc_types) if not name.startswith("_")}
+    expected = declared & rpc_names
+    # Drop helper functions (not enums) from the comparison.
+    expected -= {"artifact_status_to_str", "source_status_to_str"}
+
+    listed = set(_REEXPORTED_RPC_ENUMS)
+    missing = expected - listed
+    extras = listed - expected
+    assert not missing, (
+        f"_REEXPORTED_RPC_ENUMS is missing newly re-exported enum(s): {sorted(missing)}"
+    )
+    assert not extras, (
+        f"_REEXPORTED_RPC_ENUMS contains name(s) no longer re-exported: {sorted(extras)}"
     )
 
 

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -67,6 +67,34 @@ def test_research_api_reexports_cited_source_selection_for_back_compat():
 
 
 # ---------------------------------------------------------------------------
+# PR-T4.2 section: RPC enums re-exported via notebooklm.types
+#
+# CLI modules import these enums from ``notebooklm.types`` (the public surface)
+# rather than reaching into ``notebooklm.rpc`` directly. The re-exports must be
+# the exact same objects as the canonical definitions in ``notebooklm.rpc.types``
+# (identity, not just equality), so isinstance checks and equality both work
+# regardless of which import path callers use.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "enum_name",
+    ["ChatGoal", "ChatResponseLength", "DriveMimeType", "ExportType"],
+)
+def test_rpc_enum_reexports_are_identical(enum_name: str) -> None:
+    """notebooklm.types.<Enum> is the same object as notebooklm.rpc.types.<Enum>."""
+    import notebooklm.rpc.types as rpc_types
+    import notebooklm.types as public_types
+
+    public_enum = getattr(public_types, enum_name)
+    canonical_enum = getattr(rpc_types, enum_name)
+    assert public_enum is canonical_enum, (
+        f"notebooklm.types.{enum_name} must be the same object as "
+        f"notebooklm.rpc.types.{enum_name} (identity, not equality)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # PR-D section: notebooklm.config / notebooklm.urls / notebooklm.log public shims
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Swap the three remaining `from ..rpc import <Enum>` CLI imports to use the public `notebooklm.types` re-exports. The re-exports already exist in `src/notebooklm/types.py` (lines 34-60, `__all__` at 473-476), so this is a pure import swap — no functional changes.

- `cli/artifact.py:18` — `ExportType`
- `cli/chat.py:264` (function-local) — `ChatGoal, ChatResponseLength`
- `cli/source.py:621` (function-local) — `DriveMimeType`

Also adds a parametrized identity check in `tests/unit/test_public_shims.py` so the re-exports are guaranteed to be the **same objects** as the canonical enums in `notebooklm.rpc.types` (`is`, not just `==`). This keeps `isinstance(...)` and equality safe regardless of which import path callers use.

Sets up T4.1 (extending `test_cli_boundary.py` with a block-list for `cli → rpc` imports) — once T4.2 merges, no existing violations remain.

Plan: `.sisyphus/plans/tier-4-implementation.md` PR-T4.2.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .` — all checks pass
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success
- [x] `uv run pytest tests/unit/test_public_shims.py -v` — 15 passed (including 4 new identity assertions for `ChatGoal`, `ChatResponseLength`, `DriveMimeType`, `ExportType`)
- [x] `uv run pytest tests/unit -q` — 2522 passed (2 pre-existing failures in `test_storage_context_isolation.py` exist on `main` and are unrelated)
- [x] `grep -n '\.\.rpc' src/notebooklm/cli/{artifact,chat,source}.py` returns no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure for type definitions to improve code maintainability and consistency across CLI commands.
  
* **Tests**
  * Added validation tests to ensure type definitions remain accessible from their public import paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/471)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->