### PR TITLE
test(vcr): broaden cassette sanitizer + CI guard for cookie/email leaks (T5.E)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,5 +108,10 @@ jobs:
           echo "::warning::Continuing so the non-browser test matrix can run."
         fi
 
+    - name: Assert cassettes are sanitized (T5.E)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: ./tests/check_cassettes_clean.sh
+
     - name: Run tests with coverage
       run: uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90

--- a/tests/check_cassettes_clean.sh
+++ b/tests/check_cassettes_clean.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# CI grep guard for cassette PII leaks.
+#
+# Fails the build (exit 1) if any cassette under tests/cassettes/ contains:
+#   - an unsanitized email at a real provider (gmail, googlemail, google,
+#     anthropic, outlook, hotmail, yahoo, icloud, protonmail)
+#   - an unsanitized Google session cookie value (SID/SAPISID/HSID/SSID/APISID
+#     or any __Secure-[13]PSID variant) whose value does NOT start with 'S'
+#     — the canonical scrubbed sentinel is "SCRUBBED".
+#
+# Usage:
+#   ./tests/check_cassettes_clean.sh
+#
+# Exit codes:
+#   0 — cassettes are clean
+#   1 — one or more leaks found
+set -e
+
+# Use git grep when inside a repo (fast, respects .gitignore); fall back to
+# plain grep otherwise so callers can run this against an untracked seeded
+# cassette in a tmpdir during tests.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    GREP=(git grep -nE)
+else
+    GREP=(grep -rnE)
+fi
+
+email_re='"[A-Za-z0-9._%+-]+@(gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com"'
+cookie_re='"(SID|SAPISID|HSID|SSID|APISID|__Secure-[13]PSID)"[[:space:]]*:[[:space:]]*"[^S][^"]+"'
+
+if "${GREP[@]}" "$email_re" tests/cassettes/ ; then
+    echo "ERROR: unsanitized email found in cassette" >&2
+    exit 1
+fi
+
+if "${GREP[@]}" "$cookie_re" tests/cassettes/ ; then
+    echo "ERROR: unsanitized cookie value found in cassette" >&2
+    exit 1
+fi
+
+echo "OK: cassettes are sanitized"

--- a/tests/check_cassettes_clean.sh
+++ b/tests/check_cassettes_clean.sh
@@ -4,9 +4,19 @@
 # Fails the build (exit 1) if any cassette under tests/cassettes/ contains:
 #   - an unsanitized email at a real provider (gmail, googlemail, google,
 #     anthropic, outlook, hotmail, yahoo, icloud, protonmail)
-#   - an unsanitized Google session cookie value (SID/SAPISID/HSID/SSID/APISID
-#     or any __Secure-[13]PSID variant) whose value does NOT start with 'S'
-#     — the canonical scrubbed sentinel is "SCRUBBED".
+#   - an unsanitized Google session cookie value in any of THREE cookie shapes:
+#       Shape A: HTTP "Cookie: SID=value;" header form.
+#       Shape B: JSON object with the cookie name as the key,
+#                e.g. {"SID":"value"}.
+#       Shape C: Playwright storage_state.json form,
+#                e.g. {"name":"SID","value":"value","domain":"..."}.
+#     A cookie value is considered scrubbed when it starts with 'S' (the
+#     canonical "SCRUBBED" sentinel and its "SCRUBBED_*" variants). See the
+#     "Cookie value heuristic" comment below for the trade-offs.
+#
+# The guard scans all files under ``tests/cassettes/`` (including untracked
+# ones), so a freshly recorded cassette that hasn't been staged yet still gets
+# inspected.
 #
 # Usage:
 #   ./tests/check_cassettes_clean.sh
@@ -16,25 +26,79 @@
 #   1 — one or more leaks found
 set -e
 
-# Use git grep when inside a repo (fast, respects .gitignore); fall back to
-# plain grep otherwise so callers can run this against an untracked seeded
-# cassette in a tmpdir during tests.
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    GREP=(git grep -nE)
-else
-    GREP=(grep -rnE)
+# No cassettes to check (e.g., fresh checkout with no recorded fixtures) is a
+# valid clean state — exit 0 without trying to grep a missing directory, which
+# would otherwise trip ``set -e`` even when no leak exists.
+if [ ! -d "tests/cassettes/" ]; then
+    echo "OK: no cassettes directory to check"
+    exit 0
 fi
 
-email_re='"[A-Za-z0-9._%+-]+@(gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com"'
-cookie_re='"(SID|SAPISID|HSID|SSID|APISID|__Secure-[13]PSID)"[[:space:]]*:[[:space:]]*"[^S][^"]+"'
+# Use plain ``grep -rnE`` (NOT ``git grep``) so the guard also scans cassettes
+# that have just been recorded with ``NOTEBOOKLM_VCR_RECORD=1`` but not yet
+# staged. ``git grep`` would silently skip those untracked files, creating a
+# false-negative path in local pre-commit runs (Claude review on PR #477, #5).
+GREP=(grep -rnE)
+
+# Email regex — matches the address itself (un-anchored on quotes) so an
+# unquoted leak in raw HTML/JS content (e.g., a ``mailto:`` href or an
+# inline-rendered template) is also caught. Aligned with the legacy
+# ``[a-zA-Z0-9._%+-]+@gmail.com`` pattern in ``tests/vcr_config.py`` but
+# broadened to the same provider list as the JSON-aware sanitizer.
+email_re='[A-Za-z0-9._%+-]+@(gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com'
+
+# ---------------------------------------------------------------------------
+# Cookie value heuristic
+#
+# Our sanitizer always replaces real cookie values with strings starting in
+# 'S' — "SCRUBBED" and "SCRUBBED_*" sentinels. We use ``[^S"]`` as the first
+# character of the captured value to reject a scrubbed sentinel while still
+# matching any leaked value whose first character is not 'S'. This is a
+# heuristic: a real leaked token whose first character happens to be 'S'
+# (~1/62 chance for base64) will slip through. We accept that gap because the
+# scrubber upstream is canonical — the guard is a defense-in-depth check, not
+# a content-classifier. ``[^"]*`` (zero or more) covers single-char values as
+# well, so even a one-character leak trips the guard. (Claude review on
+# PR #477, #7.)
+# ---------------------------------------------------------------------------
+
+# Shape A — Cookie header / Set-Cookie style: "SID=value;" where the value
+# does not start with the scrubbed sentinel.
+cookie_header_re='\b(SID|SAPISID|HSID|SSID|APISID|__Secure-[13]PSID)=[^;S][^;]*'
+
+# Shape B — JSON cookie-name-as-key: "SID":"value". Used by request-body JSON
+# the client sends to NotebookLM and any place that dumps cookies into a flat
+# JSON dict.
+cookie_json_key_re='"(SID|SAPISID|HSID|SSID|APISID|__Secure-[13]PSID)"[[:space:]]*:[[:space:]]*"[^S"][^"]*"'
+
+# Shape C — Playwright storage_state.json form:
+#   {"name":"SID", ... ,"value":"realvalue", ...}
+# The value field may appear before or after "name"; we check both orderings.
+cookie_storage_state_re_a='"name"[[:space:]]*:[[:space:]]*"(SID|SAPISID|HSID|SSID|APISID|__Secure-[13]PSID)"[^}]*"value"[[:space:]]*:[[:space:]]*"[^S"][^"]*"'
+cookie_storage_state_re_b='"value"[[:space:]]*:[[:space:]]*"[^S"][^"]*"[^}]*"name"[[:space:]]*:[[:space:]]*"(SID|SAPISID|HSID|SSID|APISID|__Secure-[13]PSID)"'
 
 if "${GREP[@]}" "$email_re" tests/cassettes/ ; then
     echo "ERROR: unsanitized email found in cassette" >&2
     exit 1
 fi
 
-if "${GREP[@]}" "$cookie_re" tests/cassettes/ ; then
-    echo "ERROR: unsanitized cookie value found in cassette" >&2
+if "${GREP[@]}" "$cookie_header_re" tests/cassettes/ ; then
+    echo "ERROR: unsanitized cookie header value found in cassette" >&2
+    exit 1
+fi
+
+if "${GREP[@]}" "$cookie_json_key_re" tests/cassettes/ ; then
+    echo "ERROR: unsanitized cookie JSON-key value found in cassette" >&2
+    exit 1
+fi
+
+if "${GREP[@]}" "$cookie_storage_state_re_a" tests/cassettes/ ; then
+    echo "ERROR: unsanitized Playwright storage_state cookie found in cassette (name-before-value)" >&2
+    exit 1
+fi
+
+if "${GREP[@]}" "$cookie_storage_state_re_b" tests/cassettes/ ; then
+    echo "ERROR: unsanitized Playwright storage_state cookie found in cassette (value-before-name)" >&2
     exit 1
 fi
 

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -1,0 +1,223 @@
+"""Tests for the cassette sanitizer in ``tests/vcr_config.py``.
+
+These tests cover PR-T5.E:
+
+1. Structural display-name scrub (JSON-key-anchored) — positive + negative.
+2. Regression: a legitimate two-Capitalized-word source title in cassette-style
+   JSON is NOT scrubbed (the broad ``>[A-Z][a-z]+\\s[A-Z][a-z]+<`` regex that
+   we deliberately avoided).
+3. Broadened email scrub — positive + negative + idempotency on
+   ``SCRUBBED_EMAIL@example.com``.
+4. The ``tests/check_cassettes_clean.sh`` script exits 0 on clean cassettes and
+   exits 1 when a leak is injected.
+"""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``tests/vcr_config.py`` lives directly under ``tests/`` (not in a package).
+# Other test modules add it to ``sys.path``; we follow the same convention.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO_ROOT / "tests"
+sys.path.insert(0, str(TESTS_DIR))
+
+from vcr_config import scrub_string  # noqa: E402
+
+SCRIPT_PATH = TESTS_DIR / "check_cassettes_clean.sh"
+
+
+# ---------------------------------------------------------------------------
+# Structural display-name scrub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("displayName", "Alice Example"),
+        ("givenName", "Alice"),
+        ("familyName", "Example"),
+    ],
+)
+def test_structural_display_name_scrub_positive(key: str, value: str) -> None:
+    """Each new key-anchored pattern scrubs the value to SCRUBBED_NAME."""
+    text = f'{{"{key}":"{value}"}}'
+    scrubbed = scrub_string(text)
+    assert value not in scrubbed
+    assert f'"{key}":"SCRUBBED_NAME"' in scrubbed
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("displayName", "Alice Example"),
+        ("givenName", "Alice"),
+        ("familyName", "Example"),
+    ],
+)
+def test_structural_display_name_scrub_whitespace_variants(key: str, value: str) -> None:
+    """JSON ``"key": "value"`` with whitespace around the colon is scrubbed."""
+    text = f'{{"{key}" : "{value}"}}'
+    scrubbed = scrub_string(text)
+    assert value not in scrubbed
+    # Replacement does not preserve whitespace; we only assert the value is gone
+    # and the key is now mapped to SCRUBBED_NAME.
+    assert "SCRUBBED_NAME" in scrubbed
+
+
+def test_structural_display_name_scrub_negative_sibling_keys() -> None:
+    """Sibling keys (``title``, ``name``, ``label``) MUST NOT match."""
+    text = '{"title":"My Title","name":"My Name","label":"My Label"}'
+    scrubbed = scrub_string(text)
+    # None of those keys should have been touched.
+    assert scrubbed == text
+
+
+def test_structural_display_name_no_match_on_substring_keys() -> None:
+    """The anchor is the exact JSON key. Keys like ``userDisplayName`` should
+    still match because they end with ``displayName`` — but a key like
+    ``displayNamespace`` must NOT match.
+
+    The current regex requires the closing quote immediately after the key
+    name, so ``displayName`` is required to be the full key. Confirm.
+    """
+    safe = '{"displayNamespace":"keep-me"}'
+    assert scrub_string(safe) == safe
+
+
+# ---------------------------------------------------------------------------
+# Regression: legitimate two-Capitalized-word source title is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_two_capital_word_source_title_not_scrubbed() -> None:
+    """A cassette-style JSON snippet with a two-word source title must survive.
+
+    This guards against re-introducing a broad ``>[A-Z][a-z]+\\s[A-Z][a-z]+<``
+    pattern that would clobber legitimate fixture content.
+    """
+    snippet = '{"title": "Source Title"}'
+    assert scrub_string(snippet) == snippet
+
+
+def test_two_capital_word_in_html_text_not_scrubbed() -> None:
+    """Same regression in an HTML-ish context ``>Source Title<``."""
+    snippet = "<span>Source Title</span>"
+    assert scrub_string(snippet) == snippet
+
+
+# ---------------------------------------------------------------------------
+# Broadened email scrub
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        "gmail",
+        "googlemail",
+        "google",
+        "anthropic",
+        "outlook",
+        "hotmail",
+        "yahoo",
+        "icloud",
+        "protonmail",
+    ],
+)
+def test_broadened_email_scrub_positive(provider: str) -> None:
+    """Quoted emails at any of the supported providers get scrubbed."""
+    text = f'{{"email":"alice.example+tag@{provider}.com"}}'
+    scrubbed = scrub_string(text)
+    assert provider not in scrubbed
+    assert "alice.example" not in scrubbed
+    assert '"SCRUBBED_EMAIL@example.com"' in scrubbed
+
+
+def test_email_scrub_idempotent_on_example_com() -> None:
+    """``SCRUBBED_EMAIL@example.com`` survives a second scrub pass unchanged."""
+    once = scrub_string('{"email":"alice@gmail.com"}')
+    twice = scrub_string(once)
+    assert once == twice
+    assert '"SCRUBBED_EMAIL@example.com"' in twice
+
+
+def test_email_scrub_negative_unrelated_text() -> None:
+    """Domains we don't cover (``@corp.internal``) are left alone — by design."""
+    text = '{"contact":"bob@corp.internal"}'
+    assert scrub_string(text) == text
+
+
+# ---------------------------------------------------------------------------
+# CI grep guard script: clean vs. leak cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Build a minimal repo-shaped tmpdir containing only the guard script and
+    a ``tests/cassettes/`` directory the script will scan.
+
+    The script falls back to plain ``grep -rnE`` outside a git work tree, so we
+    do NOT need to run ``git init`` here — we just need ``tests/cassettes/`` to
+    exist and the script to be executable.
+    """
+    (tmp_path / "tests" / "cassettes").mkdir(parents=True)
+    dest = tmp_path / "tests" / "check_cassettes_clean.sh"
+    shutil.copy2(SCRIPT_PATH, dest)
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return tmp_path
+
+
+def _run_guard(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(repo / "tests" / "check_cassettes_clean.sh")],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_guard_script_exits_zero_on_clean_cassettes(fake_repo: Path) -> None:
+    cassette = fake_repo / "tests" / "cassettes" / "clean.yaml"
+    cassette.write_text(
+        # Already-scrubbed sample content — no real PII, no real cookies.
+        '{"email":"SCRUBBED_EMAIL@example.com","SID":"SCRUBBED"}\n',
+    )
+    result = _run_guard(fake_repo)
+    assert result.returncode == 0, result.stderr
+    assert "OK: cassettes are sanitized" in result.stdout
+
+
+def test_guard_script_exits_one_on_email_leak(fake_repo: Path) -> None:
+    cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
+    cassette.write_text('{"email":"realname@gmail.com"}\n')
+    result = _run_guard(fake_repo)
+    assert result.returncode == 1
+    assert "unsanitized email" in result.stderr
+
+
+def test_guard_script_exits_one_on_cookie_leak(fake_repo: Path) -> None:
+    cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
+    # Cookie value starts with something other than 'S' so it is NOT the
+    # canonical "SCRUBBED" sentinel; the guard regex requires ``[^S][^"]+``.
+    cassette.write_text('{"SAPISID": "abcdef1234567890"}\n')
+    result = _run_guard(fake_repo)
+    assert result.returncode == 1
+    assert "unsanitized cookie" in result.stderr
+
+
+def test_guard_script_allows_scrubbed_cookie_sentinel(fake_repo: Path) -> None:
+    """``"SID": "SCRUBBED"`` must NOT trip the guard."""
+    cassette = fake_repo / "tests" / "cassettes" / "ok.yaml"
+    cassette.write_text('{"SID": "SCRUBBED", "__Secure-1PSID": "SCRUBBED"}\n')
+    result = _run_guard(fake_repo)
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -32,6 +32,17 @@ from vcr_config import scrub_string  # noqa: E402
 
 SCRIPT_PATH = TESTS_DIR / "check_cassettes_clean.sh"
 
+# The shell-script-driven subprocess tests need a POSIX shell + GNU grep.
+# Windows CI runners have git-bash but POSIX-quoting + grep ``-rnE`` semantics
+# don't round-trip cleanly there (path separators, line endings). The shell
+# script is also skipped in CI on Windows (see ``.github/workflows/test.yml``),
+# so we skip the matching subprocess tests here.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="check_cassettes_clean.sh is a POSIX shell script; the Windows CI"
+    " step is gated off and we skip its driver tests in lockstep.",
+)
+
 
 # ---------------------------------------------------------------------------
 # Structural display-name scrub
@@ -81,15 +92,21 @@ def test_structural_display_name_scrub_negative_sibling_keys() -> None:
 
 
 def test_structural_display_name_no_match_on_substring_keys() -> None:
-    """The anchor is the exact JSON key. Keys like ``userDisplayName`` should
-    still match because they end with ``displayName`` — but a key like
-    ``displayNamespace`` must NOT match.
+    """The regex requires the JSON key to be exactly ``displayName`` (the
+    opening quote is part of the match). So keys that *contain* the substring
+    ``displayName`` but are not equal to it MUST NOT match:
 
-    The current regex requires the closing quote immediately after the key
-    name, so ``displayName`` is required to be the full key. Confirm.
+    - ``displayNamespace`` — extra trailing characters before the closing quote
+    - ``userDisplayName`` — extra leading characters after the opening quote
+
+    Confirms the anchor is exact-key on both sides, not a substring match.
+    (Claude review on PR #477, #6 — earlier docstring claimed
+    ``userDisplayName`` would still match, which was wrong.)
     """
-    safe = '{"displayNamespace":"keep-me"}'
-    assert scrub_string(safe) == safe
+    extra_trailing = '{"displayNamespace":"keep-me"}'
+    extra_leading = '{"userDisplayName":"Alice Example"}'
+    assert scrub_string(extra_trailing) == extra_trailing
+    assert scrub_string(extra_leading) == extra_leading
 
 
 # ---------------------------------------------------------------------------
@@ -118,20 +135,20 @@ def test_two_capital_word_in_html_text_not_scrubbed() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "provider",
-    [
-        "gmail",
-        "googlemail",
-        "google",
-        "anthropic",
-        "outlook",
-        "hotmail",
-        "yahoo",
-        "icloud",
-        "protonmail",
-    ],
-)
+_EMAIL_PROVIDERS = [
+    "gmail",
+    "googlemail",
+    "google",
+    "anthropic",
+    "outlook",
+    "hotmail",
+    "yahoo",
+    "icloud",
+    "protonmail",
+]
+
+
+@pytest.mark.parametrize("provider", _EMAIL_PROVIDERS)
 def test_broadened_email_scrub_positive(provider: str) -> None:
     """Quoted emails at any of the supported providers get scrubbed."""
     text = f'{{"email":"alice.example+tag@{provider}.com"}}'
@@ -139,6 +156,21 @@ def test_broadened_email_scrub_positive(provider: str) -> None:
     assert provider not in scrubbed
     assert "alice.example" not in scrubbed
     assert '"SCRUBBED_EMAIL@example.com"' in scrubbed
+
+
+@pytest.mark.parametrize("provider", _EMAIL_PROVIDERS)
+def test_broadened_email_scrub_unquoted_context(provider: str) -> None:
+    """Unquoted emails in raw HTML/JS contexts get scrubbed too.
+
+    Addresses gemini-code-assist review feedback on PR #477: the legacy
+    unquoted-context fallback was Gmail-only; it now covers the full provider
+    list, mirroring the JSON-quoted pattern.
+    """
+    text = f'<a href="mailto:alice.example+tag@{provider}.com">Mail me</a>'
+    scrubbed = scrub_string(text)
+    assert provider not in scrubbed
+    assert "alice.example" not in scrubbed
+    assert "SCRUBBED_EMAIL@example.com" in scrubbed
 
 
 def test_email_scrub_idempotent_on_example_com() -> None:
@@ -157,6 +189,10 @@ def test_email_scrub_negative_unrelated_text() -> None:
 
 # ---------------------------------------------------------------------------
 # CI grep guard script: clean vs. leak cases
+#
+# All tests below shell out to ``bash`` + ``grep -rnE``; we skip them on
+# Windows in lockstep with the CI workflow (``runner.os != 'Windows'`` on the
+# guard step in .github/workflows/test.yml).
 # ---------------------------------------------------------------------------
 
 
@@ -186,6 +222,7 @@ def _run_guard(repo: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+@_skip_on_windows
 def test_guard_script_exits_zero_on_clean_cassettes(fake_repo: Path) -> None:
     cassette = fake_repo / "tests" / "cassettes" / "clean.yaml"
     cassette.write_text(
@@ -197,6 +234,7 @@ def test_guard_script_exits_zero_on_clean_cassettes(fake_repo: Path) -> None:
     assert "OK: cassettes are sanitized" in result.stdout
 
 
+@_skip_on_windows
 def test_guard_script_exits_one_on_email_leak(fake_repo: Path) -> None:
     cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
     cassette.write_text('{"email":"realname@gmail.com"}\n')
@@ -205,19 +243,99 @@ def test_guard_script_exits_one_on_email_leak(fake_repo: Path) -> None:
     assert "unsanitized email" in result.stderr
 
 
-def test_guard_script_exits_one_on_cookie_leak(fake_repo: Path) -> None:
+@_skip_on_windows
+def test_guard_script_exits_one_on_cookie_json_key_leak(fake_repo: Path) -> None:
+    """Shape B — JSON dict with the cookie name as a top-level key."""
     cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
     # Cookie value starts with something other than 'S' so it is NOT the
     # canonical "SCRUBBED" sentinel; the guard regex requires ``[^S][^"]+``.
     cassette.write_text('{"SAPISID": "abcdef1234567890"}\n')
     result = _run_guard(fake_repo)
     assert result.returncode == 1
-    assert "unsanitized cookie" in result.stderr
+    assert "JSON-key" in result.stderr or "cookie" in result.stderr
 
 
+@_skip_on_windows
+def test_guard_script_exits_one_on_cookie_header_leak(fake_repo: Path) -> None:
+    """Shape A — HTTP ``Cookie:`` / ``Set-Cookie:`` header form."""
+    cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
+    cassette.write_text("Set-Cookie: SID=abc1234567xyz; Path=/\n")
+    result = _run_guard(fake_repo)
+    assert result.returncode == 1
+    assert "cookie header" in result.stderr
+
+
+@_skip_on_windows
+def test_guard_script_exits_one_on_storage_state_leak_name_first(fake_repo: Path) -> None:
+    """Shape C — Playwright ``storage_state.json``, ``name`` before ``value``."""
+    cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
+    cassette.write_text(
+        '{"name":"SID","value":"abc1234567","domain":".google.com"}\n',
+    )
+    result = _run_guard(fake_repo)
+    assert result.returncode == 1
+    assert "storage_state" in result.stderr
+
+
+@_skip_on_windows
+def test_guard_script_exits_one_on_storage_state_leak_value_first(fake_repo: Path) -> None:
+    """Shape C — Playwright ``storage_state.json``, ``value`` before ``name``."""
+    cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
+    cassette.write_text(
+        '{"value":"abc1234567","name":"__Secure-1PSID","domain":".google.com"}\n',
+    )
+    result = _run_guard(fake_repo)
+    assert result.returncode == 1
+    assert "storage_state" in result.stderr
+
+
+@_skip_on_windows
+def test_guard_script_catches_single_char_cookie_leak(fake_repo: Path) -> None:
+    """A 1-character cookie value (``"SID": "x"``) still trips the guard.
+
+    Earlier the cookie-value regex was ``[^S][^"]+`` which required two-or-more
+    characters; a single-character non-scrubbed leak slipped through. The
+    regex was tightened to ``[^S"][^"]*`` (Claude review on PR #477, #7).
+    """
+    cassette = fake_repo / "tests" / "cassettes" / "leak.yaml"
+    cassette.write_text('{"SID": "x"}\n')
+    result = _run_guard(fake_repo)
+    assert result.returncode == 1
+
+
+@_skip_on_windows
+def test_guard_script_exits_zero_when_cassettes_directory_missing(tmp_path: Path) -> None:
+    """Fresh checkouts with no recorded cassettes must not fail the guard.
+
+    Addresses gemini-code-assist review feedback on PR #477.
+    """
+    dest = tmp_path / "tests" / "check_cassettes_clean.sh"
+    dest.parent.mkdir()
+    shutil.copy2(SCRIPT_PATH, dest)
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    # NOTE: deliberately do NOT create tests/cassettes/.
+    result = subprocess.run(
+        ["bash", str(dest)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "no cassettes" in result.stdout
+
+
+@_skip_on_windows
 def test_guard_script_allows_scrubbed_cookie_sentinel(fake_repo: Path) -> None:
-    """``"SID": "SCRUBBED"`` must NOT trip the guard."""
+    """All three cookie shapes with the ``SCRUBBED`` sentinel must NOT trip the guard."""
     cassette = fake_repo / "tests" / "cassettes" / "ok.yaml"
-    cassette.write_text('{"SID": "SCRUBBED", "__Secure-1PSID": "SCRUBBED"}\n')
+    cassette.write_text(
+        # Shape B — JSON dict, cookie name as key
+        '{"SID": "SCRUBBED", "__Secure-1PSID": "SCRUBBED"}\n'
+        # Shape A — HTTP header
+        "Set-Cookie: SID=SCRUBBED; Path=/\n"
+        # Shape C — Playwright storage_state
+        '{"name":"SAPISID","value":"SCRUBBED","domain":".google.com"}\n',
+    )
     result = _run_guard(fake_repo)
     assert result.returncode == 0, result.stderr

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -84,10 +84,30 @@ SENSITIVE_PATTERNS: list[tuple[str, str]] = [
     # ==========================================================================
     # PII scrubbing for Google account holder information
     # ==========================================================================
-    # Generic email pattern for Gmail/Google accounts (safe - only in account context)
+    # Broadened email scrub: common providers + idempotent on @example.com
+    # (the replacement value itself contains @example.com, so a second pass is a no-op).
+    # NOTE: we intentionally exclude @example.com from the match so SCRUBBED_EMAIL@example.com
+    #   left from a previous scrub round-trips cleanly.
+    (
+        r'"[A-Za-z0-9._%+\-]+@(?:gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com"',
+        '"SCRUBBED_EMAIL@example.com"',
+    ),
+    # Legacy unquoted-context fallback for raw Gmail mentions (e.g. inside HTML/JS chunks).
     (r"[a-zA-Z0-9._%+-]+@gmail\.com", "SCRUBBED_EMAIL@example.com"),
     # Display name in aria-label (generic - "Google Account:" prefix is specific enough)
     (r"Google Account: [^\"<]+", "Google Account: SCRUBBED_NAME"),
+    # ----------------------------------------------------------------
+    # Structural display-name scrub — JSON-key-anchored ONLY.
+    # We do NOT use a broad ``>[A-Z][a-z]+\s[A-Z][a-z]+<`` pattern: that would
+    # also clobber legitimate two-Capitalized-word fixture content such as
+    # ``>Source Title<`` in source-rename cassettes. Anchoring on the JSON key
+    # keeps the scrubber surgical.
+    # ----------------------------------------------------------------
+    (r'"displayName"\s*:\s*"[^"]+"', '"displayName":"SCRUBBED_NAME"'),
+    (r'"givenName"\s*:\s*"[^"]+"', '"givenName":"SCRUBBED_NAME"'),
+    (r'"familyName"\s*:\s*"[^"]+"', '"familyName":"SCRUBBED_NAME"'),
+    # Legacy hard-coded patterns (kept for backward compat with existing cassettes
+    # that were sanitized before the structural patterns above were added).
     # Display name in HTML tags (user-specific - add your name if recording new cassettes)
     (r">People Conf<", ">SCRUBBED_NAME<"),
     # Display name in JSON (user-specific - add your name if recording new cassettes)

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -92,8 +92,14 @@ SENSITIVE_PATTERNS: list[tuple[str, str]] = [
         r'"[A-Za-z0-9._%+\-]+@(?:gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com"',
         '"SCRUBBED_EMAIL@example.com"',
     ),
-    # Legacy unquoted-context fallback for raw Gmail mentions (e.g. inside HTML/JS chunks).
-    (r"[a-zA-Z0-9._%+-]+@gmail\.com", "SCRUBBED_EMAIL@example.com"),
+    # Unquoted-context fallback for raw email mentions (e.g. inside HTML/JS
+    # chunks, mailto: hrefs, or rendered templates). Broadened to match the
+    # same provider list as the JSON-quoted pattern above so the two stay in
+    # sync — gemini-code-assist review thread on PR #477.
+    (
+        r"[a-zA-Z0-9._%+-]+@(?:gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com",
+        "SCRUBBED_EMAIL@example.com",
+    ),
     # Display name in aria-label (generic - "Google Account:" prefix is specific enough)
     (r"Google Account: [^\"<]+", "Google Account: SCRUBBED_NAME"),
     # ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Broadens the cassette sanitizer in `tests/vcr_config.py` so we no longer rely on hard-coded display names or a single email provider, and adds a CI grep guard that fails the build if any unsanitized cookie/email value slips into `tests/cassettes/`.

- **Structural display-name scrub** (JSON-key-anchored ONLY) for `displayName` / `givenName` / `familyName`. We deliberately avoid a broad `>[A-Z][a-z]+\s[A-Z][a-z]+<` pattern because it would clobber legitimate two-word source titles in cassette fixtures.
- **Broadened email scrub** covering gmail / googlemail / google / anthropic / outlook / hotmail / yahoo / icloud / protonmail. `@example.com` is intentionally excluded so `SCRUBBED_EMAIL@example.com` round-trips cleanly (idempotent).
- New `tests/check_cassettes_clean.sh` — runs in `Test` workflow on Linux + macOS before pytest. Fails the build on any unsanitized provider email or any `SID/SAPISID/HSID/SSID/APISID/__Secure-[13]PSID` whose value does not start with `SCRUBBED`.
- New `tests/unit/test_cassette_sanitizer.py` — 25 tests covering positive + negative cases per pattern, an explicit regression test that a `{"title": "Source Title"}` snippet is NOT scrubbed, and `subprocess.run` coverage of the guard script for clean / leaked / sentinel inputs.

Refs: T5.E in `.sisyphus/plans/tier-5-implementation.md`.

## Test plan

- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest tests/unit -x -q` — 2582 passed, 5 skipped
- [x] `./tests/check_cassettes_clean.sh` exits 0 on the current repo
- [x] Manual: seeded `"x@gmail.com"` and `"SID": "abc..."` cassette leaks both trip the guard with exit 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI validation step to detect and prevent sensitive data leaks in test cassettes.

* **Tests**
  * Expanded test coverage for cassette sanitization, including email, cookie, and PII scrubbing scenarios.
  * Updated sanitization rules to provide broader protection against common data exposure patterns across multiple providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/477)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->