### PR TITLE
fix(scripts): align RPC health create transport

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -39,19 +39,29 @@ import sys
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import urlencode
 from uuid import uuid4
 
 import httpx
 
-from notebooklm.auth import AuthTokens, fetch_tokens, load_auth_from_storage
+from notebooklm._env import get_default_language
+from notebooklm._notebooks import build_create_notebook_params
+from notebooklm.auth import (
+    AuthTokens,
+    fetch_tokens,
+    get_account_email_for_storage,
+    get_authuser_for_storage,
+    load_auth_from_storage,
+)
+from notebooklm.paths import get_storage_path
 from notebooklm.rpc import (
-    BATCHEXECUTE_URL,
     RPCError,
     RPCMethod,
     build_request_body,
     encode_rpc_request,
+    get_batchexecute_url,
 )
 from notebooklm.rpc.decoder import (
     collect_rpc_ids,
@@ -208,6 +218,13 @@ def load_auth() -> dict[str, str]:
     return cookies
 
 
+def resolve_storage_path() -> Path | None:
+    """Return the file-based auth path, or None when NOTEBOOKLM_AUTH_JSON is used."""
+    if "NOTEBOOKLM_AUTH_JSON" in os.environ:
+        return None
+    return get_storage_path()
+
+
 async def make_rpc_request(
     client: httpx.AsyncClient,
     auth: AuthTokens,
@@ -227,14 +244,22 @@ async def make_rpc_request(
     Returns:
         Tuple of (response text or None, error message or None)
     """
-    url = f"{BATCHEXECUTE_URL}?f.sid={auth.session_id}&source-path={quote(source_path, safe='')}"
+    query_params = {
+        "rpcids": method.value,
+        "source-path": source_path,
+        "f.sid": auth.session_id,
+        "hl": get_default_language(),
+        "rt": "c",
+    }
+    if auth.account_email or auth.authuser:
+        query_params["authuser"] = auth.account_route
+    url = f"{get_batchexecute_url()}?{urlencode(query_params)}"
     rpc_request = encode_rpc_request(method, params)
     body = build_request_body(rpc_request, auth.csrf_token)
 
-    cookie_header = "; ".join(f"{k}={v}" for k, v in auth.cookies.items())
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
-        "Cookie": cookie_header,
+        "Cookie": auth.cookie_header,
     }
 
     try:
@@ -629,8 +654,12 @@ async def setup_temp_resources(
     temp = TempResources()
 
     # Test CREATE_NOTEBOOK - extract notebook_id from response[0]
+    title = f"RPC-Health-Check-{uuid4().hex[:8]}"
     result, data = await test_rpc_method_with_data(
-        client, auth, RPCMethod.CREATE_NOTEBOOK, [f"RPC-Health-Check-{uuid4().hex[:8]}"]
+        client,
+        auth,
+        RPCMethod.CREATE_NOTEBOOK,
+        build_create_notebook_params(title),
     )
     results.append(result)
     print(format_check_with_success(result, "temp notebook created"))
@@ -892,6 +921,7 @@ async def cleanup_temp_resources(
 
 async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
     """Run health check on all RPC methods."""
+    storage_path = resolve_storage_path()
     cookies = load_auth()
 
     notebook_id = os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID") or os.environ.get(
@@ -906,14 +936,21 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
 
     print("Fetching auth tokens...")
     try:
-        csrf_token, session_id = await fetch_tokens(cookies)
+        csrf_token, session_id = await fetch_tokens(cookies, storage_path=storage_path)
     except ValueError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         sys.exit(2)
     except httpx.HTTPError as e:
         print(f"ERROR: Network error while fetching auth tokens: {e}", file=sys.stderr)
         sys.exit(2)
-    auth = AuthTokens(cookies=cookies, csrf_token=csrf_token, session_id=session_id)
+    auth = AuthTokens(
+        cookies=cookies,
+        csrf_token=csrf_token,
+        session_id=session_id,
+        storage_path=storage_path,
+        authuser=get_authuser_for_storage(storage_path),
+        account_email=get_account_email_for_storage(storage_path),
+    )
     print(f"Auth OK (CSRF token length: {len(auth.csrf_token)})")
     print()
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3
 
 
+def build_create_notebook_params(title: str) -> list[Any]:
+    """Return the canonical CREATE_NOTEBOOK RPC payload."""
+    return [title, None, None, [2], [1]]
+
+
 class NotebooksAPI:
     """Operations on NotebookLM notebooks.
 
@@ -71,7 +76,7 @@ class NotebooksAPI:
             The created Notebook object.
         """
         logger.debug("Creating notebook: %s", title)
-        params = [title, None, None, [2], [1]]
+        params = build_create_notebook_params(title)
         try:
             result = await self._core.rpc_call(RPCMethod.CREATE_NOTEBOOK, params)
         except RPCError as exc:

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -183,6 +183,7 @@ async def test_make_rpc_request_uses_flat_cookie_header_and_auth_route() -> None
     assert query["rpcids"] == [check_rpc_health.RPCMethod.CREATE_NOTEBOOK.value]
     assert query["source-path"] == ["/notebook/nb_123"]
     assert query["f.sid"] == ["session"]
+    assert query["hl"] == [check_rpc_health.get_default_language()]
     assert query["rt"] == ["c"]
     assert query["authuser"] == ["bob@example.com"]
     assert "at=csrf" in captured["content"]

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -23,7 +23,9 @@ import sys
 from collections import Counter
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
+import httpx
 import pytest
 
 # Load scripts/check_rpc_health.py as a module. The ``scripts`` directory
@@ -45,6 +47,8 @@ compute_exit_code = check_rpc_health.compute_exit_code
 is_transient_error = check_rpc_health.is_transient_error
 partition_errors = check_rpc_health.partition_errors
 print_summary = check_rpc_health.print_summary
+setup_temp_resources = check_rpc_health.setup_temp_resources
+make_rpc_request = check_rpc_health.make_rpc_request
 
 
 def _result(
@@ -125,6 +129,131 @@ def test_partition_errors_separates_transient_from_real() -> None:
     non_transient, transient = partition_errors(results)
     assert [r.method.name for r in non_transient] == ["timeout", "parse"]
     assert [r.method.name for r in transient] == ["rate", "quota"]
+
+
+@pytest.mark.asyncio
+async def test_make_rpc_request_uses_flat_cookie_header_and_auth_route() -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeClient:
+        async def post(
+            self,
+            url: str,
+            *,
+            content: str,
+            headers: dict[str, str],
+        ) -> httpx.Response:
+            captured["url"] = url
+            captured["content"] = content
+            captured["headers"] = headers
+            return httpx.Response(
+                200,
+                text=")]}'\n\n[]",
+                request=httpx.Request("POST", url),
+            )
+
+    auth = check_rpc_health.AuthTokens(
+        cookies={
+            "SID": "sid",
+            "__Secure-1PSIDTS": "ts",
+            "APISID": "apisid",
+            "SAPISID": "sapisid",
+        },
+        csrf_token="csrf",
+        session_id="session",
+        authuser=2,
+        account_email="bob@example.com",
+    )
+
+    response_text, error = await make_rpc_request(
+        FakeClient(),
+        auth,
+        check_rpc_health.RPCMethod.CREATE_NOTEBOOK,
+        ["Title"],
+        source_path="/notebook/nb_123",
+    )
+
+    assert response_text == ")]}'\n\n[]"
+    assert error is None
+    cookie_header = captured["headers"]["Cookie"]
+    assert "SID=sid" in cookie_header
+    assert "__Secure-1PSIDTS=ts" in cookie_header
+    assert "('SID'," not in cookie_header
+    query = parse_qs(urlparse(captured["url"]).query)
+    assert query["rpcids"] == [check_rpc_health.RPCMethod.CREATE_NOTEBOOK.value]
+    assert query["source-path"] == ["/notebook/nb_123"]
+    assert query["f.sid"] == ["session"]
+    assert query["rt"] == ["c"]
+    assert query["authuser"] == ["bob@example.com"]
+    assert "at=csrf" in captured["content"]
+
+    captured.clear()
+    default_auth = check_rpc_health.AuthTokens(
+        cookies={
+            "SID": "sid",
+            "__Secure-1PSIDTS": "ts",
+            "APISID": "apisid",
+            "SAPISID": "sapisid",
+        },
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+    await make_rpc_request(
+        FakeClient(),
+        default_auth,
+        check_rpc_health.RPCMethod.LIST_NOTEBOOKS,
+        [],
+    )
+
+    default_query = parse_qs(urlparse(captured["url"]).query)
+    assert "authuser" not in default_query
+
+
+@pytest.mark.asyncio
+async def test_setup_temp_resources_uses_canonical_create_notebook_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_test_rpc_method_with_data(
+        client: object,
+        auth: object,
+        method: Any,
+        params: list[Any],
+        source_path: str = "/",
+    ) -> tuple[CheckResult, None]:
+        captured["method"] = method
+        captured["params"] = params
+        captured["source_path"] = source_path
+        return (
+            CheckResult(
+                method=method,
+                status=CheckStatus.ERROR,
+                expected_id=method.value,
+                found_ids=[],
+                error="stop after create",
+            ),
+            None,
+        )
+
+    monkeypatch.setattr(
+        check_rpc_health,
+        "test_rpc_method_with_data",
+        fake_test_rpc_method_with_data,
+    )
+
+    results: list[CheckResult] = []
+    temp = await setup_temp_resources(object(), object(), results)
+    _ = capsys.readouterr()
+
+    assert captured["method"] is check_rpc_health.RPCMethod.CREATE_NOTEBOOK
+    assert captured["source_path"] == "/"
+    assert captured["params"][0].startswith("RPC-Health-Check-")
+    assert captured["params"][1:] == [None, None, [2], [1]]
+    assert results[0].status == CheckStatus.ERROR
+    assert temp.notebook_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_encoder.py
+++ b/tests/unit/test_encoder.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from notebooklm._notebooks import build_create_notebook_params
 from notebooklm.rpc.encoder import build_request_body, encode_rpc_request, nest_source_ids
 from notebooklm.rpc.types import RPCMethod
 
@@ -30,13 +31,13 @@ class TestEncodeRPCRequest:
 
     def test_encode_create_notebook(self):
         """Test encoding create notebook request."""
-        params = ["Test Notebook", None, None, [2], [1]]
+        params = build_create_notebook_params("Test Notebook")
         result = encode_rpc_request(RPCMethod.CREATE_NOTEBOOK, params)
 
         inner = result[0][0]
         assert inner[0] == RPCMethod.CREATE_NOTEBOOK.value
         decoded_params = json.loads(inner[1])
-        assert decoded_params[0] == "Test Notebook"
+        assert decoded_params == ["Test Notebook", None, None, [2], [1]]
 
     def test_encode_with_nested_params(self):
         """Test encoding with deeply nested parameters."""

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from notebooklm._notebooks import NotebooksAPI
+from notebooklm._notebooks import NotebooksAPI, build_create_notebook_params
 from notebooklm.exceptions import (
     NetworkError,
     NotebookLimitError,
@@ -39,6 +39,10 @@ def _create_invalid_argument_error(
     )
 
 
+def test_build_create_notebook_params_matches_live_payload() -> None:
+    assert build_create_notebook_params("Daily News") == ["Daily News", None, None, [2], [1]]
+
+
 def _set_account_limit(api: NotebooksAPI, limit: int | None) -> AsyncMock:
     mock = AsyncMock(return_value=AccountLimits(notebook_limit=limit))
     api._get_account_limits = mock  # type: ignore[method-assign]
@@ -46,6 +50,26 @@ def _set_account_limit(api: NotebooksAPI, limit: int | None) -> AsyncMock:
 
 
 class TestCreateNotebookQuotaDetection:
+    @pytest.mark.asyncio
+    async def test_create_uses_canonical_payload(self):
+        api = _make_api()
+        api._core.rpc_call.return_value = [
+            "Daily News",
+            None,
+            "new_notebook_id",
+            None,
+            None,
+            [None, False, None, None, None, [1704067200, 0]],
+        ]
+
+        notebook = await api.create("Daily News")
+
+        assert notebook.id == "new_notebook_id"
+        api._core.rpc_call.assert_awaited_once_with(
+            RPCMethod.CREATE_NOTEBOOK,
+            build_create_notebook_params("Daily News"),
+        )
+
     @pytest.mark.asyncio
     async def test_create_invalid_argument_near_paid_limit_raises_limit_error(self):
         api = _make_api()


### PR DESCRIPTION
## Summary
- Fix CREATE_NOTEBOOK full-mode health setup to use the same canonical payload as NotebooksAPI.create.
- Align check_rpc_health transport with the client by adding rpcids/hl/rt/authuser routing and using AuthTokens.cookie_header instead of tuple-key cookies.
- Add regression tests for the health-check Cookie header, auth routing, and create-notebook payload drift.

## Root Cause
Issue #459 was not only an RPC payload drift. The script created AuthTokens, then manually joined auth.cookies into a Cookie header after AuthTokens normalized keys to (name, domain, path). That produced malformed cookie names for live write RPCs. CREATE_NOTEBOOK returned gRPC 16 Unauthenticated until the script used the flattened cookie header and client-style URL routing.

## RPC Descriptor Audit
Authenticated static asset audit of the current NotebookLM app found 31 live RPC descriptors not represented in RPCMethod, including GenerateArtifact, CreateAudioOverview, DiscoverSources, DeleteChatTurns, labels, Magic View, prompt suggestions, and artifact user-state calls. I left those out of this PR because they need captured payloads and tests in a dedicated inventory/update pass.

## Test Plan
- rtk uv run pytest tests/unit/test_check_rpc_health.py tests/unit/test_encoder.py tests/unit/test_notebook_api.py tests/integration/test_notebooks.py -q
- rtk uv run pytest -q
- rtk uv run ruff check .
- rtk uv run ruff format --check .
- rtk uv run mypy src/notebooklm
- rtk uv run python scripts/check_rpc_health.py --full

Fixes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal RPC health checking and authentication handling for improved system reliability.
  * Improved test coverage with comprehensive validation of notebook creation and RPC request construction.
  * Refactored notebook creation parameter handling for better code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/488)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->