### PR TITLE
docs(skill): document portrait/vertical slide-deck trigger via prompt

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -292,11 +292,11 @@ All generate commands support:
 
 ¹ `--append` only customizes the built-in templates. With `--format custom`, pass the prompt as the positional `DESCRIPTION` argument (`notebooklm generate report "PROMPT" --format custom`); `--append` is silently ignored in that mode (the CLI prints a warning).
 
-² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic). Treat portrait decks as skill-level prompt guidance, not a typed CLI/API contract: NotebookLM currently honors orientation cues written into the `instructions` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"竖屏"`, or `"纵向排版"` can make NotebookLM render each slide as a 9:16 portrait image. Empirically:
+² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic). Treat portrait decks as skill-level prompt guidance, not a typed CLI/API contract: NotebookLM currently honors orientation cues written into the `instructions` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"portrait mobile format"`, or `"vertical 9:16 layout"` can make NotebookLM render each slide as a 9:16 portrait image. Empirically:
 
 - The `.pptx` canvas itself may stay 16:9, but each slide's embedded image can be rendered as 9:16 portrait — useful for vertical/mobile video material extracted via `python-pptx`.
 - Orientation is steered once at generation time. `generate revise-slide` edits content within an existing slide but does not change its orientation; if a slide falls back to landscape (occasional inconsistency), regenerate the whole deck rather than revising the single page.
-- Combine with an explicit page count in the prompt (e.g. `"必须精准生成 8 页，且使用竖屏（9:16 纵向排版）"`) for the most predictable output.
+- Combine with an explicit page count in the prompt (e.g. `"Create exactly 8 pages, using a vertical 9:16 portrait layout"`) for the most predictable output.
 
 ```bash
 # Skill prompt hint: ask NotebookLM to render each slide as a 9:16 portrait image

--- a/SKILL.md
+++ b/SKILL.md
@@ -292,14 +292,14 @@ All generate commands support:
 
 ¹ `--append` only customizes the built-in templates. With `--format custom`, pass the prompt as the positional `DESCRIPTION` argument (`notebooklm generate report "PROMPT" --format custom`); `--append` is silently ignored in that mode (the CLI prints a warning).
 
-² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic), but the underlying model honors orientation cues written into the `instructions` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"竖屏"`, or `"纵向排版"` causes NotebookLM to render each slide as a 9:16 portrait image. Empirically:
+² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic). Treat portrait decks as skill-level prompt guidance, not a typed CLI/API contract: NotebookLM currently honors orientation cues written into the `instructions` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"竖屏"`, or `"纵向排版"` can make NotebookLM render each slide as a 9:16 portrait image. Empirically:
 
-- The `.pptx` canvas itself usually stays 16:9, but each slide's embedded image is rendered as 9:16 portrait — useful for vertical/mobile video material extracted via `python-pptx`.
-- Orientation is decided once at generation time. `generate revise-slide` edits content within an existing slide but does not change its orientation; if a slide falls back to landscape (occasional inconsistency), regenerate the whole deck rather than revising the single page.
+- The `.pptx` canvas itself may stay 16:9, but each slide's embedded image can be rendered as 9:16 portrait — useful for vertical/mobile video material extracted via `python-pptx`.
+- Orientation is steered once at generation time. `generate revise-slide` edits content within an existing slide but does not change its orientation; if a slide falls back to landscape (occasional inconsistency), regenerate the whole deck rather than revising the single page.
 - Combine with an explicit page count in the prompt (e.g. `"必须精准生成 8 页，且使用竖屏（9:16 纵向排版）"`) for the most predictable output.
 
 ```bash
-# Generates a deck where every slide is rendered as a 9:16 portrait image
+# Skill prompt hint: ask NotebookLM to render each slide as a 9:16 portrait image
 notebooklm generate slide-deck "Create an 8-page deck in 9:16 portrait orientation for mobile viewing" --length default
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -292,7 +292,7 @@ All generate commands support:
 
 ¹ `--append` only customizes the built-in templates. With `--format custom`, pass the prompt as the positional `DESCRIPTION` argument (`notebooklm generate report "PROMPT" --format custom`); `--append` is silently ignored in that mode (the CLI prints a warning).
 
-² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic). Treat portrait decks as skill-level prompt guidance, not a typed CLI/API contract: NotebookLM currently honors orientation cues written into the `instructions` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"portrait mobile format"`, or `"vertical 9:16 layout"` can make NotebookLM render each slide as a 9:16 portrait image. Empirically:
+² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic). Treat portrait decks as skill-level prompt guidance, not a typed CLI/API contract: NotebookLM currently honors orientation cues written into the `DESCRIPTION` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"portrait mobile format"`, or `"vertical 9:16 layout"` can make NotebookLM render each slide as a 9:16 portrait image. Empirically:
 
 - The `.pptx` canvas itself may stay 16:9, but each slide's embedded image can be rendered as 9:16 portrait — useful for vertical/mobile video material extracted via `python-pptx`.
 - Orientation is steered once at generation time. `generate revise-slide` edits content within an existing slide but does not change its orientation; if a slide falls back to landscape (occasional inconsistency), regenerate the whole deck rather than revising the single page.

--- a/SKILL.md
+++ b/SKILL.md
@@ -281,7 +281,7 @@ All generate commands support:
 |------|---------|---------|----------|
 | Podcast | `generate audio` | `--format [deep-dive\|brief\|critique\|debate]`, `--length [short\|default\|long]` | .mp3 |
 | Video | `generate video` | `--format [explainer\|brief]`, `--style [auto\|classic\|whiteboard\|kawaii\|anime\|watercolor\|retro-print\|heritage\|paper-craft]` | .mp4 |
-| Slide Deck | `generate slide-deck` | `--format [detailed\|presenter]`, `--length [default\|short]` | .pdf / .pptx |
+| Slide Deck | `generate slide-deck` | `--format [detailed\|presenter]`, `--length [default\|short]` (²) | .pdf / .pptx |
 | Slide Revision | `generate revise-slide "prompt" --artifact <id> --slide N` | `--wait`, `--notebook` | *(re-downloads parent deck)* |
 | Infographic | `generate infographic` | `--orientation [landscape\|portrait\|square]`, `--detail [concise\|standard\|detailed]`, `--style [auto\|sketch-note\|professional\|bento-grid\|editorial\|instructional\|bricks\|clay\|anime\|kawaii\|scientific]` | .png |
 | Report | `generate report` | `--format [briefing-doc\|study-guide\|blog-post\|custom]`, `--append "extra instructions"` (¹) | .md |
@@ -291,6 +291,17 @@ All generate commands support:
 | Flashcards | `generate flashcards` | `--difficulty [easy\|medium\|hard]`, `--quantity [fewer\|standard\|more]` | .json/.md/.html |
 
 ¹ `--append` only customizes the built-in templates. With `--format custom`, pass the prompt as the positional `DESCRIPTION` argument (`notebooklm generate report "PROMPT" --format custom`); `--append` is silently ignored in that mode (the CLI prints a warning).
+
+² **Portrait / vertical slide decks via prompt.** Slide-deck has no `--orientation` flag (unlike infographic), but the underlying model honors orientation cues written into the `instructions` positional argument. Including phrases like `"9:16 portrait"`, `"vertical layout"`, `"竖屏"`, or `"纵向排版"` causes NotebookLM to render each slide as a 9:16 portrait image. Empirically:
+
+- The `.pptx` canvas itself usually stays 16:9, but each slide's embedded image is rendered as 9:16 portrait — useful for vertical/mobile video material extracted via `python-pptx`.
+- Orientation is decided once at generation time. `generate revise-slide` edits content within an existing slide but does not change its orientation; if a slide falls back to landscape (occasional inconsistency), regenerate the whole deck rather than revising the single page.
+- Combine with an explicit page count in the prompt (e.g. `"必须精准生成 8 页，且使用竖屏（9:16 纵向排版）"`) for the most predictable output.
+
+```bash
+# Generates a deck where every slide is rendered as a 9:16 portrait image
+notebooklm generate slide-deck "Create an 8-page deck in 9:16 portrait orientation for mobile viewing" --length default
+```
 
 ## Features Beyond the Web UI
 


### PR DESCRIPTION
## Summary

Document an undocumented but reliable capability: NotebookLM's slide-deck generator renders **9:16 portrait slide images** when the `instructions` argument contains orientation cues like `"9:16 portrait"`, `"vertical"`, `"竖屏"`, or `"纵向排版"`. There is no `--orientation` flag on slide-deck (unlike infographic), so agents currently default to landscape and have no signal that portrait is possible.

This footnote in SKILL.md lets agent runtimes (Claude, etc.) discover the trigger and produce portrait decks on request — particularly useful for generating frames for vertical/mobile video.

## Related Issue

No tracking issue — discovered while building mobile-video material with the CLI.

## Changes

- `SKILL.md`: add footnote `²` on the Slide Deck row of the Generation Types table, explaining:
  - Which prompt phrases trigger portrait rendering
  - That only the embedded slide images become 9:16; the `.pptx` canvas typically stays 16:9 (extract images via `python-pptx` for video frames)
  - That `revise-slide` cannot flip a single page's orientation — regenerate the whole deck if one slide falls back to landscape
  - That combining the orientation cue with an explicit page count gives the most predictable output

## Test Plan

- [x] Docs-only change — no code paths touched
- [x] Empirically verified: prompt `"必须精准生成 8 页，且使用竖屏（9:16 纵向排版）"` produced 7–8/8 portrait slide images via `generate slide-deck` on `notebooklm-py 0.4.1`
- [x] Cross-checked against a NotebookLM web-UI-generated `.pptx` (3:4 canvas, 8/8 9:16 portrait images) — same prompt-driven mechanism, web UI just packages slightly differently
- [ ] Tests pass (\`pytest\`) — N/A, docs only
- [ ] Linting passes (\`ruff check .\`) — N/A, Markdown only
- [ ] Formatting passes (\`ruff format --check .\`) — N/A, Markdown only
- [ ] Type checking passes (\`mypy src/notebooklm --ignore-missing-imports\`) — N/A, no Python touched

## Notes

The orientation behavior appears to be a property of the upstream Google model rather than the Python wrapper, so this is best documented as a prompt convention rather than added as a new CLI flag. If a future `--orientation` flag is added to slide-deck, this footnote could be folded into the main row.

Caveat: NotebookLM is occasionally non-deterministic — a single page in an 8-page deck may fall back to landscape even with a strong portrait cue. The footnote calls this out so agents know to regenerate rather than retry-revise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated slide-deck generation docs to reference a new footnote that explains additional slide-deck behavior.
  * Added a footnote describing how to request portrait/vertical slide decks via orientation cues in prompts.
  * Clarified expected 9:16 portrait rendering, when orientation is decided during generation, and included a concrete example prompt to guide users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->