### PR TITLE
docs(CONTRIBUTING): cross-link to docs/development.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ suite imports and patches `playwright.sync_api`. The command
 `uv sync --frozen --extra dev` is only the test/lint toolchain; it is not enough
 for `uv run pytest`.
 
+> **Architecture & testing context.** Once installed, read [docs/development.md](docs/development.md) for the layered RPC/Core/Client/CLI design, test-tree layout, concurrency model (file locks), and release workflow before touching `src/notebooklm/`.
+
 ### Code Quality
 
 This project uses **ruff** for linting and formatting:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ suite imports and patches `playwright.sync_api`. The command
 `uv sync --frozen --extra dev` is only the test/lint toolchain; it is not enough
 for `uv run pytest`.
 
-> **Architecture & testing context.** Once installed, read [docs/development.md](docs/development.md) for the layered RPC/Core/Client/CLI design, test-tree layout, concurrency model (file locks), and release workflow before touching `src/notebooklm/`.
+> **Architecture & testing context.** Once installed, read [docs/development.md](docs/development.md) for the layered RPC/Core/Client/CLI design, test-tree layout, and release workflow before touching `src/notebooklm/`.
 
 ### Code Quality
 


### PR DESCRIPTION
## Summary
- Adds an inline pointer from CONTRIBUTING.md → `docs/development.md` so contributors find architecture / test-layout / concurrency / release context once they finish the install.
- Single insertion (2 lines) between the install section and `### Code Quality` — preserves existing structure.

## Task
Wave 3 / T17 of `.sisyphus/plans/documentation-fix.md`.
Audit reference: iter2 finding #13 — *"CONTRIBUTING.md ↔ docs/development.md cross-link gap — neither doc links the other despite overlapping contributor content"* (`.sisyphus/plans/documentation-audit.md`).

The reverse direction (development.md → CONTRIBUTING.md) is owned by **T10** (separate PR), so this PR deliberately touches CONTRIBUTING.md only.

## Test plan
- [x] `rg -e 'docs/development\.md' CONTRIBUTING.md` returns the new line (audit QA pattern).
- [x] `uv run ruff format --check .` → clean.
- [x] `uv run ruff check .` → All checks passed.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` → no issues.
- [x] `uv run pytest --cov=src/notebooklm --cov-fail-under=90` → 3683 passed, 11 skipped, 92.91% coverage.
- [x] F2 doc-only guard: only `CONTRIBUTING.md` in diff.

## Deferred polish findings
None — single-line cross-link, no surrounding cleanup in scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines with a new "Architecture & testing context" section to guide contributors on the project's design patterns, testing structure, concurrency approach, and release procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/528)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->