### PR TITLE
docs(cli-reference): fix breaking examples + add T3.D/T5.C/T5.G flags

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -563,7 +563,7 @@ notebooklm auth check --json
 **Checks performed:**
 1. Storage file exists and is readable
 2. JSON structure is valid
-3. Required cookies (SID) are present
+3. Required cookies (`SID` + `__Secure-1PSIDTS`) are present (the Tier 1 `MINIMUM_REQUIRED_COOKIES` set; either `OSID` or the `APISID`+`SAPISID` pair is also needed for the secondary-binding check — see [auth-keepalive.md](auth-keepalive.md) §3.5)
 4. Cookie domains are correct (.google.com vs regional)
 5. (With `--test`) Token fetch succeeds
 
@@ -692,6 +692,20 @@ For `-s` and `-a` the active notebook is resolved with the same precedence the c
 
 **Print-only by design:** the command never writes to your shell config; you decide where the script lands. This keeps the install path discoverable and avoids surprising shutdowns of existing completion setups.
 
+### Source: `add` — `--follow-symlinks` security gate
+
+File-source uploads reject symlinks by default. If the path you pass (or any ancestor directory) is a symbolic link, `source add` refuses the upload rather than silently following it — a workspace symlink could otherwise exfiltrate the file it points at (e.g. `~/Downloads/foo.pdf -> /etc/passwd`). Pass `--follow-symlinks` to opt in explicitly.
+
+```bash
+# Default — symlink rejected with: "Path is a symlink; pass --follow-symlinks to follow it explicitly."
+notebooklm source add ./link-to-doc.pdf --type file
+
+# Opt-in: resolve the symlink, then upload the resolved target
+notebooklm source add ./link-to-doc.pdf --type file --follow-symlinks
+```
+
+The same gate applies on the explicit `--type file` path (no auto-detect), so typing the source type as `file` does not bypass the check.
+
 ### Source: `add` — `--mime-type` deprecation
 
 The `--mime-type` flag on `notebooklm source add` (file-source path) is a
@@ -736,15 +750,17 @@ notebooklm source add-research [query] [OPTIONS]
 - `--timeout SECONDS` - Retry budget for `--import-all` when the IMPORT_RESEARCH RPC times out (default: 1800). Mirrors `research wait --timeout`. Has no effect without `--import-all`.
 - `--prompt-file PATH` - Read query from a file (or `-` for stdin) instead of the positional argument
 
+> **Note:** `--mode deep` is only supported with `--from web` (the default). Combining `--mode deep --from drive` is rejected by the backend with `ValidationError("Deep Research only supports Web sources.")` — for Drive, stick with `--mode fast`.
+
 **Examples:**
 ```bash
 # Fast web research (blocking)
 notebooklm source add-research "Quantum computing basics"
 
-# Deep research into Google Drive
-notebooklm source add-research "Project Alpha" --from drive --mode deep
+# Drive research (fast mode only — Drive does not support --mode deep)
+notebooklm source add-research "Project Alpha" --from drive
 
-# Non-blocking deep research for agent workflows
+# Non-blocking deep research for agent workflows (web only — see note above)
 notebooklm source add-research "AI safety papers" --mode deep --no-wait
 
 # Import only cited sources for tighter relevance


### PR DESCRIPTION
## Summary

Closes the residual T2 gaps in `docs/cli-reference.md` from the [`documentation-fix` Phase 1 plan](.sisyphus/plans/documentation-fix/phase-1.md), targeting the BREAKING and MISSING items in [`documentation-audit.md`](.sisyphus/plans/documentation-audit.md).

This PR is intentionally small. PR #525 (eab6ec1) landed a full CLI-surface sync ~minutes before this PR was branched, and resolved most T2 acceptance items already. This PR adds only the items still outstanding after that sync.

## What's in this PR

1. **BREAKING #6 — `source add-research --from drive --mode deep` example was invalid.** The backend rejects this combination with `ValidationError("Deep Research only supports Web sources.")` ([`_research.py:149-154`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/_research.py#L149-L154)). Replaced the example block and added a Note explaining the web-only constraint on `--mode deep`.

2. **MISSING (consensus) — `auth check` minimum cookies.** "Checks performed" said only `SID` is required. Updated bullet 3 to reflect the actual Tier-1 set `MINIMUM_REQUIRED_COOKIES = {"SID", "__Secure-1PSIDTS"}` ([`auth.py:118-127`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/auth.py#L118-L127)) and cross-link to `auth-keepalive.md §3.5` for the secondary-binding (`OSID` or `APISID`+`SAPISID`) requirement.

3. **MISSING (T5.C) — `--follow-symlinks` security rationale.** The flag is in the quick-ref table after #525 but had no dedicated section. Added a "Source: add — `--follow-symlinks` security gate" subsection covering the exfiltration-vector rationale (mirrors the option help at [`cli/source.py:533-542`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/cli/source.py#L533-L542)) and noting the gate fires on both auto-detected and explicit `--type file` paths ([`cli/source.py:637-641`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/cli/source.py#L637-L641)).

## Already resolved by #525 (no doc churn needed in this PR)

| Audit item | Resolved by |
|---|---|
| BREAKING #3 — `artifact export` example missing `--title` | #525 |
| BREAKING #4 — `artifact suggestions` quick-ref listed nonexistent `-s/--source` | #525 |
| BREAKING #7 — "all generate commands" claim excluded `mind-map` | #525 |
| MISSING — `--include-domains` on login | #525 |
| MISSING (T3.D) — `notebooklm use` fail-closed behavior paragraph | #525 |

## Note on BREAKING #5 (audit's `source wait --interval` claim)

The audit listed `source wait --interval` as a "nonexistent flag" but it's actually fully implemented via the shared [`wait_polling_options`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/cli/options.py#L215-L240) decorator at [`cli/source.py:1377`](https://github.com/teng-lin/notebooklm-py/blob/main/src/notebooklm/cli/source.py#L1377). PR #525 correctly documents `--interval` for `source wait` (line 152 quick-ref). The audit's cited line range `cli/source.py:1052-1067` actually points at `source add-research`, not `source wait` — appears to be a misread in the audit. No change to the docs is warranted here; the audit's QA assertion `! uv run notebooklm source wait --help | grep -q "--interval"` cannot pass without lying about the live CLI surface.

## Test plan

- [x] `uv run ruff format --check .` (232 files already formatted)
- [x] `uv run ruff check .` (all checks passed)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (no issues found, 58 files)
- [x] `uv run pytest` (3680 passed, 14 skipped, 1 unrelated warning)
- [x] `uv run notebooklm artifact export --help | grep -q -- "--title"` → exits 0
- [x] `rg -e 'artifact suggestions.*-s ' docs/cli-reference.md` → no match
- [x] `rg -e 'follow-symlinks' -e 'include-domains' docs/cli-reference.md` → matches found
- [x] `rg -e '__Secure-1PSIDTS' docs/cli-reference.md` → match found (auth check + auth refresh cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)