### PR TITLE
fix(auth): offload storage saves to thread to unblock event loop (T7.D1)

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -503,8 +503,13 @@ class AuthTokens:
         # fails, carry the old baseline into the returned AuthTokens so a
         # later ClientCore can retry the delta instead of treating the mutated
         # jar as clean state.
+        # ``save_cookies_to_storage`` performs atomic-replace + fsync + flock
+        # under a synchronous file lock; offload to a worker thread so a
+        # slow filesystem (network FS, encrypted home, fcntl contention)
+        # can't freeze the event loop. T7.D1 / audit §6.
         post_save_snapshot = snapshot_cookie_jar(jar)
-        save_result = save_cookies_to_storage(
+        save_result = await asyncio.to_thread(
+            save_cookies_to_storage,
             jar,
             path,
             original_snapshot=snapshot,
@@ -3201,5 +3206,8 @@ async def fetch_tokens_with_domains(
         # added redirect Set-Cookies); re-snapshotting here would let those
         # retry rotations be absorbed into the baseline and never reach disk.
         snapshot = post_refresh_snapshot
-    save_cookies_to_storage(jar, path, original_snapshot=snapshot)
+    # Offload the blocking storage save to a worker thread so the
+    # atomic-replace + fsync + flock can't stall the event loop on
+    # slow filesystems. T7.D1 / audit §27.
+    await asyncio.to_thread(save_cookies_to_storage, jar, path, original_snapshot=snapshot)
     return csrf, session_id

--- a/tests/integration/concurrency/test_auth_load_blocks_loop.py
+++ b/tests/integration/concurrency/test_auth_load_blocks_loop.py
@@ -1,0 +1,199 @@
+"""Regression test for T7.D1 — offload save_cookies_to_storage off the loop.
+
+Pre-fix (audit §6, §27): ``AuthTokens.from_storage`` and
+``fetch_tokens_with_domains`` called the *synchronous*
+``save_cookies_to_storage`` directly from an ``async`` context. The
+function performs file I/O (atomic-replace + fsync + flock); when the
+underlying storage is slow (network FS, encrypted home, fcntl
+contention with a sibling process), it stalls the whole event loop.
+
+Post-fix (T7.D1): each call site wraps the synchronous save with
+``await asyncio.to_thread(save_cookies_to_storage, ...)``, so the
+blocking work runs on the default thread executor and the event loop
+keeps spinning sibling tasks.
+
+This test monkeypatches ``notebooklm.auth.save_cookies_to_storage`` to
+``time.sleep(0.5)``. While ``AuthTokens.from_storage`` is mid-save, a
+concurrently scheduled async task increments a counter every 50 ms.
+Pre-fix the counter is ~0–1 (loop frozen by the sync sleep); post-fix
+it is >= 5 (the sleep runs on a thread, loop keeps ticking).
+
+Why a unit-style test under ``tests/integration/concurrency/``: the
+wave-3 plan places every blocking-I/O regression under this directory
+even when the assertion is structural; the harness fixtures are
+re-usable but not required for this surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from notebooklm import auth as auth_module
+from notebooklm.auth import AuthTokens
+
+# Time budget for the "blocking sleep" injected into save_cookies_to_storage.
+# Half a second is comfortably above the asyncio scheduler resolution but
+# short enough to keep the test fast.
+_SLEEP_SECONDS = 0.5
+
+# Heartbeat cadence for the sibling task that proves the loop is alive.
+# 50 ms gives ~10 ticks in the 0.5 s window; we assert >= 5 to allow for
+# scheduler jitter, CI noise, and the unavoidable initial round-trip
+# before the save site is reached.
+_HEARTBEAT_INTERVAL = 0.05
+
+# Lower bound on observed heartbeats during the save window. Pre-fix
+# the synchronous sleep blocks the loop for ~0.5 s, so the counter
+# stays at 0 or 1 (one tick may sneak in before the save is entered).
+# Post-fix the loop is free; 5 is comfortably below the ~10 expected.
+_MIN_HEARTBEATS = 5
+
+
+@pytest.mark.asyncio
+async def test_from_storage_save_does_not_block_event_loop(
+    tmp_path,
+    monkeypatch,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``AuthTokens.from_storage`` must not freeze the loop on save.
+
+    Wraps a ``time.sleep(0.5)`` over the storage save and asserts a
+    concurrently scheduled heartbeat ticks at least 5 times during the
+    save window — proof that the save runs off the loop (i.e. via
+    ``asyncio.to_thread``).
+    """
+    storage_file = tmp_path / "storage_state.json"
+    storage_file.write_text(
+        json.dumps(
+            {
+                "cookies": [
+                    {"name": "SID", "value": "sid", "domain": ".google.com"},
+                    {
+                        "name": "__Secure-1PSIDTS",
+                        "value": "test_1psidts",
+                        "domain": ".google.com",
+                    },
+                ]
+            }
+        )
+    )
+    # Match the existing TestAuthTokensFromStorage fixture so the token
+    # fetch resolves to a complete AuthTokens (csrf + session_id).
+    html = '"SNlM0e":"csrf_token" "FdrFJe":"session_id"'
+    httpx_mock.add_response(content=html.encode())
+
+    # Replace the storage save with a synchronous sleep. Returning ``True``
+    # mirrors the legacy "ok" return path of save_cookies_to_storage when
+    # the caller does not request a structured result. The from_storage
+    # caller passes ``return_result=True`` and expects a ``CookieSaveResult``
+    # or ``bool``; ``True`` flows the no-snapshot branch (cookie_snapshot
+    # is set to ``None``), which is fine for this test's assertions.
+    def _blocking_save(*args: object, **kwargs: object) -> bool:
+        time.sleep(_SLEEP_SECONDS)
+        return True
+
+    monkeypatch.setattr(auth_module, "save_cookies_to_storage", _blocking_save)
+
+    heartbeats = 0
+    stop = asyncio.Event()
+
+    async def _heartbeat() -> None:
+        """Increment a counter every _HEARTBEAT_INTERVAL until stopped."""
+        nonlocal heartbeats
+        while not stop.is_set():
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=_HEARTBEAT_INTERVAL)
+            except asyncio.TimeoutError:
+                heartbeats += 1
+
+    heartbeat_task = asyncio.create_task(_heartbeat())
+    try:
+        # Give the heartbeat one tick to start, then drive the save path.
+        await asyncio.sleep(0)
+        tokens = await AuthTokens.from_storage(storage_file)
+    finally:
+        stop.set()
+        await heartbeat_task
+
+    # Sanity: the save path completed successfully.
+    assert tokens.csrf_token == "csrf_token"
+    assert tokens.session_id == "session_id"
+
+    assert heartbeats >= _MIN_HEARTBEATS, (
+        f"Event loop was blocked during save_cookies_to_storage: only "
+        f"{heartbeats} heartbeats fired in {_SLEEP_SECONDS}s "
+        f"(expected >= {_MIN_HEARTBEATS}). The synchronous save is "
+        f"still running on the event-loop thread."
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_tokens_with_domains_save_does_not_block_event_loop(
+    tmp_path,
+    monkeypatch,
+    httpx_mock: HTTPXMock,
+) -> None:
+    """``fetch_tokens_with_domains`` (auth.py:3204) must offload its save too.
+
+    Same protocol as the from_storage test but exercises the second
+    documented call site so a regression that fixes only one of the two
+    sites still fails this suite.
+    """
+    storage_file = tmp_path / "storage_state.json"
+    storage_file.write_text(
+        json.dumps(
+            {
+                "cookies": [
+                    {"name": "SID", "value": "sid", "domain": ".google.com"},
+                    {
+                        "name": "__Secure-1PSIDTS",
+                        "value": "test_1psidts",
+                        "domain": ".google.com",
+                    },
+                ]
+            }
+        )
+    )
+    html = '"SNlM0e":"csrf_token" "FdrFJe":"session_id"'
+    httpx_mock.add_response(content=html.encode())
+
+    def _blocking_save(*args: object, **kwargs: object) -> None:
+        # fetch_tokens_with_domains discards the return value, so any
+        # return is fine; mirror the real function's None-by-default.
+        time.sleep(_SLEEP_SECONDS)
+
+    monkeypatch.setattr(auth_module, "save_cookies_to_storage", _blocking_save)
+
+    heartbeats = 0
+    stop = asyncio.Event()
+
+    async def _heartbeat() -> None:
+        nonlocal heartbeats
+        while not stop.is_set():
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=_HEARTBEAT_INTERVAL)
+            except asyncio.TimeoutError:
+                heartbeats += 1
+
+    heartbeat_task = asyncio.create_task(_heartbeat())
+    try:
+        await asyncio.sleep(0)
+        csrf, session_id = await auth_module.fetch_tokens_with_domains(storage_file)
+    finally:
+        stop.set()
+        await heartbeat_task
+
+    assert csrf == "csrf_token"
+    assert session_id == "session_id"
+
+    assert heartbeats >= _MIN_HEARTBEATS, (
+        f"Event loop was blocked during fetch_tokens_with_domains save: only "
+        f"{heartbeats} heartbeats fired in {_SLEEP_SECONDS}s "
+        f"(expected >= {_MIN_HEARTBEATS}). The synchronous save is still "
+        f"running on the event-loop thread."
+    )


### PR DESCRIPTION
## Summary
- Wrap the two `save_cookies_to_storage` call sites at `src/notebooklm/auth.py:507` (`AuthTokens.from_storage`) and `:3204` (`fetch_tokens_with_domains`) with `await asyncio.to_thread(...)` so the synchronous atomic-replace + fsync + flock no longer freezes the event loop on slow filesystems.
- `save_cookies_to_storage` itself is correctly synchronous and unchanged — only the callers were wrong.
- Stdlib only; `asyncio` was already imported.

## Task
- Plan: `.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-3.md#T7.D1`
- Audit references: §6, §27
- Wave-3 task T7.D1 (D-series blocking-I/O offload)

## Test plan
- [x] New red test `tests/integration/concurrency/test_auth_load_blocks_loop.py` — monkeypatches `save_cookies_to_storage` to `time.sleep(0.5)`; a concurrently scheduled 50 ms heartbeat must tick ≥ 5 times during the save window. Pre-fix: 0 ticks (loop frozen). Post-fix: ~10 ticks. Both call sites exercised so a regression on either one trips the suite.
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/integration/concurrency/ tests/unit/test_auth.py` — **339 passed**, including the 2 new regression cases.

## Deferred polish findings
None. The change is a 10-line semantic delta plus a focused regression test; no refactor surface to clean up (the spec explicitly forbids touching `save_cookies_to_storage` itself).

## Wave-2 invariant carried forward
T7.D1 introduces no new `asyncio.create_task` for fire-and-forget cleanup — only `asyncio.to_thread` await sites — so the C4 strong-reference task-GC pattern (module-level `set` + `add_done_callback(set.discard)`) does not apply here. Flagged preemptively per wave-3 dispatch notes; no action needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication token refresh operations no longer cause responsiveness delays during credential persistence.

* **Tests**
  * Added integration tests to verify token operations maintain system responsiveness under concurrent workloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/574)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->