### PR TITLE
test: extend CLI boundary block-list (T4.1)

### DIFF
--- a/src/notebooklm/cli/profile.py
+++ b/src/notebooklm/cli/profile.py
@@ -251,9 +251,9 @@ def delete_cmd(name, confirm):
         raise click.ClickException(str(e)) from None
 
     # Block deletion of active or configured default profile
-    from ..paths import _read_default_profile
+    from ..paths import read_default_profile
 
-    configured_default = _read_default_profile() or "default"
+    configured_default = read_default_profile() or "default"
     effective_active = resolve_profile()
     if name in (configured_default, effective_active):
         raise click.ClickException(

--- a/src/notebooklm/cli/profile.py
+++ b/src/notebooklm/cli/profile.py
@@ -25,6 +25,7 @@ from ..paths import (
     get_profile_dir,
     get_storage_path,
     list_profiles,
+    read_default_profile,
     resolve_profile,
 )
 from .helpers import console, json_output_response
@@ -251,8 +252,6 @@ def delete_cmd(name, confirm):
         raise click.ClickException(str(e)) from None
 
     # Block deletion of active or configured default profile
-    from ..paths import read_default_profile
-
     configured_default = read_default_profile() or "default"
     effective_active = resolve_profile()
     if name in (configured_default, effective_active):

--- a/src/notebooklm/paths.py
+++ b/src/notebooklm/paths.py
@@ -160,6 +160,12 @@ def _read_default_profile() -> str | None:
         return None
 
 
+# Public alias for ``_read_default_profile``. The implementation is module-
+# private (underscore prefix) but the value it reads is part of the public
+# configuration contract, so callers outside paths.py may use this name.
+read_default_profile = _read_default_profile
+
+
 def resolve_profile(profile: str | None = None) -> str:
     """Resolve the active profile name.
 

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -2,19 +2,23 @@
 
 Block-list rules applied to every ``src/notebooklm/cli/**/*.py`` file:
 
-1. No imports of private top-level modules:
-   ``from notebooklm._foo import ...`` / ``from .._foo import ...`` /
-   ``from notebooklm import _foo`` / ``from .. import _foo`` are all rejected.
+1. No imports of private modules anywhere in the ``notebooklm`` tree:
+   any path segment that starts with a single underscore (and is not a
+   dunder) is rejected. Catches ``from notebooklm._foo import ...``,
+   ``from notebooklm.pkg._bar import ...``, ``from .._foo import ...``,
+   ``from notebooklm import _foo``, ``from .. import _foo``, etc.
 2. No imports from the RPC layer:
    ``from notebooklm.rpc`` / ``from notebooklm.rpc.<x>`` / ``from ..rpc`` /
-   ``from ..rpc.<x>`` / ``import notebooklm.rpc`` are all rejected. The CLI
-   must consume RPC enums via the public ``notebooklm.types`` re-export.
+   ``from ..rpc.<x>`` / ``import notebooklm.rpc`` / ``from .. import rpc``
+   are all rejected. The CLI must consume RPC enums via the public
+   ``notebooklm.types`` re-export.
 3. No private-name leakage from a public module:
-   ``from notebooklm.<public> import _symbol`` / ``from ..<public> import _symbol``
-   is rejected when ``<public>`` does not itself start with ``_``. This stops
-   the CLI from reaching into a public module's internals (e.g.
-   ``from notebooklm.auth import _internal_helper``). Dunders (``__version__``)
-   are allowed.
+   ``from notebooklm.<public...> import _symbol`` /
+   ``from ..<public...> import _symbol`` is rejected when no segment of
+   the source path is itself underscored. This stops the CLI from
+   reaching into a public module's internals (e.g.
+   ``from notebooklm.auth import _internal_helper``). Dunders
+   (``__version__``) remain allowed.
 
 Allowed:
 - Intra-cli imports (level == 1): ``from ._encoding import ...``, including
@@ -31,69 +35,89 @@ import pathlib
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
 
 
-def _is_rpc_module(mod: str) -> bool:
-    """True if ``mod`` is the RPC layer (``rpc`` or ``rpc.<anything>``)."""
-    return mod == "rpc" or mod.startswith("rpc.")
+def _is_private_segment(seg: str) -> bool:
+    """True if ``seg`` is a single-underscore-prefixed name (not a dunder).
+
+    Empty strings and dunders (``__version__``) are not private.
+    """
+    return bool(seg) and seg.startswith("_") and not seg.startswith("__")
 
 
-def _violations(tree: ast.AST) -> list[str]:
+def _has_private_segment(parts: list[str]) -> bool:
+    """True if any segment in ``parts`` is private (per Rule 1)."""
+    return any(_is_private_segment(p) for p in parts)
+
+
+def _is_rpc_path(parts: list[str]) -> bool:
+    """True if ``parts`` is the RPC layer or a sub-path (per Rule 2).
+
+    ``parts`` is the path *below* the ``notebooklm`` prefix, e.g.
+    ``["rpc"]`` or ``["rpc", "types"]``.
+    """
+    return bool(parts) and parts[0] == "rpc"
+
+
+def _violations(tree: ast.AST) -> list[str]:  # noqa: C901 - flat dispatch on import shape
     bad: list[str] = []
     for node in ast.walk(tree):
-        # `from X import …`
         if isinstance(node, ast.ImportFrom):
             mod = node.module or ""
+            mod_parts = mod.split(".") if mod else []
+
             if node.level == 0:
-                # Absolute imports: only inspect notebooklm.* roots.
-                parts = mod.split(".")
-                if len(parts) >= 2 and parts[0] == "notebooklm":
-                    sub = parts[1]
-                    sub_path = ".".join(parts[1:])
-                    # Rule 1 (notebooklm._<private_module>) or
-                    # Rule 2 (notebooklm.rpc[.x]) — both reject the whole import.
-                    if sub.startswith("_") or _is_rpc_module(sub_path):
-                        bad.append(f"from {mod} import ...")
-                    # Rule 3: notebooklm.<public_module> import _symbol
-                    elif len(parts) == 2:
+                # Absolute import: only inspect notebooklm.* roots.
+                if mod_parts and mod_parts[0] == "notebooklm":
+                    if len(mod_parts) >= 2:
+                        sub_parts = mod_parts[1:]
+                        # Rule 1 (any private segment) or Rule 2 (rpc layer).
+                        if _has_private_segment(sub_parts) or _is_rpc_path(sub_parts):
+                            bad.append(f"from {mod} import ...")
+                        else:
+                            # Rule 3: private-name leakage from a public module.
+                            for alias in node.names:
+                                if _is_private_segment(alias.name):
+                                    bad.append(f"from {mod} import {alias.name}")
+                    else:
+                        # ``from notebooklm import X`` — inspect each name.
+                        # Rule 1 (private name) or Rule 2 (``rpc`` sub-package).
                         for alias in node.names:
-                            if alias.name.startswith("_") and not alias.name.startswith("__"):
-                                bad.append(f"from {mod} import {alias.name}")
-                # `from notebooklm import _foo` — private module via imported names.
-                # Dunders like `__version__` are public package attrs by convention.
-                if mod == "notebooklm":
-                    for alias in node.names:
-                        if alias.name.startswith("_") and not alias.name.startswith("__"):
-                            bad.append(f"from notebooklm import {alias.name}")
+                            if _is_private_segment(alias.name) or alias.name == "rpc":
+                                bad.append(f"from notebooklm import {alias.name}")
             elif node.level >= 2:
-                # Relative parent-package imports (cli reaches into notebooklm/*).
-                # Rule 1 (`from .._foo import ...`) or
-                # Rule 2 (`from ..rpc[.x] import ...`) — both reject the import.
-                if mod.startswith("_") or (mod and _is_rpc_module(mod)):
-                    bad.append(f"from {'.' * node.level}{mod} import ...")
-                # Rule 3: `from ..<public> import _symbol`
-                # Only single-segment public modules — sub-modules under a
-                # private parent are already covered by rule 1 on the parent.
-                elif mod and "." not in mod:
+                # Relative parent-package import (cli reaches into notebooklm/*).
+                if mod:
+                    # Rule 1 (any private segment) or Rule 2 (rpc layer).
+                    if _has_private_segment(mod_parts) or _is_rpc_path(mod_parts):
+                        bad.append(f"from {'.' * node.level}{mod} import ...")
+                        continue
+                    # Rule 3: private-name leakage from a public source module.
                     for alias in node.names:
-                        if alias.name.startswith("_") and not alias.name.startswith("__"):
+                        if _is_private_segment(alias.name):
                             bad.append(f"from {'.' * node.level}{mod} import {alias.name}")
-                # `from .. import _foo` — private parent module via imported names.
-                # Dunders like `__version__` are public package attrs by convention.
-                if mod == "":
+                else:
+                    # ``from .. import X`` — inspect each imported name.
+                    # Rule 1 (private name) or Rule 2 (``rpc`` sub-package).
                     for alias in node.names:
-                        if alias.name.startswith("_") and not alias.name.startswith("__"):
+                        if _is_private_segment(alias.name) or alias.name == "rpc":
                             bad.append(f"from {'.' * node.level} import {alias.name}")
-            # level == 1 is intra-cli; underscore there is fine (cli's own private modules)
-        # `import X` / `import X as Y`
+            else:
+                # level == 1 (intra-cli). Inspect ``from . import X`` only for
+                # the explicit ``rpc`` name — siblings starting with ``_`` are
+                # cli's own private modules and remain allowed.
+                if not mod:
+                    for alias in node.names:
+                        if alias.name == "rpc":
+                            bad.append(f"from . import {alias.name}")
+
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 parts = alias.name.split(".")
-                if len(parts) >= 2 and parts[0] == "notebooklm":
-                    sub = parts[1]
-                    sub_path = ".".join(parts[1:])
-                    # Rule 1 (import notebooklm._<private>) or
-                    # Rule 2 (import notebooklm.rpc[.x]) — both rejected.
-                    if sub.startswith("_") or _is_rpc_module(sub_path):
-                        bad.append(f"import {alias.name}")
+                if not (len(parts) >= 2 and parts[0] == "notebooklm"):
+                    continue
+                sub_parts = parts[1:]
+                # Rule 1 (any private segment) or Rule 2 (rpc layer).
+                if _has_private_segment(sub_parts) or _is_rpc_path(sub_parts):
+                    bad.append(f"import {alias.name}")
     return bad
 
 

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -1,8 +1,26 @@
-"""Lint: cli/ files must not import notebooklm._* (private modules).
+"""AST lint: enforce the CLI -> client/types boundary.
+
+Block-list rules applied to every ``src/notebooklm/cli/**/*.py`` file:
+
+1. No imports of private top-level modules:
+   ``from notebooklm._foo import ...`` / ``from .._foo import ...`` /
+   ``from notebooklm import _foo`` / ``from .. import _foo`` are all rejected.
+2. No imports from the RPC layer:
+   ``from notebooklm.rpc`` / ``from notebooklm.rpc.<x>`` / ``from ..rpc`` /
+   ``from ..rpc.<x>`` / ``import notebooklm.rpc`` are all rejected. The CLI
+   must consume RPC enums via the public ``notebooklm.types`` re-export.
+3. No private-name leakage from a public module:
+   ``from notebooklm.<public> import _symbol`` / ``from ..<public> import _symbol``
+   is rejected when ``<public>`` does not itself start with ``_``. This stops
+   the CLI from reaching into a public module's internals (e.g.
+   ``from notebooklm.auth import _internal_helper``). Dunders (``__version__``)
+   are allowed.
 
 Allowed:
-- intra-cli imports like `from ._encoding import ...` or `from ._firefox_containers import ...`
-- imports of non-underscored siblings/parents (e.g., `from ..types import ...`, `from ..research import ...`)
+- Intra-cli imports (level == 1): ``from ._encoding import ...``, including
+  underscored siblings — those are the CLI's own private modules.
+- Imports of non-underscored siblings/parents:
+  ``from ..types import ...``, ``from ..research import ...``, etc.
 """
 
 from __future__ import annotations
@@ -13,6 +31,11 @@ import pathlib
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
 
 
+def _is_rpc_module(mod: str) -> bool:
+    """True if ``mod`` is the RPC layer (``rpc`` or ``rpc.<anything>``)."""
+    return mod == "rpc" or mod.startswith("rpc.")
+
+
 def _violations(tree: ast.AST) -> list[str]:
     bad: list[str] = []
     for node in ast.walk(tree):
@@ -20,10 +43,20 @@ def _violations(tree: ast.AST) -> list[str]:
         if isinstance(node, ast.ImportFrom):
             mod = node.module or ""
             if node.level == 0:
-                # `from notebooklm._foo import ...`
+                # Absolute imports: only inspect notebooklm.* roots.
                 parts = mod.split(".")
-                if len(parts) >= 2 and parts[0] == "notebooklm" and parts[1].startswith("_"):
-                    bad.append(f"from {mod} import ...")
+                if len(parts) >= 2 and parts[0] == "notebooklm":
+                    sub = parts[1]
+                    sub_path = ".".join(parts[1:])
+                    # Rule 1 (notebooklm._<private_module>) or
+                    # Rule 2 (notebooklm.rpc[.x]) — both reject the whole import.
+                    if sub.startswith("_") or _is_rpc_module(sub_path):
+                        bad.append(f"from {mod} import ...")
+                    # Rule 3: notebooklm.<public_module> import _symbol
+                    elif len(parts) == 2:
+                        for alias in node.names:
+                            if alias.name.startswith("_") and not alias.name.startswith("__"):
+                                bad.append(f"from {mod} import {alias.name}")
                 # `from notebooklm import _foo` — private module via imported names.
                 # Dunders like `__version__` are public package attrs by convention.
                 if mod == "notebooklm":
@@ -31,9 +64,18 @@ def _violations(tree: ast.AST) -> list[str]:
                         if alias.name.startswith("_") and not alias.name.startswith("__"):
                             bad.append(f"from notebooklm import {alias.name}")
             elif node.level >= 2:
-                # `from .._foo import ...` (parent-package private)
-                if mod.startswith("_"):
+                # Relative parent-package imports (cli reaches into notebooklm/*).
+                # Rule 1 (`from .._foo import ...`) or
+                # Rule 2 (`from ..rpc[.x] import ...`) — both reject the import.
+                if mod.startswith("_") or (mod and _is_rpc_module(mod)):
                     bad.append(f"from {'.' * node.level}{mod} import ...")
+                # Rule 3: `from ..<public> import _symbol`
+                # Only single-segment public modules — sub-modules under a
+                # private parent are already covered by rule 1 on the parent.
+                elif mod and "." not in mod:
+                    for alias in node.names:
+                        if alias.name.startswith("_") and not alias.name.startswith("__"):
+                            bad.append(f"from {'.' * node.level}{mod} import {alias.name}")
                 # `from .. import _foo` — private parent module via imported names.
                 # Dunders like `__version__` are public package attrs by convention.
                 if mod == "":
@@ -45,8 +87,13 @@ def _violations(tree: ast.AST) -> list[str]:
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 parts = alias.name.split(".")
-                if len(parts) >= 2 and parts[0] == "notebooklm" and parts[1].startswith("_"):
-                    bad.append(f"import {alias.name}")
+                if len(parts) >= 2 and parts[0] == "notebooklm":
+                    sub = parts[1]
+                    sub_path = ".".join(parts[1:])
+                    # Rule 1 (import notebooklm._<private>) or
+                    # Rule 2 (import notebooklm.rpc[.x]) — both rejected.
+                    if sub.startswith("_") or _is_rpc_module(sub_path):
+                        bad.append(f"import {alias.name}")
     return bad
 
 
@@ -58,7 +105,8 @@ def test_no_private_module_imports_in_cli():
         if bad:
             offenders.append((str(path.relative_to(CLI_ROOT.parent)), bad))
     assert not offenders, (
-        "CLI must not import notebooklm._* (private). "
-        "Promote needed symbols to a public module (config/urls/log/research) "
+        "CLI must not import notebooklm._* (private modules), notebooklm.rpc.*, "
+        "or `_private` names out of public notebooklm modules. "
+        "Promote needed symbols to a public module (config/urls/log/research/types) "
         f"and import from there.\nOffenders: {offenders}"
     )


### PR DESCRIPTION
## Summary

Extends `tests/unit/test_cli_boundary.py` with two additional block-list rules that complement the existing `notebooklm._<private_module>` guard:

1. **No `cli -> notebooklm.rpc` imports.** Catches `from notebooklm.rpc`, `from notebooklm.rpc.<x>`, `from ..rpc`, `from ..rpc.<x>`, `import notebooklm.rpc`. The CLI must consume RPC enums via the public `notebooklm.types` re-export (T4.2 already migrated all call sites).
2. **No `from notebooklm.<public> import _symbol`.** Rejects private-name leakage out of public modules (e.g. `from notebooklm.auth import _internal_helper`). Dunders (`__version__`) remain allowed.

Block-list, not allow-list — legitimate imports like `..auth`, `..migration`, `..research`, `..types` continue to work without listing.

### Existing violation fixed

The new rule surfaced one pre-existing leak: `cli/profile.py` was importing `paths._read_default_profile` (private symbol from a public module). Fix:
- Add public alias `read_default_profile = _read_default_profile` in `paths.py`.
- Update the cli call site to use the public name.

## Test plan

- [x] `uv run pytest tests/unit/test_cli_boundary.py -v` passes (1/1).
- [x] Negative test: injecting `from ..rpc import ExportType` into `cli/helpers.py` makes the test fail; reverting restores green.
- [x] Negative test: injecting `from ..auth import _fake_internal` into `cli/helpers.py` makes the test fail; reverting restores green.
- [x] Full unit suite green: `uv run pytest tests/unit -x -q` -> 2542 passed, 5 skipped.
- [x] Integration suite green: `uv run pytest tests/integration -x -q` -> 599 passed, 4 skipped.
- [x] `uv run ruff format . && uv run ruff check .` clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean.

Refs: tier-4-implementation.md PR-T4.1. Depends on #471 (T4.2, already merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default profile deletion protection to correctly identify configured default profiles.

* **Tests**
  * Enhanced CLI boundary validation with stricter rules to prevent architectural violations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/473)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->