### PR TITLE
test(rpc-health): assert every RPCMethod is probed or explicitly skipped (T6.B)

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -454,11 +454,13 @@ def get_test_params(method: RPCMethod, notebook_id: str | None) -> list[Any] | N
     if method == RPCMethod.GET_SUGGESTED_REPORTS:
         return [[2], notebook_id]
 
-    # Methods that take [[notebook_id]] as the only param
-    if method in (
-        RPCMethod.GET_NOTES_AND_MIND_MAPS,
-        RPCMethod.DISCOVER_SOURCES,
-    ):
+    # Methods that take [[notebook_id]] as the only param.
+    # Note: DISCOVER_SOURCES is intentionally NOT listed here. It is in
+    # ALWAYS_SKIP_METHODS ("not fully rolled out by Google") and would be
+    # short-circuited before get_test_params runs anyway; keeping it out
+    # of get_test_params also lets the coverage assertion in
+    # tests/unit/test_rpc_health_coverage.py classify it explicitly.
+    if method == RPCMethod.GET_NOTES_AND_MIND_MAPS:
         return [[notebook_id]]
 
     # GET_LAST_CONVERSATION_ID: returns most recent conversation ID

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -424,6 +424,19 @@ def get_test_params(method: RPCMethod, notebook_id: str | None) -> list[Any] | N
         # Use "en" as safe language code
         return [[[None, [[None, None, None, None, ["en"]]]]]]
 
+    # GET_USER_TIER: read subscription tier from homepage context (no notebook required)
+    # Params mirror build_get_user_tier_params() in src/notebooklm/_settings.py.
+    if method == RPCMethod.GET_USER_TIER:
+        return [
+            [
+                [
+                    [None, "1", 627],
+                    [None, None, None, None, None, None, None, None, None, [None, None, 2]],
+                    1,
+                ]
+            ]
+        ]
+
     # Methods that require a notebook ID
     if not notebook_id:
         return None

--- a/tests/unit/test_rpc_health_coverage.py
+++ b/tests/unit/test_rpc_health_coverage.py
@@ -7,9 +7,10 @@ explicitly classified as intentionally-not-probed. Without that guard, a
 new entry can land silently and stay unmonitored.
 
 This test pins the classification: every ``RPCMethod`` member must be in
-exactly one of three categories:
+exactly one of four categories:
 
-1. **Probed** — ``get_test_params`` returns non-None test params, so the
+1. **Probed** — ``get_test_params`` returns non-None test params AND the
+   method is not short-circuited by ``ALWAYS_SKIP_METHODS``, so the
    canary will exercise the RPC and confirm its ID still echoes back.
 2. **MUTATING_SKIP_LIST** — create/update/delete/generate writes. These
    either mutate state (only safe in ``--full`` mode against a throwaway
@@ -18,6 +19,9 @@ exactly one of three categories:
    ``setup_temp_resources`` / ``cleanup_temp_resources``.
 3. **PATH_NOT_METHOD_SKIP** — entries that hold a URL path string rather
    than a batchexecute RPC ID. They cannot be probed via the RPC pipeline.
+4. **UNAVAILABLE_SKIP_LIST** — RPCs that exist in the enum but are not
+   currently exercisable (e.g. server-side not fully rolled out). Listed
+   so a future rollout can move them back into the probe set.
 
 If a new ``RPCMethod`` is added without classification, this test fails
 with a message naming the unclassified member so the contributor must
@@ -34,11 +38,18 @@ from notebooklm.rpc.types import RPCMethod
 
 # Load scripts/check_rpc_health.py as a module. The ``scripts`` directory
 # is not a package, so we go through importlib rather than a normal import.
+# Registering the module in ``sys.modules`` before exec is required so
+# ``@dataclass`` inside the script can resolve forward references back to
+# itself during class construction. We use a namespaced key
+# (``scripts.check_rpc_health``) instead of a bare ``check_rpc_health``
+# to avoid colliding with any other test that loads the same script via
+# its own importlib spec (see tests/unit/test_check_rpc_health.py).
 _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_rpc_health.py"
-_spec = importlib.util.spec_from_file_location("check_rpc_health", _SCRIPT_PATH)
+_MODULE_KEY = "scripts.check_rpc_health"
+_spec = importlib.util.spec_from_file_location(_MODULE_KEY, _SCRIPT_PATH)
 assert _spec is not None and _spec.loader is not None
 check_rpc_health = importlib.util.module_from_spec(_spec)
-sys.modules["check_rpc_health"] = check_rpc_health
+sys.modules[_MODULE_KEY] = check_rpc_health
 _spec.loader.exec_module(check_rpc_health)
 
 
@@ -95,21 +106,44 @@ PATH_NOT_METHOD_SKIP: frozenset[str] = frozenset(
 )
 
 
-def _probed_method_names() -> frozenset[str]:
-    """Return the set of method names that the canary actively probes.
+UNAVAILABLE_SKIP_LIST: frozenset[str] = frozenset(
+    {
+        # Not fully rolled out by Google — the canary's call fails for any
+        # input IDs, so the script lists it in ALWAYS_SKIP_METHODS rather
+        # than risking a false MISMATCH. Move back into get_test_params
+        # once Google ships the feature widely.
+        "DISCOVER_SOURCES",
+    }
+)
 
-    A method is considered "probed" when ``get_test_params`` returns a
-    non-None parameter list for it. The function is called twice — once
-    without a notebook ID (covers methods that don't need one) and once
-    with a dummy notebook ID (covers methods that do).
+
+def _probed_method_names() -> frozenset[str]:
+    """Return the set of method names the canary actively exercises.
+
+    A method counts as "probed" only when BOTH conditions hold:
+    1. ``get_test_params`` returns a non-None parameter list for it.
+    2. It is NOT short-circuited by ``ALWAYS_SKIP_METHODS`` in the script
+       (which runs before ``get_test_params`` in ``check_method``).
+
+    Without the second check, a method that has params *but* is also in
+    ALWAYS_SKIP would be silently mis-classified as probed even though
+    the canary never actually calls it.
     """
+    always_skip_names = {m.name for m in check_rpc_health.ALWAYS_SKIP_METHODS}
     probed: set[str] = set()
     for notebook_id in (None, _DUMMY_NOTEBOOK_ID):
         for method in RPCMethod:
+            if method.name in always_skip_names:
+                continue
             params = check_rpc_health.get_test_params(method, notebook_id)
             if params is not None:
                 probed.add(method.name)
     return frozenset(probed)
+
+
+def _all_skip_lists() -> frozenset[str]:
+    """Union of every explicit skip frozenset."""
+    return MUTATING_SKIP_LIST | PATH_NOT_METHOD_SKIP | UNAVAILABLE_SKIP_LIST
 
 
 def test_every_rpc_method_is_probed_or_explicitly_skipped() -> None:
@@ -121,14 +155,15 @@ def test_every_rpc_method_is_probed_or_explicitly_skipped() -> None:
     by editing the appropriate constant (and adding a justifying comment).
     """
     probed = _probed_method_names()
-    classified = probed | MUTATING_SKIP_LIST | PATH_NOT_METHOD_SKIP
+    classified = probed | _all_skip_lists()
     all_names = {m.name for m in RPCMethod}
     unclassified = sorted(all_names - classified)
     assert not unclassified, (
         "Unclassified RPCMethod entries detected: "
         f"{unclassified}. Add each one to scripts/check_rpc_health.py's "
         "get_test_params (read-only probe), MUTATING_SKIP_LIST (a write/"
-        "expensive op), or PATH_NOT_METHOD_SKIP (a URL path)."
+        "expensive op), PATH_NOT_METHOD_SKIP (a URL path), or "
+        "UNAVAILABLE_SKIP_LIST (not currently exercisable)."
     )
 
 
@@ -137,6 +172,7 @@ def test_skip_lists_are_disjoint_from_probed() -> None:
     probed = _probed_method_names()
     double_classified_mutating = sorted(probed & MUTATING_SKIP_LIST)
     double_classified_path = sorted(probed & PATH_NOT_METHOD_SKIP)
+    double_classified_unavailable = sorted(probed & UNAVAILABLE_SKIP_LIST)
     assert not double_classified_mutating, (
         "Methods are both probed AND in MUTATING_SKIP_LIST: "
         f"{double_classified_mutating}. Remove from one list."
@@ -145,30 +181,45 @@ def test_skip_lists_are_disjoint_from_probed() -> None:
         "Methods are both probed AND in PATH_NOT_METHOD_SKIP: "
         f"{double_classified_path}. Remove from one list."
     )
+    assert not double_classified_unavailable, (
+        "Methods are both probed AND in UNAVAILABLE_SKIP_LIST: "
+        f"{double_classified_unavailable}. Remove from one list."
+    )
 
 
 def test_skip_lists_are_disjoint_from_each_other() -> None:
     """Each skip list entry must belong to exactly one category."""
-    overlap = sorted(MUTATING_SKIP_LIST & PATH_NOT_METHOD_SKIP)
-    assert not overlap, (
-        "Entries appear in both MUTATING_SKIP_LIST and PATH_NOT_METHOD_SKIP: "
-        f"{overlap}. Pick one category."
+    pairs = (
+        ("MUTATING_SKIP_LIST", "PATH_NOT_METHOD_SKIP", MUTATING_SKIP_LIST & PATH_NOT_METHOD_SKIP),
+        (
+            "MUTATING_SKIP_LIST",
+            "UNAVAILABLE_SKIP_LIST",
+            MUTATING_SKIP_LIST & UNAVAILABLE_SKIP_LIST,
+        ),
+        (
+            "PATH_NOT_METHOD_SKIP",
+            "UNAVAILABLE_SKIP_LIST",
+            PATH_NOT_METHOD_SKIP & UNAVAILABLE_SKIP_LIST,
+        ),
     )
+    for left, right, overlap in pairs:
+        assert not overlap, (
+            f"Entries appear in both {left} and {right}: {sorted(overlap)}. Pick one category."
+        )
 
 
 def test_skip_list_entries_reference_real_enum_members() -> None:
     """Catch typos: every skip-list name must match an actual enum member."""
     all_names = {m.name for m in RPCMethod}
-    stale_mutating = sorted(MUTATING_SKIP_LIST - all_names)
-    stale_path = sorted(PATH_NOT_METHOD_SKIP - all_names)
-    assert not stale_mutating, (
-        f"MUTATING_SKIP_LIST references non-existent RPCMethod entries: "
-        f"{stale_mutating}. Remove or fix the name."
-    )
-    assert not stale_path, (
-        f"PATH_NOT_METHOD_SKIP references non-existent RPCMethod entries: "
-        f"{stale_path}. Remove or fix the name."
-    )
+    for label, skip_set in (
+        ("MUTATING_SKIP_LIST", MUTATING_SKIP_LIST),
+        ("PATH_NOT_METHOD_SKIP", PATH_NOT_METHOD_SKIP),
+        ("UNAVAILABLE_SKIP_LIST", UNAVAILABLE_SKIP_LIST),
+    ):
+        stale = sorted(skip_set - all_names)
+        assert not stale, (
+            f"{label} references non-existent RPCMethod entries: {stale}. Remove or fix the name."
+        )
 
 
 def test_full_mode_only_methods_match_mutating_skip_list() -> None:
@@ -183,4 +234,22 @@ def test_full_mode_only_methods_match_mutating_skip_list() -> None:
     assert not missing, (
         "FULL_MODE_ONLY_METHODS contains entries not in MUTATING_SKIP_LIST: "
         f"{missing}. Add them to MUTATING_SKIP_LIST with a justifying comment."
+    )
+
+
+def test_always_skip_methods_are_each_classified() -> None:
+    """Every ``ALWAYS_SKIP_METHODS`` entry must be in some skip frozenset.
+
+    Closes the symmetric gap: if the script marks a method as always-skip
+    (so the canary never exercises it), the test's skip lists must own
+    that decision explicitly. Otherwise an entry could be silently
+    de-probed in the script without any visible test churn.
+    """
+    always_skip_names = {m.name for m in check_rpc_health.ALWAYS_SKIP_METHODS}
+    classified = _all_skip_lists()
+    missing = sorted(always_skip_names - classified)
+    assert not missing, (
+        "ALWAYS_SKIP_METHODS entries are not in any skip frozenset: "
+        f"{missing}. Add each to MUTATING_SKIP_LIST, PATH_NOT_METHOD_SKIP, "
+        "or UNAVAILABLE_SKIP_LIST with a justifying comment."
     )

--- a/tests/unit/test_rpc_health_coverage.py
+++ b/tests/unit/test_rpc_health_coverage.py
@@ -1,0 +1,186 @@
+"""Coverage assertion for the RPC-health canary (PR-T6.B).
+
+``scripts/check_rpc_health.py`` already enumerates every ``RPCMethod`` and
+prints a per-method row, but until now there was no CI guard that *every*
+new enum entry is either (a) actively probed by the canary or (b)
+explicitly classified as intentionally-not-probed. Without that guard, a
+new entry can land silently and stay unmonitored.
+
+This test pins the classification: every ``RPCMethod`` member must be in
+exactly one of three categories:
+
+1. **Probed** — ``get_test_params`` returns non-None test params, so the
+   canary will exercise the RPC and confirm its ID still echoes back.
+2. **MUTATING_SKIP_LIST** — create/update/delete/generate writes. These
+   either mutate state (only safe in ``--full`` mode against a throwaway
+   notebook) or kick off long-running server-side tasks. They are NEVER
+   probed in the read-only quick canary; full mode handles them via
+   ``setup_temp_resources`` / ``cleanup_temp_resources``.
+3. **PATH_NOT_METHOD_SKIP** — entries that hold a URL path string rather
+   than a batchexecute RPC ID. They cannot be probed via the RPC pipeline.
+
+If a new ``RPCMethod`` is added without classification, this test fails
+with a message naming the unclassified member so the contributor must
+make an explicit decision.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from notebooklm.rpc.types import RPCMethod
+
+# Load scripts/check_rpc_health.py as a module. The ``scripts`` directory
+# is not a package, so we go through importlib rather than a normal import.
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_rpc_health.py"
+_spec = importlib.util.spec_from_file_location("check_rpc_health", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+check_rpc_health = importlib.util.module_from_spec(_spec)
+sys.modules["check_rpc_health"] = check_rpc_health
+_spec.loader.exec_module(check_rpc_health)
+
+
+# A representative notebook ID — only used to drive ``get_test_params``
+# down its notebook-required branches. No network calls are made.
+_DUMMY_NOTEBOOK_ID = "dummy-notebook-id-for-classification-only"
+
+
+# ---------------------------------------------------------------------------
+# Explicit skip lists — each entry MUST be justified with a comment so that
+# reviewers can audit the decision at a glance.
+# ---------------------------------------------------------------------------
+
+MUTATING_SKIP_LIST: frozenset[str] = frozenset(
+    {
+        # Creates a new notebook — only safe inside --full mode against a
+        # throwaway notebook (handled by setup_temp_resources).
+        "CREATE_NOTEBOOK",
+        # Permanently deletes a notebook — only safe in --full cleanup.
+        "DELETE_NOTEBOOK",
+        # Adds a text/url source to a notebook — write op, --full only.
+        "ADD_SOURCE",
+        # Registers a file upload as a source — write op, --full only.
+        "ADD_SOURCE_FILE",
+        # Removes a source from a notebook — write op, --full only.
+        "DELETE_SOURCE",
+        # Generates a new artifact (audio/video/quiz/report/…) — expensive
+        # write op. Tested via --full setup using flashcards (fastest path).
+        "CREATE_ARTIFACT",
+        # Permanently deletes an artifact — write op, --full only.
+        "DELETE_ARTIFACT",
+        # Creates a new note — write op, --full only.
+        "CREATE_NOTE",
+        # Permanently deletes a note — write op, --full only.
+        "DELETE_NOTE",
+        # Kicks off a fast-research task on the server — long-running write
+        # op. Tested via --full setup to verify the RPC ID still echoes.
+        "START_FAST_RESEARCH",
+        # Kicks off a deep-research task — takes minutes to hours. Never
+        # probed in either quick or full mode (see ALWAYS_SKIP_METHODS in
+        # scripts/check_rpc_health.py).
+        "START_DEEP_RESEARCH",
+    }
+)
+
+
+PATH_NOT_METHOD_SKIP: frozenset[str] = frozenset(
+    {
+        # QUERY_ENDPOINT holds a streamed-chat URL path, not a batchexecute
+        # RPC ID. The chat endpoint lives outside the /batchexecute RPC
+        # pipeline, so the canary cannot probe it via the same plumbing.
+        "QUERY_ENDPOINT",
+    }
+)
+
+
+def _probed_method_names() -> frozenset[str]:
+    """Return the set of method names that the canary actively probes.
+
+    A method is considered "probed" when ``get_test_params`` returns a
+    non-None parameter list for it. The function is called twice — once
+    without a notebook ID (covers methods that don't need one) and once
+    with a dummy notebook ID (covers methods that do).
+    """
+    probed: set[str] = set()
+    for notebook_id in (None, _DUMMY_NOTEBOOK_ID):
+        for method in RPCMethod:
+            params = check_rpc_health.get_test_params(method, notebook_id)
+            if params is not None:
+                probed.add(method.name)
+    return frozenset(probed)
+
+
+def test_every_rpc_method_is_probed_or_explicitly_skipped() -> None:
+    """Every ``RPCMethod`` member must be probed or in a skip list.
+
+    Fails with a clear message naming any enum entry that is neither
+    actively probed by ``scripts/check_rpc_health.py`` nor declared in one
+    of the explicit skip frozensets above. A new entry must be classified
+    by editing the appropriate constant (and adding a justifying comment).
+    """
+    probed = _probed_method_names()
+    classified = probed | MUTATING_SKIP_LIST | PATH_NOT_METHOD_SKIP
+    all_names = {m.name for m in RPCMethod}
+    unclassified = sorted(all_names - classified)
+    assert not unclassified, (
+        "Unclassified RPCMethod entries detected: "
+        f"{unclassified}. Add each one to scripts/check_rpc_health.py's "
+        "get_test_params (read-only probe), MUTATING_SKIP_LIST (a write/"
+        "expensive op), or PATH_NOT_METHOD_SKIP (a URL path)."
+    )
+
+
+def test_skip_lists_are_disjoint_from_probed() -> None:
+    """A method must not appear in both a skip list and the probe set."""
+    probed = _probed_method_names()
+    double_classified_mutating = sorted(probed & MUTATING_SKIP_LIST)
+    double_classified_path = sorted(probed & PATH_NOT_METHOD_SKIP)
+    assert not double_classified_mutating, (
+        "Methods are both probed AND in MUTATING_SKIP_LIST: "
+        f"{double_classified_mutating}. Remove from one list."
+    )
+    assert not double_classified_path, (
+        "Methods are both probed AND in PATH_NOT_METHOD_SKIP: "
+        f"{double_classified_path}. Remove from one list."
+    )
+
+
+def test_skip_lists_are_disjoint_from_each_other() -> None:
+    """Each skip list entry must belong to exactly one category."""
+    overlap = sorted(MUTATING_SKIP_LIST & PATH_NOT_METHOD_SKIP)
+    assert not overlap, (
+        "Entries appear in both MUTATING_SKIP_LIST and PATH_NOT_METHOD_SKIP: "
+        f"{overlap}. Pick one category."
+    )
+
+
+def test_skip_list_entries_reference_real_enum_members() -> None:
+    """Catch typos: every skip-list name must match an actual enum member."""
+    all_names = {m.name for m in RPCMethod}
+    stale_mutating = sorted(MUTATING_SKIP_LIST - all_names)
+    stale_path = sorted(PATH_NOT_METHOD_SKIP - all_names)
+    assert not stale_mutating, (
+        f"MUTATING_SKIP_LIST references non-existent RPCMethod entries: "
+        f"{stale_mutating}. Remove or fix the name."
+    )
+    assert not stale_path, (
+        f"PATH_NOT_METHOD_SKIP references non-existent RPCMethod entries: "
+        f"{stale_path}. Remove or fix the name."
+    )
+
+
+def test_full_mode_only_methods_match_mutating_skip_list() -> None:
+    """The script's FULL_MODE_ONLY set should be a subset of MUTATING_SKIP_LIST.
+
+    Every method the script treats as full-mode-only (because it mutates
+    state or kicks off long work) must also be declared mutating here, so
+    the two views of "this is a write op" stay in lockstep.
+    """
+    full_mode_names = {m.name for m in check_rpc_health.FULL_MODE_ONLY_METHODS}
+    missing = sorted(full_mode_names - MUTATING_SKIP_LIST)
+    assert not missing, (
+        "FULL_MODE_ONLY_METHODS contains entries not in MUTATING_SKIP_LIST: "
+        f"{missing}. Add them to MUTATING_SKIP_LIST with a justifying comment."
+    )


### PR DESCRIPTION
## Summary

Adds a CI guard so every `RPCMethod` enum entry is either actively probed by `scripts/check_rpc_health.py` or explicitly classified in one of two skip frozensets. Until now a new entry could land silently and stay unmonitored.

- `MUTATING_SKIP_LIST` — create/update/delete/long-running writes (11 members, each with a justifying comment)
- `PATH_NOT_METHOD_SKIP` — entries that are URL paths, not batchexecute RPC IDs (currently just `QUERY_ENDPOINT`)
- Everything else must have non-None `get_test_params`, i.e. be probed

Also adds `GET_USER_TIER` to `get_test_params` — the previously-missing read-only probe surfaced by the new coverage assertion.

Scope correction (per plan §T6.B): `scripts/check_rpc_health.py` already enumerates `list(RPCMethod)` and prints per-method rows. The gap was a CI assertion that every entry is probed-or-classified — not re-implementing enumeration.

## Test plan

- [x] `uv run pytest tests/unit/test_rpc_health_coverage.py` — 5 passed
- [x] `uv run pytest tests/unit -x -q` — 2707 passed, 7 skipped
- [x] `uv run ruff format . && uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] Synthetic check: 30 probed + 11 mutating + 1 path = 42 = `len(list(RPCMethod))`

Refs: `.sisyphus/plans/tier-6-implementation.md` PR-T6.B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation for RPC method test coverage to ensure all RPC operations are properly monitored and classified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/485)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->