### PR TITLE
fix(tests): avoid os.environ race in threaded migration_lock test

### DIFF
--- a/tests/unit/test_migration_lock.py
+++ b/tests/unit/test_migration_lock.py
@@ -54,7 +54,9 @@ def _seed_legacy_layout(home: Path) -> None:
     (home / "browser_profile" / "data").write_text("chrome data", encoding="utf-8")
 
 
-def test_concurrent_threads_only_one_migrates(tmp_path: Path) -> None:
+def test_concurrent_threads_only_one_migrates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Two threads race on a fresh home — only one performs the copy.
 
     The loser must acquire the lock AFTER the winner has written the
@@ -70,6 +72,13 @@ def test_concurrent_threads_only_one_migrates(tmp_path: Path) -> None:
     cases; we accept the unit-test tradeoff to avoid subprocess overhead.
     """
     _seed_legacy_layout(tmp_path)
+    # Set NOTEBOOKLM_HOME once outside the workers. Using
+    # ``patch.dict(os.environ, ..., clear=True)`` inside concurrent
+    # threads races: each thread snapshots the *current* (already
+    # cleared) env as its "original", and the last thread to exit
+    # restores a near-empty env — wiping USERPROFILE on Windows and
+    # breaking later tests that call ``Path.home()``.
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
 
     results: list[bool] = []
     errors: list[BaseException] = []
@@ -78,8 +87,7 @@ def test_concurrent_threads_only_one_migrates(tmp_path: Path) -> None:
     def worker() -> None:
         try:
             barrier.wait()
-            with patch.dict(os.environ, {"NOTEBOOKLM_HOME": str(tmp_path)}, clear=True):
-                results.append(migrate_to_profiles())
+            results.append(migrate_to_profiles())
         except BaseException as exc:  # noqa: BLE001 - capture all failures
             errors.append(exc)
 


### PR DESCRIPTION
## Summary

- Fixes 4 Windows test failures (Python 3.11/3.12/3.13) on `main`: `test_paths::test_default_path`, `test_paths::test_expands_tilde`, `test_version_check_exits_on_old_python`, `test_playwright_initializes_with_context_manager`.
- Root cause: `test_concurrent_threads_only_one_migrates` used `patch.dict(os.environ, {...}, clear=True)` **inside each worker thread**. Two threads racing on the same dict each capture the already-cleared env as their "original", so whichever exits last restores a near-empty env — wiping `USERPROFILE` on Windows and breaking every later test that calls `Path.home()`.
- Linux/macOS hide the bug because `Path.home()` falls back to `/etc/passwd`.

## Fix

Move `NOTEBOOKLM_HOME` setup outside the workers using `monkeypatch.setenv`. `migrate_to_profiles` reads the env on every call, so a single set is sufficient; pytest restores it on teardown.

## Repro (macOS-confirmed before the fix)

```python
# Two threads with patch.dict(..., clear=True) on the same dict:
#   final HOME: None
#   env keys: ['CUSTOM_VAR']  # everything else wiped
```

## Failing CI

[Run 25863474568 (job 75999518663)](https://github.com/teng-lin/notebooklm-py/actions/runs/25863474568/job/75999518663)

## Test plan

- [x] `uv run pytest tests/unit/test_migration_lock.py` (5 passed)
- [x] `uv run pytest tests/unit/test_paths.py tests/unit/test_version_check.py tests/unit/test_windows_compatibility.py` (all pass)
- [x] Full local suite: `uv run pytest` → 3251 passed, 11 skipped
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports`
- [ ] Windows CI matrix (3.11/3.12/3.13) passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved concurrency test reliability for migration functionality to reduce potential race conditions during concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/484)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->