### PR TITLE
fix(artifacts): unique temp file per download to prevent concurrent collision (T7.B1)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -12,7 +12,9 @@ import csv
 import html
 import json
 import logging
+import os
 import re
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -2321,8 +2323,21 @@ class ArtifactsAPI:
         output_file = Path(output_path)
         output_file.parent.mkdir(parents=True, exist_ok=True)
 
-        # Use temp file to avoid leaving corrupted partial files on failure
-        temp_file = output_file.with_suffix(output_file.suffix + ".tmp")
+        # Use a unique temp file per call (not ``<output>.tmp``) so two
+        # concurrent downloads targeting the same ``output_path`` cannot
+        # interleave bytes into a shared file or have one task's
+        # ``rename`` clobber the other's. ``mkstemp`` creates+opens an
+        # exclusive FD; we close it immediately and re-open via ``open``
+        # in the worker-thread write loop below — passing the raw FD
+        # into ``asyncio.to_thread(f.write, ...)`` would risk Windows
+        # sharing violations and FD leaks across the rename.
+        fd, temp_path_str = tempfile.mkstemp(
+            dir=output_file.parent,
+            prefix=output_file.name + ".",
+            suffix=".tmp",
+        )
+        os.close(fd)
+        temp_file = Path(temp_path_str)
 
         # Load cookies with domain info for cross-domain redirect handling
         cookies = load_httpx_cookies(path=self._storage_path)
@@ -2387,8 +2402,11 @@ class ArtifactsAPI:
                                 ),
                             )
 
-                        # Only move to final location on success
-                        temp_file.rename(output_file)
+                        # Only move to final location on success.
+                        # ``os.replace`` is atomic on POSIX and overwrites on
+                        # Windows; ``Path.rename`` would raise on Windows when
+                        # ``output_file`` already exists.
+                        os.replace(temp_file, output_file)
                         # Log host+path only; full URLs may carry capability
                         # tokens in query params (see _download_urls_batch for
                         # the same redaction pattern).

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2339,15 +2339,22 @@ class ArtifactsAPI:
         os.close(fd)
         temp_file = Path(temp_path_str)
 
-        # Load cookies with domain info for cross-domain redirect handling
-        cookies = load_httpx_cookies(path=self._storage_path)
-
-        # Use granular timeouts: 10s to connect, 30s per chunk read/write
-        # This allows large files to download without timeout while still
-        # detecting network failures quickly
-        timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
-
+        # NOTE: outer try MUST start here, immediately after the temp file
+        # exists on disk, so the ``except BaseException`` cleanup at the
+        # bottom unlinks the empty temp if anything between mkstemp and the
+        # download (e.g. ``load_httpx_cookies``) raises. Pre-existing code
+        # had `temp_file = output_file.with_suffix(...)` which only built a
+        # ``Path`` (no filesystem entry); switching to mkstemp creates the
+        # file immediately, so the cleanup window must widen.
         try:
+            # Load cookies with domain info for cross-domain redirect handling
+            cookies = load_httpx_cookies(path=self._storage_path)
+
+            # Use granular timeouts: 10s to connect, 30s per chunk read/write
+            # This allows large files to download without timeout while still
+            # detecting network failures quickly
+            timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
+
             try:
                 # Nested context managers required: client.stream() returns an
                 # async context manager that must run within the client's scope

--- a/tests/integration/concurrency/test_download_collision.py
+++ b/tests/integration/concurrency/test_download_collision.py
@@ -111,14 +111,12 @@ async def test_no_leftover_tmp_files_after_concurrent_downloads(
     httpx_mock: HTTPXMock,
     tmp_path,
 ) -> None:
-    """No `<output>.tmp` or mkstemp leftovers should remain on success.
+    """Both calls succeed and leave zero tempfiles behind.
 
-    Pre-fix: even on success, the shared `<output>.tmp` was renamed
-    away — no leftover. Post-fix: each call's mkstemp temp is renamed
-    onto `output_path`; the loser's temp is left ONLY if the winner
-    raced through the rename first (filesystem-dependent). Be lenient:
-    assert at most one leftover tempfile is acceptable, and only with
-    the expected `<name>.<random>.tmp` shape.
+    With the mock transport, both `_download_url` invocations always
+    succeed and atomically `os.replace` their unique mkstemp temps onto
+    `output_path` (one wins, the other clobbers — both get a final
+    state). No tempfile should remain in `tmp_path` after the gather.
     """
     url_a = "https://storage.googleapis.com/file_a.bin"
     url_b = "https://storage.googleapis.com/file_b.bin"
@@ -128,25 +126,23 @@ async def test_no_leftover_tmp_files_after_concurrent_downloads(
     output_path = tmp_path / "out.bin"
 
     async with NotebookLMClient(auth_tokens) as client:
-        await asyncio.gather(
+        results = await asyncio.gather(
             client.artifacts._download_url(url_a, str(output_path)),
             client.artifacts._download_url(url_b, str(output_path)),
             return_exceptions=True,
         )
 
-    # mkstemp temp names have shape `out.bin.<random>.tmp`. List leftovers.
+    # Both calls must succeed (no exception slipped through return_exceptions).
+    assert all(isinstance(r, str) for r in results), f"unexpected exception: {results}"
+    assert output_path.exists(), "expected final output file to exist after both downloads"
+
+    # mkstemp temp names have shape `out.bin.<random>.tmp`. With deterministic
+    # mock-transport completion, both renames succeed and zero leftovers remain.
     leftovers = sorted(p for p in tmp_path.iterdir() if p != output_path)
-    assert len(leftovers) <= 1, f"unexpected leftover temp files: {leftovers}"
-    for p in leftovers:
-        assert p.name.startswith("out.bin.") and p.name.endswith(".tmp"), (
-            f"unexpected leftover shape: {p.name}"
-        )
+    assert leftovers == [], f"unexpected leftover temp files: {leftovers}"
 
 
 @pytest.fixture
 def non_mocked_hosts() -> list[str]:
-    """Tell pytest-httpx to NOT intercept calls to googleapis.com only — we
-    want to intercept those — but allow other hosts through. Returning an
-    empty list means "intercept everything matching the registered URLs."
-    """
+    """Empty list: intercept all hosts via pytest-httpx. No real network."""
     return []

--- a/tests/integration/concurrency/test_download_collision.py
+++ b/tests/integration/concurrency/test_download_collision.py
@@ -1,0 +1,136 @@
+"""Regression test for T7.B1 — concurrent download temp-file collision.
+
+Audit item #1 (`thread-safety-concurrency-audit.md` §1):
+Pre-fix, two concurrent `_download_url(...)` calls targeting the same
+`output_path` shared a single `<output>.tmp` file, interleaving bytes
+and racing on `temp_file.rename(output_file)`. Post-fix (T7.B1), each
+call uses `tempfile.mkstemp(...)` for a unique temp path and commits
+via `os.replace`, so concurrent writers cannot corrupt the final file.
+
+This test exercises the previously-broken path directly via
+`client.artifacts._download_url`, intercepting the internal
+`httpx.AsyncClient` with the `httpx_mock` fixture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from notebooklm import NotebookLMClient
+
+
+async def test_concurrent_downloads_to_same_output_path_no_corruption(
+    auth_tokens,
+    httpx_mock: HTTPXMock,
+    tmp_path,
+) -> None:
+    """Two concurrent _download_url calls writing to the same path produce
+    valid bytes (one URL wins cleanly), never interleaved."""
+    url_a = "https://storage.googleapis.com/file_a.bin"
+    url_b = "https://storage.googleapis.com/file_b.bin"
+    body_a = b"AAAA" * 4096  # 16 KB of 'A'
+    body_b = b"BBBB" * 4096  # 16 KB of 'B'
+
+    httpx_mock.add_response(url=url_a, content=body_a)
+    httpx_mock.add_response(url=url_b, content=body_b)
+
+    output_path = tmp_path / "out.bin"
+
+    async with NotebookLMClient(auth_tokens) as client:
+        results = await asyncio.gather(
+            client.artifacts._download_url(url_a, str(output_path)),
+            client.artifacts._download_url(url_b, str(output_path)),
+            return_exceptions=True,
+        )
+
+    # Both calls should return the output_path string (not raise) — pre-fix
+    # one could raise FileNotFoundError on the rename if the other had
+    # already moved its temp file.
+    assert all(isinstance(r, str) for r in results), f"unexpected exception: {results}"
+
+    # The final file must contain EXACTLY one of the two URL's bytes,
+    # NOT a mix or partial content. Pre-fix, the shared `<output>.tmp`
+    # could be open()ed twice with mode "wb" (truncating), so the
+    # observed bytes were a non-deterministic interleave of A's and B's.
+    final_bytes = output_path.read_bytes()
+    assert final_bytes in (body_a, body_b), (
+        f"output bytes corrupted: not equal to body_a or body_b. "
+        f"len={len(final_bytes)}, head={final_bytes[:16]!r}"
+    )
+
+
+async def test_concurrent_downloads_to_distinct_paths_both_succeed(
+    auth_tokens,
+    httpx_mock: HTTPXMock,
+    tmp_path,
+) -> None:
+    """Sanity: distinct output paths still work — no regression on the
+    common case (each URL ends up at its own destination)."""
+    url_a = "https://storage.googleapis.com/file_a.bin"
+    url_b = "https://storage.googleapis.com/file_b.bin"
+    body_a = b"DISTINCT-A" * 1024
+    body_b = b"DISTINCT-B" * 1024
+
+    httpx_mock.add_response(url=url_a, content=body_a)
+    httpx_mock.add_response(url=url_b, content=body_b)
+
+    out_a = tmp_path / "a.bin"
+    out_b = tmp_path / "b.bin"
+
+    async with NotebookLMClient(auth_tokens) as client:
+        await asyncio.gather(
+            client.artifacts._download_url(url_a, str(out_a)),
+            client.artifacts._download_url(url_b, str(out_b)),
+        )
+
+    assert out_a.read_bytes() == body_a
+    assert out_b.read_bytes() == body_b
+
+
+async def test_no_leftover_tmp_files_after_concurrent_downloads(
+    auth_tokens,
+    httpx_mock: HTTPXMock,
+    tmp_path,
+) -> None:
+    """No `<output>.tmp` or mkstemp leftovers should remain on success.
+
+    Pre-fix: even on success, the shared `<output>.tmp` was renamed
+    away — no leftover. Post-fix: each call's mkstemp temp is renamed
+    onto `output_path`; the loser's temp is left ONLY if the winner
+    raced through the rename first (filesystem-dependent). Be lenient:
+    assert at most one leftover tempfile is acceptable, and only with
+    the expected `<name>.<random>.tmp` shape.
+    """
+    url_a = "https://storage.googleapis.com/file_a.bin"
+    url_b = "https://storage.googleapis.com/file_b.bin"
+    httpx_mock.add_response(url=url_a, content=b"a" * 1024)
+    httpx_mock.add_response(url=url_b, content=b"b" * 1024)
+
+    output_path = tmp_path / "out.bin"
+
+    async with NotebookLMClient(auth_tokens) as client:
+        await asyncio.gather(
+            client.artifacts._download_url(url_a, str(output_path)),
+            client.artifacts._download_url(url_b, str(output_path)),
+            return_exceptions=True,
+        )
+
+    # mkstemp temp names have shape `out.bin.<random>.tmp`. List leftovers.
+    leftovers = sorted(p for p in tmp_path.iterdir() if p != output_path)
+    assert len(leftovers) <= 1, f"unexpected leftover temp files: {leftovers}"
+    for p in leftovers:
+        assert p.name.startswith("out.bin.") and p.name.endswith(".tmp"), (
+            f"unexpected leftover shape: {p.name}"
+        )
+
+
+@pytest.fixture
+def non_mocked_hosts() -> list[str]:
+    """Tell pytest-httpx to NOT intercept calls to googleapis.com only — we
+    want to intercept those — but allow other hosts through. Returning an
+    empty list means "intercept everything matching the registered URLs."
+    """
+    return []

--- a/tests/integration/concurrency/test_download_collision.py
+++ b/tests/integration/concurrency/test_download_collision.py
@@ -22,6 +22,22 @@ from pytest_httpx import HTTPXMock
 from notebooklm import NotebookLMClient
 
 
+@pytest.fixture(autouse=True)
+def _stub_storage_cookies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass on-disk storage_state.json lookup in `_download_url`.
+
+    `_download_url` calls `load_httpx_cookies(path=self._storage_path)`
+    which raises `FileNotFoundError` on a clean CI runner that hasn't
+    been through `notebooklm login`. We don't care about the cookies for
+    this test (the mock transport doesn't validate auth) — return an
+    empty dict.
+    """
+    monkeypatch.setattr(
+        "notebooklm._artifacts.load_httpx_cookies",
+        lambda path=None: {},
+    )
+
+
 async def test_concurrent_downloads_to_same_output_path_no_corruption(
     auth_tokens,
     httpx_mock: HTTPXMock,


### PR DESCRIPTION
## Summary

**Tier 7 / Phase 2 / Wave 1 — CRITICAL fix.** Audit item #1 from `thread-safety-concurrency-audit.md` §1.

`ArtifactsAPI._download_url` previously used `output_file.with_suffix(suffix + \".tmp\")` for its staging file. Two concurrent calls to the same `output_path` shared one temp file, with `open(..., \"wb\")` truncating mid-write and `temp_file.rename` racing — bytes interleaved or one task raised `FileNotFoundError` when the other had already moved the file.

This fix gives each call its own unique staging file via `tempfile.mkstemp(dir=output_file.parent, prefix=output_file.name + \".\", suffix=\".tmp\")`, then commits atomically with `os.replace`.

## Why `mkstemp` over `NamedTemporaryFile(delete=False)`

`NamedTemporaryFile(delete=False)` returns an open file object. Re-opening its path in a worker thread leaks an FD on Unix and causes sharing violations on Windows. `mkstemp` returns `(fd, path)`; we close the FD immediately and re-open via plain `open()` inside the existing per-chunk write loop.

## Why `os.replace` over `Path.rename`

`os.replace` is atomic on POSIX and overwrites on Windows. `Path.rename` raises on Windows when the target already exists — a latent Windows bug fixed for free.

## Test plan

- [x] New `tests/integration/concurrency/test_download_collision.py` with 3 cases:
  - Concurrent downloads to the **same** path: bytes match exactly one URL's body (no interleave).
  - Concurrent downloads to **distinct** paths: both files complete with correct bytes (sanity).
  - **No leftover** `.tmp` files after success (cleanup hygiene).
- [x] **RED verified** on pre-fix HEAD: `git stash` the source change, run the same test → fails with `FileNotFoundError` from the racing `rename` (exactly the audit's repro).
- [x] **GREEN**: 3/3 pass post-fix in 0.05s.
- [x] Full suite: `3655 passed, 11 skipped` — no regressions, no new warnings.
- [x] Pre-commit gate: `ruff format`, `ruff check`, `mypy src/notebooklm`, `pytest` all green.

## Risk

Low. Behavior is bit-identical for the normal single-call path (one staging file per call → atomic commit). The only observable difference is the staging-file name format: `out.bin.<random>.tmp` instead of `out.bin.tmp`. Cleanup-on-failure path uses the same variable name so the existing `temp_file.unlink(missing_ok=True)` still works.

## References

- Audit: `.sisyphus/plans/thread-safety-concurrency-audit.md` §1
- Plan: `.sisyphus/plans/tier-7-thread-safety-concurrency.md` T7.B1
- Phase 2 Wave 1 sequence: T7.B1 (this), T7.B2, T7.B3, T7.B4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer temporary-file handling and atomic replacement for media downloads to prevent collisions, incomplete files, and improve Windows reliability
  * Prevented corruption when multiple downloads target the same destination concurrently

* **Tests**
  * Added integration tests for concurrent download collisions, distinct-path concurrency, and cleanup of temporary files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/523)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->