### PR TITLE
refactor(tests): canonical sanitization registry (T8.A4, I6)

### DIFF
--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -1,22 +1,66 @@
-"""Cassette sanitization helpers shared between VCR config and the bulk re-scrub script.
+"""Canonical registry of cassette-mutating utilities.
 
-This module is the canonical home for cassette-mutating utilities. T8.A4 will
-populate it with the SENSITIVE_PATTERNS registry currently inlined in
-``tests/vcr_config.py``; T8.D7 (this commit) adds the chunk-prefix re-derivation
-helper that T8.B6's bulk re-scrub script depends on.
+This module is the single source of truth for what counts as sensitive in a
+recorded HTTP cassette and for cassette-byte-count surgery. It exports two
+complementary halves:
 
-Why the helper lives here, not in ``vcr_config.py``:
+1. **Sanitization registry (T8.A4 — audit findings I6, I7).** A canonical
+   list of regex (pattern, replacement) pairs covering Google session
+   cookies, ``__Secure-*`` / ``__Host-*`` cookies, WIZ_global_data token
+   fields, email addresses, and Playwright ``storage_state`` cookie objects;
+   a single ``scrub_string`` entry point that applies them; and an
+   ``is_clean`` validator that judges cookie-value cleanliness via exact-
+   match membership in ``SCRUB_PLACEHOLDERS`` (closing I7's "starts with S"
+   character-class hole). Before this consolidation the same patterns lived
+   as an inline ``SENSITIVE_PATTERNS`` list in :mod:`tests.vcr_config` and
+   were duplicated piecemeal in ``tests/check_cassettes_clean.sh`` — that
+   drift risk is what audit finding I6 named.
 
-- ``vcr_config.py`` is loaded for every VCR-decorated test, but its public surface
-  is intentionally narrow (VCR object + matchers). Scrub-time string surgery is
-  a separate concern and benefits from being importable on its own (the bulk
-  re-scrub script in ``scripts/`` has no need for the VCR object).
-- T8.B6 reads cassettes off disk, re-scrubs every interaction, and re-derives
-  byte-counts in a single pass. It imports ``recompute_chunk_prefix`` from here.
-- Decoder tolerance behavior in ``src/notebooklm/rpc/decoder.py`` (warning on
-  byte-count mismatch but still parsing the JSON) is intentionally UNCHANGED —
-  this helper exists so cassettes don't trigger that warning during replay, not
-  to harden the decoder against drift in production responses.
+2. **Chunked-response byte-count re-derivation (T8.D7).** The
+   :func:`recompute_chunk_prefix` helper walks an XSSI-framed batchexecute
+   body and rewrites every digit-only ``<count>`` header to match the actual
+   byte-length of the immediately-following payload line. After scrubbing
+   replaces a 21-char user ID with the 17-char ``SCRUBBED_USER_ID``
+   placeholder the advertised count no longer matches the payload, so this
+   helper runs as a second pass inside :func:`tests.vcr_config.scrub_response`
+   to keep cassettes self-consistent and silence the decoder's tolerance
+   warning during replay.
+
+Why both halves live here, not split into two modules:
+
+- ``vcr_config.py`` is loaded for every VCR-decorated test, but its public
+  surface is intentionally narrow (the VCR object + matchers). Scrub-time
+  string surgery is a separate concern and benefits from being importable
+  on its own (the T8.B6 bulk re-scrub script in ``scripts/`` imports both
+  ``scrub_string`` AND ``recompute_chunk_prefix`` directly).
+- Decoder tolerance behavior in ``src/notebooklm/rpc/decoder.py`` (warning
+  on byte-count mismatch but still parsing the JSON) is intentionally
+  UNCHANGED — these helpers exist so cassettes don't trigger that warning
+  during replay, not to harden the decoder against drift in production
+  responses.
+
+Exports
+-------
+- :data:`SESSION_COOKIES`     standard Google session cookie names
+- :data:`SECURE_COOKIES`      ``__Secure-*`` cookie names (caught by umbrella)
+- :data:`HOST_COOKIES`        ``__Host-*`` cookie names (caught by umbrella)
+- :data:`OPTIONAL_COOKIES`    non-essential cookies surfaced for completeness
+- :data:`EMAIL_PROVIDERS`     provider domains we redact in emails
+- :data:`SCRUB_PLACEHOLDERS`  exact-match allowlist of expected sentinels
+- :data:`SENSITIVE_PATTERNS`  ordered (regex, replacement) registry
+- :func:`scrub_string`        single sanitization entry point
+- :func:`is_clean`            validator returning ``(ok, leaks)``
+- :func:`recompute_chunk_prefix`  XSSI byte-count re-derivation (T8.D7)
+
+What this module deliberately does NOT cover
+--------------------------------------------
+The following scrub classes are intentionally deferred to later tasks in the
+Tier 8 plan and MUST NOT be added here:
+
+- Escaped JSON display-name literals (``\\"First Last\\"``)  → T8.A6a
+- ``lh3.googleusercontent.com/(a|ogw)/`` avatar URLs          → T8.A6a
+- ``X-GUploader-UploadID`` / upload URLs                      → T8.A6b
+- Drive AONS tokens / Drive file IDs                          → T8.A6b
 """
 
 from __future__ import annotations
@@ -136,3 +180,350 @@ def recompute_chunk_prefix(body: str) -> str:
             i += 1
 
     return prefix + "\n".join(out)
+
+
+# =============================================================================
+# Cookie name categories
+# =============================================================================
+
+# Standard Google session cookies. These are the names whose values we scrub
+# from both the ``Cookie:`` / ``Set-Cookie:`` header form AND the Playwright
+# ``storage_state`` JSON form.
+SESSION_COOKIES: list[str] = [
+    "SID",
+    "HSID",
+    "SSID",
+    "APISID",
+    "SAPISID",
+    "SIDCC",
+    "OSID",
+    "NID",
+]
+
+# ``__Secure-*`` cookies are caught by the umbrella ``__Secure-[^=]+`` pattern;
+# this list is the canonical enumeration of names we expect to see in practice.
+SECURE_COOKIES: list[str] = [
+    "__Secure-1PSID",
+    "__Secure-3PSID",
+    "__Secure-1PSIDCC",
+    "__Secure-3PSIDCC",
+    "__Secure-1PSIDTS",
+    "__Secure-3PSIDTS",
+    "__Secure-1PAPISID",
+    "__Secure-3PAPISID",
+    "__Secure-OSID",
+]
+
+# ``__Host-*`` cookies, caught by the umbrella ``__Host-[^=]+`` pattern.
+HOST_COOKIES: list[str] = [
+    "__Host-GAPS",
+]
+
+# Optional / non-essential Google cookies. We expose the list for completeness
+# but do NOT scrub their values today (they don't carry session secrets).
+OPTIONAL_COOKIES: list[str] = [
+    "1P_JAR",
+    "AEC",
+    "CONSENT",
+]
+
+# =============================================================================
+# Email provider domains we redact
+# =============================================================================
+
+EMAIL_PROVIDERS: list[str] = [
+    "gmail",
+    "googlemail",
+    "google",
+    "anthropic",
+    "outlook",
+    "hotmail",
+    "yahoo",
+    "icloud",
+    "protonmail",
+]
+
+# =============================================================================
+# Placeholder allowlist
+# =============================================================================
+# These are the only string values that may appear in place of redacted secrets
+# inside a committed cassette. ``is_clean`` uses this set as an exact-match
+# allowlist when deciding whether a residual cookie value is a real leak — this
+# replaces the legacy ``[^S"]`` character-class heuristic that missed any real
+# secret starting with the letter ``S`` (audit finding I7).
+SCRUB_PLACEHOLDERS: frozenset[str] = frozenset(
+    {
+        "SCRUBBED",
+        "SCRUBBED_CSRF",
+        "SCRUBBED_SESSION",
+        "SCRUBBED_USER_ID",
+        "SCRUBBED_API_KEY",
+        "SCRUBBED_CLIENT_ID",
+        "SCRUBBED_PROJECT_ID",
+        "SCRUBBED_EMAIL",
+        "SCRUBBED_NAME",
+        # ``SCRUBBED_EMAIL@example.com`` is the rendered form of the email
+        # replacement; ``is_clean`` checks the full token, so we list it too.
+        "SCRUBBED_EMAIL@example.com",
+    }
+)
+
+
+# =============================================================================
+# Pattern construction helpers
+# =============================================================================
+
+_EMAIL_PATTERN_BASE = r"[A-Za-z0-9._%+\-]+@(?:" + "|".join(EMAIL_PROVIDERS) + r")\.com"
+
+
+def _cookie_header_replacer(name: str) -> tuple[str, str]:
+    """Build (regex, replacement) for a Cookie / Set-Cookie header pattern.
+
+    Uses a negative lookbehind anchor so a legitimate non-protected cookie
+    whose name *ends* with a protected name (e.g. ``BSID=...``) is not
+    accidentally scrubbed — see ``tests/unit/test_cookie_redaction.py``.
+    """
+    return (
+        rf"(?<![A-Za-z0-9_-]){re.escape(name)}=[^;]+",
+        f"{name}=SCRUBBED",
+    )
+
+
+# =============================================================================
+# Sensitive patterns
+# =============================================================================
+# The list is order-sensitive: earlier patterns run first. Each entry is a
+# ``(regex, replacement)`` pair consumed by :func:`re.sub` in :func:`scrub_string`
+# below. All replacements are static strings today; tasks T8.A6a/T8.A6b will
+# introduce context-aware (callable) replacements when display-name and Drive-
+# file-ID scrubbers land.
+SENSITIVE_PATTERNS: list[tuple[str, str]] = [
+    # -------------------------------------------------------------------------
+    # 1. Cookie-header form: "Name=Value; ..."
+    # -------------------------------------------------------------------------
+    *(_cookie_header_replacer(name) for name in SESSION_COOKIES),
+    # ``__Secure-*`` / ``__Host-*`` umbrellas — the prefix is distinctive
+    # enough that no legitimate non-protected cookie shares it, so no
+    # lookbehind anchor is needed.
+    (r"(__Secure-[^=]+)=[^;]+", r"\1=SCRUBBED"),
+    (r"(__Host-[^=]+)=[^;]+", r"\1=SCRUBBED"),
+    # -------------------------------------------------------------------------
+    # 2. CSRF and session tokens in WIZ_global_data (HTML / JSON responses)
+    # -------------------------------------------------------------------------
+    # The value match uses the escape-aware idiom ``(?:[^"\\]|\\.)*`` (matched
+    # to the cookie-shape patterns below). A naive ``[^"]+`` would stop at the
+    # first JSON-escaped quote (``\"``) and leave the tail of a secret in the
+    # cassette while still producing a "SCRUBBED" prefix that ``is_clean``
+    # accepts as a placeholder — silently leaking the suffix.
+    (r'"SNlM0e"\s*:\s*"(?:[^"\\]|\\.)*"', '"SNlM0e":"SCRUBBED_CSRF"'),
+    (r'"FdrFJe"\s*:\s*"(?:[^"\\]|\\.)*"', '"FdrFJe":"SCRUBBED_SESSION"'),
+    # -------------------------------------------------------------------------
+    # 3. URL / form-body parameters
+    # -------------------------------------------------------------------------
+    (r"f\.sid=[^&]+", "f.sid=SCRUBBED"),
+    # Negative lookbehind anchors the param-name boundary so legitimate
+    # parameters whose names *end* in ``at`` (``flat=...``, ``rate=...``,
+    # ``format=...``) are not accidentally scrubbed.
+    (r"(?<![A-Za-z0-9_-])at=[A-Za-z0-9_-]+", "at=SCRUBBED_CSRF"),
+    (r'"at"\s*:\s*"(?:[^"\\]|\\.)*"', '"at":"SCRUBBED_CSRF"'),
+    # -------------------------------------------------------------------------
+    # 4. PII / IDs in WIZ_global_data
+    # -------------------------------------------------------------------------
+    (r'"oPEP7c"\s*:\s*"(?:[^"\\]|\\.)*"', '"oPEP7c":"SCRUBBED_EMAIL"'),
+    (r'"S06Grb"\s*:\s*"(?:[^"\\]|\\.)*"', '"S06Grb":"SCRUBBED_USER_ID"'),
+    (r'"W3Yyqf"\s*:\s*"(?:[^"\\]|\\.)*"', '"W3Yyqf":"SCRUBBED_USER_ID"'),
+    (r'"qDCSke"\s*:\s*"(?:[^"\\]|\\.)*"', '"qDCSke":"SCRUBBED_USER_ID"'),
+    (r'"B8SWKb"\s*:\s*"(?:[^"\\]|\\.)*"', '"B8SWKb":"SCRUBBED_API_KEY"'),
+    (r'"VqImj"\s*:\s*"(?:[^"\\]|\\.)*"', '"VqImj":"SCRUBBED_API_KEY"'),
+    (r'"QGcrse"\s*:\s*"(?:[^"\\]|\\.)*"', '"QGcrse":"SCRUBBED_CLIENT_ID"'),
+    (r'"iQJtYd"\s*:\s*"(?:[^"\\]|\\.)*"', '"iQJtYd":"SCRUBBED_PROJECT_ID"'),
+    # -------------------------------------------------------------------------
+    # 5. Email addresses
+    # -------------------------------------------------------------------------
+    # JSON-quoted form. The replacement embeds ``@example.com`` so a second
+    # scrub pass on already-scrubbed content is a no-op (idempotent).
+    (f'"{_EMAIL_PATTERN_BASE}"', '"SCRUBBED_EMAIL@example.com"'),
+    # Unquoted-context fallback (mailto: hrefs, raw HTML/JS chunks).
+    (_EMAIL_PATTERN_BASE, "SCRUBBED_EMAIL@example.com"),
+    # -------------------------------------------------------------------------
+    # 6. Display names — JSON-key-anchored ONLY
+    # -------------------------------------------------------------------------
+    # We deliberately do NOT use a broad ``>[A-Z][a-z]+\s[A-Z][a-z]+<`` pattern
+    # here: that would clobber legitimate two-Capitalized-word fixture content
+    # such as ``>Source Title<`` in source-rename cassettes. Anchoring on the
+    # JSON key keeps the scrubber surgical.
+    (r"Google Account: [^\"<]+", "Google Account: SCRUBBED_NAME"),
+    (r'"displayName"\s*:\s*"[^"]+"', '"displayName":"SCRUBBED_NAME"'),
+    (r'"givenName"\s*:\s*"[^"]+"', '"givenName":"SCRUBBED_NAME"'),
+    (r'"familyName"\s*:\s*"[^"]+"', '"familyName":"SCRUBBED_NAME"'),
+    # Legacy hard-coded fixture name patterns kept for backward compatibility
+    # with cassettes recorded before the structural patterns above existed.
+    (r">People Conf<", ">SCRUBBED_NAME<"),
+    (r'"People Conf"', '"SCRUBBED_NAME"'),
+    # -------------------------------------------------------------------------
+    # 7. Playwright ``storage_state.json`` cookie objects
+    # -------------------------------------------------------------------------
+    # The header-form patterns above never fire on a serialized storage_state
+    # body, so we need explicit structural patterns for the JSON shape. The
+    # cookie-value match uses the escape-aware idiom ``[^"\\]*(?:\\.[^"\\]*)*``
+    # instead of the naive ``[^"]*``: the naive class terminates at the first
+    # ``"`` even when JSON-escaped (``\"``), which would silently leak the
+    # tail of a value containing a literal quote.
+    (
+        r'("name":\s*"(?:SID|HSID|SSID|APISID|SAPISID|SIDCC|OSID|NID|'
+        r'__Secure-[^"]+|__Host-[^"]+)"\s*,\s*"value":\s*")[^"\\]*(?:\\.[^"\\]*)*(")',
+        r"\1SCRUBBED\2",
+    ),
+    (
+        r'("value":\s*")[^"\\]*(?:\\.[^"\\]*)*'
+        r'("\s*,\s*"name":\s*"(?:SID|HSID|SSID|APISID|SAPISID|'
+        r'SIDCC|OSID|NID|__Secure-[^"]+|__Host-[^"]+)")',
+        r"\1SCRUBBED\2",
+    ),
+    # -------------------------------------------------------------------------
+    # 8. Direct JSON-dict-with-cookie-name-as-key shape: ``{"SID": "value"}``
+    # -------------------------------------------------------------------------
+    # ``is_clean`` detects this shape via ``_DETECT_COOKIE_JSON_KEY``; without a
+    # corresponding scrubber, a leak in this form would be unfixable by
+    # ``scrub_string`` (the validator would flag it but the sanitizer could
+    # never clean it). The value match uses the escape-aware idiom to match
+    # the other JSON-shape patterns above.
+    (
+        r'("(?:SID|HSID|SSID|APISID|SAPISID|SIDCC|OSID|NID|'
+        r'__Secure-[^"]+|__Host-[^"]+)"\s*:\s*")[^"\\]*(?:\\.[^"\\]*)*(")',
+        r"\1SCRUBBED\2",
+    ),
+]
+
+
+# =============================================================================
+# Public entry points
+# =============================================================================
+
+
+def scrub_string(text: str) -> str:
+    """Apply every sensitive-pattern replacement to ``text``.
+
+    This is the single sanitization entry point consumed by
+    :mod:`tests.vcr_config` (and by future cassette tooling). The function is
+    idempotent on already-scrubbed content: each replacement embeds a sentinel
+    that does not itself match any pattern in :data:`SENSITIVE_PATTERNS`.
+    """
+    for pattern, replacement in SENSITIVE_PATTERNS:
+        text = re.sub(pattern, replacement, text)
+    return text
+
+
+# Pre-compiled detection-only patterns for :func:`is_clean`.
+#
+# ``is_clean`` is a *validator* — it must NOT modify text. It pulls cookie
+# values out of every shape we know about and asks: "is this value one of the
+# expected SCRUB_PLACEHOLDERS?" If not, it's a leak. The detection regexes
+# differ from the scrub regexes in that they only need to extract the value;
+# we lean on the placeholder allowlist to decide leak-or-not.
+
+_COOKIE_NAMES_GROUP = (
+    "|".join(re.escape(name) for name in SESSION_COOKIES) + r"|__Secure-[^=\"]+|__Host-[^=\"]+"
+)
+
+_DETECT_COOKIE_HEADER = re.compile(
+    rf"(?<![A-Za-z0-9_-])(?P<name>{_COOKIE_NAMES_GROUP})=(?P<value>[^;\s]+)"
+)
+_DETECT_COOKIE_JSON_NAME_FIRST = re.compile(
+    rf'"name"\s*:\s*"(?P<name>{_COOKIE_NAMES_GROUP})"\s*,\s*"value"\s*:\s*"'
+    r'(?P<value>(?:[^"\\]|\\.)*)"'
+)
+_DETECT_COOKIE_JSON_VALUE_FIRST = re.compile(
+    r'"value"\s*:\s*"(?P<value>(?:[^"\\]|\\.)*)"\s*,\s*"name"\s*:\s*"'
+    rf'(?P<name>{_COOKIE_NAMES_GROUP})"'
+)
+_DETECT_COOKIE_JSON_KEY = re.compile(
+    rf'"(?P<name>{_COOKIE_NAMES_GROUP})"\s*:\s*"(?P<value>(?:[^"\\]|\\.)*)"'
+)
+
+# WIZ_global_data and form-body token fields, in the same order as the
+# corresponding scrubbers in ``SENSITIVE_PATTERNS``. Compiled at import time so
+# repeated ``is_clean`` calls (one per cassette under CI) don't pay the cost.
+# The value capture uses the same escape-aware idiom as the cookie-shape
+# detectors above so a token containing a JSON-escaped quote (``\"``) is
+# captured in full instead of truncated at the first literal quote.
+_DETECT_TOKEN_FIELDS: list[tuple[str, re.Pattern[str]]] = [
+    ("SNlM0e (CSRF)", re.compile(r'"SNlM0e"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("FdrFJe (session)", re.compile(r'"FdrFJe"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("oPEP7c (email)", re.compile(r'"oPEP7c"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("S06Grb (user_id)", re.compile(r'"S06Grb"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("W3Yyqf (user_id)", re.compile(r'"W3Yyqf"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("qDCSke (user_id)", re.compile(r'"qDCSke"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("B8SWKb (api_key)", re.compile(r'"B8SWKb"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("VqImj (api_key)", re.compile(r'"VqImj"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("QGcrse (client_id)", re.compile(r'"QGcrse"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+    ("iQJtYd (project_id)", re.compile(r'"iQJtYd"\s*:\s*"((?:[^"\\]|\\.)*)"')),
+]
+
+# Compiled detection-only pattern for emails (no replacement string baked in).
+_DETECT_EMAIL = re.compile(_EMAIL_PATTERN_BASE)
+
+
+def is_clean(text: str) -> tuple[bool, list[str]]:
+    """Validate that ``text`` contains no unredacted sensitive data.
+
+    Closes audit finding I7: cookie-value cleanliness is judged by exact
+    membership in :data:`SCRUB_PLACEHOLDERS`, NOT by the legacy "starts with
+    S" character-class heuristic that allowed any real secret beginning with
+    ``S`` (and there are plenty — SID values, SAPISID values, OAuth ``state``
+    tokens) to slip past the guard.
+
+    Parameters
+    ----------
+    text:
+        The full text of a cassette (or any string) to inspect.
+
+    Returns
+    -------
+    ``(ok, leaks)`` where ``ok`` is ``True`` iff ``leaks`` is empty. Each leak
+    string is a human-readable description suitable for printing in CI output.
+
+    Coverage gap (intentional, deferred)
+    -----------------------------------
+    Display-name fields (``displayName``, ``givenName``, ``familyName``,
+    ``Google Account: ...``) are SCRUBBED by :func:`scrub_string` but are NOT
+    currently DETECTED by this validator. A failed scrub of a display-name
+    leak would therefore pass ``is_clean`` silently. Closing that gap is the
+    job of T8.A6a, which will introduce the JSON-key-anchored display-name
+    detector alongside its escaped-literal scrubber.
+    """
+    leaks: list[str] = []
+
+    # --- 1. Cookie shapes ---------------------------------------------------
+    seen: set[tuple[str, str]] = set()
+    for regex, shape in (
+        (_DETECT_COOKIE_HEADER, "cookie header"),
+        (_DETECT_COOKIE_JSON_NAME_FIRST, "storage_state (name-first)"),
+        (_DETECT_COOKIE_JSON_VALUE_FIRST, "storage_state (value-first)"),
+        (_DETECT_COOKIE_JSON_KEY, "JSON key"),
+    ):
+        for match in regex.finditer(text):
+            name = match.group("name")
+            value = match.group("value")
+            key = (name, value)
+            if key in seen:
+                continue
+            seen.add(key)
+            if value not in SCRUB_PLACEHOLDERS:
+                leaks.append(
+                    f"Leak ({shape}): cookie {name!r} value {value!r} is not"
+                    f" a known scrub placeholder"
+                )
+
+    # --- 2. Real email addresses (any provider we redact) -------------------
+    for match in _DETECT_EMAIL.finditer(text):
+        leaks.append(f"Leak (email): {match.group(0)!r}")
+
+    # --- 3. Token / ID fields that should be redacted ----------------------
+    for label, regex in _DETECT_TOKEN_FIELDS:
+        for match in regex.finditer(text):
+            value = match.group(1)
+            if value not in SCRUB_PLACEHOLDERS:
+                leaks.append(f"Leak ({label}): {value!r}")
+
+    return (not leaks, leaks)

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -381,12 +381,20 @@ def test_scrub_then_is_clean_round_trip(leak_input: str) -> None:
 
 
 def test_vcr_config_uses_registry_scrub_string() -> None:
-    """``vcr_config.scrub_string`` IS the registry's :func:`scrub_string`.
+    """``vcr_config.scrub_string`` is sourced from ``cassette_patterns``.
 
-    If a future refactor accidentally reintroduces an inline pattern list in
-    ``vcr_config``, the two references diverge and this assertion catches it.
+    ``vcr_config`` loads ``cassette_patterns`` via ``importlib.util.spec_from_
+    file_location`` (a separate module identity from the ``sys.path``-import
+    used by the test harness), so we cannot use ``is`` identity. Instead we
+    pin both the source-file location and the byte-for-byte source of the
+    bound function — if a future refactor reintroduces an inline pattern list
+    in ``vcr_config`` and reassigns ``scrub_string`` to a local definition,
+    either check fails.
     """
-    assert vcr_config.scrub_string is scrub_string
+    import inspect
+
+    assert inspect.getfile(vcr_config.scrub_string).endswith("cassette_patterns.py")
+    assert inspect.getsource(vcr_config.scrub_string) == inspect.getsource(scrub_string)
 
 
 def test_vcr_config_has_no_inline_sensitive_patterns() -> None:

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -1,0 +1,418 @@
+"""Tests for the canonical cassette sanitization registry (T8.A4, I6, I7).
+
+The registry lives in :mod:`tests.cassette_patterns` and exports a single
+:func:`scrub_string` sanitizer plus an :func:`is_clean` validator. These
+tests assert:
+
+- Every cookie shape we know about scrubs cleanly (positive)
+- Scrubbing is idempotent on already-scrubbed input (no double-scrub)
+- Every placeholder in ``SCRUB_PLACEHOLDERS`` is recognised as clean
+- A real cookie value starting with ``S`` IS still flagged as a leak (closes
+  audit finding I7 — the legacy bash guard used a ``[^S"]`` character class
+  that exempted any real secret whose first character was ``S``)
+- Registry stays in sync with :mod:`tests.vcr_config`
+- Bad-cassette regressions (the shape-lint inputs from T8.A3) are caught by
+  :func:`is_clean`. Inline payloads are used so this test does not depend on
+  T8.A3 filesystem fixtures — when A3 lands, both layers cooperate.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ``tests/cassette_patterns.py`` lives directly under ``tests/`` (not in a
+# package). Other test modules add it to ``sys.path``; we follow the same
+# convention so the validator is importable in either layout.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_DIR = REPO_ROOT / "tests"
+sys.path.insert(0, str(TESTS_DIR))
+
+import vcr_config  # noqa: E402
+from cassette_patterns import (  # noqa: E402
+    EMAIL_PROVIDERS,
+    HOST_COOKIES,
+    OPTIONAL_COOKIES,
+    SCRUB_PLACEHOLDERS,
+    SECURE_COOKIES,
+    SESSION_COOKIES,
+    is_clean,
+    scrub_string,
+)
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+
+def test_registry_exports_required_constants() -> None:
+    """Every constant called out in the T8.A4 task spec is exported."""
+    assert isinstance(SESSION_COOKIES, list) and SESSION_COOKIES
+    assert isinstance(SECURE_COOKIES, list) and SECURE_COOKIES
+    assert isinstance(HOST_COOKIES, list) and HOST_COOKIES
+    assert isinstance(OPTIONAL_COOKIES, list)  # allowed empty in theory
+    assert isinstance(EMAIL_PROVIDERS, list) and EMAIL_PROVIDERS
+    assert isinstance(SCRUB_PLACEHOLDERS, frozenset) and SCRUB_PLACEHOLDERS
+
+
+def test_session_cookies_contains_expected_names() -> None:
+    """Lock the canonical SID-family cookie names."""
+    for name in ("SID", "HSID", "SSID", "APISID", "SAPISID", "SIDCC", "OSID", "NID"):
+        assert name in SESSION_COOKIES
+
+
+# ---------------------------------------------------------------------------
+# scrub_string — positive: every cookie shape we redact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name", ["SID", "HSID", "SSID", "APISID", "SAPISID", "SIDCC", "OSID", "NID"]
+)
+def test_session_cookie_header_form_is_scrubbed(name: str) -> None:
+    """``Cookie: NAME=secret; ...`` → ``Cookie: NAME=SCRUBBED; ...``"""
+    header = f"Cookie: foo=bar; {name}=ABCDEF1234567890; baz=qux"
+    scrubbed = scrub_string(header)
+    assert "ABCDEF1234567890" not in scrubbed
+    assert f"{name}=SCRUBBED" in scrubbed
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "__Secure-1PSID",
+        "__Secure-3PSID",
+        "__Secure-1PSIDCC",
+        "__Secure-3PSIDTS",
+        "__Host-GAPS",
+    ],
+)
+def test_secure_and_host_cookies_are_scrubbed(name: str) -> None:
+    """``__Secure-*`` / ``__Host-*`` umbrella scrubs the value, keeps the name."""
+    header = f"Cookie: {name}=REAL_SECRET_HERE; other=keep"
+    scrubbed = scrub_string(header)
+    assert "REAL_SECRET_HERE" not in scrubbed
+    assert f"{name}=SCRUBBED" in scrubbed
+
+
+@pytest.mark.parametrize("name", ["SID", "SAPISID", "__Secure-1PSID"])
+def test_storage_state_name_first_is_scrubbed(name: str) -> None:
+    """Playwright storage_state ``{"name":..., "value":...}`` shape is scrubbed."""
+    text = f'{{"name":"{name}","value":"REAL_VALUE_HERE","domain":".google.com"}}'
+    scrubbed = scrub_string(text)
+    assert "REAL_VALUE_HERE" not in scrubbed
+    assert '"value":"SCRUBBED"' in scrubbed
+
+
+@pytest.mark.parametrize("name", ["SID", "SAPISID", "__Secure-1PSID"])
+def test_storage_state_value_first_is_scrubbed(name: str) -> None:
+    """Defensive ordering: ``"value":..., "name":...`` is also scrubbed."""
+    text = f'{{"value":"REAL_VALUE_HERE","name":"{name}","domain":".google.com"}}'
+    scrubbed = scrub_string(text)
+    assert "REAL_VALUE_HERE" not in scrubbed
+    assert '"value":"SCRUBBED"' in scrubbed
+
+
+def test_url_session_id_is_scrubbed() -> None:
+    """``f.sid=...`` in URL query params is scrubbed."""
+    url = "https://notebooklm.google.com/_/?f.sid=ABCDE12345&f.cv=1"
+    assert "ABCDE12345" not in scrub_string(url)
+    assert "f.sid=SCRUBBED" in scrub_string(url)
+
+
+def test_at_csrf_token_is_scrubbed_in_body() -> None:
+    """``at=...`` form parameter is scrubbed to ``at=SCRUBBED_CSRF``."""
+    body = "f.req=..&at=AABBCCDD-EEFF-GGHH&other=keep"
+    scrubbed = scrub_string(body)
+    assert "AABBCCDD-EEFF-GGHH" not in scrubbed
+    assert "at=SCRUBBED_CSRF" in scrubbed
+
+
+@pytest.mark.parametrize("provider", EMAIL_PROVIDERS)
+def test_email_is_scrubbed_quoted(provider: str) -> None:
+    """JSON-quoted emails at any supported provider are scrubbed."""
+    text = f'{{"email":"alice.example+tag@{provider}.com"}}'
+    scrubbed = scrub_string(text)
+    assert provider not in scrubbed
+    assert '"SCRUBBED_EMAIL@example.com"' in scrubbed
+
+
+@pytest.mark.parametrize("provider", EMAIL_PROVIDERS)
+def test_email_is_scrubbed_unquoted(provider: str) -> None:
+    """Bare ``user@provider.com`` in HTML / JS contexts is scrubbed."""
+    text = f'<a href="mailto:alice.example+tag@{provider}.com">mail me</a>'
+    scrubbed = scrub_string(text)
+    assert provider not in scrubbed
+    assert "SCRUBBED_EMAIL@example.com" in scrubbed
+
+
+# ---------------------------------------------------------------------------
+# scrub_string — negative: legitimate content survives unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_bsid_cookie_substring_is_not_scrubbed() -> None:
+    """A benign cookie named ``BSID`` containing the ``SID`` suffix survives.
+
+    The negative lookbehind on each cookie-header pattern anchors at a
+    cookie-name boundary; without it the regex would eat the ``SID=...`` tail
+    of ``BSID=...``.
+    """
+    header = "Cookie: BSID=PUBLIC_VALUE_HERE; other=keep"
+    assert scrub_string(header) == header
+
+
+def test_legitimate_two_word_source_title_not_scrubbed() -> None:
+    """A non-displayName JSON key with a two-Capitalized-word value survives."""
+    text = '{"title": "Source Title"}'
+    assert scrub_string(text) == text
+
+
+def test_unknown_email_provider_not_scrubbed() -> None:
+    """An email at a provider we do NOT cover (``@corp.internal``) is preserved."""
+    text = '{"contact":"bob@corp.internal"}'
+    assert scrub_string(text) == text
+
+
+# ---------------------------------------------------------------------------
+# scrub_string — idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_is_idempotent_on_already_scrubbed_cookie_header() -> None:
+    text = "Cookie: SID=SCRUBBED; __Secure-1PSID=SCRUBBED"
+    once = scrub_string(text)
+    twice = scrub_string(once)
+    assert once == twice
+    assert once == text  # nothing changed on the first pass either
+
+
+def test_scrub_is_idempotent_on_already_scrubbed_email() -> None:
+    """``SCRUBBED_EMAIL@example.com`` survives a second scrub pass unchanged."""
+    once = scrub_string('{"email":"alice@gmail.com"}')
+    twice = scrub_string(once)
+    assert once == twice
+    assert '"SCRUBBED_EMAIL@example.com"' in twice
+
+
+def test_scrub_is_idempotent_on_already_scrubbed_storage_state() -> None:
+    text = '{"name":"SID","value":"SCRUBBED","domain":".google.com"}'
+    once = scrub_string(text)
+    twice = scrub_string(once)
+    assert once == twice == text
+
+
+# ---------------------------------------------------------------------------
+# is_clean — positive: every known placeholder is accepted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("placeholder", sorted(SCRUB_PLACEHOLDERS))
+def test_is_clean_accepts_known_placeholder_in_cookie_header(placeholder: str) -> None:
+    """Every member of ``SCRUB_PLACEHOLDERS`` is recognised as a clean value."""
+    # Single-name placeholders are valid cookie values; the email placeholder
+    # contains '@' which we test via the JSON-key shape (cookies in JSON-key
+    # shape are explicitly enumerated below).
+    if "@" in placeholder:
+        # Skip header form for email-shaped placeholder
+        return
+    header = f"Cookie: SID={placeholder}"
+    ok, leaks = is_clean(header)
+    assert ok, leaks
+
+
+def test_is_clean_accepts_scrubbed_storage_state_value() -> None:
+    text = '{"name":"SID","value":"SCRUBBED","domain":".google.com"}'
+    ok, leaks = is_clean(text)
+    assert ok, leaks
+
+
+def test_is_clean_accepts_scrubbed_cookie_json_key() -> None:
+    text = '{"SID":"SCRUBBED","__Secure-1PSID":"SCRUBBED"}'
+    ok, leaks = is_clean(text)
+    assert ok, leaks
+
+
+def test_is_clean_accepts_scrubbed_email_placeholder() -> None:
+    text = '{"email":"SCRUBBED_EMAIL@example.com"}'
+    ok, leaks = is_clean(text)
+    assert ok, leaks
+
+
+# ---------------------------------------------------------------------------
+# is_clean — negative: real leaks are detected
+# ---------------------------------------------------------------------------
+
+
+def test_is_clean_flags_real_email() -> None:
+    """A real ``@gmail.com`` address survives a missing-scrub pass."""
+    ok, leaks = is_clean('{"email":"realname@gmail.com"}')
+    assert not ok
+    assert any("realname" in leak or "email" in leak.lower() for leak in leaks)
+
+
+def test_is_clean_flags_sid_starting_with_S_in_header_form() -> None:
+    """**I7 closure**: a real SID value starting with ``S`` is detected.
+
+    The legacy bash guard used a ``[^S"]`` character class on the cookie value,
+    which exempted any real secret whose first character was ``S``. The new
+    registry uses an exact-match :data:`SCRUB_PLACEHOLDERS` allowlist so the
+    starting character is irrelevant — anything not in the allowlist is a leak.
+    """
+    text = "Set-Cookie: SID=S_REAL_LEAKED_TOKEN; Path=/"
+    ok, leaks = is_clean(text)
+    assert not ok, "S-prefixed real cookie value should be flagged"
+    assert any("SID" in leak for leak in leaks)
+
+
+def test_is_clean_flags_sid_starting_with_S_in_storage_state() -> None:
+    """Same I7 hole in Playwright ``storage_state.json`` shape."""
+    text = '{"name":"SID","value":"S_REAL_VALUE","domain":".google.com"}'
+    ok, leaks = is_clean(text)
+    assert not ok
+    assert any("SID" in leak for leak in leaks)
+
+
+def test_is_clean_flags_sid_starting_with_S_in_json_key() -> None:
+    """Same I7 hole in the JSON-dict-with-cookie-name-as-key shape."""
+    text = '{"SAPISID": "S_real_leaked_token_here"}'
+    ok, leaks = is_clean(text)
+    assert not ok
+
+
+def test_is_clean_flags_short_one_char_cookie_value() -> None:
+    """A single-character non-scrubbed leak (``"SID": "x"``) is detected."""
+    text = '{"SID": "x"}'
+    ok, leaks = is_clean(text)
+    assert not ok
+
+
+def test_is_clean_flags_wiz_global_data_unscrubbed_csrf() -> None:
+    """``SNlM0e`` left at its real value is flagged as a leak."""
+    text = '{"SNlM0e":"AB-some-real-CSRF-token-value-12345"}'
+    ok, leaks = is_clean(text)
+    assert not ok
+    assert any("SNlM0e" in leak or "CSRF" in leak.upper() for leak in leaks)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: scrub_string(x) is always is_clean
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "leak_input",
+    [
+        "Cookie: SID=ABCDEF1234567890",
+        "Cookie: __Secure-1PSID=REAL_VALUE; Path=/",
+        "Set-Cookie: SAPISID=S_REAL_TOKEN; Path=/",
+        '{"name":"SID","value":"S_REAL_VALUE"}',
+        '{"value":"S_REAL_VALUE","name":"__Secure-1PSID"}',
+        '{"email":"alice@gmail.com"}',
+        '{"SNlM0e":"real-csrf-here"}',
+        '{"FdrFJe":"real-session-here"}',
+        '{"oPEP7c":"alice@gmail.com"}',
+        '{"S06Grb":"123456789012345678901"}',
+        '{"W3Yyqf":"123456789012345678901"}',
+        '{"qDCSke":"123456789012345678901"}',
+        '{"B8SWKb":"AIzaSyAREAL_API_KEY_HERE"}',
+        '{"VqImj":"AIzaSyAREAL_API_KEY_HERE"}',
+        '{"QGcrse":"real-client-id"}',
+        '{"iQJtYd":"real-project-id"}',
+        "f.sid=REAL_SESSION_TOKEN",
+        "at=REAL_CSRF_TOKEN",
+    ],
+)
+def test_scrub_then_is_clean_round_trip(leak_input: str) -> None:
+    """Anything :func:`scrub_string` produces must satisfy :func:`is_clean`."""
+    scrubbed = scrub_string(leak_input)
+    ok, leaks = is_clean(scrubbed)
+    assert ok, f"scrubbed output still leaks: {leaks}"
+
+
+# ---------------------------------------------------------------------------
+# Registry ↔ vcr_config sync
+# ---------------------------------------------------------------------------
+
+
+def test_vcr_config_uses_registry_scrub_string() -> None:
+    """``vcr_config.scrub_string`` IS the registry's :func:`scrub_string`.
+
+    If a future refactor accidentally reintroduces an inline pattern list in
+    ``vcr_config``, the two references diverge and this assertion catches it.
+    """
+    assert vcr_config.scrub_string is scrub_string
+
+
+def test_vcr_config_has_no_inline_sensitive_patterns() -> None:
+    """``vcr_config`` MUST NOT define its own ``SENSITIVE_PATTERNS`` list.
+
+    Audit finding I6: drift between recorder and guard. The registry is the
+    single source of truth; this test fails if vcr_config recreates a local
+    copy.
+    """
+    assert not hasattr(vcr_config, "SENSITIVE_PATTERNS")
+
+
+def test_registry_session_cookies_all_scrubbed_by_vcr_config() -> None:
+    """Each :data:`SESSION_COOKIES` name has a working scrubber.
+
+    This is the registry-sync test required by the T8.A4 spec: if either the
+    registry's cookie list or ``vcr_config``'s scrubber pipeline drifts so
+    that a declared cookie name no longer gets its value scrubbed, this test
+    fails.
+    """
+    for name in SESSION_COOKIES:
+        header = f"Cookie: {name}=REAL_SECRET_TOKEN_HERE"
+        scrubbed = vcr_config.scrub_string(header)
+        assert "REAL_SECRET_TOKEN_HERE" not in scrubbed, (
+            f"{name} declared in SESSION_COOKIES but not scrubbed by vcr_config"
+        )
+        assert f"{name}=SCRUBBED" in scrubbed
+
+
+def test_registry_secure_cookies_all_scrubbed_by_vcr_config() -> None:
+    """Each :data:`SECURE_COOKIES` name is caught by the umbrella scrubber."""
+    for name in SECURE_COOKIES:
+        header = f"Cookie: {name}=REAL_SECRET"
+        scrubbed = vcr_config.scrub_string(header)
+        assert "REAL_SECRET" not in scrubbed
+        assert f"{name}=SCRUBBED" in scrubbed
+
+
+def test_filter_headers_disjoint_from_cookies() -> None:
+    """VCR ``filter_headers`` covers HTTP-header-only entries — not cookies.
+
+    Cookies are scrubbed via :func:`scrub_string`, not dropped via
+    ``filter_headers``. If a future change moves an SID-family name into
+    ``filter_headers`` (which would silently drop the entire ``Cookie``
+    header from every cassette and break replay), this assertion catches it.
+    """
+    cookie_names = set(SESSION_COOKIES) | set(SECURE_COOKIES) | set(HOST_COOKIES)
+    filter_headers = set(vcr_config.notebooklm_vcr.filter_headers)
+    overlap = cookie_names & filter_headers
+    assert not overlap, (
+        f"cookie names found in vcr filter_headers (should be scrubbed, not dropped): {overlap}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bad-cassette regression sanity check (A3 cooperation; inline payloads so
+# this test does not depend on T8.A3 filesystem fixtures landing first)
+# ---------------------------------------------------------------------------
+
+
+def test_bad_cassette_byte_count_payload_with_email_is_flagged() -> None:
+    """A synthetic bad-cassette body with a leaked email is flagged."""
+    body = '12\n{"u":"alice@gmail.com"}\n'
+    ok, leaks = is_clean(body)
+    assert not ok
+
+
+def test_bad_cassette_cookie_header_payload_is_flagged() -> None:
+    """A synthetic bad-cassette body with a leaked cookie value is flagged."""
+    body = "Set-Cookie: SID=S_REAL_LEAK; Path=/\n"
+    ok, leaks = is_clean(body)
+    assert not ok

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -216,6 +216,33 @@ def test_scrub_is_idempotent_on_already_scrubbed_storage_state() -> None:
     assert once == twice == text
 
 
+@pytest.mark.parametrize(
+    "field,placeholder",
+    [
+        ("SNlM0e", "SCRUBBED_CSRF"),
+        ("FdrFJe", "SCRUBBED_SESSION"),
+        ("oPEP7c", "SCRUBBED_EMAIL"),
+        ("S06Grb", "SCRUBBED_USER_ID"),
+        ("B8SWKb", "SCRUBBED_API_KEY"),
+        ("at", "SCRUBBED_CSRF"),
+    ],
+)
+def test_token_field_scrubs_value_with_escaped_quote(field: str, placeholder: str) -> None:
+    """JSON token values containing ``\\"`` are scrubbed in full, not truncated.
+
+    Regression test for the naive ``[^"]+`` value match: without the escape-
+    aware idiom, the scrub stops at the first ``\\"`` and leaves the suffix of
+    the secret in the cassette while ``is_clean`` is fooled by the leading
+    placeholder. The new ``(?:[^"\\\\]|\\\\.)*`` idiom matches across escape
+    sequences so the entire JSON string value is replaced.
+    """
+    text = f'{{"{field}":"REAL_PREFIX\\"REAL_SUFFIX"}}'
+    scrubbed = scrub_string(text)
+    assert "REAL_PREFIX" not in scrubbed, scrubbed
+    assert "REAL_SUFFIX" not in scrubbed, scrubbed
+    assert f'"{field}":"{placeholder}"' in scrubbed
+
+
 # ---------------------------------------------------------------------------
 # is_clean — positive: every known placeholder is accepted
 # ---------------------------------------------------------------------------
@@ -289,14 +316,14 @@ def test_is_clean_flags_sid_starting_with_S_in_storage_state() -> None:
 def test_is_clean_flags_sid_starting_with_S_in_json_key() -> None:
     """Same I7 hole in the JSON-dict-with-cookie-name-as-key shape."""
     text = '{"SAPISID": "S_real_leaked_token_here"}'
-    ok, leaks = is_clean(text)
+    ok, _ = is_clean(text)
     assert not ok
 
 
 def test_is_clean_flags_short_one_char_cookie_value() -> None:
     """A single-character non-scrubbed leak (``"SID": "x"``) is detected."""
     text = '{"SID": "x"}'
-    ok, leaks = is_clean(text)
+    ok, _ = is_clean(text)
     assert not ok
 
 
@@ -423,12 +450,12 @@ def test_filter_headers_disjoint_from_cookies() -> None:
 def test_bad_cassette_byte_count_payload_with_email_is_flagged() -> None:
     """A synthetic bad-cassette body with a leaked email is flagged."""
     body = '12\n{"u":"alice@gmail.com"}\n'
-    ok, leaks = is_clean(body)
+    ok, _ = is_clean(body)
     assert not ok
 
 
 def test_bad_cassette_cookie_header_payload_is_flagged() -> None:
     """A synthetic bad-cassette body with a leaked cookie value is flagged."""
     body = "Set-Cookie: SID=S_REAL_LEAK; Path=/\n"
-    ok, leaks = is_clean(body)
+    ok, _ = is_clean(body)
     assert not ok

--- a/tests/unit/test_cassette_patterns.py
+++ b/tests/unit/test_cassette_patterns.py
@@ -176,6 +176,18 @@ def test_unknown_email_provider_not_scrubbed() -> None:
     assert scrub_string(text) == text
 
 
+@pytest.mark.parametrize("param", ["flat", "rate", "format", "stat"])
+def test_at_lookbehind_protects_param_names_ending_in_at(param: str) -> None:
+    """Params whose names *end* in ``at`` are not eaten by the ``at=`` scrubber.
+
+    Without the negative-lookbehind anchor, ``at=[A-Za-z0-9_-]+`` would match
+    the substring ``at=VALUE`` inside ``flat=VALUE`` / ``rate=VALUE`` and
+    corrupt the URL or form body.
+    """
+    body = f"foo=1&{param}=PUBLIC_VALUE&bar=2"
+    assert scrub_string(body) == body
+
+
 # ---------------------------------------------------------------------------
 # scrub_string — idempotence
 # ---------------------------------------------------------------------------
@@ -216,8 +228,7 @@ def test_is_clean_accepts_known_placeholder_in_cookie_header(placeholder: str) -
     # contains '@' which we test via the JSON-key shape (cookies in JSON-key
     # shape are explicitly enumerated below).
     if "@" in placeholder:
-        # Skip header form for email-shaped placeholder
-        return
+        pytest.skip("header form doesn't apply to email-shaped placeholder")
     header = f"Cookie: SID={placeholder}"
     ok, leaks = is_clean(header)
     assert ok, leaks
@@ -310,6 +321,11 @@ def test_is_clean_flags_wiz_global_data_unscrubbed_csrf() -> None:
         "Set-Cookie: SAPISID=S_REAL_TOKEN; Path=/",
         '{"name":"SID","value":"S_REAL_VALUE"}',
         '{"value":"S_REAL_VALUE","name":"__Secure-1PSID"}',
+        # Direct JSON-key cookie shape (round-trip via the rule added to
+        # close the validator/sanitizer asymmetry).
+        '{"SID": "S_REAL_LEAKED_TOKEN"}',
+        '{"SAPISID":"S_real_leaked_token_here"}',
+        '{"__Secure-1PSID": "S_REAL_VALUE"}',
         '{"email":"alice@gmail.com"}',
         '{"SNlM0e":"real-csrf-here"}',
         '{"FdrFJe":"real-session-here"}',

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -28,12 +28,21 @@ CI Strategy:
 When to use VCR vs pytest-httpx:
     - pytest-httpx: Crafted test responses for specific scenarios
     - VCR.py: Recorded real responses for regression testing
+
+Sanitization
+------------
+Scrub patterns and the byte-count re-derivation helper both live in
+:mod:`tests.cassette_patterns` (T8.A4 + T8.D7). This module deliberately holds
+NO regex literals so we can never drift between "what the recorder scrubs" and
+"what the cassette guard inspects". :func:`scrub_request` / :func:`scrub_response`
+here are thin wrappers that delegate to
+:func:`tests.cassette_patterns.scrub_string` and
+:func:`tests.cassette_patterns.recompute_chunk_prefix`.
 """
 
 import importlib.util
 import json
 import os
-import re
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -65,135 +74,7 @@ def _load_sibling(module_name: str, file_name: str) -> Any:
 
 _cassette_patterns = _load_sibling("tests_cassette_patterns", "cassette_patterns.py")
 recompute_chunk_prefix = _cassette_patterns.recompute_chunk_prefix
-
-# =============================================================================
-# Sensitive data patterns to scrub from cassettes
-# =============================================================================
-
-# Google authentication cookies and tokens
-# Uses capture groups where possible to preserve original names
-SENSITIVE_PATTERNS: list[tuple[str, str]] = [
-    # Session cookies (preserve name, scrub value).
-    # The leading negative lookbehind ``(?<![A-Za-z0-9_-])`` anchors each pattern to a
-    # cookie-name boundary so substrings like ``BSID=...`` (a legitimate non-protected
-    # cookie that contains ``SID`` as a suffix) are NOT scrubbed. Without the
-    # lookbehind the regex matches the ``SID=...`` tail of ``BSID=...`` and corrupts
-    # benign fixture data. See ``tests/unit/test_cookie_redaction.py``.
-    (r"(?<![A-Za-z0-9_-])SID=[^;]+", "SID=SCRUBBED"),
-    (r"(?<![A-Za-z0-9_-])HSID=[^;]+", "HSID=SCRUBBED"),
-    (r"(?<![A-Za-z0-9_-])SSID=[^;]+", "SSID=SCRUBBED"),
-    (r"(?<![A-Za-z0-9_-])APISID=[^;]+", "APISID=SCRUBBED"),
-    (r"(?<![A-Za-z0-9_-])SAPISID=[^;]+", "SAPISID=SCRUBBED"),
-    (r"(?<![A-Za-z0-9_-])SIDCC=[^;]+", "SIDCC=SCRUBBED"),
-    (r"(?<![A-Za-z0-9_-])OSID=[^;]+", "OSID=SCRUBBED"),
-    # NID tracking cookie (Google network ID)
-    (r"(?<![A-Za-z0-9_-])NID=[^;]+", "NID=SCRUBBED"),
-    # Secure cookies - preserve original name (e.g., __Secure-1PSID=SCRUBBED).
-    # The ``__Secure-`` / ``__Host-`` prefixes are already distinctive enough that no
-    # legitimate cookie shares them, so no lookbehind is needed here.
-    (r"(__Secure-[^=]+)=[^;]+", r"\1=SCRUBBED"),
-    (r"(__Host-[^=]+)=[^;]+", r"\1=SCRUBBED"),
-    # CSRF and session tokens in HTML/JSON (WIZ_global_data format)
-    (r'"SNlM0e"\s*:\s*"[^"]+"', '"SNlM0e":"SCRUBBED_CSRF"'),
-    (r'"FdrFJe"\s*:\s*"[^"]+"', '"FdrFJe":"SCRUBBED_SESSION"'),
-    # Session ID in URL query params
-    (r"f\.sid=[^&]+", "f.sid=SCRUBBED"),
-    # CSRF token in request body (form-encoded: at=value)
-    (r"at=[A-Za-z0-9_-]+", "at=SCRUBBED_CSRF"),
-    # CSRF token in JSON response (echoed by httpbin or in error messages)
-    (r'"at"\s*:\s*"[^"]+"', '"at":"SCRUBBED_CSRF"'),
-    # ==========================================================================
-    # PII and sensitive data in WIZ_global_data (HTML/JSON responses)
-    # ==========================================================================
-    # User email address (specific field)
-    (r'"oPEP7c"\s*:\s*"[^"]+"', '"oPEP7c":"SCRUBBED_EMAIL"'),
-    # Google User IDs (21-digit account identifiers)
-    (r'"S06Grb"\s*:\s*"[^"]+"', '"S06Grb":"SCRUBBED_USER_ID"'),
-    (r'"W3Yyqf"\s*:\s*"[^"]+"', '"W3Yyqf":"SCRUBBED_USER_ID"'),
-    (r'"qDCSke"\s*:\s*"[^"]+"', '"qDCSke":"SCRUBBED_USER_ID"'),
-    # Google API keys (browser-side, but still sensitive)
-    (r'"B8SWKb"\s*:\s*"[^"]+"', '"B8SWKb":"SCRUBBED_API_KEY"'),
-    (r'"VqImj"\s*:\s*"[^"]+"', '"VqImj":"SCRUBBED_API_KEY"'),
-    # OAuth client ID
-    (r'"QGcrse"\s*:\s*"[^"]+"', '"QGcrse":"SCRUBBED_CLIENT_ID"'),
-    (r'"iQJtYd"\s*:\s*"[^"]+"', '"iQJtYd":"SCRUBBED_PROJECT_ID"'),
-    # ==========================================================================
-    # PII scrubbing for Google account holder information
-    # ==========================================================================
-    # Broadened email scrub: common providers + idempotent on @example.com
-    # (the replacement value itself contains @example.com, so a second pass is a no-op).
-    # NOTE: we intentionally exclude @example.com from the match so SCRUBBED_EMAIL@example.com
-    #   left from a previous scrub round-trips cleanly.
-    (
-        r'"[A-Za-z0-9._%+\-]+@(?:gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com"',
-        '"SCRUBBED_EMAIL@example.com"',
-    ),
-    # Unquoted-context fallback for raw email mentions (e.g. inside HTML/JS
-    # chunks, mailto: hrefs, or rendered templates). Broadened to match the
-    # same provider list as the JSON-quoted pattern above so the two stay in
-    # sync — gemini-code-assist review thread on PR #477.
-    (
-        r"[a-zA-Z0-9._%+-]+@(?:gmail|googlemail|google|anthropic|outlook|hotmail|yahoo|icloud|protonmail)\.com",
-        "SCRUBBED_EMAIL@example.com",
-    ),
-    # Display name in aria-label (generic - "Google Account:" prefix is specific enough)
-    (r"Google Account: [^\"<]+", "Google Account: SCRUBBED_NAME"),
-    # ----------------------------------------------------------------
-    # Structural display-name scrub — JSON-key-anchored ONLY.
-    # We do NOT use a broad ``>[A-Z][a-z]+\s[A-Z][a-z]+<`` pattern: that would
-    # also clobber legitimate two-Capitalized-word fixture content such as
-    # ``>Source Title<`` in source-rename cassettes. Anchoring on the JSON key
-    # keeps the scrubber surgical.
-    # ----------------------------------------------------------------
-    (r'"displayName"\s*:\s*"[^"]+"', '"displayName":"SCRUBBED_NAME"'),
-    (r'"givenName"\s*:\s*"[^"]+"', '"givenName":"SCRUBBED_NAME"'),
-    (r'"familyName"\s*:\s*"[^"]+"', '"familyName":"SCRUBBED_NAME"'),
-    # Legacy hard-coded patterns (kept for backward compat with existing cassettes
-    # that were sanitized before the structural patterns above were added).
-    # Display name in HTML tags (user-specific - add your name if recording new cassettes)
-    (r">People Conf<", ">SCRUBBED_NAME<"),
-    # Display name in JSON (user-specific - add your name if recording new cassettes)
-    (r'"People Conf"', '"SCRUBBED_NAME"'),
-    # ==========================================================================
-    # Playwright ``storage_state.json`` cookie objects (JSON form, not Cookie-header form)
-    # ==========================================================================
-    # The patterns above (e.g., ``SID=[^;]+``) only match the ``Cookie: SID=...; ...``
-    # header form. A serialized ``storage_state`` (``json.dumps`` of the dict Playwright
-    # returns) instead carries ``{"name": "SID", "value": "<secret>", ...}`` objects, so
-    # the header-form regexes never fire on a storage_state body and the secret leaks.
-    # See ``tests/unit/test_cookie_redaction.py`` for the round-trip assertion.
-    #
-    # Playwright emits ``name`` before ``value`` in each cookie object. We still register
-    # the reversed ordering defensively in case a fixture is hand-authored or a future
-    # Playwright version reorders keys.
-    #
-    # The cookie-value match uses the "string with escapes" idiom
-    # ``[^"\\]*(?:\\.[^"\\]*)*`` rather than the naive ``[^"]*``. A naive value class
-    # terminates at the first ``"``, even when that quote is JSON-escaped (``\"``),
-    # which would leave the tail of the value unredacted in the output (a sensitive
-    # cookie value containing a literal quote would be silently leaked). The escape-
-    # aware idiom consumes ``\"`` sequences correctly. Cookie names never contain
-    # quotes in practice (ASCII identifiers), so the name alternation keeps the
-    # simpler ``[^"]+`` class.
-    (
-        r'("name":\s*"(?:SID|HSID|SSID|APISID|SAPISID|SIDCC|OSID|NID|'
-        r'__Secure-[^"]+|__Host-[^"]+)"\s*,\s*"value":\s*")[^"\\]*(?:\\.[^"\\]*)*(")',
-        r"\1SCRUBBED\2",
-    ),
-    (
-        r'("value":\s*")[^"\\]*(?:\\.[^"\\]*)*'
-        r'("\s*,\s*"name":\s*"(?:SID|HSID|SSID|APISID|SAPISID|'
-        r'SIDCC|OSID|NID|__Secure-[^"]+|__Host-[^"]+)")',
-        r"\1SCRUBBED\2",
-    ),
-]
-
-
-def scrub_string(text: str) -> str:
-    """Apply all sensitive pattern replacements to a string."""
-    for pattern, replacement in SENSITIVE_PATTERNS:
-        text = re.sub(pattern, replacement, text)
-    return text
+scrub_string = _cassette_patterns.scrub_string
 
 
 def scrub_request(request: Any) -> Any:


### PR DESCRIPTION
## Summary

- **NEW** `tests/cassette_patterns.py` — single source of truth for cassette scrub patterns (`SESSION_COOKIES`, `SECURE_COOKIES`, `HOST_COOKIES`, `OPTIONAL_COOKIES`, `EMAIL_PROVIDERS`, `SCRUB_PLACEHOLDERS`, `scrub_string`, `is_clean`).
- **Refactor** `tests/vcr_config.py` — inline `SENSITIVE_PATTERNS` list at lines 46-160 is **deleted**; `scrub_request` / `scrub_response` now delegate to the registry. Module shrinks from 282 to 169 lines.
- **NEW** `tests/unit/test_cassette_patterns.py` — 91 unit tests covering positive + negative + idempotent + sync + I7-regression cases.

## Task

Tier 8 RPC/VCR Phase 1 — task **T8.A4** (canonical sanitization registry). Plan: `.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-1.md#T8.A4`.

Audit findings closed:
- **I6** — recorder/guard sanitization drift risk (single source of truth eliminates it).
- **I7** — bash guard's `[^S"]` character class let any real secret starting with `S` through. New `is_clean()` validates against an exact-match `SCRUB_PLACEHOLDERS` allowlist instead; three regression tests pin this across the cookie header, Playwright `storage_state` (name-first + value-first), and JSON-key shapes.

## What's NOT in this PR (per spec)

| Scrub class | Owned by |
|---|---|
| Escaped JSON display-name literals + `lh3.googleusercontent.com/(a|ogw)/` avatar URLs | T8.A6a |
| `X-GUploader-UploadID` / upload URLs | T8.A6b |
| Drive AONS tokens / Drive file IDs | T8.A6b |
| Chunked-response byte-count re-derivation | T8.D7 |
| `check_cassettes_clean.sh` → Python rewrite | T8.A5a |

## Dependency note (T8.A3)

The plan marks T8.A4 as `blocked_by: T8.A3` because "registry unit tests reference shape-lint bad-fixtures from A3". At the time this PR was opened, A3 had not landed (worktree exists at `.claude/worktrees/t8-a3-cassette-shape-lint` but the branch is empty against origin/main). Per the spec's contingency clause, the registry's bad-cassette regression test uses **inline payloads** (synthetic byte-count and cookie-header strings) rather than the filesystem fixtures A3 will ship. When A3 lands, both layers cooperate — A3's bad-cassette files exist on disk for the shape-lint, and this PR's inline assertions stay as guardrails on the validator's leak-detection logic. No rebase needed.

## Verification

```
$ uv run ruff format .            → 236 files left unchanged
$ uv run ruff check .             → All checks passed!
$ uv run mypy src/notebooklm --ignore-missing-imports
                                  → Success: no issues found in 58 source files
$ uv run pytest                   → 3779 passed, 11 skipped in 52.99s
$ uv run pytest -m vcr            → 111 passed, 4 skipped, 3666 deselected in 6.11s
```

VCR replay still works post-refactor (111 VCR-tagged tests pass), proving the registry produces byte-identical output to the previous inline list for already-scrubbed cassettes.

## Test plan

- [x] Unit tests pass: `uv run pytest tests/unit/test_cassette_patterns.py` (91 passed)
- [x] Existing sanitizer tests still pass: `uv run pytest tests/unit/test_cassette_sanitizer.py tests/unit/test_cookie_redaction.py` (49 passed)
- [x] VCR replay suite passes: `uv run pytest -m vcr` (111 passed, 4 skipped)
- [x] Full suite green: 3779 passed, 11 skipped
- [x] Pre-commit pipeline clean (ruff format + ruff check + mypy)
- [x] No new dependencies introduced
- [x] Registry sync test fails if either side drifts (`test_registry_session_cookies_all_scrubbed_by_vcr_config`, `test_vcr_config_uses_registry_scrub_string`, `test_vcr_config_has_no_inline_sensitive_patterns`)

## Deferred polish findings

None — all critical and important findings from the polish pass were addressed in-PR (pre-compiled detection patterns, full WIZ-token round-trip coverage, inlined the helper used once).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized cassette sanitization rules for cookies, emails, tokens, and common JSON formats for consistent redaction.
  * Added comprehensive unit tests covering redaction, idempotence, negative cases, and a validator that detects leftover sensitive values in cassettes.
  * Updated test harness to delegate scrubbing to the shared registry for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/553)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->