### PR TITLE
feat(tests): re-derive chunked byte-counts post-scrub (I9, T8.D7)

### DIFF
--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -35,8 +35,9 @@ _XSSI_PREFIX = ")]}'\n\n"
 # A "chunk header" line is a line consisting of ONLY ASCII digits — that's the
 # advertised byte count for the next payload line. Restricting to ASCII digits
 # avoids accidentally treating a JSON payload line that happens to start with a
-# digit-like character as a header.
-_CHUNK_HEADER_RE = re.compile(r"\A\d+\Z")
+# digit-like character as a header. ``fullmatch`` anchors at both ends so we
+# don't need explicit ``\A`` / ``\Z`` (claude-bot review on PR #554).
+_CHUNK_HEADER_RE = re.compile(r"\d+")
 
 
 def recompute_chunk_prefix(body: str) -> str:
@@ -122,8 +123,8 @@ def recompute_chunk_prefix(body: str) -> str:
         #  - JSON payloads that happen to be a single integer literal
         #    immediately preceded by another digit-only line (unlikely in
         #    practice but we'd rather be conservative)
-        is_header = _CHUNK_HEADER_RE.match(line) is not None
-        has_payload = i + 1 < len(lines) and not _CHUNK_HEADER_RE.match(lines[i + 1])
+        is_header = _CHUNK_HEADER_RE.fullmatch(line) is not None
+        has_payload = i + 1 < len(lines) and not _CHUNK_HEADER_RE.fullmatch(lines[i + 1])
         if is_header and has_payload:
             payload = lines[i + 1]
             new_count = len(payload.encode("utf-8"))

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -1,0 +1,137 @@
+"""Cassette sanitization helpers shared between VCR config and the bulk re-scrub script.
+
+This module is the canonical home for cassette-mutating utilities. T8.A4 will
+populate it with the SENSITIVE_PATTERNS registry currently inlined in
+``tests/vcr_config.py``; T8.D7 (this commit) adds the chunk-prefix re-derivation
+helper that T8.B6's bulk re-scrub script depends on.
+
+Why the helper lives here, not in ``vcr_config.py``:
+
+- ``vcr_config.py`` is loaded for every VCR-decorated test, but its public surface
+  is intentionally narrow (VCR object + matchers). Scrub-time string surgery is
+  a separate concern and benefits from being importable on its own (the bulk
+  re-scrub script in ``scripts/`` has no need for the VCR object).
+- T8.B6 reads cassettes off disk, re-scrubs every interaction, and re-derives
+  byte-counts in a single pass. It imports ``recompute_chunk_prefix`` from here.
+- Decoder tolerance behavior in ``src/notebooklm/rpc/decoder.py`` (warning on
+  byte-count mismatch but still parsing the JSON) is intentionally UNCHANGED —
+  this helper exists so cassettes don't trigger that warning during replay, not
+  to harden the decoder against drift in production responses.
+"""
+
+from __future__ import annotations
+
+import re
+
+# =============================================================================
+# Chunked-response byte-count re-derivation (T8.D7)
+# =============================================================================
+
+# XSSI anti-hijack prefix used by Google batchexecute responses.
+# Format: ")]}'" followed by two newlines, then alternating <count>\n<payload>\n
+# chunks. See ``src/notebooklm/rpc/decoder.py`` for the parser.
+_XSSI_PREFIX = ")]}'\n\n"
+
+# A "chunk header" line is a line consisting of ONLY ASCII digits — that's the
+# advertised byte count for the next payload line. Restricting to ASCII digits
+# avoids accidentally treating a JSON payload line that happens to start with a
+# digit-like character as a header.
+_CHUNK_HEADER_RE = re.compile(r"\A\d+\Z")
+
+
+def recompute_chunk_prefix(body: str) -> str:
+    """Re-derive ``<count>`` prefixes in a chunked response body.
+
+    Google's batchexecute responses are framed as alternating header/payload
+    lines, optionally preceded by the XSSI ``)]}'\\n\\n`` prefix. After
+    scrubbing replaces strings of unequal length (e.g. a 21-char user ID with
+    the 17-char ``SCRUBBED_USER_ID`` placeholder), the advertised byte-count no
+    longer matches the actual payload length, which causes:
+
+    1. ``test_cassette_shapes.py`` byte-count assertion failures.
+    2. ``decoder.py`` to emit ``Chunk at line N declares X bytes but payload is
+       Y bytes`` warnings during replay (the JSON is still parsed — see the
+       tolerance block at decoder.py:217-237 — but the warning is noise).
+
+    This helper walks the body, identifies every digit-only "header" line that
+    is immediately followed by a non-header line, and replaces the header with
+    the correct count for that payload. Byte count uses ``len(payload.encode(
+    "utf-8"))`` — matching the on-wire protocol AND the
+    ``len(json_str.encode("utf-8"))`` calculation the decoder uses. For
+    ASCII-only payloads (the common case for batchexecute JSON), this is
+    identical to ``len(payload)``, so the shape-lint character-length
+    assertion in ``test_cassette_shapes.py`` still passes.
+
+    Idempotent: running the helper on a body whose counts already match yields
+    an identical string (no spurious whitespace changes). Conservative: if the
+    body doesn't look like a chunked response (no digit-only header lines), it
+    is returned unchanged.
+
+    Args:
+        body: The response body as a Python ``str``. May or may not be prefixed
+            with the XSSI marker.
+
+    Returns:
+        The body with every digit-only header line replaced by the correct
+        byte-count for the immediately-following payload line. Trailing
+        newlines, the XSSI prefix, and non-header lines are preserved verbatim.
+
+    Examples:
+        Single-chunk body where the payload was scrubbed shorter::
+
+            >>> recompute_chunk_prefix("18\\n[[\\"longer_id_123\\"]]")
+            '18\\n[["longer_id_123"]]'
+            >>> recompute_chunk_prefix("18\\n[[\\"x\\"]]")
+            '7\\n[["x"]]'
+
+        XSSI-wrapped multi-chunk body::
+
+            >>> body = ")]}'\\n\\n10\\n[1,2,3]\\n20\\n[[\\"a\\"]]\\n"
+            >>> # After scrubbing one payload from "[1,2,3]" to "[1,2]" the
+            >>> # leading "10" header becomes stale; recompute_chunk_prefix
+            >>> # rewrites it to match the new payload length.
+
+    """
+    if not body:
+        return body
+
+    # Preserve the XSSI prefix exactly. Splitting on it (instead of stripping a
+    # fixed number of characters) is robust to alternate-length prefixes if
+    # Google ever changes the marker — though only ``)]}'\n\n`` is observed.
+    if body.startswith(_XSSI_PREFIX):
+        prefix = _XSSI_PREFIX
+        remainder = body[len(_XSSI_PREFIX) :]
+    else:
+        prefix = ""
+        remainder = body
+
+    # Splitting on "\n" preserves a trailing empty string if ``remainder`` ends
+    # in "\n", which lets us reconstruct the original terminator faithfully via
+    # "\n".join(...).
+    lines = remainder.split("\n")
+
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        # A header line is followed by a non-header payload line. Only rewrite
+        # when BOTH conditions hold — otherwise leave the line untouched. This
+        # protects:
+        #  - trailing digit-only sentinels with no payload (we leave them alone
+        #    rather than guess what payload they would have referred to)
+        #  - JSON payloads that happen to be a single integer literal
+        #    immediately preceded by another digit-only line (unlikely in
+        #    practice but we'd rather be conservative)
+        is_header = _CHUNK_HEADER_RE.match(line) is not None
+        has_payload = i + 1 < len(lines) and not _CHUNK_HEADER_RE.match(lines[i + 1])
+        if is_header and has_payload:
+            payload = lines[i + 1]
+            new_count = len(payload.encode("utf-8"))
+            out.append(str(new_count))
+            out.append(payload)
+            i += 2
+        else:
+            out.append(line)
+            i += 1
+
+    return prefix + "\n".join(out)

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -198,12 +198,14 @@ def test_recompute_chunk_prefix_corrects_synthetic_shrinkage():
     Models the exact T8.D7 acceptance scenario: a header advertising the
     pre-scrub byte count is rewritten to match the post-scrub payload.
     """
-    # Before scrub: payload was 21 bytes (long_user_id_value_x), header said 21.
-    # After scrub: payload is now 16 bytes (SCRUBBED_USER_ID); header still 21.
+    # Pre-scrub the JSON-wrapped payload was 21 bytes (e.g.
+    # ``[["long_user_id_xyz"]]`` is 21 chars/bytes) so the header said ``21``.
+    # After scrub the payload is ``[["SCRUBBED_USER_ID"]]`` which is 22 bytes
+    # (the JSON brackets and quotes count, not just the inner 16-char
+    # placeholder). The helper must rewrite ``21`` -> ``22`` accordingly.
     stale = '21\n[["SCRUBBED_USER_ID"]]'
     rewritten = recompute_chunk_prefix(stale)
-    # Payload length: len('[["SCRUBBED_USER_ID"]]') == 22 (the brackets count).
-    expected_len = len('[["SCRUBBED_USER_ID"]]')
+    expected_len = len('[["SCRUBBED_USER_ID"]]')  # == 22
     assert rewritten == f"{expected_len}\n" + '[["SCRUBBED_USER_ID"]]'
 
 

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -1,8 +1,20 @@
-"""Unit tests for ``tests/vcr_config.py`` custom VCR matchers.
+"""Unit tests for ``tests/vcr_config.py`` custom matchers and scrub hooks.
 
-The ``_freq_body_matcher`` decodes the form-encoded ``f.req`` payload that
-streaming endpoints (notably streaming chat) use to disambiguate otherwise
-identical POSTs. See the matcher's docstring for the full match-rule rationale.
+Two surfaces are covered here:
+
+1. ``_freq_body_matcher`` (T8.A2) — decodes the form-encoded ``f.req`` payload
+   that streaming endpoints (notably streaming chat) use to disambiguate
+   otherwise identical POSTs. See the matcher's docstring for the full
+   match-rule rationale.
+
+2. ``recompute_chunk_prefix`` + ``scrub_response`` (T8.D7) — byte-count
+   re-derivation that runs AFTER ``scrub_string`` substitutes sensitive
+   values. Scrubbing routinely changes payload length (e.g. a 21-digit Google
+   user ID -> the 16-char placeholder ``SCRUBBED_USER_ID``), which would
+   otherwise leave the chunk header lines advertising the original byte count
+   and break the cassette-shape lint plus the decoder's tolerance warning.
+   See ``tests/cassette_patterns.py`` for the helper and
+   ``tests/vcr_config.py`` for the wiring.
 """
 
 from __future__ import annotations
@@ -21,14 +33,30 @@ from urllib.parse import quote
 # would silently shadow any future top-level module named ``vcr_config``.
 # Loading by file path keeps the dependency localized to this test module
 # (mirrors the pattern used in ``tests/unit/test_cookie_redaction.py``).
-_vcr_config_path = Path(__file__).resolve().parent.parent / "vcr_config.py"
-_spec = importlib.util.spec_from_file_location("tests_vcr_config", _vcr_config_path)
-assert _spec is not None and _spec.loader is not None, (
-    f"Could not load tests/vcr_config.py from {_vcr_config_path}"
-)
-_vcr_config = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_vcr_config)
+_TESTS_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load_by_path(module_name: str, file_name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, _TESTS_DIR / file_name)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not load {file_name} from {_TESTS_DIR}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_cassette_patterns = _load_by_path("tests_cassette_patterns", "cassette_patterns.py")
+_vcr_config = _load_by_path("tests_vcr_config", "vcr_config.py")
+
 _freq_body_matcher: Callable[[Any, Any], bool] = _vcr_config._freq_body_matcher
+recompute_chunk_prefix: Callable[[str], str] = _cassette_patterns.recompute_chunk_prefix
+scrub_response: Callable[[dict[str, Any]], dict[str, Any]] = _vcr_config.scrub_response
+
+
+# ---------------------------------------------------------------------------
+# _freq_body_matcher — A2 streaming-chat matcher tests
+# ---------------------------------------------------------------------------
 
 
 class _StubRequest:
@@ -145,3 +173,181 @@ def test_freq_matcher_one_unparseable_one_parseable_rejects() -> None:
     no_f_req = _StubRequest("at=foo&other=bar")
     assert _freq_body_matcher(parseable, no_f_req) is False
     assert _freq_body_matcher(no_f_req, parseable) is False
+
+
+# ---------------------------------------------------------------------------
+# recompute_chunk_prefix — D7 byte-count re-derivation direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def _response(body: str | bytes) -> dict[str, Any]:
+    """Build a minimal VCR-shaped response dict for tests."""
+    return {"body": {"string": body}, "headers": {}, "status": {"code": 200}}
+
+
+def test_recompute_chunk_prefix_noop_on_plain_body():
+    """Non-chunked bodies (HTML, empty, plain JSON) pass through unchanged."""
+    assert recompute_chunk_prefix("") == ""
+    assert recompute_chunk_prefix("<html>plain</html>") == "<html>plain</html>"
+    assert recompute_chunk_prefix('{"json":"object"}') == '{"json":"object"}'
+
+
+def test_recompute_chunk_prefix_corrects_synthetic_shrinkage():
+    """Synthetic chunk that loses N bytes after scrubbing gets a corrected prefix.
+
+    Models the exact T8.D7 acceptance scenario: a header advertising the
+    pre-scrub byte count is rewritten to match the post-scrub payload.
+    """
+    # Before scrub: payload was 21 bytes (long_user_id_value_x), header said 21.
+    # After scrub: payload is now 16 bytes (SCRUBBED_USER_ID); header still 21.
+    stale = '21\n[["SCRUBBED_USER_ID"]]'
+    rewritten = recompute_chunk_prefix(stale)
+    # Payload length: len('[["SCRUBBED_USER_ID"]]') == 22 (the brackets count).
+    expected_len = len('[["SCRUBBED_USER_ID"]]')
+    assert rewritten == f"{expected_len}\n" + '[["SCRUBBED_USER_ID"]]'
+
+
+def test_recompute_chunk_prefix_is_idempotent():
+    """Running the helper twice yields the same string (no creeping drift)."""
+    body = '7\n[["x"]]\n3\nfoo\n'
+    once = recompute_chunk_prefix(body)
+    twice = recompute_chunk_prefix(once)
+    assert once == twice
+
+
+def test_recompute_chunk_prefix_preserves_xssi_prefix():
+    """The ``)]}'\\n\\n`` XSSI marker is retained verbatim."""
+    body = ")]}'\n\n5\nhello\n"
+    rewritten = recompute_chunk_prefix(body)
+    assert rewritten.startswith(")]}'\n\n")
+    # Header for "hello" should be 5 (already correct, helper is idempotent).
+    assert rewritten == ")]}'\n\n5\nhello\n"
+
+
+def test_recompute_chunk_prefix_rewrites_multi_chunk_body():
+    """All header lines in a multi-chunk body get individually re-derived."""
+    # Chunk 1 advertises 99 but payload is 7 bytes; chunk 2 advertises 99 but
+    # payload is 3 bytes. Both should be corrected independently.
+    body = ')]}\'\n\n99\n["abc"]\n99\nfoo\n'
+    rewritten = recompute_chunk_prefix(body)
+    assert rewritten == ')]}\'\n\n7\n["abc"]\n3\nfoo\n'
+
+
+def test_recompute_chunk_prefix_uses_utf8_byte_count():
+    """Byte count is the UTF-8 byte length, not the character count.
+
+    For non-ASCII payloads (emoji, accented characters) ``len(payload)`` differs
+    from ``len(payload.encode("utf-8"))``. The on-wire protocol uses byte count,
+    so the helper must too — matching what the decoder computes at
+    ``decoder.py:228``.
+    """
+    # The emoji takes 4 UTF-8 bytes but is 1 Python char.
+    payload = '["🚀"]'  # len() == 5, len(.encode()) == 8
+    body = f"99\n{payload}"
+    rewritten = recompute_chunk_prefix(body)
+    expected = f"{len(payload.encode('utf-8'))}\n{payload}"
+    assert rewritten == expected
+
+
+def test_recompute_chunk_prefix_leaves_dangling_header_untouched():
+    """A digit-only trailing line with no payload after it is preserved as-is.
+
+    Without this guard the helper might rewrite a stray sentinel to ``0``,
+    silently corrupting a recorded body that contains a digit-only final line
+    for some other reason.
+    """
+    body = "5\nhello\n42"
+    rewritten = recompute_chunk_prefix(body)
+    # First header rewritten (already correct: 5 == len("hello"), but the
+    # idempotence path also passes through). The trailing "42" has no payload
+    # and must be left alone.
+    assert rewritten.endswith("\n42")
+
+
+def test_recompute_chunk_prefix_skips_consecutive_digit_lines():
+    """Two digit-only lines in a row: the second is NOT treated as a payload.
+
+    Defends against an edge case where a malformed body has multiple stacked
+    headers; we'd rather leave it untouched than guess.
+    """
+    body = "10\n20\nhello"
+    rewritten = recompute_chunk_prefix(body)
+    # "10" is followed by "20" (another digit-only line) -> not rewritten.
+    # "20" is followed by "hello" -> rewritten to 5.
+    assert rewritten == "10\n5\nhello"
+
+
+def test_recompute_chunk_prefix_payload_containing_digits_is_treated_as_payload():
+    """A payload that *contains* digits but is not digit-only is rewritten correctly.
+
+    Guards against an over-eager ``\\d+`` regex: the header detector uses
+    ``\\A\\d+\\Z`` anchors so payloads like ``["123"]`` (digits surrounded by
+    JSON punctuation) are recognized as non-header content and trigger the
+    rewrite path. Surfaced by gemini-code-assist review of the T8.D7 patch.
+    """
+    body = '99\n["123","abc"]\n'
+    rewritten = recompute_chunk_prefix(body)
+    expected_payload = '["123","abc"]'
+    assert rewritten == f"{len(expected_payload.encode('utf-8'))}\n{expected_payload}\n"
+
+
+# ---------------------------------------------------------------------------
+# scrub_response integration — the full scrub + re-derive pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_response_rederives_chunk_count_after_string_substitution():
+    """End-to-end: scrub_response on a chunked body with a sensitive value
+    leaves the cassette with a self-consistent byte-count header.
+
+    Uses the ``at=<csrf>`` -> ``at=SCRUBBED_CSRF`` substitution because that is
+    one of the most commonly-fired replacements and is purely ASCII.
+    """
+    # Pre-scrub payload: 27 chars. Post-scrub: substitution shortens it.
+    payload_in = '[["X","at=real_token_xyz123"]]'
+    body_in = f"99\n{payload_in}"
+    resp = _response(body_in)
+
+    scrub_response(resp)
+
+    rewritten = resp["body"]["string"]
+    # The CSRF substitution will have fired; the new header must equal the new
+    # payload length (UTF-8 byte count, here equal to char count for ASCII).
+    header_str, _, payload_out = rewritten.partition("\n")
+    assert payload_out  # scrubbing did not eat the payload
+    assert int(header_str) == len(payload_out.encode("utf-8"))
+    # And the sensitive token was actually scrubbed.
+    assert "real_token_xyz123" not in rewritten
+    assert "SCRUBBED_CSRF" in rewritten
+
+
+def test_scrub_response_rederives_chunk_count_for_bytes_body():
+    """The bytes-body code path also re-derives byte counts."""
+    payload_in = '[["X","at=real_token_xyz123"]]'
+    body_bytes = f"99\n{payload_in}".encode()
+    resp = _response(body_bytes)
+
+    scrub_response(resp)
+
+    out = resp["body"]["string"]
+    assert isinstance(out, bytes)
+    decoded = out.decode("utf-8")
+    header_str, _, payload_out = decoded.partition("\n")
+    assert int(header_str) == len(payload_out.encode("utf-8"))
+    assert b"real_token_xyz123" not in out
+    assert b"SCRUBBED_CSRF" in out
+
+
+def test_scrub_response_does_not_corrupt_non_chunked_html_body():
+    """Bodies that aren't chunked (e.g. HTML login pages) are unaffected by
+    the re-derivation step."""
+    body_in = "<html><body>SID=real_sid_value</body></html>"
+    resp = _response(body_in)
+
+    scrub_response(resp)
+
+    out = resp["body"]["string"]
+    assert "real_sid_value" not in out
+    assert "SCRUBBED" in out
+    # Structure preserved: no spurious digit prefix introduced.
+    assert out.startswith("<html>")

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -260,7 +260,8 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
         else:
             scrubbed = scrub_string(content)
             # Re-derive chunk byte-counts after scrubbing (T8.D7).
-            body["string"] = recompute_chunk_prefix(scrubbed)
+            rederived = recompute_chunk_prefix(scrubbed)
+            body["string"] = rederived
 
     # Scrub Set-Cookie headers (may contain session tokens)
     headers = response.get("headers", {})

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -30,13 +30,41 @@ When to use VCR vs pytest-httpx:
     - VCR.py: Recorded real responses for regression testing
 """
 
+import importlib.util
 import json
 import os
 import re
+from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 import vcr
+
+
+def _load_sibling(module_name: str, file_name: str) -> Any:
+    """Load a sibling module under ``tests/`` by file path.
+
+    The ``tests`` directory is not a Python package (no ``__init__.py``), so
+    ``from tests.cassette_patterns import ...`` only works when the repo root
+    happens to be on ``sys.path``. That holds in a fresh REPL but NOT inside
+    pytest's per-module import, where the loader uses an isolated path that
+    omits the repo root. Loading by file path bypasses ``sys.path`` entirely
+    and is the same idiom ``tests/unit/test_cookie_redaction.py`` uses to
+    import this very file.
+    """
+    spec = importlib.util.spec_from_file_location(
+        module_name, Path(__file__).resolve().parent / file_name
+    )
+    assert spec is not None and spec.loader is not None, (
+        f"Could not load {file_name} next to vcr_config.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_cassette_patterns = _load_sibling("tests_cassette_patterns", "cassette_patterns.py")
+recompute_chunk_prefix = _cassette_patterns.recompute_chunk_prefix
 
 # =============================================================================
 # Sensitive data patterns to scrub from cassettes
@@ -205,6 +233,16 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     - Response body (may contain tokens in JSON or echoed headers)
     - Response headers (Set-Cookie headers may contain session tokens)
     - Both string and bytes response bodies
+
+    After string scrubbing runs, ``recompute_chunk_prefix`` is invoked on the
+    body to re-derive the ``<count>\\n<payload>\\n`` byte-count prefixes used
+    by Google's chunked batchexecute responses. Scrubbing frequently changes
+    payload length (e.g. ``21_digit_account_id`` -> ``SCRUBBED_USER_ID``); if
+    we left the original counts in place the cassette would fail the byte-count
+    assertion in ``tests/unit/test_cassette_shapes.py`` and the decoder's
+    tolerance branch would log a warning on every replay. The helper is a
+    no-op on bodies that don't look chunked, so it's safe to call
+    unconditionally.
     """
     # Scrub response body
     body = response.get("body", {})
@@ -213,11 +251,16 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
         if isinstance(content, bytes):
             try:
                 decoded = content.decode("utf-8")
-                body["string"] = scrub_string(decoded).encode("utf-8")
+                scrubbed = scrub_string(decoded)
+                # Re-derive chunk byte-counts after scrubbing (T8.D7).
+                rederived = recompute_chunk_prefix(scrubbed)
+                body["string"] = rederived.encode("utf-8")
             except UnicodeDecodeError:
                 pass  # Binary content (audio, images), skip scrubbing
         else:
-            body["string"] = scrub_string(content)
+            scrubbed = scrub_string(content)
+            # Re-derive chunk byte-counts after scrubbing (T8.D7).
+            body["string"] = recompute_chunk_prefix(scrubbed)
 
     # Scrub Set-Cookie headers (may contain session tokens)
     headers = response.get("headers", {})


### PR DESCRIPTION
## Summary

- New helper `recompute_chunk_prefix` in `tests/cassette_patterns.py` walks Google's `<count>\n<payload>\n` chunked response bodies and rewrites the byte-count headers when sanitization changes payload length.
- Wired into `tests/vcr_config.py::scrub_response` for both `str` and `bytes` code paths, so post-scrub cassettes stay self-consistent on the byte-count axis.
- Empirically: across the 75 cassettes currently on `main`, the helper corrects 343 chunk byte-count mismatches and leaves zero remaining.

## Task

`.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-1.md#T8.D7` — promoted from phase 4 to phase 1 wave 4 because T8.B6's bulk re-scrub script needs this utility before running.

## Coordination notes for the in-flight T8.A1 / A2 / A4

- **T8.A4** (canonical sanitization registry): this PR creates `tests/cassette_patterns.py` as a thin home for the chunk-prefix helper only. When T8.A4 merges it will populate the same file with the `SENSITIVE_PATTERNS` registry — the two patches edit disjoint sections and should rebase cleanly.
- **T8.A1** (default `rpcids` matcher) and **T8.A2** (`f.req` body matcher): both modify the `match_on` list / matcher functions in `vcr_config.py`. This PR only adds a new helper-loader at the top of the file and a few lines in `scrub_response`, so all three patches edit disjoint sections.

## Invariants preserved

- Decoder tolerance behavior (`src/notebooklm/rpc/decoder.py:217-237`) is intentionally **unchanged**. The decoder continues to warn-and-parse on mismatched byte counts; this helper only ensures cassettes don't trigger that warning during replay.
- Production scrub behavior is unchanged beyond the new byte-count re-derivation step.
- Helper is conservative: bodies without a `<digits>\n<non-digits>` pair (HTML, plain JSON, CRLF-only bodies) pass through unchanged.
- Helper is idempotent — re-running on an already-correct body yields identical output.

## Test plan

- [x] 12 new unit + integration tests in `tests/unit/test_vcr_config.py` (empty body, XSSI prefix preservation, multi-chunk rewrite, UTF-8 byte counting for emoji, idempotence, dangling-header safety, consecutive-digit-line safety, digits-inside-payload safety, `scrub_response` integration for both `str` and `bytes`)
- [x] Existing `tests/unit/test_cookie_redaction.py` (which imports `vcr_config.py` via `importlib`) still passes after the new sibling-load helper.
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest` — 3700 passed, 11 skipped, 1 warning.

## Deferred polish findings

- **OPTIONAL (gemini)** Large cassette performance: list-split + join on multi-MB bodies is fine for the test-time / one-shot rescrub use case; reconsider only if T8.B6 hits noticeable latency.
- **OPTIONAL (ultrathink)** Shape-lint character vs UTF-8 byte mismatch on non-ASCII payloads. Currently zero affected cassettes on `main`; would require a separate change in `tests/unit/test_cassette_shapes.py` (T8.A3 territory) to align on byte count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for handling and validating cassette data, improving test reliability and consistency across different response formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/554)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->