### PR TITLE
docs(rpc-development): document non-transient ERROR triage

### DIFF
--- a/docs/rpc-development.md
+++ b/docs/rpc-development.md
@@ -1,7 +1,7 @@
 # RPC Development Guide
 
 **Status:** Active
-**Last Updated:** 2026-05-13
+**Last Updated:** 2026-05-14
 
 This guide covers everything about NotebookLM's RPC protocol: capturing calls, debugging issues, and implementing new methods.
 
@@ -480,11 +480,17 @@ async def validate_rpc_call(rpc_id: str, params: list, expected_action: str):
 ## RPC Health Check Triage Policy
 
 The `rpc-health.yml` workflow runs daily (07:00 UTC) and opens an issue on any
-detected RPC ID mismatch or auth failure:
+detected RPC ID mismatch, auth failure, or non-transient RPC error:
 
-- **RPC ID mismatch** issues: labeled `bug, rpc-breakage, automated`.
-- **Auth failure** issues: labeled `bug, automated` (no `rpc-breakage` label —
-  auth is an operational concern, not a protocol break).
+- **RPC ID mismatch** issues (exit code 1): labeled `bug, rpc-breakage, automated`.
+- **Auth failure** issues (exit code 2): labeled `bug, automated` (no `rpc-breakage`
+  label — auth is an operational concern, not a protocol break).
+- **Non-transient ERROR detected** issues (exit code 3): labeled `rpc-error, bug,
+  automated`. Opened when `check_rpc_health.py` surfaces failures that survive
+  the rate-limit / `RESOURCE_EXHAUSTED` filter (timeouts, parse failures,
+  unexpected HTTP errors). The issue body lists the affected method IDs
+  extracted from the report, so triage can start without re-running the check.
+  See `.github/workflows/rpc-health.yml:76-109` for the body-assembly step.
 
 Routing:
 


### PR DESCRIPTION
## Summary

- Add the third issue type opened by `rpc-health.yml` — **Non-transient ERROR detected** (exit code 3, labels: `rpc-error, bug, automated`) — to the triage policy list at `docs/rpc-development.md:480-487`, alongside the existing RPC ID mismatch (exit 1) and auth-failure (exit 2) entries.
- Cross-references the workflow body-assembly step at `.github/workflows/rpc-health.yml:76-109` so future readers can trace the issue body back to its source.
- Bumps `Last Updated:` to 2026-05-14.

## Task

T15 of `.sisyphus/plans/documentation-fix.md` — close the gap between the daily RPC health workflow (three exit-code → issue paths) and the doc that only listed two of them.

## Test plan

- [x] `rg -e 'Non-transient ERROR detected' docs/rpc-development.md` matches (acceptance from plan).
- [x] `uv run ruff format --check .` clean.
- [x] `uv run ruff check .` clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean.
- [x] `uv run pytest` — 3683 passed, 11 skipped.
- [x] `git diff --name-only` shows `docs/rpc-development.md` only (docs-only guardrail).

## Deferred polish findings

None.