### PR TITLE
feat(tests): generation notebook setup script + tier-8 follow-up issue (T8.A0)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -205,12 +205,60 @@ uv run pytest tests/integration/
 
 # Run only CLI VCR tests
 uv run pytest tests/integration/cli_vcr/
-
-# Record new cassettes (sensitive data auto-scrubbed)
-NOTEBOOKLM_VCR_RECORD=1 uv run pytest tests/integration/test_vcr_*.py -v
 ```
 
 Sensitive data (cookies, tokens, emails) is automatically scrubbed from cassettes.
+
+### Cassette recording
+
+Maintainers re-record cassettes against the live API when an RPC payload
+shape changes. Recording is opt-in (`NOTEBOOKLM_VCR_RECORD=1`) and requires
+a valid `notebooklm login` session.
+
+Two notebook env vars steer which notebook the recording session targets.
+**Neither UUID is committed** — both are per-maintainer secrets (notebook IDs
+are linkable to a Google account):
+
+| Env var | Used by | Notebook role |
+|---------|---------|---------------|
+| `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID` | read-heavy cassettes (`list`, `download`, `get`) | A maintainer-owned notebook pre-populated with sources + artifacts. Tests only READ from it. |
+| `NOTEBOOKLM_GENERATION_NOTEBOOK_ID` | mutation/generation cassettes (`add source`, `generate`, `delete`) | A **separate** maintainer-owned notebook used only for destructive/generation flows, so the read-only notebook stays pristine. |
+
+#### One-time setup — generation notebook
+
+Run the setup script once per Google account that records cassettes:
+
+```bash
+uv run python tests/scripts/setup-generation-notebook.py
+```
+
+The script is idempotent: it reuses an existing notebook titled
+`VCR Generation Notebook (Tier 8)` if one already exists, otherwise creates it.
+It prints the notebook UUID and an `export` line. Copy the export line into
+your maintainer environment (e.g. `~/.zshrc` or a profile-specific `.env`
+file you do NOT commit):
+
+```bash
+export NOTEBOOKLM_GENERATION_NOTEBOOK_ID=<printed-uuid>
+```
+
+The script is a manual maintainer helper — CI never runs it.
+
+#### Recording a cassette
+
+```bash
+# Re-record (or record-new) cassettes; sensitive data auto-scrubbed
+NOTEBOOKLM_VCR_RECORD=1 uv run pytest tests/integration/test_vcr_*.py -v
+```
+
+The scrubbing pipeline (`tests/vcr_config.py`) redacts cookies, CSRF tokens,
+emails, and other sensitive patterns before the cassette hits disk. Verify
+the result with the cassette guard before committing:
+
+```bash
+# Current guard (a Python replacement is landing in the Tier 8 arc)
+tests/check_cassettes_clean.sh
+```
 
 ### E2E Fixtures
 

--- a/tests/scripts/setup-generation-notebook.py
+++ b/tests/scripts/setup-generation-notebook.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""One-time maintainer setup for the Tier 8 VCR generation notebook.
+
+This is a **manual, local-only** helper. It is NOT run by CI and must NOT be
+called from any test or workflow. Run it once per Google account that records
+VCR cassettes for mutation/generation endpoints:
+
+    uv run python tests/scripts/setup-generation-notebook.py
+
+The script is idempotent: if a notebook titled
+"VCR Generation Notebook (Tier 8)" already exists on the authenticated
+account, its UUID is reported instead of creating a duplicate.
+
+After running, export the printed UUID in your maintainer environment (e.g.
+`~/.zshrc` or a per-profile env file):
+
+    export NOTEBOOKLM_GENERATION_NOTEBOOK_ID=<printed-uuid>
+
+The UUID is per-maintainer and MUST NOT be committed to the repository —
+notebook IDs are linkable to a Google account and leak account identity. See
+`docs/development.md` -> "Cassette recording" for the full env-var workflow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from notebooklm.client import NotebookLMClient
+
+GENERATION_NOTEBOOK_TITLE = "VCR Generation Notebook (Tier 8)"
+
+
+async def main() -> int:
+    """Ensure a generation notebook exists; print its UUID and export line."""
+    async with await NotebookLMClient.from_storage() as client:
+        print(f"Checking for existing notebook titled {GENERATION_NOTEBOOK_TITLE!r}...")
+        notebooks = await client.notebooks.list()
+        existing = next(
+            (nb for nb in notebooks if nb.title == GENERATION_NOTEBOOK_TITLE),
+            None,
+        )
+
+        if existing is not None:
+            notebook_id = existing.id
+            print(f"Found existing notebook: {notebook_id}")
+        else:
+            print(f"Creating notebook {GENERATION_NOTEBOOK_TITLE!r}...")
+            created = await client.notebooks.create(GENERATION_NOTEBOOK_TITLE)
+            notebook_id = created.id
+            print(f"Created notebook: {notebook_id}")
+
+    separator = "=" * 60
+    print()
+    print(separator)
+    print("Generation notebook is ready.")
+    print(f"  Notebook ID: {notebook_id}")
+    print(separator)
+    print("Export this in your maintainer environment (NOT in the repo):")
+    print()
+    print(f"  export NOTEBOOKLM_GENERATION_NOTEBOOK_ID={notebook_id}")
+    print()
+    print("See docs/development.md -> 'Cassette recording' for usage.")
+    print(separator)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        sys.exit(130)
+    except Exception as exc:  # noqa: BLE001 — top-level CLI surface
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Tier 8 RPC/VCR remediation — phase 1 / wave 1 foundation work. Establishes the maintainer plumbing every later phase relies on:

- **New script** `tests/scripts/setup-generation-notebook.py` — idempotent helper that creates (or reuses) a notebook titled "VCR Generation Notebook (Tier 8)" and prints its UUID + the `export NOTEBOOKLM_GENERATION_NOTEBOOK_ID=...` line for the maintainer's local env. Manual / local-only; CI never runs it.
- **New docs section** in `docs/development.md` -> "Cassette recording" with an env-var table covering both `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID` (read-heavy cassettes) and `NOTEBOOKLM_GENERATION_NOTEBOOK_ID` (mutation/generation cassettes), plus the one-time setup + recording workflow.
- **Tracker issue filed** — #542 "Nightly cassette drift CI (Tier 8 follow-up)", labeled `tier-8-followup`, enumerating audit Strategic item 8 requirements without scoping a design.

## Task

`/execute-task` ship of `.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-1.md#T8.A0`. Unblocks T8.E3–E7, T8.C1–C6, T8.D8–D10.

## Why no UUIDs in the diff

NotebookLM notebook IDs are linkable to a Google account — committing one leaks maintainer identity. The script prints the UUID at runtime; each maintainer copy-pastes the `export` line into their own shell config or per-profile `.env`. Documented in both the script docstring and the new docs section.

## Test plan

- [x] `uv run ruff format .` — 234 files unchanged
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues, 58 files
- [x] `uv run pytest tests/unit` — 3059 passed, 7 skipped
- [x] `gh label list --search tier-8-followup` — label already exists (no-op creation)
- [x] Issue #542 filed with label `tier-8-followup`
- [ ] After merge: run the script locally; export the UUID; verify a mutation cassette records cleanly (deferred to phase-2 PRs that consume the env var)

## Out of scope (per task spec)

- Implementing the nightly drift CI — that's the deferred follow-up tracked by #542.
- Re-recording any cassettes.
- Touching `tests/cassette_patterns.py` / scrub patterns (T8.A4 / T8.A6a/b).
- Replacing `check_cassettes_clean.sh` with a Python tool (T8.A5a).

## Deferred polish findings

None — the deliverables are small (one 76-line script + a doc section) and the self-review surfaced no critical or important findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded VCR testing documentation with comprehensive "Cassette recording" section, including opt-in re-recording flow, environment variable mappings, and detailed notebook setup instructions.

* **Tests**
  * Added setup script to initialize and configure test notebook environment for cassette recording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/543)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->