### PR TITLE
test(concurrent): reusable assertion helpers (T7.A2)

### DIFF
--- a/tests/integration/concurrency/helpers.py
+++ b/tests/integration/concurrency/helpers.py
@@ -216,6 +216,13 @@ async def with_simulated_cancel(
     "the leader survived; the canceled follower received
     ``CancelledError``" — returning makes that two assertions, not
     one ``pytest.raises`` block per scenario.
+
+    Footgun: if ``T`` is itself a ``BaseException`` subclass (a
+    coroutine that legitimately RETURNS an exception object rather
+    than raising), the caller cannot distinguish "coro returned an
+    exception value" from "coro raised". Phase 2 tests that need
+    that distinction should write a custom assertion rather than
+    rely on ``isinstance(result, BaseException)``.
     """
     if delay < 0:
         # Close the coro so misuse doesn't trigger
@@ -240,6 +247,13 @@ async def with_simulated_cancel(
     try:
         return await task
     except BaseException as exc:  # noqa: BLE001 — we explicitly return any exception
+        # Outer-cancellation safety: if THIS helper's invoking task is
+        # cancelled (vs. the inner ``task`` being cancelled by our own
+        # canceller), propagate the cancel into ``task`` so it doesn't
+        # become a stray background task. The exception is still
+        # returned per the helper's contract.
+        if isinstance(exc, asyncio.CancelledError) and not task.done():
+            task.cancel()
         return exc
     finally:
         # Best-effort cleanup; the canceller has either fired or is
@@ -248,7 +262,7 @@ async def with_simulated_cancel(
             canceller.cancel()
             try:
                 await canceller
-            except (asyncio.CancelledError, BaseException):  # noqa: BLE001
+            except BaseException:  # noqa: BLE001 — cleanup must not propagate
                 pass
 
 

--- a/tests/integration/concurrency/helpers.py
+++ b/tests/integration/concurrency/helpers.py
@@ -1,0 +1,262 @@
+"""Reusable assertion helpers for the Tier 7 concurrency harness.
+
+Three helpers, each scoped to a recurring assertion shape that
+appears across the Phase 2 fix tests. Add new helpers here only when
+they would be repeated in two or more Phase 2 tests — single-use
+assertions stay inline in their test module.
+
+Helpers
+-------
+``assert_no_concurrent_overlap(events)``
+    Given a stream of ``(timestamp, kind)`` events from a section that
+    is supposed to be serialized (a lock, a per-resource queue, a
+    per-conversation guard), asserts that no two ``enter`` events
+    occur without an intervening ``exit``. Used by Phase 2 tests for
+    `_refresh_lock`, the conversation-cache lock (T7.F1), the
+    per-task polling dedupe leader (T7.E2), etc.
+
+``assert_unique_outputs(make_coro, n_concurrent)``
+    Asserts N concurrent invocations of an async callable produce N
+    distinct outputs. Used by tests that verify monotonic/unique IDs
+    under fan-out (e.g. `next_reqid` regression coverage).
+
+``with_simulated_cancel(coro, delay, *, label=None)``
+    Creates a task from ``coro`` and schedules ``task.cancel()`` after
+    ``delay`` seconds. Returns the task's result, or the captured
+    exception (including ``CancelledError``). Used by Phase 2 tests
+    for `asyncio.shield` regressions (T7.C1, T7.C2, T7.C3, T7.C4):
+    cancel one waiter mid-flight, assert sibling work survives.
+
+Non-helpers
+-----------
+Module-level fixtures live in ``conftest.py``. ``helpers.py`` exposes
+plain functions so per-bug tests can import them explicitly. Tests
+that live UNDER ``tests/integration/concurrency/`` use the relative
+form (``from .helpers import ...``); tests at other locations should
+use whatever import path pytest's rootdir/pythonpath discovery
+exposes for their layout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, Literal, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+EventKind = Literal["enter", "exit"]
+"""Discriminator for ``assert_no_concurrent_overlap`` events."""
+
+
+def assert_no_concurrent_overlap(
+    events: Iterable[tuple[float, EventKind]],
+) -> None:
+    """Replay an enter/exit event stream and assert peak depth == 1.
+
+    Parameters
+    ----------
+    events:
+        Iterable of ``(timestamp, kind)`` pairs where ``kind`` is
+        ``"enter"`` or ``"exit"``. Events are replayed in input
+        order — the timestamps are recorded for the assertion message
+        but do not need to be monotonic (the caller is responsible for
+        ordering or pre-sorting if needed).
+
+    Raises
+    ------
+    AssertionError
+        If at any replay step the inflight count exceeds 1, OR if an
+        ``exit`` is observed when the inflight count is already 0
+        (caller bug — unmatched exit). The error message identifies
+        the offending event by index and timestamp so a failing test
+        can point at the offending coroutine in its log capture.
+
+    Notes
+    -----
+    This helper does not record the events itself — the caller is
+    expected to instrument the section under test, typically via a
+    list shared across coroutines and protected by the asyncio
+    event-loop's single-thread invariant. Example pattern::
+
+        events: list[tuple[float, EventKind]] = []
+
+        async def serialized_section():
+            events.append((time.monotonic(), "enter"))
+            try:
+                await do_work()
+            finally:
+                events.append((time.monotonic(), "exit"))
+
+        await asyncio.gather(*[serialized_section() for _ in range(10)])
+        assert_no_concurrent_overlap(events)
+    """
+    inflight = 0
+    for index, (timestamp, kind) in enumerate(events):
+        if kind == "enter":
+            inflight += 1
+            if inflight > 1:
+                raise AssertionError(
+                    f"concurrent overlap detected at event index {index} "
+                    f"(timestamp={timestamp}): inflight={inflight} > 1. "
+                    f"The section is not serialized."
+                )
+        elif kind == "exit":
+            if inflight == 0:
+                raise AssertionError(
+                    f"unmatched exit at event index {index} "
+                    f"(timestamp={timestamp}): no matching enter. "
+                    f"Caller instrumentation bug."
+                )
+            inflight -= 1
+        else:
+            raise AssertionError(
+                f"unknown event kind {kind!r} at index {index}; expected 'enter' or 'exit'."
+            )
+    if inflight != 0:
+        raise AssertionError(
+            f"event stream ended with inflight={inflight} (expected 0). "
+            f"Some enters had no matching exit."
+        )
+
+
+async def assert_unique_outputs(
+    make_coro: Callable[[], Awaitable[T]],
+    n_concurrent: int,
+) -> list[T]:
+    """Run ``make_coro()`` ``n_concurrent`` times via gather, assert distinct.
+
+    Parameters
+    ----------
+    make_coro:
+        Zero-argument callable that returns a fresh coroutine on each
+        call. Required to be a callable rather than a coroutine
+        because each gather slot needs its own coroutine instance.
+    n_concurrent:
+        Number of concurrent invocations to fan out. Must be >= 1.
+
+    Returns
+    -------
+    list[T]
+        The collected outputs in completion order. Returned so the
+        caller can assert additional shape properties (e.g.
+        monotonicity) beyond uniqueness.
+
+    Raises
+    ------
+    AssertionError
+        If the collected outputs contain any duplicate. Error message
+        identifies the duplicate value and the duplicated indices.
+    ValueError
+        If ``n_concurrent < 1``.
+
+    Notes
+    -----
+    Outputs must be hashable. For non-hashable outputs (lists, dicts),
+    the caller should write a custom assertion rather than try to
+    coerce here.
+    """
+    if n_concurrent < 1:
+        raise ValueError(f"n_concurrent must be >= 1, got {n_concurrent}")
+    coros = [make_coro() for _ in range(n_concurrent)]
+    outputs: list[T] = await asyncio.gather(*coros)
+    seen: dict[Any, int] = {}
+    for index, value in enumerate(outputs):
+        if value in seen:
+            raise AssertionError(
+                f"duplicate output {value!r} at indices {seen[value]} and "
+                f"{index} (of {n_concurrent} concurrent invocations)."
+            )
+        seen[value] = index
+    return outputs
+
+
+async def with_simulated_cancel(
+    coro: Awaitable[T],
+    delay: float,
+    *,
+    label: str | None = None,
+) -> T | BaseException:
+    """Run ``coro`` and cancel it after ``delay`` seconds.
+
+    Parameters
+    ----------
+    coro:
+        The awaitable to wrap. Will be scheduled as a task immediately.
+    delay:
+        Seconds to wait before issuing ``task.cancel()``. Must be
+        >= 0. Use a small positive value (50ms-500ms) for most tests.
+    label:
+        Optional string to embed in the diagnostic log line emitted
+        when the cancel fires. Helpful when a test wraps several
+        coroutines under cancel and needs to identify which one in
+        its log capture.
+
+    Returns
+    -------
+    T | BaseException
+        The task's result if it completed before the cancel fired,
+        OR the captured exception (typically ``asyncio.CancelledError``,
+        but any exception the coro raises is captured and returned).
+        Exceptions are RETURNED, not raised, so the caller can assert
+        on the exception type without a ``pytest.raises`` block.
+
+    Raises
+    ------
+    ValueError
+        If ``delay < 0``.
+
+    Notes
+    -----
+    Returning the exception (rather than raising) is intentional:
+    Phase 2 cancellation tests typically want to assert
+    "the leader survived; the canceled follower received
+    ``CancelledError``" — returning makes that two assertions, not
+    one ``pytest.raises`` block per scenario.
+    """
+    if delay < 0:
+        # Close the coro so misuse doesn't trigger
+        # ``RuntimeWarning: coroutine '...' was never awaited``.
+        if hasattr(coro, "close"):
+            coro.close()  # type: ignore[union-attr]
+        raise ValueError(f"delay must be >= 0, got {delay}")
+
+    task: asyncio.Task[T] = asyncio.create_task(_as_coroutine(coro))
+
+    async def _cancel_after_delay() -> None:
+        await asyncio.sleep(delay)
+        if not task.done():
+            logger.info(
+                "with_simulated_cancel: firing cancel after %.3fs (label=%s)",
+                delay,
+                label,
+            )
+            task.cancel()
+
+    canceller = asyncio.create_task(_cancel_after_delay())
+    try:
+        return await task
+    except BaseException as exc:  # noqa: BLE001 — we explicitly return any exception
+        return exc
+    finally:
+        # Best-effort cleanup; the canceller has either fired or is
+        # mid-sleep. Cancel it to avoid a stray task at test teardown.
+        if not canceller.done():
+            canceller.cancel()
+            try:
+                await canceller
+            except (asyncio.CancelledError, BaseException):  # noqa: BLE001
+                pass
+
+
+async def _as_coroutine(awaitable: Awaitable[T]) -> T:
+    """Wrap an arbitrary awaitable in a coroutine for ``create_task``.
+
+    ``asyncio.create_task`` requires a coroutine, but callers may pass
+    any awaitable (a future, a generator-coroutine wrapper). This
+    trivial wrapper bridges the gap.
+    """
+    return await awaitable

--- a/tests/integration/concurrency/test_helpers.py
+++ b/tests/integration/concurrency/test_helpers.py
@@ -1,0 +1,194 @@
+"""Unit tests for ``tests/integration/concurrency/helpers.py``.
+
+Each helper has happy-path + at least one edge case. Helpers are
+covered here (not via dogfooding in Phase 2 fix tests) so a
+helper-level regression surfaces before any Phase 2 PR depends on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from .helpers import (
+    assert_no_concurrent_overlap,
+    assert_unique_outputs,
+    with_simulated_cancel,
+)
+
+# ---------------------------------------------------------------------------
+# assert_no_concurrent_overlap
+# ---------------------------------------------------------------------------
+
+
+def test_no_concurrent_overlap_serialized_passes() -> None:
+    """A serialized stream (each enter followed by exit) passes."""
+    events = [
+        (0.0, "enter"),
+        (0.1, "exit"),
+        (0.2, "enter"),
+        (0.3, "exit"),
+    ]
+    assert_no_concurrent_overlap(events)  # type: ignore[arg-type]
+
+
+def test_no_concurrent_overlap_detects_overlap() -> None:
+    """Two enters without an intervening exit raises with index/timestamp."""
+    events = [
+        (0.0, "enter"),
+        (0.1, "enter"),  # overlap at index 1
+        (0.2, "exit"),
+        (0.3, "exit"),
+    ]
+    with pytest.raises(AssertionError, match="index 1.*timestamp=0.1"):
+        assert_no_concurrent_overlap(events)  # type: ignore[arg-type]
+
+
+def test_no_concurrent_overlap_unmatched_exit_raises() -> None:
+    """An exit before any enter is a caller bug; raise with a clear msg."""
+    events = [
+        (0.0, "exit"),
+    ]
+    with pytest.raises(AssertionError, match="unmatched exit.*index 0"):
+        assert_no_concurrent_overlap(events)  # type: ignore[arg-type]
+
+
+def test_no_concurrent_overlap_dangling_enter_raises() -> None:
+    """A stream that ends with inflight > 0 raises (caller bug)."""
+    events = [
+        (0.0, "enter"),
+        # no matching exit
+    ]
+    with pytest.raises(AssertionError, match="ended with inflight=1"):
+        assert_no_concurrent_overlap(events)  # type: ignore[arg-type]
+
+
+def test_no_concurrent_overlap_unknown_kind_raises() -> None:
+    """An unknown event kind is a caller bug."""
+    events = [(0.0, "wat")]
+    with pytest.raises(AssertionError, match="unknown event kind"):
+        assert_no_concurrent_overlap(events)  # type: ignore[arg-type]
+
+
+def test_no_concurrent_overlap_empty_stream_passes() -> None:
+    """No events is vacuously serialized."""
+    assert_no_concurrent_overlap([])
+
+
+# ---------------------------------------------------------------------------
+# assert_unique_outputs
+# ---------------------------------------------------------------------------
+
+
+async def test_unique_outputs_distinct_passes() -> None:
+    """Each invocation returns a fresh value -> no duplicates."""
+    counter = 0
+
+    async def _next() -> int:
+        nonlocal counter
+        counter += 1
+        return counter
+
+    outputs = await assert_unique_outputs(_next, 50)
+    assert len(outputs) == 50
+    assert sorted(outputs) == list(range(1, 51))
+
+
+async def test_unique_outputs_duplicate_raises_with_indices() -> None:
+    """A constant-returning callable trips the duplicate check."""
+
+    async def _const() -> str:
+        return "same"
+
+    with pytest.raises(AssertionError, match=r"duplicate output 'same'"):
+        await assert_unique_outputs(_const, 3)
+
+
+async def test_unique_outputs_zero_raises_value_error() -> None:
+    """``n_concurrent < 1`` is a misuse and raises early."""
+
+    async def _noop() -> None:
+        return None
+
+    with pytest.raises(ValueError, match="n_concurrent must be >= 1"):
+        await assert_unique_outputs(_noop, 0)
+
+
+async def test_unique_outputs_returns_outputs_for_caller_assertions() -> None:
+    """Callers may add their own assertions on the returned list."""
+    seq = iter(range(5))
+
+    async def _seq() -> int:
+        return next(seq)
+
+    outputs = await assert_unique_outputs(_seq, 5)
+    # Caller can check ordering / monotonicity beyond uniqueness.
+    assert outputs == [0, 1, 2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# with_simulated_cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_with_simulated_cancel_returns_result_when_fast_enough() -> None:
+    """A coro that finishes before the cancel fires returns its result."""
+
+    async def _quick() -> str:
+        await asyncio.sleep(0.01)
+        return "done"
+
+    result = await with_simulated_cancel(_quick(), delay=1.0)
+    assert result == "done"
+
+
+async def test_with_simulated_cancel_returns_cancelled_error_on_timeout() -> None:
+    """A coro slower than the cancel returns ``CancelledError``."""
+
+    async def _slow() -> str:
+        await asyncio.sleep(10.0)
+        return "never"
+
+    result = await with_simulated_cancel(_slow(), delay=0.05, label="slow")
+    assert isinstance(result, asyncio.CancelledError)
+
+
+async def test_with_simulated_cancel_returns_application_exception() -> None:
+    """If the coro raises before the cancel, that exception is captured."""
+
+    async def _raises() -> str:
+        await asyncio.sleep(0.01)
+        raise RuntimeError("boom")
+
+    result = await with_simulated_cancel(_raises(), delay=1.0)
+    assert isinstance(result, RuntimeError)
+    assert str(result) == "boom"
+
+
+async def test_with_simulated_cancel_negative_delay_raises() -> None:
+    """``delay < 0`` is a misuse and raises early."""
+
+    async def _noop() -> None:
+        return None
+
+    with pytest.raises(ValueError, match="delay must be >= 0"):
+        await with_simulated_cancel(_noop(), delay=-1.0)
+
+
+async def test_with_simulated_cancel_cleans_up_canceller_task() -> None:
+    """The canceller task should not leak after the helper returns.
+
+    No direct API to inspect; we rely on no warnings about
+    "Task was destroyed but it is pending" emerging at teardown. This
+    test exists so a future regression that drops the cleanup `cancel()`
+    will surface as a noisy test run.
+    """
+
+    async def _quick() -> int:
+        return 42
+
+    result = await with_simulated_cancel(_quick(), delay=0.5)
+    assert result == 42
+    # Yield once so any pending cancellation can complete cleanly.
+    await asyncio.sleep(0)

--- a/tests/integration/concurrency/test_helpers.py
+++ b/tests/integration/concurrency/test_helpers.py
@@ -123,8 +123,12 @@ async def test_unique_outputs_returns_outputs_for_caller_assertions() -> None:
         return next(seq)
 
     outputs = await assert_unique_outputs(_seq, 5)
-    # Caller can check ordering / monotonicity beyond uniqueness.
-    assert outputs == [0, 1, 2, 3, 4]
+    # Caller can check shape beyond uniqueness. Use ``sorted`` /
+    # ``set`` rather than positional equality so the test stays
+    # stable across asyncio event-loop scheduling implementations
+    # (CPython runs zero-await coroutines FIFO; uvloop/others may not).
+    assert sorted(outputs) == [0, 1, 2, 3, 4]
+    assert set(outputs) == set(range(5))
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +178,57 @@ async def test_with_simulated_cancel_negative_delay_raises() -> None:
 
     with pytest.raises(ValueError, match="delay must be >= 0"):
         await with_simulated_cancel(_noop(), delay=-1.0)
+
+
+async def test_with_simulated_cancel_propagates_outer_cancellation_to_inner() -> None:
+    """Outer cancel of the helper itself must cancel the wrapped task too.
+
+    Otherwise the inner task becomes a stray background task and the
+    cancellation is silently consumed. Regression coverage for the
+    claude[bot] iter-2 finding.
+    """
+    inner_started = asyncio.Event()
+    inner_finished = False
+
+    async def _slow() -> str:
+        nonlocal inner_finished
+        inner_started.set()
+        try:
+            await asyncio.sleep(10.0)
+            inner_finished = True
+            return "never"
+        except asyncio.CancelledError:
+            # Re-raise so the cancellation actually takes effect on
+            # the task (the helper expects to receive CancelledError
+            # from awaiting the task).
+            raise
+
+    helper_task = asyncio.create_task(
+        with_simulated_cancel(_slow(), delay=10.0, label="outer-cancel-test")
+    )
+
+    # Wait until the inner coro has started (so the task is real).
+    await inner_started.wait()
+    # Give the canceller a tick to schedule, then cancel the OUTER helper.
+    await asyncio.sleep(0)
+    helper_task.cancel()
+
+    # The helper catches CancelledError and returns it as a value
+    # (per its contract); we just verify the outer cancel did NOT
+    # leave the inner running.
+    try:
+        result = await helper_task
+        assert isinstance(result, asyncio.CancelledError)
+    except asyncio.CancelledError:
+        # Acceptable: depending on timing, the outer cancel may
+        # propagate before the helper's except block runs.
+        pass
+
+    # Yield to let the inner task observe its own cancellation.
+    await asyncio.sleep(0)
+    assert not inner_finished, (
+        "Inner task should have been cancelled when the outer helper was cancelled."
+    )
 
 
 async def test_with_simulated_cancel_cleans_up_canceller_task() -> None:


### PR DESCRIPTION
## Summary

Tier 7 foundation — adds `tests/integration/concurrency/helpers.py` with three plain-function helpers consumed by Phase 2 fix tests:

- **`assert_no_concurrent_overlap(events)`** — replays an enter/exit event stream and asserts peak depth ≤ 1. Used for serialization regression tests (per-conversation lock T7.F1, polling-dedupe leader T7.E2).
- **`assert_unique_outputs(make_coro, n_concurrent)`** — N concurrent invocations must produce N distinct results. Used for monotonic/unique-ID tests (`next_reqid` regression coverage).
- **`with_simulated_cancel(coro, delay, *, label=None)`** — schedules `task.cancel()` after `delay` and **returns** (not raises) the result or captured exception. Used for `asyncio.shield` regressions (T7.C1–C4): cancel one waiter mid-flight, assert sibling work survives.

Plain functions (not fixtures) so per-bug tests can `from .helpers import ...` from anywhere under `tests/integration/concurrency/`.

## Design notes

- `with_simulated_cancel` returns the exception rather than raising — Phase 2 tests typically want "leader survived; canceled follower received `CancelledError`" as two assertions, not one `pytest.raises` block.
- `assert_no_concurrent_overlap` raises with the offending event index + timestamp so a failing test points at the offending coroutine in its log capture.
- `assert_unique_outputs` requires hashable outputs; non-hashable cases stay inline (no over-design here).
- All three reject misuse (negative delays, `n_concurrent < 1`, unknown event kinds) with `ValueError`/`AssertionError` and clear messages.

## Test plan

- [x] `uv run pytest tests/integration/concurrency -v` — 18 tests pass in 0.21s
- [x] `uv run pytest -W error::RuntimeWarning` — clean (caught one un-awaited-coroutine on misuse path; fixed by `coro.close()` in the validation branch)
- [x] Pre-commit suite: `ruff format`, `ruff check`, `mypy src/notebooklm`, full `pytest` (3640 passed, 11 skipped, 0 new warnings)

## Out of scope

- Tests for specific Tier 7 bugs (those go in per-fix PRs in Phase 2; the helpers here are dependencies of those tests).
- Helpers for fixture composition / barrier orchestration (already in `conftest.py` from T7.A1).

Refs: T7.A2 of the Tier 7 thread-safety remediation arc; sequential after #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new concurrency test helpers to validate serialized/overlap behavior, enforce uniqueness of concurrent outputs, and simulate cancellations safely.
  * Added comprehensive integration tests covering helpers, edge cases (invalid inputs, duplicate results, leak prevention), and cancellation propagation/cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/520)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->