### PR TITLE
fix(core): shield shared refresh task from waiter cancellation (T7.C1)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -1004,6 +1004,16 @@ class ClientCore:
         401s on the same client triggers exactly one token refresh. The lock
         protects task-creation only; the await on the task itself happens
         outside the lock so other callers can join.
+
+        The join is wrapped in :func:`asyncio.shield` (T7.C1, audit §4) so
+        that a caller cancelled while waiting — e.g. via
+        ``asyncio.wait_for(..., timeout=...)`` — unwinds locally without
+        propagating the ``CancelledError`` into the *shared* refresh task.
+        Without the shield, one cancelled waiter would cancel the
+        underlying task, taking down every sibling joined to the same
+        single-flight refresh. The slot at ``self._refresh_task`` is left
+        intact across the cancellation and is replaced only on the next
+        refresh wave once the current task transitions to ``done()``.
         """
         assert self._refresh_callback is not None
         assert self._refresh_lock is not None
@@ -1017,7 +1027,7 @@ class ClientCore:
                 self._refresh_task = asyncio.create_task(coro)
                 refresh_task = self._refresh_task
 
-        await refresh_task
+        await asyncio.shield(refresh_task)
 
     async def query_post(
         self,

--- a/tests/integration/concurrency/test_refresh_cancellation_propagation.py
+++ b/tests/integration/concurrency/test_refresh_cancellation_propagation.py
@@ -1,0 +1,228 @@
+"""T7.C1 — shielded shared refresh task survives waiter cancellation.
+
+Regression test for the cancellation-propagation bug at
+``src/notebooklm/_core.py:_await_refresh``: prior to T7.C1, a caller
+cancelled via ``asyncio.wait_for(timeout=...)`` while
+``await self._refresh_task`` was pending would propagate the
+``CancelledError`` into the *shared* refresh task itself, taking down
+every other waiter joining the single in-flight refresh.
+
+The fix (audit §4) wraps the await in ``asyncio.shield`` so the
+cancelled waiter unwinds locally while the underlying task continues
+producing a value for its siblings.
+
+Acceptance (per ``.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2.md#T7.C1``):
+
+    Two ``asyncio.gather`` tasks await refresh; cancel one via
+    ``wait_for(timeout=0.01)``; assert the other still receives a
+    successful refresh result.
+
+The test is the red gate — it must fail on origin/main (unshielded
+await cancels the shared task) and pass once the shield is applied.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+
+# Event-wait deadlines: tight enough to fail fast on a regression that
+# hangs, generous enough not to flake on a slow CI runner. Every
+# event-wait below resolves in <100ms locally.
+EVENT_TIMEOUT_S = 5.0
+
+
+@asynccontextmanager
+async def _opened_core(refresh_callback):
+    """Open a ``ClientCore`` with the given refresh callback; close cleanly.
+
+    Mirrors ``tests/unit/conftest.make_core`` but lives here because the
+    ``tests/unit/`` conftest is not importable from
+    ``tests/integration/concurrency/`` (pytest only adds the test root
+    directory to ``sys.path`` for sibling imports).
+    """
+    auth = AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "old_sid_cookie"},
+    )
+    core = ClientCore(
+        auth=auth,
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=0.0,
+    )
+    await core.open()
+    try:
+        yield core
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_waiter_cancellation_does_not_kill_shared_refresh():
+    """Cancelling one waiter must not cancel the shared refresh task.
+
+    Two coroutines call ``_await_refresh()`` concurrently. The first is
+    wrapped in ``asyncio.wait_for(timeout=0.01)`` so it gets cancelled
+    while the gated refresh callback is still blocked. The second
+    coroutine continues awaiting the shared task. After the callback is
+    released, the second coroutine must observe a successful refresh
+    (no ``CancelledError`` leaking from the shared task).
+
+    Pre-fix (unshielded ``await self._refresh_task``): the cancelled
+    waiter's ``CancelledError`` propagates into the shared task,
+    cancelling it; the second waiter raises ``CancelledError``.
+    Post-fix (``await asyncio.shield(self._refresh_task)``): the
+    cancelled waiter unwinds locally; the shared task completes; the
+    second waiter resolves to ``None`` (``_await_refresh`` returns
+    ``None`` on success).
+    """
+    callback_entered = asyncio.Event()
+    release_refresh = asyncio.Event()
+    call_count = 0
+    core_ref: list[ClientCore] = []
+
+    async def cb():
+        nonlocal call_count
+        call_count += 1
+        callback_entered.set()
+        await release_refresh.wait()
+        tokens = AuthTokens(
+            csrf_token="CSRF_REFRESHED",
+            session_id="SID_REFRESHED",
+            cookies={"SID": "post_refresh"},
+        )
+        # Mirror the production callback contract: update core.auth
+        # in place so the freshly-refreshed values are observable on
+        # the shared core after the task completes.
+        core_ref[0].auth.csrf_token = tokens.csrf_token
+        core_ref[0].auth.session_id = tokens.session_id
+        return tokens
+
+    async with _opened_core(refresh_callback=cb) as core:
+        core_ref.append(core)
+
+        # Caller #1: wrapped in a tight wait_for so it gets cancelled
+        # while the callback is gated. The 10ms timeout is deliberately
+        # short — the callback is gated on ``release_refresh.wait()`` and
+        # we never release until both callers are joined, so #1 is
+        # guaranteed to time out.
+        async def cancelled_waiter():
+            await asyncio.wait_for(core._await_refresh(), timeout=0.01)
+
+        # Caller #2: plain await — represents a parallel 401 retry path
+        # that should observe a successful shared refresh regardless of
+        # what happens to caller #1.
+        async def surviving_waiter():
+            return await core._await_refresh()
+
+        task1 = asyncio.create_task(cancelled_waiter())
+        task2 = asyncio.create_task(surviving_waiter())
+
+        # Wait for the gated callback to fire — this proves both tasks
+        # are now joined on the same shared refresh task (single-flight
+        # invariant from T7.A2 / refresh state machine).
+        await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
+        assert call_count == 1, (
+            f"Single-flight broken: callback fired {call_count} times "
+            "before release; both waiters should share one task."
+        )
+
+        # Caller #1 should now have timed out and raised TimeoutError.
+        # Awaiting it surfaces the timeout cleanly so the failure mode
+        # is observable in the test log.
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await task1
+
+        # The shared task must still be alive — caller #1's cancellation
+        # should not have cancelled it. This is the load-bearing
+        # invariant the shield protects.
+        assert core._refresh_task is not None, "shared refresh task vanished"
+        assert not core._refresh_task.done(), (
+            "Shared refresh task completed/cancelled before release — "
+            "T7.C1 regression: waiter cancellation propagated into the "
+            "shared task."
+        )
+
+        # Release the gate. The shared task should complete successfully
+        # and caller #2 should resolve to ``None`` (``_await_refresh``
+        # returns None on success).
+        release_refresh.set()
+        result = await asyncio.wait_for(task2, EVENT_TIMEOUT_S)
+
+        # The successful refresh propagated to the surviving waiter.
+        assert result is None
+        # The callback fired exactly once — confirms the surviving
+        # waiter joined the shared task rather than spawning a new one
+        # after caller #1's cancellation cleared the slot.
+        assert call_count == 1, (
+            f"Refresh re-fired after waiter cancellation: {call_count}. "
+            "Dedupe semantics broken — the shield should preserve the "
+            "single in-flight task, not trigger a respawn."
+        )
+        # The in-place core.auth update from the callback is observable,
+        # proving the shared task ran to completion despite the
+        # cancellation of caller #1.
+        assert core.auth.csrf_token == "CSRF_REFRESHED"
+
+
+@pytest.mark.asyncio
+async def test_refresh_task_slot_not_cleared_on_waiter_cancellation():
+    """``self._refresh_task`` must persist across a waiter cancellation.
+
+    Acceptance invariant: ``self._refresh_task`` is only cleared after
+    the task completes (success OR failure), NOT on caller cancellation.
+
+    In the current implementation the slot is never explicitly cleared —
+    it is overwritten on the next refresh wave (see
+    ``test_second_wave_creates_distinct_refresh_task``). This test pins
+    that contract: a cancelled waiter does NOT cause the slot to be
+    cleared mid-flight, which would break the single-flight invariant
+    for any sibling waiter that arrives between the cancellation and
+    the callback completing.
+    """
+    callback_entered = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def cb():
+        callback_entered.set()
+        await release_refresh.wait()
+        return AuthTokens(
+            csrf_token="CSRF_NEW",
+            session_id="SID_NEW",
+            cookies={"SID": "x"},
+        )
+
+    async with _opened_core(refresh_callback=cb) as core:
+
+        async def cancelled_waiter():
+            await asyncio.wait_for(core._await_refresh(), timeout=0.01)
+
+        task = asyncio.create_task(cancelled_waiter())
+        await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
+
+        # Snapshot the task identity before the cancellation lands.
+        in_flight = core._refresh_task
+        assert in_flight is not None
+
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await task
+
+        # Slot still points at the same task — not cleared, not replaced.
+        assert core._refresh_task is in_flight, (
+            "Refresh slot mutated by waiter cancellation — invariant "
+            "broken: the slot must persist until the task completes."
+        )
+        assert not in_flight.done(), (
+            "Shared task done before release — waiter cancellation "
+            "leaked into the shared task (T7.C1 regression)."
+        )
+
+        # Clean up so the fixture teardown doesn't hang.
+        release_refresh.set()
+        await asyncio.wait_for(in_flight, EVENT_TIMEOUT_S)


### PR DESCRIPTION
## Summary

- Wrap `await refresh_task` in `_core.py:_await_refresh` with `asyncio.shield(...)` so a caller cancelled via `asyncio.wait_for(timeout=...)` (or any outer cancellation) unwinds locally without taking down the shared single-flight refresh task.
- `self._refresh_task` is left intact across the cancellation and replaced only on the next refresh wave once the current task transitions to `done()` — pinned by a new regression test.
- 1-line behavioral change in `_core.py`, ~10 lines of invariant docstring, and 2 new red-green regression tests in `tests/integration/concurrency/`. Dedupe semantics and lock structure unchanged.

## Task

- Spec: `.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2.md#T7.C1`
- Audit reference: §4 (cancellation propagation cluster)
- Wave 2 of the Tier 7 thread-safety / concurrency remediation arc

## The bug

Before this PR, the join in `_await_refresh` was an unshielded `await self._refresh_task`. If any caller was cancelled while joined to the shared task — for example, a `wait_for(timeout=...)` firing while the refresh callback was still in flight — the `CancelledError` propagated into the *underlying task itself*, cancelling the single in-flight refresh and surfacing `CancelledError` to every sibling waiter joined to it.

## The fix

```python
await asyncio.shield(refresh_task)
```

The `asyncio.shield` wrapper future is what gets cancelled; the underlying task continues to produce a value for non-cancelled siblings. The shield is placed *outside* the `_refresh_lock` block (matching the pre-existing comment) so a cancelled waiter never tears down the lock.

## Tests

`tests/integration/concurrency/test_refresh_cancellation_propagation.py` — 2 regression tests, both confirmed red on `origin/main` and green with the shield applied:

1. **`test_waiter_cancellation_does_not_kill_shared_refresh`** — behavioral invariant: two concurrent waiters, one cancelled via `wait_for(timeout=0.01)`, asserts the surviving waiter still receives the successful refresh result and the callback fired exactly once (single-flight preserved).
2. **`test_refresh_task_slot_not_cleared_on_waiter_cancellation`** — structural invariant: pins that `self._refresh_task` retains the same task object identity across a waiter cancellation and the task is still alive (`not done()`) when the cancellation lands.

All 3 existing `test_refresh_state_machine.py` tests (single-flight, failure-propagation, second-wave-distinct) still pass — dedupe semantics preserved.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest tests/integration/concurrency/ tests/unit/test_refresh_state_machine.py` — 43 passed
- [x] Full suite: `uv run pytest` — 3798 passed, 12 skipped, 102 xfailed, 0 failed

## Deferred polish findings

None — the change is the minimal surgical shield. The harness duplication of `make_core` as a local `_opened_core` helper is intentional (per the file docstring) because `tests/unit/conftest` is not importable from `tests/integration/concurrency/`; consolidating shared test infra is out of scope and risks colliding with other Tier 7 waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cancelling a refresh operation could inadvertently interrupt other concurrent refresh requests, ensuring independent operation of concurrent refresh calls.

* **Tests**
  * Added integration tests to verify proper handling of concurrent refresh cancellation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/562)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->