### PR TITLE
feat(rpc): NOTEBOOKLM_RPC_OVERRIDES env var for community self-patch (T6.A)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -278,6 +278,56 @@ If the IDs don't match, the method ID has changed. Report the new ID in a GitHub
 - Try with fewer sources selected
 - Reduce generation frequency
 
+#### RPC method ID rotated by Google — self-patch with `NOTEBOOKLM_RPC_OVERRIDES`
+
+Google rotates undocumented batchexecute method IDs without warning. When
+this happens, `notebooklm-py` raises `UnknownRPCMethodError` with the new ID
+the server now uses (see the previous section's diagnosis recipe). Rather
+than waiting for a release, you can patch the mapping for your process with
+the `NOTEBOOKLM_RPC_OVERRIDES` environment variable.
+
+**Format:** JSON object mapping `RPCMethod` member names (the Python enum
+member name, not the obfuscated value) to the override RPC ID:
+
+```bash
+export NOTEBOOKLM_RPC_OVERRIDES='{"LIST_NOTEBOOKS": "newId123", "CREATE_NOTEBOOK": "newId456"}'
+notebooklm list
+```
+
+Or in Python:
+
+```python
+import os
+os.environ["NOTEBOOKLM_RPC_OVERRIDES"] = '{"LIST_NOTEBOOKS": "newId123"}'
+
+from notebooklm import NotebookLMClient
+# Subsequent client calls send the override IDs on the wire.
+```
+
+**Behavior:**
+
+- The override is applied at BOTH the URL `rpcids=` query parameter AND the
+  request body `f.req` payload, so the wire format stays consistent.
+- The override is gated on the configured base host being a known Google
+  NotebookLM endpoint (`notebooklm.google.com` or
+  `notebooklm.cloud.google.com`). Overrides do NOT apply to non-Google
+  hosts, so this env var cannot be weaponised to leak custom RPC IDs to a
+  hostile endpoint.
+- Method names not listed in the override map continue to use the canonical
+  IDs from `notebooklm.rpc.types.RPCMethod`.
+- Malformed input (invalid JSON, top-level array, etc.) is logged at
+  `WARNING` and treated as no overrides.
+- The first time a distinct override set is applied in a process, the
+  mapping is logged at `INFO` so you can confirm the config you intended is
+  live.
+
+**Discovering the new ID:** see the `NOTEBOOKLM_DEBUG_RPC=1` recipe above —
+the `Found RPC IDs in response: [...]` line tells you what the server is
+now returning. Cross-reference against the call site that failed.
+
+Please also report the rotated IDs in a GitHub issue so the canonical
+mapping in `src/notebooklm/rpc/types.py` can be updated for everyone.
+
 #### How to get the full response preview from an RPCError
 
 `RPCError.raw_response` is truncated to **80 chars + `"..."`** by default so

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -44,6 +44,7 @@ from .rpc import (
     decode_response,
     encode_rpc_request,
     get_batchexecute_url,
+    resolve_rpc_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -698,18 +699,29 @@ class ClientCore:
             account_email=self.auth.account_email,
         )
 
-    def _build_url(self, rpc_method: RPCMethod, source_path: str = "/") -> str:
+    def _build_url(
+        self,
+        rpc_method: RPCMethod,
+        source_path: str = "/",
+        rpc_id_override: str | None = None,
+    ) -> str:
         """Build the batchexecute URL for an RPC call.
 
         Args:
             rpc_method: The RPC method to call.
             source_path: The source path parameter (usually notebook path).
+            rpc_id_override: Optional resolved RPC id string used in the
+                ``rpcids=`` query param. When provided, the SAME string must
+                also be passed to :func:`encode_rpc_request` so the URL and
+                body stay in sync. See ``resolve_rpc_id`` for the
+                ``NOTEBOOKLM_RPC_OVERRIDES`` plumbing.
 
         Returns:
             Full URL with query parameters.
         """
+        rpc_id = rpc_id_override if rpc_id_override is not None else rpc_method.value
         params: dict[str, str] = {
-            "rpcids": rpc_method.value,
+            "rpcids": rpc_id,
             "source-path": source_path,
             "f.sid": self.auth.session_id,
             "hl": get_default_language(),
@@ -1102,12 +1114,20 @@ class ClientCore:
         start = time.perf_counter()
         logger.debug("RPC %s starting", method.name)
 
+        # Resolve the RPC id ONCE per logical call. ``NOTEBOOKLM_RPC_OVERRIDES``
+        # lets users self-patch when Google rotates an obfuscated method id;
+        # the resolved value MUST flow into both the URL's ``rpcids=`` query
+        # param and the request body's ``f.req`` payload (the wire format
+        # treats a mismatch as malformed). Resolving once also means decode
+        # below uses the same id we asked the server for.
+        resolved_id = resolve_rpc_id(method.name, method.value)
+
         # ``_perform_authed_post`` calls this factory once per HTTP attempt;
         # on retry it passes a fresh snapshot so the body is rebuilt with the
         # refreshed CSRF and the URL with the refreshed session id /
         # authuser. Capturing ``self.auth.csrf_token`` here directly would
         # snapshot at outer-call time and replay a stale token on retry.
-        rpc_request = encode_rpc_request(method, params)
+        rpc_request = encode_rpc_request(method, params, rpc_id_override=resolved_id)
 
         def _build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             # Deliberate divergence: the body uses the snapshot's csrf_token
@@ -1124,7 +1144,7 @@ class ClientCore:
             # refresh). The snapshot's session_id/authuser/account_email
             # fields are carried for symmetry / future-proofing but are not
             # the source of truth on this code path.
-            url = self._build_url(method, source_path)
+            url = self._build_url(method, source_path, rpc_id_override=resolved_id)
             body = build_request_body(rpc_request, snapshot.csrf_token)
             return url, body, {}
 
@@ -1207,7 +1227,11 @@ class ClientCore:
         # streaming format doesn't have this pattern, so the retry lives
         # here, not in ``_perform_authed_post``.
         try:
-            result = decode_response(response.text, method.value, allow_null=allow_null)
+            # The server echoes back whatever RPC id we sent on the wire, so
+            # decode against the resolved id (override-aware) rather than the
+            # canonical ``method.value`` — otherwise an override would parse
+            # as "RPC id not found in response".
+            result = decode_response(response.text, resolved_id, allow_null=allow_null)
             elapsed = time.perf_counter() - start
             logger.debug("RPC %s completed in %.3fs", method.name, elapsed)
             return result

--- a/src/notebooklm/rpc/__init__.py
+++ b/src/notebooklm/rpc/__init__.py
@@ -47,6 +47,7 @@ from .types import (
     get_batchexecute_url,
     get_query_url,
     get_upload_url,
+    resolve_rpc_id,
 )
 
 __all__ = [
@@ -57,6 +58,7 @@ __all__ = [
     "get_batchexecute_url",
     "get_query_url",
     "get_upload_url",
+    "resolve_rpc_id",
     "ArtifactTypeCode",
     "StudioContentType",  # Deprecated alias
     "ArtifactStatus",

--- a/src/notebooklm/rpc/encoder.py
+++ b/src/notebooklm/rpc/encoder.py
@@ -10,7 +10,11 @@ from .types import RPCMethod
 logger = logging.getLogger(__name__)
 
 
-def encode_rpc_request(method: RPCMethod, params: list[Any]) -> list:
+def encode_rpc_request(
+    method: RPCMethod,
+    params: list[Any],
+    rpc_id_override: str | None = None,
+) -> list:
     """
     Encode an RPC request into batchexecute format.
 
@@ -20,16 +24,23 @@ def encode_rpc_request(method: RPCMethod, params: list[Any]) -> list:
     Args:
         method: The RPC method ID enum
         params: Parameters for the RPC call
+        rpc_id_override: Optional resolved RPC id string. When provided, this
+            value is embedded in the request body instead of ``method.value``.
+            Callers must pass the SAME string to the URL builder so the
+            ``rpcids=`` query param and the ``f.req`` body stay in sync —
+            mismatched IDs reach the wire as malformed requests. Used by
+            ``ClientCore`` to thread ``NOTEBOOKLM_RPC_OVERRIDES`` through.
 
     Returns:
         Triple-nested array structure for batchexecute
     """
+    rpc_id = rpc_id_override if rpc_id_override is not None else method.value
     # JSON-encode params without spaces (compact format matching Chrome)
     params_json = json.dumps(params, separators=(",", ":"))
-    logger.debug("Encoding RPC: method=%s, param_count=%d", method.value, len(params))
+    logger.debug("Encoding RPC: method=%s, param_count=%d", rpc_id, len(params))
 
     # Build inner request: [rpc_id, json_params, null, "generic"]
-    inner = [method.value, params_json, None, "generic"]
+    inner = [rpc_id, params_json, None, "generic"]
 
     # Triple-nest the request
     return [[inner]]

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from enum import Enum
+from functools import lru_cache
 
 from .._env import DEFAULT_BASE_URL, get_base_url
 
@@ -13,6 +14,32 @@ logger = logging.getLogger(__name__)
 # hash of the canonical (sorted) item tuple. This dedupes multi-client tests
 # while still emitting one INFO line per *distinct* override set in a process.
 _logged_override_hashes: set[int] = set()
+
+
+@lru_cache(maxsize=8)
+def _parse_rpc_overrides(raw: str | None) -> tuple[tuple[str, str], ...]:
+    """Parse and validate the raw env-var string, returning an immutable mapping.
+
+    Cached on the raw string so JSON parsing — and the WARNING emitted for
+    malformed input — happens once per distinct env value rather than once
+    per RPC call. Returns a tuple-of-pairs (immutable, hashable) so the
+    caller can rebuild a fresh dict without mutating cached state.
+    """
+    if not raw:
+        return ()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("NOTEBOOKLM_RPC_OVERRIDES is not valid JSON: %s", exc)
+        return ()
+    if not isinstance(data, dict):
+        logger.warning(
+            "NOTEBOOKLM_RPC_OVERRIDES must be a JSON object mapping "
+            "method names to RPC IDs, got %s",
+            type(data).__name__,
+        )
+        return ()
+    return tuple((str(k), str(v)) for k, v in data.items())
 
 
 def _load_rpc_overrides() -> dict[str, str]:
@@ -25,22 +52,7 @@ def _load_rpc_overrides() -> dict[str, str]:
 
     Returns an empty dict when the env var is unset or invalid.
     """
-    raw = os.environ.get("NOTEBOOKLM_RPC_OVERRIDES")
-    if not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        logger.warning("NOTEBOOKLM_RPC_OVERRIDES is not valid JSON: %s", exc)
-        return {}
-    if not isinstance(data, dict):
-        logger.warning(
-            "NOTEBOOKLM_RPC_OVERRIDES must be a JSON object mapping "
-            "method names to RPC IDs, got %s",
-            type(data).__name__,
-        )
-        return {}
-    return {str(k): str(v) for k, v in data.items()}
+    return dict(_parse_rpc_overrides(os.environ.get("NOTEBOOKLM_RPC_OVERRIDES")))
 
 
 def resolve_rpc_id(method_name: str, canonical_id: str) -> str:

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -47,7 +47,22 @@ def _parse_rpc_overrides(raw: str | None) -> tuple[tuple[str, str], ...]:
     # module; the lookup is deferred to call time so the forward reference
     # is resolved by the time any caller invokes us.
     valid_methods = set(RPCMethod.__members__)
-    normalized = [(str(k), str(v)) for k, v in data.items()]
+    normalized: list[tuple[str, str]] = []
+    null_keys: list[str] = []
+    for k, v in data.items():
+        if v is None:
+            # ``json.loads('{"X": null}')`` would coerce to ``str(None) ==
+            # "None"`` — a literal four-character string on the wire, almost
+            # certainly not what the user meant. Drop and warn loudly.
+            null_keys.append(str(k))
+            continue
+        normalized.append((str(k), str(v)))
+    if null_keys:
+        logger.warning(
+            "Ignoring NOTEBOOKLM_RPC_OVERRIDES entries with null values "
+            "(provide a non-null RPC id string): %s",
+            ", ".join(sorted(null_keys)),
+        )
     unknown = sorted(k for k, _ in normalized if k not in valid_methods)
     if unknown:
         logger.warning(
@@ -103,11 +118,13 @@ def resolve_rpc_id(method_name: str, canonical_id: str) -> str:
 
     try:
         host = get_base_host()
-    except Exception:
-        # If the host can't even be resolved (e.g. malformed
-        # NOTEBOOKLM_BASE_URL), pretend overrides are disabled rather than
-        # crashing the resolver. The URL builder itself will surface the
-        # real error.
+    except ValueError:
+        # ``get_base_host()`` raises ``ValueError`` for a malformed
+        # ``NOTEBOOKLM_BASE_URL`` (the only failure mode it documents).
+        # Treat overrides as disabled in that case rather than crashing the
+        # resolver — the URL builder itself will surface the real error to
+        # the caller. A broader ``except Exception`` would mask unrelated
+        # bugs in ``get_base_host`` during development.
         return canonical_id
     if host not in _ALLOWED_BASE_HOSTS:
         return canonical_id

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -39,7 +39,22 @@ def _parse_rpc_overrides(raw: str | None) -> tuple[tuple[str, str], ...]:
             type(data).__name__,
         )
         return ()
-    return tuple((str(k), str(v)) for k, v in data.items())
+    # Reject keys that don't match an RPCMethod enum member. Without this
+    # gate, a typo like ``"LIST_NOTEBOOK"`` would silently no-op (resolver
+    # only matches exact enum names) while the INFO log line proudly claims
+    # the override was applied — making the escape hatch look live while
+    # calls keep using canonical IDs. ``RPCMethod`` is defined later in this
+    # module; the lookup is deferred to call time so the forward reference
+    # is resolved by the time any caller invokes us.
+    valid_methods = set(RPCMethod.__members__)
+    normalized = [(str(k), str(v)) for k, v in data.items()]
+    unknown = sorted(k for k, _ in normalized if k not in valid_methods)
+    if unknown:
+        logger.warning(
+            "Ignoring unknown NOTEBOOKLM_RPC_OVERRIDES method names (not in RPCMethod): %s",
+            ", ".join(unknown),
+        )
+    return tuple((k, v) for k, v in normalized if k in valid_methods)
 
 
 def _load_rpc_overrides() -> dict[str, str]:

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -1,8 +1,104 @@
 """RPC types and constants for NotebookLM API."""
 
+import json
+import logging
+import os
 from enum import Enum
 
 from .._env import DEFAULT_BASE_URL, get_base_url
+
+logger = logging.getLogger(__name__)
+
+# Track which override dicts we've already logged at INFO level, keyed by the
+# hash of the canonical (sorted) item tuple. This dedupes multi-client tests
+# while still emitting one INFO line per *distinct* override set in a process.
+_logged_override_hashes: set[int] = set()
+
+
+def _load_rpc_overrides() -> dict[str, str]:
+    """Parse ``NOTEBOOKLM_RPC_OVERRIDES`` into a ``{method_name: rpc_id}`` map.
+
+    The env var is a JSON object mapping :class:`RPCMethod` member names
+    (e.g. ``"LIST_NOTEBOOKS"``) to override RPC ID strings. Any malformed
+    input — invalid JSON, non-object top-level (array, string, etc.) —
+    is logged at WARNING and treated as no overrides.
+
+    Returns an empty dict when the env var is unset or invalid.
+    """
+    raw = os.environ.get("NOTEBOOKLM_RPC_OVERRIDES")
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning("NOTEBOOKLM_RPC_OVERRIDES is not valid JSON: %s", exc)
+        return {}
+    if not isinstance(data, dict):
+        logger.warning(
+            "NOTEBOOKLM_RPC_OVERRIDES must be a JSON object mapping "
+            "method names to RPC IDs, got %s",
+            type(data).__name__,
+        )
+        return {}
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def resolve_rpc_id(method_name: str, canonical_id: str) -> str:
+    """Return the override RPC id for ``method_name`` when applicable, else ``canonical_id``.
+
+    Overrides are sourced from the ``NOTEBOOKLM_RPC_OVERRIDES`` env var and
+    are gated on the configured base host being on the allowlist
+    (:data:`notebooklm._env._ALLOWED_BASE_HOSTS`). When the host is off the
+    allowlist — which the strict ``get_base_url()`` validator already
+    enforces, but we re-check here as defense in depth — overrides are
+    ignored to avoid leaking custom RPC IDs to untrusted endpoints.
+
+    The first time a distinct override set is consulted in a process, the
+    full mapping is logged at INFO level so operators can confirm the
+    config they intended is live. Subsequent calls with the same set are
+    silent to avoid spamming multi-client tests / long-running daemons.
+
+    Args:
+        method_name: The :class:`RPCMethod` enum member name
+            (e.g. ``"LIST_NOTEBOOKS"``).
+        canonical_id: The fallback RPC ID — usually
+            ``RPCMethod.<member>.value`` — returned when no override applies.
+
+    Returns:
+        Either the override RPC id (when an override is configured AND the
+        host is on the allowlist) or ``canonical_id``.
+    """
+    # Local import to avoid a circular import at module-load time —
+    # ``_env`` is dependency-free, but the public package ``notebooklm``
+    # imports ``rpc.types`` during init, and ``_env`` ships from the same
+    # package.
+    from .._env import _ALLOWED_BASE_HOSTS, get_base_host
+
+    try:
+        host = get_base_host()
+    except Exception:
+        # If the host can't even be resolved (e.g. malformed
+        # NOTEBOOKLM_BASE_URL), pretend overrides are disabled rather than
+        # crashing the resolver. The URL builder itself will surface the
+        # real error.
+        return canonical_id
+    if host not in _ALLOWED_BASE_HOSTS:
+        return canonical_id
+
+    overrides = _load_rpc_overrides()
+    if not overrides:
+        return canonical_id
+
+    key = hash(tuple(sorted(overrides.items())))
+    if key not in _logged_override_hashes:
+        _logged_override_hashes.add(key)
+        logger.info(
+            "NOTEBOOKLM_RPC_OVERRIDES applied: %s",
+            ", ".join(f"{k}={v}" for k, v in sorted(overrides.items())),
+        )
+
+    return overrides.get(method_name, canonical_id)
+
 
 # Backward-compatible default-host endpoint constants. Runtime code should use
 # the lazy get_* helpers below so NOTEBOOKLM_BASE_URL is honored after import.

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -94,6 +94,26 @@ def test_load_rpc_overrides_coerces_values_to_str(monkeypatch):
     assert _load_rpc_overrides() == {"LIST_NOTEBOOKS": "12345"}
 
 
+def test_load_rpc_overrides_drops_unknown_keys_with_warning(monkeypatch, caplog):
+    """Keys not matching an RPCMethod member are dropped + warned, not silently kept.
+
+    Without this gate, a typo (``"LIST_NOTEBOOK"``) would silently no-op
+    while the INFO line still claimed the override was applied — exactly
+    the failure mode the escape hatch is supposed to prevent.
+    """
+    monkeypatch.setenv(
+        "NOTEBOOKLM_RPC_OVERRIDES",
+        '{"LIST_NOTEBOOK": "typo", "LIST_NOTEBOOKS": "real"}',
+    )
+    with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+        result = _load_rpc_overrides()
+    assert result == {"LIST_NOTEBOOKS": "real"}
+    assert "LIST_NOTEBOOK" not in result
+    assert any(
+        "Ignoring unknown" in r.message and "LIST_NOTEBOOK" in r.message for r in caplog.records
+    )
+
+
 # ---------------------------------------------------------------------------
 # resolve_rpc_id — host-gate + override application
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -19,7 +19,18 @@ from notebooklm._core import ClientCore
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
 from notebooklm.rpc import types as rpc_types
-from notebooklm.rpc.types import _load_rpc_overrides, resolve_rpc_id
+from notebooklm.rpc.types import _load_rpc_overrides, _parse_rpc_overrides, resolve_rpc_id
+
+
+@pytest.fixture(autouse=True)
+def _clear_override_caches():
+    """Clear parser cache + INFO-dedup set between tests so warnings reproduce."""
+    _parse_rpc_overrides.cache_clear()
+    rpc_types._logged_override_hashes.clear()
+    yield
+    _parse_rpc_overrides.cache_clear()
+    rpc_types._logged_override_hashes.clear()
+
 
 # ---------------------------------------------------------------------------
 # _load_rpc_overrides — env-var parsing

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -94,6 +94,24 @@ def test_load_rpc_overrides_coerces_values_to_str(monkeypatch):
     assert _load_rpc_overrides() == {"LIST_NOTEBOOKS": "12345"}
 
 
+def test_load_rpc_overrides_drops_null_values_with_warning(monkeypatch, caplog):
+    """JSON ``null`` values are dropped + warned, never coerced to ``"None"``.
+
+    Without this gate, ``str(None)`` would put the literal four-character
+    string ``"None"`` on the wire as the override RPC id — almost certainly
+    not what the user intended.
+    """
+    monkeypatch.setenv(
+        "NOTEBOOKLM_RPC_OVERRIDES",
+        '{"LIST_NOTEBOOKS": null, "CREATE_NOTEBOOK": "valid"}',
+    )
+    with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+        result = _load_rpc_overrides()
+    assert result == {"CREATE_NOTEBOOK": "valid"}
+    assert "LIST_NOTEBOOKS" not in result
+    assert any("null values" in r.message and "LIST_NOTEBOOKS" in r.message for r in caplog.records)
+
+
 def test_load_rpc_overrides_drops_unknown_keys_with_warning(monkeypatch, caplog):
     """Keys not matching an RPCMethod member are dropped + warned, not silently kept.
 

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -1,0 +1,377 @@
+"""Unit tests for ``NOTEBOOKLM_RPC_OVERRIDES`` self-patch escape hatch (T6.A).
+
+The override mechanism lets users self-patch when Google rotates an
+obfuscated batchexecute method id, *without* waiting for a release. The
+critical invariant: the resolved id must flow into BOTH the URL's
+``rpcids=`` query param AND the request body's ``f.req`` payload —
+mismatched ids reach the wire as malformed requests.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import RPCMethod
+from notebooklm.rpc import types as rpc_types
+from notebooklm.rpc.types import _load_rpc_overrides, resolve_rpc_id
+
+# ---------------------------------------------------------------------------
+# _load_rpc_overrides — env-var parsing
+# ---------------------------------------------------------------------------
+
+
+def test_load_rpc_overrides_unset(monkeypatch):
+    """Unset env var → empty dict, no warning."""
+    monkeypatch.delenv("NOTEBOOKLM_RPC_OVERRIDES", raising=False)
+    assert _load_rpc_overrides() == {}
+
+
+def test_load_rpc_overrides_empty_string(monkeypatch):
+    """Empty env var → empty dict (treated as unset)."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", "")
+    assert _load_rpc_overrides() == {}
+
+
+def test_load_rpc_overrides_valid_json(monkeypatch):
+    """Valid JSON object → parsed dict of string→string."""
+    monkeypatch.setenv(
+        "NOTEBOOKLM_RPC_OVERRIDES",
+        '{"LIST_NOTEBOOKS": "AbCdEf", "CREATE_NOTEBOOK": "GhIjKl"}',
+    )
+    assert _load_rpc_overrides() == {
+        "LIST_NOTEBOOKS": "AbCdEf",
+        "CREATE_NOTEBOOK": "GhIjKl",
+    }
+
+
+def test_load_rpc_overrides_invalid_json_warns(monkeypatch, caplog):
+    """Malformed JSON → WARNING logged, empty dict returned."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", "{not-valid")
+    with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+        result = _load_rpc_overrides()
+    assert result == {}
+    assert any("not valid JSON" in r.message for r in caplog.records)
+
+
+def test_load_rpc_overrides_non_dict_warns(monkeypatch, caplog):
+    """Non-dict top-level (array) → WARNING logged, empty dict returned."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '["LIST_NOTEBOOKS", "AbCdEf"]')
+    with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+        result = _load_rpc_overrides()
+    assert result == {}
+    assert any("must be a JSON object" in r.message for r in caplog.records)
+
+
+def test_load_rpc_overrides_string_top_level_warns(monkeypatch, caplog):
+    """Top-level JSON string (also non-dict) → WARNING + empty dict."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '"just_a_string"')
+    with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+        result = _load_rpc_overrides()
+    assert result == {}
+    assert any("must be a JSON object" in r.message for r in caplog.records)
+
+
+def test_load_rpc_overrides_coerces_values_to_str(monkeypatch):
+    """Non-string values in the override map are coerced to str (defensive)."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": 12345}')
+    assert _load_rpc_overrides() == {"LIST_NOTEBOOKS": "12345"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_rpc_id — host-gate + override application
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rpc_id_no_env_var_returns_canonical(monkeypatch):
+    """With no env var set, resolve returns the canonical id verbatim."""
+    monkeypatch.delenv("NOTEBOOKLM_RPC_OVERRIDES", raising=False)
+    rpc_types._logged_override_hashes.clear()
+    assert (
+        resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+        == RPCMethod.LIST_NOTEBOOKS.value
+    )
+
+
+def test_resolve_rpc_id_with_override(monkeypatch):
+    """An override mapped to the method name replaces the canonical id."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "NEW_ID_v2"}')
+    rpc_types._logged_override_hashes.clear()
+    assert resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value) == "NEW_ID_v2"
+
+
+def test_resolve_rpc_id_unknown_method_unaffected(monkeypatch):
+    """Override map entry for a method we never call → no impact on other calls."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"SOME_RENAMED_METHOD": "x9x9x9"}')
+    rpc_types._logged_override_hashes.clear()
+    assert (
+        resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+        == RPCMethod.LIST_NOTEBOOKS.value
+    )
+
+
+def test_resolve_rpc_id_host_not_allowlisted_ignores_override(monkeypatch):
+    """Host gate: if get_base_host() returns a non-allowed host, overrides are dropped."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "shouldNOTApply"}')
+    rpc_types._logged_override_hashes.clear()
+    # The host gate uses ``_env.get_base_host`` — patch it inline so we don't
+    # depend on a real off-allowlist URL (which the validator would reject).
+    monkeypatch.setattr("notebooklm._env.get_base_host", lambda: "evil.example.com")
+    assert (
+        resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+        == RPCMethod.LIST_NOTEBOOKS.value
+    )
+
+
+def test_resolve_rpc_id_host_resolver_raises_falls_back(monkeypatch):
+    """If get_base_host() raises (malformed env), override is silently skipped."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "shouldNOTApply"}')
+    rpc_types._logged_override_hashes.clear()
+
+    def _boom() -> str:
+        raise ValueError("malformed NOTEBOOKLM_BASE_URL")
+
+    monkeypatch.setattr("notebooklm._env.get_base_host", _boom)
+    assert (
+        resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+        == RPCMethod.LIST_NOTEBOOKS.value
+    )
+
+
+def test_resolve_rpc_id_enterprise_host_allowed(monkeypatch):
+    """The enterprise host (notebooklm.cloud.google.com) also passes the gate."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "ENT_ID"}')
+    rpc_types._logged_override_hashes.clear()
+    monkeypatch.setattr("notebooklm._env.get_base_host", lambda: "notebooklm.cloud.google.com")
+    assert resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value) == "ENT_ID"
+
+
+def test_resolve_rpc_id_logs_once_per_unique_set(monkeypatch, caplog):
+    """A given override mapping is logged at INFO exactly once per distinct set."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "X"}')
+    rpc_types._logged_override_hashes.clear()
+    with caplog.at_level("INFO", logger="notebooklm.rpc.types"):
+        for _ in range(5):
+            resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+    info_lines = [r for r in caplog.records if r.levelname == "INFO" and "OVERRIDES" in r.message]
+    assert len(info_lines) == 1
+
+
+def test_resolve_rpc_id_logs_again_for_different_set(monkeypatch, caplog):
+    """Two distinct override sets each emit one INFO line."""
+    rpc_types._logged_override_hashes.clear()
+    with caplog.at_level("INFO", logger="notebooklm.rpc.types"):
+        monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "v1"}')
+        resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+        monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "v2"}')
+        resolve_rpc_id("LIST_NOTEBOOKS", RPCMethod.LIST_NOTEBOOKS.value)
+    info_lines = [r for r in caplog.records if r.levelname == "INFO" and "OVERRIDES" in r.message]
+    assert len(info_lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# encode_rpc_request — rpc_id_override threading
+# ---------------------------------------------------------------------------
+
+
+def test_encode_rpc_request_default_uses_canonical():
+    """No override → ``method.value`` is embedded in the request body."""
+    from notebooklm.rpc.encoder import encode_rpc_request
+
+    result = encode_rpc_request(RPCMethod.LIST_NOTEBOOKS, [None, 1])
+    assert result[0][0][0] == RPCMethod.LIST_NOTEBOOKS.value
+
+
+def test_encode_rpc_request_override_replaces_id():
+    """When ``rpc_id_override`` is provided, the override is embedded instead."""
+    from notebooklm.rpc.encoder import encode_rpc_request
+
+    result = encode_rpc_request(RPCMethod.LIST_NOTEBOOKS, [None, 1], rpc_id_override="OVERRIDE_v9")
+    assert result[0][0][0] == "OVERRIDE_v9"
+
+
+def test_encode_rpc_request_none_override_uses_canonical():
+    """Explicit None override → falls back to canonical id (no surprise)."""
+    from notebooklm.rpc.encoder import encode_rpc_request
+
+    result = encode_rpc_request(RPCMethod.LIST_NOTEBOOKS, [None, 1], rpc_id_override=None)
+    assert result[0][0][0] == RPCMethod.LIST_NOTEBOOKS.value
+
+
+# ---------------------------------------------------------------------------
+# Integration: both call sites must use the SAME resolved id
+# ---------------------------------------------------------------------------
+
+
+def _make_core() -> ClientCore:
+    auth = AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "sid_cookie"},
+    )
+    return ClientCore(
+        auth=auth,
+        refresh_callback=None,
+        refresh_retry_delay=0.0,
+    )
+
+
+def _ok_response_for(rpc_id: str) -> httpx.Response:
+    inner = json.dumps([])
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    text = f")]}}'\n{len(chunk)}\n{chunk}\n"
+    return httpx.Response(
+        200,
+        text=text,
+        request=httpx.Request("POST", "https://example.test/x"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_id"),
+    [
+        # No env var → canonical id at both sites.
+        pytest.param(None, RPCMethod.LIST_NOTEBOOKS.value, id="no-env"),
+        # One override for the called method → override flows to both sites.
+        pytest.param(
+            '{"LIST_NOTEBOOKS": "PATCHED_v2"}',
+            "PATCHED_v2",
+            id="override-applied",
+        ),
+        # Override for a DIFFERENT method → called method still uses canonical.
+        pytest.param(
+            '{"CREATE_NOTEBOOK": "noTouch"}',
+            RPCMethod.LIST_NOTEBOOKS.value,
+            id="override-for-other-method",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rpc_call_resolved_id_at_both_sites(monkeypatch, env_value, expected_id):
+    """The resolved RPC id is consistent across URL ``rpcids=`` AND body ``f.req``.
+
+    A one-site resolver would send mismatched ids on the wire, which is the
+    failure mode that motivated the v2 plan's "both sites" critical-scope
+    correction.
+    """
+    if env_value is None:
+        monkeypatch.delenv("NOTEBOOKLM_RPC_OVERRIDES", raising=False)
+    else:
+        monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", env_value)
+    rpc_types._logged_override_hashes.clear()
+
+    core = _make_core()
+    await core.open()
+    try:
+        captured: dict[str, Any] = {}
+
+        async def fake_post(url, *, content, **kwargs):
+            captured["url"] = url
+            captured["content"] = content
+            # Server echoes back whatever rpc id we sent — that's the contract
+            # decode_response relies on. Use the EXPECTED id so the test
+            # exercises the full encode → wire → decode round-trip.
+            return _ok_response_for(expected_id)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
+
+        # URL site
+        assert f"rpcids={expected_id}" in captured["url"]
+        # Body site — f.req is URL-encoded JSON, find the inner id as a quoted token.
+        assert f'"{expected_id}"' in httpx.QueryParams(captured["content"])["f.req"]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_host_off_allowlist_ignores_override(monkeypatch):
+    """When ``get_base_host()`` is off the allowlist, overrides are inert.
+
+    Defense-in-depth: the strict ``get_base_url()`` validator already rejects
+    off-allowlist hosts at import time, but the resolver re-checks so a
+    monkeypatched env can't leak custom RPC ids to a hostile endpoint.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "shouldNOTApply"}')
+    monkeypatch.setattr("notebooklm._env.get_base_host", lambda: "evil.example.com")
+    rpc_types._logged_override_hashes.clear()
+
+    core = _make_core()
+    await core.open()
+    try:
+        captured: dict[str, Any] = {}
+
+        async def fake_post(url, *, content, **kwargs):
+            captured["url"] = url
+            captured["content"] = content
+            return _ok_response_for(RPCMethod.LIST_NOTEBOOKS.value)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
+
+        assert f"rpcids={RPCMethod.LIST_NOTEBOOKS.value}" in captured["url"]
+        assert "shouldNOTApply" not in captured["url"]
+        assert "shouldNOTApply" not in captured["content"]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_invalid_json_falls_back_with_warning(monkeypatch, caplog):
+    """Invalid JSON in env var → WARNING + canonical ids on the wire."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", "{not-json")
+    rpc_types._logged_override_hashes.clear()
+
+    core = _make_core()
+    await core.open()
+    try:
+        captured: dict[str, Any] = {}
+
+        async def fake_post(url, *, content, **kwargs):
+            captured["url"] = url
+            captured["content"] = content
+            return _ok_response_for(RPCMethod.LIST_NOTEBOOKS.value)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
+
+        assert any("not valid JSON" in r.message for r in caplog.records)
+        assert f"rpcids={RPCMethod.LIST_NOTEBOOKS.value}" in captured["url"]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_rpc_call_non_dict_json_falls_back_with_warning(monkeypatch, caplog):
+    """Top-level array → WARNING + canonical ids on the wire."""
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '["LIST_NOTEBOOKS", "ignored"]')
+    rpc_types._logged_override_hashes.clear()
+
+    core = _make_core()
+    await core.open()
+    try:
+        captured: dict[str, Any] = {}
+
+        async def fake_post(url, *, content, **kwargs):
+            captured["url"] = url
+            captured["content"] = content
+            return _ok_response_for(RPCMethod.LIST_NOTEBOOKS.value)
+
+        monkeypatch.setattr(core._http_client, "post", fake_post)
+
+        with caplog.at_level("WARNING", logger="notebooklm.rpc.types"):
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
+
+        assert any("must be a JSON object" in r.message for r in caplog.records)
+        assert f"rpcids={RPCMethod.LIST_NOTEBOOKS.value}" in captured["url"]
+    finally:
+        await core.close()


### PR DESCRIPTION
## Summary

Google rotates undocumented batchexecute method IDs without warning. Today, users wait for a release before they can self-recover. This PR adds an escape hatch so the community can patch the mapping in a few minutes:

```bash
export NOTEBOOKLM_RPC_OVERRIDES='{"LIST_NOTEBOOKS": "newId123"}'
```

**Critical-scope invariant (v2 plan "both sites" correction):** The resolved id must flow into BOTH

- the URL `rpcids=` query parameter (`_core._build_url`), and
- the request body `f.req` payload (`rpc.encoder.encode_rpc_request`).

A one-site resolver would send mismatched ids on the wire and produce a malformed request. The resolver is invoked ONCE per logical RPC call in `_rpc_call_impl` and the same string is threaded into both call sites and into `decode_response` (the server echoes back whatever id we sent).

**Host-gate (v2 plan correction):** overrides are gated on `get_base_host() in _env._ALLOWED_BASE_HOSTS` (existing frozenset of `notebooklm.google.com` + `notebooklm.cloud.google.com`). `boq_*` is a frontend build label, not a host, and is intentionally NOT used here. Off-allowlist hosts silently drop the override as defense in depth against a monkeypatched env leaking custom RPC ids.

**Malformed-input contract:** invalid JSON or top-level non-object → WARNING + canonical ids. Applied overrides log at INFO exactly once per distinct override set (hash-deduped via `_logged_override_hashes`) so multi-client tests don't spam.

## Files

- `src/notebooklm/rpc/types.py` — adds `_load_rpc_overrides()` + `resolve_rpc_id(method_name, canonical_id)` helpers and `_logged_override_hashes` dedup set.
- `src/notebooklm/rpc/encoder.py` — `encode_rpc_request(..., rpc_id_override=None)` threading.
- `src/notebooklm/rpc/__init__.py` — re-exports `resolve_rpc_id`.
- `src/notebooklm/_core.py` — resolves once in `_rpc_call_impl`, passes the same id to `_build_url`, `encode_rpc_request`, and `decode_response`.
- `tests/unit/test_rpc_overrides.py` (new, 24 tests).
- `docs/troubleshooting.md` — adds "RPC method ID rotated by Google — self-patch with `NOTEBOOKLM_RPC_OVERRIDES`" section with usage examples.

## Test plan

- [x] `tests/unit/test_rpc_overrides.py` — 24 cases including parametrized integration test that asserts the resolved id appears in BOTH the URL and the body.
- [x] No env var → canonical ids at both sites (parity preserved).
- [x] One override → that method uses override at BOTH sites.
- [x] Invalid JSON → WARNING + fall back.
- [x] Non-dict JSON (top-level array, string) → WARNING + fall back.
- [x] Override for unknown method name → other calls unaffected.
- [x] Mocked off-allowlist host (`evil.example.com`) → override ignored.
- [x] INFO logged once per unique override set; logs again for a different set.
- [x] Full `tests/unit` suite (2726 passed, 7 skipped).
- [x] Full `tests/integration` suite (599 passed, 4 skipped).
- [x] `ruff format`, `ruff check`, `mypy src/notebooklm` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting on RPC method ID rotations and how to self-patch using NOTEBOOKLM_RPC_OVERRIDES (format, logging, discovery via NOTEBOOKLM_DEBUG_RPC).

* **New Features**
  * Runtime support for per-RPC ID overrides that are applied consistently to both the request payload and URL when permitted by host allowlist.

* **Tests**
  * Added unit and integration tests for parsing, host-gating, logging, and end-to-end override behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/486)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->