### PR TITLE
fix(sources): surface decoder status codes on source registration (closes #474, closes #407)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -472,6 +472,11 @@ class SourcesAPI:
         """
         logger.debug("Adding URL source to notebook %s: %s", notebook_id, url[:80])
         video_id = self._extract_youtube_video_id(url)
+        # Preserve transport-level signals so callers can act on the specific
+        # type (AuthError → re-login, RateLimitError → back-off with retry_after,
+        # ServerError → transient-retry). Only the generic RPCError catch wraps
+        # into SourceAddError with the underlying cause attached. Mirrors the
+        # propagation contract in _register_file_source (#474, #407).
         try:
             if video_id:
                 result = await self._add_youtube_source(notebook_id, url)
@@ -485,8 +490,9 @@ class SourcesAPI:
                         url[:100],
                     )
                 result = await self._add_url_source(notebook_id, url)
+        except (AuthError, RateLimitError, ServerError):
+            raise
         except RPCError as e:
-            # Wrap RPC error with more helpful context for users
             raise SourceAddError(url, cause=e) from e
 
         if result is None:
@@ -1153,11 +1159,16 @@ class SourcesAPI:
             [2],
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
+        # allow_null=False mirrors _register_file_source — ADD_SOURCE on
+        # success returns the new source row. A null result with a status
+        # code at wrb.fr[5] is the #407 / #474 mode; allow_null=True would
+        # swallow that diagnostic. The decoder now raises RPCError with the
+        # status code so add_url can wrap it into SourceAddError with detail.
         return await self._core.rpc_call(
             RPCMethod.ADD_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
+            allow_null=False,
         )
 
     async def _add_url_source(self, notebook_id: str, url: str) -> Any:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -16,7 +16,7 @@ from ._core import ClientCore
 from ._env import get_base_url
 from ._url_utils import is_youtube_url
 from .auth import authuser_query, format_authuser_value
-from .exceptions import NetworkError, ValidationError
+from .exceptions import AuthError, NetworkError, ValidationError
 from .rpc import RPCError, RPCMethod, get_upload_url
 from .rpc.types import SourceStatus
 from .types import (
@@ -1186,21 +1186,40 @@ class SourcesAPI:
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
 
-        result = await self._core.rpc_call(
-            RPCMethod.ADD_SOURCE_FILE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
+        # allow_null=False: ADD_SOURCE_FILE should always return the source id
+        # on success. When the server quietly returns null with a status code
+        # at wrb.fr[5] — the suspected #474 mode for account-routing mismatches
+        # (issues #114, #294) — the decoder enriches the error with that code
+        # and an account-routing hint. Surface that diagnostic to the caller
+        # via SourceAddError, instead of swallowing the null with allow_null=True
+        # and raising a generic "Failed to get SOURCE_ID" with no detail.
+        # AuthError is allowed to propagate so the core auth-refresh retry path
+        # is not disrupted.
+        try:
+            result = await self._core.rpc_call(
+                RPCMethod.ADD_SOURCE_FILE,
+                params,
+                source_path=f"/notebook/{notebook_id}",
+                allow_null=False,
+            )
+        except AuthError:
+            raise
+        except RPCError as exc:
+            raise SourceAddError(
+                filename,
+                cause=exc,
+                message=f"Failed to register file source for {filename}: {exc}",
+            ) from exc
 
         source_id = _extract_register_file_source_id(result, filename)
         if source_id:
             return source_id
 
-        # Shape drift: the registration succeeded at the RPC layer but the
-        # decoder couldn't locate the SOURCE_ID. Include a faithful preview of
-        # the actual response (repr, not json — repr surfaces types that the
-        # walker rejected) so future drift produces an actionable report (#474).
+        # The decoder returned a non-null payload that the walker couldn't
+        # parse — a genuine shape drift, not a null-result rejection. Include
+        # a faithful preview of the actual response (repr, not json — repr
+        # surfaces types the walker rejected) so future drift produces an
+        # actionable bug report (#474).
         preview = repr(result)
         if len(preview) > 200:
             preview = preview[:200] + "..."

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -51,17 +51,21 @@ def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
     """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
 
     The historical shape was a strictly position-0 walk: ``[[[[id]]]]``. Issue
-    #474 surfaced a new shape where that walk lands on ``None`` (or on the
-    echoed filename) and silently fails. Walk the whole structure instead,
-    prefer a UUID-shaped leaf, and fall back to any other id-shaped string that
-    is plausibly not a status label.
+    #474 surfaced cases where that walk lands on ``None`` or on the echoed
+    filename and silently fails. Walk the whole structure instead, prefer a
+    UUID-shaped leaf, and fall back to any other id-shaped string that is
+    plausibly not a status label.
     """
     uuid_match: str | None = None
     fallback: str | None = None
+    # Depth guard mirrors the existing _extract_all_text pattern — Google's
+    # responses are shallow in practice, but a malformed/adversarial payload
+    # shouldn't be able to trigger RecursionError.
+    max_depth = 50
 
-    def walk(node: Any) -> None:
+    def walk(node: Any, depth: int) -> None:
         nonlocal uuid_match, fallback
-        if uuid_match is not None:
+        if uuid_match is not None or depth > max_depth:
             return
         if isinstance(node, str):
             candidate = node.strip()
@@ -70,24 +74,37 @@ def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
             if _SOURCE_ID_UUID_PATTERN.match(candidate):
                 uuid_match = candidate
                 return
-            # Fallback: reject obvious non-id strings (status labels like "OK",
-            # mime types like "application/pdf", free-form messages). An id-shaped
-            # string has no embedded whitespace, no slashes, and is at least 4 chars.
-            if fallback is None and len(candidate) >= 4 and not any(c in candidate for c in " \t/"):
+            # Fallback: reject obvious non-id strings — status labels ("OK",
+            # "DONE", "true"), mime types ("application/pdf"), free-form
+            # messages. An id-shaped string has no embedded whitespace, no
+            # slashes, is at least 4 chars, and contains at least one digit,
+            # hyphen, or underscore (excludes all-alpha status tokens).
+            if fallback is None and _looks_like_id_string(candidate):
                 fallback = candidate
         elif isinstance(node, list):
             for child in node:
                 if uuid_match is not None:
                     return
-                walk(child)
-        elif isinstance(node, dict):
-            for value in node.values():
-                if uuid_match is not None:
-                    return
-                walk(value)
+                walk(child, depth + 1)
 
-    walk(result)
+    walk(result, 0)
     return uuid_match or fallback
+
+
+def _looks_like_id_string(candidate: str) -> bool:
+    """Heuristic for the non-UUID fallback in :func:`_extract_register_file_source_id`.
+
+    Accepts strings that look like an id (`src_pdf`, `source_id_123`) and
+    rejects short status tokens (`OK`, `DONE`, `true`) and structured fields
+    (`application/pdf`, anything with whitespace).
+    """
+    if len(candidate) < 4:
+        return False
+    if any(c in candidate for c in " \t/"):
+        return False
+    # Require at least one digit, hyphen, or underscore — blocks all-alpha
+    # status tokens while still admitting test-style ids like ``src_pdf``.
+    return any(c.isdigit() or c in "-_" for c in candidate)
 
 
 class SourcesAPI:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -42,6 +42,54 @@ logger = logging.getLogger(__name__)
 _TRANSIENT_ERROR_TYPES: tuple[int | None, ...] = (10, 0, None)
 
 
+_SOURCE_ID_UUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
+    """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
+
+    The historical shape was a strictly position-0 walk: ``[[[[id]]]]``. Issue
+    #474 surfaced a new shape where that walk lands on ``None`` (or on the
+    echoed filename) and silently fails. Walk the whole structure instead,
+    prefer a UUID-shaped leaf, and fall back to any other id-shaped string that
+    is plausibly not a status label.
+    """
+    uuid_match: str | None = None
+    fallback: str | None = None
+
+    def walk(node: Any) -> None:
+        nonlocal uuid_match, fallback
+        if uuid_match is not None:
+            return
+        if isinstance(node, str):
+            candidate = node.strip()
+            if not candidate or candidate == filename:
+                return
+            if _SOURCE_ID_UUID_PATTERN.match(candidate):
+                uuid_match = candidate
+                return
+            # Fallback: reject obvious non-id strings (status labels like "OK",
+            # mime types like "application/pdf", free-form messages). An id-shaped
+            # string has no embedded whitespace, no slashes, and is at least 4 chars.
+            if fallback is None and len(candidate) >= 4 and not any(c in candidate for c in " \t/"):
+                fallback = candidate
+        elif isinstance(node, list):
+            for child in node:
+                if uuid_match is not None:
+                    return
+                walk(child)
+        elif isinstance(node, dict):
+            for value in node.values():
+                if uuid_match is not None:
+                    return
+                walk(value)
+
+    walk(result)
+    return uuid_match or fallback
+
+
 class SourcesAPI:
     """Operations on NotebookLM sources.
 
@@ -1128,23 +1176,23 @@ class SourcesAPI:
             allow_null=True,
         )
 
-        # Parse SOURCE_ID from response - handle various nesting formats
-        # API returns different structures: [[[[id]]]], [[[id]]], [[id]], etc.
-        if result and isinstance(result, list):
+        source_id = _extract_register_file_source_id(result, filename)
+        if source_id:
+            return source_id
 
-            def extract_id(data):
-                """Recursively extract first string from nested lists."""
-                if isinstance(data, str):
-                    return data
-                if isinstance(data, list) and len(data) > 0:
-                    return extract_id(data[0])
-                return None
-
-            source_id = extract_id(result)
-            if source_id:
-                return source_id
-
-        raise SourceAddError(filename, message="Failed to get SOURCE_ID from registration response")
+        # Shape drift: the registration succeeded at the RPC layer but the
+        # decoder couldn't locate the SOURCE_ID. Include a faithful preview of
+        # the actual response (repr, not json — repr surfaces types that the
+        # walker rejected) so future drift produces an actionable report (#474).
+        preview = repr(result)
+        if len(preview) > 200:
+            preview = preview[:200] + "..."
+        raise SourceAddError(
+            filename,
+            message=(
+                f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
+            ),
+        )
 
     async def _start_resumable_upload(
         self,

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -16,7 +16,7 @@ from ._core import ClientCore
 from ._env import get_base_url
 from ._url_utils import is_youtube_url
 from .auth import authuser_query, format_authuser_value
-from .exceptions import AuthError, NetworkError, ValidationError
+from .exceptions import AuthError, NetworkError, RateLimitError, ServerError, ValidationError
 from .rpc import RPCError, RPCMethod, get_upload_url
 from .rpc.types import SourceStatus
 from .types import (
@@ -58,9 +58,8 @@ def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
     """
     uuid_match: str | None = None
     fallback: str | None = None
-    # Depth guard mirrors the existing _extract_all_text pattern — Google's
-    # responses are shallow in practice, but a malformed/adversarial payload
-    # shouldn't be able to trigger RecursionError.
+    # Depth guard for malformed/adversarial payloads — Google's real responses
+    # are shallow (≤5 levels), so 50 is generous without risking RecursionError.
     max_depth = 50
 
     def walk(node: Any, depth: int) -> None:
@@ -1193,8 +1192,11 @@ class SourcesAPI:
         # and an account-routing hint. Surface that diagnostic to the caller
         # via SourceAddError, instead of swallowing the null with allow_null=True
         # and raising a generic "Failed to get SOURCE_ID" with no detail.
-        # AuthError is allowed to propagate so the core auth-refresh retry path
-        # is not disrupted.
+        #
+        # AuthError, RateLimitError, and ServerError are allowed to propagate
+        # unchanged so callers can keep using their specific exception types
+        # for auth-refresh retry, rate-limit back-off, and server-error handling
+        # without having to unwrap SourceAddError.cause.
         try:
             result = await self._core.rpc_call(
                 RPCMethod.ADD_SOURCE_FILE,
@@ -1202,7 +1204,7 @@ class SourcesAPI:
                 source_path=f"/notebook/{notebook_id}",
                 allow_null=False,
             )
-        except AuthError:
+        except (AuthError, RateLimitError, ServerError):
             raise
         except RPCError as exc:
             raise SourceAddError(

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -290,9 +290,44 @@ class TestRegisterFileSource:
             await sources_api._register_file_source("nb_123", "test.pdf")
 
     @pytest.mark.asyncio
+    async def test_register_file_source_lets_rate_limit_error_propagate(
+        self, sources_api, mock_core
+    ):
+        """RateLimitError must propagate so callers implementing back-off keep
+        their specific exception type (and ``retry_after``) without having to
+        unwrap ``SourceAddError.cause``.
+        """
+        from notebooklm.exceptions import RateLimitError
+
+        mock_core.rpc_call.side_effect = RateLimitError(
+            "API rate limit exceeded",
+            method_id="o4cbdc",
+            rpc_code="USER_DISPLAYABLE_ERROR",
+        )
+
+        with pytest.raises(RateLimitError, match="rate limit"):
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_lets_server_error_propagate(self, sources_api, mock_core):
+        """ServerError must propagate so callers handling transient 5xx
+        backend errors keep the specific exception type for retry logic.
+        """
+        from notebooklm.exceptions import ServerError
+
+        mock_core.rpc_call.side_effect = ServerError(
+            "Backend unavailable",
+            method_id="o4cbdc",
+            rpc_code=500,
+        )
+
+        with pytest.raises(ServerError, match="Backend unavailable"):
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
+    @pytest.mark.asyncio
     async def test_register_file_source_walker_has_recursion_guard(self, sources_api, mock_core):
-        """A pathological deeply-nested response shouldn't trigger
-        RecursionError — the depth guard mirrors :func:`_extract_all_text`.
+        """A pathological deeply-nested response must not trigger
+        RecursionError — the depth guard caps recursion at ``max_depth=50``.
         """
         # 200-deep nest with a UUID at the bottom. Past the depth guard the
         # walker stops, so the UUID is unreachable and we raise — but we don't

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -248,6 +248,48 @@ class TestRegisterFileSource:
             await sources_api._register_file_source("nb_123", "test.pdf")
 
     @pytest.mark.asyncio
+    async def test_register_file_source_wraps_rpc_error_with_status_code(
+        self, sources_api, mock_core
+    ):
+        """When the decoder raises RPCError (e.g. server returned null result
+        with a status code at wrb.fr[5] — the suspected #474 mode for account-
+        routing mismatches), wrap the rich diagnostic into SourceAddError so
+        the user sees actionable detail instead of a generic "Failed to get
+        SOURCE_ID" with no context.
+        """
+        from notebooklm.exceptions import ClientError, SourceAddError
+
+        # ClientError is what the decoder raises for status codes 5/7 (NOT_FOUND
+        # / PERMISSION_DENIED) with an account-routing hint attached — exactly
+        # the #114/#294 pattern we suspect for #474.
+        mock_core.rpc_call.side_effect = ClientError(
+            "RPC o4cbdc returned null result with status code 7 (Permission denied). "
+            "If you have multiple Google accounts signed in...",
+            method_id="o4cbdc",
+            rpc_code=7,
+        )
+
+        with pytest.raises(SourceAddError, match="Permission denied") as exc_info:
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
+        # The original RPCError is preserved as the cause so debuggers can
+        # inspect the full decoder context.
+        assert isinstance(exc_info.value.cause, ClientError)
+        assert exc_info.value.cause.rpc_code == 7
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_lets_auth_error_propagate(self, sources_api, mock_core):
+        """AuthError must NOT be wrapped — the core auth-refresh retry path
+        relies on the exception bubbling up unchanged.
+        """
+        from notebooklm.exceptions import AuthError
+
+        mock_core.rpc_call.side_effect = AuthError("session expired")
+
+        with pytest.raises(AuthError, match="session expired"):
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
+    @pytest.mark.asyncio
     async def test_register_file_source_walker_has_recursion_guard(self, sources_api, mock_core):
         """A pathological deeply-nested response shouldn't trigger
         RecursionError — the depth guard mirrors :func:`_extract_all_text`.

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -231,6 +231,40 @@ class TestRegisterFileSource:
         with pytest.raises(SourceAddError, match=r"Response shape:.*\[\[\[1, 2, 3\]\]\]"):
             await sources_api._register_file_source("nb_123", "test.pdf")
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_token", ["OK", "DONE", "true", "null"])
+    async def test_register_file_source_rejects_all_alpha_status_tokens(
+        self, sources_api, mock_core, status_token
+    ):
+        """Fallback must reject all-alpha status tokens — ``OK``/``DONE``/``true``
+        in the response position would otherwise be picked up as a bogus
+        SOURCE_ID and break the downstream upload silently.
+        """
+        from notebooklm.exceptions import SourceAddError
+
+        mock_core.rpc_call.return_value = [[[status_token]]]
+
+        with pytest.raises(SourceAddError, match="Failed to get SOURCE_ID"):
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_walker_has_recursion_guard(self, sources_api, mock_core):
+        """A pathological deeply-nested response shouldn't trigger
+        RecursionError — the depth guard mirrors :func:`_extract_all_text`.
+        """
+        # 200-deep nest with a UUID at the bottom. Past the depth guard the
+        # walker stops, so the UUID is unreachable and we raise — but we don't
+        # crash with RecursionError.
+        from notebooklm.exceptions import SourceAddError
+
+        deep: list = ["dc84ca28-2629-49ac-aec3-de45f0ec93e4"]
+        for _ in range(200):
+            deep = [deep]
+        mock_core.rpc_call.return_value = deep
+
+        with pytest.raises(SourceAddError, match="Failed to get SOURCE_ID"):
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
 
 # =============================================================================
 # _start_resumable_upload() tests

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -162,6 +162,75 @@ class TestRegisterFileSource:
         with pytest.raises(SourceAddError, match="Failed to get SOURCE_ID"):
             await sources_api._register_file_source("nb_123", "test.pdf")
 
+    @pytest.mark.asyncio
+    async def test_register_file_source_handles_leading_none_shape(self, sources_api, mock_core):
+        """Shape drift (#474): the new wrb.fr result_data starts with a None
+        element, so the legacy position-0 walk lands on None. The full-tree
+        scan should still find the UUID-shaped SOURCE_ID elsewhere.
+        """
+        uuid = "dc84ca28-2629-49ac-aec3-de45f0ec93e4"
+        mock_core.rpc_call.return_value = [None, [[[uuid]]]]
+
+        result = await sources_api._register_file_source("nb_123", "report.pdf")
+        assert result == uuid
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "filename,response,expected",
+        [
+            # Filename echoed next to the SOURCE_ID (sibling).
+            (
+                "report.pdf",
+                [[[["report.pdf", ["11111111-2222-3333-4444-555555555555"]]]]],
+                "11111111-2222-3333-4444-555555555555",
+            ),
+            # Filename at the first leaf position — the legacy data[0] walker
+            # would have returned 'doc.pdf' and broken downstream upload (#474).
+            (
+                "doc.pdf",
+                [[["doc.pdf"], [["aabbccdd-eeff-1122-3344-556677889900"]]]],
+                "aabbccdd-eeff-1122-3344-556677889900",
+            ),
+        ],
+        ids=["filename-sibling-of-uuid", "filename-at-position-zero"],
+    )
+    async def test_register_file_source_prefers_uuid_over_echoed_filename(
+        self, sources_api, mock_core, filename, response, expected
+    ):
+        """The extractor must skip the echoed filename and return the UUID,
+        regardless of where the filename sits in the structure (#474).
+        """
+        mock_core.rpc_call.return_value = response
+
+        result = await sources_api._register_file_source("nb_123", filename)
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_falls_back_to_non_uuid_string(self, sources_api, mock_core):
+        """Existing tests pass non-UUID IDs like 'src_pdf' — when no UUID
+        candidate is present, the extractor falls back to the first non-
+        filename string. Preserves backward compatibility with prior shapes.
+        """
+        mock_core.rpc_call.return_value = [[[["src_pdf"]]]]
+
+        result = await sources_api._register_file_source("nb_123", "doc.pdf")
+        assert result == "src_pdf"
+
+    @pytest.mark.asyncio
+    async def test_register_file_source_error_message_includes_shape_preview(
+        self, sources_api, mock_core
+    ):
+        """Future shape drift should surface a structural preview in the error
+        so users can file actionable bug reports (#474).
+        """
+        from notebooklm.exceptions import SourceAddError
+
+        # Pure-numeric response — no string leaves → no candidates → raises.
+        mock_core.rpc_call.return_value = [[[1, 2, 3]]]
+
+        with pytest.raises(SourceAddError, match=r"Response shape:.*\[\[\[1, 2, 3\]\]\]"):
+            await sources_api._register_file_source("nb_123", "test.pdf")
+
 
 # =============================================================================
 # _start_resumable_upload() tests

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -1204,6 +1204,58 @@ class TestAddUrlWithYouTube:
         # Regular URL params have the URL at position [0][0][2] (different from YouTube's [7])
         assert params[0][0][2] == ["https://example.com/article"]
 
+    @pytest.mark.asyncio
+    async def test_add_url_wraps_rpc_error_with_status_code(self, sources_api, mock_core):
+        """When ADD_SOURCE returns null with a status code at wrb.fr[5] —
+        the #407 mode shared with #474 — the decoder raises ClientError /
+        RPCError and add_url wraps it into SourceAddError with the rich
+        diagnostic preserved as .cause. Previously allow_null=True on
+        _add_youtube_source swallowed the status code silently.
+        """
+        from notebooklm.exceptions import ClientError, SourceAddError
+
+        mock_core.rpc_call.side_effect = ClientError(
+            "RPC <id> returned null result with status code 7 (Permission denied). ...",
+            method_id="<id>",
+            rpc_code=7,
+        )
+
+        with pytest.raises(SourceAddError) as exc_info:
+            await sources_api.add_url("nb_123", "https://youtu.be/dQw4w9WgXcQ")
+
+        assert isinstance(exc_info.value.cause, ClientError)
+        assert exc_info.value.cause.rpc_code == 7
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc_factory",
+        [
+            lambda: __import__("notebooklm.exceptions", fromlist=["AuthError"]).AuthError(
+                "session expired"
+            ),
+            lambda: __import__("notebooklm.exceptions", fromlist=["RateLimitError"]).RateLimitError(
+                "rate limited", method_id="<id>"
+            ),
+            lambda: __import__("notebooklm.exceptions", fromlist=["ServerError"]).ServerError(
+                "backend down", method_id="<id>", rpc_code=503
+            ),
+        ],
+        ids=["auth", "rate-limit", "server"],
+    )
+    async def test_add_url_lets_transport_errors_propagate(
+        self, sources_api, mock_core, exc_factory
+    ):
+        """AuthError, RateLimitError, and ServerError must NOT be wrapped —
+        callers rely on the specific exception type for re-login / back-off
+        / transient retry. Mirrors the propagation contract on
+        _register_file_source for #474.
+        """
+        exc = exc_factory()
+        mock_core.rpc_call.side_effect = exc
+
+        with pytest.raises(type(exc)):
+            await sources_api.add_url("nb_123", "https://example.com/article")
+
 
 # =============================================================================
 # _add_youtube_source() tests


### PR DESCRIPTION
## Summary

Closes #474 and #407 — both report the same root cause: source-registration RPCs (`ADD_SOURCE_FILE`, `ADD_SOURCE`) return null on some accounts, but `allow_null=True` on the RPC call silently swallows the diagnostic, leaving callers with a generic "Failed to get SOURCE_ID" / "API returned no data" error instead of the actionable status code (NOT_FOUND, PERMISSION_DENIED, account-routing mismatch — #114 / #294 pattern).

Three-part fix:

1. **File registration** (`_register_file_source`). Flipped `allow_null=False` so the decoder enriches null responses with the `wrb.fr[5]` status code and account-routing hint. Wraps any generic `RPCError` into `SourceAddError` (`.cause` preserved). `AuthError` / `RateLimitError` / `ServerError` propagate unchanged so callers keep auth-refresh / back-off / transient-retry behavior intact.

2. **URL registration** (`_add_youtube_source` + `add_url`). Same change to the YouTube helper (`allow_null=True → False`) and the same propagation contract in `add_url`'s exception handler. `_add_url_source` already defaulted to `allow_null=False`, so no change there.

3. **Shape-drift tolerance on the success path** (`_register_file_source`). Replaced the strict position-0 walker with a depth-bounded full-tree walker that prefers a UUID-shaped leaf, skips the echoed filename, and falls back to id-shaped strings (rejecting all-alpha status tokens like `OK`/`DONE`/`true`/`null`). On extraction failure the error includes a `repr()` preview of the response so any future shape drift produces an actionable bug report.

## Live API verification

- `notebooklm source add <pdf>` succeeds on the fix branch (legacy `[[[[uuid], filename, [...]]]]` shape, 337 bytes).
- `notebooklm source add https://example.com` succeeds.
- `notebooklm source add https://youtu.be/<id>` succeeds.
- Could not reproduce the original null-response symptom on this account; the diagnostic-surfacing change is the higher-confidence fix because it directly resolves @teng-lin's own observation in [#407](https://github.com/teng-lin/notebooklm-py/issues/407#issuecomment): *"if the backend returns a literal null while still creating/registering the source, the current client has no SOURCE_ID to continue with"*.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest` — 3174 passed, 9 skipped
- [x] Live API: file + URL + YouTube add all succeed
- [x] New unit tests covering:
  - shape-drift walker (leading-None, filename-at-position-0, filename-as-sibling-of-uuid — parametrized; non-UUID fallback; all-alpha token rejection; depth guard)
  - `RPCError` → `SourceAddError` wrapping on both paths
  - `AuthError` / `RateLimitError` / `ServerError` propagate unchanged on both paths (parametrized on `add_url`)
  - structural `repr()` preview in the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved source identifier detection with more robust pattern matching
  * Enhanced error messages when adding files or URLs fail
  * Better handling of unexpected or malformed API responses

* **Tests**
  * Expanded test coverage for edge cases and error scenarios in source addition workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/481)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->