### PR TITLE
feat(tests): f.req body matcher for streaming chat (T8.A2, mitigates C3)

### DIFF
--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -531,7 +531,21 @@ class TestChatAPI:
 
     @pytest.mark.vcr
     @pytest.mark.asyncio
-    @notebooklm_vcr.use_cassette("chat_ask.yaml")
+    @pytest.mark.xfail(
+        reason="T8.B2 re-record: chat_ask.yaml predates the f.req body matcher "
+        "and carries a stale 5-param shape (C3). This xfail must be removed in "
+        "the same PR that re-records chat_ask.yaml against the freq matcher.",
+        strict=False,
+    )
+    @notebooklm_vcr.use_cassette(
+        "chat_ask.yaml",
+        # Opt this streaming-chat test in to the ``freq`` body matcher (T8.A2).
+        # The matcher decodes the form-encoded ``f.req`` payload so two
+        # otherwise-identical POSTs (same method/scheme/host/port/path) can be
+        # disambiguated by their param shape. ``freq`` is opt-in per-cassette
+        # because most endpoints do not send ``f.req``.
+        match_on=["method", "scheme", "host", "port", "path", "freq"],
+    )
     async def test_ask(self):
         """Ask a question."""
         async with vcr_client() as client:

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -1,0 +1,147 @@
+"""Unit tests for ``tests/vcr_config.py`` custom VCR matchers.
+
+The ``_freq_body_matcher`` decodes the form-encoded ``f.req`` payload that
+streaming endpoints (notably streaming chat) use to disambiguate otherwise
+identical POSTs. See the matcher's docstring for the full match-rule rationale.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+# Load ``tests/vcr_config.py`` via ``importlib`` rather than mutating
+# ``sys.path``. The ``tests`` directory is not a package (no ``__init__.py``),
+# so a plain ``from tests.vcr_config import _freq_body_matcher`` fails; a
+# ``sys.path`` insertion would work but is module-load-time side-effectful and
+# would silently shadow any future top-level module named ``vcr_config``.
+# Loading by file path keeps the dependency localized to this test module
+# (mirrors the pattern used in ``tests/unit/test_cookie_redaction.py``).
+_vcr_config_path = Path(__file__).resolve().parent.parent / "vcr_config.py"
+_spec = importlib.util.spec_from_file_location("tests_vcr_config", _vcr_config_path)
+assert _spec is not None and _spec.loader is not None, (
+    f"Could not load tests/vcr_config.py from {_vcr_config_path}"
+)
+_vcr_config = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_vcr_config)
+_freq_body_matcher: Callable[[Any, Any], bool] = _vcr_config._freq_body_matcher
+
+
+class _StubRequest:
+    """Minimal stand-in for a ``vcr.request.Request`` with just the ``body`` attr.
+
+    The matcher reads only ``request.body``, so we don't need any of the other
+    request plumbing for these unit tests.
+    """
+
+    def __init__(self, body: Any) -> None:
+        self.body = body
+
+
+def _build_freq_body(params: list[Any]) -> str:
+    """Build the same ``application/x-www-form-urlencoded`` body shape the
+    NotebookLM streaming-chat endpoint sends.
+
+    The wire format is ``f.req=<url-encoded JSON envelope>&at=<csrf>`` where the
+    JSON envelope is ``[null, "<inner_json>"]`` and ``<inner_json>`` is itself a
+    JSON-encoded list of positional parameters.
+    """
+    inner_json = json.dumps(params, separators=(",", ":"))
+    envelope = json.dumps([None, inner_json], separators=(",", ":"))
+    return f"f.req={quote(envelope, safe='')}&at=mock_csrf_token"
+
+
+# Canonical 9-param shape for the streaming-chat endpoint:
+#   slot 0: leading null
+#   slot 1: question text
+#   slot 2: null
+#   slot 3: feature bitmask
+#   slot 4: conversation_id  <- legitimately varies; matcher MUST ignore
+#   slot 5: null
+#   slot 6: null
+#   slot 7: notebook_id      <- matcher MUST check
+#   slot 8: trailing flag
+def _nine_params(
+    question: str = "What is this notebook about?",
+    conv_id: str = "conv_abc",
+    notebook_id: str = "nb_xyz",
+) -> list[Any]:
+    return [None, question, None, [2], conv_id, None, None, notebook_id, 1]
+
+
+def test_freq_matcher_identical_nine_param_match() -> None:
+    """Two requests with the exact same 9-param shape match."""
+    params = _nine_params()
+    r1 = _StubRequest(_build_freq_body(params))
+    r2 = _StubRequest(_build_freq_body(params))
+    assert _freq_body_matcher(r1, r2) is True
+
+
+def test_freq_matcher_param_count_mismatch_nine_vs_five() -> None:
+    """A 9-param request must not match a 5-param request (C3 regression)."""
+    nine = _nine_params()
+    five = [None, "What is this notebook about?", None, [2], "conv_abc"]
+    r1 = _StubRequest(_build_freq_body(nine))
+    r2 = _StubRequest(_build_freq_body(five))
+    assert _freq_body_matcher(r1, r2) is False
+
+
+def test_freq_matcher_notebook_id_mismatch_at_slot_seven() -> None:
+    """Differing notebook_id at slot 7 must NOT match (distinct interactions)."""
+    p1 = _nine_params(notebook_id="nb_alpha")
+    p2 = _nine_params(notebook_id="nb_beta")
+    r1 = _StubRequest(_build_freq_body(p1))
+    r2 = _StubRequest(_build_freq_body(p2))
+    assert _freq_body_matcher(r1, r2) is False
+
+
+def test_freq_matcher_conversation_id_difference_still_matches() -> None:
+    """Differing conversation_id at slot 4 DOES match — conv_id varies per replay."""
+    p1 = _nine_params(conv_id="conv_recorded_at_t1")
+    p2 = _nine_params(conv_id="conv_recorded_at_t2")
+    r1 = _StubRequest(_build_freq_body(p1))
+    r2 = _StubRequest(_build_freq_body(p2))
+    assert _freq_body_matcher(r1, r2) is True
+
+
+def test_freq_matcher_handles_bytes_body() -> None:
+    """The matcher should transparently decode ``bytes`` request bodies.
+
+    VCR's request.body is bytes for recorded requests, so we exercise that path
+    explicitly to prevent a TypeError regression in production replay.
+    """
+    params = _nine_params()
+    body_text = _build_freq_body(params)
+    r1 = _StubRequest(body_text.encode("utf-8"))
+    r2 = _StubRequest(body_text.encode("utf-8"))
+    assert _freq_body_matcher(r1, r2) is True
+
+
+def test_freq_matcher_both_bodies_unparseable_defers_to_other_matchers() -> None:
+    """Two requests neither carrying f.req return True (defer to other matchers).
+
+    Covers the (unlikely) case where this opt-in matcher is consulted for a
+    non-streaming request. Returning True keeps VCR's other matchers
+    (method/path/etc.) in charge of the decision; returning False would
+    incorrectly block matches on every non-streaming request the cassette
+    contains.
+    """
+    r1 = _StubRequest("at=foo&other=bar")
+    r2 = _StubRequest("at=baz&other=qux")
+    assert _freq_body_matcher(r1, r2) is True
+
+
+def test_freq_matcher_one_unparseable_one_parseable_rejects() -> None:
+    """A parseable f.req body must not match a body that lacks f.req.
+
+    Structurally different requests should not be silently collapsed even when
+    one side is "no f.req at all".
+    """
+    parseable = _StubRequest(_build_freq_body(_nine_params()))
+    no_f_req = _StubRequest("at=foo&other=bar")
+    assert _freq_body_matcher(parseable, no_f_req) is False
+    assert _freq_body_matcher(no_f_req, parseable) is False

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -30,6 +30,7 @@ When to use VCR vs pytest-httpx:
     - VCR.py: Recorded real responses for regression testing
 """
 
+import json
 import os
 import re
 from typing import Any
@@ -247,6 +248,103 @@ def _rpcids_matcher(r1, r2):
     assert qs1.get("rpcids") == qs2.get("rpcids")
 
 
+def _freq_body_matcher(r1: Any, r2: Any) -> bool:
+    """Match form-encoded streaming requests by their decoded ``f.req`` payload.
+
+    This matcher is for **non-batchexecute streaming endpoints** (notably the
+    streaming chat endpoint) that POST an ``application/x-www-form-urlencoded``
+    body carrying an ``f.req`` field whose value is itself a JSON-encoded
+    ``[null, "<inner_json>"]`` envelope. The inner JSON, once decoded, is a
+    list of positional parameters whose structure is endpoint-specific.
+
+    The default VCR matchers (``method``, ``scheme``, ``host``, ``port``,
+    ``path``) cannot distinguish two streaming-chat POSTs because they share
+    everything except the body. ``rpcids`` is a query-string concept and does
+    not apply to streaming endpoints, so a body-aware matcher is required.
+
+    Match rules:
+
+    1. Both requests must decode to a parseable ``f.req`` param list. If
+       neither body parses (e.g. this matcher was invoked for a non-streaming
+       request), return ``True`` so the other ``match_on`` matchers
+       (``method`` / ``path`` / etc.) drive the decision. If exactly one body
+       parses, return ``False`` — the two requests are structurally different.
+    2. **Param count** must match. A 9-param shape must not match a 5-param
+       shape (catches the C3 stale-cassette regression class).
+    3. **Notebook ID** at slot 7 (when the shape has at least 8 elements) must
+       match. Two requests differing only in notebook_id are distinct
+       interactions.
+
+    Match rules **deliberately ignored**:
+
+    - ``conversation_id`` (slot 4) — legitimately varies across replays. The
+       server assigns a fresh conversation_id on each unique ask, and the
+       client echoes it back on follow-ups; cassette replay would otherwise
+       break on every recording.
+    - Per-request nonces / counters at later slots — same rationale.
+
+    This matcher is **opt-in per cassette** (not added to the default
+    ``match_on`` list) because most endpoints do not send ``f.req`` and the
+    matcher would either no-op or — worse — collapse to identity equality on
+    every request.
+
+    Returns:
+        ``True`` if the two requests are considered the same interaction,
+        ``False`` otherwise.
+    """
+
+    def _extract_freq(request: Any) -> list[Any] | None:
+        body = request.body
+        if not body:
+            return None
+        if isinstance(body, bytes):
+            try:
+                body = body.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+
+        # Parse application/x-www-form-urlencoded
+        qs = parse_qs(body)
+        f_req_values = qs.get("f.req", [])
+        if not f_req_values:
+            return None
+        f_req = f_req_values[0]
+        if not f_req:
+            return None
+
+        try:
+            # f.req is the JSON envelope [null, "<inner_json>"].
+            outer = json.loads(f_req)
+            if not isinstance(outer, list) or len(outer) < 2:
+                return None
+            inner = outer[1]
+            if not isinstance(inner, str):
+                return None
+            params = json.loads(inner)
+            if not isinstance(params, list):
+                return None
+            return params
+        except (json.JSONDecodeError, TypeError, IndexError):
+            return None
+
+    p1 = _extract_freq(r1)
+    p2 = _extract_freq(r2)
+
+    # If neither side parses, defer to the other matchers (return True so this
+    # matcher doesn't block). If exactly one parses, the requests are
+    # structurally different — return False.
+    if p1 is None or p2 is None:
+        return p1 is None and p2 is None
+
+    # Rule 1: param count must agree (catches C3 stale-cassette regression).
+    if len(p1) != len(p2):
+        return False
+
+    # Rule 2: notebook_id at slot 7 must agree (when present). Two requests
+    # carrying different notebook_ids are distinct interactions.
+    return not (len(p1) >= 8 and p1[7] != p2[7])
+
+
 # =============================================================================
 # VCR Configuration
 # =============================================================================
@@ -280,3 +378,9 @@ notebooklm_vcr = vcr.VCR(
 
 # Register custom matcher for rpcids-based request differentiation
 notebooklm_vcr.register_matcher("rpcids", _rpcids_matcher)
+# Opt-in matcher for streaming endpoints whose disambiguator lives in the
+# form-encoded ``f.req`` body rather than the query string (e.g. streaming
+# chat). Tests that need it add ``"freq"`` to a per-cassette ``match_on``
+# override; it is intentionally NOT in the default list because most endpoints
+# do not send ``f.req``.
+notebooklm_vcr.register_matcher("freq", _freq_body_matcher)


### PR DESCRIPTION
## Summary

Adds an **opt-in** VCR matcher (`"freq"`) that decodes the form-encoded `f.req`
body of streaming-chat POSTs so two otherwise-identical requests can be
disambiguated by their decoded param shape. Mitigates the **C3 stale-cassette**
regression class.

- `tests/vcr_config.py` — new `_freq_body_matcher` registered as `"freq"`.
  Matches by **param count + notebook_id (slot 7)**; deliberately ignores
  **conversation_id (slot 4)** and per-request nonces because they
  legitimately vary across replays.
- `tests/unit/test_vcr_config.py` — 7 unit tests (identical 9-param match,
  5-vs-9 count mismatch, notebook_id mismatch, conv_id divergence still
  matches, bytes-body decoding, both-unparseable deferral, one-vs-other-
  unparseable rejection).
- `tests/integration/test_vcr_comprehensive.py` — opts `TestChatAPI.test_ask`
  in to the `freq` matcher, marked `xfail(reason="T8.B2 re-record")` until
  T8.B2 re-records `chat_ask.yaml` against the new matcher.

## Task

Phase 1 of the Tier 8 RPC/VCR remediation arc.
Plan: `.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-1.md#T8.A2`

## Scope guarantees (per plan's MUST NOT DO list)

- Default `match_on` is **unchanged** — that's T8.A1.
- The `"freq"` matcher is **NOT** added to default `match_on` — it's opt-in
  per-cassette because most endpoints do not send `f.req`.
- The existing `rpcids` matcher is **untouched**.
- No cassette is re-recorded in this PR — T8.B2 owns the `chat_ask.yaml`
  re-record and will remove the `xfail` marker in the same PR.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` — passes
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — passes
- [x] `uv run pytest tests/unit/test_vcr_config.py -v` — 7 passed
- [x] `uv run pytest` (full suite) — 3694 passed, 11 skipped, 1 xfailed
  (the new `test_ask` opt-in, as designed)

## Follow-up tracked in plan

- **T8.B2** must remove the `xfail` marker on `TestChatAPI.test_ask` in the
  same PR that re-records `chat_ask.yaml`.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for custom request matching logic in test infrastructure.
  * Enhanced API integration test reliability with improved request payload matching configuration.
  * Expanded test coverage for handling complex form-encoded request bodies in test recording and playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/550)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->