### PR TITLE
feat(exceptions): truncate response_preview to 80 chars; NOTEBOOKLM_DEBUG=1 opt-in (T5.D)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -278,6 +278,29 @@ If the IDs don't match, the method ID has changed. Report the new ID in a GitHub
 - Try with fewer sources selected
 - Reduce generation frequency
 
+#### How to get the full response preview from an RPCError
+
+`RPCError.raw_response` is truncated to **80 chars + `"..."`** by default so
+error messages stay readable in logs and CLI output. When you need the
+full body to diagnose schema drift or a malformed response, opt in:
+
+```bash
+NOTEBOOKLM_DEBUG=1 notebooklm <your-command>
+```
+
+Or in Python, set the env var before instantiating the client:
+
+```python
+import os
+os.environ["NOTEBOOKLM_DEBUG"] = "1"
+
+from notebooklm import NotebookLMClient
+# Subsequent RPCError instances will carry the full untruncated body.
+```
+
+The value must be exactly `"1"` — `"0"`, `"true"`, etc. are treated as
+unset (still truncated).
+
 #### "RPCError: [3]" or "UserDisplayableError"
 
 **Cause:** Google API returned an error, typically:
@@ -590,6 +613,7 @@ Windows systems with non-English locales (Chinese cp950, Japanese cp932, etc.) m
 |----------|---------|--------|
 | `NOTEBOOKLM_LOG_LEVEL` | `WARNING` | Set to `DEBUG`, `INFO`, `WARNING`, or `ERROR` |
 | `NOTEBOOKLM_DEBUG_RPC` | (unset) | Legacy: Set to `1` to enable `DEBUG` level |
+| `NOTEBOOKLM_DEBUG` | (unset) | Set to `1` to preserve the full raw RPC response body on `RPCError.raw_response` (default: truncated to 80 chars + `"..."`) |
 
 **When to use each level:**
 

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -21,6 +21,14 @@ from .helpers import (
     with_client,
 )
 
+# UI-only cap for the research summary preview shown in `research status` /
+# `research wait`. Unlike RPC error previews (see
+# :func:`notebooklm.exceptions._truncate_response_preview`), this is a
+# user-facing display cap — not a leak-prevention truncation — and intentionally
+# does not respect ``NOTEBOOKLM_DEBUG`` (users can re-fetch the full summary
+# with the underlying API or with `research wait --import-all`).
+_SUMMARY_PREVIEW_CHARS = 500
+
 
 @click.group()
 def research():
@@ -91,7 +99,7 @@ def research_status(ctx, notebook_id, json_output, client_auth):
                 display_research_sources(sources)
 
                 if summary:
-                    console.print(f"\n[bold]Summary:[/bold]\n{summary[:500]}")
+                    console.print(f"\n[bold]Summary:[/bold]\n{summary[:_SUMMARY_PREVIEW_CHARS]}")
 
                 display_report(status.get("report", ""))
 

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -264,14 +264,13 @@ class UnknownRPCMethodError(DecodingError):
         # Override base found_ids with the typed list (may contain ints).
         if found_ids is not None:
             self.found_ids = found_ids  # type: ignore[assignment]
-        # Honor RPCError's truncation contract for stringy raw_response while
-        # preserving non-string payloads (dict/list/etc) supported by this
-        # subclass's widened ``Any`` type.
-        self.raw_response = (
-            _truncate_response_preview(raw_response)
-            if isinstance(raw_response, str)
-            else raw_response
-        )
+        # The base class already truncated the string branch via
+        # ``_truncate_response_preview`` (see ``base_raw_response`` above).
+        # Only override here for non-string payloads (dict/list/etc) supported
+        # by this subclass's widened ``Any`` type — those bypass the base
+        # class's ``str | None`` contract entirely.
+        if not isinstance(raw_response, str):
+            self.raw_response = raw_response
         self.data_at_failure = data_at_failure
 
     def __str__(self) -> str:

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -14,10 +14,28 @@ Example:
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Any
 
 from ._env import DEFAULT_BASE_URL, get_base_url
+
+
+def _truncate_response_preview(raw: str | None) -> str | None:
+    """Truncate a raw RPC response preview for safe display in error contexts.
+
+    Default behavior keeps the preview compact (80 chars + ``"..."`` suffix) so
+    error logs and CLI output stay readable. Set ``NOTEBOOKLM_DEBUG=1`` to opt
+    into the full untruncated body for deep debugging.
+    """
+    if raw is None:
+        return None
+    if os.environ.get("NOTEBOOKLM_DEBUG") == "1":
+        return raw
+    if len(raw) > 80:
+        return raw[:80] + "..."
+    return raw
+
 
 __all__ = [
     # Base
@@ -134,7 +152,9 @@ class RPCError(NotebookLMError):
 
     Attributes:
         method_id: The RPC method ID (e.g., "abc123") for debugging.
-        raw_response: First 500 chars of raw response for debugging.
+        raw_response: First 80 chars of raw response for debugging
+            (with ``"..."`` suffix if truncated). Set ``NOTEBOOKLM_DEBUG=1`` to
+            preserve the full body.
         rpc_code: Google's internal error code if available.
         found_ids: List of RPC IDs found in the response (for debugging).
     """
@@ -150,7 +170,7 @@ class RPCError(NotebookLMError):
     ):
         super().__init__(message)
         self.method_id = method_id
-        self.raw_response = raw_response[:500] if raw_response else None
+        self.raw_response = _truncate_response_preview(raw_response)
         self.rpc_code = rpc_code
         self.found_ids = found_ids or []
 
@@ -202,7 +222,8 @@ class UnknownRPCMethodError(DecodingError):
             this error (e.g. ``"_notebooks.list"``).
         found_ids: When raised by the response-level decoder, the list of RPC
             IDs actually present in the response.
-        raw_response: First 500 chars of the raw response, when available.
+        raw_response: First 80 chars of the raw response, when available
+            (``NOTEBOOKLM_DEBUG=1`` preserves the full body).
         data_at_failure: Truncated repr (~200 chars) of the data the helper
             was attempting to index into when descent failed.
     """
@@ -243,10 +264,14 @@ class UnknownRPCMethodError(DecodingError):
         # Override base found_ids with the typed list (may contain ints).
         if found_ids is not None:
             self.found_ids = found_ids  # type: ignore[assignment]
-        # Honor RPCError's 500-char truncation contract for stringy
-        # raw_response while preserving non-string payloads (dict/list/etc)
-        # supported by this subclass's widened ``Any`` type.
-        self.raw_response = raw_response[:500] if isinstance(raw_response, str) else raw_response
+        # Honor RPCError's truncation contract for stringy raw_response while
+        # preserving non-string payloads (dict/list/etc) supported by this
+        # subclass's widened ``Any`` type.
+        self.raw_response = (
+            _truncate_response_preview(raw_response)
+            if isinstance(raw_response, str)
+            else raw_response
+        )
         self.data_at_failure = data_at_failure
 
     def __str__(self) -> str:
@@ -465,7 +490,8 @@ class NotebookNotFoundError(RPCError, NotebookError):
     Attributes:
         notebook_id: The ID that was not found.
         method_id: The RPC method ID (inherited from :class:`RPCError`).
-        raw_response: First 500 chars of the raw response, if any.
+        raw_response: First 80 chars of the raw response, if any
+            (``NOTEBOOKLM_DEBUG=1`` preserves the full body).
     """
 
     def __init__(

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -16,6 +16,7 @@ from ..exceptions import (
     RPCTimeoutError,
     ServerError,
     UnknownRPCMethodError,
+    _truncate_response_preview,
 )
 from ._safe_index import safe_index
 
@@ -467,8 +468,9 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
     chunks = parse_chunked_response(cleaned)
     logger.debug("Parsed %d chunks from response", len(chunks))
 
-    # Create response preview for error context (first 500 chars)
-    response_preview = cleaned[:500] if len(cleaned) > 500 else cleaned
+    # Create response preview for error context (first 80 chars by default;
+    # ``NOTEBOOKLM_DEBUG=1`` preserves the full body).
+    response_preview = _truncate_response_preview(cleaned)
 
     # Collect all RPC IDs for debugging
     found_ids = collect_rpc_ids(chunks)

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -233,7 +233,7 @@ def parse_chunked_response(response: str) -> list[Any]:
                     i + 1,
                     byte_count,
                     actual_byte_count,
-                    json_str[:100],
+                    _truncate_response_preview(json_str),
                 )
 
             try:
@@ -246,7 +246,7 @@ def parse_chunked_response(response: str) -> list[Any]:
                     "Skipping malformed chunk at line %d: %s. Preview: %s",
                     i + 1,
                     e,
-                    json_str[:100],
+                    _truncate_response_preview(json_str),
                 )
             i += 1
         except ValueError:
@@ -262,7 +262,7 @@ def parse_chunked_response(response: str) -> list[Any]:
                     "Skipping non-JSON line at %d: %s. Preview: %s",
                     i + 1,
                     e,
-                    line[:100],
+                    _truncate_response_preview(line),
                 )
             i += 1
 
@@ -274,7 +274,7 @@ def parse_chunked_response(response: str) -> list[Any]:
                 f"Response parsing failed: {skipped_count} of {total_records} response records "
                 f"malformed. "
                 f"This may indicate API changes or data corruption.",
-                raw_response=response[:500],
+                raw_response=response,
             )
         # Non-critical but warn user results may be incomplete
         logger.warning(

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -468,9 +468,12 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
     chunks = parse_chunked_response(cleaned)
     logger.debug("Parsed %d chunks from response", len(chunks))
 
-    # Create response preview for error context (first 80 chars by default;
-    # ``NOTEBOOKLM_DEBUG=1`` preserves the full body).
-    response_preview = _truncate_response_preview(cleaned)
+    # Pass the full cleaned body to exception constructors; ``RPCError.__init__``
+    # routes ``raw_response`` through ``_truncate_response_preview`` so the
+    # truncation contract (and ``NOTEBOOKLM_DEBUG=1`` opt-in) lives in one
+    # place. We keep a separate pre-truncated copy for the direct
+    # attribute-assignment branch below, which bypasses ``__init__``.
+    response_preview = cleaned
 
     # Collect all RPC IDs for debugging
     found_ids = collect_rpc_ids(chunks)
@@ -481,11 +484,14 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
     try:
         result = extract_rpc_result(chunks, rpc_id)
     except RPCError as e:
-        # Add context to errors from extract_rpc_result
+        # Add context to errors from extract_rpc_result. This branch sets
+        # ``raw_response`` directly on an already-constructed exception, so
+        # ``__init__`` does not run again — apply the helper explicitly here
+        # to honor the truncation contract.
         if not e.found_ids:
             e.found_ids = found_ids
         if not e.raw_response:
-            e.raw_response = response_preview
+            e.raw_response = _truncate_response_preview(response_preview)
         raise
 
     if result is None and not allow_null:

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -471,8 +471,9 @@ def decode_response(raw_response: str, rpc_id: str, allow_null: bool = False) ->
     # Pass the full cleaned body to exception constructors; ``RPCError.__init__``
     # routes ``raw_response`` through ``_truncate_response_preview`` so the
     # truncation contract (and ``NOTEBOOKLM_DEBUG=1`` opt-in) lives in one
-    # place. We keep a separate pre-truncated copy for the direct
-    # attribute-assignment branch below, which bypasses ``__init__``.
+    # place. The one branch that bypasses ``__init__`` (direct attribute set
+    # on an already-constructed exception) calls the helper explicitly at the
+    # call site below.
     response_preview = cleaned
 
     # Collect all RPC IDs for debugging

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -803,5 +803,6 @@ class TestUnknownRPCMethodErrorRouting:
         assert err.method_id == requested
         assert err.found_ids == found
         assert err.raw_response is not None
-        # raw_response preview cap (500 chars) preserved by the base RPCError contract.
-        assert len(err.raw_response) <= 500
+        # raw_response preview cap (80 chars + "..." = 83) preserved by the
+        # base RPCError contract (NOTEBOOKLM_DEBUG=1 opts into full body).
+        assert len(err.raw_response) <= 83

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -150,11 +150,15 @@ class TestRPCErrorAttributes:
             assert issubclass(w[0].category, DeprecationWarning)
             assert "code" in str(w[0].message)
 
-    def test_rpc_error_truncates_raw_response(self):
-        """RPCError truncates raw_response to 500 chars."""
+    def test_rpc_error_truncates_raw_response(self, monkeypatch):
+        """RPCError truncates raw_response to 80 chars + '...' by default."""
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
         long_response = "x" * 1000
         e = RPCError("Failed", raw_response=long_response)
-        assert len(e.raw_response) == 500
+        assert e.raw_response is not None
+        assert len(e.raw_response) == 83
+        assert e.raw_response.endswith("...")
+        assert e.raw_response[:-3] == "x" * 80
 
     def test_rpc_error_stores_found_ids(self):
         """RPCError stores found_ids list."""

--- a/tests/unit/test_response_preview.py
+++ b/tests/unit/test_response_preview.py
@@ -1,0 +1,97 @@
+"""Tests for the response-preview truncation helper used in RPC errors.
+
+The library truncates raw RPC response bodies in error contexts so they are
+safe to display in logs / CLI output. ``NOTEBOOKLM_DEBUG=1`` is the opt-in to
+preserve the full body for deep debugging.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm.exceptions import RPCError, _truncate_response_preview
+
+
+class TestTruncateResponsePreview:
+    """Behavior of the ``_truncate_response_preview`` helper."""
+
+    def test_long_body_default_truncates_to_80_plus_ellipsis(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Long body with no NOTEBOOKLM_DEBUG env returns 80 chars + '...'."""
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        body = "x" * 200
+        result = _truncate_response_preview(body)
+        assert result is not None
+        assert result.endswith("...")
+        # Exactly 80 chars before the "..." suffix.
+        assert result[:-3] == "x" * 80
+        assert len(result) == 83
+
+    def test_debug_env_one_returns_full_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NOTEBOOKLM_DEBUG=1 disables truncation entirely."""
+        monkeypatch.setenv("NOTEBOOKLM_DEBUG", "1")
+        body = "y" * 500
+        result = _truncate_response_preview(body)
+        assert result == body
+        assert len(result) == 500  # type: ignore[arg-type]
+
+    def test_debug_env_zero_still_truncates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NOTEBOOKLM_DEBUG=0 (explicit zero) must NOT disable truncation.
+
+        Common env-var footgun: users sometimes set ``=0`` expecting it to mean
+        "off", but the contract is strictly ``=1`` to opt-in. Guard against
+        regression where any truthy-looking string disables truncation.
+        """
+        monkeypatch.setenv("NOTEBOOKLM_DEBUG", "0")
+        body = "z" * 200
+        result = _truncate_response_preview(body)
+        assert result is not None
+        assert result == "z" * 80 + "..."
+
+    def test_short_body_unchanged_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bodies <= 80 chars are returned unchanged when env is unset."""
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        body = "short body"
+        assert _truncate_response_preview(body) == body
+
+    def test_short_body_unchanged_with_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bodies <= 80 chars are returned unchanged even with debug enabled."""
+        monkeypatch.setenv("NOTEBOOKLM_DEBUG", "1")
+        body = "short body"
+        assert _truncate_response_preview(body) == body
+
+    def test_exactly_80_chars_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Boundary: a body of exactly 80 chars is not truncated."""
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        body = "a" * 80
+        assert _truncate_response_preview(body) == body
+
+    def test_none_input_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """None input short-circuits to None regardless of env."""
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        assert _truncate_response_preview(None) is None
+
+        monkeypatch.setenv("NOTEBOOKLM_DEBUG", "1")
+        assert _truncate_response_preview(None) is None
+
+
+class TestRPCErrorIntegration:
+    """End-to-end: constructing an RPCError truncates the stored body."""
+
+    def test_rpc_error_truncates_raw_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RPCError.raw_response is truncated to 80 chars + '...' by default."""
+        monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
+        long_body = "Q" * 300
+        err = RPCError("boom", raw_response=long_body)
+        assert err.raw_response is not None
+        assert len(err.raw_response) == 83
+        assert err.raw_response.endswith("...")
+        assert err.raw_response[:-3] == "Q" * 80
+
+    def test_rpc_error_full_body_with_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NOTEBOOKLM_DEBUG=1 preserves the full body on RPCError."""
+        monkeypatch.setenv("NOTEBOOKLM_DEBUG", "1")
+        long_body = "Q" * 300
+        err = RPCError("boom", raw_response=long_body)
+        assert err.raw_response == long_body

--- a/tests/unit/test_safe_index.py
+++ b/tests/unit/test_safe_index.py
@@ -142,17 +142,20 @@ def test_data_at_failure_is_truncated(monkeypatch):
     assert len(exc_info.value.data_at_failure) <= 210  # 200 + ellipsis margin
 
 
-def test_unknown_rpc_method_error_truncates_string_raw_response():
-    """Regression: ``UnknownRPCMethodError`` must honor RPCError's 500-char cap.
+def test_unknown_rpc_method_error_truncates_string_raw_response(monkeypatch):
+    """Regression: ``UnknownRPCMethodError`` must honor RPCError's truncation cap.
 
     Previously the subclass unconditionally reassigned ``self.raw_response``
-    after the base class truncated, bypassing the contract.
+    after the base class truncated, bypassing the contract. The preview is now
+    capped at 80 chars + "..." (NOTEBOOKLM_DEBUG=1 opts into the full body).
     """
+    monkeypatch.delenv("NOTEBOOKLM_DEBUG", raising=False)
     huge = "x" * 5000
     err = UnknownRPCMethodError("boom", raw_response=huge)
     assert err.raw_response is not None
     assert isinstance(err.raw_response, str)
-    assert len(err.raw_response) == 500
+    assert len(err.raw_response) == 83
+    assert err.raw_response.endswith("...")
 
 
 def test_unknown_rpc_method_error_preserves_non_string_raw_response():


### PR DESCRIPTION
## Summary

- Cap `RPCError.raw_response` (and decoder error-context preview) at **80 chars + `"..."`** by default; previously 500 chars verbatim. Keeps logs/CLI output concise while still giving enough context to recognize a payload at a glance.
- Add `NOTEBOOKLM_DEBUG=1` as the explicit opt-in to preserve the full untruncated body for deep debugging.
- Centralize all three truncation sites (`RPCError.__init__`, `UnknownRPCMethodError.__init__`, `decode_response.response_preview`) behind a single `_truncate_response_preview` helper in `exceptions.py`.

## Behavior contract

- `NOTEBOOKLM_DEBUG` must be exactly `"1"` — `"0"`, `"true"`, etc. fall back to truncation (footgun guard, tested).
- `UnknownRPCMethodError`'s widened `Any` payload type is preserved: only string payloads are truncated.
- Six downstream uses of `response_preview` in `decoder.py` (lines 486/498/521/528/535/543) keep referencing the local unchanged.

## Test plan

- [x] New `tests/unit/test_response_preview.py`: long body default, `NOTEBOOKLM_DEBUG=1` full, `NOTEBOOKLM_DEBUG=0` still truncates, short body unchanged, exactly-80 boundary, `None` short-circuits, `RPCError` integration.
- [x] Updated 3 existing 500-char regression tests (`test_decoder.py`, `test_exceptions.py`, `test_safe_index.py`) to the new 83-char cap.
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest tests/unit -x -q` — all 2566 unit tests pass.
- [x] Integration suite (599 tests) passes.
- [x] Troubleshooting docs updated: env-var table row + "How to get the full response preview" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NOTEBOOKLM_DEBUG=1 to show full RPC error response bodies instead of truncated previews.

* **Bug Fixes / Improvements**
  * Standardized preview truncation to 80 characters (with "..." when truncated) by default; preserves full content when debug is enabled.
  * Clarified that the human-readable summary preview in research commands is a UI-only 500-char cap.

* **Documentation**
  * Updated troubleshooting and logging docs to document the new env var and truncation behavior.

* **Tests**
  * Added/updated tests to validate truncation and debug override behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/479)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->