### PR TITLE
docs(stability): bring __all__ surface in line with __init__.py exports

### DIFF
--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,7 +1,7 @@
 # API Stability and Versioning
 
 **Status:** Active
-**Last Updated:** 2026-05-09
+**Last Updated:** 2026-05-14
 
 This document describes the stability guarantees and versioning policy for `notebooklm-py`.
 
@@ -52,6 +52,9 @@ The following are considered **public API** and are subject to stability guarant
 ### Stable (Won't break without major version bump)
 
 ```python
+# Version
+__version__               # Package version string (read-only)
+
 # Client
 NotebookLMClient
 NotebookLMClient.from_storage()
@@ -102,6 +105,23 @@ AuthTokens
 
 # Helpers (cookies extra) - imported from notebooklm.auth
 notebooklm.auth.convert_rookiepy_cookies_to_storage_state  # requires `pip install "notebooklm-py[cookies]"` — see docs/installation.md#optional-extras-matrix
+```
+
+### Internal helpers exported for compatibility
+
+The following symbols appear in `notebooklm/__all__` so that downstream code can
+import them via `from notebooklm import ...`, but they are **not** covered by
+the stability guarantee above. They support narrow integration use cases
+(typed exception handling, warning filters, deprecated-name shims) and may be
+renamed, narrowed, or removed in a future minor release. Prefer the stable
+surface when possible.
+
+```python
+CitedSourceSelection      # Chat citation payload — internal shape, exposed for typing
+AuthExtractionError       # Specialized AuthError raised by browser-based login
+NotebookLimitError        # Raised when account notebook quota is exhausted
+UnknownTypeWarning        # Warning category emitted when .kind falls back to UNKNOWN
+StudioContentType         # ⚠️ Deprecated — use ArtifactType (see "Currently Deprecated" below)
 ```
 
 ### Internal (May change without notice)


### PR DESCRIPTION
## Summary

T12 of [documentation-fix plan](https://github.com/teng-lin/notebooklm-py/blob/main/.sisyphus/plans/documentation-fix.md). The "Public API Surface" listing in `docs/stability.md` had drifted from `src/notebooklm/__init__.py:137-225` — `__version__` was missing entirely, and five other exports (`CitedSourceSelection`, `AuthExtractionError`, `NotebookLimitError`, `UnknownTypeWarning`, deprecated `StudioContentType`) were neither in the stable list nor explicitly explained.

Per the parent plan's metis-recorded decision (auto-promoting all of them would over-commit on the stability promise):
- `__version__` joins the **Stable** surface
- the other five live in a new **"Internal helpers exported for compatibility"** subsection — they remain importable from `notebooklm` for narrow integration use cases (typed exception handling, warning filters, deprecated-name shims) but are not covered by the stability guarantee
- `Last Updated` bumped to 2026-05-14

## Test plan

- [x] `rg -e '__version__' docs/stability.md` — present
- [x] `rg -e 'Internal helpers' -e 'compatibility' docs/stability.md` — present
- [x] `uv run ruff format --check .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest` — 3683 passed, 11 skipped

## Constraints honored

- Only touches `docs/stability.md`
- No additions to `notebooklm/__all__` (this PR documents what already IS exported)
- No `src/`, `tests/`, `pyproject.toml`, `uv.lock`, or `.github/` edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)