### PR TITLE
feat(auth): default NOTEBOOKLM_REFRESH_CMD to shell=False via shlex.split (T5.A)

### DIFF
--- a/docs/auth-keepalive.md
+++ b/docs/auth-keepalive.md
@@ -45,8 +45,12 @@ The headline tradeoffs:
 
 A separate, complementary refresh hook also lives in the codebase:
 ``NOTEBOOKLM_REFRESH_CMD`` ([#336](https://github.com/teng-lin/notebooklm-py/pull/336))
-runs an arbitrary user-supplied shell command on auth-expiry signals (the
-"`Authentication expired`" redirect), then retries token fetch once. It's
+runs a user-supplied recovery command on auth-expiry signals (the
+"`Authentication expired`" redirect), then retries token fetch once. The
+command string is parsed with :func:`shlex.split` and executed with
+``shell=False`` by default; set ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1`` to
+opt back into the legacy ``shell=True`` behavior when the command needs
+shell features (pipes, redirection, ``$VAR`` expansion). It's
 orthogonal to L1–L3 — those proactively keep `*PSIDTS` fresh, while
 `NOTEBOOKLM_REFRESH_CMD` is the reactive "we lost the session anyway, run
 my recovery script" lever. See §9 below.
@@ -1415,17 +1419,24 @@ When to set it:
 - **Test environments** that mock the auth surface and don't want real
   POSTs leaking out.
 
-### 9.2 `NOTEBOOKLM_REFRESH_CMD=<shell-command>`
+### 9.2 `NOTEBOOKLM_REFRESH_CMD=<command-line>`
 
 Reactive recovery hook (merged in
-[#336](https://github.com/teng-lin/notebooklm-py/pull/336),
+[#336](https://github.com/teng-lin/notebooklm-py/pull/336), hardened to
+`shell=False` by default in
+[#475](https://github.com/teng-lin/notebooklm-py/pull/475);
 `auth.py::_should_try_refresh` and `_run_refresh_cmd`). When token fetch
 fails with an auth-expiry signal (the
 "`Authentication expired or invalid`" / `accounts.google.com` redirect),
 the library:
 
-1. Runs the configured shell command via `subprocess.run(..., shell=True)`
-   with a 60 s timeout.
+1. Parses the configured command with :func:`shlex.split` (POSIX) or
+   `CommandLineToArgvW` (Windows) and runs it via
+   `subprocess.run(argv, shell=False, ...)` with a 60 s timeout. To opt
+   back into the legacy `shell=True` semantics (when the command needs
+   pipes, redirection, or `$VAR` expansion), set
+   `NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1` — a `WARNING` is logged on each
+   invocation in this mode so the security trade-off stays visible.
 2. Sets `NOTEBOOKLM_REFRESH_PROFILE` and `NOTEBOOKLM_REFRESH_STORAGE_PATH`
    in the child env so the script knows which profile to refresh.
 3. Sets `_NOTEBOOKLM_REFRESH_ATTEMPTED=1` in the child env to prevent

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ Google rotates `__Secure-1PSIDTS` (the freshness partner of `__Secure-1PSID`) an
    - Poke failures are logged at DEBUG and never propagate. Persistence failures (the more dangerous failure mode — a rotation succeeded in memory but never landed on disk) are logged at WARNING with the storage path. Either way, the next iteration retries.
    - Honors `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1` (the poke itself becomes a no-op when set, but the task still wakes; pass `keepalive=None` to disable the loop entirely).
 
-3. **External recovery script (opt-in).** When auth has fully expired (idle past the rotation window, force-logout, password change), `fetch_tokens` can shell out to a user-provided refresh script, reload `storage_state.json`, and retry once.
+3. **External recovery script (opt-in).** When auth has fully expired (idle past the rotation window, force-logout, password change), `fetch_tokens` can invoke a user-provided refresh command, reload `storage_state.json`, and retry once. The command is parsed with `shlex.split` (POSIX) / `CommandLineToArgvW` (Windows) and executed with `shell=False` by default; set `NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1` to opt back into the legacy `shell=True` behavior when the command relies on pipes, redirection, or `$VAR` expansion.
    - Wire it up:
      ```bash
      pip install 'notebooklm-py[cookies]'

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -2306,6 +2307,7 @@ def _replace_cookie_jar(target: httpx.Cookies, source: httpx.Cookies) -> None:
 
 
 NOTEBOOKLM_REFRESH_CMD_ENV = "NOTEBOOKLM_REFRESH_CMD"
+NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV = "NOTEBOOKLM_REFRESH_CMD_USE_SHELL"
 _REFRESH_ATTEMPTED_ENV = "_NOTEBOOKLM_REFRESH_ATTEMPTED"
 # The ContextVar prevents same-task retry loops in the parent process. The env
 # flag is passed only to child refresh commands so recursive CLI calls skip refresh.
@@ -2375,8 +2377,16 @@ def _should_try_refresh(err: Exception) -> bool:
 async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None = None) -> None:
     """Run ``NOTEBOOKLM_REFRESH_CMD`` to refresh stored cookies.
 
+    By default, the command string is parsed with :func:`shlex.split` and
+    executed with ``shell=False`` to avoid shell-injection footguns when the
+    env var is sourced from CI configs or container env files. Set
+    ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1`` to opt back into the legacy
+    ``shell=True`` behavior (e.g., when the command relies on shell features
+    like pipes, redirection, or env-var expansion).
+
     Raises:
-        RuntimeError: If the refresh command is missing, times out, or exits
+        RuntimeError: If the refresh command is missing, parses to an empty
+            argv, is malformed (unterminated quote), times out, or exits
             non-zero.
     """
     cmd = os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV)
@@ -2388,11 +2398,37 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
     refresh_env["NOTEBOOKLM_REFRESH_STORAGE_PATH"] = str(
         storage_path or get_storage_path(profile=profile)
     )
+
+    use_shell = os.environ.get(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV) == "1"
+    run_target: str | list[str]
+    run_shell: bool
+    if use_shell:
+        logger.warning("Using shell-mode for %s (opt-in)", NOTEBOOKLM_REFRESH_CMD_ENV)
+        run_target = cmd
+        run_shell = True
+    else:
+        try:
+            # ``shlex.split`` uses POSIX rules on POSIX systems and non-POSIX
+            # rules on Windows so backslash-containing paths round-trip with
+            # ``subprocess.list2cmdline``.
+            argv = shlex.split(cmd, posix=(os.name != "nt"))
+        except ValueError as split_err:
+            raise RuntimeError(
+                f"{NOTEBOOKLM_REFRESH_CMD_ENV} could not be parsed: {split_err}"
+            ) from split_err
+        if not argv:
+            raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} parsed to empty argv")
+        # Log basename only — full argv may carry tokens and absolute paths
+        # can leak secrets-directory layouts.
+        logger.info("Running refresh command: %s ...", os.path.basename(argv[0]))
+        run_target = argv
+        run_shell = False
+
     try:
         result = await asyncio.to_thread(
             subprocess.run,
-            cmd,
-            shell=True,
+            run_target,
+            shell=run_shell,
             capture_output=True,
             text=True,
             timeout=60,

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -2374,6 +2374,45 @@ def _should_try_refresh(err: Exception) -> bool:
     return any(sig in msg for sig in _AUTH_ERROR_SIGNALS)
 
 
+def _split_refresh_cmd(cmd: str) -> list[str]:
+    """Parse ``NOTEBOOKLM_REFRESH_CMD`` into an argv for ``shell=False`` exec.
+
+    On POSIX systems, defers to :func:`shlex.split`. On Windows, uses
+    ``CommandLineToArgvW`` so quoted paths like
+    ``"C:\\Program Files\\Python\\python.exe"`` produce a properly unquoted
+    argv that ``subprocess.run(argv, shell=False)`` can locate. ``shlex``
+    in non-POSIX mode preserves the literal quote characters and would
+    leave the OS unable to find the executable.
+
+    Raises:
+        ValueError: If the command is malformed (e.g., unterminated quote).
+    """
+    if os.name != "nt":
+        return shlex.split(cmd)
+
+    import ctypes
+    from ctypes import wintypes
+
+    CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW  # type: ignore[attr-defined]
+    CommandLineToArgvW.argtypes = [wintypes.LPCWSTR, ctypes.POINTER(ctypes.c_int)]
+    CommandLineToArgvW.restype = ctypes.POINTER(wintypes.LPWSTR)
+    LocalFree = ctypes.windll.kernel32.LocalFree  # type: ignore[attr-defined]
+    LocalFree.argtypes = [wintypes.HLOCAL]
+    LocalFree.restype = wintypes.HLOCAL
+
+    argc = ctypes.c_int(0)
+    argv_ptr = CommandLineToArgvW(cmd, ctypes.byref(argc))
+    if not argv_ptr:
+        # CommandLineToArgvW returns NULL for empty / whitespace-only input.
+        # Mirror shlex.split's behavior and return an empty list; the caller
+        # surfaces this as ``RuntimeError("...parsed to empty argv")``.
+        return []
+    try:
+        return [argv_ptr[i] for i in range(argc.value)]
+    finally:
+        LocalFree(ctypes.cast(argv_ptr, wintypes.HLOCAL))
+
+
 async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None = None) -> None:
     """Run ``NOTEBOOKLM_REFRESH_CMD`` to refresh stored cookies.
 
@@ -2408,10 +2447,9 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
         run_shell = True
     else:
         try:
-            # ``shlex.split`` uses POSIX rules on POSIX systems and non-POSIX
-            # rules on Windows so backslash-containing paths round-trip with
-            # ``subprocess.list2cmdline``.
-            argv = shlex.split(cmd, posix=(os.name != "nt"))
+            # POSIX → shlex.split. Windows → CommandLineToArgvW so quoted
+            # paths like ``"C:\\Program Files\\..."`` arrive unquoted.
+            argv = _split_refresh_cmd(cmd)
         except ValueError as split_err:
             raise RuntimeError(
                 f"{NOTEBOOKLM_REFRESH_CMD_ENV} could not be parsed: {split_err}"

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -2403,12 +2403,17 @@ def _split_refresh_cmd(cmd: str) -> list[str]:
     argc = ctypes.c_int(0)
     argv_ptr = CommandLineToArgvW(cmd, ctypes.byref(argc))
     if not argv_ptr:
-        # CommandLineToArgvW returns NULL for empty / whitespace-only input.
+        # CommandLineToArgvW returns NULL for some empty-input edge cases.
         # Mirror shlex.split's behavior and return an empty list; the caller
         # surfaces this as ``RuntimeError("...parsed to empty argv")``.
         return []
     try:
-        return [argv_ptr[i] for i in range(argc.value)]
+        # On Windows, ``CommandLineToArgvW`` is documented to return a single
+        # empty-string entry (argc=1, argv[0]="") for whitespace-only input,
+        # rather than NULL. Filter out empty entries so the caller's
+        # ``if not argv`` empty-argv guard catches this case the same way
+        # ``shlex.split("   ") == []`` does on POSIX.
+        return [argv_ptr[i] for i in range(argc.value) if argv_ptr[i]]
     finally:
         LocalFree(ctypes.cast(argv_ptr, wintypes.HLOCAL))
 

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -2443,6 +2443,11 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
     run_shell: bool
     if use_shell:
         logger.warning("Using shell-mode for %s (opt-in)", NOTEBOOKLM_REFRESH_CMD_ENV)
+        # Deliberately do NOT log a basename/preview of ``cmd`` here: in
+        # shell-mode the entire string is forwarded to ``/bin/sh -c`` and
+        # may contain pipes, redirection, ``$VAR`` expansion, or inline
+        # tokens. We can't extract a single "first token" without risking
+        # leaking the rest, so we stay silent past the opt-in warning.
         run_target = cmd
         run_shell = True
     else:

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -205,18 +205,36 @@ class TestShellOptIn:
         )
 
     @pytest.mark.asyncio
-    async def test_opt_in_zero_string_does_not_use_shell(self, monkeypatch, tmp_path):
-        """Only the literal '1' opts in; '0' / 'false' / anything else stays safe."""
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "0",  # numeric falsy
+            "true",  # YAML/JSON boolean false-friend
+            "True",  # capitalized Python literal
+            "yes",  # natural-language affirmative
+            "on",  # systemd/INI affirmative
+            "1 ",  # trailing whitespace (env files often add it)
+            " 1",  # leading whitespace
+            "",  # empty string (explicit unset-equivalent)
+        ],
+    )
+    async def test_opt_in_only_strict_literal_one(self, monkeypatch, tmp_path, value):
+        """Only the literal '1' opts in. Common truthy-looking strings
+        ('true', 'yes', 'on', whitespace-padded '1', ...) MUST stay on the
+        safe shell=False default — these are the YAML/INI footguns users
+        most easily hit when copying ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1``
+        from one config to another.
+        """
         _stub_storage_path(monkeypatch, tmp_path)
         monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
-        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, "0")
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, value)
         recorder = _RecordingRun(returncode=0)
         monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
 
         await _run_refresh_cmd()
 
         call = recorder.calls[0]
-        assert isinstance(call["args"][0], list)
+        assert isinstance(call["args"][0], list), f"value={value!r} unexpectedly opted into shell"
         assert call["kwargs"]["shell"] is False
 
 

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -90,8 +90,17 @@ class TestShlexDefault:
         await _run_refresh_cmd()
 
         target = recorder.calls[0]["args"][0]
-        assert target == ["echo", "hello world"]
-        assert len(target) == 2  # quoted segment stays one token
+        # The load-bearing invariant: the quoted span stays a single argv
+        # element, so the child sees one "hello world" arg instead of two.
+        # POSIX ``shlex.split`` strips the surrounding quotes; non-POSIX
+        # (Windows) preserves them — the child shell-less invocation then
+        # rejects them, but that's the user's problem and not ours.
+        assert len(target) == 2
+        assert target[0] == "echo"
+        if os.name == "nt":
+            assert target[1] == '"hello world"'
+        else:
+            assert target[1] == "hello world"
 
     @pytest.mark.asyncio
     async def test_malformed_command_raises_runtime_error(self, monkeypatch, tmp_path):

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -21,6 +21,7 @@ from notebooklm.auth import (
     NOTEBOOKLM_REFRESH_CMD_ENV,
     NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV,
     _run_refresh_cmd,
+    _split_refresh_cmd,
 )
 
 
@@ -90,25 +91,22 @@ class TestShlexDefault:
         await _run_refresh_cmd()
 
         target = recorder.calls[0]["args"][0]
-        # The load-bearing invariant: the quoted span stays a single argv
-        # element, so the child sees one "hello world" arg instead of two.
-        # POSIX ``shlex.split`` strips the surrounding quotes; non-POSIX
-        # (Windows) preserves them — the child shell-less invocation then
-        # rejects them, but that's the user's problem and not ours.
+        # The quoted span stays a single argv element AND the syntactic
+        # quotes are stripped on both platforms — POSIX via shlex.split,
+        # Windows via CommandLineToArgvW.
+        assert target == ["echo", "hello world"]
         assert len(target) == 2
-        assert target[0] == "echo"
-        if os.name == "nt":
-            assert target[1] == '"hello world"'
-        else:
-            assert target[1] == "hello world"
 
     @pytest.mark.asyncio
     async def test_malformed_command_raises_runtime_error(self, monkeypatch, tmp_path):
         _stub_storage_path(monkeypatch, tmp_path)
         # Unterminated double quote — POSIX ``shlex.split`` raises ValueError.
-        # Skip on Windows where ``posix=False`` mode is lenient about quoting.
+        # Skip on Windows: ``CommandLineToArgvW`` is lenient and treats the
+        # remainder of the string as the final quoted token rather than
+        # signaling an error. We still get a valid argv, so this specific
+        # surface is POSIX-only.
         if os.name == "nt":
-            pytest.skip("shlex non-POSIX mode does not raise on unterminated quotes")
+            pytest.skip("CommandLineToArgvW is lenient about unterminated quotes")
         monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, 'echo "unterminated')
         # subprocess.run should never be reached.
         called = {"hit": False}
@@ -222,6 +220,55 @@ class TestShellOptIn:
         assert call["kwargs"]["shell"] is False
 
 
+class TestSplitRefreshCmd:
+    """Unit-level coverage of the per-platform parser ``_split_refresh_cmd``.
+
+    The Windows branch uses ``CommandLineToArgvW`` (not ``shlex.split``) so
+    quoted paths like ``"C:\\Program Files\\Python\\python.exe"`` arrive
+    in argv WITHOUT the surrounding literal quotes. This was the regression
+    flagged by CodeRabbit on the initial review.
+    """
+
+    def test_posix_split_strips_quotes(self):
+        if os.name == "nt":
+            pytest.skip("POSIX-only branch")
+        assert _split_refresh_cmd("echo hi") == ["echo", "hi"]
+        assert _split_refresh_cmd('echo "hello world"') == ["echo", "hello world"]
+
+    def test_posix_split_raises_on_unterminated_quote(self):
+        if os.name == "nt":
+            pytest.skip("POSIX-only branch")
+        with pytest.raises(ValueError):
+            _split_refresh_cmd('echo "unterminated')
+
+    def test_windows_split_strips_quotes_from_paths(self):
+        """Regression: CodeRabbit-flagged case — quoted Windows paths must
+        arrive in argv WITHOUT the literal quote characters so
+        ``subprocess.run(argv, shell=False)`` can locate the executable.
+        """
+        if os.name != "nt":
+            pytest.skip("Windows-only branch")
+        cmd = (
+            r'"C:\Program Files\Python\python.exe" '
+            r'"C:\Temp\script with spaces.py"'
+        )
+        argv = _split_refresh_cmd(cmd)
+        assert argv == [
+            r"C:\Program Files\Python\python.exe",
+            r"C:\Temp\script with spaces.py",
+        ]
+        for token in argv:
+            assert not token.startswith('"'), f"literal quote leaked into argv: {token!r}"
+            assert not token.endswith('"'), f"literal quote leaked into argv: {token!r}"
+
+    def test_windows_split_handles_whitespace_only(self):
+        if os.name != "nt":
+            pytest.skip("Windows-only branch")
+        # Whitespace-only / empty input: parser returns an empty argv (the
+        # caller surfaces it as RuntimeError).
+        assert _split_refresh_cmd("   ") == []
+
+
 class TestEndToEndWithRealSubprocess:
     """Integration smoke: real subprocess invocation under shell=False."""
 
@@ -232,7 +279,7 @@ class TestEndToEndWithRealSubprocess:
         script = tmp_path / "refresh.py"
         marker = tmp_path / "ran.txt"
         script.write_text(f"from pathlib import Path\nPath({str(marker)!r}).write_text('ok')\n")
-        # Build a properly-quoted command line that shlex.split can re-parse.
+        # Build a properly-quoted command line that the parser can re-parse.
         if os.name == "nt":
             cmd = subprocess.list2cmdline([sys.executable, str(script)])
         else:

--- a/tests/unit/test_refresh_cmd_shlex.py
+++ b/tests/unit/test_refresh_cmd_shlex.py
@@ -1,0 +1,237 @@
+"""Tier-5 PR-T5.A — ``_run_refresh_cmd`` shell-injection hardening.
+
+Pins the contract that ``NOTEBOOKLM_REFRESH_CMD`` defaults to ``shell=False``
+via :func:`shlex.split`, with an explicit opt-in for the legacy ``shell=True``
+mode and basename-only logging of the first token.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from notebooklm import auth as auth_mod
+from notebooklm.auth import (
+    NOTEBOOKLM_REFRESH_CMD_ENV,
+    NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV,
+    _run_refresh_cmd,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_refresh_env(monkeypatch):
+    """Each test starts with no inherited refresh-cmd env vars."""
+    monkeypatch.delenv(NOTEBOOKLM_REFRESH_CMD_ENV, raising=False)
+    monkeypatch.delenv(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, raising=False)
+    monkeypatch.delenv("_NOTEBOOKLM_REFRESH_ATTEMPTED", raising=False)
+
+
+def _stub_storage_path(monkeypatch, tmp_path: Path) -> Path:
+    """Point ``get_storage_path`` at a writable temp file."""
+    storage = tmp_path / "storage_state.json"
+    storage.write_text("{}")
+    monkeypatch.setattr(auth_mod, "get_storage_path", lambda profile=None: storage)
+    return storage
+
+
+class _RecordingRun:
+    """Stand-in for ``subprocess.run`` that records its call args."""
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, *args, **kwargs):
+        # ``subprocess.run(target, shell=..., ...)`` — first positional is the
+        # command. We record both positional and keyword args.
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return subprocess.CompletedProcess(
+            args=args[0] if args else kwargs.get("args"),
+            returncode=self.returncode,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
+
+class TestShlexDefault:
+    """Default path: ``shlex.split`` + ``shell=False``."""
+
+    @pytest.mark.asyncio
+    async def test_simple_command_split_and_run_without_shell(self, monkeypatch, tmp_path):
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd()
+
+        assert recorder.calls, "subprocess.run was not invoked"
+        call = recorder.calls[0]
+        target = call["args"][0]
+        assert isinstance(target, list), "expected a list argv when shell=False"
+        assert target == ["echo", "hi"]
+        assert call["kwargs"]["shell"] is False
+
+    @pytest.mark.asyncio
+    async def test_quoted_command_split_preserves_tokens(self, monkeypatch, tmp_path):
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, 'echo "hello world"')
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd()
+
+        target = recorder.calls[0]["args"][0]
+        assert target == ["echo", "hello world"]
+        assert len(target) == 2  # quoted segment stays one token
+
+    @pytest.mark.asyncio
+    async def test_malformed_command_raises_runtime_error(self, monkeypatch, tmp_path):
+        _stub_storage_path(monkeypatch, tmp_path)
+        # Unterminated double quote — POSIX ``shlex.split`` raises ValueError.
+        # Skip on Windows where ``posix=False`` mode is lenient about quoting.
+        if os.name == "nt":
+            pytest.skip("shlex non-POSIX mode does not raise on unterminated quotes")
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, 'echo "unterminated')
+        # subprocess.run should never be reached.
+        called = {"hit": False}
+
+        def _boom(*args, **kwargs):
+            called["hit"] = True
+            raise AssertionError("subprocess.run must not run on parse failure")
+
+        monkeypatch.setattr(auth_mod.subprocess, "run", _boom)
+
+        with pytest.raises(RuntimeError, match="could not be parsed"):
+            await _run_refresh_cmd()
+
+        assert called["hit"] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_argv_raises_runtime_error(self, monkeypatch, tmp_path):
+        _stub_storage_path(monkeypatch, tmp_path)
+        # All-whitespace string splits to []; the env-not-set guard treats ""
+        # as missing, so we use spaces to bypass that and exercise the
+        # empty-argv branch.
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "   ")
+        called = {"hit": False}
+
+        def _boom(*args, **kwargs):
+            called["hit"] = True
+            raise AssertionError("subprocess.run must not run on empty argv")
+
+        monkeypatch.setattr(auth_mod.subprocess, "run", _boom)
+
+        with pytest.raises(RuntimeError, match="parsed to empty argv"):
+            await _run_refresh_cmd()
+
+        assert called["hit"] is False
+
+    @pytest.mark.asyncio
+    async def test_first_token_logged_basename_only(self, monkeypatch, tmp_path, caplog):
+        _stub_storage_path(monkeypatch, tmp_path)
+        secret_path = "/home/user/.secrets/refresh.sh"
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, f"{secret_path} --token=hunter2")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        caplog.set_level(logging.INFO, logger=auth_mod.logger.name)
+        await _run_refresh_cmd()
+
+        # Argv reached the runner with the full path + token intact.
+        assert recorder.calls[0]["args"][0] == [secret_path, "--token=hunter2"]
+        # But neither the parent directory nor the token appear in the INFO log.
+        info_lines = [
+            record.getMessage() for record in caplog.records if record.levelno == logging.INFO
+        ]
+        running_lines = [line for line in info_lines if "Running refresh command" in line]
+        assert running_lines, f"missing 'Running refresh command' log; got: {info_lines}"
+        joined = "\n".join(running_lines)
+        assert "refresh.sh" in joined
+        assert "/home/user/.secrets" not in joined
+        assert "hunter2" not in joined
+
+
+class TestShellOptIn:
+    """Legacy opt-in path: ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1``."""
+
+    @pytest.mark.asyncio
+    async def test_opt_in_uses_shell_true_with_raw_string(self, monkeypatch, tmp_path):
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo $HOME | tr a-z A-Z")
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, "1")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd()
+
+        call = recorder.calls[0]
+        target = call["args"][0]
+        # In shell-mode the raw string is forwarded verbatim — no split.
+        assert target == "echo $HOME | tr a-z A-Z"
+        assert call["kwargs"]["shell"] is True
+
+    @pytest.mark.asyncio
+    async def test_opt_in_emits_warning(self, monkeypatch, tmp_path, caplog):
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, "1")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        caplog.set_level(logging.WARNING, logger=auth_mod.logger.name)
+        await _run_refresh_cmd()
+
+        warnings_emitted = [
+            record.getMessage() for record in caplog.records if record.levelno == logging.WARNING
+        ]
+        assert any("shell-mode" in msg.lower() for msg in warnings_emitted), (
+            f"expected shell-mode warning, got: {warnings_emitted}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_opt_in_zero_string_does_not_use_shell(self, monkeypatch, tmp_path):
+        """Only the literal '1' opts in; '0' / 'false' / anything else stays safe."""
+        _stub_storage_path(monkeypatch, tmp_path)
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, "echo hi")
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV, "0")
+        recorder = _RecordingRun(returncode=0)
+        monkeypatch.setattr(auth_mod.subprocess, "run", recorder)
+
+        await _run_refresh_cmd()
+
+        call = recorder.calls[0]
+        assert isinstance(call["args"][0], list)
+        assert call["kwargs"]["shell"] is False
+
+
+class TestEndToEndWithRealSubprocess:
+    """Integration smoke: real subprocess invocation under shell=False."""
+
+    @pytest.mark.asyncio
+    async def test_python_command_via_shlex_split(self, monkeypatch, tmp_path):
+        """A real refresh script runs successfully via shlex.split."""
+        _stub_storage_path(monkeypatch, tmp_path)
+        script = tmp_path / "refresh.py"
+        marker = tmp_path / "ran.txt"
+        script.write_text(f"from pathlib import Path\nPath({str(marker)!r}).write_text('ok')\n")
+        # Build a properly-quoted command line that shlex.split can re-parse.
+        if os.name == "nt":
+            cmd = subprocess.list2cmdline([sys.executable, str(script)])
+        else:
+            import shlex as _shlex
+
+            cmd = _shlex.join([sys.executable, str(script)])
+        monkeypatch.setenv(NOTEBOOKLM_REFRESH_CMD_ENV, cmd)
+
+        await _run_refresh_cmd()
+
+        assert marker.read_text() == "ok"


### PR DESCRIPTION
## Summary

Closes Tier-5 #1 / synthesis C9 — shell-injection footgun when ``NOTEBOOKLM_REFRESH_CMD`` is sourced from CI configs or container env files.

- ``_run_refresh_cmd`` now parses the env var with ``shlex.split`` and invokes ``subprocess.run(argv, shell=False, ...)`` by default.
- Empty-argv → ``RuntimeError("NOTEBOOKLM_REFRESH_CMD parsed to empty argv")``. Malformed quoting → ``RuntimeError("... could not be parsed: <ValueError msg>")``. Matches the existing ``RuntimeError`` pattern in the same function — no new exception class added.
- First-token logging uses ``os.path.basename(argv[0])`` only — full argv may carry tokens, and the leading absolute path itself can leak a secrets-directory layout (``/home/user/.secrets/refresh.sh``).

## Opt-in legacy shell mode

Set ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1`` to keep the prior ``shell=True`` behavior for cmd strings that rely on shell features (pipes, redirection, ``$VAR`` expansion). Each invocation in shell-mode emits ``logger.warning("Using shell-mode for NOTEBOOKLM_REFRESH_CMD (opt-in)")`` so the security trade-off stays visible in logs. Only the literal string ``"1"`` opts in — ``"0"``, ``"false"``, or any other value stays on the safe default.

## Breaking-change note

Cmd strings that depended on shell features must either be rewritten as a single argv or opt in via ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1``. Existing test fixtures already build their commands with ``shlex.join`` / ``subprocess.list2cmdline`` and round-trip cleanly under the new default; no fixture changes were needed.

On Windows, ``shlex.split(cmd, posix=False)`` is used so backslash-containing paths produced by ``subprocess.list2cmdline`` round-trip correctly.

## Test plan

- [x] ``cmd='echo hi'`` → succeeds with ``shell=False`` (argv = ``["echo", "hi"]``).
- [x] ``cmd='echo "hello world"'`` → quoted split keeps the quoted span as one token (argv has 2 elements).
- [x] ``cmd='echo "unterminated'`` → ``ValueError`` from ``shlex`` surfaces as ``RuntimeError`` and ``subprocess.run`` is never reached.
- [x] All-whitespace cmd → empty argv → ``RuntimeError("...parsed to empty argv")``; ``subprocess.run`` is never reached.
- [x] ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1`` → still uses ``shell=True`` with the raw string verbatim; warning logged.
- [x] ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=0`` → safe default (regression guard against truthy-string footguns).
- [x] Basename-only logging assertion via ``caplog`` — full secrets-directory path and trailing token do NOT appear in the INFO log.
- [x] Real-subprocess smoke: a ``shlex.join``'d Python invocation runs and writes a marker file under the new default.
- [x] Existing 347 auth + refresh tests in ``tests/unit/test_auth.py``, ``test_refresh_lock_registry.py``, ``test_refresh_state_machine.py``, ``test_concurrency_refresh_race.py``, ``test_auth_cookie_save_race.py`` still pass — they already use ``shlex.join`` / ``list2cmdline`` so they round-trip cleanly.
- [x] Full ``tests/unit`` suite green (2566 passed, 5 skipped).
- [x] ``ruff format`` / ``ruff check`` / ``mypy src/notebooklm`` all clean.

Generated with Claude Code as part of the Tier-5 security hardening series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication refresh command is now parsed and run more safely by default (avoids invoking a shell). Legacy shell behavior is available via the NOTEBOOKLM_REFRESH_CMD_USE_SHELL environment flag.

* **Tests**
  * Added comprehensive unit and end-to-end tests covering safe parsing, execution modes, failure cases, and logging.

* **Documentation**
  * Updated docs and troubleshooting to describe the hardened refresh command behavior and the opt-in legacy shell option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/475)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->