### PR TITLE
fix(artifacts): leader/follower polling dedupe in wait_for_completion (T7.E2)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1852,15 +1852,18 @@ class ArtifactsAPI:
             # Follower path. ``asyncio.shield`` ensures that *this* caller's
             # cancellation does not propagate into the shared future; the
             # leader's poll task continues on behalf of every other follower.
-            return await asyncio.shield(existing)
+            return await asyncio.shield(existing[0])
 
-        # Leader path. Create the shared future, spawn a shielded poll task,
-        # then await the future. The poll task survives this leader's
-        # cancellation: its done-callback resolves the future and pops the
-        # registry regardless of who (if anyone) is still awaiting.
+        # Leader path. Create the shared future, spawn the poll task,
+        # register the pair so any follower can attach. Both the future
+        # and the task live in the registry entry — the task reference
+        # alone is what anchors the running poll against GC (Python's
+        # task-GC contract is permissive; see asyncio C4 lesson /
+        # Python 3.11+ task GC fix). The done-callback pops the entry
+        # on every termination path (success / exception / cancel) so
+        # the registry cannot leak.
         loop = asyncio.get_running_loop()
         future: asyncio.Future[GenerationStatus] = loop.create_future()
-        pending[key] = future
 
         # Consume any exception set on the future if no caller ever
         # retrieves it (e.g. leader cancelled with no followers). Without
@@ -1874,8 +1877,8 @@ class ArtifactsAPI:
 
         future.add_done_callback(_consume_orphan_exception)
 
-        async def _poll_loop_inner() -> GenerationStatus:
-            return await self._run_poll_loop(
+        poll_task = asyncio.create_task(
+            self._run_poll_loop(
                 notebook_id,
                 task_id,
                 initial_interval=initial_interval,
@@ -1883,59 +1886,45 @@ class ArtifactsAPI:
                 timeout=timeout,
                 max_not_found=max_not_found,
                 min_not_found_window=min_not_found_window,
-            )
-
-        poll_task = asyncio.create_task(
-            _poll_loop_inner(),
+            ),
             name=f"artifact-poll-{notebook_id}-{task_id}",
         )
 
-        # Hold a strong reference to the poll task on the future itself.
-        # Without this, if the leader is cancelled before the task
-        # completes AND no follower attached, the only remaining
-        # reference would be the loop's internal task scheduling, which
-        # the GC docs do NOT guarantee is strong (see asyncio C4 lesson
-        # / Python 3.11+ task GC fix). Stashing on the future ensures the
-        # task lives at least as long as the registry entry, which lives
-        # until the done-callback fires.
-        future._t7e2_poll_task = poll_task  # type: ignore[attr-defined]
+        pending[key] = (future, poll_task)
 
         def _on_poll_done(task: asyncio.Task[GenerationStatus]) -> None:
-            # Always pop the registry entry first so a follower that
-            # arrives concurrently with completion either (a) attaches
-            # to the already-resolved future and gets the cached result,
-            # or (b) misses the entry entirely and starts a fresh poll
-            # for the *next* generation. Either is correct.
+            # Pop the registry entry first so a follower that arrives
+            # concurrently with completion either (a) attaches to the
+            # already-resolved future and gets the cached result, or
+            # (b) misses the entry entirely and starts a fresh poll for
+            # the *next* generation. Either is correct.
             pending.pop(key, None)
+            # Inside this callback there are no ``await`` points, so
+            # the single-threaded asyncio model guarantees ``future`` is
+            # still pending — assert that invariant rather than guard
+            # silently. A regression in callback ordering would surface
+            # loudly instead of dropping a result on the floor.
+            assert not future.done(), "future resolved before poll task done-callback"
             if task.cancelled():
-                # The poll task itself was cancelled. This should be
-                # exceedingly rare — followers shield the future, and
-                # the leader's cancel doesn't propagate to the task.
-                # Surface as CancelledError to any still-attached
-                # waiters. ``Future.cancel()`` is the right primitive.
+                # The poll task itself was cancelled. Followers shield
+                # the future and the leader's cancel doesn't propagate
+                # to the task, so this is exceedingly rare — but if it
+                # happens, surface ``CancelledError`` to attached waiters.
                 future.cancel()
                 return
             exc = task.exception()
             if exc is not None:
-                if not future.done():
-                    future.set_exception(exc)
+                future.set_exception(exc)
                 return
-            if not future.done():
-                future.set_result(task.result())
+            future.set_result(task.result())
 
         poll_task.add_done_callback(_on_poll_done)
 
-        # Leader awaits via shield so that *its* cancellation also
-        # unwinds locally without taking down the shared poll. The
-        # shielded poll task continues until the done-callback fires.
-        try:
-            return await asyncio.shield(future)
-        except asyncio.CancelledError:
-            # Leader cancelled before the poll completed. The poll task
-            # continues running on behalf of any followers; eventually
-            # its done-callback will resolve the future and pop the
-            # registry. We just unwind our own coroutine.
-            raise
+        # Leader awaits via ``asyncio.shield`` so that the leader's
+        # cancellation unwinds locally without taking down the shared
+        # poll. The shielded poll task continues until the done-callback
+        # fires; remaining followers still receive the result.
+        return await asyncio.shield(future)
 
     async def _run_poll_loop(
         self,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1787,22 +1787,45 @@ class ArtifactsAPI:
 
         Uses exponential backoff for polling to reduce API load.
 
+        Concurrent callers for the same ``(notebook_id, task_id)`` share a
+        single underlying poll loop via the leader/follower registry on
+        ``ClientCore._pending_polls`` (audit §21 / T7.E2). The first
+        caller is the *leader* and drives the poll loop; subsequent
+        *followers* attach to the leader's future without issuing their
+        own ``LIST_ARTIFACTS`` requests. Cancellation is per-caller —
+        only the cancelled caller's ``await`` raises ``CancelledError``;
+        the underlying poll continues and remaining followers still
+        receive the result.
+
+        Because followers attach to the leader's already-running poll,
+        only the *leader's* ``initial_interval`` / ``max_interval`` /
+        ``timeout`` / ``max_not_found`` / ``min_not_found_window`` apply
+        to the shared poll loop. Followers' values for these parameters
+        are ignored once they attach. This is acceptable for the
+        intended use case (deduping accidental fan-out from the same
+        application) — distinct waiters that genuinely need distinct
+        timeouts should serialize their calls instead.
+
         Args:
             notebook_id: The notebook ID.
             task_id: The task/artifact ID to wait for.
-            initial_interval: Initial seconds between status checks.
-            max_interval: Maximum seconds between status checks.
-            timeout: Maximum seconds to wait.
+            initial_interval: Initial seconds between status checks
+                (leader only — see note above).
+            max_interval: Maximum seconds between status checks
+                (leader only).
+            timeout: Maximum seconds to wait (leader only).
             poll_interval: Deprecated. Use initial_interval instead.
             max_not_found: Consecutive "not found" polls before treating
                 the task as failed.  When the API removes an artifact
                 from the list (e.g. after a daily-quota rejection), the
                 poller would otherwise spin until *timeout*.  Defaults
                 to 5 to tolerate brief replication lag and slow networks.
+                (Leader only.)
             min_not_found_window: Minimum seconds that must have elapsed
                 since the *first* not-found response before a consecutive
                 run triggers failure.  This avoids false positives on
                 slow or unreliable networks.  Defaults to 10.0.
+                (Leader only.)
 
         Returns:
             Final GenerationStatus.
@@ -1821,6 +1844,116 @@ class ArtifactsAPI:
             )
             initial_interval = poll_interval
 
+        pending = self._core._pending_polls
+        key = (notebook_id, task_id)
+
+        existing = pending.get(key)
+        if existing is not None:
+            # Follower path. ``asyncio.shield`` ensures that *this* caller's
+            # cancellation does not propagate into the shared future; the
+            # leader's poll task continues on behalf of every other follower.
+            return await asyncio.shield(existing)
+
+        # Leader path. Create the shared future, spawn a shielded poll task,
+        # then await the future. The poll task survives this leader's
+        # cancellation: its done-callback resolves the future and pops the
+        # registry regardless of who (if anyone) is still awaiting.
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[GenerationStatus] = loop.create_future()
+        pending[key] = future
+
+        # Consume any exception set on the future if no caller ever
+        # retrieves it (e.g. leader cancelled with no followers). Without
+        # this, ``set_exception`` on an unawaited future logs
+        # "Future exception was never retrieved" at GC time.
+        def _consume_orphan_exception(fut: asyncio.Future[GenerationStatus]) -> None:
+            if not fut.cancelled():
+                # ``exception()`` clears the _log_traceback flag inside the
+                # future. We intentionally drop the value.
+                fut.exception()
+
+        future.add_done_callback(_consume_orphan_exception)
+
+        async def _poll_loop_inner() -> GenerationStatus:
+            return await self._run_poll_loop(
+                notebook_id,
+                task_id,
+                initial_interval=initial_interval,
+                max_interval=max_interval,
+                timeout=timeout,
+                max_not_found=max_not_found,
+                min_not_found_window=min_not_found_window,
+            )
+
+        poll_task = asyncio.create_task(
+            _poll_loop_inner(),
+            name=f"artifact-poll-{notebook_id}-{task_id}",
+        )
+
+        # Hold a strong reference to the poll task on the future itself.
+        # Without this, if the leader is cancelled before the task
+        # completes AND no follower attached, the only remaining
+        # reference would be the loop's internal task scheduling, which
+        # the GC docs do NOT guarantee is strong (see asyncio C4 lesson
+        # / Python 3.11+ task GC fix). Stashing on the future ensures the
+        # task lives at least as long as the registry entry, which lives
+        # until the done-callback fires.
+        future._t7e2_poll_task = poll_task  # type: ignore[attr-defined]
+
+        def _on_poll_done(task: asyncio.Task[GenerationStatus]) -> None:
+            # Always pop the registry entry first so a follower that
+            # arrives concurrently with completion either (a) attaches
+            # to the already-resolved future and gets the cached result,
+            # or (b) misses the entry entirely and starts a fresh poll
+            # for the *next* generation. Either is correct.
+            pending.pop(key, None)
+            if task.cancelled():
+                # The poll task itself was cancelled. This should be
+                # exceedingly rare — followers shield the future, and
+                # the leader's cancel doesn't propagate to the task.
+                # Surface as CancelledError to any still-attached
+                # waiters. ``Future.cancel()`` is the right primitive.
+                future.cancel()
+                return
+            exc = task.exception()
+            if exc is not None:
+                if not future.done():
+                    future.set_exception(exc)
+                return
+            if not future.done():
+                future.set_result(task.result())
+
+        poll_task.add_done_callback(_on_poll_done)
+
+        # Leader awaits via shield so that *its* cancellation also
+        # unwinds locally without taking down the shared poll. The
+        # shielded poll task continues until the done-callback fires.
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            # Leader cancelled before the poll completed. The poll task
+            # continues running on behalf of any followers; eventually
+            # its done-callback will resolve the future and pop the
+            # registry. We just unwind our own coroutine.
+            raise
+
+    async def _run_poll_loop(
+        self,
+        notebook_id: str,
+        task_id: str,
+        *,
+        initial_interval: float,
+        max_interval: float,
+        timeout: float,
+        max_not_found: int,
+        min_not_found_window: float,
+    ) -> GenerationStatus:
+        """The actual polling loop. Driven by the leader's shielded task.
+
+        This is intentionally private and parameter-keyword-only — direct
+        callers should always go through ``wait_for_completion`` so the
+        leader/follower dedupe is honored.
+        """
         start_time = asyncio.get_running_loop().time()
         current_interval = initial_interval
         consecutive_not_found = 0

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -391,6 +391,16 @@ class ClientCore:
         # clobber sibling-process writes (docs/auth-keepalive.md §3.4.1).
         # Per-instance, never module-global.
         self._loaded_cookie_snapshot: CookieSnapshot | None = None
+        # Leader/follower polling-dedupe registry for
+        # ``ArtifactsAPI.wait_for_completion`` (audit §21 / T7.E2).
+        # Keyed by ``(notebook_id, task_id)``. The first caller for a key is
+        # the *leader* and spawns a shielded ``_poll_loop`` task; subsequent
+        # callers (*followers*) attach to the shared future via
+        # ``asyncio.shield(future)`` so their per-caller cancellations don't
+        # propagate to the underlying poll. Per-instance — never module-global,
+        # so a fresh ``ClientCore`` cannot inherit a dangling entry from a
+        # prior instance.
+        self._pending_polls: dict[tuple[str, str], asyncio.Future[Any]] = {}
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -393,14 +393,20 @@ class ClientCore:
         self._loaded_cookie_snapshot: CookieSnapshot | None = None
         # Leader/follower polling-dedupe registry for
         # ``ArtifactsAPI.wait_for_completion`` (audit §21 / T7.E2).
-        # Keyed by ``(notebook_id, task_id)``. The first caller for a key is
-        # the *leader* and spawns a shielded ``_poll_loop`` task; subsequent
-        # callers (*followers*) attach to the shared future via
-        # ``asyncio.shield(future)`` so their per-caller cancellations don't
-        # propagate to the underlying poll. Per-instance — never module-global,
-        # so a fresh ``ClientCore`` cannot inherit a dangling entry from a
-        # prior instance.
-        self._pending_polls: dict[tuple[str, str], asyncio.Future[Any]] = {}
+        # Keyed by ``(notebook_id, task_id)``. Each entry is a
+        # ``(future, task)`` pair: the first caller for a key is the
+        # *leader* and spawns the ``task`` (a shielded ``_poll_loop`` task);
+        # subsequent callers (*followers*) attach to ``future`` via
+        # ``asyncio.shield(future)`` so their per-caller cancellations
+        # don't propagate to the underlying poll. The task reference is
+        # kept alongside the future so the running poll task can't be
+        # GC'd if the leader is cancelled with no followers attached
+        # (Python's task-GC contract is permissive). Per-instance —
+        # never module-global, so a fresh ``ClientCore`` cannot inherit
+        # a dangling entry from a prior instance.
+        self._pending_polls: dict[
+            tuple[str, str], tuple[asyncio.Future[Any], asyncio.Task[Any]]
+        ] = {}
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).

--- a/tests/integration/concurrency/test_artifact_poll_dedupe.py
+++ b/tests/integration/concurrency/test_artifact_poll_dedupe.py
@@ -13,7 +13,7 @@ shielded poll task; *followers* await the shared future via
 cancelled caller's await raises; the underlying poll continues; remaining
 followers still receive the result.
 
-Four scenarios:
+Five scenarios:
 
 A. Dedupe — two concurrent waiters; only ONE poll loop runs; both receive
    the same ``GenerationStatus``.
@@ -23,6 +23,11 @@ C. Cleanup on success — after both waiters return, ``_pending_polls`` is
    empty.
 D. Cleanup on exception — poll raises; both waiters see the exception;
    ``_pending_polls`` is empty.
+E. Orphan-exception suppression — leader cancels with no follower
+   attached AND the poll subsequently fails. The
+   ``_consume_orphan_exception`` callback must retrieve the exception
+   from the unawaited future so asyncio does not log
+   "Future exception was never retrieved" at GC time.
 
 Implementation strategy: monkey-patch ``ArtifactsAPI.poll_status`` to a
 controllable async function so the test owns the poll-loop's progression
@@ -114,10 +119,13 @@ async def test_scenario_a_two_waiters_share_one_poll_loop(_auth_tokens):
         w1 = asyncio.create_task(waiter())
         w2 = asyncio.create_task(waiter())
 
-        # Spin until both have registered (one as leader, one as follower).
-        # We assert via the pending-polls registry, which is the public
-        # invariant the fix introduces. Cap iterations to avoid a hang
-        # if the fix isn't applied at all.
+        # Spin until the leader has registered. The follower's
+        # ``asyncio.shield`` attach happens within the same
+        # ``wait_for_completion`` call, so by the time the registry
+        # has one entry and neither task is done, the follower is
+        # parked at the shield. We yield additional times below to
+        # ensure both have been scheduled before releasing the poll —
+        # extra yields are safer than too few.
         for _ in range(50):
             if len(client._core._pending_polls) >= 1 and (
                 w1.done() is False and w2.done() is False
@@ -125,8 +133,13 @@ async def test_scenario_a_two_waiters_share_one_poll_loop(_auth_tokens):
                 # Both have parked; allow the poll to fire.
                 break
             await asyncio.sleep(0.01)
+        # Yield a few times to be sure both leader and follower have
+        # entered their ``await asyncio.shield(future)``. CPython's
+        # task scheduling makes one yield reliable in practice; a
+        # handful is defensive against future event-loop changes.
+        for _ in range(3):
+            await asyncio.sleep(0)
         both_waiters_attached.set()
-        # Tiny yield so the poll enters its await.
         await asyncio.sleep(0)
         release_first_poll.set()
 
@@ -281,4 +294,98 @@ async def test_scenario_d_pending_polls_empty_after_exception(_auth_tokens):
         )
         assert poll_call_count == 1, (
             f"expected 1 poll, got {poll_call_count} (dedupe must hold on exception path)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scenario_e_orphan_exception_does_not_log_unraisable(_auth_tokens, caplog, recwarn):
+    """E. Orphan-exception suppression: leader cancelled, no followers, poll raises.
+
+    Sequence:
+
+    1. A single waiter (leader) starts ``wait_for_completion``; the
+       poll task is in flight.
+    2. The leader is cancelled before any follower attaches.
+    3. The poll task subsequently fails with an exception.
+    4. The future is resolved via ``set_exception`` with nobody
+       awaiting it.
+
+    Without ``_consume_orphan_exception`` registered on the future,
+    asyncio's ``Future.__del__`` would log a
+    ``Future exception was never retrieved`` traceback at GC time
+    (visible as a logger.error from ``asyncio`` or as an unraisable
+    hook event). This test confirms the suppression is in place.
+
+    We assert two things:
+      * the registry is empty after teardown (cleanup path holds);
+      * no ``Future exception was never retrieved`` log record fires.
+    """
+
+    class _Boom(RuntimeError):
+        pass
+
+    async with _opened_client(_auth_tokens) as client:
+        poll_started = asyncio.Event()
+        release_poll = asyncio.Event()
+        poll_call_count = 0
+
+        async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+            nonlocal poll_call_count
+            poll_call_count += 1
+            poll_started.set()
+            await release_poll.wait()
+            raise _Boom("orphan poll failure")
+
+        client.artifacts.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+        leader = asyncio.create_task(
+            client.artifacts.wait_for_completion(
+                "nb_001", "task_e", initial_interval=0.01, timeout=TEST_TIMEOUT_S
+            )
+        )
+        await asyncio.wait_for(poll_started.wait(), timeout=TEST_TIMEOUT_S)
+
+        # Cancel the leader BEFORE releasing the poll. No follower
+        # ever attaches.
+        leader.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await leader
+
+        # Now let the poll task fail. The done-callback will set the
+        # exception on the orphan future; the ``_consume_orphan_exception``
+        # callback should retrieve it so no GC-time warning fires.
+        release_poll.set()
+
+        # Yield until the poll task has actually run and resolved the
+        # future. The registry is the readiness signal.
+        for _ in range(50):
+            if not client._core._pending_polls:
+                break
+            await asyncio.sleep(0.01)
+
+        # Force a GC pass so any unretrieved-exception warning would
+        # surface NOW rather than at unspecified later teardown.
+        import gc
+
+        gc.collect()
+        await asyncio.sleep(0)
+
+        assert client._core._pending_polls == {}, (
+            "registry leaked on leader-cancel-with-orphan-exception path: "
+            f"{client._core._pending_polls!r}"
+        )
+
+        # The poll ran exactly once; the suppression callback consumed
+        # the orphan exception so no log record nor warning should mention
+        # an unretrieved future exception.
+        assert poll_call_count == 1
+        unretrieved_records = [r for r in caplog.records if "never retrieved" in r.getMessage()]
+        assert not unretrieved_records, (
+            f"orphan future exception logged 'never retrieved': "
+            f"{[r.getMessage() for r in unretrieved_records]}"
+        )
+        unretrieved_warnings = [w for w in recwarn.list if "never retrieved" in str(w.message)]
+        assert not unretrieved_warnings, (
+            f"orphan future exception warning fired: "
+            f"{[str(w.message) for w in unretrieved_warnings]}"
         )

--- a/tests/integration/concurrency/test_artifact_poll_dedupe.py
+++ b/tests/integration/concurrency/test_artifact_poll_dedupe.py
@@ -1,0 +1,284 @@
+"""T7.E2 — leader/follower polling dedupe for ``wait_for_completion``.
+
+Regression test for the audit §21 finding: when N callers concurrently
+invoke ``ArtifactsAPI.wait_for_completion`` for the *same* ``(notebook_id,
+task_id)``, each runs its own poll loop and issues N independent
+``LIST_ARTIFACTS`` requests per polling tick — wasteful at best and a
+rate-limit / quota burner at worst.
+
+The fix wires a per-instance registry ``ClientCore._pending_polls`` keyed
+by ``(notebook_id, task_id)``. The *leader* (first caller) spawns a
+shielded poll task; *followers* await the shared future via
+``asyncio.shield(future)``. Cancellation is per-caller — only the
+cancelled caller's await raises; the underlying poll continues; remaining
+followers still receive the result.
+
+Four scenarios:
+
+A. Dedupe — two concurrent waiters; only ONE poll loop runs; both receive
+   the same ``GenerationStatus``.
+B. Leader cancellation — cancel the first waiter mid-poll; the second
+   waiter still receives a result (poll continues via shielded task).
+C. Cleanup on success — after both waiters return, ``_pending_polls`` is
+   empty.
+D. Cleanup on exception — poll raises; both waiters see the exception;
+   ``_pending_polls`` is empty.
+
+Implementation strategy: monkey-patch ``ArtifactsAPI.poll_status`` to a
+controllable async function so the test owns the poll-loop's progression
+deterministically — no httpx mocking, no race-prone sleeps. We assert
+on the *number of times* ``poll_status`` was called for the deduped
+``(nb, task_id)`` pair: one leader = one logical poll loop = one call
+sequence, regardless of how many followers piled on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+
+from notebooklm import NotebookLMClient
+from notebooklm.auth import AuthTokens
+from notebooklm.types import GenerationStatus
+
+# Bounded test deadline: every scenario completes in <500ms locally; a
+# 5-second cap lets CI absorb a slow runner without masking a real
+# regression that hangs.
+TEST_TIMEOUT_S = 5.0
+
+
+@pytest.fixture
+def _auth_tokens() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "test_sid"},
+        csrf_token="test_csrf",
+        session_id="test_session",
+    )
+
+
+@asynccontextmanager
+async def _opened_client(auth: AuthTokens) -> AsyncIterator[NotebookLMClient]:
+    """Open a ``NotebookLMClient`` and close cleanly.
+
+    The test never touches the transport — ``poll_status`` is
+    monkey-patched on the ``ArtifactsAPI`` instance directly — so no
+    httpx mock is wired in. The client just needs ``_core`` to exist so
+    we can inspect ``_core._pending_polls``.
+    """
+    client = NotebookLMClient(auth)
+    await client.__aenter__()
+    try:
+        yield client
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_scenario_a_two_waiters_share_one_poll_loop(_auth_tokens):
+    """A. Dedupe: two concurrent waiters → one ``LIST_ARTIFACTS`` flight.
+
+    Both waiters receive the same ``GenerationStatus``. The polling loop
+    runs exactly once on behalf of both.
+    """
+    async with _opened_client(_auth_tokens) as client:
+        poll_call_count = 0
+        release_first_poll = asyncio.Event()
+        both_waiters_attached = asyncio.Event()
+        completed_status = GenerationStatus(
+            task_id="task_xyz", status="completed", url="https://example/url"
+        )
+
+        async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+            nonlocal poll_call_count
+            poll_call_count += 1
+            # Hold the first poll until BOTH waiters have registered.
+            # Subsequent polls (none expected) return immediately.
+            if poll_call_count == 1:
+                # Yield once so both waiters can race to register.
+                await both_waiters_attached.wait()
+                await release_first_poll.wait()
+            return completed_status
+
+        client.artifacts.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+        async def waiter():
+            return await client.artifacts.wait_for_completion(
+                "nb_001", "task_xyz", initial_interval=0.01, timeout=TEST_TIMEOUT_S
+            )
+
+        # Start both waiters; ensure they're both parked at the await
+        # inside ``wait_for_completion`` before releasing the poll.
+        w1 = asyncio.create_task(waiter())
+        w2 = asyncio.create_task(waiter())
+
+        # Spin until both have registered (one as leader, one as follower).
+        # We assert via the pending-polls registry, which is the public
+        # invariant the fix introduces. Cap iterations to avoid a hang
+        # if the fix isn't applied at all.
+        for _ in range(50):
+            if len(client._core._pending_polls) >= 1 and (
+                w1.done() is False and w2.done() is False
+            ):
+                # Both have parked; allow the poll to fire.
+                break
+            await asyncio.sleep(0.01)
+        both_waiters_attached.set()
+        # Tiny yield so the poll enters its await.
+        await asyncio.sleep(0)
+        release_first_poll.set()
+
+        r1, r2 = await asyncio.wait_for(asyncio.gather(w1, w2), timeout=TEST_TIMEOUT_S)
+
+        # Exactly one logical poll for the shared (nb, task) pair.
+        assert poll_call_count == 1, (
+            f"expected 1 deduped poll, got {poll_call_count} "
+            "(followers should attach to the leader's future, not run their own loop)"
+        )
+        assert r1 == completed_status
+        assert r2 == completed_status
+
+
+@pytest.mark.asyncio
+async def test_scenario_b_leader_cancel_does_not_kill_follower(_auth_tokens):
+    """B. Leader cancellation: cancel waiter 1; waiter 2 still completes.
+
+    The leader's await on ``asyncio.shield(future)`` unwinds on cancel,
+    but the underlying shielded poll task keeps running and eventually
+    sets the future. The follower receives the result.
+    """
+    async with _opened_client(_auth_tokens) as client:
+        poll_started = asyncio.Event()
+        release_poll = asyncio.Event()
+        completed_status = GenerationStatus(task_id="task_b", status="completed")
+        poll_call_count = 0
+
+        async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+            nonlocal poll_call_count
+            poll_call_count += 1
+            poll_started.set()
+            await release_poll.wait()
+            return completed_status
+
+        client.artifacts.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+        # Leader (will be cancelled).
+        w1 = asyncio.create_task(
+            client.artifacts.wait_for_completion(
+                "nb_001", "task_b", initial_interval=0.01, timeout=TEST_TIMEOUT_S
+            )
+        )
+        # Wait until the leader has spawned its poll task.
+        await asyncio.wait_for(poll_started.wait(), timeout=TEST_TIMEOUT_S)
+
+        # Follower attaches AFTER the leader has registered.
+        w2 = asyncio.create_task(
+            client.artifacts.wait_for_completion(
+                "nb_001", "task_b", initial_interval=0.01, timeout=TEST_TIMEOUT_S
+            )
+        )
+        # Yield so the follower enters its await on the shared future.
+        await asyncio.sleep(0)
+
+        # Cancel the leader.
+        w1.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await w1
+
+        # Now release the poll; the follower must still observe a result.
+        release_poll.set()
+        result = await asyncio.wait_for(w2, timeout=TEST_TIMEOUT_S)
+
+        assert result == completed_status
+        # Exactly one poll ran — the follower never spun up its own loop
+        # and the leader's cancel did not retrigger the poll.
+        assert poll_call_count == 1, (
+            f"expected exactly 1 poll across leader+follower, got {poll_call_count}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scenario_c_pending_polls_empty_after_success(_auth_tokens):
+    """C. Cleanup on success: registry is empty after both waiters return."""
+    async with _opened_client(_auth_tokens) as client:
+        completed_status = GenerationStatus(task_id="task_c", status="completed")
+
+        async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+            return completed_status
+
+        client.artifacts.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+        async def waiter():
+            return await client.artifacts.wait_for_completion(
+                "nb_001", "task_c", initial_interval=0.01, timeout=TEST_TIMEOUT_S
+            )
+
+        r1, r2 = await asyncio.wait_for(asyncio.gather(waiter(), waiter()), timeout=TEST_TIMEOUT_S)
+
+        assert r1 == completed_status
+        assert r2 == completed_status
+        # Give the done-callback a tick to run; on CPython 3.10+ it runs
+        # synchronously when the task transitions, but yield once to be
+        # safe across event loops.
+        await asyncio.sleep(0)
+        assert client._core._pending_polls == {}, (
+            f"registry leaked entries on success path: {client._core._pending_polls!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_scenario_d_pending_polls_empty_after_exception(_auth_tokens):
+    """D. Cleanup on exception: poll raises → both waiters see it; registry clean."""
+
+    class _Boom(RuntimeError):
+        pass
+
+    async with _opened_client(_auth_tokens) as client:
+        release_poll = asyncio.Event()
+        both_attached = asyncio.Event()
+        poll_call_count = 0
+
+        async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+            nonlocal poll_call_count
+            poll_call_count += 1
+            if poll_call_count == 1:
+                await both_attached.wait()
+                await release_poll.wait()
+                raise _Boom("simulated poll failure")
+            # Defensive: if somehow a second poll fires, fail loudly so
+            # the dedupe regression is visible rather than masked.
+            raise AssertionError("dedupe broken: poll_status called twice")
+
+        client.artifacts.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+        async def waiter():
+            return await client.artifacts.wait_for_completion(
+                "nb_001", "task_d", initial_interval=0.01, timeout=TEST_TIMEOUT_S
+            )
+
+        w1 = asyncio.create_task(waiter())
+        w2 = asyncio.create_task(waiter())
+
+        # Spin briefly for both to register on the shared future.
+        for _ in range(50):
+            if len(client._core._pending_polls) >= 1 and not (w1.done() or w2.done()):
+                break
+            await asyncio.sleep(0.01)
+        both_attached.set()
+        await asyncio.sleep(0)
+        release_poll.set()
+
+        with pytest.raises(_Boom):
+            await asyncio.wait_for(w1, timeout=TEST_TIMEOUT_S)
+        with pytest.raises(_Boom):
+            await asyncio.wait_for(w2, timeout=TEST_TIMEOUT_S)
+
+        await asyncio.sleep(0)
+        assert client._core._pending_polls == {}, (
+            f"registry leaked on exception path: {client._core._pending_polls!r}"
+        )
+        assert poll_call_count == 1, (
+            f"expected 1 poll, got {poll_call_count} (dedupe must hold on exception path)"
+        )

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -21,6 +21,11 @@ def mock_artifacts_api():
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
+    # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
+    # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
+    # A MagicMock attribute would return a child Mock and confuse the
+    # ``existing is not None`` branch.
+    mock_core._pending_polls = {}
     mock_notes = MagicMock()
     mock_notes.list_mind_maps = AsyncMock(return_value=[])
     mock_note = MagicMock()

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -9,6 +9,9 @@ from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 @pytest.fixture
 def api():
     core = MagicMock()
+    # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
+    # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
+    core._pending_polls = {}
     notes_api = MagicMock()
     return ArtifactsAPI(core, notes_api)
 

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -30,6 +30,9 @@ def _make_api():
     core = MagicMock()
     core.rpc_call = AsyncMock()
     core.get_source_ids = AsyncMock(return_value=[])
+    # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
+    # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
+    core._pending_polls = {}
     notes = MagicMock()
     notes.list_mind_maps = AsyncMock(return_value=[])
     notes.create = AsyncMock(return_value=MagicMock(id="note_1"))


### PR DESCRIPTION
## Summary

Concurrent callers of `ArtifactsAPI.wait_for_completion` for the same `(notebook_id, task_id)` now share a single poll loop via a per-instance leader/follower registry, instead of each running its own poll loop and fanning out parallel `LIST_ARTIFACTS` requests (audit §21 / [T7.E2 plan](.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-3.md#T7.E2)).

- **Leader**: first caller for a `(nb, task)` key — creates a shared `asyncio.Future`, spawns the poll task, awaits via `asyncio.shield(future)` so leader cancellation unwinds locally while the underlying poll continues.
- **Follower**: subsequent callers attach to the shared future via `asyncio.shield(future)`; their own cancellations don't propagate.
- **Cleanup**: the poll task's done-callback pops the registry first, then resolves the future — success, exception, and leader-cancel paths all clean up.
- **Strong reference**: the poll task is anchored on `future._t7e2_poll_task` so it cannot be GC'd if the leader is cancelled before any follower attaches (C4 lesson).

## Files

- `src/notebooklm/_core.py` — new `self._pending_polls: dict[tuple[str, str], asyncio.Future]` (per-instance only — never module-global).
- `src/notebooklm/_artifacts.py` — `wait_for_completion` refactored into the leader/follower dispatcher; existing poll body extracted to `_run_poll_loop`.
- `tests/integration/concurrency/test_artifact_poll_dedupe.py` — four red scenarios (dedupe / leader-cancel / cleanup-on-success / cleanup-on-exception).
- `tests/unit/test_*` — three fixtures that mock `_core` via `MagicMock` now seed `core._pending_polls = {}` so the real dict semantics kick in.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest tests/integration/concurrency/ tests/integration/test_artifacts.py` — 154 passed
- [x] Wait-for-completion-touching unit tests — 77 passed
- [x] Four new red scenarios — all pass under the fix; the dedupe scenario red-gates against `AttributeError: 'ClientCore' object has no attribute '_pending_polls'` on origin/main

## Architectural decision

Leader/follower (locked iter-1). Cancellation semantics: per-caller — only the cancelled caller's `await` raises; the underlying poll continues; remaining followers still receive the result. Followers inherit the *leader's* `initial_interval` / `max_interval` / `timeout` / `max_not_found` / `min_not_found_window`; this is documented in the new `wait_for_completion` docstring. Distinct waiters that genuinely need distinct timeouts should serialize their calls.

## Wave context

- Wave 3, blocked by T7.A2 (already merged).
- Shares `_core.py` with D3 — D3 adds `max_concurrent_uploads` plumbing; E2 adds `_pending_polls` field. Different concerns; trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized artifact completion polling to deduplicate concurrent waits for the same artifact, reducing redundant network requests and improving performance when multiple callers wait for identical tasks simultaneously.

* **Tests**
  * Added comprehensive integration tests verifying deduplication behavior, cancellation handling, and proper cleanup of pending polling operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/578)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->