### PR TITLE
fix(notes): shield UPDATE_NOTE finalize, cleanup on cancel (T7.C4)

### DIFF
--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -13,6 +13,7 @@ raw RPC-shaped data (lists). Higher-level dataclass parsing stays in
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -21,6 +22,32 @@ from .rpc import RPCMethod
 from .types import Note
 
 logger = logging.getLogger(__name__)
+
+
+async def _delete_note_best_effort(core: ClientCore, notebook_id: str, note_id: str) -> None:
+    """Best-effort DELETE_NOTE cleanup for a partially-finalized create.
+
+    Used as a fire-and-forget ``asyncio.create_task`` target when an
+    outer cancel arrives mid-UPDATE_NOTE: we never block the re-raise on
+    this call, and any failure (network, auth refresh, etc.) is logged
+    and swallowed — the only side-effect we want is the orphan-row
+    removal, not a secondary exception.
+    """
+    try:
+        params = [notebook_id, None, [note_id]]
+        await core.rpc_call(
+            RPCMethod.DELETE_NOTE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+    except Exception:  # noqa: BLE001 — best-effort cleanup, must not surface
+        logger.warning(
+            "Best-effort DELETE_NOTE cleanup failed for note %s in notebook %s",
+            note_id,
+            notebook_id,
+            exc_info=True,
+        )
 
 
 async def fetch_all_notes_and_mind_maps(core: ClientCore, notebook_id: str) -> list[Any]:
@@ -172,7 +199,25 @@ async def create_note(
     if note_id:
         # CREATE_NOTE ignores the title param server-side, so set it via
         # UPDATE_NOTE alongside the actual content payload.
-        await update_note(core, notebook_id, note_id, content, title)
+        #
+        # T7.C4: shield the UPDATE_NOTE finalize from outer cancellation.
+        # CREATE_NOTE has already persisted a row server-side; without the
+        # shield, a cancel arriving between CREATE_NOTE and UPDATE_NOTE
+        # completion leaves an orphan row with no title/content. The shield
+        # lets the in-flight finalize run to completion; if the outer cancel
+        # still propagates (await released before finalize completed), fire
+        # a best-effort DELETE_NOTE via create_task — NOT awaited, so the
+        # re-raise is never blocked on cleanup — to remove the orphan row.
+        try:
+            await asyncio.shield(update_note(core, notebook_id, note_id, content, title))
+        except asyncio.CancelledError:
+            # Fire-and-forget cleanup. We deliberately discard the task
+            # handle: callers cancelling create_note() must not be made to
+            # wait on (or even know about) the cleanup.
+            asyncio.create_task(  # noqa: RUF006 — fire-and-forget by design
+                _delete_note_best_effort(core, notebook_id, note_id)
+            )
+            raise
 
     return Note(
         id=note_id or "",

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -203,17 +203,14 @@ async def create_note(
         # T7.C4: shield the UPDATE_NOTE finalize from outer cancellation.
         # CREATE_NOTE has already persisted a row server-side; without the
         # shield, a cancel arriving between CREATE_NOTE and UPDATE_NOTE
-        # completion leaves an orphan row with no title/content. The shield
-        # lets the in-flight finalize run to completion; if the outer cancel
-        # still propagates (await released before finalize completed), fire
-        # a best-effort DELETE_NOTE via create_task — NOT awaited, so the
-        # re-raise is never blocked on cleanup — to remove the orphan row.
+        # completion leaves an orphan row with no title/content. If the
+        # outer cancel still propagates (the await released before finalize
+        # completed), schedule a fire-and-forget DELETE_NOTE to remove the
+        # orphan row — the task handle is intentionally discarded so the
+        # CancelledError re-raise never blocks on cleanup.
         try:
             await asyncio.shield(update_note(core, notebook_id, note_id, content, title))
         except asyncio.CancelledError:
-            # Fire-and-forget cleanup. We deliberately discard the task
-            # handle: callers cancelling create_note() must not be made to
-            # wait on (or even know about) the cleanup.
             asyncio.create_task(  # noqa: RUF006 — fire-and-forget by design
                 _delete_note_best_effort(core, notebook_id, note_id)
             )

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -23,6 +23,13 @@ from .types import Note
 
 logger = logging.getLogger(__name__)
 
+# Strong references for fire-and-forget cleanup tasks. ``asyncio.create_task``
+# returns a Task that the event loop only holds via a weak reference, so an
+# unrooted Task can be garbage-collected mid-execution — losing the orphan-row
+# cleanup the T7.C4 shield is supposed to guarantee. Each created task adds
+# itself here and removes itself in a done-callback so the set stays bounded.
+_cleanup_tasks: set[asyncio.Task[Any]] = set()
+
 
 async def _delete_note_best_effort(core: ClientCore, notebook_id: str, note_id: str) -> None:
     """Best-effort DELETE_NOTE cleanup for a partially-finalized create.
@@ -203,17 +210,25 @@ async def create_note(
         # T7.C4: shield the UPDATE_NOTE finalize from outer cancellation.
         # CREATE_NOTE has already persisted a row server-side; without the
         # shield, a cancel arriving between CREATE_NOTE and UPDATE_NOTE
-        # completion leaves an orphan row with no title/content. If the
-        # outer cancel still propagates (the await released before finalize
-        # completed), schedule a fire-and-forget DELETE_NOTE to remove the
-        # orphan row — the task handle is intentionally discarded so the
-        # CancelledError re-raise never blocks on cleanup.
+        # completion leaves an orphan row with no title/content.
+        #
+        # When CancelledError lands here, the shielded UPDATE_NOTE Task is
+        # still running on the loop. Fire a best-effort DELETE_NOTE that
+        # covers both sub-cases:
+        #   (a) UPDATE_NOTE hasn't applied yet → orphan-row cleanup.
+        #   (b) UPDATE_NOTE completes between the cancel and DELETE_NOTE →
+        #       the now-applied note is deleted; caller's cancel intent
+        #       (note should not exist) is honoured.
+        # Strong-ref the cleanup task in ``_cleanup_tasks`` so the loop's
+        # weak-ref Task storage cannot GC it mid-flight (RUF006); the
+        # done-callback discards on completion so the set stays bounded.
+        # The re-raise never awaits the cleanup task.
         try:
             await asyncio.shield(update_note(core, notebook_id, note_id, content, title))
         except asyncio.CancelledError:
-            asyncio.create_task(  # noqa: RUF006 — fire-and-forget by design
-                _delete_note_best_effort(core, notebook_id, note_id)
-            )
+            cleanup_task = asyncio.create_task(_delete_note_best_effort(core, notebook_id, note_id))
+            _cleanup_tasks.add(cleanup_task)
+            cleanup_task.add_done_callback(_cleanup_tasks.discard)
             raise
 
     return Note(

--- a/tests/integration/concurrency/test_note_create_cancel.py
+++ b/tests/integration/concurrency/test_note_create_cancel.py
@@ -112,6 +112,7 @@ class _NoteCancelTransport(httpx.AsyncBaseTransport):
         return [rpc_id for rpc_id, _ in self.captured]
 
 
+@pytest.mark.asyncio
 async def test_cancel_during_update_note_shields_or_cleans_up(auth_tokens) -> None:
     """Cancel after CREATE_NOTE / before UPDATE_NOTE completes.
 

--- a/tests/integration/concurrency/test_note_create_cancel.py
+++ b/tests/integration/concurrency/test_note_create_cancel.py
@@ -1,0 +1,230 @@
+"""Regression test for T7.C4 — shield UPDATE_NOTE finalize, cleanup on cancel.
+
+Audit item §28: ``_mind_map.create_note`` issued CREATE_NOTE then UPDATE_NOTE
+back-to-back. A cancellation arriving after CREATE_NOTE returned but before
+UPDATE_NOTE completed left an empty/orphan note on the server (CREATE_NOTE
+persists; UPDATE_NOTE applies the title/content payload that callers expect).
+
+Post-fix:
+- UPDATE_NOTE call is wrapped in ``asyncio.shield`` so an outer cancel cannot
+  abort an in-flight finalize.
+- On ``CancelledError`` raised by the shielded await, a best-effort
+  DELETE_NOTE fires via ``asyncio.create_task`` (NOT awaited — re-raise must
+  not block on cleanup), then the cancellation re-raises.
+
+Acceptance invariant (per plan §T7.C4):
+  cancel mid-flight after CREATE_NOTE returns but before UPDATE_NOTE
+  completes; assert either
+    (a) both succeed (shield wins — UPDATE_NOTE finished within the shielded
+        await before the outer cancel arrived), OR
+    (b) both effectively undone (UPDATE_NOTE was cancelled and the best-effort
+        DELETE_NOTE cleanup ran on the mock transport).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from notebooklm import NotebookLMClient
+from notebooklm.rpc import RPCMethod
+
+
+def _wrb_response(rpc_id: str, payload) -> str:
+    """Single-RPC batchexecute response body in ``)]}}\\n<len>\\n<chunk>\\n`` form."""
+    inner = json.dumps(payload)
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def _rpc_id_in_request(request: httpx.Request) -> str | None:
+    """Extract the ``rpcids=`` query param from a batchexecute request URL."""
+    for key, value in request.url.params.multi_items():
+        if key == "rpcids":
+            return value
+    return None
+
+
+def _make_client_with_transport(
+    transport: httpx.AsyncBaseTransport, auth_tokens
+) -> NotebookLMClient:
+    """Wire a ``NotebookLMClient`` to a mock transport, bypassing full open()."""
+    client = NotebookLMClient(auth_tokens)
+    client._core._http_client = httpx.AsyncClient(
+        transport=transport,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+    )
+    return client
+
+
+class _NoteCancelTransport(httpx.AsyncBaseTransport):
+    """Mock transport that lets the caller pace UPDATE_NOTE precisely.
+
+    ``update_started`` fires on UPDATE_NOTE entry so the test can cancel the
+    outer task at exactly that point. ``release_update`` (an asyncio.Event)
+    is awaited inside UPDATE_NOTE so the test controls when the shielded
+    finalize actually completes.
+    """
+
+    def __init__(self) -> None:
+        self.captured: list[tuple[str | None, httpx.Request]] = []
+        self.update_started = asyncio.Event()
+        self.release_update = asyncio.Event()
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        rpc_id = _rpc_id_in_request(request)
+        self.captured.append((rpc_id, request))
+
+        if rpc_id == RPCMethod.CREATE_NOTE.value:
+            # CREATE_NOTE returns the new note id; mirrors _mind_map.create_note
+            # parsing path that pulls ``result[0][0]`` when result is nested.
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.CREATE_NOTE.value, [["note_new_001"]]),
+            )
+
+        if rpc_id == RPCMethod.UPDATE_NOTE.value:
+            # Signal the test that UPDATE_NOTE has begun, then suspend until
+            # the test releases us. This is the precise window the C4 shield
+            # must protect.
+            self.update_started.set()
+            await self.release_update.wait()
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.UPDATE_NOTE.value, None),
+            )
+
+        if rpc_id == RPCMethod.DELETE_NOTE.value:
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.DELETE_NOTE.value, None),
+            )
+
+        # Any other RPC: empty payload (decodes to None / []).
+        return httpx.Response(200, text=_wrb_response(rpc_id or "unknown", None))
+
+    def rpc_ids(self) -> list[str | None]:
+        return [rpc_id for rpc_id, _ in self.captured]
+
+
+async def test_cancel_during_update_note_shields_or_cleans_up(auth_tokens) -> None:
+    """Cancel after CREATE_NOTE / before UPDATE_NOTE completes.
+
+    The acceptance invariant from the T7.C4 plan: assert EITHER both writes
+    succeed (shield wins) OR a DELETE_NOTE cleanup task fired on the
+    transport. Either branch proves the orphan-note bug is gone.
+    """
+    transport = _NoteCancelTransport()
+    client = _make_client_with_transport(transport, auth_tokens)
+
+    try:
+        create_task = asyncio.create_task(
+            client.notes.create("nb_test", title="Hello", content="World")
+        )
+
+        # Let CREATE_NOTE run to completion AND let UPDATE_NOTE enter the
+        # transport. This is the window where the bug used to allow an
+        # orphan note to be left behind on cancel.
+        await asyncio.wait_for(transport.update_started.wait(), timeout=2.0)
+
+        # Cancel mid-UPDATE_NOTE. With the shield in place, UPDATE_NOTE
+        # keeps running until release_update is set; the outer awaiter
+        # receives CancelledError and schedules best-effort DELETE_NOTE.
+        create_task.cancel()
+
+        # Yield so the cancellation can be delivered and any best-effort
+        # cleanup task can be scheduled.
+        await asyncio.sleep(0)
+
+        # Release the in-flight UPDATE_NOTE so the inner shielded task can
+        # finish (it would otherwise hang the mock transport indefinitely).
+        transport.release_update.set()
+
+        # Drain the outer task. May raise CancelledError (cancel propagated
+        # because the await released after release_update fired) or return
+        # normally if the shielded UPDATE_NOTE happened to complete before
+        # the cancel landed. Both are acceptance-valid.
+        cancelled = False
+        try:
+            await create_task
+        except asyncio.CancelledError:
+            cancelled = True
+
+        # Yield enough times for the best-effort DELETE_NOTE create_task to
+        # be scheduled AND issue its request on the mock transport.
+        for _ in range(50):  # up to ~0.5s
+            if RPCMethod.DELETE_NOTE.value in transport.rpc_ids():
+                break
+            await asyncio.sleep(0.01)
+
+        rpc_ids = transport.rpc_ids()
+
+        # CREATE_NOTE is always observed — that's the prerequisite for the
+        # cancellation window we're testing.
+        assert RPCMethod.CREATE_NOTE.value in rpc_ids, (
+            f"CREATE_NOTE never reached the transport: rpc_ids={rpc_ids!r}"
+        )
+
+        # UPDATE_NOTE is always observed: even when shield-protected, the
+        # inner task keeps running through the await point.
+        assert RPCMethod.UPDATE_NOTE.value in rpc_ids, (
+            f"UPDATE_NOTE never reached the transport: rpc_ids={rpc_ids!r}"
+        )
+
+        # Acceptance OR:
+        #   (a) shield won — outer task returned normally, both writes
+        #       succeeded, no cleanup required.
+        #   (b) cancel landed — DELETE_NOTE cleanup task ran.
+        delete_ran = RPCMethod.DELETE_NOTE.value in rpc_ids
+        if cancelled:
+            assert delete_ran, (
+                "outer task was cancelled but no best-effort DELETE_NOTE "
+                f"cleanup reached the transport: rpc_ids={rpc_ids!r}"
+            )
+        else:
+            # Shield won: UPDATE_NOTE completed before cancel propagated.
+            # No cleanup expected.
+            assert not delete_ran, (
+                "shield won (no CancelledError) yet DELETE_NOTE still fired — "
+                f"cleanup should only run on cancel: rpc_ids={rpc_ids!r}"
+            )
+    finally:
+        # Defensive cleanup so a failing assertion doesn't leak the http
+        # client and warn at gc time.
+        if client._core._http_client is not None:
+            await client._core._http_client.aclose()
+            client._core._http_client = None
+
+
+@pytest.mark.asyncio
+async def test_no_cancel_no_cleanup(auth_tokens) -> None:
+    """Sanity: when no cancel arrives, CREATE+UPDATE succeed and DELETE never fires.
+
+    Guards against an over-eager fix that fires DELETE_NOTE unconditionally
+    (which would silently nuke every newly-created note).
+    """
+    transport = _NoteCancelTransport()
+    # Release UPDATE_NOTE immediately — no cancel will arrive.
+    transport.release_update.set()
+    client = _make_client_with_transport(transport, auth_tokens)
+
+    try:
+        note = await client.notes.create("nb_test", title="Hello", content="World")
+        assert note.id == "note_new_001"
+
+        rpc_ids = transport.rpc_ids()
+        assert RPCMethod.CREATE_NOTE.value in rpc_ids
+        assert RPCMethod.UPDATE_NOTE.value in rpc_ids
+        assert RPCMethod.DELETE_NOTE.value not in rpc_ids, (
+            "DELETE_NOTE fired on a non-cancelled create — cleanup is "
+            f"over-eager: rpc_ids={rpc_ids!r}"
+        )
+    finally:
+        if client._core._http_client is not None:
+            await client._core._http_client.aclose()
+            client._core._http_client = None


### PR DESCRIPTION
## Summary

`_mind_map.create_note` issued CREATE_NOTE then UPDATE_NOTE back-to-back. A cancel arriving in that window (CREATE_NOTE persisted, UPDATE_NOTE not yet applied) left an orphan row on the server with no title/content.

- Wrap the UPDATE_NOTE call in `asyncio.shield` so an outer cancel cannot abort the in-flight finalize.
- On `CancelledError`, schedule a best-effort DELETE_NOTE via `asyncio.create_task` (NOT awaited — re-raise must not block on cleanup), then re-raise.
- Best-effort cleanup swallows secondary exceptions (logs at WARNING) so the discarded task never surfaces a noisy secondary failure.

## Task

`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2.md#T7.C4` — Wave 2 cancellation cluster. Audit §28.

## Test plan

- [x] Red regression test (`tests/integration/concurrency/test_note_create_cancel.py`) confirmed failing before the shield landed (outer task cancelled but no DELETE_NOTE cleanup observed).
- [x] Green after fix: cancel mid-UPDATE_NOTE → either shield wins (both writes succeed) or cleanup task reaches the transport.
- [x] Sanity test: a non-cancelled `notes.create` never fires DELETE_NOTE (guards against over-eager cleanup).
- [x] `uv run ruff format .`
- [x] `uv run ruff check .` — All checks passed.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — no issues in 59 source files.
- [x] `uv run pytest tests/integration/concurrency/ tests/unit/test_notes_unit.py` — 97 passed.
- [x] Broader sweep: notes unit + CLI note + artifacts coverage + artifact downloads + concurrency harness — 211 passed.

## Notes

- Surgical change: only `src/notebooklm/_mind_map.py` modified. `_notes.py` and `_artifacts.py` untouched per spec.
- `asyncio.create_task` handle is intentionally discarded (`noqa: RUF006`) — the cleanup is fire-and-forget by design.
- Disjoint from sibling Wave-2 PRs (C1/C2 touch `_core.py`; C3 touches `_sources.py`).

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancellations during note creation. The system now properly completes in-flight updates and cleans up orphaned notes if cancellation occurs during finalization, ensuring more reliable operation.

* **Tests**
  * Added comprehensive concurrency tests to verify correct behavior when note creation is cancelled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/561)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->