### PR TITLE
feat(migration): single-writer migrate_to_profiles() under filelock (T5.B)

### DIFF
--- a/src/notebooklm/migration.py
+++ b/src/notebooklm/migration.py
@@ -8,6 +8,8 @@ The migration is:
 - Idempotent: safe to run multiple times
 - Crash-safe: uses copy-then-delete with marker file
 - Non-destructive: originals kept until all copies succeed
+- Single-writer: cross-process ``filelock`` serializes concurrent CLI
+  invocations so a container start-up race cannot interleave copies.
 """
 
 import json
@@ -15,16 +17,29 @@ import logging
 import shutil
 import sys
 
+from filelock import FileLock, Timeout
+
 from ._atomic_io import atomic_update_json
 from .paths import get_config_path, get_home_dir
 
 logger = logging.getLogger(__name__)
 
 _MIGRATION_MARKER = ".migration_complete"
+_MIGRATION_LOCK = ".migration.lock"
+_MIGRATION_LOCK_TIMEOUT = 30.0
 
 # Legacy files that should be moved into profiles/default/
 _LEGACY_FILES = ["storage_state.json", "context.json"]
 _LEGACY_DIRS = ["browser_profile"]
+
+
+class MigrationLockTimeoutError(RuntimeError):
+    """Raised when ``migrate_to_profiles()`` cannot acquire the migration lock.
+
+    Surfaces the underlying :class:`filelock.Timeout` so callers can
+    distinguish a stuck peer from other migration failures (e.g., a CI
+    runner whose previous job left a stale process holding the lock).
+    """
 
 
 def _has_legacy_files(home) -> bool:
@@ -45,11 +60,53 @@ def migrate_to_profiles() -> bool:
     2. Delete originals
     3. Write .migration_complete marker (last — incomplete runs retry)
 
+    The migration body runs under a cross-process ``filelock`` rooted at
+    ``<home>/.migration.lock`` so concurrent CLI invocations (e.g., a
+    container start-up race) cannot interleave copies. The loser of the
+    race re-checks the marker inside the lock and no-ops.
+
     Returns:
         True if migration was performed, False if already migrated or no-op.
+
+    Raises:
+        MigrationLockTimeoutError: If the migration lock cannot be acquired
+            within ``_MIGRATION_LOCK_TIMEOUT`` seconds — usually means a
+            sibling process is stuck mid-migration.
     """
     home = get_home_dir()
+
+    # Ensure the home dir exists BEFORE the lock so ``filelock`` has a
+    # writable parent for the lock file. Permissions are also set here.
+    get_home_dir(create=True)
+
+    lock_path = home / _MIGRATION_LOCK
+    try:
+        with FileLock(str(lock_path), timeout=_MIGRATION_LOCK_TIMEOUT):
+            return _migrate_to_profiles_locked(home)
+    except Timeout as exc:
+        raise MigrationLockTimeoutError(
+            f"Could not acquire migration lock at {lock_path} within "
+            f"{_MIGRATION_LOCK_TIMEOUT:.0f}s; another process may be "
+            "stuck mid-migration."
+        ) from exc
+
+
+def _migrate_to_profiles_locked(home) -> bool:
+    """Core migration body, executed while holding the migration lock.
+
+    Split out so the lock-acquisition wrapper stays small and the locked
+    region is straightforward to reason about.
+    """
     profiles_dir = home / "profiles"
+    default_dir = profiles_dir / "default"
+
+    # Inside the lock, re-check the marker FIRST. If another process completed
+    # the migration while we were waiting, the marker is the authoritative
+    # signal — return immediately as a no-op. The marker lives at
+    # ``default_dir / _MIGRATION_MARKER`` (NOT the home root); see the
+    # marker-write site at the end of this function.
+    if (default_dir / _MIGRATION_MARKER).exists() and not _has_legacy_files(home):
+        return False
 
     # Already migrated: profiles dir exists and no legacy files left to clean up
     if profiles_dir.exists() and not _has_legacy_files(home):
@@ -60,8 +117,7 @@ def migrate_to_profiles() -> bool:
     legacy_dirs = [home / name for name in _LEGACY_DIRS if (home / name).is_dir()]
 
     if not legacy_files and not legacy_dirs:
-        # Fresh install — ensure home dir has correct permissions first
-        get_home_dir(create=True)
+        # Fresh install — home dir permissions already set by caller.
         if sys.platform == "win32":
             profiles_dir.mkdir(exist_ok=True)
         else:
@@ -70,9 +126,6 @@ def migrate_to_profiles() -> bool:
         return True
 
     # Migrate legacy files into profiles/default/
-    # Ensure home dir has correct 0o700 permissions (may already exist from legacy)
-    get_home_dir(create=True)
-    default_dir = profiles_dir / "default"
     if sys.platform == "win32":
         default_dir.mkdir(parents=True, exist_ok=True)
     else:
@@ -101,13 +154,18 @@ def migrate_to_profiles() -> bool:
             shutil.copytree(src, dst)
             logger.debug("Copied %s/ → %s/", src.name, dst)
 
-    # Remove originals (copies already in place as fallback)
+    # Remove originals (copies already in place as fallback). Tolerate
+    # already-removed paths (a previous interrupted run, or another
+    # concurrent migration that partially completed before we entered).
     for src in legacy_files:
-        src.unlink()
+        try:
+            src.unlink()
+        except FileNotFoundError:
+            pass
         logger.debug("Removed legacy %s", src.name)
 
     for src in legacy_dirs:
-        shutil.rmtree(src)
+        shutil.rmtree(src, ignore_errors=True)
         logger.debug("Removed legacy %s/", src.name)
 
     # Update config.json with default_profile

--- a/src/notebooklm/migration.py
+++ b/src/notebooklm/migration.py
@@ -73,11 +73,10 @@ def migrate_to_profiles() -> bool:
             within ``_MIGRATION_LOCK_TIMEOUT`` seconds — usually means a
             sibling process is stuck mid-migration.
     """
-    home = get_home_dir()
-
     # Ensure the home dir exists BEFORE the lock so ``filelock`` has a
-    # writable parent for the lock file. Permissions are also set here.
-    get_home_dir(create=True)
+    # writable parent for the lock file. Permissions (0o700 on POSIX) are
+    # also set here, before any concurrent peer can observe an open dir.
+    home = get_home_dir(create=True)
 
     lock_path = home / _MIGRATION_LOCK
     try:

--- a/tests/unit/test_migration_lock.py
+++ b/tests/unit/test_migration_lock.py
@@ -62,6 +62,12 @@ def test_concurrent_threads_only_one_migrates(tmp_path: Path) -> None:
     the lock, both threads would copy + delete, racing on the same legacy
     files (and the second ``unlink`` would have crashed pre-fix with
     ``FileNotFoundError``).
+
+    Note: thread-based contention exercises ``filelock``'s internal
+    ``threading.Lock`` rather than the OS-level ``fcntl``/``LockFileEx``
+    layer that production cross-process races would hit. The invariant
+    under test — single-writer migration body — is identical in both
+    cases; we accept the unit-test tradeoff to avoid subprocess overhead.
     """
     _seed_legacy_layout(tmp_path)
 

--- a/tests/unit/test_migration_lock.py
+++ b/tests/unit/test_migration_lock.py
@@ -1,0 +1,209 @@
+"""Tests for cross-process locking in :func:`migrate_to_profiles`.
+
+The migration moves legacy flat-layout files into ``profiles/default/`` and
+must run as a single writer: two ``notebooklm`` CLI invocations starting
+under a fresh home (e.g., container start-up race) would otherwise both
+copy + delete, leaving partial state visible to either.
+
+Critical invariants exercised here:
+
+* Two concurrent threads → exactly one copy is performed; the second
+  observes the marker inside the lock and no-ops.
+* Pre-existing partial state (a legacy source dir removed mid-migration)
+  does not crash the loser of the race.
+* The lock file is intentionally left on disk after migration completes
+  (``filelock`` reuses lock files across runs — see ``_atomic_io.py``).
+* A held lock surfaces :class:`MigrationLockTimeoutError` rather than
+  blocking forever.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from filelock import FileLock
+
+from notebooklm.migration import (
+    _MIGRATION_LOCK,
+    _MIGRATION_MARKER,
+    MigrationLockTimeoutError,
+    migrate_to_profiles,
+)
+from notebooklm.paths import _reset_config_cache, set_active_profile
+
+
+@pytest.fixture(autouse=True)
+def _reset_profile_state():
+    """Reset module-level profile state between tests."""
+    set_active_profile(None)
+    _reset_config_cache()
+    yield
+    set_active_profile(None)
+    _reset_config_cache()
+
+
+def _seed_legacy_layout(home: Path) -> None:
+    """Create a minimal legacy flat layout under ``home``."""
+    (home / "storage_state.json").write_text('{"cookies":[]}', encoding="utf-8")
+    (home / "context.json").write_text('{"notebook_id":"nb1"}', encoding="utf-8")
+    (home / "browser_profile").mkdir()
+    (home / "browser_profile" / "data").write_text("chrome data", encoding="utf-8")
+
+
+def test_concurrent_threads_only_one_migrates(tmp_path: Path) -> None:
+    """Two threads race on a fresh home — only one performs the copy.
+
+    The loser must acquire the lock AFTER the winner has written the
+    marker, re-check the marker, and return ``False`` as a no-op. Without
+    the lock, both threads would copy + delete, racing on the same legacy
+    files (and the second ``unlink`` would have crashed pre-fix with
+    ``FileNotFoundError``).
+    """
+    _seed_legacy_layout(tmp_path)
+
+    results: list[bool] = []
+    errors: list[BaseException] = []
+    barrier = threading.Barrier(2)
+
+    def worker() -> None:
+        try:
+            barrier.wait()
+            with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+                results.append(migrate_to_profiles())
+        except BaseException as exc:  # noqa: BLE001 - capture all failures
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"unexpected exception(s) in worker(s): {errors}"
+    assert sorted(results) == [False, True], (
+        f"exactly one thread should migrate; got results={results}"
+    )
+
+    default_dir = tmp_path / "profiles" / "default"
+    assert (default_dir / _MIGRATION_MARKER).exists()
+    assert (default_dir / "storage_state.json").exists()
+    assert (default_dir / "context.json").exists()
+    assert (default_dir / "browser_profile" / "data").exists()
+    # Originals removed exactly once — no leftover legacy files.
+    assert not (tmp_path / "storage_state.json").exists()
+    assert not (tmp_path / "context.json").exists()
+    assert not (tmp_path / "browser_profile").exists()
+
+
+def test_loser_tolerates_partial_state_mid_race(tmp_path: Path) -> None:
+    """Pre-existing partial state (legacy dir removed) does not crash.
+
+    Simulates the window where the winner copied + unlinked the legacy
+    files but the loser entered before the marker was written. The loser
+    must not crash on the missing source paths.
+    """
+    _seed_legacy_layout(tmp_path)
+
+    # Simulate winner having copied + removed legacy files BUT not yet
+    # written the marker (which is normally the last step).
+    default_dir = tmp_path / "profiles" / "default"
+    default_dir.mkdir(parents=True)
+    (default_dir / "storage_state.json").write_text('{"cookies":[]}', encoding="utf-8")
+    (default_dir / "context.json").write_text('{"notebook_id":"nb1"}', encoding="utf-8")
+    (default_dir / "browser_profile").mkdir()
+    (default_dir / "browser_profile" / "data").write_text("chrome data", encoding="utf-8")
+
+    # Remove the legacy SOURCES (winner already unlinked them) but skip
+    # writing the marker (winner crashed before marker write).
+    (tmp_path / "storage_state.json").unlink()
+    (tmp_path / "context.json").unlink()
+    import shutil as _shutil
+
+    _shutil.rmtree(tmp_path / "browser_profile")
+
+    # Loser enters with NO legacy files left and NO marker yet — exercises
+    # the "already migrated" no-legacy branch.
+    with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+        # Must not raise on already-removed sources.
+        result = migrate_to_profiles()
+
+    assert result is False
+    # Profile copies are intact regardless of which branch the loser took.
+    assert (default_dir / "storage_state.json").exists()
+    assert (default_dir / "context.json").exists()
+
+
+def test_lock_does_not_block_subsequent_runs(tmp_path: Path) -> None:
+    """The migration lock does not interfere with subsequent invocations.
+
+    ``filelock`` on POSIX unlinks the lock file on release (3.25+ behavior),
+    while on Windows the file may persist — either outcome is acceptable
+    because the lock is recreated lazily on next acquisition. What matters
+    is that subsequent ``migrate_to_profiles()`` calls are clean no-ops
+    and do not leave the home dir in a broken state.
+    """
+    _seed_legacy_layout(tmp_path)
+
+    with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+        assert migrate_to_profiles() is True
+
+    # Subsequent invocations are clean no-ops — proves the lock state from
+    # the first run did not poison the second acquisition.
+    with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+        assert migrate_to_profiles() is False
+        assert migrate_to_profiles() is False
+
+    # Marker still present — no accidental wipe.
+    assert (tmp_path / "profiles" / "default" / _MIGRATION_MARKER).exists()
+
+
+def test_held_lock_surfaces_timeout_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A held lock causes :class:`MigrationLockTimeoutError` to surface.
+
+    A separate thread holds the lock for the duration of the call under
+    test; we shrink the timeout to 1s so the test runs quickly. The
+    expected outcome is the new wrapper exception, NOT a raw
+    :class:`filelock.Timeout` (callers should see a domain-specific
+    error).
+    """
+    # Pre-create the home so the lock file's parent directory exists.
+    tmp_path.mkdir(exist_ok=True)
+    _seed_legacy_layout(tmp_path)
+
+    lock_path = tmp_path / _MIGRATION_LOCK
+    holder = FileLock(str(lock_path))
+    holder.acquire()
+
+    # Shrink the migration timeout so the assertion runs in ~1 second.
+    monkeypatch.setattr("notebooklm.migration._MIGRATION_LOCK_TIMEOUT", 1.0, raising=True)
+
+    try:
+        with (
+            patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True),
+            pytest.raises(MigrationLockTimeoutError) as exc_info,
+        ):
+            migrate_to_profiles()
+    finally:
+        holder.release()
+
+    # Wrapper preserves the underlying filelock Timeout as the cause.
+    assert exc_info.value.__cause__ is not None
+    assert "migration lock" in str(exc_info.value).lower()
+
+    # Once released, the call succeeds — proves the lock was the cause.
+    with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
+        assert migrate_to_profiles() is True
+
+
+def test_migration_lock_timeout_error_is_runtime_error() -> None:
+    """The exception class is a ``RuntimeError`` subclass.
+
+    Lets callers catch ``RuntimeError`` and still hit our migration-
+    specific failure (matches the existing ``RuntimeError`` pattern in
+    ``auth.py``).
+    """
+    assert issubclass(MigrationLockTimeoutError, RuntimeError)


### PR DESCRIPTION
## Summary

Two `notebooklm` CLI invocations starting under a fresh home (e.g., a container start-up race) previously both ran the copy + delete migration concurrently, producing partial state visible to either. This PR wraps the migration body in a cross-process `filelock` rooted at `<home>/.migration.lock` and re-checks the `.migration_complete` marker inside the lock so the loser of the race no-ops cleanly.

- New exception `MigrationLockTimeoutError(RuntimeError)` for the >30s wait case; raw `filelock.Timeout` is wrapped so callers see a domain-specific failure.
- Legacy-source unlink/rmtree is now tolerant of already-removed paths so a concurrent migration that crashed mid-run between copy and marker write does not crash the next runner.
- Marker re-check uses `default_dir / _MIGRATION_MARKER` (the path where `migration.py` actually writes the marker), not the home root.

Closes the T5.B item in `.sisyphus/plans/tier-5-implementation.md`.

## Test plan

- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit -x -q` (2562 passed, 5 skipped)
- [x] New `tests/unit/test_migration_lock.py` covers:
  - Two-thread race produces exactly one `True` + one `False`, profile dir + marker intact, originals removed exactly once.
  - Pre-existing partial state (legacy sources already unlinked, marker not yet written) does not crash the loser.
  - Subsequent invocations are clean no-ops (lock state from first run does not poison second acquisition; marker survives).
  - Held lock surfaces `MigrationLockTimeoutError` with the underlying `filelock.Timeout` preserved as `__cause__`.
  - `MigrationLockTimeoutError` is a `RuntimeError` subclass (matches the existing `RuntimeError` pattern in `auth.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)