### PR TITLE
test(cli/source): isolate get_storage_path in symlink upload tests

### DIFF
--- a/tests/unit/test_source_symlink.py
+++ b/tests/unit/test_source_symlink.py
@@ -49,8 +49,23 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def mock_auth():
-    """Stub auth loading + token fetch so CLI paths run offline."""
+def mock_auth(tmp_path: Path, monkeypatch):
+    """Stub auth loading + token fetch so CLI paths run offline.
+
+    Also points ``get_storage_path`` at a non-existent path inside the
+    test's ``tmp_path`` so ``build_cookie_jar`` takes the in-memory branch
+    (using the cookie dict returned by our mock) instead of reading any
+    real storage file the runner may have left behind from a prior test.
+    Without this, ``build_cookie_jar`` calls ``build_httpx_cookies_from_storage``
+    on the runner's default-profile storage, which validates against the
+    real cookie set and fails this test with
+    "Missing required cookies: SID, __Secure-1PSIDTS".
+    """
+    fake_storage = tmp_path / "no_such_storage.json"
+    monkeypatch.setattr(
+        "notebooklm.paths.get_storage_path",
+        lambda profile=None, **_kw: fake_storage,
+    )
     with (
         patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
         patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,


### PR DESCRIPTION
## Summary

Test isolation fix for `tests/unit/test_source_symlink.py` (introduced in #476). The new tests were intermittently failing post-merge on main with:

```
AssertionError: Unexpected error: Missing required cookies: SID, __Secure-1PSIDTS
```

across mixed runner/Python combinations (e.g. macOS 3.12, Ubuntu 3.10/3.13, Windows 3.12/3.14) — and consistently when the runner's default-profile storage was populated from a prior test run.

## Root cause

`mock_auth` patched `notebooklm.cli.helpers.load_auth_from_storage` but left `get_storage_path` returning the real default path. When the CI runner had a default-profile storage file present, `build_cookie_jar` saw `storage_path.exists() is True` and routed to `build_httpx_cookies_from_storage`, which validates the *real* cookie set and failed before the mocked cookies were ever used.

## Fix

Patch `notebooklm.paths.get_storage_path` to return a path inside `tmp_path` that deliberately doesn't exist, forcing `build_cookie_jar` onto the in-memory branch.

## Test plan
- [x] All 9 symlink tests pass locally
- [x] Full unit suite green (2566 passed, 5 skipped)
- [ ] CI green across all platform/Python combos

🤖 Generated with [Claude Code](https://claude.com/claude-code)