### PR TITLE
fix(client+core): __aexit__ exception arbitration + close-leak shield (T7.B4)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -578,27 +578,45 @@ class ClientCore:
         """Close the HTTP client connection.
 
         Called automatically by NotebookLMClient.__aexit__.
-        """
-        # Stop the keepalive task before tearing down the HTTP client so the
-        # loop can't issue a poke against an already-closed transport.
-        if self._keepalive_task is not None:
-            self._keepalive_task.cancel()
-            await asyncio.gather(self._keepalive_task, return_exceptions=True)
-            self._keepalive_task = None
 
-        if self._http_client:
-            try:
-                # Single source of truth for the on-close save: takes the
-                # in-process lock, snapshots, off-loads. Serializes naturally
-                # with any keepalive save still finishing in a worker thread
-                # — close() owns the freshest jar and must win, not the older
-                # snapshot.
-                await self.save_cookies(self._http_client.cookies)
-            except Exception as e:
-                logger.warning("Failed to sync refreshed cookies during close: %s", e)
-            finally:
-                await self._http_client.aclose()
-                self._http_client = None
+        Cancellation safety (T7.B4 / audit §7):
+        the entire close sequence is wrapped in ``try/finally`` and the
+        final ``self._http_client.aclose()`` is wrapped in
+        ``asyncio.shield`` — without the shield, a ``CancelledError``
+        arriving during keepalive teardown or the cookie save would
+        skip ``aclose()`` and leak the underlying httpx transport.
+        ``self._http_client = None`` runs in an inner ``finally`` so
+        the instance is consistently marked closed even if the
+        shielded ``aclose`` itself raises.
+        """
+        try:
+            # Stop the keepalive task before tearing down the HTTP client so
+            # the loop can't issue a poke against an already-closed transport.
+            if self._keepalive_task is not None:
+                self._keepalive_task.cancel()
+                await asyncio.gather(self._keepalive_task, return_exceptions=True)
+                self._keepalive_task = None
+
+            if self._http_client:
+                try:
+                    # Single source of truth for the on-close save: takes the
+                    # in-process lock, snapshots, off-loads. Serializes
+                    # naturally with any keepalive save still finishing in a
+                    # worker thread — close() owns the freshest jar and must
+                    # win, not the older snapshot.
+                    await self.save_cookies(self._http_client.cookies)
+                except Exception as e:
+                    logger.warning("Failed to sync refreshed cookies during close: %s", e)
+        finally:
+            if self._http_client:
+                try:
+                    # Shield: cancellation arriving mid-aclose must not leak
+                    # the transport. The shielded aclose runs to completion;
+                    # ``self._http_client = None`` then makes ``is_open``
+                    # return False correctly.
+                    await asyncio.shield(self._http_client.aclose())
+                finally:
+                    self._http_client = None
 
     async def _keepalive_loop(self, interval: float) -> None:
         """Background loop that periodically pokes the identity surface.

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -167,9 +167,26 @@ class NotebookLMClient:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        """Close the client connection."""
+        """Close the client connection.
+
+        Exception arbitration (T7.B4 / audit §25): if the ``async with``
+        body raised, prefer that exception and demote any ``close()``
+        failure to a WARNING log so the original cause isn't masked.
+        If the body succeeded, propagate ``close()`` failures normally.
+        ``BaseException`` is caught so ``CancelledError`` /
+        ``KeyboardInterrupt`` mid-close also flow through arbitration.
+        """
         logger.debug("Closing NotebookLM client")
-        await self._core.close()
+        try:
+            await self._core.close()
+        except BaseException as close_exc:
+            if exc_val is not None:
+                logger.warning(
+                    "Suppressing close() error to preserve original exception: %s",
+                    close_exc,
+                )
+                return
+            raise
 
     @property
     def is_connected(self) -> bool:

--- a/tests/integration/concurrency/test_aexit_exception_masking.py
+++ b/tests/integration/concurrency/test_aexit_exception_masking.py
@@ -141,8 +141,14 @@ async def test_cancel_mid_close_does_not_leak_transport(
     except asyncio.CancelledError:
         pass
 
-    # Give shielded aclose a tick to finalize if it's still in progress.
-    await asyncio.sleep(0.01)
+    # Give the shielded aclose bounded time to finalize. asyncio.shield
+    # raises CancelledError in the outer task immediately, but the inner
+    # aclose() future keeps running — poll for completion rather than
+    # rely on a fixed sleep that could flake on a slow CI runner.
+    for _ in range(50):  # up to ~0.5s total
+        if http_client_ref.is_closed:
+            break
+        await asyncio.sleep(0.01)
 
     assert http_client_ref.is_closed, (
         "transport leaked: cancel during close left the httpx client open"

--- a/tests/integration/concurrency/test_aexit_exception_masking.py
+++ b/tests/integration/concurrency/test_aexit_exception_masking.py
@@ -1,0 +1,149 @@
+"""Regression tests for T7.B4 — `__aexit__` exception arbitration + close-leak repair.
+
+Audit items:
+- §25: `NotebookLMClient.__aexit__` lacked try/except, so a `close()` exception
+  masked the body's exception (and could leave the transport open).
+- §7: `_core.close()` did not shield `aclose()`, so a `CancelledError` arriving
+  mid-close could leak the underlying httpx client.
+
+Coverage:
+1. Body raises + close raises → body exception propagates, close logged at
+   WARNING, transport closed.
+2. Body succeeds + close raises → close exception propagates.
+3. Cancel mid-close (audit §7) → transport still closed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from notebooklm import NotebookLMClient
+
+
+@pytest.fixture(autouse=True)
+def _stub_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make `_core.open()` a no-op that just installs a stub `_http_client`.
+
+    The full `open()` path constructs a real `httpx.AsyncClient` and runs
+    auth refresh; for these arbitration tests we only need a non-None
+    `_http_client` whose `aclose()` we can control.
+    """
+
+    async def _stub_open(self) -> None:
+        if self._http_client is not None:
+            return
+        # Lazy import keeps the test file dep-free at module load.
+        import httpx
+
+        self._http_client = httpx.AsyncClient()
+
+    monkeypatch.setattr("notebooklm._core.ClientCore.open", _stub_open)
+
+
+async def test_body_raises_and_close_raises_body_wins(
+    auth_tokens,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Body's ValueError must propagate; close's RuntimeError logged + suppressed.
+
+    Also asserts the underlying httpx transport is closed even though
+    close() raised.
+    """
+    client = NotebookLMClient(auth_tokens)
+
+    # Capture the http client reference BEFORE entering the cm — successful
+    # close sets `client._core._http_client = None`, so we need our own ref.
+    async with client:
+        http_client_ref = client._core._http_client
+        assert http_client_ref is not None
+
+        # Patch _core.close to raise after closing the transport, so we
+        # exercise the exception-arbitration path. Forward to the original
+        # close so the leak-shield path also runs.
+        original_close = client._core.close
+
+        async def _close_then_raise() -> None:
+            await original_close()
+            raise RuntimeError("synthetic close failure")
+
+        with (
+            patch.object(client._core, "close", _close_then_raise),
+            caplog.at_level(logging.WARNING),
+            pytest.raises(ValueError, match="user error"),
+        ):
+            async with client:
+                # Sanity: client is open here.
+                assert client._core._http_client is not None
+                raise ValueError("user error")
+
+    # 1. The body's ValueError propagated (verified by pytest.raises above).
+    # 2. The close error was logged at WARNING with the suppression text.
+    assert any(
+        "Suppressing close() error to preserve original exception" in rec.message
+        for rec in caplog.records
+    ), f"expected suppression-warning in caplog; got {[r.message for r in caplog.records]}"
+
+    # 3. The transport reference we captured before the second cm exit
+    # should now be closed (the first close in our patched _close_then_raise
+    # ran to completion before the synthetic raise).
+    assert http_client_ref.is_closed, (
+        "underlying httpx transport should be closed even when close() raised"
+    )
+
+
+async def test_body_succeeds_and_close_raises_close_propagates(
+    auth_tokens,
+) -> None:
+    """No body exception → close() failure propagates as the cm exit exception."""
+    client = NotebookLMClient(auth_tokens)
+
+    async def _bad_close() -> None:
+        raise RuntimeError("close failed")
+
+    with (
+        patch.object(client._core, "close", _bad_close),
+        pytest.raises(RuntimeError, match="close failed"),
+    ):
+        async with client:
+            pass
+
+
+async def test_cancel_mid_close_does_not_leak_transport(
+    auth_tokens,
+) -> None:
+    """`asyncio.shield` in `_core.close()` keeps `aclose()` running through cancel.
+
+    Strategy: open a client, capture the http_client ref, then call
+    `_core.close()` from within an outer task and cancel that outer task
+    immediately. Assert the underlying transport ends up closed despite
+    the cancel.
+    """
+    client = NotebookLMClient(auth_tokens)
+    await client._core.open()
+    http_client_ref = client._core._http_client
+    assert http_client_ref is not None
+
+    # Wrap close() in a task so we can cancel it.
+    close_task = asyncio.create_task(client._core.close())
+    # Yield once so close() can start, then cancel.
+    await asyncio.sleep(0)
+    close_task.cancel()
+
+    # The cancel may or may not propagate, depending on whether the shielded
+    # aclose was already in flight. Either way the transport must end up
+    # closed.
+    try:
+        await close_task
+    except asyncio.CancelledError:
+        pass
+
+    # Give shielded aclose a tick to finalize if it's still in progress.
+    await asyncio.sleep(0.01)
+
+    assert http_client_ref.is_closed, (
+        "transport leaked: cancel during close left the httpx client open"
+    )


### PR DESCRIPTION
## Summary

**Tier 7 / Phase 2 / Wave 1 — CRITICAL fix.** Audit items #25 + #7.

Two related close-path bugs land in one PR because they touch the same surface (`_core.close()` and `client.__aexit__`):

### #25 — `__aexit__` exception masking
Pre-fix, `__aexit__` called `await self._core.close()` with no try/except. If both the `async with` body and `close()` raised, the close error propagated as the cm exit exception and masked the original. The user's actual error was lost.

Fix: catch `BaseException` around `close()` and arbitrate — if `exc_val is not None`, demote the close error to a `WARNING` log and preserve the original exception. If the body succeeded, propagate the close error normally.

### #7 — `_core.close()` cancellation leak
Pre-fix, `close()` had inner `try/finally` around the cookie save, but **no shield around `aclose()` itself**. A `CancelledError` mid-close skipped the entire close sequence, leaking the underlying httpx transport.

Fix: wrap the entire close sequence in outer `try/finally`. Finally does `await asyncio.shield(self._http_client.aclose())` so cancellation can't cut the close.

## Test plan

`tests/integration/concurrency/test_aexit_exception_masking.py` — 3 tests:

1. **Body raises ValueError + close raises RuntimeError** → ValueError propagates, close error logged at WARNING with the suppression text, underlying transport closed (asserted via reference held before the cm exit).
2. **Body succeeds + close raises** → close error propagates as cm exit exception (no-prior-exc path regression check).
3. **Cancel mid-close** (audit §7 repro) → transport `is_closed` despite outer cancel; shield wins.

- [x] Pre-commit: `ruff format`, `ruff check`, `mypy src/notebooklm`, full `pytest` (3683 passed, 11 skipped, no new warnings)
- [x] All 3 new tests pass in 0.04s

## Coordination with T7.C2

The close-leak shield this PR adds is the same fix that T7.C2 (later in Wave 2) was specced to do. C2 may end up doc-only or a small addendum once this lands. Captured in the contention map.

## References

- Audit: `.sisyphus/plans/thread-safety-concurrency-audit.md` §25 + §7
- Plan: `.sisyphus/plans/tier-7-thread-safety-concurrency.md` T7.B4
- Phase 2 Wave 1: T7.B1 (#523, merged), **T7.B4 (this)**, T7.B2 (next), T7.B3 (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup to reliably close network connections during async close and cancellations.
  * Prevented cleanup errors from masking exceptions raised by user code; such errors are now logged or propagated appropriately.
  * Ensured no transport/resource leaks occur when close is interrupted by cancellation.

* **Tests**
  * Added integration tests validating close/error-arbitration and cancellation-safe teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/526)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->