### PR TITLE
fix(tests): scrub upload tokens in sources_add_file (I17, T8.B4)

### DIFF
--- a/tests/cassettes/sources_add_file.yaml
+++ b/tests/cassettes/sources_add_file.yaml
@@ -1357,9 +1357,9 @@ interactions:
         fill=\"#249A41\"></path><path d=\"M33.49,34.77C37.49,31.12,40,25.85,40,20c0-5.86-2.52-11.13-6.54-14.79l-1.37,1.46C35.72,9.97,38,14.72,38,20c0,5.25-2.26,9.98-5.85,13.27L33.49,34.77z\"
         fill=\"#3174F1\"></path><path d=\"M20,2c4.65,0,8.89,1.77,12.09,4.67l1.37-1.46C29.91,1.97,25.19,0,20,0l0,0C12.21,0,5.46,4.46,2.16,10.96L3.88,12C6.83,6.08,12.95,2,20,2\"
         fill=\"#E92D18\"></path></svg></div><span class=\"gb_be\"><img class=\"gb_Q
-        gbii\" src=\"https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s32-c-mo\"
-        srcset=\"https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s32-c-mo
-        1x, https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s64-c-mo
+        gbii\" src=\"SCRUBBED_AVATAR_URL\"
+        srcset=\"SCRUBBED_AVATAR_URL
+        1x, SCRUBBED_AVATAR_URL
         2x \" alt=\"\" aria-hidden=\"true\" data-noaft=\"\"></span><div class=\"gb_R
         gb_S\" aria-hidden=\"true\"><svg class=\"gb_La\" height=\"14\" viewBox=\"0
         0 14 14\" width=\"14\" xmlns=\"http://www.w3.org/2000/svg\"><circle class=\"gb_Ma\"
@@ -1367,9 +1367,9 @@ interactions:
         2H8V8H6V2Z\"></path></svg></div></a></div><div class=\"gb_Ab gb_ma gb_4 gb_Bb\"
         aria-label=\"Account Information\" aria-hidden=\"true\"><div class=\"gb_Kb\"><div
         class=\"gb_Lb\"><img class=\"gb_nb gbip gb_Pb gb_Sb\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\"
-        data-src=\"https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s83-c-mo\"
-        data-srcset=\"https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s83-c-mo
-        1x, https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s192-c-mo
+        data-src=\"SCRUBBED_AVATAR_URL\"
+        data-srcset=\"SCRUBBED_AVATAR_URL
+        1x, SCRUBBED_AVATAR_URL
         2x \" title=\"Profile\" alt=\"\" aria-hidden=\"true\"><div class=\"gb_Hc\"><svg
         height=\"88\" width=\"88\" focusable=\"false\" version=\"1.1\" viewbox=\"0
         0 108 108\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
@@ -1395,7 +1395,7 @@ interactions:
         gb_ec\"><div class=\"gb_Cf gb_Ic gb_S\"><div class=\"gb_Jc\"></div></div><div
         class=\"gb_zf gb_gc gb_S\" aria-hidden=\"true\"><a class=\"gb_fc gb_pc\" aria-hidden=\"true\"
         href=\"/?authuser=0\" target=\"_blank\"><img class=\"gb_rc gb_Pb\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\"
-        data-src=\"https://lh3.googleusercontent.com/ogw/AF2bZyi16LQ_0jOcB_3NwTmyCfSFpN74FaCfwF0mWwtxF--cwSQ=s48-c-mo\"
+        data-src=\"SCRUBBED_AVATAR_URL\"
         alt=\"\" aria-hidden=\"true\"><div class=\"gb_ic\"><div><div class=\"gb_wc\">Default</div></div><div
         class=\"gb_tc\">SCRUBBED_NAME</div><div class=\"gb_vc\">SCRUBBED_EMAIL@example.com</div></div></a></div><div
         class=\"gb_8b\" aria-hidden=\"true\"><svg class=\"gb_9b\" focusable=\"false\"
@@ -1721,15 +1721,15 @@ interactions:
       Server:
       - UploadServer
       X-GUploader-UploadID:
-      - AJRbA5XZXPNXlx1hKDDNJIHCRQ7p4vybm7qMHVbYaAdiNfTb0ET8p0Nlsm-qkGtk_kgIy12mZYM4eNv6U0Qi2i4FX23Mr-RKOiR0OXwOXeQsRg
+      - SCRUBBED_UPLOAD_ID
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Control-URL:
-      - https://notebooklm.google.com/upload/_/?authuser=0&upload_id=AJRbA5XZXPNXlx1hKDDNJIHCRQ7p4vybm7qMHVbYaAdiNfTb0ET8p0Nlsm-qkGtk_kgIy12mZYM4eNv6U0Qi2i4FX23Mr-RKOiR0OXwOXeQsRg&upload_protocol=resumable
+      - https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID&upload_protocol=resumable
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-URL:
-      - https://notebooklm.google.com/upload/_/?authuser=0&upload_id=AJRbA5XZXPNXlx1hKDDNJIHCRQ7p4vybm7qMHVbYaAdiNfTb0ET8p0Nlsm-qkGtk_kgIy12mZYM4eNv6U0Qi2i4FX23Mr-RKOiR0OXwOXeQsRg&upload_protocol=resumable
+      - https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID&upload_protocol=resumable
     status:
       code: 200
       message: OK
@@ -1765,7 +1765,7 @@ interactions:
       x-goog-upload-offset:
       - '0'
     method: POST
-    uri: https://notebooklm.google.com/upload/_/?authuser=0&upload_id=AJRbA5XZXPNXlx1hKDDNJIHCRQ7p4vybm7qMHVbYaAdiNfTb0ET8p0Nlsm-qkGtk_kgIy12mZYM4eNv6U0Qi2i4FX23Mr-RKOiR0OXwOXeQsRg&upload_protocol=resumable
+    uri: https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID&upload_protocol=resumable
   response:
     body:
       string: 'OK: Enqueued blob bytes to spanner queue for processing.'
@@ -1783,7 +1783,7 @@ interactions:
       Server:
       - UploadServer
       X-GUploader-UploadID:
-      - AJRbA5XZXPNXlx1hKDDNJIHCRQ7p4vybm7qMHVbYaAdiNfTb0ET8p0Nlsm-qkGtk_kgIy12mZYM4eNv6U0Qi2i4FX23Mr-RKOiR0OXwOXeQsRg
+      - SCRUBBED_UPLOAD_ID
       X-Goog-Upload-Status:
       - final
     status:

--- a/tests/scripts/cassette_repair_allowlist.txt
+++ b/tests/scripts/cassette_repair_allowlist.txt
@@ -36,16 +36,17 @@
 example_batchexecute_pattern.yaml
 example_scrubbed_cookies.yaml
 
-# --- spec-explicit entries (4 total; 3 also in the /ogw/ group) -----------
+# --- spec-explicit entries (3 total; 2 also in the /ogw/ group) -----------
+# ``sources_add_file.yaml`` was previously in this list and the /ogw/ group;
+# it was re-scrubbed in T8.B4 (I17 upload tokens) and its avatar URLs were
+# collapsed in the same pass, so it is removed from both groupings.
 artifacts_revise_slide.yaml
 chat_ask.yaml
 chat_ask_with_references.yaml
-sources_add_file.yaml
 
 # --- /ogw/ avatar URL group (61 entries unique to this group;
-# 3 more cassettes — chat_ask, chat_ask_with_references, sources_add_file —
-# also contain ``/ogw/`` and are already listed in the spec-explicit group
-# above) -------------------------------------------------------------------
+# 2 more cassettes — chat_ask, chat_ask_with_references — also contain
+# ``/ogw/`` and are already listed in the spec-explicit group above) -------
 artifacts_delete.yaml
 artifacts_download_data_table.yaml
 artifacts_download_flashcards.yaml

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -368,6 +368,8 @@ def test_python_guard_repo_allowlist_is_explicit_basename_list() -> None:
     }
     # Spec-explicit entries that must always be in the allowlist while
     # phase-2 repair is outstanding.
+    # ``sources_add_file.yaml`` is NOT in this required-set anymore — it was
+    # repaired in T8.B4 (the audit's I17 upload-token leak scrubbed in place).
     # ``sources_add_drive.yaml`` + ``sources_check_freshness_drive.yaml`` are
     # NOT in this required-set anymore — they were repaired in T8.B5 (the
     # audit's I17 Drive AONS-token leak scrubbed in place).
@@ -378,6 +380,5 @@ def test_python_guard_repo_allowlist_is_explicit_basename_list() -> None:
         "artifacts_revise_slide.yaml",
         "chat_ask.yaml",
         "chat_ask_with_references.yaml",
-        "sources_add_file.yaml",
     ):
         assert required in entries, f"missing required allowlist entry: {required}"

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -81,13 +81,13 @@ AUDIT_REPAIR_LIST: dict[str, str] = {
     "chat_ask_with_references.yaml": (
         "Phase 2 T8.B2 will fix (C3: stale chat-ask shape / shape drift)"
     ),
-    "sources_add_file.yaml": ("Phase 2 T8.B4 will fix (I17: upload tokens unscrubbed)"),
-    # sources_add_drive.yaml + sources_check_freshness_drive.yaml were
-    # repaired in T8.B5 (this PR) — Drive AONS tokens scrubbed in place.
-    # example_httpbin_{get,post}.yaml were deleted in T8.B7 — the
-    # I-misc origin-IP leak was in illustrative VCR examples, not real
-    # NotebookLM cassettes. The example tests in test_vcr_example.py that
-    # used them were also removed in the same PR.
+    # sources_add_file.yaml was repaired in T8.B4 — upload tokens (I17)
+    # scrubbed in place. sources_add_drive.yaml +
+    # sources_check_freshness_drive.yaml were repaired in T8.B5 — Drive AONS
+    # tokens scrubbed in place. example_httpbin_{get,post}.yaml were deleted
+    # in T8.B7 — the I-misc origin-IP leak was in illustrative VCR examples,
+    # not real NotebookLM cassettes. The example tests in test_vcr_example.py
+    # that used them were also removed in the same PR.
 }
 
 


### PR DESCRIPTION
## Summary

Re-scrubs `tests/cassettes/sources_add_file.yaml` in place using the canonical `cassette_patterns.scrub_string` sanitizer (T8.A6b, PR #551).  Audit finding **I17** flagged this cassette for three upload-token leak sites — all three are now redacted while keeping the 3-interaction resumable-upload flow (init / upload / finalize) intact.

- `X-GUploader-UploadID:` response headers → `SCRUBBED_UPLOAD_ID`
- `upload_id=<token>` query params in `X-Goog-Upload-URL` / `X-Goog-Upload-Control-URL` → canonical placeholder
- `upload_id=<token>` in the finalize request URI → canonical placeholder
- Avatar URLs in the GET / response body → `SCRUBBED_AVATAR_URL` (incidental coverage from T8.A6a)

The cassette is removed from `cassette_repair_allowlist.txt` (both the spec-explicit group AND the `/ogw/` avatar group, since avatar URLs were scrubbed in the same pass), and the corresponding xfail entries in `tests/unit/test_cassette_shapes.py::AUDIT_REPAIR_LIST` and `tests/unit/test_cassette_sanitizer.py` `required` allowlist tuple are retired.

## Transport-level adapters

Two YAML/replay-shape fixups bridge gaps the registry can't close on its own without a re-record (which is not possible — no auth):

1. **YAML two-line header reshape** — `X-GUploader-UploadID:` is stored as a block-scalar key with the token on the next `- <token>` line; the registry's single-line regex cannot span that newline.
2. **Upload URL replay rehydration** — the canonical `SCRUBBED_UPLOAD_URL` placeholder is NOT a valid URL.  On replay, httpx raises `ValueError: unknown url type` before VCR's matcher fires.  The cassette rehydrates the placeholder to `https://upload-scrubbed.example/?upload_id=SCRUBBED_UPLOAD_ID` — a parseable URL whose host is invisible to `_DETECT_UPLOAD_URL` (which anchors on `notebooklm.google.com`) and whose `upload_id` value is the canonical `SCRUBBED_UPLOAD_ID` placeholder.  The canonical scrubber output is unchanged for fresh recordings; this rehydration lives only in this single cassette and is documented inline in the PR description and via the commit message.

A future fix to the registry pattern (replacing just the token instead of collapsing the full URL) would make the rehydration unnecessary; that is out of scope for T8.B4.

## Test plan

- [x] `uv run ruff format .` + `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest` — 3836 passed, 102 xfailed
- [x] `uv run python tests/scripts/check_cassettes_clean.py --strict` — cassette clean (validated standalone)
- [x] `uv run pytest tests/unit/test_cassette_shapes.py` — 8 passed, 72 xfailed (sources_add_file no longer in AUDIT_REPAIR_LIST)
- [x] `uv run pytest tests/integration -k "add_file or sources"` — 135 passed, 2 skipped, 6 xfailed
- [x] `uv run pytest -m vcr` — 81 passed, 4 skipped, 30 xfailed (full VCR replay suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-scrubbed test cassettes to replace non-deterministic identifiers with standardized placeholders, improving test reliability.
  * Updated test configuration files and assertions to reflect cassette maintenance changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/570)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->