### PR TITLE
docs(cli): add codebase-wide exit-code convention (M5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`docs/cli-exit-codes.md`** — Documents the codebase-wide CLI exit-code convention (`0` success, `1` user/app error, `2` system/unexpected, `130` SIGINT) cited from the canonical implementation in `src/notebooklm/cli/error_handler.py`. Calls out the two intentional exceptions (`source stale` is inverted; `source wait` is three-way) and flags upcoming Phase 3 changes for `get`-on-not-found and the `download` exception path (M5 from the cli-ux-remediation plan).
 - **`notebooklm ask --timeout` CLI option** - Per-invocation HTTP request timeout for the `ask` command. Useful when long or complex prompts exceed the library's default 30 s timeout. Accepts a positive integer (seconds); omitting the flag preserves the existing library default, matching the established `source add --timeout` pattern. Supersedes #260.
 - **Source fulltext markdown format** - Retrieve source content as structured Markdown with headings, tables, links, and emphasis preserved (closes #222)
   - New `output_format` parameter on `client.sources.get_fulltext()` (`"text"` default, `"markdown"`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,7 @@ Agents should ignore files marked `Deprecated`.
 docs/
 ├── installation.md        # Canonical install guide (personas, extras, platform notes)
 ├── cli-reference.md       # CLI command reference
+├── cli-exit-codes.md      # CLI exit-code convention (binding contract for scripts/CI)
 ├── python-api.md          # Python API reference
 ├── configuration.md       # Storage and settings
 ├── troubleshooting.md     # Common issues and solutions
@@ -195,3 +196,5 @@ docs/
 ├── rpc-reference.md       # RPC payload structures
 └── examples/              # Runnable example scripts
 ```
+
+> When adding or modifying a CLI command, follow the [CLI Exit-Code Convention](docs/cli-exit-codes.md) — the policy table and the two intentional exceptions (`source stale`, `source wait`) are binding.

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -8,9 +8,11 @@ scripts, CI pipelines, and AI-agent automations should rely on these codes for
 control flow rather than scraping stdout/stderr text — the text is intended for
 humans and may evolve, but the exit-code contract is stable.
 
-For the canonical implementation, see
+For the canonical implementation, see the `handle_errors` context manager in
 [`src/notebooklm/cli/error_handler.py`](../src/notebooklm/cli/error_handler.py)
-(lines 64-67 for the policy table, line 81 for the SIGINT handler).
+— the policy table lives in its docstring and the `KeyboardInterrupt` clause
+sits immediately below (at the time of writing, around lines 64-67 and :81;
+rely on the symbol names rather than the line numbers if they drift).
 
 ## Standard exit codes
 
@@ -47,11 +49,17 @@ mapping in `error_handler.py`:
 | `NotebookLMError` (other) | `NOTEBOOKLM_ERROR` | `1` |
 | `KeyboardInterrupt`     | `CANCELLED`         | `130` |
 | Anything else (`Exception`) | `UNEXPECTED_ERROR` | `2` |
-| `click.ClickException` (e.g. bad CLI args) | — | re-raised; Click exits `2` |
+| `click.UsageError` / `click.BadParameter` (bad CLI args) | — | re-raised; Click exits `2` |
+| Other `click.ClickException` subclasses                  | — | re-raised; Click exits `1` |
 
-`click.ClickException` (raised by `click.UsageError` / `click.BadParameter` and
-the like) is intentionally re-raised so Click can render its own
-`Usage: ...` error and exit with its standard code (`2` for usage errors).
+`click.ClickException` and its subclasses are intentionally re-raised so
+Click can render its own `Usage: ...` / `Error: ...` message. The exit code
+is whatever Click's own `exit_code` class attribute provides — `2` for
+`UsageError` (and `BadParameter`, which subclasses it), `1` for the base
+`ClickException` and other non-usage subclasses. This aligns Click's "bad
+arguments" exit (`2`) with our "system/unexpected" code, and Click's other
+exceptions with our "user/app error" code, so callers can branch on the
+exit code without distinguishing the two sources.
 
 ## JSON output mode (`--json`)
 
@@ -81,9 +89,9 @@ change.** Code referencing them should comment the inverted semantics.
 
 ### `notebooklm source stale <SOURCE_ID>` — inverted
 
-Implemented at
-[`src/notebooklm/cli/source.py`](../src/notebooklm/cli/source.py) lines
-1056-1082.
+Implemented by `source_stale` in
+[`src/notebooklm/cli/source.py`](../src/notebooklm/cli/source.py) (around
+lines 1056-1082 at the time of writing).
 
 | Exit | Meaning |
 |------|---------|
@@ -101,15 +109,26 @@ fi
 A `0` exit reads as "yes, the predicate (stale) holds, run the body" — the
 same convention as `test`, `grep -q`, etc.
 
+> **Important — exit-1 ambiguity.** `source stale` is wrapped by the
+> standard `handle_errors` context, so `AuthError`, `NetworkError`,
+> `ValidationError`, an unresolvable source ID, etc. *also* exit `1` and are
+> indistinguishable from "source is fresh" by exit code alone. The naive
+> `if`-chain above will silently skip the refresh body on an auth/network
+> outage. For unattended scripts, validate the session first
+> (`notebooklm status` or `notebooklm auth check`), wrap with `|| die "..."`
+> on the predicate, or check `source get` succeeds before relying on the
+> staleness verdict.
+
 Note: under `set -e` the `1` exit when the source is fresh will abort the
 script. Use the predicate inside an `if`/`elif`/`||` (as above), which
 shell's errexit explicitly excludes, or `set +e` around the call.
 
 ### `notebooklm source wait <SOURCE_ID>` — three-way
 
-Implemented at
-[`src/notebooklm/cli/source.py`](../src/notebooklm/cli/source.py) lines
-1113-1116.
+Implemented by `source_wait` in
+[`src/notebooklm/cli/source.py`](../src/notebooklm/cli/source.py) (the
+exit-code table is in the command's docstring, around lines 1113-1116 at
+the time of writing).
 
 | Exit | Meaning |
 |------|---------|
@@ -178,10 +197,10 @@ elif result.returncode == 130:
 
 ## Migration notes
 
-The following shifts will land in **Phase 3** of the
-[`cli-ux-remediation`](../.sisyphus/plans/cli-ux-remediation.md) plan and are
-documented here so callers can prepare. The current behavior is described
-above; these notes describe the upcoming change.
+The following shifts will land in **Phase 3** of the internal
+`cli-ux-remediation` plan and are documented here so callers can prepare.
+The current behavior is described above; these notes describe the upcoming
+change.
 
 ### C1 — `get`-on-not-found will exit `1` (currently `0`)
 

--- a/docs/cli-exit-codes.md
+++ b/docs/cli-exit-codes.md
@@ -1,0 +1,223 @@
+# CLI Exit-Code Convention
+
+**Status:** Active
+**Last Updated:** 2026-05-14
+
+This document defines the exit-code policy for the `notebooklm` CLI. Shell
+scripts, CI pipelines, and AI-agent automations should rely on these codes for
+control flow rather than scraping stdout/stderr text — the text is intended for
+humans and may evolve, but the exit-code contract is stable.
+
+For the canonical implementation, see
+[`src/notebooklm/cli/error_handler.py`](../src/notebooklm/cli/error_handler.py)
+(lines 64-67 for the policy table, line 81 for the SIGINT handler).
+
+## Standard exit codes
+
+| Code | Meaning | When you'll see it |
+|------|---------|-------------------|
+| `0`  | Success | The command completed and produced its intended effect. |
+| `1`  | User / application error | Validation, authentication, rate limiting, network failure, configuration error, or any `NotebookLMError` raised by the library. |
+| `2`  | System / unexpected error | Unhandled exception (likely a bug). The CLI suggests reporting at the issue tracker. Also used for the `source wait` timeout (see exceptions below). |
+| `130`| Cancelled by user | The process received `SIGINT` (Ctrl-C). `130 = 128 + signal 2`, the conventional shell value for SIGINT-terminated processes. |
+
+The policy comment in `error_handler.py:64-67` is the source of truth:
+
+```text
+Exit codes:
+    1: User/application error (validation, auth, rate limit, etc.)
+    2: System/unexpected error (bugs, unhandled exceptions)
+    130: Keyboard interrupt (128 + signal 2)
+```
+
+## Exception → exit-code mapping
+
+The `handle_errors` context manager wrapping every CLI command translates
+library exceptions into exit codes. The table below summarises the live
+mapping in `error_handler.py`:
+
+| Library exception | JSON `code` | Exit |
+|---|---|---|
+| `RateLimitError`        | `RATE_LIMITED`      | `1` |
+| `AuthError`             | `AUTH_ERROR`        | `1` |
+| `ValidationError`       | `VALIDATION_ERROR`  | `1` |
+| `ConfigurationError`    | `CONFIG_ERROR`      | `1` |
+| `NetworkError`          | `NETWORK_ERROR`     | `1` |
+| `NotebookLimitError`    | `NOTEBOOK_LIMIT`    | `1` |
+| `NotebookLMError` (other) | `NOTEBOOKLM_ERROR` | `1` |
+| `KeyboardInterrupt`     | `CANCELLED`         | `130` |
+| Anything else (`Exception`) | `UNEXPECTED_ERROR` | `2` |
+| `click.ClickException` (e.g. bad CLI args) | — | re-raised; Click exits `2` |
+
+`click.ClickException` (raised by `click.UsageError` / `click.BadParameter` and
+the like) is intentionally re-raised so Click can render its own
+`Usage: ...` error and exit with its standard code (`2` for usage errors).
+
+## JSON output mode (`--json`)
+
+When a command supports `--json` (or `--json-output`) and the flag is set,
+errors are emitted as a JSON document on stdout *and* the exit code still
+applies. The shape is:
+
+```json
+{
+  "error": true,
+  "code": "RATE_LIMITED",
+  "message": "Error: Rate limited. Retry after 30s.",
+  "retry_after": 30
+}
+```
+
+The `code` field is the stable identifier (see table above); `message` is the
+human string and may change. Some errors include extra fields
+(`retry_after`, `method_id` when `-v/--verbose` is set, etc.). Automation
+should branch on `code` (or, more simply, on the exit code).
+
+## Intentional exceptions to the standard convention
+
+Two commands deliberately invert or extend the standard codes because their
+primary use case is shell control flow. **These are by design and will not
+change.** Code referencing them should comment the inverted semantics.
+
+### `notebooklm source stale <SOURCE_ID>` — inverted
+
+Implemented at
+[`src/notebooklm/cli/source.py`](../src/notebooklm/cli/source.py) lines
+1056-1082.
+
+| Exit | Meaning |
+|------|---------|
+| `0`  | Source is **stale** (needs `source refresh`) |
+| `1`  | Source is **fresh** (no action required) |
+
+The inversion lets you write the natural shell idiom:
+
+```sh
+if notebooklm source stale "$SRC_ID"; then
+    notebooklm source refresh "$SRC_ID"
+fi
+```
+
+A `0` exit reads as "yes, the predicate (stale) holds, run the body" — the
+same convention as `test`, `grep -q`, etc.
+
+Note: under `set -e` the `1` exit when the source is fresh will abort the
+script. Use the predicate inside an `if`/`elif`/`||` (as above), which
+shell's errexit explicitly excludes, or `set +e` around the call.
+
+### `notebooklm source wait <SOURCE_ID>` — three-way
+
+Implemented at
+[`src/notebooklm/cli/source.py`](../src/notebooklm/cli/source.py) lines
+1113-1116.
+
+| Exit | Meaning |
+|------|---------|
+| `0`  | Source is ready |
+| `1`  | Source not found or processing failed |
+| `2`  | Timeout reached before the source became ready |
+
+This is the only command whose `2` exit does **not** indicate a bug — it is
+a recoverable condition the caller may want to retry with a longer
+`--timeout`. Scripts that distinguish "transient" from "fatal" should branch
+on the specific code rather than the truthy/falsy value:
+
+```sh
+notebooklm source wait "$SRC_ID" --timeout 300
+case $? in
+  0)  echo "ready" ;;
+  1)  echo "failed"; exit 1 ;;
+  2)  echo "timed out, retry later"; exit 75 ;;  # EX_TEMPFAIL
+  *)  echo "unexpected"; exit 1 ;;
+esac
+```
+
+## Recipes for callers
+
+### Shell
+
+```sh
+# Standard — non-zero is failure
+if ! notebooklm ask "$NOTEBOOK_ID" "Summarize"; then
+    echo "ask failed (exit $?)" >&2
+    exit 1
+fi
+
+# Distinguish bug from user error
+notebooklm <cmd> --json > out.json
+case $? in
+  0)   ;;                                 # success
+  1)   jq -r .code out.json ;;            # user/app error — branch on code
+  2)   echo "internal CLI error" >&2 ;;   # bug; report it
+  130) echo "cancelled by user" >&2 ;;    # ^C
+esac
+```
+
+### Python `subprocess`
+
+```python
+import json
+import subprocess
+import time
+
+result = subprocess.run(
+    ["notebooklm", "ask", nb_id, prompt, "--json"],
+    capture_output=True, text=True,
+)
+if result.returncode == 0:
+    payload = json.loads(result.stdout)
+elif result.returncode == 1:
+    err = json.loads(result.stdout)  # JSON error document
+    if err["code"] == "RATE_LIMITED":
+        time.sleep(err.get("retry_after", 30))
+elif result.returncode == 2:
+    raise RuntimeError(f"CLI bug: {result.stdout}")
+elif result.returncode == 130:
+    raise KeyboardInterrupt
+```
+
+## Migration notes
+
+The following shifts will land in **Phase 3** of the
+[`cli-ux-remediation`](../.sisyphus/plans/cli-ux-remediation.md) plan and are
+documented here so callers can prepare. The current behavior is described
+above; these notes describe the upcoming change.
+
+### C1 — `get`-on-not-found will exit `1` (currently `0`)
+
+`notebooklm source get`, `notebooklm artifact get`, and `notebooklm note get`
+currently print a "not found" message to stdout and exit `0` when the
+requested ID is missing. Phase 3 will change all three to exit `1` so the
+"not found" condition matches the rest of the CLI's user-error convention
+and so scripts can branch on the exit code without parsing output text.
+
+If your script relies on the current `0`-on-not-found behavior, switch to
+inspecting the command output (or, after Phase 3 lands, branch on the exit
+code: `notebooklm source get "$SRC_ID" || handle_missing`).
+
+### I14 — `download` exception paths will route through the typed handler
+
+The `download` command group currently catches some exceptions in
+command-local `try/except` blocks that bypass the central `handle_errors`
+context. Concretely, generic `Exception` bubbles do not always honor `--json`
+(emitting plain stderr text instead of the JSON error document) and the exit
+code may not match the standard exception → exit-code mapping.
+
+Phase 3 will route all `download` exception paths through `handle_errors` so
+that:
+
+- `--json` consistently produces the JSON error document on every failure.
+- Exit codes match the standard table above (`1` for known library errors,
+  `2` for unexpected, `130` for `^C`).
+
+Callers already relying on `--json` should see no behavior change for
+*successful* downloads or for already-typed errors; only the previously
+plain-text exception paths will start emitting JSON.
+
+## See also
+
+- [CLI Reference](cli-reference.md) — command-by-command documentation
+- [Configuration](configuration.md) — `--json` and global options
+- [Troubleshooting](troubleshooting.md) — interpreting common errors
+- [`src/notebooklm/cli/error_handler.py`](../src/notebooklm/cli/error_handler.py)
+  — canonical implementation

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,6 +5,8 @@
 
 Complete command reference for the `notebooklm` CLI—providing full programmatic access to all NotebookLM features, including capabilities not exposed in the web UI.
 
+> **Exit codes:** every command follows the convention documented in [CLI Exit-Code Convention](cli-exit-codes.md) (`0` success, `1` user/app error, `2` system/unexpected, `130` SIGINT). Two commands intentionally invert this for shell-pipeline use; see the doc for details.
+
 ## Command Structure
 
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,7 +5,7 @@
 
 Complete command reference for the `notebooklm` CLI—providing full programmatic access to all NotebookLM features, including capabilities not exposed in the web UI.
 
-> **Exit codes:** every command follows the convention documented in [CLI Exit-Code Convention](cli-exit-codes.md) (`0` success, `1` user/app error, `2` system/unexpected, `130` SIGINT). Two commands intentionally invert this for shell-pipeline use; see the doc for details.
+> **Exit codes:** every command follows the convention documented in [CLI Exit-Code Convention](cli-exit-codes.md) (`0` success, `1` user/app error, `2` system/unexpected, `130` SIGINT). Two commands intentionally deviate for shell control-flow use (`source stale` is inverted; `source wait` is three-way); see the doc for details.
 
 ## Command Structure
 


### PR DESCRIPTION
## Summary
- Adds `docs/cli-exit-codes.md` as the canonical reference for the CLI's exit-code policy (`0` / `1` / `2` / `130`), cited directly from `src/notebooklm/cli/error_handler.py` lines 64-67 and :81.
- Documents the **two intentional exceptions** to the standard convention: `source stale` (inverted: stale=0, fresh=1; designed for shell `if`-chains) at `src/notebooklm/cli/source.py:1056-1082`, and `source wait` (three-way: ready=0, failed=1, timeout=2) at `src/notebooklm/cli/source.py:1113-1116`.
- Migration notes flag the upcoming **Phase 3** changes so callers can prepare: **C1** (`source/artifact/note get` will exit `1` on not-found, currently `0`) and **I14** (`download` exception paths will route through `handle_errors` so `--json` is honored and exit codes match the standard mapping).
- Cross-links added: one-line callout near the top of `docs/cli-reference.md` and one line in `CONTRIBUTING.md`'s Documentation Structure section.
- CHANGELOG entry under `[Unreleased] → Added`.

## Scope
**Documentation only.** No code is modified. The inverted semantics of `source stale` / `source wait` are documented as INTENTIONAL — they will not be changed.

## Plan reference
- Parent plan: `.sisyphus/plans/cli-ux-remediation.md` (audit row **M5**)
- Phase plan: `.sisyphus/plans/cli-ux-remediation/phase-1.md` → Task **P1.T1**
- Runs in parallel with **P1.T2** (decorator consolidation); file sets are disjoint.

## Test plan
- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` passes
- [x] `uv run pytest` — 3388 passed, 11 skipped
- [x] `docs/cli-exit-codes.md` is 223 lines (≥80 acceptance threshold)
- [x] Both cross-links resolve (relative paths inside `docs/` and from `CONTRIBUTING.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation defining the CLI exit-code convention (standard codes, JSON error output behavior, caller recipes for shell/Python) and notes on two intentional semantic exceptions for specific subcommands.
  * Updated the CLI reference to clarify exit-code behavior across commands.
  * Updated contributor guidelines to require following the CLI exit-code convention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/493)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->