### PR TITLE
docs(installation): list filelock base dep + fix login flow + timestamp

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+**Last Updated:** 2026-05-14
+
 This is the canonical installation guide for `notebooklm-py`. The README has a quickstart; everything else lives here.
 
 **Contents**
@@ -150,7 +152,7 @@ uv tool install "notebooklm-py[browser]"
 <!-- not mirrored: end-user post-install verify (Persona B); contributors run the test suite instead -->
 ```bash
 notebooklm --version              # → 0.4.x
-notebooklm login                  # opens Chromium; press ENTER after sign-in
+notebooklm login                  # opens Chromium for Google sign-in
 notebooklm auth check --test      # confirms auth roundtrip, with explicit success message
 ```
 
@@ -209,7 +211,7 @@ print(notebooklm.__version__)
    notebooklm auth check --test    # verifies the cookies still authenticate against Google
    ```
 
-**Why no extras:** reduces the install surface to 3 deps (`httpx`, `click`, `rich`); avoids 200+ MB Chromium download in CI images.
+**Why no extras:** reduces the install surface to 4 deps (`httpx`, `click`, `rich`, `filelock`); avoids 200+ MB Chromium download in CI images.
 
 For runtime configuration (env vars, profiles, parallel agents), see [configuration.md#headless-and-ci-environments](configuration.md#headless-and-ci-environments).
 
@@ -276,7 +278,7 @@ Source of truth: `pyproject.toml` `[project.optional-dependencies]`.
 
 | Extra | What it adds | When you need it | pip command | uv (in your project) |
 |---|---|---|---|---|
-| (none) | `httpx`, `click`, `rich` | All RPC operations, all CLI commands except `login`. Suffices when you ship a `storage_state.json`. | `pip install notebooklm-py` | `uv add notebooklm-py` |
+| (none) | `httpx`, `click`, `rich`, `filelock` | All RPC operations, all CLI commands except `login`. Suffices when you ship a `storage_state.json`. | `pip install notebooklm-py` | `uv add notebooklm-py` |
 | `browser` | `playwright>=1.40.0` | `notebooklm login` (interactive). | `pip install "notebooklm-py[browser]"` | `uv add "notebooklm-py[browser]"` |
 | `cookies` | `rookiepy>=0.1.0` | `notebooklm login --browser-cookies <browser>`, `notebooklm auth inspect`. | `pip install "notebooklm-py[cookies]"` | `uv add "notebooklm-py[cookies]"` |
 | `markdown` | `markdownify>=0.14.1` | `notebooklm source fulltext -f markdown`. | `pip install "notebooklm-py[markdown]"` | `uv add "notebooklm-py[markdown]"` |
@@ -309,7 +311,7 @@ Works without `sudo` if you're root or have passwordless sudo. Otherwise `sudo p
 
 <!-- not mirrored: end-user first-login walkthrough; contributors typically reuse an existing storage_state.json -->
 ```bash
-notebooklm login                       # opens Chromium, you sign in to Google, press ENTER
+notebooklm login                       # opens Chromium for Google sign-in
 notebooklm auth check --test           # verify
 ```
 


### PR DESCRIPTION
## Summary

T11 of [`.sisyphus/plans/documentation-fix.md`](../tree/main/.sisyphus/plans/documentation-fix.md). Docs-only — `docs/installation.md` is the only file touched.

- **`filelock` base dep listed**: bumped the "Why no extras" note (Persona D) and the `(none)` row of the extras matrix from `httpx`, `click`, `rich` → `httpx`, `click`, `rich`, `filelock` (and "3 deps" → "4 deps"). Source of truth: `pyproject.toml:29-34` ships `filelock>=3.13,<4` as a base dep.
- **Stale login flow text removed**: dropped the "press ENTER after sign-in" hints from the Persona B verify block (`docs/installation.md:153`) and the first-time login walkthrough (`docs/installation.md:312`). `cli/session.py` no longer waits on stdin after sign-in (verified by grep — no `input(`/Enter prompt remains in the login codepath).
- **`Last Updated` timestamp added**: `**Last Updated:** 2026-05-14` placed at line 3, matching the convention every other doc in `docs/` already uses.

## Task

- Plan: `.sisyphus/plans/documentation-fix.md` (T11)
- Audit: `.sisyphus/plans/documentation-audit.md`

## Test plan

- [x] `rg -e 'filelock' docs/installation.md` — matches in both base-dep locations.
- [x] `! rg -e 'press Enter after sign' -e 'press ENTER' docs/installation.md` — silent.
- [x] `rg -e 'Last Updated' docs/installation.md` — present.
- [x] `uv run ruff format --check .` — 232 files already formatted.
- [x] `uv run ruff check .` — all checks passed.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — no issues in 58 source files.
- [x] `uv run pytest` — 3683 passed, 11 skipped.
- [x] `git diff --name-only main..HEAD` — only `docs/installation.md`.

## Deferred polish findings

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified login instructions to improve setup experience
  * Updated dependency information in the installation guide

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/529)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->