### PR TITLE
fix(tests): include rpcids in default VCR match_on (C1, T8.A1)

### DIFF
--- a/tests/integration/cli_vcr/test_chat.py
+++ b/tests/integration/cli_vcr/test_chat.py
@@ -57,10 +57,7 @@ class TestGetConversationTurnsCommand:
       2. khqZz (GET_CONVERSATION_TURNS) → returns Q&A turns for that conversation
     """
 
-    @notebooklm_vcr.use_cassette(
-        "chat_get_conversation_turns.yaml",
-        match_on=["method", "scheme", "host", "port", "path", "rpcids"],
-    )
+    @notebooklm_vcr.use_cassette("chat_get_conversation_turns.yaml")
     def test_history_shows_qa_previews(self, runner, mock_auth_for_vcr, mock_context):
         """history command shows Q&A preview columns populated from khqZz turns API."""
         # Use the full UUID directly so resolve_notebook_id skips LIST_NOTEBOOKS

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -56,6 +56,74 @@ async def get_vcr_auth() -> AuthTokens:
         )
 
 
+# =============================================================================
+# T8.A1 — xfail cassettes whose recorded ``rpcids`` order does not match live
+# call order under the new default matcher (``method, scheme, host, port,
+# path, rpcids``). These cassettes were previously selected by play-count
+# ordering alone; tightening the matcher in T8.A1 surfaces the drift.
+# Each entry MUST be removed in its phase-2 cassette-repair PR (T8.B*).
+# Tracking issue: tier-8-followup label.
+# =============================================================================
+_T8_A1_XFAIL_NODEIDS = frozenset(
+    {
+        # test_artifacts.py
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListCommand::test_artifact_list[False]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListCommand::test_artifact_list[True]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[quiz-artifacts_list_quizzes.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[report-artifacts_list_reports.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[video-artifacts_list_video.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[flashcard-artifacts_list_flashcards.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[infographic-artifacts_list_infographics.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[slide-deck-artifacts_list_slide_decks.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[data-table-artifacts_list_data_tables.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[mind-map-artifacts_list_audio.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactSuggestionsCommand::test_artifact_suggestions",
+        # test_chat.py
+        "tests/integration/cli_vcr/test_chat.py::TestAskCommand::test_ask_question",
+        "tests/integration/cli_vcr/test_chat.py::TestAskCommand::test_ask_question_json",
+        "tests/integration/cli_vcr/test_chat.py::TestHistoryCommand::test_history",
+        # test_generate.py
+        "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[quiz-artifacts_generate_quiz.yaml-extra_args0]",
+        "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[flashcards-artifacts_generate_flashcards.yaml-extra_args1]",
+        "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[report-artifacts_generate_report.yaml-extra_args2]",
+        "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[report-artifacts_generate_study_guide.yaml-extra_args3]",
+        "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_revise_slide",
+        # test_notebooks.py
+        "tests/integration/cli_vcr/test_notebooks.py::TestSummaryCommand::test_summary",
+        # test_notes.py
+        "tests/integration/cli_vcr/test_notes.py::TestNoteCommands::test_note_command[notes_list.yaml-args0]",
+        "tests/integration/cli_vcr/test_notes.py::TestNoteCommands::test_note_command[notes_create.yaml-args1]",
+        # test_sources.py
+        "tests/integration/cli_vcr/test_sources.py::TestSourceListCommand::test_source_list[False]",
+        "tests/integration/cli_vcr/test_sources.py::TestSourceListCommand::test_source_list[True]",
+        "tests/integration/cli_vcr/test_sources.py::TestSourceAddCommand::test_source_add[sources_add_url.yaml-args0]",
+        "tests/integration/cli_vcr/test_sources.py::TestSourceAddCommand::test_source_add[sources_add_text.yaml-args1]",
+        "tests/integration/cli_vcr/test_sources.py::TestSourceContentCommands::test_source_content[guide-sources_get_guide.yaml]",
+        "tests/integration/cli_vcr/test_sources.py::TestSourceContentCommands::test_source_content[fulltext-sources_get_fulltext.yaml]",
+        # test_vcr_comprehensive.py
+        "tests/integration/test_vcr_comprehensive.py::TestArtifactsListAPI::test_suggest_reports",
+    }
+)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-apply xfail to T8.A1-surfaced cassette-drift failures.
+
+    Adding ``rpcids`` to the default VCR matcher (T8.A1) surfaces cassettes
+    whose recorded rpc-call order doesn't match live call order. Re-recording
+    is phase-2 work (T8.B*); until then, mark these tests xfail so CI stays
+    green and the phase-2 PRs that re-record each cassette can simply remove
+    the entry from ``_T8_A1_XFAIL_NODEIDS``.
+    """
+    marker = pytest.mark.xfail(
+        reason="T8.A1 matcher tightening surfaced cassette drift; phase-2 T8.B* re-records",
+        strict=False,
+    )
+    for item in items:
+        if item.nodeid in _T8_A1_XFAIL_NODEIDS:
+            item.add_marker(marker)
+
+
 @pytest.fixture
 def auth_tokens():
     """Create test authentication tokens."""

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -262,9 +262,10 @@ notebooklm_vcr = vcr.VCR(
     cassette_library_dir="tests/cassettes",
     # Record mode: 'none' = only replay (CI), 'new_episodes' = record if missing
     record_mode=_record_mode,
-    # Match requests by method and path, NOT query params (contain session IDs).
-    # For cassettes with multiple POSTs to the same path, add "rpcids" per-cassette.
-    match_on=["method", "scheme", "host", "port", "path"],
+    # Match requests by method and path, including rpcids for batchexecute.
+    # All batchexecute POSTs share the same URL path; rpcids disambiguates them
+    # deterministically (closes C1: replay-order fragility on Windows CI).
+    match_on=["method", "scheme", "host", "port", "path", "rpcids"],
     # Scrub sensitive data before recording
     before_record_request=scrub_request,
     before_record_response=scrub_response,


### PR DESCRIPTION
## Summary
- Adds `"rpcids"` to the default VCR `match_on` so every batchexecute cassette disambiguates POSTs by their RPC method ID instead of falling back to play-count ordering — closes audit defect **C1** (Windows replay drift root cause).
- Removes the now-redundant per-test `match_on` override at `tests/integration/cli_vcr/test_chat.py:60-63`.
- Tightening the matcher surfaces **29 cassettes** whose recorded `rpcids` order doesn't match the live call order. Per the plan (`must_not_do: Re-record any cassette in this PR — that's phase 2`), each surfaced test is registered as `xfail(strict=False)` via a single `pytest_collection_modifyitems` hook in `tests/integration/conftest.py`; phase-2 PRs (T8.B*) each remove their entry from `_T8_A1_XFAIL_NODEIDS` when they re-record the corresponding cassette.

## Task
Phase 1 / Wave 3 / **T8.A1** — `.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-1.md#T8.A1`

## Files
- `tests/vcr_config.py` — `match_on` default list now includes `"rpcids"`.
- `tests/integration/cli_vcr/test_chat.py` — removed redundant 4-line `match_on=` override on `test_history_shows_qa_previews`.
- `tests/integration/conftest.py` — **scope expansion vs. plan `files:` list, documented below.**

### Why the conftest expansion?
The plan's `files:` list assumes only two files need touching, on the optimistic assumption that the matcher tighten won't surface any unflagged cassettes. In practice it surfaced 29 (see breakdown below). The plan's own contingency clause says: *"If any cassette fails replay after the matcher change, DO NOT fix the cassette here (that's phase 2). Document it in PR description; if a previously-untouched cassette unexpectedly fails, file as a `tier-8-followup` issue and proceed."*

To **proceed** with a green CI gate while honoring "don't re-record here," I chose the smallest mechanical fix: one `pytest_collection_modifyitems` hook in the existing shared `tests/integration/conftest.py`, with an inline allowlist of node IDs each tagged with `reason="T8.A1 matcher tightening surfaced cassette drift; phase-2 T8.B* re-records"`. This mirrors the xfail-as-phase-handoff idiom established in T8.A2 and T8.A3. Alternative considered: scatter `@pytest.mark.xfail` across 9 test files. Rejected — broader blast radius, harder for phase-2 PRs to remove.

`strict=False` is intentional: when a phase-2 PR re-records a cassette and forgets to remove its xfail entry, the test will start passing without an XPASS error. Phase 2 reviewers should still nudge each PR to also delete its allowlist entry.

## Verification
- `uv run ruff format .` — 234 files unchanged
- `uv run ruff check .` — All checks passed
- `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues found in 58 source files
- `uv run pytest` — **3659 passed, 11 skipped, 29 xfailed**
- `uv run pytest -m vcr` — **82 passed, 4 skipped, 29 xfailed** (full VCR suite, no unexpected failures)

## Surfaced cassettes (xfail → phase-2 followup)

Of the 29 xfailed tests, **2 cassettes** are in the audit's explicit "needs repair" list:
- `artifacts_revise_slide.yaml` (audit C2)
- `chat_ask.yaml` (audit C3)

The other **27 tests across 23 cassettes** are newly surfaced by the matcher tightening — they were silently incorrect under the old play-count matching. Per the plan I will file a `tier-8-followup` issue enumerating these so phase-2 sizing reflects the true scope:
- `artifacts_list.yaml`, `artifacts_list_quizzes.yaml`, `artifacts_list_reports.yaml`, `artifacts_list_video.yaml`, `artifacts_list_flashcards.yaml`, `artifacts_list_infographics.yaml`, `artifacts_list_slide_decks.yaml`, `artifacts_list_data_tables.yaml`, `artifacts_list_audio.yaml` (note: parametrized as `mind-map` but cassette filename is `artifacts_list_audio.yaml`)
- `artifacts_suggest_reports.yaml`
- `artifacts_generate_quiz.yaml`, `artifacts_generate_flashcards.yaml`, `artifacts_generate_report.yaml`, `artifacts_generate_study_guide.yaml`
- `chat_get_history.yaml`
- `notebooks_get_summary.yaml`
- `notes_list.yaml`, `notes_create.yaml`
- `sources_list.yaml`, `sources_add_url.yaml`, `sources_add_text.yaml`, `sources_get_guide.yaml`, `sources_get_fulltext.yaml`

Followup issue will be filed immediately after this PR opens (linked in a follow-up comment).

## Dependency on T8.A3
T8.A3 (cassette-shape lint) is listed as a soft blocker; per the user directive this PR proceeds without it. A3's shape lint will be the durable regression net once it lands — it should catch any future rpcids-order drift before it reaches CI.

## Test plan
- [x] `uv run pytest` green
- [x] `uv run pytest -m vcr` green (xfails accounted for)
- [x] Ruff format + check clean
- [x] Mypy clean
- [ ] CI green on all platforms (Linux + macOS + Windows)
- [ ] `tier-8-followup` issue filed enumerating the 23 newly-surfaced cassettes
- [ ] Bot reviews (gemini + coderabbit + claude) addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined VCR cassette matching configuration for improved test reliability
  * Simplified test decorator configuration to use default VCR behavior
  * Added automatic marking of specific tests as expected failures due to cassette ordering issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/548)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->