### PR TITLE
refactor(client): decouple ArtifactsAPI from NotesAPI via _mind_map module (T6.F)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -20,6 +20,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from . import _mind_map
 from ._core import ClientCore
 from ._env import get_default_language
 from .auth import load_httpx_cookies
@@ -77,7 +78,7 @@ _MEDIA_ARTIFACT_TYPES = frozenset(
 )
 
 if TYPE_CHECKING:
-    from ._notes import NotesAPI
+    from ._notes import NotesAPI  # retained for backward-compatible type hints
 
 
 @dataclass(frozen=False)
@@ -263,18 +264,27 @@ class ArtifactsAPI:
     def __init__(
         self,
         core: ClientCore,
-        notes_api: "NotesAPI",
+        notes_api: "NotesAPI | None" = None,
         storage_path: Path | None = None,
     ):
         """Initialize the artifacts API.
 
         Args:
             core: The core client infrastructure.
-            notes_api: The notes API for accessing notes/mind maps.
+            notes_api: Deprecated. Retained as an optional, ignored
+                keyword for backward compatibility — ``ArtifactsAPI`` no
+                longer depends on :class:`NotesAPI`. Mind-map RPC
+                primitives are accessed directly through the
+                :mod:`_mind_map` module, so the construction order of
+                ``client.artifacts`` and ``client.notes`` is no longer
+                significant.
             storage_path: Path to storage state file for loading download cookies.
         """
         self._core = core
-        self._notes = notes_api
+        # ``notes_api`` is intentionally not stored — it is accepted only
+        # so that existing call sites (tests, third-party code) keep
+        # working through the deprecation cycle.
+        del notes_api
         self._storage_path = storage_path
 
     # =========================================================================
@@ -326,7 +336,7 @@ class ArtifactsAPI:
         # Fetch mind maps from notes system (if not filtering to non-mind-map type)
         if artifact_type is None or artifact_type == ArtifactType.MIND_MAP:
             try:
-                mind_maps = await self._notes.list_mind_maps(notebook_id)
+                mind_maps = await _mind_map.list_mind_maps(self._core, notebook_id)
                 for mm_data in mind_maps:
                     mind_map_artifact = Artifact.from_mind_map(mm_data)
                     if mind_map_artifact is not None:  # None means deleted (status=2)
@@ -1135,7 +1145,9 @@ class ArtifactsAPI:
 
                 # The GENERATE_MIND_MAP RPC generates content but does NOT persist it.
                 # We must explicitly create a note to save the mind map.
-                note = await self._notes.create(notebook_id, title=title, content=mind_map_json)
+                note = await _mind_map.create_note(
+                    self._core, notebook_id, title=title, content=mind_map_json
+                )
                 note_id = note.id if note else None
 
                 return {
@@ -1522,7 +1534,7 @@ class ArtifactsAPI:
         Returns:
             The output path where the file was saved.
         """
-        mind_maps = await self._notes.list_mind_maps(notebook_id)
+        mind_maps = await _mind_map.list_mind_maps(self._core, notebook_id)
         if not mind_maps:
             raise ArtifactNotReadyError("mind_map")
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1546,8 +1546,13 @@ class ArtifactsAPI:
             mind_map = mind_maps[0]
 
         try:
-            json_string = mind_map[1][1]
-            if not isinstance(json_string, str):
+            # Use the shared extractor so legacy ``[id, content_str]`` rows
+            # work too — direct ``[1][1]`` indexing into a legacy item would
+            # string-index the content (``"…"[1] == "…"`` of length 1) and
+            # then fail downstream JSON parsing instead of returning the real
+            # payload.
+            json_string = _mind_map.extract_content(mind_map)
+            if json_string is None:
                 raise ArtifactParseError("mind_map_content", details="Invalid structure")
 
             json_data = json.loads(json_string)

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -151,7 +151,11 @@ async def create_note(
         The created :class:`Note` with the assigned ID.
     """
     logger.debug("Creating note in notebook %s: %s", notebook_id, title)
-    params = [notebook_id, "", [1], None, "New Note"]
+    # The server currently ignores this slot (the follow-up UPDATE_NOTE is
+    # what actually persists the title) but pass the caller-supplied title
+    # rather than a hardcoded literal so the wire payload reflects the user
+    # intent if Google ever starts honoring it.
+    params = [notebook_id, "", [1], None, title]
     result = await core.rpc_call(
         RPCMethod.CREATE_NOTE,
         params,

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -1,0 +1,178 @@
+"""Mind-map RPC primitives shared by ``ArtifactsAPI`` and ``NotesAPI``.
+
+Mind maps live in the "notes" backend (same ``GET_NOTES_AND_MIND_MAPS`` /
+``CREATE_NOTE`` / ``UPDATE_NOTE`` / ``DELETE_NOTE`` RPCs as user notes) but
+they are AI-generated artifacts from the caller's perspective. This module
+hosts the low-level RPC primitives so neither :class:`NotesAPI` nor
+:class:`ArtifactsAPI` needs to import the other.
+
+Functions here take a :class:`ClientCore` as their first argument and return
+raw RPC-shaped data (lists). Higher-level dataclass parsing stays in
+:mod:`_notes` / :mod:`_artifacts`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ._core import ClientCore
+from .rpc import RPCMethod
+from .types import Note
+
+logger = logging.getLogger(__name__)
+
+
+async def fetch_all_notes_and_mind_maps(core: ClientCore, notebook_id: str) -> list[Any]:
+    """Fetch all notes + mind maps in a notebook.
+
+    Both notes and mind maps share the same backend collection; callers
+    filter by content shape (``"children":`` / ``"nodes":`` for mind maps).
+
+    Args:
+        core: The shared :class:`ClientCore`.
+        notebook_id: The notebook ID to query.
+
+    Returns:
+        Raw list of items; each item is a list whose first element is the
+        item ID. Empty list on missing/unexpected payloads.
+    """
+    params = [notebook_id]
+    result = await core.rpc_call(
+        RPCMethod.GET_NOTES_AND_MIND_MAPS,
+        params,
+        source_path=f"/notebook/{notebook_id}",
+        allow_null=True,
+    )
+    if result and isinstance(result, list) and len(result) > 0 and isinstance(result[0], list):
+        notes_list = result[0]
+        valid_notes = []
+        for item in notes_list:
+            if isinstance(item, list) and len(item) > 0 and isinstance(item[0], str):
+                valid_notes.append(item)
+        return valid_notes
+    return []
+
+
+def is_deleted(item: list[Any]) -> bool:
+    """Return True if a note/mind-map item is soft-deleted (``status=2``).
+
+    Deleted items have structure ``['id', None, 2]`` — content is None and
+    the third position holds the status sentinel.
+    """
+    if not isinstance(item, list) or len(item) < 3:
+        return False
+    return item[1] is None and item[2] == 2
+
+
+def extract_content(item: list[Any]) -> str | None:
+    """Extract the content string from a note/mind-map item.
+
+    Handles both the legacy ``[id, content]`` and the current
+    ``[id, [id, content, metadata, None, title]]`` shapes.
+    """
+    if len(item) <= 1:
+        return None
+
+    if isinstance(item[1], str):
+        return item[1]
+    if isinstance(item[1], list) and len(item[1]) > 1 and isinstance(item[1][1], str):
+        return item[1][1]
+    return None
+
+
+async def list_mind_maps(core: ClientCore, notebook_id: str) -> list[Any]:
+    """List raw mind-map items in a notebook (excluding soft-deleted ones).
+
+    Mind maps are stored in the same collection as notes but contain JSON
+    data with ``"children"`` or ``"nodes"`` keys. This function filters that
+    collection down to mind-map-shaped entries.
+
+    Args:
+        core: The shared :class:`ClientCore`.
+        notebook_id: The notebook ID to query.
+
+    Returns:
+        List of raw mind-map items (each a list, first element is the ID).
+    """
+    all_items = await fetch_all_notes_and_mind_maps(core, notebook_id)
+    mind_maps: list[Any] = []
+    for item in all_items:
+        if is_deleted(item):
+            continue
+        content = extract_content(item)
+        if content and ('"children":' in content or '"nodes":' in content):
+            mind_maps.append(item)
+    return mind_maps
+
+
+async def update_note(
+    core: ClientCore,
+    notebook_id: str,
+    note_id: str,
+    content: str,
+    title: str,
+) -> None:
+    """Update a note/mind-map row's content and title in place."""
+    logger.debug("Updating note %s in notebook %s", note_id, notebook_id)
+    params = [
+        notebook_id,
+        note_id,
+        [[[content, title, [], 0]]],
+    ]
+    await core.rpc_call(
+        RPCMethod.UPDATE_NOTE,
+        params,
+        source_path=f"/notebook/{notebook_id}",
+        allow_null=True,
+    )
+
+
+async def create_note(
+    core: ClientCore,
+    notebook_id: str,
+    title: str = "New Note",
+    content: str = "",
+) -> Note:
+    """Create a note (or mind-map row) and set its content + title.
+
+    Google's ``CREATE_NOTE`` ignores the title param, so this function
+    always follows up with an ``UPDATE_NOTE`` to set both content and
+    title. Returns a :class:`Note` dataclass for consistency with the
+    higher-level :class:`NotesAPI`.
+
+    Args:
+        core: The shared :class:`ClientCore`.
+        notebook_id: The notebook ID to create the note in.
+        title: The desired title.
+        content: The desired body content (mind-map JSON, plain text, ...).
+
+    Returns:
+        The created :class:`Note` with the assigned ID.
+    """
+    logger.debug("Creating note in notebook %s: %s", notebook_id, title)
+    params = [notebook_id, "", [1], None, "New Note"]
+    result = await core.rpc_call(
+        RPCMethod.CREATE_NOTE,
+        params,
+        source_path=f"/notebook/{notebook_id}",
+    )
+
+    note_id: str | None = None
+    if result and isinstance(result, list) and len(result) > 0:
+        if isinstance(result[0], list) and len(result[0]) > 0:
+            note_id = result[0][0]
+        elif isinstance(result[0], str):
+            note_id = result[0]
+
+    if note_id:
+        # CREATE_NOTE ignores the title param server-side, so set it via
+        # UPDATE_NOTE alongside the actual content payload.
+        await update_note(core, notebook_id, note_id, content, title)
+
+    return Note(
+        id=note_id or "",
+        notebook_id=notebook_id,
+        title=title,
+        content=content,
+    )

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -3,12 +3,17 @@
 Provides operations for creating, updating, listing, and deleting
 user-created notes in notebooks. Notes are distinct from artifacts -
 they are user-created content, not AI-generated.
+
+Mind-map-related RPC primitives live in :mod:`_mind_map` and are shared
+with :class:`ArtifactsAPI`. This module exposes them through the
+historical ``NotesAPI`` method surface for backward compatibility.
 """
 
 import builtins
 import logging
 from typing import Any
 
+from . import _mind_map
 from ._core import ClientCore
 from .rpc import RPCMethod
 from .types import Note
@@ -102,31 +107,7 @@ class NotesAPI:
         Returns:
             The created Note object.
         """
-        logger.debug("Creating note in notebook %s: %s", notebook_id, title)
-        params = [notebook_id, "", [1], None, "New Note"]
-        result = await self._core.rpc_call(
-            RPCMethod.CREATE_NOTE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-        )
-
-        note_id = None
-        if result and isinstance(result, list) and len(result) > 0:
-            if isinstance(result[0], list) and len(result[0]) > 0:
-                note_id = result[0][0]
-            elif isinstance(result[0], str):
-                note_id = result[0]
-
-        if note_id:
-            # Google ignores title param in CREATE_NOTE, so always update
-            await self.update(notebook_id, note_id, content, title)
-
-        return Note(
-            id=note_id or "",
-            notebook_id=notebook_id,
-            title=title,
-            content=content,
-        )
+        return await _mind_map.create_note(self._core, notebook_id, title=title, content=content)
 
     async def update(
         self,
@@ -143,18 +124,7 @@ class NotesAPI:
             content: The new content.
             title: The new title.
         """
-        logger.debug("Updating note %s in notebook %s", note_id, notebook_id)
-        params = [
-            notebook_id,
-            note_id,
-            [[[content, title, [], 0]]],
-        ]
-        await self._core.rpc_call(
-            RPCMethod.UPDATE_NOTE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
+        await _mind_map.update_note(self._core, notebook_id, note_id, content, title)
 
     async def delete(self, notebook_id: str, note_id: str) -> bool:
         """Delete a note from the notebook.
@@ -196,19 +166,7 @@ class NotesAPI:
         Returns:
             List of raw mind map data.
         """
-        all_items = await self._get_all_notes_and_mind_maps(notebook_id)
-        mind_maps = []
-
-        for item in all_items:
-            # Skip deleted items (status=2): ['id', None, 2]
-            if self._is_deleted(item):
-                continue
-
-            content = self._extract_content(item)
-            if content and ('"children":' in content or '"nodes":' in content):
-                mind_maps.append(item)
-
-        return mind_maps
+        return await _mind_map.list_mind_maps(self._core, notebook_id)
 
     async def delete_mind_map(self, notebook_id: str, mind_map_id: str) -> bool:
         """Delete a mind map from the notebook.
@@ -235,21 +193,7 @@ class NotesAPI:
 
     async def _get_all_notes_and_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """Fetch all notes and mind maps from the API."""
-        params = [notebook_id]
-        result = await self._core.rpc_call(
-            RPCMethod.GET_NOTES_AND_MIND_MAPS,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        if result and isinstance(result, list) and len(result) > 0 and isinstance(result[0], list):
-            notes_list = result[0]
-            valid_notes = []
-            for item in notes_list:
-                if isinstance(item, list) and len(item) > 0 and isinstance(item[0], str):
-                    valid_notes.append(item)
-            return valid_notes
-        return []
+        return await _mind_map.fetch_all_notes_and_mind_maps(self._core, notebook_id)
 
     def _is_deleted(self, item: builtins.list[Any]) -> bool:
         """Check if a note/mind map item is deleted (status=2).
@@ -263,20 +207,11 @@ class NotesAPI:
         Returns:
             True if the item is deleted (soft-deleted with status=2).
         """
-        if not isinstance(item, list) or len(item) < 3:
-            return False
-        return item[1] is None and item[2] == 2
+        return _mind_map.is_deleted(item)
 
     def _extract_content(self, item: builtins.list[Any]) -> str | None:
         """Extract content string from note/mind map item."""
-        if len(item) <= 1:
-            return None
-
-        if isinstance(item[1], str):
-            return item[1]
-        elif isinstance(item[1], list) and len(item[1]) > 1 and isinstance(item[1][1], str):
-            return item[1][1]
-        return None
+        return _mind_map.extract_content(item)
 
     def _parse_note(self, item: builtins.list[Any], notebook_id: str) -> Note:
         """Parse a raw note item into a Note object."""

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -137,12 +137,14 @@ class NotebookLMClient:
             server_error_max_retries=server_error_max_retries,
         )
 
-        # Initialize sub-client APIs
-        # Note: notes must be initialized before artifacts (artifacts uses notes API)
+        # Initialize sub-client APIs.
+        # ArtifactsAPI and NotesAPI both consume the shared ``_mind_map``
+        # module for mind-map primitives, so their construction order is
+        # not significant (see T6.F).
         self.notebooks = NotebooksAPI(self._core)
         self.sources = SourcesAPI(self._core)
+        self.artifacts = ArtifactsAPI(self._core, storage_path=storage_path)
         self.notes = NotesAPI(self._core)
-        self.artifacts = ArtifactsAPI(self._core, notes_api=self.notes, storage_path=storage_path)
         self.chat = ChatAPI(self._core)
         self.research = ResearchAPI(self._core)
         self.settings = SettingsAPI(self._core)

--- a/tests/integration/test_artifacts.py
+++ b/tests/integration/test_artifacts.py
@@ -1238,10 +1238,12 @@ class TestListMindMapErrorHandling:
         httpx_mock.add_response(content=list_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch.object(
-                client.artifacts._notes,
-                "list_mind_maps",
-                AsyncMock(side_effect=RPCError("mind map fetch failed")),
+            # After T6.F, ArtifactsAPI reaches mind maps through the
+            # shared ``_mind_map`` module rather than an injected
+            # NotesAPI. Patch the primitive at its consumer-side import.
+            with patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(side_effect=RPCError("mind map fetch failed")),
             ):
                 result = await client.artifacts.list("nb_123")
 
@@ -1265,10 +1267,9 @@ class TestListMindMapErrorHandling:
         httpx_mock.add_response(content=list_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch.object(
-                client.artifacts._notes,
-                "list_mind_maps",
-                AsyncMock(side_effect=httpx.HTTPError("connection failed")),
+            with patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(side_effect=httpx.HTTPError("connection failed")),
             ):
                 result = await client.artifacts.list("nb_123")
 
@@ -1480,14 +1481,21 @@ class TestGenerateMindMapParsing:
         httpx_mock.add_response(content=notebook_response.encode())
         httpx_mock.add_response(content=mindmap_response.encode())
 
-        mock_note = MagicMock()
-        mock_note.id = "note_created_001"
+        from notebooklm.types import Note
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch.object(
-                client.artifacts._notes,
-                "create",
-                AsyncMock(return_value=mock_note),
+            # After T6.F, mind-map persistence is driven through
+            # ``_mind_map.create_note`` rather than ``NotesAPI.create``.
+            with patch(
+                "notebooklm._artifacts._mind_map.create_note",
+                new=AsyncMock(
+                    return_value=Note(
+                        id="note_created_001",
+                        notebook_id="nb_123",
+                        title="Root Topic",
+                        content=mind_map_json_str,
+                    )
+                ),
             ):
                 result = await client.artifacts.generate_mind_map("nb_123")
 
@@ -1522,14 +1530,19 @@ class TestGenerateMindMapParsing:
         httpx_mock.add_response(content=notebook_response.encode())
         httpx_mock.add_response(content=mindmap_response.encode())
 
-        mock_note = MagicMock()
-        mock_note.id = "note_dict_001"
+        from notebooklm.types import Note
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch.object(
-                client.artifacts._notes,
-                "create",
-                AsyncMock(return_value=mock_note),
+            with patch(
+                "notebooklm._artifacts._mind_map.create_note",
+                new=AsyncMock(
+                    return_value=Note(
+                        id="note_dict_001",
+                        notebook_id="nb_123",
+                        title="Topic",
+                        content=json.dumps(mind_map_dict),
+                    )
+                ),
             ):
                 result = await client.artifacts.generate_mind_map("nb_123")
 

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -27,17 +27,18 @@ def auth_tokens():
 
 @pytest.fixture
 def mock_artifacts_api():
-    """Create an ArtifactsAPI with mocked core and notes API."""
+    """Create an ArtifactsAPI with mocked core.
+
+    After T6.F, ``ArtifactsAPI`` no longer takes a ``notes_api`` parameter;
+    mind-map persistence goes through the shared ``_mind_map`` module which
+    calls the same ``ClientCore.rpc_call``. Tests that exercise mind-map
+    creation should drive responses through ``mock_core.rpc_call`` (via
+    ``side_effect``) rather than mocking a separate notes object.
+    """
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
-    mock_notes = MagicMock()
-    mock_notes.list_mind_maps = AsyncMock(return_value=[])
-    # Mock create to return a Note-like object with an id
-    mock_note = MagicMock()
-    mock_note.id = "created_note_123"
-    mock_notes.create = AsyncMock(return_value=mock_note)
-    api = ArtifactsAPI(mock_core, notes_api=mock_notes)
+    api = ArtifactsAPI(mock_core)
     return api, mock_core
 
 
@@ -343,20 +344,34 @@ class TestMindMapGeneration:
         api, mock_core = mock_artifacts_api
         # Mock get_source_ids for source ID fetching
         mock_core.get_source_ids.return_value = ["src_001"]
-        # Mock the actual mind map generation RPC call
-        mock_core.rpc_call.return_value = [
-            [
-                '{"nodes": [{"id": "1", "text": "Root"}]}',  # JSON string
-                None,
-                ["note_123"],  # note info (not used anymore, note is created explicitly)
-            ]
-        ]
+
+        # ArtifactsAPI.generate_mind_map now drives the full
+        # GENERATE_MIND_MAP -> CREATE_NOTE -> UPDATE_NOTE flow itself via
+        # the shared ``_mind_map`` primitives. The mock RPC needs to react
+        # to each method name so the created note ID surfaces correctly.
+        async def fake_rpc(method, params, **_):
+            name = getattr(method, "name", str(method))
+            if name == "GENERATE_MIND_MAP":
+                return [
+                    [
+                        '{"nodes": [{"id": "1", "text": "Root"}]}',
+                        None,
+                        ["note_123"],
+                    ]
+                ]
+            if name == "CREATE_NOTE":
+                return [["created_note_123"]]
+            if name == "UPDATE_NOTE":
+                return None
+            return None
+
+        mock_core.rpc_call.side_effect = fake_rpc
 
         result = await api.generate_mind_map("nb_123")
 
         assert result is not None
         assert "mind_map" in result
-        # note_id is now from the explicitly created note
+        # note_id is from the explicit CREATE_NOTE call.
         assert result["note_id"] == "created_note_123"
 
     @pytest.mark.asyncio
@@ -365,20 +380,30 @@ class TestMindMapGeneration:
         api, mock_core = mock_artifacts_api
         # Mock get_source_ids for source ID fetching
         mock_core.get_source_ids.return_value = ["src_001"]
-        # Mock the actual mind map generation RPC call
-        mock_core.rpc_call.return_value = [
-            [
-                {"nodes": [{"id": "1"}]},  # Already a dict
-                None,
-                ["note_456"],  # note info (not used anymore)
-            ]
-        ]
+
+        async def fake_rpc(method, params, **_):
+            name = getattr(method, "name", str(method))
+            if name == "GENERATE_MIND_MAP":
+                return [
+                    [
+                        {"nodes": [{"id": "1"}]},  # Already a dict
+                        None,
+                        ["note_456"],  # note info (not used anymore)
+                    ]
+                ]
+            if name == "CREATE_NOTE":
+                return [["created_note_123"]]
+            if name == "UPDATE_NOTE":
+                return None
+            return None
+
+        mock_core.rpc_call.side_effect = fake_rpc
 
         result = await api.generate_mind_map("nb_123")
 
         assert result is not None
         assert result["mind_map"]["nodes"][0]["id"] == "1"
-        # note_id is now from the explicitly created note
+        # note_id is from the explicit CREATE_NOTE call.
         assert result["note_id"] == "created_note_123"
 
     @pytest.mark.asyncio
@@ -387,7 +412,7 @@ class TestMindMapGeneration:
         api, mock_core = mock_artifacts_api
         # Mock get_source_ids for source ID fetching
         mock_core.get_source_ids.return_value = ["src_001"]
-        # Mock the actual mind map generation with empty response
+        # GENERATE_MIND_MAP returns null/empty — no note should be created.
         mock_core.rpc_call.return_value = None
 
         result = await api.generate_mind_map("nb_123")
@@ -580,21 +605,26 @@ class TestDownloadMindMap:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "mindmap.json")
 
-            # Mock mind maps via notes API
+            # After T6.F, ``ArtifactsAPI.download_mind_map`` reads mind maps
+            # via the shared ``_mind_map.list_mind_maps`` primitive rather
+            # than through an injected ``NotesAPI``. Patch the primitive at
+            # its consumer-side import to drive the response.
             json_content = '{"name": "Root", "children": [{"name": "Child1"}]}'
-            api._notes.list_mind_maps = AsyncMock(
-                return_value=[
-                    [
-                        "mindmap_001",  # mm[0] = id
-                        [None, json_content],  # mm[1][1] = JSON string
-                        None,
-                        None,
-                        "Mind Map Title",  # mm[4] = title
+            with patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(
+                    return_value=[
+                        [
+                            "mindmap_001",  # mm[0] = id
+                            [None, json_content],  # mm[1][1] = JSON string
+                            None,
+                            None,
+                            "Mind Map Title",  # mm[4] = title
+                        ]
                     ]
-                ]
-            )
-
-            result = await api.download_mind_map("nb_123", output_path)
+                ),
+            ):
+                result = await api.download_mind_map("nb_123", output_path)
 
             assert result == output_path
             # Verify JSON was written correctly
@@ -609,20 +639,28 @@ class TestDownloadMindMap:
     async def test_download_mind_map_no_mind_map_found(self, mock_artifacts_api):
         """Test error when no mind map exists."""
         api, mock_core = mock_artifacts_api
-        api._notes.list_mind_maps = AsyncMock(return_value=[])
 
-        with pytest.raises(ArtifactNotReadyError):
+        with (
+            patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(return_value=[]),
+            ),
+            pytest.raises(ArtifactNotReadyError),
+        ):
             await api.download_mind_map("nb_123", "/tmp/mindmap.json")
 
     @pytest.mark.asyncio
     async def test_download_mind_map_specific_id_not_found(self, mock_artifacts_api):
         """Test error when specific mind map ID not found."""
         api, mock_core = mock_artifacts_api
-        api._notes.list_mind_maps = AsyncMock(
-            return_value=[["other_id", [None, "{}"], None, None, "Other"]]
-        )
 
-        with pytest.raises(ArtifactNotFoundError):
+        with (
+            patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(return_value=[["other_id", [None, "{}"], None, None, "Other"]]),
+            ),
+            pytest.raises(ArtifactNotFoundError),
+        ):
             await api.download_mind_map("nb_123", "/tmp/mindmap.json", artifact_id="mindmap_001")
 
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -1,0 +1,172 @@
+"""Init-order regression tests for ``ArtifactsAPI`` / ``NotesAPI`` (T6.F).
+
+Before T6.F, :class:`ArtifactsAPI` required ``notes_api=client.notes`` at
+construction time, so :class:`NotesAPI` had to be built first. The shared
+:mod:`_mind_map` module decouples the two APIs — these tests pin that
+invariant down so the load-bearing init order can't silently come back.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._notes import NotesAPI
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
+
+
+@pytest.fixture
+def mock_auth() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "test"},
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+
+def test_client_exposes_artifacts_and_notes(mock_auth: AuthTokens) -> None:
+    """The client should construct both APIs regardless of order."""
+    client = NotebookLMClient(mock_auth)
+    assert isinstance(client.artifacts, ArtifactsAPI)
+    assert isinstance(client.notes, NotesAPI)
+
+
+def test_artifacts_constructible_without_notes_api(mock_auth: AuthTokens) -> None:
+    """``ArtifactsAPI`` must be constructible without ``notes_api`` — that is
+    the whole point of the T6.F decoupling."""
+    core = MagicMock()
+    api = ArtifactsAPI(core)
+    assert api is not None
+    # The legacy private attribute must not leak back: code that depends on
+    # ``self._notes`` would re-introduce the coupling.
+    assert not hasattr(api, "_notes")
+
+
+def test_artifacts_accepts_legacy_notes_api_kwarg(mock_auth: AuthTokens) -> None:
+    """Existing callers passing ``notes_api=`` must keep working as a no-op
+    for the deprecation cycle."""
+    core = MagicMock()
+    notes = NotesAPI(core)
+    api = ArtifactsAPI(core, notes_api=notes)
+    assert api is not None
+    # Even when supplied, the legacy attribute is intentionally not stored.
+    assert not hasattr(api, "_notes")
+
+
+def test_artifacts_before_notes_construction_order(mock_auth: AuthTokens) -> None:
+    """Both construction orders must succeed and produce working APIs."""
+    core = MagicMock()
+    artifacts_first = ArtifactsAPI(core)
+    notes_first = NotesAPI(core)
+    # Build in the opposite order too, just to make the symmetry explicit.
+    notes_then = NotesAPI(core)
+    artifacts_then = ArtifactsAPI(core)
+    assert artifacts_first is not None
+    assert notes_first is not None
+    assert artifacts_then is not None
+    assert notes_then is not None
+
+
+# ---------------------------------------------------------------------------
+# Mind-map regression — ``generate_mind_map`` + ``list`` + ``download_mind_map``
+# must keep working without an explicit ``NotesAPI`` injection.
+# ---------------------------------------------------------------------------
+
+
+def _make_core_for_mind_map_flow() -> tuple[MagicMock, list[tuple[Any, Any]]]:
+    """Build a ``MagicMock`` core whose ``rpc_call`` returns canned mind-map
+    responses keyed on the RPC method.
+
+    Returns ``(core, calls)`` where ``calls`` is a list of ``(method, params)``
+    tuples populated as the test exercises the API.
+    """
+    calls: list[tuple[Any, Any]] = []
+
+    mind_map_payload = {
+        "name": "Mind Map Title",
+        "children": [{"name": "child"}],
+    }
+    mind_map_json = json.dumps(mind_map_payload)
+
+    async def fake_rpc_call(method: Any, params: Any, **_: Any) -> Any:
+        calls.append((method, params))
+        name = getattr(method, "name", str(method))
+        if name == "GENERATE_MIND_MAP":
+            return [[mind_map_json]]
+        if name == "CREATE_NOTE":
+            return [["note_abc"]]
+        if name == "UPDATE_NOTE":
+            return None
+        if name == "GET_NOTES_AND_MIND_MAPS":
+            return [
+                [
+                    [
+                        "note_abc",
+                        ["note_abc", mind_map_json, [], None, "Mind Map Title"],
+                    ]
+                ]
+            ]
+        if name == "LIST_ARTIFACTS":
+            return [[]]
+        return None
+
+    core = MagicMock()
+    core.rpc_call = AsyncMock(side_effect=fake_rpc_call)
+    core.get_source_ids = AsyncMock(return_value=["src_1"])
+    return core, calls
+
+
+@pytest.mark.asyncio
+async def test_generate_mind_map_works_without_notes_injection() -> None:
+    """``generate_mind_map`` must persist the mind map via ``_mind_map``
+    primitives, not via an injected ``NotesAPI``."""
+    core, calls = _make_core_for_mind_map_flow()
+    api = ArtifactsAPI(core)
+
+    result = await api.generate_mind_map("nb_123", source_ids=["src_1"])
+
+    assert isinstance(result, dict)
+    assert result["note_id"] == "note_abc"
+    assert result["mind_map"]["name"] == "Mind Map Title"
+
+    # The flow must have gone GENERATE_MIND_MAP -> CREATE_NOTE -> UPDATE_NOTE
+    method_names = [getattr(m, "name", str(m)) for m, _ in calls]
+    assert "GENERATE_MIND_MAP" in method_names
+    assert "CREATE_NOTE" in method_names
+    assert "UPDATE_NOTE" in method_names
+
+
+@pytest.mark.asyncio
+async def test_artifacts_list_pulls_mind_maps_without_notes_injection(
+    tmp_path: Any,
+) -> None:
+    """``ArtifactsAPI.list`` must read mind maps through ``_mind_map`` —
+    no ``NotesAPI`` reference required."""
+    core, _ = _make_core_for_mind_map_flow()
+    api = ArtifactsAPI(core)
+
+    artifacts = await api.list("nb_123")
+    # One mind map should surface from GET_NOTES_AND_MIND_MAPS.
+    assert any(a.kind.name == "MIND_MAP" for a in artifacts)
+
+
+@pytest.mark.asyncio
+async def test_download_mind_map_works_without_notes_injection(
+    tmp_path: Any,
+) -> None:
+    """``download_mind_map`` reaches into mind-map storage via ``_mind_map``
+    rather than ``self._notes``."""
+    core, _ = _make_core_for_mind_map_flow()
+    api = ArtifactsAPI(core)
+
+    output = tmp_path / "mm.json"
+    returned = await api.download_mind_map("nb_123", str(output))
+
+    assert returned == str(output)
+    saved = json.loads(output.read_text(encoding="utf-8"))
+    assert saved["name"] == "Mind Map Title"

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -578,10 +578,14 @@ class TestArtifactsSourceSelection:
         # Verify get_source_ids was called
         mock_core.get_source_ids.assert_called_once_with("nb_123")
 
-        # Verify GENERATE_MIND_MAP RPC was called with correct source encoding
-        mock_core.rpc_call.assert_called_once()
-        call_args = mock_core.rpc_call.call_args
-        params = call_args.args[1]
+        # After T6.F, ``generate_mind_map`` also drives the CREATE_NOTE +
+        # UPDATE_NOTE calls itself (previously delegated to NotesAPI), so
+        # rpc_call is invoked three times. The source-encoding assertion
+        # targets the GENERATE_MIND_MAP call specifically.
+        generate_call = next(
+            c for c in mock_core.rpc_call.call_args_list if c.args[0].name == "GENERATE_MIND_MAP"
+        )
+        params = generate_call.args[1]
 
         # Mind map uses source_ids_nested = [[[sid]] for sid]
         source_ids_nested = params[0]
@@ -605,8 +609,12 @@ class TestArtifactsSourceSelection:
             instructions="Focus on key themes",
         )
 
-        call_args = mock_core.rpc_call.call_args
-        params = call_args.args[1]
+        # Pick the GENERATE_MIND_MAP call specifically — CREATE_NOTE and
+        # UPDATE_NOTE are now invoked alongside it.
+        generate_call = next(
+            c for c in mock_core.rpc_call.call_args_list if c.args[0].name == "GENERATE_MIND_MAP"
+        )
+        params = generate_call.args[1]
 
         # params[5] should contain the mind map config with language and instructions
         mind_map_config = params[5]

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -84,13 +84,18 @@ def mock_core():
 
 @pytest.fixture
 def mock_notes_api():
-    """Create a mock NotesAPI."""
-    notes = MagicMock()
-    notes.list_mind_maps = AsyncMock(return_value=[])
-    mock_note = MagicMock()
-    mock_note.id = "created_note_123"
-    notes.create = AsyncMock(return_value=mock_note)
-    return notes
+    """Placeholder for the legacy ``ArtifactsAPI(core, notes_api)`` signature.
+
+    After T6.F, ``ArtifactsAPI`` no longer reads ``notes_api`` (it consumes
+    the shared ``_mind_map`` module directly). The arg is still accepted for
+    backward compatibility and immediately discarded inside ``__init__``, so
+    this fixture intentionally returns a bare mock — no method stubs, since
+    none of the downstream code paths under test invoke any methods on it.
+    Future readers: if you find yourself adding ``AsyncMock`` setup here,
+    you probably want to drop the second positional arg from the call sites
+    instead.
+    """
+    return MagicMock()
 
 
 class TestChatSourceSelection:


### PR DESCRIPTION
## Summary
- Lift mind-map RPC primitives (``list_mind_maps``, ``create_note``, ``update_note``, ``fetch_all_notes_and_mind_maps``, ``is_deleted``, ``extract_content``) into a new ``src/notebooklm/_mind_map.py`` module that both ``ArtifactsAPI`` and ``NotesAPI`` consume directly.
- ``ArtifactsAPI.__init__`` no longer requires ``notes_api=client.notes``. The keyword is retained as an optional/ignored argument for backward compatibility, and ``NotebookLMClient`` no longer has a load-bearing notes-before-artifacts init order.
- ``NotesAPI`` keeps its full public + private surface (``_is_deleted`` / ``_extract_content`` / ``_parse_note`` / ``_get_all_notes_and_mind_maps``) by delegating to the new module, so existing unit tests keep working unchanged.

Direction note: ``ArtifactsAPI`` was the consumer of ``NotesAPI`` (not the reverse — ``_notes.py`` had zero references to artifacts). This PR corrects the v1 plan's inverted dependency direction.

## Test plan
- [x] ``uv run ruff format .`` + ``uv run ruff check .`` clean
- [x] ``uv run mypy src/notebooklm --ignore-missing-imports`` clean
- [x] ``uv run pytest`` — 3308 passed, 11 skipped
- [x] New ``tests/unit/test_init_order.py`` covers: (1) ``ArtifactsAPI`` constructible without ``notes_api``, (2) legacy ``notes_api=`` kwarg accepted, (3) both construction orders succeed, (4) ``generate_mind_map`` + ``list`` + ``download_mind_map`` regressions still pass end-to-end without an injected ``NotesAPI``.

Refs: T6.F (`.sisyphus/plans/tier-6-implementation.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal mind-map implementation reorganized to improve reliability and simplify initialization; mind-map creation, listing, and download behavior unchanged for users.
* **Tests**
  * Expanded and updated test coverage to validate mind-map generation, listing, downloading, and init-order robustness across scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/489)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->