### PR TITLE
fix(tests): re-record artifacts_revise_slide preserving f.req (C2, T8.B1)

### DIFF
--- a/tests/cassettes/artifacts_revise_slide.yaml
+++ b/tests/cassettes/artifacts_revise_slide.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: f.req=SCRUBBED&at=SCRUBBED_CSRF
+    body: f.req=%5B%5B%5B%22KmcKPe%22%2C%22%5B%5B2%5D%2C%5C%22e52e81c5-613b-43ec-8f45-66a120644a26%5C%22%2C%5B%5B%5B0%2C%5C%22Move%20the%20title%20up%5C%22%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778848153629&
     headers:
       Accept:
       - '*/*'
@@ -8,34 +8,95 @@ interactions:
       - gzip, deflate
       Connection:
       - keep-alive
+      Content-Length:
+      - '241'
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/x-www-form-urlencoded;charset=UTF-8
       Cookie:
-      - SID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=1.1.1583381276.1778846987; _ga=GA1.1.1567240762.1778846987;
+        _ga_W0LDH41ZCB=GS2.1.s1778846986$o1$g0$t1778846986$j60$l0$h0
       Host:
       - notebooklm.google.com
       User-Agent:
       - python-httpx/0.28.1
     method: POST
-    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=KmcKPe&source-path=%2Fnotebook%2Ftest_notebook_id&f.sid=SCRUBBED&rt=c
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=KmcKPe&source-path=%2Fnotebook%2Fbb00c9e3-656c-4fd2-b890-2b71e1cf3814&f.sid=SCRUBBED&hl=en&rt=c
   response:
     body:
       string: ')]}''
 
 
-        99
+        412
 
-        [["wrb.fr", "KmcKPe", "[[\"artifact_456\", \"Slide Deck\", \"2024-01-05\",
-        null, 1]]", null, null]]
+        [["wrb.fr","KmcKPe","[[\"b84c4e66-ce7b-43b8-ac86-80c8add3fa23\",\"NotebookLM
+        Redefined (2)\",8,[[[\"466b9ee3-c1ce-45ef-861c-1d4bfcd939ad\"]]],1,null,null,null,null,null,null,null,null,null,null,null,[[null,\"fr\",1,1],null,null,null,null,[[[0,\"Move
+        the title up\"]]]],null,null,null,[\"e52e81c5-613b-43ec-8f45-66a120644a26\"]]]",null,null,null,"generic"],["di",1552],["af.httprm",1552,"6514068800340100612",10]]
+
+        23
+
+        [["e",4,null,null,450]]
 
         '
     headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
       Content-Type:
       - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Fri, 15 May 2026 12:29:13 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '450'
     status:
       code: 200
       message: OK
-    url: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=KmcKPe&source-path=%2Fnotebook%2Ftest_notebook_id&f.sid=SCRUBBED&rt=c
 version: 1

--- a/tests/integration/cli_vcr/test_generate.py
+++ b/tests/integration/cli_vcr/test_generate.py
@@ -31,7 +31,16 @@ class TestGenerateCommands:
             assert_command_success(result)
 
     def test_revise_slide(self, runner, mock_auth_for_vcr, mock_context):
-        """revise-slide command sends REVISE_SLIDE RPC with correct args."""
+        """revise-slide command sends REVISE_SLIDE RPC with correct args.
+
+        Uses an explicit ``-n <36-char UUID>`` so ``resolve_notebook_id``
+        short-circuits (its prefix-resolution path needs ``LIST_NOTEBOOKS``
+        which the cassette doesn't carry). The UUID value doesn't have to
+        match what was recorded — the VCR matcher only compares path +
+        rpcids, not source-path query parameters. The artifact_id is
+        likewise passed verbatim through the request body, which the
+        matcher ignores.
+        """
         with notebooklm_vcr.use_cassette("artifacts_revise_slide.yaml"):
             result = runner.invoke(
                 cli,
@@ -39,8 +48,10 @@ class TestGenerateCommands:
                     "generate",
                     "revise-slide",
                     "Move the title up",
+                    "-n",
+                    "00000000-0000-0000-0000-000000000000",
                     "--artifact",
-                    "artifact_456",
+                    "00000000-0000-0000-0000-000000000001",
                     "--slide",
                     "0",
                 ],

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,7 +87,8 @@ _T8_A1_XFAIL_NODEIDS = frozenset(
         "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[flashcards-artifacts_generate_flashcards.yaml-extra_args1]",
         "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[report-artifacts_generate_report.yaml-extra_args2]",
         "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_generate[report-artifacts_generate_study_guide.yaml-extra_args3]",
-        "tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_revise_slide",
+        # ``test_revise_slide`` was repaired in T8.B1 — cassette re-recorded
+        # against the live REVISE_SLIDE RPC.
         # test_notebooks.py
         "tests/integration/cli_vcr/test_notebooks.py::TestSummaryCommand::test_summary",
         # test_notes.py

--- a/tests/scripts/cassette_repair_allowlist.txt
+++ b/tests/scripts/cassette_repair_allowlist.txt
@@ -36,14 +36,18 @@
 example_batchexecute_pattern.yaml
 example_scrubbed_cookies.yaml
 
-# --- spec-explicit entries (1 total; also in the /ogw/ group) ------------
-# ``sources_add_file.yaml`` was removed in T8.B4 (I17 upload tokens re-scrub,
-# /ogw/ avatar URLs collapsed in the same pass).
-# ``chat_ask.yaml`` + ``chat_ask_with_references.yaml`` were removed in T8.B2
-# — both were re-recorded against the current 9-param streaming-chat builder
-# (src/notebooklm/_chat.py:459-469) so they no longer need the allowlist
-# escape hatch.
-artifacts_revise_slide.yaml
+# --- spec-explicit entries (none remaining) -------------------------------
+# All spec-explicit phase-2 cassettes have been repaired or removed:
+# - ``artifacts_revise_slide.yaml`` — re-recorded in T8.B1 against the live
+#   REVISE_SLIDE RPC; f.req is real urlencoded JSON now.
+# - ``chat_ask.yaml`` + ``chat_ask_with_references.yaml`` — re-recorded in
+#   T8.B2 against the current 9-param streaming-chat builder.
+# - ``sharing_get_status.yaml`` + ``sharing_set_public.yaml`` — re-scrubbed
+#   in T8.B3 for escaped display names + avatar URLs.
+# - ``sources_add_file.yaml`` — re-scrubbed in T8.B4 for upload tokens.
+# - ``sources_add_drive.yaml`` + ``sources_check_freshness_drive.yaml`` —
+#   re-scrubbed in T8.B5 for Drive tokens.
+# - ``example_httpbin_*.yaml`` — deleted in T8.B7 (illustrative fixtures).
 
 # --- /ogw/ avatar URL group (61 entries; no spec-explicit cassettes overlap
 # with this group anymore — sources_add_file was repaired in T8.B4 and

--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -379,5 +379,12 @@ def test_python_guard_repo_allowlist_is_explicit_basename_list() -> None:
     # ``chat_ask.yaml`` + ``chat_ask_with_references.yaml`` are NOT in this
     # required-set anymore — they were re-recorded in T8.B2 against the
     # current 9-param streaming-chat builder (C3 stale-shape regression).
-    for required in ("artifacts_revise_slide.yaml",):
+    # ``artifacts_revise_slide.yaml`` is NOT in this required-set anymore —
+    # it was repaired in T8.B1 (re-recorded so f.req carries a real
+    # urlencoded JSON payload with only sensitive scalars scrubbed inside).
+    # ``sharing_get_status.yaml`` + ``sharing_set_public.yaml`` are NOT in
+    # this required-set anymore — they were re-scrubbed in T8.B3.
+    # With all phase-2 cassette repairs landed, this loop has nothing to
+    # assert; future regressions would re-introduce entries here.
+    for required in ():
         assert required in entries, f"missing required allowlist entry: {required}"

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -74,9 +74,10 @@ def _real_cassettes() -> list[Path]:
 # set is detected dynamically — see `_xfail_reason` below — and mapped to
 # T8.B6 (bulk avatar re-scrub).
 AUDIT_REPAIR_LIST: dict[str, str] = {
-    "artifacts_revise_slide.yaml": (
-        "Phase 2 T8.B1 will fix (C2: f.req=SCRUBBED destroyed payload)"
-    ),
+    # artifacts_revise_slide.yaml was repaired in T8.B1 (this PR) — the
+    # cassette was re-recorded against the live REVISE_SLIDE RPC so f.req
+    # carries the real urlencoded JSON payload again (only sensitive scalars
+    # scrubbed inside, not the whole body collapsed to ``"SCRUBBED"``).
     # chat_ask.yaml + chat_ask_with_references.yaml were repaired in T8.B2 —
     # re-recorded against the current 9-param streaming-chat builder
     # (src/notebooklm/_chat.py:459-469) with the ``freq`` body matcher


### PR DESCRIPTION
## Summary

Re-records ``tests/cassettes/artifacts_revise_slide.yaml`` against the live ``REVISE_SLIDE`` (``KmcKPe``) RPC. The previous cassette had its ``f.req`` collapsed to the literal string ``"SCRUBBED"`` — destroying the payload and rendering the cassette useless. Audit finding **C2**.

Recording done against generation notebook ``bb00c9e3-...`` (T8.A0 setup) with a freshly-generated slide-deck artifact. The cassette is a single interaction (REVISE_SLIDE only) — the test passes an explicit 36-char UUID via ``-n`` so ``resolve_notebook_id`` short-circuits and doesn't issue ``LIST_NOTEBOOKS``.

## Test plan

- [x] ``uv run pytest tests/integration/cli_vcr/test_generate.py::TestGenerateCommands::test_revise_slide`` — passes against new cassette
- [x] ``uv run python tests/scripts/check_cassettes_clean.py`` — 0 leaks
- [x] ``uv run pytest tests/unit/test_cassette_shapes.py`` — shape lint passes, xfail entry for this cassette removed
- [x] Allowlist + ``AUDIT_REPAIR_LIST`` + required-set entries retired in lockstep
- [x] Full pre-commit chain — ruff format / ruff check / mypy / pytest all green

## Notes for reviewers

This PR is the last spec-explicit allowlist entry to clear. After merge, ``tests/scripts/cassette_repair_allowlist.txt`` will hold only:
- 2 illustrative documentation fixtures (``example_*`` non-recordings)
- 61 cassettes with ``/ogw/`` avatar URLs awaiting bulk re-scrub in T8.B6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration and unit test fixtures to reflect corrected request/response data.
  * Repaired test configuration to remove obsolete xfail markers.
  * Cleaned up test allowlist entries for completed repairs.

* **Chores**
  * Simplified cassette repair allowlist documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/573)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->