### PR TITLE
fix(tests): read cassette files with explicit UTF-8 encoding (Windows CI)

### DIFF
--- a/tests/unit/test_cassette_sanitizer.py
+++ b/tests/unit/test_cassette_sanitizer.py
@@ -363,7 +363,7 @@ def test_python_guard_repo_allowlist_is_explicit_basename_list() -> None:
     assert allowlist.is_file()
     entries = {
         line.strip()
-        for line in allowlist.read_text().splitlines()
+        for line in allowlist.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.strip().startswith("#")
     }
     # Spec-explicit entries that must always be in the allowlist while

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -101,7 +101,11 @@ def _has_ogw_avatar(cassette: Path) -> bool:
     the xfail goes away.
     """
     try:
-        return "/ogw/" in cassette.read_text()
+        # Explicit UTF-8 — cassettes routinely carry emoji bytes in
+        # notebook/artifact titles. Default Python text mode uses the
+        # platform encoding (cp1252 on Windows), which can't decode the
+        # 4-byte UTF-8 emoji sequences.
+        return "/ogw/" in cassette.read_text(encoding="utf-8")
     except OSError:
         return False
 
@@ -354,7 +358,11 @@ def _load_cassette(path: Path) -> tuple[dict[str, Any], str]:
     inside escaped JSON-string payloads (the parsed structure would lose the
     escape characters in the regex).
     """
-    raw = path.read_text()
+    # Explicit UTF-8 — cassettes routinely carry emoji bytes in notebook /
+    # artifact titles. Default Python text mode uses the platform encoding
+    # (cp1252 on Windows), which can't decode the 4-byte UTF-8 emoji
+    # sequences.
+    raw = path.read_text(encoding="utf-8")
     data = yaml.safe_load(raw) or {}
     return data, raw
 


### PR DESCRIPTION
## Summary

Fixes Windows CI failures introduced by T8.B5 — the new Drive cassettes contain emoji (🔍 / ``\xf0\x9f\x94\x8d``) which can't be decoded by ``cp1252`` (Python's default text mode encoding on Windows).

Three call sites read cassette / allowlist files without specifying encoding:
- ``tests/unit/test_cassette_shapes.py:104`` (``_has_ogw_avatar``)
- ``tests/unit/test_cassette_shapes.py:357`` (``_load_cassette``)
- ``tests/unit/test_cassette_sanitizer.py:366`` (allowlist reader)

All three now pass ``encoding="utf-8"`` explicitly. ``check_cassettes_clean.py`` already did the right thing.

## Test plan

- [x] ``uv run pytest tests/unit/test_cassette_shapes.py tests/unit/test_cassette_sanitizer.py`` — passes locally
- [x] Pre-commit chain green
- [ ] Windows matrix CI on this PR confirms the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed encoding handling in test utilities by explicitly specifying UTF-8, preventing potential issues on systems with different default text encodings.

* **Tests**
  * Updated test suite to use explicit UTF-8 encoding when reading configuration and data files, improving cross-platform reliability and support for international character content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/577)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->