### PR TITLE
test(concurrent): integration harness for asyncio fan-out (T7.A1)

### DIFF
--- a/tests/integration/concurrency/README.md
+++ b/tests/integration/concurrency/README.md
@@ -1,0 +1,170 @@
+# Tier 7 Concurrency Integration Test Harness
+
+Reusable fixtures and a smoke test for the **Tier 7 thread-safety /
+concurrency remediation arc**. Every Phase 2 fix PR consumes the
+fixtures here to TDD red-green against a specific Tier 7 bug.
+
+This directory is **infrastructure**, not regression tests. Per-bug
+tests live in their own modules (also under `tests/integration/`) that
+import the fixtures from `conftest.py`.
+
+## Fixture API
+
+### `mock_transport_concurrent` → `ConcurrentMockTransport`
+
+A class-based `httpx.AsyncBaseTransport` that records peak concurrent
+in-flight requests and supports controllable per-request response
+timing.
+
+```python
+async def test_my_fix(mock_transport_concurrent):
+    transport = mock_transport_concurrent
+
+    # Configure
+    transport.set_delay(0.05)                 # 50ms artificial delay
+    transport.queue_response((200, "..."))    # FIFO queue of responses
+    # (or pass an httpx.Response, or a callable (req) -> Response)
+
+    # ... drive the SUT ...
+
+    # Observe
+    assert transport.get_peak_inflight() >= 80
+    assert transport.request_count() == 100
+    assert transport.get_inflight_count() == 0
+    requests = transport.captured_requests()  # list[httpx.Request]
+```
+
+**Method surface**:
+
+| Method | Purpose |
+|---|---|
+| `queue_response(item)` | Append to FIFO queue. `item` may be `httpx.Response`, `(status, text)` tuple, or `Callable[[Request], Response]`. |
+| `set_delay(seconds)` | Artificial per-request `asyncio.sleep` delay. Default `0.05`s. `0` disables delay (defeats fan-out). |
+| `get_inflight_count()` | Current concurrent requests. |
+| `get_peak_inflight()` | High-water mark since construction (or last `reset()`). |
+| `request_count()` | Total requests served. |
+| `captured_requests()` | Snapshot of every `httpx.Request` observed. |
+| `reset()` | Clear counters and queue. |
+
+**Default response**: empty `LIST_NOTEBOOKS` payload (decodes to `[]`).
+Tests that need a different shape should `queue_response(...)` enough
+items for their fan-out width.
+
+### `barrier_factory` → `Callable[[int], EventBarrier]`
+
+Returns a factory that builds N-arrival one-shot barriers (built on
+`asyncio.Event`, NOT `asyncio.Barrier`, so behavior is identical on
+Python 3.10).
+
+```python
+async def test_two_coroutines_meet(barrier_factory):
+    barrier = barrier_factory(2)
+
+    async def worker():
+        # ... do setup ...
+        await barrier.arrive()    # blocks until 2nd arrival
+        # ... critical section both coroutines hit simultaneously ...
+
+    await asyncio.gather(worker(), worker())
+    assert barrier.is_set
+```
+
+Re-arming is intentionally NOT supported. Build a fresh barrier per
+synchronization point — this matches the existing
+`tests/unit/test_concurrency_refresh_race.py` pattern of one
+`asyncio.Event` per checkpoint.
+
+### `cancellation_helper` → `(coro, *, timeout, label) -> result`
+
+Wraps a coroutine in `asyncio.wait_for` and emits a structured error
+log on timeout/cancellation.
+
+```python
+async def test_no_deadlock(cancellation_helper):
+    result = await cancellation_helper(
+        suspect_coroutine(),
+        timeout=2.0,
+        label="suspect-coro",
+    )
+```
+
+The diagnostic surfaces *which* coroutine deadlocked when several are
+in flight — cheaper to debug than `pytest --timeout` killing the whole
+process.
+
+## Non-goals (read before adding to this directory)
+
+- **NOT a load tester.** `get_peak_inflight()` assertions are coarse
+  (`>= 80` of `100`) because asyncio scheduling is not perfectly
+  parallel. Use a real load tool (k6, locust) for performance work.
+- **NOT a property-based generator.** Hypothesis is intentionally NOT
+  added as a dependency. Per-bug tests use specific seeded scenarios.
+- **NOT a thread-pool stress harness.** Pure asyncio. If a future bug
+  involves real threads, add a separate `tests/integration/threaded/`
+  package.
+- **NOT a place for per-bug regression tests.** Those go in dedicated
+  PR-aligned modules in `tests/integration/`. This directory is fixture
+  infrastructure only.
+
+## pytest-xdist + asyncio caveat
+
+Each `pytest-xdist` worker has its own event loop. Fixture state is
+**never** shared across workers, which means:
+
+- `ConcurrentMockTransport` peak-inflight is per-worker; tests that
+  need to observe global concurrency must run single-threaded.
+- The `_reset_poke_state` autouse fixture in the parent
+  `tests/conftest.py` resets module-level rotation guards per-loop, so
+  each xdist worker starts clean — no cross-worker leakage.
+- Tests asserting on process-global state (e.g. an `_LRU_CACHE`) should
+  mark themselves with `@pytest.mark.xdist_group("name")` to keep all
+  cases on the same worker.
+
+Default `uv run pytest` runs single-process (no `-n`), so the caveat
+only applies to contributors who pass `-n auto` locally or in CI.
+
+## How to add a new fixture
+
+1. Add the fixture function to `conftest.py` next to the existing three.
+2. Document the API surface in this README under "Fixture API".
+3. If the fixture needs new dependencies, **STOP** — Tier 7 ground
+   rules forbid adding new deps in any harness PR. Open an RFC issue
+   first.
+4. Add a sanity check to `test_harness_smoke.py` so the fixture is
+   exercised by `uv run pytest tests/integration/concurrency`.
+
+## How to add a per-bug test (not here)
+
+Per-bug tests live in `tests/integration/<bug-slug>/` (or a flat
+`tests/integration/test_<bug-slug>.py`), NOT in this package. They
+should:
+
+- Import fixtures from `tests.integration.concurrency.conftest` (the
+  fixtures are auto-discovered by pytest if the per-bug test lives
+  *underneath* this package, but explicit imports work for tests at
+  any path).
+- Be one PR per bug.
+- Include a docstring linking the audit item (e.g.
+  `audit/thread-safety-concurrency-audit.md#NN`).
+
+## Running the harness
+
+```bash
+uv run pytest tests/integration/concurrency -v
+```
+
+Expected wall time: < 2s locally, < 5s in CI.
+
+## Why `concurrency/` and not `concurrent/`?
+
+The natural directory name `concurrent/` collides with Python's stdlib
+`concurrent` package. Pytest puts each test root on `sys.path` for
+collection, so a `tests/integration/concurrent/` directory would shadow
+`concurrent.futures` for any test that imports it (and ours and the
+project's deps do). Renaming to `concurrency/` sidesteps the collision
+without changing the semantic intent.
+
+## Plan reference
+
+- Plan: [`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-1.md#T7.A1`](../../../.sisyphus/plans/tier-7-thread-safety-concurrency/phase-1.md#T7.A1)
+- Parent arc: Tier 7 thread-safety / concurrency remediation

--- a/tests/integration/concurrency/README.md
+++ b/tests/integration/concurrency/README.md
@@ -139,10 +139,12 @@ Per-bug tests live in `tests/integration/<bug-slug>/` (or a flat
 `tests/integration/test_<bug-slug>.py`), NOT in this package. They
 should:
 
-- Import fixtures from `tests.integration.concurrency.conftest` (the
-  fixtures are auto-discovered by pytest if the per-bug test lives
-  *underneath* this package, but explicit imports work for tests at
-  any path).
+- Use the fixtures by parameter name — pytest auto-discovers them via
+  this package's `conftest.py` for any test that lives *underneath*
+  `tests/integration/concurrency/`. (pytest fixtures are not imported,
+  they are injected by name.) If you need the *class* types for type
+  annotations or for constructing transports manually, import them:
+  `from tests.integration.concurrency.conftest import ConcurrentMockTransport, EventBarrier`.
 - Be one PR per bug.
 - Include a docstring linking the audit item (e.g.
   `audit/thread-safety-concurrency-audit.md#NN`).
@@ -164,7 +166,9 @@ collection, so a `tests/integration/concurrent/` directory would shadow
 project's deps do). Renaming to `concurrency/` sidesteps the collision
 without changing the semantic intent.
 
-## Plan reference
+## Parent arc
 
-- Plan: [`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-1.md#T7.A1`](../../../.sisyphus/plans/tier-7-thread-safety-concurrency/phase-1.md#T7.A1)
-- Parent arc: Tier 7 thread-safety / concurrency remediation
+- Tier 7 thread-safety / concurrency remediation. Per-task plans are
+  tracked locally (the `.sisyphus/` tree is gitignored); each Phase 2
+  fix PR will reference its source audit item directly in its
+  description and commit message.

--- a/tests/integration/concurrency/__init__.py
+++ b/tests/integration/concurrency/__init__.py
@@ -1,0 +1,10 @@
+"""Tier 7 thread-safety / concurrency integration test harness.
+
+This package houses the reusable test infrastructure that every Phase 2
+fix PR in the Tier 7 remediation arc consumes. It is intentionally
+*infrastructure-only*: no production-code coverage, no per-bug regression
+tests. Those live in dedicated per-fix PRs that ``import`` from this
+package's ``conftest.py`` fixtures.
+
+See ``README.md`` for fixture API and explicit non-goals.
+"""

--- a/tests/integration/concurrency/conftest.py
+++ b/tests/integration/concurrency/conftest.py
@@ -44,6 +44,7 @@ import asyncio
 import json
 import logging
 import traceback
+from collections import deque
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
@@ -92,6 +93,11 @@ class _InflightTracker:
             self.peak = self.current
 
     def exit(self) -> None:
+        # Hard assert: a double-`finally` or transport-reuse bug would
+        # silently drive `current` negative and quietly invalidate every
+        # peak assertion downstream. As a test helper we want loud
+        # failure, not silent corruption.
+        assert self.current > 0, "exit() called more times than enter()"
         self.current -= 1
 
 
@@ -144,7 +150,10 @@ class ConcurrentMockTransport(httpx.AsyncBaseTransport):
 
     def __init__(self, *, default_delay: float = 0.05) -> None:
         self._tracker = _InflightTracker()
-        self._queue: list[ConcurrentMockTransport._QueuedResponse] = []
+        # ``deque`` for O(1) FIFO popleft. ``list.pop(0)`` shifts the whole
+        # backing array each dequeue; immaterial at ~100 items but the wrong
+        # data structure for a queue.
+        self._queue: deque[ConcurrentMockTransport._QueuedResponse] = deque()
         self._delay: float = default_delay
         self._captured: list[httpx.Request] = []
         self._request_count: int = 0
@@ -215,7 +224,7 @@ class ConcurrentMockTransport(httpx.AsyncBaseTransport):
     def _next_response(self, request: httpx.Request) -> httpx.Response:
         if not self._queue:
             return httpx.Response(200, text=_default_rpc_response_text())
-        item = self._queue.pop(0)
+        item = self._queue.popleft()
         if isinstance(item, httpx.Response):
             return item
         if isinstance(item, tuple):

--- a/tests/integration/concurrency/conftest.py
+++ b/tests/integration/concurrency/conftest.py
@@ -1,0 +1,347 @@
+"""Fixtures for the Tier 7 concurrency integration harness.
+
+Three fixtures, all explicitly named and class-based — no clever hooks,
+no monkeypatching. Phase 2 fix PRs consume these to TDD red-green
+against specific Tier 7 bugs (refresh races, semaphore gating,
+cancellation propagation, etc.).
+
+Fixtures
+--------
+``mock_transport_concurrent``
+    A class-based ``httpx.AsyncBaseTransport`` that records peak in-flight
+    concurrency and supports per-request controllable response timing.
+    See ``ConcurrentMockTransport`` for the full method surface.
+
+``barrier_factory``
+    Returns a callable ``make_barrier(n)`` that produces a
+    ``EventBarrier`` for deterministic interleaving of N coroutines.
+    Each barrier is a one-shot synchronization point: every arriver
+    awaits ``arrive()``; once N have arrived, all are released.
+    Built on ``asyncio.Event`` (not ``asyncio.Barrier``) so behavior is
+    identical on Python 3.10 (the project's minimum supported version).
+
+``cancellation_helper``
+    Wraps a coroutine in ``asyncio.wait_for`` and emits a structured
+    diagnostic on cancellation: which coroutine label, what timeout,
+    and the captured traceback. Used by per-fix tests that need to
+    distinguish "the bug under test deadlocked" from "the test timed
+    out for an unrelated reason."
+
+Non-goals
+---------
+- NOT a load tester. Peak-inflight assertions are coarse (>= 80 of 100)
+  because asyncio task scheduling is not perfectly parallel.
+- NOT a property-based generator (no Hypothesis dep added).
+- NOT a thread-pool stress harness (no real threads — pure asyncio).
+- pytest-xdist + asyncio: each xdist worker has its own event loop, so
+  fixture state is never shared across workers. Tests that assert on
+  process-global state must mark themselves ``@pytest.mark.xdist_group``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import traceback
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, TypeVar
+
+import httpx
+import pytest
+
+from notebooklm.rpc import RPCMethod
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Default response payload
+# ---------------------------------------------------------------------------
+# A minimal valid batchexecute response that decodes to ``[]`` for
+# ``LIST_NOTEBOOKS``. Reused by ``ConcurrentMockTransport`` whenever the
+# response queue is empty so tests don't have to enqueue 100 identical
+# responses for a 100-way fan-out.
+_DEFAULT_RPC_ID = RPCMethod.LIST_NOTEBOOKS.value
+
+
+def _default_rpc_response_text(rpc_id: str = _DEFAULT_RPC_ID) -> str:
+    """Build a minimal valid batchexecute response that decodes to ``[]``."""
+    inner = json.dumps([])
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+# ---------------------------------------------------------------------------
+# ConcurrentMockTransport
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InflightTracker:
+    """Plain counter pair. Single-threaded asyncio — no lock needed."""
+
+    current: int = 0
+    peak: int = 0
+
+    def enter(self) -> None:
+        self.current += 1
+        if self.current > self.peak:
+            self.peak = self.current
+
+    def exit(self) -> None:
+        self.current -= 1
+
+
+class ConcurrentMockTransport(httpx.AsyncBaseTransport):
+    """Mock transport that records concurrent in-flight requests.
+
+    Designed for asyncio fan-out tests: every ``handle_async_request``
+    increments an in-flight counter, awaits a configurable delay (so
+    sibling tasks can pile up at the same await point), then decrements
+    and returns a queued (or default) response.
+
+    Methods
+    -------
+    queue_response(response_or_factory)
+        Append a response to the FIFO queue. May be:
+          - ``httpx.Response`` instance.
+          - Tuple ``(status_code, text)`` for convenience.
+          - Callable ``(httpx.Request) -> httpx.Response`` for per-request
+            shaping (e.g. echoing the URL, returning an error for one URL).
+        When the queue is empty, ``_default_rpc_response_text`` is used.
+    set_delay(seconds)
+        Set the per-request artificial delay (default ``0.05``s — long
+        enough that a 100-way ``asyncio.gather`` reliably stacks all 100
+        callers at the await point before any returns).
+    get_inflight_count()
+        Current in-flight request count.
+    get_peak_inflight()
+        High-water mark observed since construction (or last ``reset()``).
+    request_count()
+        Total requests served so far.
+    captured_requests()
+        Snapshot of every request observed (for assertions on URL,
+        headers, body — useful in per-fix PRs).
+    reset()
+        Clear counters, queued responses, and captured request history.
+        The configured ``_delay`` is preserved (a session-scoped consumer
+        wants its delay choice to survive reset). Call ``set_delay(...)``
+        explicitly if you need to reset the timing too.
+
+    Thread-safety note
+    ------------------
+    All state mutation happens on the asyncio event loop's single thread.
+    No locks are needed. If a future test wires this into a real
+    threadpool, add an ``asyncio.Lock`` around the counter mutations.
+    """
+
+    # Type alias kept inline so readers don't have to scroll for it.
+    _ResponseFactory = Callable[[httpx.Request], httpx.Response]
+    _QueuedResponse = httpx.Response | tuple[int, str] | _ResponseFactory
+
+    def __init__(self, *, default_delay: float = 0.05) -> None:
+        self._tracker = _InflightTracker()
+        self._queue: list[ConcurrentMockTransport._QueuedResponse] = []
+        self._delay: float = default_delay
+        self._captured: list[httpx.Request] = []
+        self._request_count: int = 0
+
+    # -- configuration -------------------------------------------------
+
+    def queue_response(self, response_or_factory: _QueuedResponse) -> None:
+        """Append a response to the FIFO queue.
+
+        Acceptable shapes documented on the class docstring.
+        """
+        self._queue.append(response_or_factory)
+
+    def set_delay(self, seconds: float) -> None:
+        """Set the artificial per-request delay.
+
+        ``0`` is allowed but defeats the purpose of fan-out tests:
+        without a delay, requests complete before the next coroutine
+        even enters the transport. Use a small positive value (50ms is
+        the default) for fan-out work.
+        """
+        if seconds < 0:
+            raise ValueError(f"delay must be >= 0, got {seconds}")
+        self._delay = seconds
+
+    # -- observation ---------------------------------------------------
+
+    def get_inflight_count(self) -> int:
+        return self._tracker.current
+
+    def get_peak_inflight(self) -> int:
+        return self._tracker.peak
+
+    def request_count(self) -> int:
+        return self._request_count
+
+    def captured_requests(self) -> list[httpx.Request]:
+        # Defensive copy so callers can iterate without racing future
+        # in-flight requests (which would mutate the underlying list
+        # via append).
+        return list(self._captured)
+
+    def reset(self) -> None:
+        self._tracker = _InflightTracker()
+        self._queue.clear()
+        self._captured.clear()
+        self._request_count = 0
+
+    # -- AsyncBaseTransport ABI ---------------------------------------
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self._captured.append(request)
+        self._request_count += 1
+        self._tracker.enter()
+        try:
+            if self._delay > 0:
+                # The yield point that lets sibling coroutines stack up
+                # in the in-flight counter. Every concurrent caller hits
+                # ``enter()`` synchronously before any reaches this
+                # ``await``, so peak-inflight reflects the gather width.
+                await asyncio.sleep(self._delay)
+            return self._next_response(request)
+        finally:
+            self._tracker.exit()
+
+    # -- internal ------------------------------------------------------
+
+    def _next_response(self, request: httpx.Request) -> httpx.Response:
+        if not self._queue:
+            return httpx.Response(200, text=_default_rpc_response_text())
+        item = self._queue.pop(0)
+        if isinstance(item, httpx.Response):
+            return item
+        if isinstance(item, tuple):
+            status, text = item
+            return httpx.Response(status, text=text)
+        if callable(item):
+            return item(request)
+        raise TypeError(
+            f"Unsupported queued response type: {type(item).__name__}. "
+            "Pass an httpx.Response, a (status, text) tuple, or a callable."
+        )
+
+
+@pytest.fixture
+def mock_transport_concurrent() -> ConcurrentMockTransport:
+    """A fresh ``ConcurrentMockTransport`` per test."""
+    return ConcurrentMockTransport()
+
+
+# ---------------------------------------------------------------------------
+# barrier_factory
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EventBarrier:
+    """One-shot N-arrival barrier built on ``asyncio.Event``.
+
+    Every arriver calls ``await arrive()``. The first ``N - 1`` arrivers
+    suspend at ``event.wait()``; the Nth arrival sets the event,
+    releasing all of them simultaneously.
+
+    Re-arming is intentionally NOT supported. Per-test barriers are
+    cheap; spawn a fresh one for each synchronization point. This
+    matches the guidance in the existing ``test_concurrency_refresh_race``
+    suite which uses one ``asyncio.Event`` per checkpoint.
+    """
+
+    n: int
+    _event: asyncio.Event = field(default_factory=asyncio.Event)
+    _arrived: int = 0
+
+    async def arrive(self) -> None:
+        self._arrived += 1
+        if self._arrived >= self.n:
+            self._event.set()
+        await self._event.wait()
+
+    @property
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    @property
+    def arrived_count(self) -> int:
+        return self._arrived
+
+
+@pytest.fixture
+def barrier_factory() -> Callable[[int], EventBarrier]:
+    """Return a callable that builds N-arrival ``EventBarrier`` instances.
+
+    Usage::
+
+        async def test_thing(barrier_factory):
+            barrier = barrier_factory(3)
+            await asyncio.gather(
+                worker(barrier),
+                worker(barrier),
+                worker(barrier),
+            )
+
+    Implementation note: the factory is the fixture (not a barrier
+    instance) so a single test can spawn multiple independent
+    synchronization points without re-fixturing.
+    """
+
+    def _make(n: int) -> EventBarrier:
+        if n <= 0:
+            raise ValueError(f"barrier arrivals must be >= 1, got {n}")
+        return EventBarrier(n=n)
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# cancellation_helper
+# ---------------------------------------------------------------------------
+
+
+CancellationHelper = Callable[..., Awaitable[Any]]
+
+
+@pytest.fixture
+def cancellation_helper() -> CancellationHelper:
+    """Wrap a coroutine in ``asyncio.wait_for`` with diagnostic on cancel.
+
+    Signature::
+
+        await cancellation_helper(coro, timeout=5.0, label="my-coro")
+
+    On ``asyncio.TimeoutError`` (Python 3.10) / ``TimeoutError`` (3.11+),
+    logs the label and timeout via the harness logger then re-raises.
+    The re-raise preserves test failure semantics — the helper's job is
+    to surface *which* coroutine deadlocked, not to swallow the failure.
+
+    The diagnostic is stderr-friendly and includes the traceback so a
+    CI failure with several pending coroutines is debuggable from the
+    log alone.
+    """
+
+    async def _run(
+        coro: Awaitable[T],
+        *,
+        timeout: float = 5.0,
+        label: str = "<unlabeled>",
+    ) -> T:
+        try:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        except (TimeoutError, asyncio.TimeoutError):
+            tb = traceback.format_exc()
+            logger.error(
+                "cancellation_helper: coroutine %r timed out after %.3fs\n%s",
+                label,
+                timeout,
+                tb,
+            )
+            raise
+
+    return _run

--- a/tests/integration/concurrency/test_harness_smoke.py
+++ b/tests/integration/concurrency/test_harness_smoke.py
@@ -88,7 +88,6 @@ async def _open_core_with_transport(transport: ConcurrentMockTransport) -> Clien
     return core
 
 
-@pytest.mark.asyncio
 async def test_harness_100_way_fanout_records_peak_inflight(
     mock_transport_concurrent: ConcurrentMockTransport,
 ) -> None:
@@ -157,7 +156,6 @@ async def test_harness_100_way_fanout_records_peak_inflight(
     )
 
 
-@pytest.mark.asyncio
 async def test_barrier_factory_releases_n_arrivers(
     barrier_factory,
 ) -> None:
@@ -178,7 +176,6 @@ async def test_barrier_factory_releases_n_arrivers(
     assert barrier.arrived_count == 3
 
 
-@pytest.mark.asyncio
 async def test_cancellation_helper_surfaces_label_on_timeout(
     cancellation_helper,
     caplog: pytest.LogCaptureFixture,

--- a/tests/integration/concurrency/test_harness_smoke.py
+++ b/tests/integration/concurrency/test_harness_smoke.py
@@ -1,0 +1,199 @@
+"""Smoke test for the Tier 7 concurrency integration harness.
+
+Demonstrates that:
+
+1. ``ConcurrentMockTransport`` correctly records peak concurrent
+   in-flight requests under a 100-way ``asyncio.gather`` fan-out.
+2. ``ClientCore`` can be wired with the mock transport via the same
+   "replace ``_http_client`` after ``open()``" pattern used in
+   ``tests/unit/conftest.py::make_core``.
+3. All 100 fan-out RPC calls complete successfully (each returns the
+   default empty-list response).
+
+Future-knob note (max_concurrent_rpcs)
+--------------------------------------
+The eventual ``ClientCore(max_concurrent_rpcs=...)`` knob is added in
+PR T7.H1. When that lands, this smoke test should be updated to
+construct the core with ``max_concurrent_rpcs=None`` so the asyncio
+semaphore is *explicitly* disabled — proving the harness still
+demonstrates true 100-way fan-out at the transport boundary even when
+the production default may have been clamped to a lower bound.
+
+Until T7.H1 lands the knob doesn't exist, so this test uses the
+current ``ClientCore.__init__`` signature unchanged. Future contributors
+who modify this file should:
+
+  - Pass ``max_concurrent_rpcs=None`` explicitly to ``ClientCore``.
+  - Keep the 100-way ``asyncio.gather``.
+  - Keep the ``>= 80`` peak-inflight assertion (asyncio scheduling is
+    not perfectly parallel; the margin absorbs CI jitter).
+
+Performance budget
+------------------
+Wall-clock target: < 2s locally, < 5s in CI. The transport's per-request
+delay (50ms default) is the dominant cost; 100 requests serialized
+would take 5s, but at 100-way fan-out they overlap and should complete
+in ~50–200ms of wall time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import httpx
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import RPCMethod
+
+from .conftest import ConcurrentMockTransport
+
+
+def _make_auth() -> AuthTokens:
+    """Synthetic auth tokens — values don't matter, the mock transport
+    ignores them. Mirrors ``tests/unit/conftest.py::make_core`` defaults
+    so a regression in either place surfaces consistently.
+    """
+    return AuthTokens(
+        csrf_token="CSRF_TEST",
+        session_id="SID_TEST",
+        cookies={"SID": "test_sid_cookie"},
+    )
+
+
+async def _open_core_with_transport(transport: ConcurrentMockTransport) -> ClientCore:
+    """Open a ``ClientCore`` and swap in the mock transport.
+
+    Mirrors the documented pattern from ``tests/unit/conftest.py``:
+    ``ClientCore.open()`` builds its own ``httpx.AsyncClient`` and we
+    can't override the transport via the constructor. So we open
+    normally, then close-and-replace the underlying client with one
+    that routes through our recording transport.
+
+    Once ``ClientCore(transport=...)`` exists (or ``max_concurrent_rpcs``
+    grows a transport hook) this can be simplified.
+    """
+    core = ClientCore(auth=_make_auth())
+    await core.open()
+    assert core._http_client is not None
+    prior_cookies = core._http_client.cookies
+    await core._http_client.aclose()
+    core._http_client = httpx.AsyncClient(
+        cookies=prior_cookies,
+        transport=transport,
+        timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+    )
+    return core
+
+
+@pytest.mark.asyncio
+async def test_harness_100_way_fanout_records_peak_inflight(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """100-way ``asyncio.gather`` over ``rpc_call`` — all complete, peak >= 80.
+
+    The threshold is ``>= 80`` (not ``== 100``) because asyncio task
+    scheduling is not perfectly parallel: a few coroutines may complete
+    before the last few enter the transport. ``80`` is comfortably above
+    "the gather is broken / serialized" (which would show ~1) and below
+    the theoretical maximum, leaving ~20% headroom for CI jitter.
+    """
+    transport = mock_transport_concurrent
+    transport.set_delay(0.05)  # 50ms per request — long enough to stack
+
+    core = await _open_core_with_transport(transport)
+    try:
+        start = time.perf_counter()
+        results = await asyncio.gather(
+            *[core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []) for _ in range(100)]
+        )
+        elapsed = time.perf_counter() - start
+    finally:
+        await core.close()
+
+    # All 100 completed (the gather doesn't hide exceptions because
+    # return_exceptions defaults to False — any failure would have
+    # already raised).
+    assert len(results) == 100, f"expected 100 results, got {len(results)}"
+
+    # The default response decodes to ``[]`` for LIST_NOTEBOOKS.
+    assert all(r == [] for r in results), (
+        f"expected all-empty list responses, got first divergent: "
+        f"{next((r for r in results if r != []), None)!r}"
+    )
+
+    # Transport observed all 100 wire requests.
+    assert transport.request_count() == 100, (
+        f"transport saw {transport.request_count()} requests, expected 100"
+    )
+
+    # Peak in-flight was high — the harness is genuinely fanning out.
+    # Lower bound 80: asyncio scheduling isn't perfectly parallel, allow
+    # ~20% slack for CI jitter. Upper bound 100: we only fired 100
+    # requests; a peak >100 means the counter is broken (e.g. enter()
+    # called twice per request).
+    peak = transport.get_peak_inflight()
+    assert 80 <= peak <= 100, (
+        f"peak in-flight was {peak}; expected 80 <= peak <= 100 for a "
+        f"100-way asyncio.gather. A peak near 1 means the requests "
+        f"serialized (check for a missing `await asyncio.sleep` in the "
+        f"transport or an unintended global lock); a peak above 100 "
+        f"means the in-flight counter is double-incrementing."
+    )
+
+    # All in-flight requests have drained.
+    assert transport.get_inflight_count() == 0, (
+        f"transport still reports {transport.get_inflight_count()} in-flight after gather completed"
+    )
+
+    # Performance budget: warn-loud if we blew past 5s. Test target is
+    # <2s locally; this assertion is the CI safety net.
+    assert elapsed < 5.0, (
+        f"smoke test took {elapsed:.2f}s; budget is <5s in CI / <2s locally. "
+        f"Either CI is heavily loaded or the harness regressed (the per-request "
+        f"delay should overlap, not serialize, across 100 gather'd coroutines)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_barrier_factory_releases_n_arrivers(
+    barrier_factory,
+) -> None:
+    """Sanity check: N arrivers all unblock once the Nth arrives."""
+    barrier = barrier_factory(3)
+
+    async def arrive_then_return(label: str) -> str:
+        await barrier.arrive()
+        return label
+
+    results = await asyncio.gather(
+        arrive_then_return("a"),
+        arrive_then_return("b"),
+        arrive_then_return("c"),
+    )
+    assert sorted(results) == ["a", "b", "c"]
+    assert barrier.is_set
+    assert barrier.arrived_count == 3
+
+
+@pytest.mark.asyncio
+async def test_cancellation_helper_surfaces_label_on_timeout(
+    cancellation_helper,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A timeout re-raises and logs the label."""
+
+    async def _hangs() -> None:
+        await asyncio.sleep(10)
+
+    with (
+        caplog.at_level("ERROR"),
+        pytest.raises((TimeoutError, asyncio.TimeoutError)),
+    ):
+        await cancellation_helper(_hangs(), timeout=0.05, label="hang-coro")
+
+    assert any("hang-coro" in record.message for record in caplog.records), (
+        f"Expected 'hang-coro' in error log; got records: {[r.message for r in caplog.records]}"
+    )


### PR DESCRIPTION
## Summary
Tier 7 foundation. Adds `tests/integration/concurrency/` package with reusable fixtures (mock transport recording peak in-flight, barrier factory, cancellation helper) plus a 100-way `asyncio.gather` smoke test.

Each Phase 2 fix PR will TDD-red-green against these fixtures.

## Why `concurrency/` and not `concurrent/`
A directory named `concurrent/` under `tests/integration/` would shadow Python's stdlib `concurrent` package once pytest puts the test root on `sys.path` (verified — `import concurrent` resolved to the new dir, breaking `concurrent.futures`). Renamed to `concurrency/` to sidestep the collision; semantic intent is unchanged. Documented at the bottom of the package README.

## Test plan
- [x] `uv run pytest tests/integration/concurrency -v` passes (3 tests, 0.13s)
- [x] Smoke test demonstrates 100 concurrent in-flight requests at peak (asserts `80 <= peak <= 100`)
- [x] Smoke test runs in <2s (target met: 0.13s)
- [x] Pre-commit suite: ruff format, ruff check, mypy, pytest all green (3580 passed, 11 skipped)

## Out of scope
- Tests for specific Tier 7 bugs (those go in per-fix PRs in Phase 2)
- The `max_concurrent_rpcs` knob (added in T7.H1; smoke test docstring notes the intent and what to update once it lands)

Refs: T7.A1 of the Tier 7 thread-safety remediation arc — `.sisyphus/plans/tier-7-thread-safety-concurrency/phase-1.md#T7.A1`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Tier‑7 concurrency integration test harness README and package-level docs describing fixture APIs, usage guidance, caveats, and running the harness smoke suite.

* **Tests**
  * Added concurrency test fixtures (recording mock transport, one‑shot barrier factory, cancellation helper) and smoke tests, including a 100‑way fan‑out concurrency check, barrier behavior, and timeout logging validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/514)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->