### PR TITLE
docs(python-api): flashcard→flashcards plural (orphan from #558)

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -461,7 +461,7 @@ print(f"Keywords: {guide['keywords']}")
 
 #### Type-Specific List Methods
 
-**CLI equivalent:** `notebooklm artifact list --type <audio|video|slide-deck|quiz|flashcard|infographic|data-table|mind-map|report>` (see [Artifact Commands](cli-reference.md#artifact-commands-notebooklm-artifact-cmd)).
+**CLI equivalent:** `notebooklm artifact list --type <audio|video|slide-deck|quiz|flashcards|infographic|data-table|mind-map|report>` (see [Artifact Commands](cli-reference.md#artifact-commands-notebooklm-artifact-cmd)).
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|


### PR DESCRIPTION
## Summary
One-line fix for an unresolved gemini-code-assist thread from already-merged PR #558.

`docs/python-api.md:464` — CLI equivalent `--type` list used singular `flashcard`; the rest of the file (lines 479, 495) and the `ArtifactType` enum use plural `flashcards`.

## Related
- Resolves [orphan thread](https://github.com/teng-lin/notebooklm-py/pull/558#discussion_r3247606283) on #558

## Test plan
- [x] Docs-only diff (1 word change)
- [x] Pre-commit checks (no source code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the CLI command syntax in the Python API documentation for the artifact listing command to ensure accurate parameter formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/559)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->