### PR TITLE
fix(audit): p2-t2-artifact-json review fallout (#496)

### DIFF
--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -153,9 +153,12 @@ def artifact_get(ctx, artifact_id, notebook_id, json_output, client_auth):
 
             if json_output:
                 if art is None:
-                    json_output_response({"id": resolved_id, "found": False})
+                    json_output_response(
+                        {"notebook_id": nb_id_resolved, "id": resolved_id, "found": False}
+                    )
                     return
                 data = {
+                    "notebook_id": nb_id_resolved,
                     "id": art.id,
                     "title": art.title,
                     "type": get_artifact_type_display(art).split(" ", 1)[-1],
@@ -241,9 +244,12 @@ def artifact_delete(ctx, artifact_id, notebook_id, yes, json_output, client_auth
                 client, nb_id_resolved, artifact_id, json_output=json_output
             )
 
-            if not yes and not click.confirm(f"Delete artifact {resolved_id}?"):
-                if json_output:
-                    json_output_response({"id": resolved_id, "deleted": False, "cancelled": True})
+            # ``--json`` implies ``--yes`` so a script that pipes ``--json`` but
+            # forgets ``-y`` does not hang on ``click.confirm``'s stdin read
+            # (which would also clobber JSON stdout purity). Interactive users
+            # who want a confirm prompt should omit ``--json``; scripts that
+            # explicitly want the confirm round-trip can omit ``--json``.
+            if not yes and not json_output and not click.confirm(f"Delete artifact {resolved_id}?"):
                 return
 
             # Check if this is a mind map (stored with notes)
@@ -343,15 +349,18 @@ def artifact_poll(ctx, task_id, notebook_id, json_output, client_auth):
 
             if json_output:
                 # Mirror the GenerationStatus dataclass fields so automation can
-                # introspect status / url / error without parsing prose.
+                # introspect status / url / error without parsing prose. Direct
+                # attribute access (rather than getattr) matches how
+                # ``artifact wait`` consumes the same dataclass and surfaces
+                # type drift instead of swallowing it.
                 json_output_response(
                     {
-                        "task_id": getattr(status, "task_id", task_id),
-                        "status": getattr(status, "status", None),
-                        "url": getattr(status, "url", None),
-                        "error": getattr(status, "error", None),
-                        "error_code": getattr(status, "error_code", None),
-                        "metadata": getattr(status, "metadata", None),
+                        "task_id": status.task_id,
+                        "status": status.status,
+                        "url": status.url,
+                        "error": status.error,
+                        "error_code": status.error_code,
+                        "metadata": status.metadata,
                     }
                 )
                 return

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -191,10 +191,42 @@ class TestArtifactGet:
             assert data["id"] == "art_123"
             assert data["title"] == "Test Artifact"
             assert data["found"] is True
+            # notebook_id mirrors the wrapper used by `artifact list --json`,
+            # so cached responses share one schema across the two commands.
+            assert data["notebook_id"] == "nb_123"
             # type / status / created_at keys must be present for automation
             assert "type" in data
             assert "status" in data
             assert "created_at" in data
+
+    def test_artifact_get_json_not_found(self, runner, mock_auth):
+        """`artifact get --json` emits ``{found: False}`` when the artifact is gone.
+
+        ``client.artifacts.get`` may return ``None`` after a successful partial-ID
+        resolve when the server reports the artifact has been deleted between
+        the list call and the get call.
+        """
+        with patch_client_for_module("artifact") as mock_client_cls:
+            mock_client = create_mock_client()
+            # Resolve succeeds (list contains the ID) but get() returns None
+            # (e.g., concurrent delete from another session).
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[Artifact(id="art_123", title="Doomed", _artifact_type=4, status=3)]
+            )
+            mock_client.artifacts.get = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["artifact", "get", "art_123", "-n", "nb_123", "--json"]
+                )
+
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert data == {"notebook_id": "nb_123", "id": "art_123", "found": False}
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Follow-up to #496 (P2.T2). The original PR was merged before the bot-review fix commit landed; this PR carries the fixes forward.

Three findings folded into one commit (cherry-picked from the original branch):

1. **artifact delete --json no longer hangs / breaks JSON purity** (Claude medium / CodeRabbit major). `click.confirm()` would block on stdin even when `--json` was set, and the prompt itself wrote to stdout — clobbering JSON parseability. Fix: `--json` implies `--yes`, so the prompt is silently skipped. Interactive users who want a confirm omit `--json`. The dead JSON-cancellation payload is removed since the cancel branch is now unreachable in JSON mode.
2. **artifact poll --json uses direct attribute access** (Claude low). `getattr(status, "task_id", task_id)` etc. is replaced with direct `status.task_id` access on the typed `GenerationStatus` dataclass, matching how `artifact wait` consumes the same object.
3. **artifact get --json includes notebook_id** (Claude minor). Mirrors the wrapper used by `artifact list --json` so cached responses share one schema across the two commands. Both the normal and the not-found payload carry it.

Plus one test addition:
- `test_artifact_get_json_not_found` exercises the `art is None` JSON path that #496 introduced but didn't test (Claude nit).

## Push-backs (logged here for the record)
- **Claude low — `exported: false` + exit 0**: pre-existing non-JSON behavior; in scope for I14 (Phase 3), not P2.T2.
- **CodeRabbit nit — JSON-cancel regression test for `delete`**: fix #1 makes the cancel branch unreachable when `--json` is set, so there is nothing left to regress against in the targeted code path.

## Phase / plan
- Audit follow-up to Phase 2 / P2.T2 from `.sisyphus/plans/cli-ux-remediation/phase-2.md` (audit row I3).
- Strict file isolation: only `src/notebooklm/cli/artifact.py` and `tests/unit/cli/test_artifact.py`.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest --cov=src/notebooklm --cov-fail-under=90` — 3469 passed, coverage 92.61%, `cli/artifact.py` at 93%.
- [x] 32 tests in `tests/unit/cli/test_artifact.py`, including the new `test_artifact_get_json_not_found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `artifact get --json` response now includes `notebook_id` field.

* **Bug Fixes**
  * `artifact get --json` properly indicates when an artifact is not found.
  * `artifact delete --json` suppresses interactive prompts for automated workflows.
  * `artifact poll --json` provides more consistent status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/501)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->