### PR TITLE
feat(cli/source): reject symlink uploads unless --follow-symlinks (T5.C)

### DIFF
--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -346,10 +346,29 @@ def source_list(ctx, notebook_id, json_output, client_auth):
         "Increase when adding slow URLs or large files that exceed the default."
     ),
 )
+@click.option(
+    "--follow-symlinks",
+    is_flag=True,
+    default=False,
+    help=(
+        "Follow symbolic links when uploading a file. By default, symlinks "
+        "are rejected so a workspace symlink cannot silently exfiltrate the "
+        "file it points at (e.g. ~/Downloads/foo.pdf -> /etc/passwd)."
+    ),
+)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @with_client
 def source_add(
-    ctx, content, notebook_id, source_type, title, mime_type, timeout, json_output, client_auth
+    ctx,
+    content,
+    notebook_id,
+    source_type,
+    title,
+    mime_type,
+    timeout,
+    follow_symlinks,
+    json_output,
+    client_auth,
 ):
     """Add a source to a notebook.
 
@@ -379,7 +398,17 @@ def source_add(
         if content.startswith(("http://", "https://")):
             detected_type = "youtube" if is_youtube_url(content) else "url"
         elif Path(content).exists():
-            file_path = Path(content).resolve()  # Resolve symlinks
+            raw = Path(content)
+            # Security: reject symlinks unless the user has explicitly opted
+            # in via --follow-symlinks. Transparent symlink resolution is a
+            # footgun on shared workstations (a workspace ``foo.pdf`` symlink
+            # could point at ``/etc/passwd`` and silently upload it).
+            if raw.is_symlink() and not follow_symlinks:
+                raise click.ClickException(
+                    "Path is a symlink; pass --follow-symlinks to follow it "
+                    f"explicitly. Refusing to upload: {raw}"
+                )
+            file_path = raw.resolve()  # Resolve only after explicit --follow-symlinks opt-in
             # Security: Ensure it's a regular file (not a symlink to sensitive file)
             if not file_path.is_file():
                 raise click.ClickException(f"Not a regular file: {content}")

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -58,6 +58,54 @@ _GATEWAY_TITLE_PATTERN = re.compile(
 _JUNK_STATUSES = frozenset({"error"})
 
 
+def _validate_upload_path(content: str, follow_symlinks: bool) -> Path:
+    """Validate a local-file path before uploading it as a source.
+
+    Returns the resolved ``Path`` so the caller can forward exactly the
+    artifact it validated (closing the time-of-check / time-of-use window
+    that ``add_file()`` would otherwise re-open).
+
+    Rules (default-deny):
+
+    1. If ``follow_symlinks`` is ``False`` and **any** component of the
+       path — the leaf or any parent directory — is a symlink, refuse.
+       Checking parents matters: ``dir_link/secret.pdf`` would otherwise
+       sneak past a leaf-only ``is_symlink()`` check.
+    2. The symlink check runs **before** ``exists()`` so a broken symlink
+       gets a clear "symlink" rejection instead of being treated as text
+       content via the fall-through branch.
+    3. After resolution the target must be a regular file (no
+       directories, FIFOs, devices, sockets).
+
+    Raises:
+        click.ClickException: on any of the above failures. The message
+            tells the user exactly which flag opts in.
+    """
+    raw = Path(content)
+
+    # 1) Symlink gate (leaf + every parent). Catches broken symlinks too,
+    # because ``is_symlink()`` is True for dangling links.
+    if not follow_symlinks:
+        for component in [raw, *raw.parents]:
+            if component.is_symlink():
+                raise click.ClickException(
+                    "Path is a symlink; pass --follow-symlinks to follow it "
+                    f"explicitly. Refusing to upload: {raw}"
+                )
+
+    # 2) Resolve only after the explicit --follow-symlinks opt-in (or after
+    # the no-symlink check above has passed).
+    file_path = raw.expanduser().resolve()
+
+    # 3) Reject directories, pipes, devices, sockets, and non-existent
+    # paths. Symlinks have already been handled above, so this guard now
+    # covers the non-symlink "weird filetype" cases.
+    if not file_path.is_file():
+        raise click.ClickException(f"Not a regular file: {content}")
+
+    return file_path
+
+
 def _normalize_url_for_dedup(url: str) -> str:
     """Return a URL with only the fragment stripped, for dedup comparison.
 
@@ -393,30 +441,31 @@ def source_add(
     detected_type = source_type
     file_content = None
     file_title = title
+    # Set once the path passes ``_validate_upload_path`` so the upload uses
+    # the resolved path we just validated (closes the TOCTOU window where a
+    # symlink could be retargeted between validation and ``add_file()``).
+    upload_path: Path | None = None
 
     if detected_type is None:
         if content.startswith(("http://", "https://")):
             detected_type = "youtube" if is_youtube_url(content) else "url"
-        elif Path(content).exists():
-            raw = Path(content)
-            # Security: reject symlinks unless the user has explicitly opted
-            # in via --follow-symlinks. Transparent symlink resolution is a
-            # footgun on shared workstations (a workspace ``foo.pdf`` symlink
-            # could point at ``/etc/passwd`` and silently upload it).
-            if raw.is_symlink() and not follow_symlinks:
-                raise click.ClickException(
-                    "Path is a symlink; pass --follow-symlinks to follow it "
-                    f"explicitly. Refusing to upload: {raw}"
-                )
-            file_path = raw.resolve()  # Resolve only after explicit --follow-symlinks opt-in
-            # Security: Ensure it's a regular file (not a symlink to sensitive file)
-            if not file_path.is_file():
-                raise click.ClickException(f"Not a regular file: {content}")
-            # All files use add_file() for proper type detection
+        elif Path(content).exists() or Path(content).is_symlink():
+            # ``is_symlink()`` short-circuits ``exists()`` for broken
+            # symlinks (``exists()`` follows the link and reports False),
+            # so we OR them together to make sure the symlink gate fires
+            # on dangling links instead of letting them slip into the
+            # text fall-through branch.
+            upload_path = _validate_upload_path(content, follow_symlinks)
             detected_type = "file"
         else:
             detected_type = "text"
             file_title = title or "Pasted Text"
+    elif detected_type == "file":
+        # Explicit ``--type file``: the auto-detect block above is skipped,
+        # so apply the same symlink + regular-file gate here. Without this,
+        # ``source add link.pdf --type file`` would silently bypass the
+        # ``--follow-symlinks`` opt-in and leak the symlink target.
+        upload_path = _validate_upload_path(content, follow_symlinks)
 
     client_kwargs: dict = {}
     if timeout is not None:
@@ -432,8 +481,15 @@ def source_add(
                 text_title = file_title or "Untitled"
                 src = await client.sources.add_text(nb_id_resolved, text_title, text_content)
             elif detected_type == "file":
+                # ``upload_path`` is always populated by the validation
+                # above when ``detected_type == "file"``. Pass the resolved
+                # path string so ``add_file()`` opens exactly the file we
+                # just validated (no second symlink hop).
+                assert upload_path is not None, (
+                    "upload_path must be set when detected_type == 'file'"
+                )
                 src = await client.sources.add_file(
-                    nb_id_resolved, content, mime_type, title=file_title
+                    nb_id_resolved, str(upload_path), mime_type, title=file_title
                 )
 
             if json_output:

--- a/tests/unit/test_source_symlink.py
+++ b/tests/unit/test_source_symlink.py
@@ -5,13 +5,19 @@ The CLI must reject symlinked paths unless the user explicitly opts in via
 file like ``~/Downloads/foo.pdf`` is silently a symlink into ``/etc/`` or
 similar — uploading the symlink target would leak sensitive content.
 
-Tests:
-- Plain regular file: uploaded normally (``sources.add_file`` is called).
-- Symlink without flag: ``ClickException`` + exit code 1, **no upload**.
-- Symlink with ``--follow-symlinks``: target resolved and uploaded.
-- Broken symlink with flag: no upload attempted (broken symlinks report
-  ``exists() == False`` and fall through to the text branch — the point
-  is that the symlink target is never read).
+Tests cover both the **auto-detect** path (no ``--type``) and the
+**explicit** ``--type file`` path — both must enforce the same gate.
+The gate also rejects:
+
+- Leaf symlinks (default).
+- Parent-directory symlinks (``dir_link/file.pdf``).
+- Broken symlinks (``exists()`` returns False but ``is_symlink()`` is True —
+  without the special-case we'd silently treat the path string as text
+  content).
+
+When ``--follow-symlinks`` is passed, the resolved path is forwarded to
+``add_file()`` so the upload opens exactly the file we validated (closes
+the TOCTOU window).
 """
 
 from __future__ import annotations
@@ -27,8 +33,13 @@ from click.testing import CliRunner
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Source
 
-# Resolve the actual source module (cli/__init__ shadows `source` with the
-# click group of the same name; we need the module to patch NotebookLMClient).
+# ``cli/__init__.py`` re-exports the ``source`` click Group under that
+# name, which shadows the underlying module. ``import notebooklm.cli.source``
+# *does* bind to the module via the dotted-path machinery, but
+# ``from notebooklm.cli import source`` would bind to the Group. We use
+# ``importlib.import_module`` here as the explicit, unambiguous form so
+# ``patch.object(_source_module, "NotebookLMClient")`` targets the module
+# attribute the CLI handler actually reads.
 _source_module = importlib.import_module("notebooklm.cli.source")
 
 
@@ -73,17 +84,29 @@ def _make_client() -> MagicMock:
     client.notebooks.list = AsyncMock(return_value=[nb_obj])
     client.notebooks.get = AsyncMock(return_value=nb_obj)
 
-    # Default upload stubs; tests override as needed.
+    # Default upload stubs; individual tests override as needed.
     client.sources.add_file = AsyncMock(return_value=Source(id="src_default", title="x"))
     client.sources.add_text = AsyncMock(return_value=Source(id="src_text", title="x"))
     return client
 
 
-class TestSourceAddSymlinkHardening:
-    """Symlink rejection logic in the auto-detect file path."""
+def _invoke(runner: CliRunner, mock_client: MagicMock, argv: list[str]):
+    """Run the CLI with NotebookLMClient patched to ``mock_client``."""
+    with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
+        return runner.invoke(cli, argv, catch_exceptions=False)
+
+
+class TestAutoDetectFilePath:
+    """Auto-detect (no ``--type``) branch — the original PR-T5.C surface."""
 
     def test_plain_regular_file_uploads(self, runner, mock_auth, tmp_path: Path) -> None:
-        """A non-symlinked file passes the symlink gate and is uploaded."""
+        """A non-symlinked file passes the gate and is uploaded.
+
+        Also locks down the *exact* path forwarded to ``add_file()``: the
+        resolved Path, not the raw argument. This is what closes the
+        TOCTOU window (issue called out by coderabbit on the initial
+        review pass).
+        """
         real_file = tmp_path / "doc.pdf"
         real_file.write_bytes(b"fake pdf content")
         assert not real_file.is_symlink()
@@ -92,20 +115,16 @@ class TestSourceAddSymlinkHardening:
         mock_client.sources.add_file = AsyncMock(
             return_value=Source(id="src_real", title="doc.pdf")
         )
-        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
-            result = runner.invoke(
-                cli,
-                ["source", "add", str(real_file), "-n", "nb_123"],
-                catch_exceptions=False,
-            )
+
+        result = _invoke(runner, mock_client, ["source", "add", str(real_file), "-n", "nb_123"])
 
         assert result.exit_code == 0, result.output
         mock_client.sources.add_file.assert_awaited_once()
-        # The path passed to add_file is the raw content string; the
-        # CLI's resolution stays local to the symlink/is_file gate and the
-        # original argument is forwarded to ``add_file``.
         called_path = mock_client.sources.add_file.await_args.args[1]
-        assert called_path == str(real_file)
+        # The CLI passes the resolved path so add_file opens the same
+        # file we validated. For a non-symlink in a real tmp_path, the
+        # resolved path equals the raw input after expanduser().
+        assert called_path == str(real_file.expanduser().resolve())
 
     def test_symlink_without_flag_is_rejected(self, runner, mock_auth, tmp_path: Path) -> None:
         """Symlink without ``--follow-symlinks`` exits 1 with a clear error."""
@@ -119,26 +138,23 @@ class TestSourceAddSymlinkHardening:
         mock_client.sources.add_file = AsyncMock(
             return_value=Source(id="should_not_be_used", title="should_not_be_used")
         )
-        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
-            result = runner.invoke(
-                cli,
-                ["source", "add", str(link), "-n", "nb_123"],
-                catch_exceptions=False,
-            )
+
+        result = _invoke(runner, mock_client, ["source", "add", str(link), "-n", "nb_123"])
 
         assert result.exit_code == 1
-        # The error message names the offending path AND tells the user
-        # exactly which flag opts in.
         assert "symlink" in result.output.lower()
         assert "--follow-symlinks" in result.output
         assert str(link) in result.output
-        # Critical: no upload happened.
         mock_client.sources.add_file.assert_not_awaited()
 
     def test_symlink_with_flag_is_followed_and_uploaded(
         self, runner, mock_auth, tmp_path: Path
     ) -> None:
-        """Symlink + ``--follow-symlinks`` resolves and uploads the target."""
+        """``--follow-symlinks`` resolves the symlink and uploads the target.
+
+        Verifies the *resolved* path is what's handed to ``add_file()``
+        (not the symlink path), closing the TOCTOU window.
+        """
         target = tmp_path / "target.pdf"
         target.write_bytes(b"real content")
         link = tmp_path / "link.pdf"
@@ -149,26 +165,28 @@ class TestSourceAddSymlinkHardening:
         mock_client.sources.add_file = AsyncMock(
             return_value=Source(id="src_resolved", title="target.pdf")
         )
-        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
-            result = runner.invoke(
-                cli,
-                ["source", "add", str(link), "-n", "nb_123", "--follow-symlinks"],
-                catch_exceptions=False,
-            )
+
+        result = _invoke(
+            runner,
+            mock_client,
+            ["source", "add", str(link), "-n", "nb_123", "--follow-symlinks"],
+        )
 
         assert result.exit_code == 0, result.output
         mock_client.sources.add_file.assert_awaited_once()
+        called_path = mock_client.sources.add_file.await_args.args[1]
+        # The upload must hit the *target*, not the link, after opt-in.
+        assert called_path == str(target.expanduser().resolve())
 
-    def test_broken_symlink_with_flag_does_not_upload(
+    def test_broken_symlink_without_flag_is_rejected(
         self, runner, mock_auth, tmp_path: Path
     ) -> None:
-        """Broken symlink + flag must not invoke the file-upload path.
+        """Broken symlink without flag is rejected by the symlink gate.
 
-        ``Path.exists()`` follows symlinks and returns ``False`` for a broken
-        link, so the auto-detect ``elif Path(content).exists():`` branch is
-        skipped entirely and the input falls into the text branch. The
-        contract this test locks: *under no circumstances* does the CLI
-        attempt to read or upload the (missing) symlink target as a file.
+        ``exists()`` follows symlinks and returns False for dangling
+        links — without our special-case OR, the CLI would silently
+        treat the broken-link *path string* as text content. We assert
+        the symlink-rejection error fires.
         """
         missing = tmp_path / "does_not_exist.pdf"
         link = tmp_path / "broken_link.pdf"
@@ -177,29 +195,171 @@ class TestSourceAddSymlinkHardening:
         assert not link.exists()  # broken — exists() follows the link
 
         mock_client = _make_client()
-        # If the CLI mistakenly invokes add_file with a broken link, the
-        # assertion below catches it.
+        mock_client.sources.add_text = AsyncMock(
+            return_value=Source(id="should_not_be_used_text", title="broken_link.pdf")
+        )
+
+        result = _invoke(runner, mock_client, ["source", "add", str(link), "-n", "nb_123"])
+
+        assert result.exit_code == 1
+        assert "symlink" in result.output.lower()
+        assert "--follow-symlinks" in result.output
+        # Critical: no upload of any kind. We must not silently turn the
+        # link string into a text source.
+        mock_client.sources.add_file.assert_not_awaited()
+        mock_client.sources.add_text.assert_not_awaited()
+
+    def test_broken_symlink_with_flag_falls_through_to_not_a_file(
+        self, runner, mock_auth, tmp_path: Path
+    ) -> None:
+        """Broken symlink + ``--follow-symlinks`` hits the regular-file gate.
+
+        After the symlink gate is bypassed, ``resolve()`` produces a path
+        whose target doesn't exist, so ``is_file()`` is False and we
+        surface "Not a regular file" instead of attempting an upload.
+        """
+        missing = tmp_path / "does_not_exist.pdf"
+        link = tmp_path / "broken_link.pdf"
+        os.symlink(missing, link)
+        assert link.is_symlink()
+        assert not link.exists()
+
+        mock_client = _make_client()
         mock_client.sources.add_file = AsyncMock(
             return_value=Source(id="should_not_be_used", title="should_not_be_used")
         )
-        mock_client.sources.add_text = AsyncMock(
-            return_value=Source(id="src_text", title="broken_link.pdf")
-        )
-        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
-            result = runner.invoke(
-                cli,
-                [
-                    "source",
-                    "add",
-                    str(link),
-                    "-n",
-                    "nb_123",
-                    "--follow-symlinks",
-                ],
-                catch_exceptions=False,
-            )
 
-        # Command must not blow up with a traceback, and must NOT have
-        # uploaded the (non-existent) symlink target as a file.
-        assert result.exit_code == 0, result.output
+        result = _invoke(
+            runner,
+            mock_client,
+            ["source", "add", str(link), "-n", "nb_123", "--follow-symlinks"],
+        )
+
+        assert result.exit_code == 1
+        assert "not a regular file" in result.output.lower()
         mock_client.sources.add_file.assert_not_awaited()
+
+    def test_parent_directory_symlink_is_rejected(self, runner, mock_auth, tmp_path: Path) -> None:
+        """A symlinked *parent* directory triggers the gate.
+
+        ``raw.is_symlink()`` only inspects the leaf path, so
+        ``dir_link/file.pdf`` would slip through a leaf-only check. The
+        helper walks parents — assert here that the gate fires.
+        """
+        real_dir = tmp_path / "real_dir"
+        real_dir.mkdir()
+        real_file = real_dir / "doc.pdf"
+        real_file.write_bytes(b"content")
+
+        dir_link = tmp_path / "dir_link"
+        os.symlink(real_dir, dir_link)
+        path_through_link = dir_link / "doc.pdf"
+        assert path_through_link.exists()  # the leaf itself is a real file
+        assert not path_through_link.is_symlink()  # leaf alone looks clean
+        assert dir_link.is_symlink()  # but the parent is a link
+
+        mock_client = _make_client()
+
+        result = _invoke(
+            runner, mock_client, ["source", "add", str(path_through_link), "-n", "nb_123"]
+        )
+
+        assert result.exit_code == 1
+        assert "symlink" in result.output.lower()
+        mock_client.sources.add_file.assert_not_awaited()
+
+
+class TestExplicitTypeFile:
+    """``--type file`` path — the security gap closed in the review pass.
+
+    Without these tests, ``source add link.pdf --type file`` would
+    silently bypass the symlink gate and leak the link target. Locked
+    down by parametrized variants that mirror the auto-detect tests.
+    """
+
+    def test_explicit_type_file_with_plain_file_uploads(
+        self, runner, mock_auth, tmp_path: Path
+    ) -> None:
+        """Sanity check: ``--type file`` on a normal file still works."""
+        real_file = tmp_path / "doc.pdf"
+        real_file.write_bytes(b"fake pdf content")
+
+        mock_client = _make_client()
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="src_real", title="doc.pdf")
+        )
+
+        result = _invoke(
+            runner,
+            mock_client,
+            ["source", "add", str(real_file), "--type", "file", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_client.sources.add_file.assert_awaited_once()
+        called_path = mock_client.sources.add_file.await_args.args[1]
+        assert called_path == str(real_file.expanduser().resolve())
+
+    def test_explicit_type_file_with_symlink_no_flag_is_rejected(
+        self, runner, mock_auth, tmp_path: Path
+    ) -> None:
+        """Critical: explicit ``--type file`` MUST honor the symlink gate.
+
+        This is the path most likely used by automation scripts (which
+        often hardcode ``--type``), so it's the higher-risk surface.
+        Pre-fix, this case bypassed the guard completely.
+        """
+        target = tmp_path / "target.pdf"
+        target.write_bytes(b"sensitive content")
+        link = tmp_path / "link.pdf"
+        os.symlink(target, link)
+
+        mock_client = _make_client()
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="should_not_be_used", title="should_not_be_used")
+        )
+
+        result = _invoke(
+            runner,
+            mock_client,
+            ["source", "add", str(link), "--type", "file", "-n", "nb_123"],
+        )
+
+        assert result.exit_code == 1
+        assert "symlink" in result.output.lower()
+        assert "--follow-symlinks" in result.output
+        mock_client.sources.add_file.assert_not_awaited()
+
+    def test_explicit_type_file_with_symlink_and_flag_is_followed(
+        self, runner, mock_auth, tmp_path: Path
+    ) -> None:
+        """``--type file --follow-symlinks`` resolves and uploads."""
+        target = tmp_path / "target.pdf"
+        target.write_bytes(b"real content")
+        link = tmp_path / "link.pdf"
+        os.symlink(target, link)
+
+        mock_client = _make_client()
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="src_resolved", title="target.pdf")
+        )
+
+        result = _invoke(
+            runner,
+            mock_client,
+            [
+                "source",
+                "add",
+                str(link),
+                "--type",
+                "file",
+                "-n",
+                "nb_123",
+                "--follow-symlinks",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_client.sources.add_file.assert_awaited_once()
+        called_path = mock_client.sources.add_file.await_args.args[1]
+        assert called_path == str(target.expanduser().resolve())

--- a/tests/unit/test_source_symlink.py
+++ b/tests/unit/test_source_symlink.py
@@ -1,0 +1,205 @@
+"""Symlink hardening for `notebooklm source add` file uploads (PR-T5.C).
+
+The CLI must reject symlinked paths unless the user explicitly opts in via
+``--follow-symlinks``. This guards against the footgun where a workspace
+file like ``~/Downloads/foo.pdf`` is silently a symlink into ``/etc/`` or
+similar — uploading the symlink target would leak sensitive content.
+
+Tests:
+- Plain regular file: uploaded normally (``sources.add_file`` is called).
+- Symlink without flag: ``ClickException`` + exit code 1, **no upload**.
+- Symlink with ``--follow-symlinks``: target resolved and uploaded.
+- Broken symlink with flag: no upload attempted (broken symlinks report
+  ``exists() == False`` and fall through to the text branch — the point
+  is that the symlink target is never read).
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import Source
+
+# Resolve the actual source module (cli/__init__ shadows `source` with the
+# click group of the same name; we need the module to patch NotebookLMClient).
+_source_module = importlib.import_module("notebooklm.cli.source")
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth():
+    """Stub auth loading + token fetch so CLI paths run offline."""
+    with (
+        patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_load.return_value = {
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        mock_fetch.return_value = ("csrf", "session")
+        yield mock_load
+
+
+def _make_client() -> MagicMock:
+    """Build a mock NotebookLMClient suitable for ``source add`` paths.
+
+    Pre-seeds notebook list so ``-n nb_123`` resolves cleanly.
+    """
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+
+    for ns in ("notebooks", "sources", "artifacts", "chat", "research", "notes", "sharing"):
+        setattr(client, ns, MagicMock())
+
+    nb_obj = MagicMock()
+    nb_obj.id = "nb_123"
+    nb_obj.title = "Test Notebook"
+    client.notebooks.list = AsyncMock(return_value=[nb_obj])
+    client.notebooks.get = AsyncMock(return_value=nb_obj)
+
+    # Default upload stubs; tests override as needed.
+    client.sources.add_file = AsyncMock(return_value=Source(id="src_default", title="x"))
+    client.sources.add_text = AsyncMock(return_value=Source(id="src_text", title="x"))
+    return client
+
+
+class TestSourceAddSymlinkHardening:
+    """Symlink rejection logic in the auto-detect file path."""
+
+    def test_plain_regular_file_uploads(self, runner, mock_auth, tmp_path: Path) -> None:
+        """A non-symlinked file passes the symlink gate and is uploaded."""
+        real_file = tmp_path / "doc.pdf"
+        real_file.write_bytes(b"fake pdf content")
+        assert not real_file.is_symlink()
+
+        mock_client = _make_client()
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="src_real", title="doc.pdf")
+        )
+        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                ["source", "add", str(real_file), "-n", "nb_123"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client.sources.add_file.assert_awaited_once()
+        # The path passed to add_file is the raw content string; the
+        # CLI's resolution stays local to the symlink/is_file gate and the
+        # original argument is forwarded to ``add_file``.
+        called_path = mock_client.sources.add_file.await_args.args[1]
+        assert called_path == str(real_file)
+
+    def test_symlink_without_flag_is_rejected(self, runner, mock_auth, tmp_path: Path) -> None:
+        """Symlink without ``--follow-symlinks`` exits 1 with a clear error."""
+        target = tmp_path / "target.pdf"
+        target.write_bytes(b"sensitive content")
+        link = tmp_path / "link.pdf"
+        os.symlink(target, link)
+        assert link.is_symlink()
+
+        mock_client = _make_client()
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="should_not_be_used", title="should_not_be_used")
+        )
+        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                ["source", "add", str(link), "-n", "nb_123"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 1
+        # The error message names the offending path AND tells the user
+        # exactly which flag opts in.
+        assert "symlink" in result.output.lower()
+        assert "--follow-symlinks" in result.output
+        assert str(link) in result.output
+        # Critical: no upload happened.
+        mock_client.sources.add_file.assert_not_awaited()
+
+    def test_symlink_with_flag_is_followed_and_uploaded(
+        self, runner, mock_auth, tmp_path: Path
+    ) -> None:
+        """Symlink + ``--follow-symlinks`` resolves and uploads the target."""
+        target = tmp_path / "target.pdf"
+        target.write_bytes(b"real content")
+        link = tmp_path / "link.pdf"
+        os.symlink(target, link)
+        assert link.is_symlink()
+
+        mock_client = _make_client()
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="src_resolved", title="target.pdf")
+        )
+        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                ["source", "add", str(link), "-n", "nb_123", "--follow-symlinks"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client.sources.add_file.assert_awaited_once()
+
+    def test_broken_symlink_with_flag_does_not_upload(
+        self, runner, mock_auth, tmp_path: Path
+    ) -> None:
+        """Broken symlink + flag must not invoke the file-upload path.
+
+        ``Path.exists()`` follows symlinks and returns ``False`` for a broken
+        link, so the auto-detect ``elif Path(content).exists():`` branch is
+        skipped entirely and the input falls into the text branch. The
+        contract this test locks: *under no circumstances* does the CLI
+        attempt to read or upload the (missing) symlink target as a file.
+        """
+        missing = tmp_path / "does_not_exist.pdf"
+        link = tmp_path / "broken_link.pdf"
+        os.symlink(missing, link)
+        assert link.is_symlink()
+        assert not link.exists()  # broken — exists() follows the link
+
+        mock_client = _make_client()
+        # If the CLI mistakenly invokes add_file with a broken link, the
+        # assertion below catches it.
+        mock_client.sources.add_file = AsyncMock(
+            return_value=Source(id="should_not_be_used", title="should_not_be_used")
+        )
+        mock_client.sources.add_text = AsyncMock(
+            return_value=Source(id="src_text", title="broken_link.pdf")
+        )
+        with patch.object(_source_module, "NotebookLMClient", return_value=mock_client):
+            result = runner.invoke(
+                cli,
+                [
+                    "source",
+                    "add",
+                    str(link),
+                    "-n",
+                    "nb_123",
+                    "--follow-symlinks",
+                ],
+                catch_exceptions=False,
+            )
+
+        # Command must not blow up with a traceback, and must NOT have
+        # uploaded the (non-existent) symlink target as a file.
+        assert result.exit_code == 0, result.output
+        mock_client.sources.add_file.assert_not_awaited()


### PR DESCRIPTION
## Summary

Closes **PR-T5.C** from `.sisyphus/plans/tier-5-implementation.md` (Security + multi-process hardening).

The `source add` CLI used to silently follow symlinks when auto-detecting file uploads — a workspace symlink like `~/Downloads/foo.pdf -> /etc/passwd` would resolve and upload the target with no warning. This PR makes symlink-following an explicit opt-in.

- Before `Path.resolve()`, check `raw.is_symlink()`. If true and `--follow-symlinks` is not passed, raise a `ClickException` naming the offending path and the opt-in flag.
- Add `--follow-symlinks` boolean flag (default `False`) to `source add`.
- Update the misleading "Resolve symlinks" inline comment to "Resolve only after explicit `--follow-symlinks` opt-in".

## Tests

New `tests/unit/test_source_symlink.py` (4 cases):
- Plain regular file → uploaded normally.
- Symlink without flag → `ClickException` + exit 1, no upload attempted.
- Symlink with `--follow-symlinks` → resolves and uploads.
- Broken symlink with flag → no upload (broken links report `exists() == False` and fall through to the text branch; the contract is that the symlink target is never read as a file).

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success
- [x] `uv run pytest tests/unit -x -q` — 2561 passed, 5 skipped
- [x] New symlink tests pass standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--follow-symlinks` flag to `notebooklm source add` command. Symlink paths are rejected by default; pass this flag to enable symlink resolution during file uploads.

* **Tests**
  * Added unit tests for symlink handling in the source add command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/476)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->