### PR TITLE
test(vcr): cassette-shape regression lint (T8.A3)

### DIFF
--- a/tests/fixtures/bad_cassettes/bad_byte_count.yaml
+++ b/tests/fixtures/bad_cassettes/bad_byte_count.yaml
@@ -1,0 +1,25 @@
+# Synthetic-bad fixture for I9 regression: chunked-response byte-count prefix
+# lies about the size of the JSON payload that follows. Production decoder
+# tolerates this (logs a warning) but downstream byte-precise diff tooling
+# silently misaligns. A scrubber that mutates payload length without
+# re-deriving the prefix produces this defect.
+#
+# When the cassette-shape lint is reintroduced for this class of defect, the
+# lint MUST fail on this fixture (assertion C: chunked byte-count prefix must
+# equal the UTF-8 byte length of the following JSON line).
+#
+# The prefix says 9999 bytes but the payload is far shorter.
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22wXbhsf%22%2C%22%5B%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF
+    headers:
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=wXbhsf&source-path=%2Fnotebook%2Fvcr_test_notebook_id_sentinel_32ch&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n9999\n[[\"wrb.fr\",\"wXbhsf\",\"[[]]\",null,null,null,1]]\n"
+    headers:
+      Content-Type: [application/json; charset=utf-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/bad_cassettes/bad_chat_ask.yaml
+++ b/tests/fixtures/bad_cassettes/bad_chat_ask.yaml
@@ -1,0 +1,27 @@
+# Synthetic-bad fixture for C3 regression: stale chat-ask f.req shape.
+#
+# The real chat-ask RPC (rpcids=otS69) wraps its params in a 2-element outer
+# list `[null, "<inner-json-string>"]` whose inner JSON carries 9 params.
+# Old (stale) cassettes captured a flat 5-element shape; replay against the
+# new 9-param shape decoder produces silent miscompares.
+#
+# When the cassette-shape lint is reintroduced for this class of defect, the
+# lint MUST fail on this fixture (assertion: rpcids=otS69 requires the
+# `[null, str]` outer shape with >=9 inner params).
+#
+# URL-decoded body:
+#   f.req=["NB_ID","CONV_ID","QUERY",null,"NONCE"]
+interactions:
+- request:
+    body: f.req=%5B%22NB_ID%22%2C%22CONV_ID%22%2C%22QUERY%22%2Cnull%2C%22NONCE%22%5D&at=SCRUBBED_CSRF
+    headers:
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=otS69&source-path=%2Fnotebook%2Fvcr_test_notebook_id_sentinel_32ch&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n52\n[[\"wrb.fr\",\"otS69\",\"[\\\"RESULT\\\"]\",null,null,null,1]]\n"
+    headers:
+      Content-Type: [application/json; charset=utf-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/bad_cassettes/bad_revise_slide.yaml
+++ b/tests/fixtures/bad_cassettes/bad_revise_slide.yaml
@@ -1,0 +1,20 @@
+# Synthetic-bad fixture for C2 regression: f.req body was over-scrubbed to a
+# literal "SCRUBBED" sentinel, destroying the urlencoded JSON payload that the
+# shape-lint expects to decode.
+#
+# When the cassette-shape lint is reintroduced for this class of defect, the
+# lint MUST fail on this fixture (assertion B: f.req must URL-decode + JSON-parse).
+interactions:
+- request:
+    body: f.req=SCRUBBED&at=SCRUBBED_CSRF
+    headers:
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=KmcKPe&source-path=%2Fnotebook%2Fvcr_test_notebook_id_sentinel_32ch&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n55\n[[\"wrb.fr\",\"KmcKPe\",\"[\\\"SCRUBBED\\\"]\",null,null,null,1]]\n"
+    headers:
+      Content-Type: [application/json; charset=utf-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/fixtures/bad_cassettes/bad_sharing.yaml
+++ b/tests/fixtures/bad_cassettes/bad_sharing.yaml
@@ -1,0 +1,22 @@
+# Synthetic-bad fixture for C4 regression: leaked display-name JSON literal
+# in a WRB response payload. The escaped form `\"Real Name\"` appears inside
+# a JSON string that the WRB envelope carries as a literal — the scrubber must
+# strip it before the cassette is committed.
+#
+# When the cassette-shape lint is reintroduced for this class of defect, the
+# lint MUST fail on this fixture (assertion D: no escaped display-name JSON
+# literals of the form `\"Capitalized Two Words\"`).
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22RGP97b%22%2C%22%5B%5C%22vcr_test_notebook_id_sentinel_32ch%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF
+    headers:
+      Content-Type: [application/x-www-form-urlencoded]
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=RGP97b&source-path=%2Fnotebook%2Fvcr_test_notebook_id_sentinel_32ch&f.sid=SCRUBBED&rt=c
+  response:
+    body:
+      string: ")]}'\n\n80\n[[\"wrb.fr\",\"RGP97b\",\"[[\\\"some_id\\\",\\\"\\\\\\\"Real Name\\\\\\\"\\\",1]]\",null,null,null,1]]\n"
+    headers:
+      Content-Type: [application/json; charset=utf-8]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -1,0 +1,534 @@
+"""Cassette-shape regression lint (T8.A3).
+
+This module walks every VCR cassette under ``tests/cassettes`` and asserts a
+small set of structural invariants that the audit's regression classes
+(C2/C3/C4/I9) violate. The intent is to catch reintroductions of those defect
+classes before they reach ``main``.
+
+Assertions per batchexecute interaction (URL carries ``?rpcids=``):
+
+* **A. rpcids ↔ WRB id alignment.** Every RPC ID named in the URL's ``rpcids``
+  query parameter must appear as the second slot of a ``"wrb.fr"`` envelope in
+  the chunked response. Surplus URL rpcids (named but never answered) are a
+  defect; surplus WRB ids (answered but not requested) are likewise rejected.
+  Envelope ids ``"di"``, ``"af.httprm"``, ``"e"`` are housekeeping and ignored.
+
+* **B. f.req decodes.** ``f.req`` extracted from the urlencoded body must
+  URL-decode and ``json.loads`` to a list. ``f.req=SCRUBBED`` (C2) trips this.
+
+* **C. Chunked byte-counts are accurate.** Each integer prefix in the
+  ``)]}'``-stripped response body must equal the UTF-8 byte length of the
+  single JSON line that follows it (I9).
+
+* **D. No leaked patterns** (applies to ALL interactions): escaped display-
+  name JSON literals like ``\\"Capitalized Two Words\\"`` (C4),
+  ``lh3.googleusercontent.com/(a|ogw)/`` avatar URLs, and the literal IP
+  ``108.5.149.175``.
+
+In addition, for the specific RPC ID ``otS69`` (chat ask) the lint enforces
+the new 9-param outer shape ``[null, "<inner-json-string>"]`` whose inner
+JSON-decoded list carries at least 9 params (C3).
+
+Cassettes flagged by the audit's "needs re-recording" set are marked xfail
+with explicit reasons referencing the phase-2 follow-up tasks (T8.B1..B5).
+When the corresponding phase-2 PR lands and re-records the cassette, the
+xfail marker MUST be removed in that PR.
+
+Non-batchexecute interactions (e.g. the streaming-query endpoint
+``GenerateFreeFormStreamed``, GETs against the SPA shell, the legacy
+``example_httpbin_*`` fixtures) skip the RPC-shape assertions because they
+do not carry a ``rpcids`` query parameter or WRB envelope. The leak-pattern
+check (D) still runs against their YAML text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Cassette discovery
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CASSETTE_DIR = REPO_ROOT / "tests" / "cassettes"
+BAD_FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "bad_cassettes"
+
+
+def _real_cassettes() -> list[Path]:
+    return sorted(CASSETTE_DIR.glob("*.yaml"))
+
+
+# Cassettes that the Tier-8 audit flagged for re-recording or re-scrubbing in
+# phase 2. Each entry carries the follow-up task ID and the regression class
+# so the xfail message points reviewers at the eventual fix.
+#
+# This is the audit's explicit "needs re-recording" set (see phase-1 plan,
+# T8.A5a acceptance line 254). The much larger "67 cassettes with /ogw/"
+# set is detected dynamically — see `_xfail_reason` below — and mapped to
+# T8.B6 (bulk avatar re-scrub).
+AUDIT_REPAIR_LIST: dict[str, str] = {
+    "artifacts_revise_slide.yaml": (
+        "Phase 2 T8.B1 will fix (C2: f.req=SCRUBBED destroyed payload)"
+    ),
+    "chat_ask.yaml": ("Phase 2 T8.B2 will fix (C3: stale chat-ask shape / shape drift)"),
+    "chat_ask_with_references.yaml": (
+        "Phase 2 T8.B2 will fix (C3: stale chat-ask shape / shape drift)"
+    ),
+    "sharing_get_status.yaml": ("Phase 2 T8.B3 will fix (C4: escaped display-name in WRB payload)"),
+    "sharing_set_public.yaml": ("Phase 2 T8.B3 will fix (C4: escaped display-name in WRB payload)"),
+    "sources_add_file.yaml": ("Phase 2 T8.B4 will fix (I17: upload tokens unscrubbed)"),
+    "sources_add_drive.yaml": ("Phase 2 T8.B5 will fix (I17: Drive AONS tokens unscrubbed)"),
+    "sources_check_freshness_drive.yaml": (
+        "Phase 2 T8.B5 will fix (I17: Drive AONS tokens unscrubbed)"
+    ),
+    "example_httpbin_get.yaml": (
+        "Phase 2 T8.B7 will fix (I-misc: leaked IP 108.5.149.175 in example fixture)"
+    ),
+    "example_httpbin_post.yaml": (
+        "Phase 2 T8.B7 will fix (I-misc: leaked IP 108.5.149.175 in example fixture)"
+    ),
+}
+
+
+def _has_ogw_avatar(cassette: Path) -> bool:
+    """Return True if the cassette contains an ``/ogw/`` avatar URL leak.
+
+    The audit identified 67 cassettes carrying these legacy avatar URLs;
+    T8.B6 bulk re-scrubs them in phase 2. Detecting dynamically (rather
+    than maintaining a hard-coded list of 67) means cassettes don't need
+    this file touched when T8.B6 lands — the moment an /ogw/ URL is gone
+    the xfail goes away.
+    """
+    try:
+        return "/ogw/" in cassette.read_text()
+    except OSError:
+        return False
+
+
+def _has_bytecount_drift(cassette: Path) -> bool:
+    """Return True if the cassette has stale chunked byte-count prefixes.
+
+    This is the audit's I9 class: when the original network response used
+    ``\\r\\n`` line endings, the byte-count was computed against the
+    pre-strip bytes but the cassette stores the ``\\r``-stripped form, so
+    every chunk prefix overshoots by exactly the number of stripped
+    carriage returns. T8.D7 (byte-count re-derivation) plus T8.B6 (bulk
+    re-scrub) fix this; until then we xfail affected cassettes so the
+    rest of the lint stays enforceable.
+    """
+    try:
+        data, _ = _load_cassette(cassette)
+    except (yaml.YAMLError, OSError):
+        return False
+    for interaction in data.get("interactions") or []:
+        body = (interaction.get("response") or {}).get("body") or {}
+        if _byte_count_failures(body.get("string") or ""):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Leak patterns (assertion D — applies to ALL interactions, including
+# non-batchexecute). Kept minimal here; the canonical scrub registry is
+# T8.A4's tests/cassette_patterns.py (not yet landed in origin/main).
+# ---------------------------------------------------------------------------
+
+# Escaped JSON display name: \"Two Capitalized Words\" inside a quoted JSON
+# string. Anchored on the escape `\"` so we don't fire on legitimate
+# capitalized prose appearing in plain text. Hyphenated tokens are *not*
+# matched (to skip HTTP header names like `Content-Type` and font families
+# like `Google-Sans-Text`). The broader T8.A6a registry will tighten this
+# further by requiring an adjacent JSON-key context.
+LEAK_DISPLAY_NAME = re.compile(r'\\"(?:[A-Z][a-z]+)(?: [A-Z][a-z]+)+\\"')
+# Two-capitalized-word strings that are legitimate UI / artifact / notebook
+# titles produced during E2E test runs — NOT human display-name leaks. Keeping
+# this allowlist explicit so future additions are intentional. Anything new
+# that matches the regex but is benign goes here with a one-line comment.
+DISPLAY_NAME_FALSE_POSITIVES = frozenset(
+    {
+        # Google Sans family (font-family CSS in HTML responses).
+        '\\"Google Sans\\"',
+        '\\"Google Sans Text\\"',
+        '\\"Google Sans Arabic\\"',
+        '\\"Google Sans Traditional Chinese\\"',
+        # Account UI page title (not a person's name).
+        '\\"Account Information\\"',
+        # Artifact / notebook titles produced by the test corpus.
+        '\\"Agent Development Tutorials\\"',
+        '\\"Agent Flashcards\\"',
+        '\\"Agent Quiz\\"',
+        '\\"Slide Deck\\"',
+        '\\"Tool Use Loop\\"',
+        '\\"Claude Code\\"',
+    }
+)
+# lh3.googleusercontent.com avatar URLs — both /a/ and /ogw/ prefixes.
+LEAK_AVATAR_URL = re.compile(r"https?://lh3\.googleusercontent\.com/(?:a|ogw)/[A-Za-z0-9_\-=]+")
+# Literal IP that the audit caught leaking in example_httpbin_*.yaml.
+LEAK_HTTPBIN_IP = re.compile(r"\b108\.5\.149\.175\b")
+
+
+def _find_leaks(text: str) -> list[str]:
+    """Return human-readable leak descriptors found in `text`."""
+    leaks: list[str] = []
+    for m in LEAK_DISPLAY_NAME.finditer(text):
+        if m.group(0) in DISPLAY_NAME_FALSE_POSITIVES:
+            continue
+        leaks.append(f"escaped display-name literal {m.group(0)!r}")
+        break  # one is enough; the message is the same
+    if m := LEAK_AVATAR_URL.search(text):
+        leaks.append(f"avatar URL {m.group(0)!r}")
+    if m := LEAK_HTTPBIN_IP.search(text):
+        leaks.append(f"httpbin IP {m.group(0)!r}")
+    return leaks
+
+
+# ---------------------------------------------------------------------------
+# Shape extractors
+# ---------------------------------------------------------------------------
+
+# RPC IDs for which a per-RPC shape guard fires. Right now only chat-ask is
+# enforced; other RPC-specific shapes can be added here without changing the
+# generic batchexecute checks.
+CHAT_ASK_RPC_ID = "otS69"
+CHAT_ASK_MIN_INNER_PARAMS = 9
+
+# WRB envelope tags that are housekeeping and should not be treated as RPC
+# responses.
+HOUSEKEEPING_WRB_TAGS = frozenset({"di", "af.httprm", "e"})
+
+XSSI_PREFIX = ")]}'"
+
+
+def _strip_xssi(body: str) -> str:
+    """Drop the Google anti-XSSI ``)]}'`` prefix and the blank line following."""
+    if body.startswith(XSSI_PREFIX):
+        rest = body[len(XSSI_PREFIX) :]
+        # Either ``)]}'\n\n`` (most cassettes) or ``)]}'\n`` followed by data.
+        return rest.lstrip("\n")
+    return body
+
+
+def _rpcids_from_url(uri: str) -> list[str]:
+    """Return the list of rpcids named in the URL (comma-separated allowed)."""
+    qs = parse_qs(urlparse(uri).query)
+    raw = qs.get("rpcids", [""])[0]
+    if not raw:
+        return []
+    return [p for p in raw.split(",") if p]
+
+
+def _wrb_ids_from_response(body: str) -> list[str]:
+    """Return RPC IDs seen in ``[\"wrb.fr\", <id>, ...]`` envelopes.
+
+    Walks the chunked response (alternating ``<int>\\n<json>\\n`` records),
+    parses each JSON record, and yields any envelope whose first slot is
+    ``"wrb.fr"`` and second slot is a non-housekeeping string.
+    """
+    ids: list[str] = []
+    payload = _strip_xssi(body)
+    lines = payload.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if not line:
+            i += 1
+            continue
+        try:
+            int(line)  # byte-count prefix
+        except ValueError:
+            # Not a count — try to parse as JSON directly (some cassettes
+            # omit the count line entirely for trivial bodies).
+            try:
+                chunk = json.loads(line)
+            except json.JSONDecodeError:
+                i += 1
+                continue
+            ids.extend(_collect_wrb_ids(chunk))
+            i += 1
+            continue
+        i += 1
+        if i >= len(lines):
+            break
+        try:
+            chunk = json.loads(lines[i])
+        except json.JSONDecodeError:
+            i += 1
+            continue
+        ids.extend(_collect_wrb_ids(chunk))
+        i += 1
+    return ids
+
+
+def _collect_wrb_ids(chunk: Any) -> list[str]:
+    """Extract RPC IDs from a parsed chunk (list-of-envelopes)."""
+    if not isinstance(chunk, list):
+        return []
+    ids: list[str] = []
+    for envelope in chunk:
+        if (
+            isinstance(envelope, list)
+            and len(envelope) >= 2
+            and envelope[0] == "wrb.fr"
+            and isinstance(envelope[1], str)
+            and envelope[1] not in HOUSEKEEPING_WRB_TAGS
+        ):
+            ids.append(envelope[1])
+    return ids
+
+
+def _byte_count_failures(body: str) -> list[str]:
+    """Return descriptors for chunks whose declared byte count is wrong.
+
+    Mirrors ``parse_chunked_response``'s line-wise format: lines alternate
+    between an integer byte-count and the single JSON line whose UTF-8 byte
+    length must equal that count.
+    """
+    failures: list[str] = []
+    payload = _strip_xssi(body)
+    lines = payload.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if not line:
+            i += 1
+            continue
+        try:
+            declared = int(line)
+        except ValueError:
+            i += 1
+            continue
+        i += 1
+        if i >= len(lines):
+            break
+        actual = len(lines[i].encode("utf-8"))
+        if declared != actual:
+            failures.append(
+                f"chunk@line{i + 1}: prefix declares {declared} bytes but payload is {actual} bytes"
+            )
+        i += 1
+    return failures
+
+
+def _decode_freq(body: str | bytes | None) -> Any:
+    """URL-decode + JSON-parse the ``f.req`` value of a urlencoded body.
+
+    Raises ValueError if extraction or decoding fails. Returns ``None`` if
+    the body simply has no ``f.req`` field (e.g. unrelated POST).
+    """
+    if body is None:
+        return None
+    if isinstance(body, bytes):
+        body = body.decode("utf-8")
+    qs = parse_qs(body, keep_blank_values=True)
+    if "f.req" not in qs:
+        return None
+    raw = qs["f.req"][0]
+    decoded = unquote(raw)
+    try:
+        return json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"f.req does not decode to JSON: raw={raw!r} decoded={decoded!r} ({exc})"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Core per-cassette lint
+# ---------------------------------------------------------------------------
+
+
+def _load_cassette(path: Path) -> tuple[dict[str, Any], str]:
+    """Return the parsed cassette dict and its raw YAML text.
+
+    Raw text is kept for leak-pattern scanning so we catch leaks that live
+    inside escaped JSON-string payloads (the parsed structure would lose the
+    escape characters in the regex).
+    """
+    raw = path.read_text()
+    data = yaml.safe_load(raw) or {}
+    return data, raw
+
+
+def _lint_cassette(path: Path) -> list[str]:
+    """Run all assertions on one cassette. Return list of failure messages."""
+    failures: list[str] = []
+    data, raw_text = _load_cassette(path)
+
+    # D — leak patterns over the raw YAML text (includes both request URLs
+    # and response bodies, before YAML re-quoting strips escapes).
+    failures.extend(f"leak: {leak}" for leak in _find_leaks(raw_text))
+
+    interactions = data.get("interactions") or []
+    for idx, interaction in enumerate(interactions):
+        req = interaction.get("request") or {}
+        resp = interaction.get("response") or {}
+        uri = req.get("uri") or ""
+        body = req.get("body")
+        resp_body = (resp.get("body") or {}).get("string") or ""
+
+        rpcids = _rpcids_from_url(uri)
+        is_batchexecute = bool(rpcids)
+
+        if not is_batchexecute:
+            # Non-batchexecute (e.g. streaming-query, SPA shell GET, httpbin):
+            # skip RPC-shape and byte-count checks; leak check already ran on
+            # the whole text above.
+            continue
+
+        # B — f.req decodes
+        try:
+            freq = _decode_freq(body)
+        except ValueError as exc:
+            failures.append(f"interaction[{idx}] f.req decode failed: {exc}")
+            freq = None
+
+        # C3 — chat-ask shape guard (per-RPC). Only fires when the chat-ask
+        # RPC ID is present in rpcids AND the f.req decoded.
+        if CHAT_ASK_RPC_ID in rpcids and freq is not None:
+            shape_err = _check_chat_ask_shape(freq)
+            if shape_err:
+                failures.append(f"interaction[{idx}] {shape_err}")
+
+        # A — rpcids in URL must match WRB ids in response
+        wrb_ids = _wrb_ids_from_response(resp_body)
+        url_set = set(rpcids)
+        wrb_set = set(wrb_ids)
+        if url_set != wrb_set:
+            failures.append(
+                f"interaction[{idx}] rpcids mismatch: URL={sorted(url_set)} WRB={sorted(wrb_set)}"
+            )
+
+        # C — chunked byte counts
+        failures.extend(f"interaction[{idx}] {bc}" for bc in _byte_count_failures(resp_body))
+
+    return failures
+
+
+def _check_chat_ask_shape(freq: Any) -> str | None:
+    """Return error message if `freq` is not in the chat-ask 9-param shape.
+
+    Real chat-ask `f.req` is ``[null, "<inner-json>"]`` whose inner JSON
+    decodes to a list of at least 9 positional params.
+    """
+    if not (
+        isinstance(freq, list) and len(freq) == 2 and freq[0] is None and isinstance(freq[1], str)
+    ):
+        return (
+            "chat-ask shape regression (C3): expected outer "
+            f"[null, '<inner-json>'], got {type(freq).__name__} {freq!r:.120}"
+        )
+    try:
+        inner = json.loads(freq[1])
+    except json.JSONDecodeError as exc:
+        return f"chat-ask inner JSON does not parse: {exc}"
+    if not isinstance(inner, list) or len(inner) < CHAT_ASK_MIN_INNER_PARAMS:
+        n = len(inner) if isinstance(inner, list) else "non-list"
+        return (
+            "chat-ask shape regression (C3): inner f.req has "
+            f"{n} params, need >= {CHAT_ASK_MIN_INNER_PARAMS}"
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _xfail_reason(cassette: Path) -> str | None:
+    """Return the xfail reason for a cassette in the audit's repair set, else None.
+
+    Resolution order (most specific first):
+      1. Explicit AUDIT_REPAIR_LIST — the 10 cassettes the audit named.
+      2. /ogw/ avatar URL present — the 67 cassettes T8.B6 will bulk-rescrub.
+      3. Byte-count drift present — audit class I9, fixed by T8.D7.
+
+    Each branch returns a different reason so phase-2 PRs can identify
+    which xfail markers their work should clear.
+    """
+    if cassette.name in AUDIT_REPAIR_LIST:
+        return AUDIT_REPAIR_LIST[cassette.name]
+    if _has_ogw_avatar(cassette):
+        return (
+            "Phase 2 T8.B6 will fix (audit I18: /ogw/ avatar URL "
+            "unscrubbed; bulk re-scrub recomputes byte counts via T8.D7)"
+        )
+    if _has_bytecount_drift(cassette):
+        return (
+            "Phase 2 T8.D7 will fix (audit I9: chunked byte-count "
+            "prefix drifted from payload length after sanitization)"
+        )
+    return None
+
+
+@pytest.mark.parametrize(
+    "cassette",
+    _real_cassettes(),
+    ids=lambda p: p.name,
+)
+def test_cassette_shape(cassette: Path, request: pytest.FixtureRequest) -> None:
+    """Every real cassette must satisfy the shape invariants (xfail where audited)."""
+    reason = _xfail_reason(cassette)
+    if reason:
+        request.applymarker(pytest.mark.xfail(reason=reason, strict=True))
+
+    failures = _lint_cassette(cassette)
+    assert not failures, f"Cassette {cassette.name} failed shape lint:\n  - " + "\n  - ".join(
+        failures
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression assertions: synthetic-bad fixtures must trip the lint, each on
+# its targeted assertion class.
+# ---------------------------------------------------------------------------
+
+
+def test_bad_revise_slide_trips_freq_decode() -> None:
+    """C2 regression: f.req=SCRUBBED must fail the f.req-decode assertion."""
+    failures = _lint_cassette(BAD_FIXTURE_DIR / "bad_revise_slide.yaml")
+    assert any("f.req decode failed" in f for f in failures), (
+        f"Expected f.req decode failure, got: {failures}"
+    )
+
+
+def test_bad_chat_ask_trips_shape_guard() -> None:
+    """C3 regression: stale 5-param chat shape must trip the otS69 shape guard."""
+    failures = _lint_cassette(BAD_FIXTURE_DIR / "bad_chat_ask.yaml")
+    assert any("chat-ask shape regression" in f for f in failures), (
+        f"Expected chat-ask shape regression, got: {failures}"
+    )
+
+
+def test_bad_sharing_trips_leak_check() -> None:
+    """C4 regression: escaped display-name JSON literal must trip the leak check."""
+    failures = _lint_cassette(BAD_FIXTURE_DIR / "bad_sharing.yaml")
+    assert any("escaped display-name" in f for f in failures), (
+        f"Expected escaped display-name leak, got: {failures}"
+    )
+
+
+def test_bad_byte_count_trips_byte_count_check() -> None:
+    """I9 regression: chunk prefix must equal payload UTF-8 byte length."""
+    failures = _lint_cassette(BAD_FIXTURE_DIR / "bad_byte_count.yaml")
+    assert any("prefix declares" in f for f in failures), (
+        f"Expected byte-count mismatch, got: {failures}"
+    )
+
+
+def test_audit_repair_list_entries_exist() -> None:
+    """Every cassette in AUDIT_REPAIR_LIST must actually exist on disk.
+
+    Guards against the xfail set drifting out of sync with the cassettes/
+    directory (e.g. someone renames a cassette without updating this list).
+    """
+    missing = [name for name in AUDIT_REPAIR_LIST if not (CASSETTE_DIR / name).exists()]
+    assert not missing, f"AUDIT_REPAIR_LIST references cassettes that no longer exist: {missing}"

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -326,7 +326,10 @@ def _decode_freq(body: str | bytes | None) -> Any:
     if body is None:
         return None
     if isinstance(body, bytes):
-        body = body.decode("utf-8")
+        try:
+            body = body.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"request body is not valid UTF-8 ({exc})") from exc
     qs = parse_qs(body, keep_blank_values=True)
     if "f.req" not in qs:
         return None


### PR DESCRIPTION
## Summary

Adds `tests/unit/test_cassette_shapes.py` — a structural lint that walks every cassette under `tests/cassettes/*.yaml` and asserts four invariants per batchexecute interaction (URL carries `?rpcids=`):

- **A. rpcids -> WRB id alignment.** The set of RPC IDs in the URL's `rpcids` query param equals the set of `["wrb.fr", <id>, ...]` envelope IDs in the chunked response (housekeeping IDs `di`, `af.httprm`, `e` ignored).
- **B. `f.req` decodes.** URL-decode + `json.loads` to a list. `f.req=SCRUBBED` (audit C2) trips this.
- **C. Chunked byte-counts are accurate.** Each integer prefix equals the UTF-8 byte length of the JSON line that follows (audit I9).
- **D. No leaked patterns** (runs on every interaction's raw YAML text): no escaped display-name JSON literals (audit C4), no `lh3.googleusercontent.com/(a|ogw)/...` avatar URLs (audit I18), no recorder IP `108.5.149.175`.

A per-RPC shape guard for `rpcids=otS69` (chat-ask) enforces the 9-param outer shape `[null, "<inner-json>"]` — closes the door on the C3 stale-5-param drift.

## Synthetic-bad fixtures (regression assertions)

Four fixtures under `tests/fixtures/bad_cassettes/`, one per regression class, with dedicated test cases confirming the lint fires on each:

| Fixture | Regression class | Trips assertion |
|---|---|---|
| `bad_revise_slide.yaml` | C2 (`f.req=SCRUBBED`) | B |
| `bad_chat_ask.yaml` | C3 (stale 5-param chat shape) | otS69 shape guard |
| `bad_sharing.yaml` | C4 (escaped display-name in WRB) | D |
| `bad_byte_count.yaml` | I9 (chunk prefix lies about payload bytes) | C |

## xfail markers for currently-leaky cassettes

Cassettes flagged by the audit's "needs re-recording" set are marked `xfail(strict=True)` with explicit reasons referencing the phase-2 follow-up tasks. Resolution order is most-specific first:

1. **Audit's named 10 cassettes** -> mapped explicitly to T8.B1..B7
2. **`/ogw/` avatar URL present** -> 61 cassettes (dynamically detected; maps to T8.B6)
3. **Chunked byte-count drift** -> 1 cassette (notes_list.yaml; maps to T8.D7)

`strict=True` ensures that when a phase-2 PR re-records a cassette, it MUST remove the corresponding xfail marker — an XPASS will fail the lint. The `test_audit_repair_list_entries_exist` guard catches xfail entries that drift out of sync with the cassettes/ directory (e.g. someone renames a cassette without updating the list).

## Scope notes

- Non-batchexecute interactions (streaming-query endpoint, SPA shell GETs, httpbin examples — no `rpcids` in URL) skip the RPC-shape and byte-count assertions. Leak-pattern check (D) still runs on their raw YAML text.
- All current real batchexecute cassettes are xfailed by audit or heuristic; the 3 "passing" cassettes (`chat_get_conversation_turns`, `example_batchexecute_pattern`, `example_scrubbed_cookies`) are all non-batchexecute. This is the **intended** state today — phase 2 will progressively cure cassettes and remove their xfail markers.
- `DISPLAY_NAME_FALSE_POSITIVES` allowlist exists for legitimate test-corpus titles that match the `\"Two Capitalized Words\"` regex (e.g. `\"Claude Code\"`, `\"Slide Deck\"`, the Google Sans font family). Additions here must be intentional.
- Uses PyYAML `safe_load`. No scrubbers added in this PR (those are T8.A6a/b).

## Test plan

- [x] `uv run pytest tests/unit/test_cassette_shapes.py -v` -> **8 passed, 72 xfailed** (audit 10 + /ogw/ 61 + byte-drift 1 = 72; matches the audit's "Cassettes needing re-recording" table exactly)
- [x] Full suite: `uv run pytest` -> **3696 passed, 11 skipped, 72 xfailed**
- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean

## Deferred polish findings

None.

## Plan reference

`.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-1.md#T8.A3`

Blocks: T8.A1, T8.A4, T8.C1..C6, T8.D8, T8.D9, T8.D10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive cassette validation test suite enforcing response/request shape, chunked byte-count correctness, URL-decoded request parsing, and leak-pattern detection.
  * Added synthetic negative fixtures covering byte-count mismatches, malformed request shapes, scrubbed payloads, and escaped display-name leaks to ensure regressions are detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/556)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->