### PR TITLE
docs(releasing): add missing pre-release scripts to checklist

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release Checklist
 
 **Status:** Active
-**Last Updated:** 2026-05-09
+**Last Updated:** 2026-05-14
 
 Checklist for releasing a new version of `notebooklm-py`.
 
@@ -138,6 +138,11 @@ Proceed with release preparation?
   uv run pre-commit run --all-files && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest
   ```
 - [ ] Ensure CI runs the same lint gate (`pre-commit run --all-files`) as local release prep
+- [ ] Run documentation drift checks (mirror the CI gates in `.github/workflows/test.yml`):
+  ```bash
+  uv run python scripts/check_ci_install_parity.py
+  uv run python scripts/check_claude_md_freshness.py
+  ```
 - [ ] Fix any issues before proceeding
 
 ### Commit


### PR DESCRIPTION
## Summary
- Add `scripts/check_ci_install_parity.py` and `scripts/check_claude_md_freshness.py` to the **Pre-Commit Checks** section of the release checklist so local release prep mirrors the CI gates already enforced in `.github/workflows/test.yml`.
- Bump `Last Updated` to 2026-05-14.

## Task
T13 of [`.sisyphus/plans/documentation-fix.md`](https://github.com/teng-lin/notebooklm-py/tree/main/.sisyphus/plans/documentation-fix.md) — iter3 STALE finding from the multi-lens documentation audit: the pre-release checklist omitted these mandatory drift checks even though both already run in CI.

The audit located the gap at "line 105" of `docs/releasing.md`. That anchor has drifted since the audit was captured; the semantically correct home for these checks is the **Pre-Commit Checks** section (the existing pre-release verification step), placed between the lint-gate bullet and the "Fix any issues" bullet so the failure-then-fix flow stays linear.

## Why these belong in the local checklist
Both scripts run unconditionally in `test.yml`:

```yaml
- run: uv run python scripts/check_ci_install_parity.py
- run: uv run python scripts/check_claude_md_freshness.py
```

Neither is wired into `.pre-commit-config.yaml`, so the existing `uv run pre-commit run --all-files` bullet does NOT cover them. Without an explicit local invocation, doc drift caught by CI surfaces only after a release PR is opened — wasted round-trip.

## Test plan
- [x] `uv run ruff format --check .` — passes
- [x] `uv run ruff check .` — passes
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — passes
- [x] `uv run pytest` — 3683 passed, 11 skipped
- [x] Plan QA: `rg -e 'check_ci_install_parity' -e 'check_claude_md_freshness' docs/releasing.md` — both lines present (143, 144)
- [x] Docs-only diff: 1 file changed, 6 insertions, 1 deletion (no `src/`, `tests/`, `pyproject.toml`, `uv.lock`, `.github/` changes)

## Deferred polish findings
none