### PR TITLE
feat(coverage): per-file floor enforcement (T6.C)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,4 +114,14 @@ jobs:
       run: ./tests/check_cassettes_clean.sh
 
     - name: Run tests with coverage
-      run: uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90
+      # Emit coverage.json so the per-file floor check below can read it
+      # without re-running the suite. ``term-missing`` is kept so build logs
+      # still show the missing-lines summary.
+      run: uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90
+
+    - name: Assert per-file coverage floors (T6.C)
+      # Only ubuntu-latest emits the canonical coverage.json — running this
+      # on every matrix slot would just repeat the same assertion against
+      # platform-equivalent coverage numbers.
+      if: runner.os == 'Linux'
+      run: uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,8 +120,10 @@ jobs:
       run: uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90
 
     - name: Assert per-file coverage floors (T6.C)
-      # Only ubuntu-latest emits the canonical coverage.json — running this
-      # on every matrix slot would just repeat the same assertion against
-      # platform-equivalent coverage numbers.
+      # Linux-only because ``coverage.json`` on Windows records backslash
+      # paths (e.g. ``src\notebooklm\cli\doctor.py``) that won't match the
+      # forward-slash keys in ``[tool.notebooklm.per_file_coverage_floors]``
+      # in pyproject.toml. macOS uses forward slashes and would also work,
+      # but a single OS is enough — the floors are platform-independent.
       if: runner.os == 'Linux'
       run: uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ env/
 venv/
 .pytest_cache/
 .coverage
+coverage.json
 htmlcov/
 dist/
 build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,24 @@ branch = true
 show_missing = true
 fail_under = 90
 
+# Per-file coverage floors enforced by ``scripts/check_coverage_thresholds.py
+# --coverage-json``. The coverage.py ``[tool.coverage.report]`` table only
+# supports a global ``fail_under``, so individual files that historically lag
+# the project-wide 90% are guarded here. Keys are the source paths exactly as
+# they appear in ``coverage.json`` (run ``uv run pytest --cov=src/notebooklm
+# --cov-report=json:coverage.json`` to confirm). Values are the minimum
+# acceptable percent_covered. To bump a floor: run the full suite locally,
+# read the new percentage from ``coverage.json``, and round down by ~2% so
+# transient flakes don't trip CI on unrelated PRs. To delete a file from the
+# guard: drop the line. Adding a new file requires a separate PR with a
+# rationale in the commit message.
+[tool.notebooklm.per_file_coverage_floors]
+"src/notebooklm/__main__.py" = 0
+"src/notebooklm/cli/_firefox_containers.py" = 75
+"src/notebooklm/cli/doctor.py" = 63
+"src/notebooklm/cli/profile.py" = 74
+"src/notebooklm/cli/session.py" = 83
+
 [tool.mypy]
 python_version = "3.10"
 warn_return_any = false

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -110,9 +110,22 @@ def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
         print(f"pyproject.toml not found: {pyproject_path}", file=sys.stderr)
         return 2
 
-    floors = pp.get("tool", {}).get("notebooklm", {}).get("per_file_coverage_floors", {})
-    if not isinstance(floors, dict) or not floors:
-        # Empty or missing table is fine — nothing to enforce.
+    floors = pp.get("tool", {}).get("notebooklm", {}).get("per_file_coverage_floors")
+    if floors is None:
+        # Missing table is fine — nothing to enforce.
+        print(f"OK: no [tool.notebooklm.per_file_coverage_floors] in {pyproject_path}")
+        return 0
+    if not isinstance(floors, dict):
+        # Misconfiguration (e.g. someone wrote a string or list instead of a
+        # table). Fail fast rather than silently returning OK.
+        print(
+            f"[tool.notebooklm.per_file_coverage_floors] must be a TOML table in "
+            f"{pyproject_path}, got {type(floors).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+    if not floors:
+        # Empty table — explicitly opted into "enforce nothing right now".
         print(f"OK: no [tool.notebooklm.per_file_coverage_floors] in {pyproject_path}")
         return 0
 
@@ -126,9 +139,17 @@ def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
         print(f"coverage.json malformed: {exc}", file=sys.stderr)
         return 2
 
-    files = cov.get("files", {})
+    files = cov.get("files")
     if not isinstance(files, dict):
-        print(f"coverage.json missing 'files' map: {coverage_json_path}", file=sys.stderr)
+        # Includes both the missing-key case (``cov.get`` returns None) and
+        # the wrong-shape case (e.g. accidentally a list); both indicate a
+        # malformed ``coverage.json`` and should fail before any per-file
+        # comparison runs.
+        print(
+            f"coverage.json 'files' must be an object map in {coverage_json_path}, "
+            f"got {type(files).__name__}",
+            file=sys.stderr,
+        )
         return 2
 
     failures: list[str] = []
@@ -143,13 +164,16 @@ def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
             continue
         try:
             actual = float(entry["summary"]["percent_covered"])
+            target = float(floor)
         except (KeyError, TypeError, ValueError) as exc:
             print(
-                f"coverage.json entry for {path!r} missing summary.percent_covered: {exc}",
+                f"coverage.json entry for {path!r} could not be compared "
+                f"(actual={entry.get('summary', {}).get('percent_covered')!r}, "
+                f"floor={floor!r}): {exc}",
                 file=sys.stderr,
             )
             return 2
-        if actual < float(floor):
+        if actual < target:
             failures.append(f"  {path}: {actual:.2f}% < floor {floor}%")
 
     if missing:

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -3,19 +3,27 @@
 Phase 1 / T5: prevents the drift bug that was discovered during the multi-agent
 audit. CI claimed 70%, pyproject claimed 90% — until they were aligned manually.
 
+Phase 6 / T6.C extension: when ``--coverage-json`` is provided, additionally
+enforces per-file floors declared in ``[tool.notebooklm.per_file_coverage_floors]``.
+Coverage.py's ``[tool.coverage.report]`` only supports a global ``fail_under``,
+so individual files that historically lag the project-wide 90% are guarded by
+this script.
+
 Usage:
     python scripts/check_coverage_thresholds.py
     python scripts/check_coverage_thresholds.py --pyproject custom/pyproject.toml --workflow custom/test.yml
+    python scripts/check_coverage_thresholds.py --coverage-json coverage.json
 
 Exit codes:
-    0  Thresholds match.
-    1  Drift detected.
-    2  Argument error / missing field.
+    0  Thresholds match (and any per-file floors are met).
+    1  Drift detected, OR a per-file floor breached.
+    2  Argument error / missing field / coverage.json missing or malformed.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 
@@ -32,33 +40,29 @@ else:
         sys.exit(2)
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--pyproject", default="pyproject.toml")
-    ap.add_argument("--workflow", default=".github/workflows/test.yml")
-    args = ap.parse_args()
-
+def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
+    """Original Phase-1 check: pyproject ``fail_under`` vs CI ``--cov-fail-under``."""
     try:
-        with open(args.pyproject, "rb") as f:
+        with open(pyproject_path, "rb") as f:
             pp = tomllib.load(f)
     except FileNotFoundError:
-        print(f"pyproject.toml not found: {args.pyproject}", file=sys.stderr)
+        print(f"pyproject.toml not found: {pyproject_path}", file=sys.stderr)
         return 2
 
     try:
         pyproject_threshold = pp["tool"]["coverage"]["report"]["fail_under"]
     except KeyError:
         print(
-            f"No [tool.coverage.report] fail_under in {args.pyproject}",
+            f"No [tool.coverage.report] fail_under in {pyproject_path}",
             file=sys.stderr,
         )
         return 2
 
     try:
-        with open(args.workflow) as f:
+        with open(workflow_path) as f:
             yml = f.read()
     except FileNotFoundError:
-        print(f"Workflow not found: {args.workflow}", file=sys.stderr)
+        print(f"Workflow not found: {workflow_path}", file=sys.stderr)
         return 2
 
     # Scan line-by-line and ignore commented YAML lines so a stale
@@ -75,19 +79,120 @@ def main() -> int:
             thresholds.append(int(m.group(1)))
 
     if not thresholds:
-        print(f"No --cov-fail-under in {args.workflow}", file=sys.stderr)
+        print(f"No --cov-fail-under in {workflow_path}", file=sys.stderr)
         return 2
 
     for ci_threshold in thresholds:
         if pyproject_threshold != ci_threshold:
             print(
                 f"DRIFT: pyproject.toml fail_under={pyproject_threshold} but "
-                f"{args.workflow} --cov-fail-under={ci_threshold}",
+                f"{workflow_path} --cov-fail-under={ci_threshold}",
                 file=sys.stderr,
             )
             return 1
 
     print(f"OK: {len(thresholds)} occurrence(s), all at {pyproject_threshold}%")
+    return 0
+
+
+def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
+    """T6.C: enforce per-file floors from ``[tool.notebooklm.per_file_coverage_floors]``.
+
+    Floors live in pyproject.toml so they're checked into the repo and bumped
+    via PR (the commit message documents the new minimum). The script reads
+    ``coverage.json`` produced by ``pytest --cov ... --cov-report=json:...``
+    and fails if any guarded file's ``percent_covered`` is below its floor.
+    """
+    try:
+        with open(pyproject_path, "rb") as f:
+            pp = tomllib.load(f)
+    except FileNotFoundError:
+        print(f"pyproject.toml not found: {pyproject_path}", file=sys.stderr)
+        return 2
+
+    floors = pp.get("tool", {}).get("notebooklm", {}).get("per_file_coverage_floors", {})
+    if not isinstance(floors, dict) or not floors:
+        # Empty or missing table is fine — nothing to enforce.
+        print(f"OK: no [tool.notebooklm.per_file_coverage_floors] in {pyproject_path}")
+        return 0
+
+    try:
+        with open(coverage_json_path) as f:
+            cov = json.load(f)
+    except FileNotFoundError:
+        print(f"coverage.json not found: {coverage_json_path}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"coverage.json malformed: {exc}", file=sys.stderr)
+        return 2
+
+    files = cov.get("files", {})
+    if not isinstance(files, dict):
+        print(f"coverage.json missing 'files' map: {coverage_json_path}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    missing: list[str] = []
+    for path, floor in sorted(floors.items()):
+        entry = files.get(path)
+        if entry is None:
+            # A guarded file with no measurement is itself a CI failure —
+            # otherwise a rename or accidental deletion would silently drop
+            # the floor and any later regression would slip through.
+            missing.append(path)
+            continue
+        try:
+            actual = float(entry["summary"]["percent_covered"])
+        except (KeyError, TypeError, ValueError) as exc:
+            print(
+                f"coverage.json entry for {path!r} missing summary.percent_covered: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+        if actual < float(floor):
+            failures.append(f"  {path}: {actual:.2f}% < floor {floor}%")
+
+    if missing:
+        print(
+            "MISSING from coverage.json (renamed/deleted? update "
+            "[tool.notebooklm.per_file_coverage_floors] or restore the file):\n  "
+            + "\n  ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+
+    if failures:
+        print(
+            "PER-FILE COVERAGE FLOOR BREACH:\n" + "\n".join(failures),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {len(floors)} per-file floor(s) all met")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pyproject", default="pyproject.toml")
+    ap.add_argument("--workflow", default=".github/workflows/test.yml")
+    ap.add_argument(
+        "--coverage-json",
+        default=None,
+        help=(
+            "Optional path to coverage.json (produced by `pytest --cov "
+            "--cov-report=json:coverage.json`). When present, also enforces "
+            "[tool.notebooklm.per_file_coverage_floors] from pyproject.toml."
+        ),
+    )
+    args = ap.parse_args(argv)
+
+    drift_rc = _check_global_drift(args.pyproject, args.workflow)
+    if drift_rc != 0:
+        return drift_rc
+
+    if args.coverage_json:
+        return _check_per_file_floors(args.pyproject, args.coverage_json)
     return 0
 
 

--- a/tests/unit/test_check_coverage_thresholds.py
+++ b/tests/unit/test_check_coverage_thresholds.py
@@ -1,0 +1,212 @@
+"""Tests for ``scripts/check_coverage_thresholds.py``.
+
+Covers both the original Phase-1 drift check and the T6.C per-file floor
+extension. The script is imported via spec-loading rather than ``from
+scripts.check_coverage_thresholds import main`` because ``scripts/`` is not
+a package in this repo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_coverage_thresholds.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_coverage_thresholds", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Original Phase-1 drift check (regression guard for the existing behavior)
+# ---------------------------------------------------------------------------
+
+
+def _write_pyproject(tmp_path: Path, fail_under: int = 90, per_file: dict | None = None) -> Path:
+    body = f"""\
+[tool.coverage.report]
+fail_under = {fail_under}
+"""
+    if per_file:
+        body += "\n[tool.notebooklm.per_file_coverage_floors]\n"
+        for k, v in per_file.items():
+            body += f'"{k}" = {v}\n'
+    p = tmp_path / "pyproject.toml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def _write_workflow(tmp_path: Path, threshold: int = 90) -> Path:
+    p = tmp_path / "test.yml"
+    p.write_text(
+        f"jobs:\n  test:\n    steps:\n    - run: pytest --cov-fail-under={threshold}\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_original_drift_match(tmp_path, capsys, script):
+    pp = _write_pyproject(tmp_path, fail_under=90)
+    yml = _write_workflow(tmp_path, threshold=90)
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "OK" in out and "90%" in out
+
+
+def test_original_drift_mismatch_fails(tmp_path, capsys, script):
+    pp = _write_pyproject(tmp_path, fail_under=90)
+    yml = _write_workflow(tmp_path, threshold=70)
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "DRIFT" in err
+
+
+# ---------------------------------------------------------------------------
+# T6.C — per-file floor enforcement
+# ---------------------------------------------------------------------------
+
+
+def _write_coverage_json(tmp_path: Path, files: dict[str, float]) -> Path:
+    """Build a minimal coverage.json with the requested per-file percentages."""
+    payload = {
+        "files": {path: {"summary": {"percent_covered": pct}} for path, pct in files.items()}
+    }
+    p = tmp_path / "coverage.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def test_per_file_floors_all_met(tmp_path, capsys, script):
+    pp = _write_pyproject(
+        tmp_path,
+        fail_under=90,
+        per_file={"src/notebooklm/cli/doctor.py": 60, "src/notebooklm/cli/profile.py": 70},
+    )
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(
+        tmp_path,
+        {
+            "src/notebooklm/cli/doctor.py": 65.0,
+            "src/notebooklm/cli/profile.py": 75.0,
+        },
+    )
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(cov)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "2 per-file floor(s) all met" in out
+
+
+def test_per_file_floor_breach_fails_with_filename(tmp_path, capsys, script):
+    pp = _write_pyproject(
+        tmp_path,
+        fail_under=90,
+        per_file={"src/notebooklm/cli/doctor.py": 80},
+    )
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(tmp_path, {"src/notebooklm/cli/doctor.py": 65.0})
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(cov)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "PER-FILE COVERAGE FLOOR BREACH" in err
+    assert "src/notebooklm/cli/doctor.py" in err
+    assert "65.00" in err
+    assert "80%" in err
+
+
+def test_per_file_missing_from_coverage_json_fails(tmp_path, capsys, script):
+    """A guarded file with no measurement is itself a CI failure."""
+    pp = _write_pyproject(
+        tmp_path,
+        fail_under=90,
+        per_file={"src/notebooklm/cli/doctor.py": 60, "src/notebooklm/renamed.py": 60},
+    )
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(tmp_path, {"src/notebooklm/cli/doctor.py": 65.0})
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(cov)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "MISSING" in err
+    assert "src/notebooklm/renamed.py" in err
+
+
+def test_per_file_no_floors_table_passes(tmp_path, capsys, script):
+    pp = _write_pyproject(tmp_path, fail_under=90)  # no per_file table
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(tmp_path, {"src/notebooklm/cli/doctor.py": 0.0})
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(cov)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "no [tool.notebooklm.per_file_coverage_floors]" in out
+
+
+def test_coverage_json_missing_returns_2(tmp_path, capsys, script):
+    pp = _write_pyproject(tmp_path, fail_under=90, per_file={"foo.py": 0})
+    yml = _write_workflow(tmp_path, threshold=90)
+    rc = script.main(
+        [
+            "--pyproject",
+            str(pp),
+            "--workflow",
+            str(yml),
+            "--coverage-json",
+            str(tmp_path / "no-such.json"),
+        ]
+    )
+    assert rc == 2
+
+
+def test_coverage_json_malformed_returns_2(tmp_path, capsys, script):
+    pp = _write_pyproject(tmp_path, fail_under=90, per_file={"foo.py": 0})
+    yml = _write_workflow(tmp_path, threshold=90)
+    bad = tmp_path / "coverage.json"
+    bad.write_text("{not-json", encoding="utf-8")
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(bad)])
+    assert rc == 2
+    assert "malformed" in capsys.readouterr().err
+
+
+def test_per_file_real_baselines_pass_against_repo_pyproject(tmp_path, capsys, script):
+    """Round-trip: the floors checked into pyproject.toml pass against a fresh
+    coverage.json that records the floor exact value (sanity check that the
+    parser+comparator agree on the data shape that ``coverage json`` emits).
+    """
+    real_pp = REPO_ROOT / "pyproject.toml"
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(
+        tmp_path,
+        {
+            # Match the floors checked in — every path at exactly its floor
+            # should pass (>= comparison).
+            "src/notebooklm/__main__.py": 0.0,
+            "src/notebooklm/cli/_firefox_containers.py": 75.0,
+            "src/notebooklm/cli/doctor.py": 63.0,
+            "src/notebooklm/cli/profile.py": 74.0,
+            "src/notebooklm/cli/session.py": 83.0,
+        },
+    )
+    rc = script.main(
+        ["--pyproject", str(real_pp), "--workflow", str(yml), "--coverage-json", str(cov)]
+    )
+    assert rc == 0
+
+
+def teardown_module():
+    """Drop the spec-loaded module so other tests aren't affected."""
+    sys.modules.pop("check_coverage_thresholds", None)

--- a/tests/unit/test_check_coverage_thresholds.py
+++ b/tests/unit/test_check_coverage_thresholds.py
@@ -172,6 +172,50 @@ def test_coverage_json_missing_returns_2(tmp_path, capsys, script):
     assert rc == 2
 
 
+def test_per_file_floors_non_table_returns_2(tmp_path, capsys, script):
+    """A non-table ``per_file_coverage_floors`` (string, list, etc.) is a
+    misconfiguration that must not silently bypass enforcement."""
+    pp = tmp_path / "pyproject.toml"
+    pp.write_text(
+        "[tool.coverage.report]\nfail_under = 90\n\n"
+        '[tool.notebooklm]\nper_file_coverage_floors = "oops"\n',
+        encoding="utf-8",
+    )
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(tmp_path, {"src/notebooklm/cli/doctor.py": 50.0})
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(cov)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "must be a TOML table" in err
+
+
+def test_per_file_floor_non_numeric_returns_2(tmp_path, capsys, script):
+    """A non-numeric floor value (string, etc.) yields exit 2 with context, not a crash."""
+    pp = _write_pyproject(
+        tmp_path,
+        fail_under=90,
+        per_file={"src/notebooklm/cli/doctor.py": '"sixty"'},  # raw TOML — string value
+    )
+    yml = _write_workflow(tmp_path, threshold=90)
+    cov = _write_coverage_json(tmp_path, {"src/notebooklm/cli/doctor.py": 70.0})
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(cov)])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "could not be compared" in err
+    assert "src/notebooklm/cli/doctor.py" in err
+
+
+def test_coverage_json_files_wrong_shape_returns_2(tmp_path, capsys, script):
+    """``coverage.json`` with ``files`` as something other than an object → exit 2."""
+    pp = _write_pyproject(tmp_path, fail_under=90, per_file={"foo.py": 0})
+    yml = _write_workflow(tmp_path, threshold=90)
+    bad = tmp_path / "coverage.json"
+    bad.write_text(json.dumps({"files": []}), encoding="utf-8")  # list, not dict
+    rc = script.main(["--pyproject", str(pp), "--workflow", str(yml), "--coverage-json", str(bad)])
+    assert rc == 2
+    assert "'files' must be an object map" in capsys.readouterr().err
+
+
 def test_coverage_json_malformed_returns_2(tmp_path, capsys, script):
     pp = _write_pyproject(tmp_path, fail_under=90, per_file={"foo.py": 0})
     yml = _write_workflow(tmp_path, threshold=90)


### PR DESCRIPTION
## Summary

- Extends \`scripts/check_coverage_thresholds.py\` with a new \`--coverage-json\` mode that enforces \`[tool.notebooklm.per_file_coverage_floors]\` from pyproject.toml. Original Phase-1 drift check is preserved.
- Adds the floor table for the 5 files called out in the synthesis (\`cli/doctor.py\`, \`cli/profile.py\`, \`cli/session.py\`, \`cli/_firefox_containers.py\`, \`__main__.py\`). Values = current measured coverage rounded down by ~2%.
- Wires CI: pytest now also emits \`coverage.json\`, a follow-up Linux-only step runs the per-file enforcement. \`coverage.json\` gitignored.

Wave 2, second of three. Tier-6 plan: \`.sisyphus/plans/tier-6-implementation.md\`.

## Test plan

- [x] 9 new tests in \`tests/unit/test_check_coverage_thresholds.py\` — all-met, breach, missing entry, empty-table, missing/malformed JSON, drift regression guards, round-trip against real pyproject
- [x] Full unit suite: 2777 passed, 7 skipped
- [x] End-to-end: \`uv run python scripts/check_coverage_thresholds.py --coverage-json coverage.json\` reports "5 per-file floor(s) all met"
- [x] \`uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports\`
- [ ] CI matrix on Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-file code-coverage floors can be configured and enforced alongside the global coverage threshold.

* **Chores**
  * CI now emits a coverage JSON artifact and only runs per-file enforcement on the Linux runner.
  * The coverage JSON artifact is ignored from version control.

* **Tests**
  * Added comprehensive tests covering global drift checks, per-file floor enforcement, and multiple error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/491)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->