### PR TITLE
fix(sources): cancel sibling pollers on first wait_for_sources failure (T7.E1)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -445,10 +445,35 @@ class SourcesAPI:
                 nb_id, [s.id for s in sources]
             )
         """
+        # T7.E1: a bare ``asyncio.gather(*coros)`` propagates the first
+        # exception but does NOT await the sibling tasks it cancels. The
+        # cancelled siblings are left in a "cancellation requested but not
+        # yet observed" state — their ``finally`` blocks may not have run by
+        # the time we re-raise. That race lets a slow poll keep ticking
+        # against the network after ``wait_for_sources`` already raised to
+        # its caller (audit §5).
+        #
+        # Fix: drive the fan-out as explicit tasks. On any exception, cancel
+        # every pending task and drain them via ``return_exceptions=True``
+        # before re-raising the first failure. The drain guarantees each
+        # sibling has reached its ``except CancelledError`` block before we
+        # return control to the caller.
         tasks = [
-            self.wait_until_ready(notebook_id, sid, timeout=timeout, **kwargs) for sid in source_ids
+            asyncio.create_task(self.wait_until_ready(notebook_id, sid, timeout=timeout, **kwargs))
+            for sid in source_ids
         ]
-        return list(await asyncio.gather(*tasks))
+        try:
+            return list(await asyncio.gather(*tasks))
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            # Drain cancelled (and any already-failed) siblings before
+            # surfacing the original exception. ``return_exceptions=True``
+            # swallows the cancellations and concurrent failures so the
+            # outer ``raise`` still raises the first task's exception.
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
     async def add_url(
         self,

--- a/tests/integration/concurrency/test_wait_for_sources_leak.py
+++ b/tests/integration/concurrency/test_wait_for_sources_leak.py
@@ -1,0 +1,94 @@
+"""Regression test for T7.E1 — cancel sibling pollers on first failure.
+
+Audit item §5: ``SourcesAPI.wait_for_sources`` fanned out to ``wait_until_ready``
+calls with a bare ``asyncio.gather(*coroutines)``. When one source poll raised
+immediately (e.g. ``SourceProcessingError`` on a bad ID), ``gather`` propagated
+the exception but did not *await* the sibling tasks it cancelled. The cancelled
+siblings were left in a "cancellation requested but not yet observed" state:
+their ``CancelledError`` handlers (e.g. cleanup ``finally`` blocks) had not yet
+run by the time ``wait_for_sources`` returned to its caller.
+
+Post-fix:
+- ``wait_for_sources`` creates explicit tasks via ``asyncio.create_task``.
+- On any exception, it cancels every pending task and then drains them with
+  ``await asyncio.gather(*tasks, return_exceptions=True)`` before re-raising.
+- The public signature is unchanged.
+
+Acceptance invariant (per plan §T7.E1):
+  invoke ``wait_for_sources(nb, ["bad-id", "slow-id"])`` against a mock that
+  errors ``bad-id`` immediately and would poll ``slow-id`` for 60 s; assert the
+  slow poll is fully cancelled (its ``CancelledError`` handler has executed)
+  by the time ``wait_for_sources`` returns control to the test, and the whole
+  thing happens well under 1 s of wall clock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from notebooklm import NotebookLMClient
+from notebooklm.types import Source, SourceProcessingError
+
+
+@pytest.mark.asyncio
+async def test_wait_for_sources_cancels_sibling_on_first_failure(auth_tokens):
+    """A failing poll must cancel AND drain sibling pollers before propagating.
+
+    Bare ``asyncio.gather(*coros)`` cancels siblings on first exception but does
+    NOT await them; ``gather`` returns before the cancelled siblings reach their
+    ``except CancelledError`` blocks. T7.E1 makes ``wait_for_sources`` await the
+    drained siblings before re-raising, so the slow task's cancellation handler
+    runs synchronously with respect to the caller.
+    """
+    slow_cancelled = asyncio.Event()
+    slow_entered = asyncio.Event()
+
+    async def fake_wait_until_ready(notebook_id, source_id, **kwargs):
+        if source_id == "bad-id":
+            # Let the slow task get scheduled before we blow up — otherwise the
+            # bad task raises before slow even enters its body, and there is no
+            # sibling to cancel.
+            await slow_entered.wait()
+            raise SourceProcessingError(source_id, status=3)
+
+        if source_id == "slow-id":
+            slow_entered.set()
+            try:
+                # In production this would be the long poll loop. Use 60 s to
+                # mirror the spec; in practice we should never sleep this long
+                # because the sibling failure must cancel us in milliseconds.
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                slow_cancelled.set()
+                raise
+            return Source(id=source_id, title="slow")
+
+        raise AssertionError(f"unexpected source_id: {source_id!r}")
+
+    async with NotebookLMClient(auth_tokens) as client:
+        with patch.object(client.sources, "wait_until_ready", side_effect=fake_wait_until_ready):
+            start = time.monotonic()
+            with pytest.raises(SourceProcessingError):
+                await asyncio.wait_for(
+                    client.sources.wait_for_sources("nb_123", ["bad-id", "slow-id"]),
+                    timeout=5.0,
+                )
+            elapsed = time.monotonic() - start
+
+    # The bad-id failure must cancel the slow-id poll and drain it.
+    assert slow_entered.is_set(), "slow-id task never started — test setup is wrong"
+    assert slow_cancelled.is_set(), (
+        "slow-id was not drained before wait_for_sources returned: its "
+        "CancelledError handler did not run. wait_for_sources must "
+        "cancel + await siblings before re-raising the first exception."
+    )
+    # The whole thing must complete in much less than the 60 s slow-poll budget.
+    # 1 s is the spec ceiling; well under in practice.
+    assert elapsed < 1.0, (
+        f"wait_for_sources took {elapsed:.3f}s — siblings were not cancelled "
+        "promptly on first failure"
+    )


### PR DESCRIPTION
## Summary
- `SourcesAPI.wait_for_sources` now drives its fan-out as explicit `asyncio.create_task` tasks, and on any exception cancels every pending task then drains them via `asyncio.gather(*tasks, return_exceptions=True)` before re-raising — so a slow sibling poll cannot keep ticking after the function returns to its caller (audit §5).
- Public signature unchanged: `async def wait_for_sources(notebook_id, source_ids, timeout=120.0, **kwargs) -> list[Source]`.
- Red test `tests/integration/concurrency/test_wait_for_sources_leak.py` asserts the slow task's `CancelledError` handler has fired by the time `wait_for_sources` returns, and total elapsed is well under the 1 s spec ceiling.

## Task
Plan: `.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-3.md#T7.E1`
Wave 3 contention: `_sources.py` is shared with D2 (line 1353–1356) and D3 (lines 643, 1327–1356); this PR owns the disjoint surface around line 451 (post-format) — trivial rebase expected with either.

## Test plan
- [x] `uv run ruff format .` (clean)
- [x] `uv run ruff check .` (clean)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (clean)
- [x] `uv run pytest tests/integration/concurrency/ tests/integration/test_sources.py` — 149 passed
- [x] Red test fails on `origin/main` baseline, passes after fix

## Deferred polish findings
none — surgical change scoped to the one call site at `_sources.py:451`. The pre-existing `cli_vcr/test_downloads.py` cassette mismatches on main are unrelated (T8 cassette work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)