### PR TITLE
fix(sources): shield upload finalize + best-effort Scotty cancel on Ctrl-C (T7.C3)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -1406,6 +1406,21 @@ class SourcesAPI:
         Uses streaming to avoid loading the entire file into memory,
         which is important for large PDFs and documents.
 
+        Cancellation contract (T7.C3 / audit §9):
+          - The finalize POST is wrapped in ``asyncio.shield``. If a
+            ``CancelledError`` arrives while the finalize POST is in
+            flight, the inner Task keeps running so the server-side
+            session reaches a known terminal state instead of dangling.
+            The cancel is then re-raised to the caller.
+          - If the cancel arrives BEFORE the finalize POST is dispatched
+            (e.g. while the local ``httpx.AsyncClient`` is being
+            constructed), a best-effort ``X-Goog-Upload-Command: cancel``
+            POST is fired against the same resumable upload URL via
+            ``asyncio.create_task``. The cleanup task is not awaited —
+            re-raising must not block on best-effort cleanup. The cleanup
+            POST itself is shielded so cooperative cancellation does not
+            tear it down before the bytes hit the wire.
+
         Args:
             upload_url: The resumable upload URL from _start_resumable_upload.
             file_path: Path to the file to upload.
@@ -1431,12 +1446,68 @@ class SourcesAPI:
                 while chunk := f.read(65536):  # 64KB chunks
                     yield chunk
 
-        # See _start_resumable_upload: pass the live cookie jar so httpx scopes
-        # cookies per Domain attribute. Scotty validates OSID against host
-        # and rejects foreign-host cookies. (#373)
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(10.0, read=300.0),
-            cookies=self._core.get_http_client().cookies,
-        ) as client:
-            response = await client.post(upload_url, headers=headers, content=file_stream())
-            response.raise_for_status()
+        # `finalize_started` flips the moment we hand the request to httpx.
+        # On cancel we use it to discriminate:
+        #   - True  → shield is keeping the in-flight POST alive; just re-raise.
+        #   - False → no POST went out, so fire a best-effort Scotty cancel.
+        # A single-element list is the simplest closure-mutable boolean.
+        finalize_started = [False]
+
+        async def _do_finalize() -> None:
+            # See _start_resumable_upload: pass the live cookie jar so
+            # httpx scopes cookies per Domain attribute. Scotty validates
+            # OSID against host and rejects foreign-host cookies. (#373)
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(10.0, read=300.0),
+                cookies=self._core.get_http_client().cookies,
+            ) as client:
+                finalize_started[0] = True
+                response = await client.post(upload_url, headers=headers, content=file_stream())
+                response.raise_for_status()
+
+        finalize_task = asyncio.create_task(_do_finalize())
+        try:
+            await asyncio.shield(finalize_task)
+        except asyncio.CancelledError:
+            if not finalize_started[0]:
+                # Pre-finalize cancel: the POST never went out. Cancel the
+                # still-setting-up inner task and fire a best-effort
+                # Scotty cancel so the resumable upload session doesn't
+                # dangle until the server's GC sweeps it.
+                finalize_task.cancel()
+                asyncio.create_task(self._cancel_upload_session(upload_url, base_url, auth_route))
+            # Post-finalize cancel: asyncio.shield is keeping the inner
+            # task alive; let it run to completion in the background, then
+            # propagate the cancel as the caller requested.
+            raise
+
+    async def _cancel_upload_session(self, upload_url: str, base_url: str, auth_route: str) -> None:
+        """Best-effort POST a Scotty resumable-upload cancel command.
+
+        Invoked fire-and-forget (via ``asyncio.create_task``) from
+        ``_upload_file_streaming`` when a ``CancelledError`` arrives
+        BEFORE the finalize POST is dispatched, so the server-side
+        session is torn down instead of held until Scotty's GC timeout.
+
+        Network failures are swallowed — Ctrl-C cleanup is best-effort;
+        the worst case is that the session lives until Scotty GCs it.
+        Since the caller schedules this on a detached task, there is no
+        outer await chain that can deliver a cancellation here, so no
+        extra shield is needed at this layer.
+        """
+        headers = {
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+            "x-goog-authuser": auth_route,
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
+            "x-goog-upload-command": "cancel",
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(10.0, read=10.0),
+                cookies=self._core.get_http_client().cookies,
+            ) as client:
+                await client.post(upload_url, headers=headers)
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            logger.debug("Best-effort Scotty cancel for %s failed: %r", upload_url, exc)

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -1418,8 +1418,9 @@ class SourcesAPI:
             POST is fired against the same resumable upload URL via
             ``asyncio.create_task``. The cleanup task is not awaited —
             re-raising must not block on best-effort cleanup. The cleanup
-            POST itself is shielded so cooperative cancellation does not
-            tear it down before the bytes hit the wire.
+            runs on a detached task with no outer await chain, so a
+            caller-level cancel cannot reach it; no explicit shield is
+            needed at that layer (see ``_cancel_upload_session`` docstring).
 
         Args:
             upload_url: The resumable upload URL from _start_resumable_upload.
@@ -1446,14 +1447,17 @@ class SourcesAPI:
                 while chunk := f.read(65536):  # 64KB chunks
                     yield chunk
 
-        # `finalize_started` flips the moment we hand the request to httpx.
-        # On cancel we use it to discriminate:
+        # `finalize_started` flips after the local ``httpx.AsyncClient``
+        # context enters and immediately before ``client.post(...)``. There
+        # is no ``await`` between the flip and the POST, so asyncio cannot
+        # deliver a cancel in that window — once the flag is True, the
+        # request is effectively in flight. On cancel we discriminate:
         #   - True  → shield is keeping the in-flight POST alive; just re-raise.
         #   - False → no POST went out, so fire a best-effort Scotty cancel.
-        # A single-element list is the simplest closure-mutable boolean.
-        finalize_started = [False]
+        finalize_started = False
 
         async def _do_finalize() -> None:
+            nonlocal finalize_started
             # See _start_resumable_upload: pass the live cookie jar so
             # httpx scopes cookies per Domain attribute. Scotty validates
             # OSID against host and rejects foreign-host cookies. (#373)
@@ -1461,15 +1465,24 @@ class SourcesAPI:
                 timeout=httpx.Timeout(10.0, read=300.0),
                 cookies=self._core.get_http_client().cookies,
             ) as client:
-                finalize_started[0] = True
+                finalize_started = True
                 response = await client.post(upload_url, headers=headers, content=file_stream())
                 response.raise_for_status()
 
+        def _log_finalize_exc(t: asyncio.Task[None]) -> None:
+            # On post-finalize cancel, ``finalize_task`` keeps running in the
+            # background. Without this callback, an unawaited exception
+            # (e.g. server 5xx) would surface as a noisy
+            # "Task exception was never retrieved" asyncio warning.
+            if not t.cancelled() and (exc := t.exception()) is not None:
+                logger.debug("Background finalize POST failed: %r", exc)
+
         finalize_task = asyncio.create_task(_do_finalize())
+        finalize_task.add_done_callback(_log_finalize_exc)
         try:
             await asyncio.shield(finalize_task)
         except asyncio.CancelledError:
-            if not finalize_started[0]:
+            if not finalize_started:
                 # Pre-finalize cancel: the POST never went out. Cancel the
                 # still-setting-up inner task and fire a best-effort
                 # Scotty cancel so the resumable upload session doesn't

--- a/tests/integration/concurrency/test_upload_cancel_dangling_session.py
+++ b/tests/integration/concurrency/test_upload_cancel_dangling_session.py
@@ -1,0 +1,282 @@
+"""Regression test for T7.C3 — shield upload finalize + Scotty cancel cleanup.
+
+Audit item §9: pre-fix, a `CancelledError` arriving mid-`_upload_file_streaming`
+abandoned the in-flight `"upload, finalize"` POST without waiting for the
+server's 200 (or its error). The server-side resumable upload session
+either:
+  - Completed silently (the server processed all bytes but the client
+    never learned), leaving a dangling registered source with no
+    title-update applied, OR
+  - Remained half-finalized, the resumable URL still alive, holding
+    quota until Scotty's GC timeout expired.
+
+Post-fix (T7.C3):
+  - The finalize POST is wrapped in ``asyncio.shield`` so a cancel
+    mid-POST lets the request complete; the cancel then propagates after
+    the response is received (or after the inner Task wins the race).
+  - If the cancel arrives BEFORE the finalize POST is dispatched, the
+    handler fires a best-effort Scotty cancel
+    (``X-Goog-Upload-Command: cancel``) to the same resumable upload URL
+    via ``asyncio.create_task`` so the re-raise is never blocked.
+
+This module asserts both branches:
+
+1. ``test_cancel_after_finalize_started_shield_completes_request``
+   Holds the mock transport handler until the test releases it. Cancels
+   AFTER the handler has started → the shielded inner Task keeps the
+   POST in flight, the handler returns 200, and the captured request
+   list shows a completed ``"upload, finalize"`` POST.
+
+2. ``test_cancel_before_finalize_fires_scotty_cleanup``
+   Blocks ``httpx.AsyncClient.__aenter__`` on an event that the test
+   never releases for the finalize client, so the cancel hits BEFORE
+   the finalize POST is dispatched. Asserts a separate POST with
+   ``X-Goog-Upload-Command: cancel`` lands on the same upload URL.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+
+from notebooklm import NotebookLMClient
+
+from .helpers import with_simulated_cancel
+
+UPLOAD_URL = "https://example.test/scotty/upload-session-abc123"
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — cancel AFTER finalize POST starts
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_after_finalize_started_shield_completes_request(
+    auth_tokens,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel mid-finalize → shield keeps the POST alive; finalize completes.
+
+    The mock transport sets ``finalize_arrived`` once the handler runs and
+    then awaits ``release`` before returning 200. The test waits for
+    ``finalize_arrived`` (so the POST is genuinely in flight), cancels the
+    upload task, then releases the handler. Because the finalize POST is
+    shielded, the inner Task is not cancelled — it observes the 200 and
+    completes. The captured request list confirms the finalize POST landed.
+    """
+    file_path = tmp_path / "doc.pdf"
+    file_path.write_bytes(b"x" * 128)
+
+    finalize_arrived = asyncio.Event()
+    release = asyncio.Event()
+    captured: list[httpx.Request] = []
+    handler_completed: list[bool] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        finalize_arrived.set()
+        # Block here so the test can deterministically cancel the caller
+        # while the POST is in flight. On the un-shielded baseline, httpx
+        # propagates the outer cancel into this coroutine and we never
+        # reach the response-construction line below — that absence is
+        # what the shield assertion catches.
+        try:
+            await release.wait()
+        except BaseException:
+            # Don't swallow — let httpx see the cancel — but record that
+            # the handler did NOT run to completion.
+            raise
+        handler_completed.append(True)
+        return httpx.Response(200, content=b"")
+
+    transport = httpx.MockTransport(handler)
+    _patch_async_client_transport(monkeypatch, transport)
+
+    async with NotebookLMClient(auth_tokens) as client:
+        upload_task = asyncio.create_task(
+            client.sources._upload_file_streaming(UPLOAD_URL, file_path),
+        )
+
+        # Wait until the mock transport has the request — i.e., the
+        # finalize POST is definitely in flight.
+        await asyncio.wait_for(finalize_arrived.wait(), timeout=2.0)
+
+        # Cancel the outer task. With the shield in place, the inner POST
+        # keeps running; without the shield, the request is abandoned.
+        upload_task.cancel()
+
+        # Release the handler so the inner request can finish.
+        # Give the cancel a beat to propagate first, mirroring the real
+        # Ctrl-C interleave.
+        await asyncio.sleep(0)
+        release.set()
+
+        # The outer task will see CancelledError (shield re-raises after
+        # the inner POST completes — or immediately, with the inner Task
+        # still scheduled). Either way, the captured POST must include
+        # the finalize command.
+        with pytest.raises(asyncio.CancelledError):
+            await upload_task
+
+        # Drain pending callbacks so the shielded background task lands
+        # — we need the handler to reach `handler_completed.append(True)`
+        # AFTER its `release` wait returns.
+        for _ in range(100):
+            if handler_completed:
+                break
+            await asyncio.sleep(0.01)
+
+    finalize_seen = [
+        r for r in captured if r.headers.get("x-goog-upload-command") == "upload, finalize"
+    ]
+    assert finalize_seen, (
+        "shield failure: finalize POST was abandoned on cancel "
+        f"(captured commands: "
+        f"{[r.headers.get('x-goog-upload-command') for r in captured]})"
+    )
+    # The strong shield assertion: without the shield, httpx cancels the
+    # underlying transport coroutine when the outer task is cancelled,
+    # and the handler is interrupted before `handler_completed.append`
+    # runs. With the shield, the handler observes `release.set()` and
+    # returns 200 — `handler_completed` is non-empty.
+    assert handler_completed, (
+        "shield failure: the in-flight finalize POST was interrupted by "
+        "cancel — the mock handler never reached its response line. "
+        "asyncio.shield should keep the POST alive through the cancel."
+    )
+    # The shield protects the in-flight finalize; the cancel POST is for the
+    # pre-finalize branch only — confirm we did NOT also fire a redundant
+    # cancel here, otherwise the patched code is shielding AND cleaning up.
+    cancel_seen = [r for r in captured if r.headers.get("x-goog-upload-command") == "cancel"]
+    assert not cancel_seen, (
+        "shield+cleanup both fired; cancel cleanup must be gated on pre-finalize state"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — cancel BEFORE finalize POST is dispatched
+# ---------------------------------------------------------------------------
+
+
+async def test_cancel_before_finalize_fires_scotty_cleanup(
+    auth_tokens,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel before the finalize POST → best-effort cancel POST is fired.
+
+    Strategy: wrap ``httpx.AsyncClient`` so the finalize client blocks
+    inside ``__aenter__`` on an event the test never releases. A
+    ``with_simulated_cancel`` cancels the upload task while it is still
+    waiting to acquire the finalize client. The fix must observe this
+    pre-finalize cancel and fire a separate ``X-Goog-Upload-Command: cancel``
+    POST (via ``asyncio.create_task`` so the re-raise is not blocked) on
+    a NEW client whose transport we observe.
+    """
+    file_path = tmp_path / "doc.pdf"
+    file_path.write_bytes(b"x" * 128)
+
+    captured: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=b"")
+
+    cleanup_transport = httpx.MockTransport(handler)
+    aenter_call_count = {"n": 0}
+    finalize_aenter_blocker = asyncio.Event()
+
+    # Discriminate by call order: the FIRST AsyncClient constructed inside
+    # _upload_file_streaming is the finalize client (we block its
+    # __aenter__ so the cancel lands before the POST). Subsequent
+    # constructions (e.g. the cleanup client created via
+    # asyncio.create_task) pass through, and we observe their requests on
+    # `cleanup_transport`.
+    class _BlockingFinalizeClient(httpx.AsyncClient):
+        async def __aenter__(self) -> httpx.AsyncClient:
+            aenter_call_count["n"] += 1
+            if aenter_call_count["n"] == 1:
+                await finalize_aenter_blocker.wait()
+            return await super().__aenter__()
+
+    def _client_factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs.setdefault("transport", cleanup_transport)
+        return _BlockingFinalizeClient(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("notebooklm._sources.httpx.AsyncClient", _client_factory)
+
+    async with NotebookLMClient(auth_tokens) as client:
+        # with_simulated_cancel cancels the inner task after `delay`
+        # seconds. The finalize client blocks indefinitely on
+        # finalize_aenter_blocker, so the cancel is guaranteed to land
+        # BEFORE the POST is dispatched.
+        result = await with_simulated_cancel(
+            client.sources._upload_file_streaming(UPLOAD_URL, file_path),
+            delay=0.05,
+            label="upload-pre-finalize-cancel",
+        )
+        # The outer call must surface CancelledError (re-raise after
+        # scheduling the cleanup task).
+        assert isinstance(result, asyncio.CancelledError), (
+            f"expected CancelledError, got {type(result).__name__}: {result!r}"
+        )
+
+        # Let the cleanup task (created via asyncio.create_task) run.
+        for _ in range(50):
+            if any(r.headers.get("x-goog-upload-command") == "cancel" for r in captured):
+                break
+            await asyncio.sleep(0.01)
+
+        # Release the finalize __aenter__ so no stray task lives past the
+        # test. (The shielded inner finalize task — if any — completes
+        # immediately because we never sent the POST.)
+        finalize_aenter_blocker.set()
+        await asyncio.sleep(0)
+
+    cancel_posts = [
+        r
+        for r in captured
+        if r.method == "POST"
+        and r.headers.get("x-goog-upload-command") == "cancel"
+        and str(r.url) == UPLOAD_URL
+    ]
+    assert cancel_posts, (
+        "pre-finalize cancel: expected a best-effort 'X-Goog-Upload-Command: "
+        "cancel' POST to the resumable upload URL; captured: "
+        f"{[(r.method, str(r.url), dict(r.headers)) for r in captured]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Patch helper
+# ---------------------------------------------------------------------------
+
+
+def _patch_async_client_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: httpx.MockTransport,
+) -> None:
+    """Force every ``httpx.AsyncClient`` constructed inside ``_sources`` to
+    use the given ``MockTransport``.
+
+    ``_upload_file_streaming`` instantiates its own ``httpx.AsyncClient``
+    (it doesn't route through the shared core client), so we replace the
+    constructor in the ``_sources`` module namespace with a wrapper that
+    pre-binds the transport kwarg.
+    """
+
+    # Capture the unpatched AsyncClient before monkeypatch swaps the
+    # attribute. `monkeypatch.setattr("notebooklm._sources.httpx.AsyncClient", ...)`
+    # mutates the shared `httpx` module object, so calling `httpx.AsyncClient`
+    # inside the factory would recurse into the factory itself.
+    original_async_client = httpx.AsyncClient
+
+    def _factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return original_async_client(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("notebooklm._sources.httpx.AsyncClient", _factory)


### PR DESCRIPTION
## Summary

- Shield the resumable-upload finalize POST in `_upload_file_streaming` with `asyncio.shield` so a `CancelledError` (Ctrl-C, gather cancel, task-group teardown) arriving while the POST is in flight lets it complete and the server-side session reaches a known terminal state. The cancel is re-raised to the caller after.
- Fire a best-effort `X-Goog-Upload-Command: cancel` POST via `asyncio.create_task` when the cancel arrives BEFORE the POST is dispatched, so the resumable upload session is torn down instead of dangling until Scotty's GC timeout. The cleanup is fire-and-forget; the re-raise is never blocked on it.
- Pre/post-finalize discrimination via a closure-mutable flag set the moment the inner Task hands the request to httpx.

## Task

Plan: [`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2.md#T7.C3`](.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2.md)
Audit item: §9 (upload-finalize cancellation)
Wave 2 sibling tasks: C1 (refresh shield), C2 (close shield), C4 (note-create shield) — fully disjoint file surfaces.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/integration/concurrency/ tests/integration/test_sources.py` — 143 passed (38 sources + 30 prior concurrency + 2 new + harness)
- [x] `uv run pytest` (full suite) — 3798 passed, 12 skipped, 102 xfailed
- [x] Red-then-green TDD: both new tests fail on the unshielded baseline for exactly the asserted invariant (handler interrupted mid-POST; no cancel POST fired). Apply the shield → both pass.

## Deferred polish findings

None — simplification pass dropped redundant outer shield in `_cancel_upload_session` and tightened test-file typings (no `type: ignore[misc, valid-type]` on the helper subclass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)