### PR TITLE
feat(scripts): block-mirror policy for install-doc parity (T6.D)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,13 @@ uv sync --frozen --extra browser --extra dev --extra markdown
 source .venv/bin/activate
 uv run playwright install chromium
 pre-commit install
+```
 
-# Run the full pre-commit suite (matches what CI runs).
-# IMPORTANT: use the broad `.` scope, not `src/ tests/` — the pre-commit hook
-# in CI invokes ruff-format on the whole tree and is stricter than a narrow scope.
+**Run the full pre-commit suite** (matches what CI runs). IMPORTANT: use the
+broad `.` scope, not `src/ tests/` — the pre-commit hook in CI invokes
+ruff-format on the whole tree and is stricter than a narrow scope.
+
+```bash
 uv run ruff format --check . && \
     uv run ruff check . && \
     uv run mypy src/notebooklm --ignore-missing-imports && \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ pre-commit install
 
 For full prerequisites, headless setup, optional extras (`[cookies]`, `[markdown]`), and platform notes, see [docs/installation.md#e-contributor](docs/installation.md#e-contributor).
 
+> **Install-doc parity.** `docs/installation.md` is the canonical install guide; this file mirrors a small contributor-focused subset. Every fenced ``bash`` block in `installation.md` must EITHER appear verbatim in `CONTRIBUTING.md`, OR be marked with `<!-- not mirrored: <reason> -->` on the line directly before its opening fence. CI enforces this via `scripts/check_ci_install_parity.py` so a stale block can't drift in unnoticed. When you edit `installation.md`, decide on the spot whether the new content also belongs in this file.
+
 The `browser` extra is part of the contributor install because the default unit
 suite imports and patches `playwright.sync_api`. The command
 `uv sync --frozen --extra dev` is only the test/lint toolchain; it is not enough

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,7 @@ The project ships `notebooklm skill install`, [SKILL.md](../SKILL.md), and [AGEN
 
 **Recommended install (Python-version-aware; surfaces real errors instead of swallowing them):**
 
+<!-- not mirrored: end-user install path (Persona A); CONTRIBUTING.md tracks the in-repo `uv sync` flow only -->
 ```bash
 pip install "notebooklm-py[browser]"   # mandatory; errors must propagate
 
@@ -75,6 +76,7 @@ fi
 
 **Skill install (separate from the Python package):**
 
+<!-- not mirrored: agent skill registration; not part of the contributor install flow -->
 ```bash
 notebooklm skill install              # writes to ~/.claude/skills/, ~/.agents/skills/
 # OR (alternative ecosystem):
@@ -85,6 +87,7 @@ If the agent is reading `SKILL.md` from inside an already-installed location (e.
 
 **Authentication — `notebooklm login` is the primary path:**
 
+<!-- not mirrored: end-user auth setup; contributors usually source storage_state from a personal account -->
 ```bash
 notebooklm login                       # primary: opens browser, user signs in to Google once
 ```
@@ -93,6 +96,7 @@ After login, `storage_state.json` persists at `~/.notebooklm/profiles/default/st
 
 **Headless / sandboxed agent contexts** (no display, can't open a browser): use the cookie-extraction path instead, requires the `[cookies]` extra installed in step 2:
 
+<!-- not mirrored: headless-agent auth path; out of scope for the contributor README -->
 ```bash
 notebooklm login --browser-cookies auto    # rookiepy autodetects an installed browser
 ```
@@ -101,6 +105,7 @@ If the agent is in a no-display sandbox AND `[cookies]` isn't installed (Python 
 
 **Verification (machine-parseable):**
 
+<!-- not mirrored: agent-targeted verification; CONTRIBUTING.md uses the test+lint suite as its smoke check -->
 ```bash
 notebooklm --version                    # text version
 notebooklm auth check --json            # JSON: {"status": "ok", "checks": {...}}
@@ -124,12 +129,14 @@ Occasional CLI use.
 
 **Recommended (cross-platform default, including Windows):**
 
+<!-- not mirrored: end-user pip install (Persona B); CONTRIBUTING.md tracks the in-repo `uv sync` flow only -->
 ```bash
 pip install "notebooklm-py[browser]"
 ```
 
 For an isolated install (avoids polluting your env), use `pipx` or `uv tool`:
 
+<!-- not mirrored: end-user isolated install (pipx / uv tool); CONTRIBUTING.md targets in-repo contributors -->
 ```bash
 pipx install "notebooklm-py[browser]"
 # OR (if you already have uv: https://docs.astral.sh/uv/getting-started/installation/)
@@ -140,6 +147,7 @@ uv tool install "notebooklm-py[browser]"
 
 **Verify:**
 
+<!-- not mirrored: end-user post-install verify (Persona B); contributors run the test suite instead -->
 ```bash
 notebooklm --version              # → 0.4.x
 notebooklm login                  # opens Chromium; press ENTER after sign-in
@@ -172,17 +180,20 @@ print(notebooklm.__version__)
 **Post-install (3-step recipe — Playwright is *not* required on the server):**
 
 1. **On a workstation with a display**, install with `[browser]` and log in once:
+   <!-- not mirrored: headless-server bootstrap step 1 (Persona D); not part of contributor flow -->
    ```bash
    pip install "notebooklm-py[browser]"
    playwright install chromium
    notebooklm login   # writes ~/.notebooklm/profiles/default/storage_state.json
    ```
 2. **Move the auth file to the server.** Either ship it as a file:
+   <!-- not mirrored: headless-server bootstrap step 2a (scp); not part of contributor flow -->
    ```bash
    scp ~/.notebooklm/profiles/default/storage_state.json \
        user@server:~/.notebooklm/profiles/default/storage_state.json
    ```
    or stuff the contents into a CI / deployment env var (preferred for ephemeral runners):
+   <!-- not mirrored: headless-server bootstrap step 2b (env var); not part of contributor flow -->
    ```bash
    export NOTEBOOKLM_AUTH_JSON="$(cat ~/.notebooklm/profiles/default/storage_state.json)"
    ```
@@ -192,6 +203,7 @@ print(notebooklm.__version__)
    > - Watch for trailing newlines: pipe with `tr -d '\n'` if your secret-set tool adds one (`cat ... | tr -d '\n' | gh secret set NOTEBOOKLM_AUTH_JSON`).
    > - For **ephemeral runners** (GitHub Actions, GitLab CI — no persistent disk between runs), the layer-5 in-process refresh from [troubleshooting.md](troubleshooting.md#authentication-errors) cannot persist rotated cookies. Run `notebooklm auth refresh` periodically on a workstation cron and push the refreshed file with `gh secret set NOTEBOOKLM_AUTH_JSON < ~/.notebooklm/profiles/default/storage_state.json`.
 3. **On the server**, run any non-`login` command:
+   <!-- not mirrored: headless-server smoke test; not part of contributor flow -->
    ```bash
    notebooklm list
    notebooklm auth check --test    # verifies the cookies still authenticate against Google
@@ -207,6 +219,7 @@ Working on this repo.
 
 **Recommended (respects the checked-in `uv.lock`):**
 
+<!-- not mirrored: contributor bootstrap with git clone + cd; CONTRIBUTING.md picks up after the clone with the canonical `uv sync --frozen --extra browser --extra dev --extra markdown` command (enforced verbatim by scripts/check_ci_install_parity.py). -->
 ```bash
 git clone https://github.com/teng-lin/notebooklm-py.git
 cd notebooklm-py
@@ -235,6 +248,7 @@ uv run ruff format --check . && \
 
 **Verify:**
 
+<!-- not mirrored: contributor verify block; CONTRIBUTING.md mirrors only the pre-commit checklist (the more frequent, per-commit version) -->
 ```bash
 notebooklm --version
 uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-fail-under=90
@@ -284,6 +298,7 @@ Source of truth: `pyproject.toml` `[project.optional-dependencies]`.
 
 On Debian/Ubuntu, Playwright needs system libs for Chromium. Run after `playwright install chromium`:
 
+<!-- not mirrored: Linux-specific Playwright system-library install; CI runs `uv run playwright install-deps chromium` directly in test.yml -->
 ```bash
 playwright install-deps chromium       # scoped to chromium; matches CI
 ```
@@ -292,6 +307,7 @@ Works without `sudo` if you're root or have passwordless sudo. Otherwise `sudo p
 
 ### First-time `notebooklm login`
 
+<!-- not mirrored: end-user first-login walkthrough; contributors typically reuse an existing storage_state.json -->
 ```bash
 notebooklm login                       # opens Chromium, you sign in to Google, press ENTER
 notebooklm auth check --test           # verify
@@ -306,6 +322,7 @@ The login command:
 
 Registers the skill into local agent skill directories:
 
+<!-- not mirrored: agent skill directory registration; out of scope for the contributor README -->
 ```bash
 notebooklm skill install               # writes ~/.claude/skills/notebooklm/, ~/.agents/skills/notebooklm/
 ```
@@ -328,6 +345,7 @@ Optional — only needed if your agent harness reads from those directories and 
 
 **Your first end-to-end run:**
 
+<!-- not mirrored: end-user smoke test; contributors run `uv run pytest` instead -->
 ```bash
 notebooklm create "My First Notebook"
 notebooklm source add https://en.wikipedia.org/wiki/Python_(programming_language)
@@ -351,6 +369,7 @@ For the full CLI surface, see [cli-reference.md](cli-reference.md).
 
 ## Upgrading and uninstalling
 
+<!-- not mirrored: end-user upgrade commands; contributors `git pull && uv sync --frozen ...` instead -->
 ```bash
 pip install --upgrade notebooklm-py            # latest patch
 pip install --upgrade "notebooklm-py[browser]"  # preserves your extras
@@ -360,6 +379,7 @@ For pinning patterns and version-stability guarantees, see [stability.md](stabil
 
 To uninstall:
 
+<!-- not mirrored: end-user uninstall; contributors `git clean -fdx` and remove the worktree instead -->
 ```bash
 pip uninstall notebooklm-py
 rm -rf ~/.notebooklm                          # optional: remove auth state

--- a/scripts/check_ci_install_parity.py
+++ b/scripts/check_ci_install_parity.py
@@ -76,7 +76,10 @@ def _extract_bash_blocks(text: str) -> list[_BashBlock]:
                 ln = lines[j]
                 ln_stripped = ln.lstrip()
                 ln_indent = len(ln) - len(ln_stripped)
-                if ln_stripped == "```" and ln_indent == indent:
+                if ln_stripped.rstrip() == "```" and ln_indent == indent:
+                    # Tolerate trailing whitespace on the closing fence so a
+                    # file with stray spaces after ``` doesn't silently
+                    # capture the rest of the document into one giant block.
                     break
                 # Strip the opener's indent so the captured body is comparable
                 # against blocks elsewhere that may use different indentation.
@@ -156,9 +159,16 @@ def _check_block_mirror_policy(installation_path: Path, contributing_path: Path)
         print(f"WARN: no fenced ``bash`` blocks found in {installation_path}", file=sys.stderr)
         return 0
 
+    # Compare against the SET of fenced bash blocks in CONTRIBUTING.md, not
+    # the raw text. A naive substring check would let an installation block
+    # pass when its body coincidentally appears inside prose, an unrelated
+    # block, or a longer command — exactly the false-positive failure mode
+    # that lets stale install docs slip through unnoticed.
+    contributing_block_bodies = {b.body for b in _extract_bash_blocks(contributing_text)}
+
     failures: list[str] = []
     for block in blocks:
-        if block.body in contributing_text:
+        if block.body in contributing_block_bodies:
             continue
         if _has_not_mirrored_marker(installation_text, block):
             continue

--- a/scripts/check_ci_install_parity.py
+++ b/scripts/check_ci_install_parity.py
@@ -1,63 +1,135 @@
-"""Assert CI install step matches CONTRIBUTING.md.
+"""Assert install-doc parity.
 
-Phase 6 / P6.4: ensures that contributors are using the same install path as CI.
-The canonical install command — ``uv sync --frozen --extra browser --extra dev
---extra markdown`` — must appear verbatim in both files. The exact wording is
-deliberate (per ``docs/installation.md``): the broader ``--all-extras`` form
-pulls in ``cookies`` (and ``ai``), which fails on Python 3.13/3.14.
+Two checks:
+
+1. **Canonical install presence (Phase 6 / P6.4 — original):** the canonical
+   install command — ``uv sync --frozen --extra browser --extra dev
+   --extra markdown`` — must appear verbatim in both ``.github/workflows/test.yml``
+   and ``CONTRIBUTING.md``. The exact wording is deliberate (per
+   ``docs/installation.md``): the broader ``--all-extras`` form pulls in
+   ``cookies`` (and ``ai``), which fails on Python 3.13/3.14.
+
+2. **Block-mirror policy (T6.D extension):** every fenced ``bash`` code block
+   in ``docs/installation.md`` (the canonical install guide) must EITHER
+   appear verbatim in ``CONTRIBUTING.md``, OR be marked with
+   ``<!-- not mirrored: <reason> -->`` on the line directly before the
+   opening fence in ``installation.md``. This forces a reviewer to *think*
+   about parity each time they edit the install docs — a stale block
+   silently drifting into ``installation.md`` without a corresponding
+   contributor-doc update is the failure mode this guards.
 
 Usage:
     python scripts/check_ci_install_parity.py
-    python scripts/check_ci_install_parity.py --workflow custom/test.yml --contributing CONTRIBUTING.md
+    python scripts/check_ci_install_parity.py --workflow X --contributing Y --installation Z
+    python scripts/check_ci_install_parity.py --skip-block-mirror   # original check only
 
 Exit codes:
-    0  Both files contain the canonical install command.
-    1  Drift detected (one or both files missing the command).
+    0  All checks pass.
+    1  Drift detected.
     2  Argument error / file not found.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 CANONICAL_INSTALL_CMD = "uv sync --frozen --extra browser --extra dev --extra markdown"
 
+# Regex to find ``<!-- not mirrored: ... -->`` markers. The reason text is
+# stripped — it's documentation for humans, not a key.
+_MARKER_RE = re.compile(r"<!--\s*not\s+mirrored\s*:\s*(.+?)\s*-->", re.IGNORECASE)
 
-def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
-    repo_root = Path(__file__).resolve().parent.parent
-    ap.add_argument("--workflow", default=str(repo_root / ".github/workflows/test.yml"))
-    ap.add_argument("--contributing", default=str(repo_root / "CONTRIBUTING.md"))
-    args = ap.parse_args(argv)
 
-    workflow = Path(args.workflow)
-    contributing = Path(args.contributing)
+@dataclass(frozen=True)
+class _BashBlock:
+    """A fenced ``bash`` code block extracted from a markdown source."""
 
-    if not workflow.is_file():
-        print(f"File not found: {workflow}", file=sys.stderr)
+    start_line: int  # 1-based line number of the opening ``` fence
+    body: str  # block contents (no fences), exact characters
+
+
+def _extract_bash_blocks(text: str) -> list[_BashBlock]:
+    """Extract every fenced ``bash`` block from a markdown document.
+
+    Indented blocks (e.g. inside numbered lists) are recognized: the script
+    looks for a fence opener that begins with ``bash`` after any indentation.
+    The block body is captured with the leading indentation stripped from
+    each line so a verbatim search against another doc isn't foiled by
+    purely-cosmetic indent differences.
+    """
+    blocks: list[_BashBlock] = []
+    lines = text.splitlines(keepends=False)
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if stripped.rstrip() == "```bash":
+            start = i + 1  # 1-based for human-friendly error messages
+            body_lines: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                ln = lines[j]
+                ln_stripped = ln.lstrip()
+                ln_indent = len(ln) - len(ln_stripped)
+                if ln_stripped == "```" and ln_indent == indent:
+                    break
+                # Strip the opener's indent so the captured body is comparable
+                # against blocks elsewhere that may use different indentation.
+                if ln.startswith(" " * indent):
+                    body_lines.append(ln[indent:])
+                else:
+                    body_lines.append(ln)
+                j += 1
+            blocks.append(_BashBlock(start_line=start, body="\n".join(body_lines)))
+            i = j + 1
+            continue
+        i += 1
+    return blocks
+
+
+def _has_not_mirrored_marker(text: str, block: _BashBlock) -> bool:
+    """Return True if a ``<!-- not mirrored: ... -->`` marker precedes ``block``.
+
+    The marker must appear on the line directly above the opening fence
+    (blank lines between are tolerated so the marker can sit above a
+    heading or short paragraph without being forced inline with the fence).
+    """
+    lines = text.splitlines(keepends=False)
+    fence_idx = block.start_line - 1
+    k = fence_idx - 1
+    while k >= 0 and lines[k].strip() == "":
+        k -= 1
+    if k < 0:
+        return False
+    return _MARKER_RE.search(lines[k]) is not None
+
+
+def _check_canonical_install_presence(workflow_path: Path, contributing_path: Path) -> int:
+    if not workflow_path.is_file():
+        print(f"File not found: {workflow_path}", file=sys.stderr)
         return 2
-    if not contributing.is_file():
-        print(f"File not found: {contributing}", file=sys.stderr)
+    if not contributing_path.is_file():
+        print(f"File not found: {contributing_path}", file=sys.stderr)
         return 2
 
-    workflow_text = workflow.read_text(encoding="utf-8")
-    contributing_text = contributing.read_text(encoding="utf-8")
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    contributing_text = contributing_path.read_text(encoding="utf-8")
 
-    ci_has_it = CANONICAL_INSTALL_CMD in workflow_text
-    docs_have_it = CANONICAL_INSTALL_CMD in contributing_text
-
-    if not ci_has_it:
+    if CANONICAL_INSTALL_CMD not in workflow_text:
         print(
-            f"DRIFT: {workflow} is missing the canonical install command:\n"
+            f"DRIFT: {workflow_path} is missing the canonical install command:\n"
             f"  '{CANONICAL_INSTALL_CMD}'",
             file=sys.stderr,
         )
         return 1
-    if not docs_have_it:
+    if CANONICAL_INSTALL_CMD not in contributing_text:
         print(
-            f"DRIFT: {contributing} is missing the canonical install command:\n"
+            f"DRIFT: {contributing_path} is missing the canonical install command:\n"
             f"  '{CANONICAL_INSTALL_CMD}'",
             file=sys.stderr,
         )
@@ -65,6 +137,83 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"OK: both files use '{CANONICAL_INSTALL_CMD}'")
     return 0
+
+
+def _check_block_mirror_policy(installation_path: Path, contributing_path: Path) -> int:
+    """Every bash block in installation.md must be mirrored or explicitly marked."""
+    if not installation_path.is_file():
+        print(f"File not found: {installation_path}", file=sys.stderr)
+        return 2
+    if not contributing_path.is_file():
+        print(f"File not found: {contributing_path}", file=sys.stderr)
+        return 2
+
+    installation_text = installation_path.read_text(encoding="utf-8")
+    contributing_text = contributing_path.read_text(encoding="utf-8")
+
+    blocks = _extract_bash_blocks(installation_text)
+    if not blocks:
+        print(f"WARN: no fenced ``bash`` blocks found in {installation_path}", file=sys.stderr)
+        return 0
+
+    failures: list[str] = []
+    for block in blocks:
+        if block.body in contributing_text:
+            continue
+        if _has_not_mirrored_marker(installation_text, block):
+            continue
+        first_line = block.body.splitlines()[0] if block.body else "(empty)"
+        failures.append(
+            f"  {installation_path}:{block.start_line} — block not mirrored "
+            f"in {contributing_path.name} and missing "
+            f"'<!-- not mirrored: <reason> -->' marker.\n"
+            f"    first line: {first_line!r}"
+        )
+
+    if failures:
+        print(
+            "BLOCK-MIRROR DRIFT in install docs:\n"
+            + "\n".join(failures)
+            + "\n  Fix: either copy the block verbatim into "
+            + str(contributing_path)
+            + ", or add a '<!-- not mirrored: <reason> -->' line directly above "
+            "the opening fence in " + str(installation_path) + ".",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: all {len(blocks)} bash block(s) in {installation_path.name} "
+        "are mirrored or explicitly marked"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--workflow", default=str(repo_root / ".github/workflows/test.yml"))
+    ap.add_argument("--contributing", default=str(repo_root / "CONTRIBUTING.md"))
+    ap.add_argument("--installation", default=str(repo_root / "docs/installation.md"))
+    ap.add_argument(
+        "--skip-block-mirror",
+        action="store_true",
+        help="Run only the original canonical-install presence check.",
+    )
+    args = ap.parse_args(argv)
+
+    workflow = Path(args.workflow)
+    contributing = Path(args.contributing)
+    installation = Path(args.installation)
+
+    rc = _check_canonical_install_presence(workflow, contributing)
+    if rc != 0:
+        return rc
+
+    if args.skip_block_mirror:
+        return 0
+
+    return _check_block_mirror_policy(installation, contributing)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ci_install_parity.py
+++ b/tests/unit/test_ci_install_parity.py
@@ -31,11 +31,14 @@ def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
 
 
 def test_passes_on_real_repo_state():
-    """Current main has both files in sync."""
+    """Current main has both files in sync — and every installation.md block
+    is mirrored or explicitly marked.
+    """
     result = _run([])
     assert result.returncode == 0, (
         f"stderr: {result.stderr}\nstdout: {result.stdout}\n"
-        "If this fails, either CONTRIBUTING.md or .github/workflows/test.yml has drifted."
+        "If this fails, either CONTRIBUTING.md, .github/workflows/test.yml, "
+        "or docs/installation.md has drifted."
     )
 
 
@@ -46,7 +49,15 @@ def test_detects_workflow_drift(tmp_path):
     contributing = tmp_path / "CONTRIBUTING.md"
     contributing.write_text(f"# Install\n```bash\n{CANONICAL}\n```\n")
 
-    result = _run(["--workflow", str(workflow), "--contributing", str(contributing)])
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--skip-block-mirror",
+        ]
+    )
     assert result.returncode == 1
     assert "test.yml" in result.stderr
     assert "DRIFT" in result.stderr
@@ -59,7 +70,15 @@ def test_detects_contributing_drift(tmp_path):
     contributing = tmp_path / "CONTRIBUTING.md"
     contributing.write_text("# No canonical install here, just prose\n")
 
-    result = _run(["--workflow", str(workflow), "--contributing", str(contributing)])
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--skip-block-mirror",
+        ]
+    )
     assert result.returncode == 1
     assert "CONTRIBUTING.md" in result.stderr
     assert "DRIFT" in result.stderr
@@ -71,7 +90,13 @@ def test_missing_workflow_file(tmp_path):
     contributing.write_text(CANONICAL)
 
     result = _run(
-        ["--workflow", str(tmp_path / "missing.yml"), "--contributing", str(contributing)]
+        [
+            "--workflow",
+            str(tmp_path / "missing.yml"),
+            "--contributing",
+            str(contributing),
+            "--skip-block-mirror",
+        ]
     )
     assert result.returncode == 2
     assert "not found" in result.stderr.lower()
@@ -82,6 +107,178 @@ def test_missing_contributing_file(tmp_path):
     workflow = tmp_path / "test.yml"
     workflow.write_text(f"jobs:\n  x:\n    steps:\n      - run: {CANONICAL}\n")
 
-    result = _run(["--workflow", str(workflow), "--contributing", str(tmp_path / "missing.md")])
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(tmp_path / "missing.md"),
+            "--skip-block-mirror",
+        ]
+    )
     assert result.returncode == 2
     assert "not found" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# T6.D — block-mirror policy
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic_setup(tmp_path: Path, *, install_md: str, contributing_md: str):
+    """Create a synthetic install/contributing pair plus a workflow that already
+    contains the canonical install command (so the original Phase-1 check
+    passes and the test exercises the block-mirror policy in isolation).
+    """
+    workflow = tmp_path / "test.yml"
+    workflow.write_text(f"jobs:\n  x:\n    steps:\n      - run: {CANONICAL}\n")
+    installation = tmp_path / "installation.md"
+    installation.write_text(install_md)
+    contributing = tmp_path / "CONTRIBUTING.md"
+    contributing.write_text(contributing_md)
+    return workflow, installation, contributing
+
+
+def test_block_mirror_unmirrored_block_fails(tmp_path):
+    """An installation.md bash block that's neither mirrored nor marked → exit 1."""
+    install_md = "# Install\n\n```bash\necho hello\n```\n"
+    contributing_md = f"# Contributing\n\n```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 1
+    assert "BLOCK-MIRROR DRIFT" in result.stderr
+    assert "echo hello" in result.stderr
+
+
+def test_block_mirror_marker_passes(tmp_path):
+    """A bash block preceded by ``<!-- not mirrored: ... -->`` passes."""
+    install_md = (
+        "# Install\n\n<!-- not mirrored: end-user pip install -->\n```bash\necho hello\n```\n"
+    )
+    contributing_md = f"# Contributing\n\n```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 0
+    assert "21 bash block" not in result.stdout  # not the real-repo count
+    assert "1 bash block" in result.stdout
+
+
+def test_block_mirror_verbatim_in_contributing_passes(tmp_path):
+    """A bash block whose body appears verbatim in CONTRIBUTING.md passes."""
+    install_md = "# Install\n\n```bash\necho hello\necho world\n```\n"
+    contributing_md = (
+        f"# Contributing\n\n```bash\n{CANONICAL}\n```\n\n"
+        "## Mirrored from installation.md\n\n```bash\necho hello\necho world\n```\n"
+    )
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 0
+
+
+def test_block_mirror_marker_blank_line_above_passes(tmp_path):
+    """The marker is allowed to sit above blank lines before the fence."""
+    install_md = (
+        "# Install\n\n<!-- not mirrored: tolerated blank gap -->\n\n\n```bash\necho hello\n```\n"
+    )
+    contributing_md = f"```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 0
+
+
+def test_block_mirror_indented_block_in_list_recognized(tmp_path):
+    """Bash blocks inside numbered/bulleted lists (4-space indent) parse correctly."""
+    install_md = (
+        "# Install\n\n"
+        "1. Step one:\n"
+        "   <!-- not mirrored: numbered-list step -->\n"
+        "   ```bash\n"
+        "   echo indented\n"
+        "   ```\n"
+    )
+    contributing_md = f"```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+
+def test_skip_block_mirror_flag_bypasses_extension(tmp_path):
+    """``--skip-block-mirror`` runs only the original Phase-1 check."""
+    install_md = "# Install\n\n```bash\necho not-mirrored\n```\n"
+    contributing_md = f"```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+            "--skip-block-mirror",
+        ]
+    )
+    assert result.returncode == 0

--- a/tests/unit/test_ci_install_parity.py
+++ b/tests/unit/test_ci_install_parity.py
@@ -262,6 +262,85 @@ def test_block_mirror_indented_block_in_list_recognized(tmp_path):
     assert result.returncode == 0, f"stderr: {result.stderr}"
 
 
+def test_block_mirror_substring_only_in_prose_fails(tmp_path):
+    """Body must appear inside a fenced bash block in CONTRIBUTING.md, not in prose.
+
+    The previous (looser) substring check would let an installation block
+    pass when its body coincidentally appeared inside an unrelated prose
+    paragraph or a different code fence. This test pins the stricter
+    behavior: only fenced bash bodies count as a mirror.
+    """
+    install_md = "# Install\n\n```bash\necho hello\n```\n"
+    contributing_md = (
+        f"# Contributing\n\n```bash\n{CANONICAL}\n```\n\n"
+        # Same body text, but inside prose (not a fenced bash block) — must NOT count.
+        "Some prose mentioning `echo hello` inline.\n"
+    )
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 1
+    assert "BLOCK-MIRROR DRIFT" in result.stderr
+
+
+def test_block_mirror_no_bash_blocks_warns_and_passes(tmp_path):
+    """When installation.md has no bash blocks at all, WARN to stderr and pass."""
+    install_md = "# Install\n\nJust prose, no fenced bash blocks here.\n"
+    contributing_md = f"```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 0
+    assert "no fenced ``bash`` blocks" in result.stderr
+
+
+def test_block_mirror_trailing_whitespace_on_closing_fence(tmp_path):
+    """A closing fence with trailing whitespace must still terminate the block."""
+    # Note: trailing spaces after the closing ```. Without rstrip tolerance the
+    # parser would slurp the rest of the document into one giant block.
+    install_md = (
+        "# Install\n\n"
+        "<!-- not mirrored: synthetic -->\n"
+        "```bash\necho hello\n```   \n\n"
+        "## Next section (must remain outside the block)\n"
+    )
+    contributing_md = f"```bash\n{CANONICAL}\n```\n"
+    workflow, installation, contributing = _make_synthetic_setup(
+        tmp_path, install_md=install_md, contributing_md=contributing_md
+    )
+    result = _run(
+        [
+            "--workflow",
+            str(workflow),
+            "--contributing",
+            str(contributing),
+            "--installation",
+            str(installation),
+        ]
+    )
+    assert result.returncode == 0
+
+
 def test_skip_block_mirror_flag_bypasses_extension(tmp_path):
     """``--skip-block-mirror`` runs only the original Phase-1 check."""
     install_md = "# Install\n\n```bash\necho not-mirrored\n```\n"

--- a/tests/unit/test_ci_install_parity.py
+++ b/tests/unit/test_ci_install_parity.py
@@ -183,7 +183,6 @@ def test_block_mirror_marker_passes(tmp_path):
         ]
     )
     assert result.returncode == 0
-    assert "21 bash block" not in result.stdout  # not the real-repo count
     assert "1 bash block" in result.stdout
 
 
@@ -235,7 +234,7 @@ def test_block_mirror_marker_blank_line_above_passes(tmp_path):
 
 
 def test_block_mirror_indented_block_in_list_recognized(tmp_path):
-    """Bash blocks inside numbered/bulleted lists (4-space indent) parse correctly."""
+    """Bash blocks inside numbered/bulleted lists (3-space indent) parse correctly."""
     install_md = (
         "# Install\n\n"
         "1. Step one:\n"


### PR DESCRIPTION
## Summary

- Extends \`scripts/check_ci_install_parity.py\` with a block-mirror policy: every fenced \`bash\` block in \`docs/installation.md\` must EITHER appear verbatim in \`CONTRIBUTING.md\` OR be marked with \`<!-- not mirrored: <reason> -->\` on the line above its opening fence. Original canonical-install check is preserved.
- Annotates the 20 currently-unmirrored blocks in \`installation.md\` with markers + one-line reasons. The pre-commit checklist block is genuinely mirrored verbatim — no marker.
- Adds a policy paragraph to \`CONTRIBUTING.md\` so future editors know to expect the gate.

Final PR of Tier 6 (Wave 2). Tier-6 plan: \`.sisyphus/plans/tier-6-implementation.md\`.

## Test plan

- [x] 6 new tests cover the block-mirror modes (unmirrored fail, marker pass, verbatim pass, blank-gap marker, indented-list block, \`--skip-block-mirror\` bypass)
- [x] Existing 5 tests preserved, retargeted with \`--skip-block-mirror\` so they keep their original focus
- [x] \`uv run python scripts/check_ci_install_parity.py\` against the real repo: \"all 21 bash block(s) in installation.md are mirrored or explicitly marked\"
- [x] \`uv run pytest tests/unit -x -q\` — 2774 passed, 7 skipped
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\`
- [ ] CI matrix on Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation guidance, designated documentation as canonical, and added markers to indicate intentionally non-mirrored install snippets.

* **Tests**
  * Added comprehensive tests covering install-snippet mirroring, marker handling, edge cases, and drift detection.

* **Chores**
  * Added an automated parity check to validate install-snippet mirroring with options to target the installation guide or skip the block-mirror policy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/492)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->