### PR TITLE
fix(cli): fan out auth inspect / --all-accounts across Chrome user-profiles

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -1012,11 +1012,17 @@ class Account:
         email: The account's email address as it appears in the NotebookLM
             page's ``WIZ_global_data`` block.
         is_default: True only for the account at ``authuser=0``.
+        browser_profile: For Chromium-family browsers with multiple
+            user-data profiles, the on-disk directory name (``"Default"``,
+            ``"Profile 1"``) the cookies came from. ``None`` for non-chromium
+            browsers and for the legacy single-jar path where source isn't
+            tracked.
     """
 
     authuser: int
     email: str
     is_default: bool
+    browser_profile: str | None = None
 
 
 # Hard cap on how many ``authuser`` indices to probe before giving up.

--- a/src/notebooklm/cli/_chromium_profiles.py
+++ b/src/notebooklm/cli/_chromium_profiles.py
@@ -253,8 +253,12 @@ def read_chromium_profile_cookies(
         Raw cookie dicts (rookiepy's native shape).
 
     Raises:
-        RuntimeError: When rookiepy fails to read or decrypt the DB. Caller
-            decides whether to skip-and-warn or propagate.
+        ImportError: When the optional ``rookiepy`` dependency isn't
+            installed. The CLI fan-out caller converts this to a friendly
+            "pip install 'notebooklm-py[cookies]'" message.
+        OSError, RuntimeError: Propagated from rookiepy on read or decrypt
+            failure (locked DB, corrupt Keychain item, etc.). Caller decides
+            whether to skip-and-warn or propagate.
     """
     import rookiepy  # imported lazily; rookiepy is an optional extra
 

--- a/src/notebooklm/cli/_chromium_profiles.py
+++ b/src/notebooklm/cli/_chromium_profiles.py
@@ -1,0 +1,261 @@
+"""Multi-user-data-profile cookie extraction for Chromium-family browsers.
+
+Chrome and its forks store cookies in a per-user-data-profile SQLite DB at
+``<user-data-dir>/<profile-dir>/Cookies``. ``profile-dir`` is ``Default``
+for the first profile and ``Profile <N>`` for additional ones. The
+human-friendly profile name (the one shown in the Chrome profile picker)
+lives in ``<user-data-dir>/Local State`` under
+``profile.info_cache.<profile-dir>.name``.
+
+``rookiepy.chrome()`` (and siblings) read the ``Default`` profile only —
+hard-coded inside rookiepy. Users with multiple Chrome user-profiles
+signed in to different Google accounts see ``--browser-cookies chrome``
+silently skip every non-Default account (issue #571).
+
+This module:
+
+1. Discovers every populated user-data profile across the chromium family.
+2. Reads cookies from each via ``rookiepy.any_browser(db_path, domains=…)``,
+   which (unlike ``rookiepy.chromium_based``) successfully decrypts non-Default
+   Chrome cookies on macOS — empirically verified, the
+   ``missing osx_key_service`` blocker noted in #511 only affects
+   ``chromium_based`` and not ``any_browser``.
+
+Public surface:
+
+* :data:`CHROMIUM_BROWSER_USER_DATA_DIRS` — per-platform, per-browser roots
+* :class:`ChromiumProfile`
+* :func:`discover_chromium_profiles`
+* :func:`read_chromium_profile_cookies`
+* :func:`is_chromium_browser`
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Browsers whose on-disk layout matches Chrome's (``<root>/<profile-dir>/Cookies``
+# plus ``<root>/Local State``). Excludes Firefox-family (separate profile model
+# via ``profiles.ini`` + ``cookies.sqlite``) and Safari.
+_CHROMIUM_BROWSERS: frozenset[str] = frozenset(
+    {"chrome", "chromium", "brave", "edge", "arc", "vivaldi", "opera", "opera-gx"}
+)
+
+
+def is_chromium_browser(browser_name: str) -> bool:
+    """Return True when ``browser_name`` uses Chrome's user-data-profile layout."""
+    return browser_name.lower() in _CHROMIUM_BROWSERS
+
+
+def _macos_user_data_dirs() -> dict[str, Path]:
+    home = Path.home()
+    app_support = home / "Library" / "Application Support"
+    return {
+        "chrome": app_support / "Google" / "Chrome",
+        "chromium": app_support / "Chromium",
+        "brave": app_support / "BraveSoftware" / "Brave-Browser",
+        "edge": app_support / "Microsoft Edge",
+        "arc": app_support / "Arc" / "User Data",
+        "vivaldi": app_support / "Vivaldi",
+        "opera": app_support / "com.operasoftware.Opera",
+        "opera-gx": app_support / "com.operasoftware.OperaGX",
+    }
+
+
+def _linux_user_data_dirs() -> dict[str, Path]:
+    home = Path.home()
+    xdg = Path(os.environ.get("XDG_CONFIG_HOME", str(home / ".config")))
+    return {
+        "chrome": xdg / "google-chrome",
+        "chromium": xdg / "chromium",
+        "brave": xdg / "BraveSoftware" / "Brave-Browser",
+        "edge": xdg / "microsoft-edge",
+        "vivaldi": xdg / "vivaldi",
+        "opera": xdg / "opera",
+        "opera-gx": xdg / "opera-gx",
+        # Arc on Linux has no stable directory yet; omit until upstream stabilizes.
+    }
+
+
+def _windows_user_data_dirs() -> dict[str, Path]:
+    out: dict[str, Path] = {}
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        base = Path(local)
+        out.update(
+            {
+                "chrome": base / "Google" / "Chrome" / "User Data",
+                "chromium": base / "Chromium" / "User Data",
+                "brave": base / "BraveSoftware" / "Brave-Browser" / "User Data",
+                "edge": base / "Microsoft" / "Edge" / "User Data",
+                "vivaldi": base / "Vivaldi" / "User Data",
+            }
+        )
+    # Opera (stable + GX) stores its user-data dir under %APPDATA% (Roaming),
+    # NOT %LOCALAPPDATA%, despite using Chromium's profile layout. Splitting
+    # the table off the wrong env var would silently no-op for Windows Opera
+    # users with multiple profiles.
+    roaming = os.environ.get("APPDATA")
+    if roaming:
+        base_roaming = Path(roaming)
+        out["opera"] = base_roaming / "Opera Software" / "Opera Stable"
+        out["opera-gx"] = base_roaming / "Opera Software" / "Opera GX Stable"
+    return out
+
+
+def _platform_user_data_dirs() -> dict[str, Path]:
+    if sys.platform == "darwin":
+        return _macos_user_data_dirs()
+    if sys.platform in ("win32", "cygwin"):
+        return _windows_user_data_dirs()
+    return _linux_user_data_dirs()
+
+
+# Per-platform, per-browser user-data directory roots. Tests can override by
+# patching this function via ``monkeypatch.setattr``.
+def _user_data_dir(browser_name: str) -> Path | None:
+    """Return the chromium-family browser's user-data directory, or None.
+
+    ``None`` means the browser isn't part of the chromium family OR the
+    current platform has no documented path for it.
+    """
+    return _platform_user_data_dirs().get(browser_name.lower())
+
+
+@dataclass(frozen=True)
+class ChromiumProfile:
+    """A single Chromium user-data profile with a populated Cookies DB.
+
+    Attributes:
+        browser: The chromium-family browser this profile belongs to
+            (e.g. ``"chrome"``, ``"brave"``).
+        directory_name: The on-disk directory name (``"Default"``, ``"Profile 1"``).
+            This is the canonical identifier — stable across renames in the UI.
+        human_name: The user-visible profile name from ``Local State``
+            (``"Personal"``, ``"Work"``). Falls back to ``directory_name`` when
+            ``Local State`` is missing or doesn't list this profile.
+        cookies_db: Absolute path to the profile's ``Cookies`` SQLite DB.
+    """
+
+    browser: str
+    directory_name: str
+    human_name: str
+    cookies_db: Path
+
+
+# Matches Chrome's profile directory naming: ``Default`` or ``Profile <N>``.
+# Guest sessions never persist cookies (the ``Guest Profile`` dir may exist
+# but has no ``Cookies`` file), so we drop it from the regex to make intent
+# explicit rather than relying on the file-existence filter to skip it.
+_PROFILE_DIR_RE = re.compile(r"^(Default|Profile\s+\d+)$")
+
+
+def _load_local_state_names(user_data_dir: Path) -> dict[str, str]:
+    """Map ``profile-dir-name`` → human-readable name from ``Local State``.
+
+    Returns ``{}`` when ``Local State`` is absent or malformed — caller falls
+    back to the directory name.
+    """
+    local_state = user_data_dir / "Local State"
+    if not local_state.is_file():
+        return {}
+    try:
+        data: Any = json.loads(local_state.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    info_cache = data.get("profile", {}).get("info_cache", {})
+    if not isinstance(info_cache, dict):
+        return {}
+    names: dict[str, str] = {}
+    for dir_name, entry in info_cache.items():
+        if isinstance(entry, dict):
+            human = entry.get("name")
+            if isinstance(human, str) and human.strip():
+                names[dir_name] = human.strip()
+    return names
+
+
+def discover_chromium_profiles(browser_name: str) -> list[ChromiumProfile]:
+    """Enumerate populated user-data profiles for a chromium-family browser.
+
+    A profile is "populated" when its ``Cookies`` SQLite file exists. Empty /
+    never-used profiles are skipped (no point trying to read them).
+
+    Returns an empty list when:
+
+    * ``browser_name`` is not a chromium-family browser
+    * The browser has no documented user-data dir on this platform
+    * The user-data dir doesn't exist (browser not installed)
+    * No profile has a populated Cookies DB
+
+    The list is ordered with ``Default`` first (if present), then other
+    profiles in directory-name order — stable across runs.
+    """
+    if not is_chromium_browser(browser_name):
+        return []
+    user_data_dir = _user_data_dir(browser_name)
+    if user_data_dir is None or not user_data_dir.is_dir():
+        return []
+
+    human_names = _load_local_state_names(user_data_dir)
+    profiles: list[ChromiumProfile] = []
+    for entry in user_data_dir.iterdir():
+        if not entry.is_dir():
+            continue
+        if not _PROFILE_DIR_RE.match(entry.name):
+            continue
+        cookies_db = entry / "Cookies"
+        if not cookies_db.is_file():
+            continue
+        profiles.append(
+            ChromiumProfile(
+                browser=browser_name.lower(),
+                directory_name=entry.name,
+                human_name=human_names.get(entry.name, entry.name),
+                cookies_db=cookies_db,
+            )
+        )
+
+    def _sort_key(p: ChromiumProfile) -> tuple[int, str]:
+        # Default first, then Profile N in numeric order, then anything else.
+        if p.directory_name == "Default":
+            return (0, "")
+        match = re.match(r"Profile\s+(\d+)$", p.directory_name)
+        if match:
+            return (1, f"{int(match.group(1)):08d}")
+        return (2, p.directory_name)
+
+    profiles.sort(key=_sort_key)
+    return profiles
+
+
+def read_chromium_profile_cookies(
+    profile: ChromiumProfile, *, domains: list[str]
+) -> list[dict[str, Any]]:
+    """Read and decrypt cookies from a single Chromium user-data profile.
+
+    Uses ``rookiepy.any_browser(db_path, domains=…)``, which auto-detects the
+    encryption scheme. On macOS it reads the per-browser Safe Storage key from
+    Keychain transparently — verified working for non-Default Chrome profiles
+    against the real ``rookiepy.chromium_based`` blocker described in #511.
+
+    Args:
+        profile: A profile from :func:`discover_chromium_profiles`.
+        domains: Domain allowlist to forward to rookiepy.
+
+    Returns:
+        Raw cookie dicts (rookiepy's native shape).
+
+    Raises:
+        RuntimeError: When rookiepy fails to read or decrypt the DB. Caller
+            decides whether to skip-and-warn or propagate.
+    """
+    import rookiepy  # imported lazily; rookiepy is an optional extra
+
+    return rookiepy.any_browser(str(profile.cookies_db), domains=domains)

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from playwright.sync_api import BrowserContext, Page
     from rich.console import Console
 
+    from ..auth import Account
+
 from ..auth import (
     GOOGLE_REGIONAL_CCTLDS,
     OPTIONAL_COOKIE_DOMAINS_BY_LABEL,
@@ -186,7 +188,7 @@ def _enumerate_one_jar(
     browser_profile: str | None,
     *,
     quiet: bool = False,
-) -> list[Any]:
+) -> "list[Account]":
     """Probe ``?authuser=N`` against one cookie set and return tagged Accounts.
 
     Shared by both the legacy single-jar path and the chromium multi-profile
@@ -200,14 +202,22 @@ def _enumerate_one_jar(
             ``"Profile 1"``, ...) or ``None`` for the legacy single-jar path.
         quiet: Suppress the loud multi-line user-facing error panels
             (``"No valid Google authentication cookies"``, ``"Account
-            discovery failed: …stale"``) and just raise ``SystemExit``. Used
-            by the fan-out caller, which prints its own per-profile soft
-            note for signed-out / stale-cookie profiles and would otherwise
-            bleed those panels into the table output.
+            discovery failed: …stale"``) for "this profile is signed out"
+            cases and just raise ``SystemExit``. Used by the fan-out caller,
+            which prints its own per-profile soft note for signed-out /
+            stale-cookie profiles and would otherwise bleed those panels into
+            the table output. Network errors (``httpx.RequestError``) are
+            NOT downgraded — they propagate as-is so the caller can
+            distinguish transport failures from per-profile "signed out".
 
     Raises:
-        SystemExit: On missing required cookies, stale-cookie rejection by
-            Google, or HTTP transport failure.
+        SystemExit: On missing required cookies or stale-cookie rejection
+            by Google (Google redirected to the account chooser, etc.).
+            These are per-profile "signed out" conditions in fan-out mode
+            and are caught and skipped by the fan-out caller.
+        httpx.RequestError: On network transport failure. Re-raised
+            unchanged so the fan-out aborts (vs. silently downgrading every
+            offline profile to a soft skip).
     """
     from ..auth import (
         Account,
@@ -247,12 +257,17 @@ def _enumerate_one_jar(
             )
         raise SystemExit(1) from None
     except httpx.RequestError as e:
+        # Distinct from "signed out / stale" SystemExit branches above:
+        # a network failure means EVERY profile probe will fail the same
+        # way, so we must surface the transport error rather than let the
+        # fan-out caller collapse it into a soft per-profile skip.
         if not quiet:
             console.print(
                 f"[red]Account discovery failed (network error):[/red] {e}\n"
                 "Check your internet connection and try again."
             )
-        raise SystemExit(1) from None
+            raise SystemExit(1) from None
+        raise
 
     if browser_profile is None:
         return list(accounts)
@@ -272,7 +287,7 @@ def _enumerate_browser_accounts(
     *,
     verbose: bool = True,
     include_domains: set[str] | None = None,
-) -> tuple[dict[str | None, list[dict[str, Any]]], list[Any]]:
+) -> "tuple[dict[str | None, list[dict[str, Any]]], list[Account]]":
     """Read cookies from ``browser_name`` and discover signed-in accounts.
 
     For chromium-family browsers with multiple populated user-data profiles
@@ -335,7 +350,7 @@ def _enumerate_chromium_profiles_fanout(
     *,
     verbose: bool,
     include_domains: set[str] | None,
-) -> tuple[dict[str | None, list[dict[str, Any]]], list[Any]]:
+) -> "tuple[dict[str | None, list[dict[str, Any]]], list[Account]]":
     """Fan out account discovery across multiple Chromium user-data profiles.
 
     Reads cookies from each profile's own ``Cookies`` SQLite DB and probes
@@ -359,12 +374,24 @@ def _enumerate_chromium_profiles_fanout(
 
     per_profile_cookies: dict[str | None, list[dict[str, Any]]] = {}
     seen_emails: dict[str, str] = {}  # email -> winning browser_profile
-    aggregated: list[Any] = []
+    aggregated: list[Account] = []
     global_default_assigned = False
 
     for profile in profiles:
         try:
             raw = read_chromium_profile_cookies(profile, domains=domains)
+        except ImportError:
+            # rookiepy isn't installed — same friendly message the legacy
+            # single-jar path prints (``_read_browser_cookies``). Abort fan-out
+            # since every profile would fail the same way.
+            console.print(
+                "[red]rookiepy is not installed.[/red]\n"
+                "Install it with:\n"
+                "  pip install 'notebooklm-py[cookies]'\n"
+                "or directly:\n"
+                "  pip install rookiepy"
+            )
+            raise SystemExit(1) from None
         except (OSError, RuntimeError) as e:
             # One profile failing (e.g. a locked DB) shouldn't kill discovery
             # of the others. Surface a per-profile note and continue.
@@ -391,6 +418,15 @@ def _enumerate_chromium_profiles_fanout(
                     f"  [dim]no signed-in Google accounts in '{profile.human_name}'[/dim]"
                 )
             continue
+        except httpx.RequestError as e:
+            # Network failure — every subsequent profile probe will hit the
+            # same error, so abort the entire fan-out rather than collapse
+            # the transport failure into per-profile "signed out" skips.
+            console.print(
+                f"[red]Account discovery failed (network error):[/red] {e}\n"
+                "Check your internet connection and try again."
+            )
+            raise SystemExit(1) from None
 
         per_profile_cookies[profile.directory_name] = raw
         for account in accounts:

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -180,13 +180,108 @@ def _handle_rookiepy_error(e: Exception, browser_name: str) -> None:
         console.print(f"[red]Failed to read cookies from {browser_name}:[/red] {e}")
 
 
+def _enumerate_one_jar(
+    raw_cookies: list[dict[str, Any]],
+    browser_name: str,
+    browser_profile: str | None,
+    *,
+    quiet: bool = False,
+) -> list[Any]:
+    """Probe ``?authuser=N`` against one cookie set and return tagged Accounts.
+
+    Shared by both the legacy single-jar path and the chromium multi-profile
+    fan-out path. ``browser_profile`` annotates the resulting Accounts so the
+    fan-out caller can route writes back to the right source.
+
+    Args:
+        raw_cookies: rookiepy cookie dicts for one source.
+        browser_name: The browser the cookies came from (for error messages).
+        browser_profile: Tag attached to each Account (``"Default"``,
+            ``"Profile 1"``, ...) or ``None`` for the legacy single-jar path.
+        quiet: Suppress the loud multi-line user-facing error panels
+            (``"No valid Google authentication cookies"``, ``"Account
+            discovery failed: …stale"``) and just raise ``SystemExit``. Used
+            by the fan-out caller, which prints its own per-profile soft
+            note for signed-out / stale-cookie profiles and would otherwise
+            bleed those panels into the table output.
+
+    Raises:
+        SystemExit: On missing required cookies, stale-cookie rejection by
+            Google, or HTTP transport failure.
+    """
+    from ..auth import (
+        Account,
+        build_cookie_jar,
+        enumerate_accounts,
+        extract_cookies_with_domains,
+    )
+
+    storage_state = convert_rookiepy_cookies_to_storage_state(raw_cookies)
+    try:
+        extract_cookies_from_storage(storage_state)
+    except ValueError as e:
+        if not quiet:
+            console.print(
+                "[red]No valid Google authentication cookies found.[/red]\n"
+                f"{e}\n\n"
+                "Make sure you are logged into Google in your browser."
+            )
+        raise SystemExit(1) from None
+
+    cookie_map = extract_cookies_with_domains(storage_state)
+    jar = build_cookie_jar(cookies=cookie_map)
+    try:
+        accounts = run_async(enumerate_accounts(jar))
+    except ValueError:
+        # Cookies are present but Google rejected them (passive sign-in
+        # redirected to the account chooser, or RotateCookies returned 401).
+        if not quiet:
+            console.print(
+                f"[red]Account discovery failed: {browser_name}'s saved cookies are "
+                f"too stale for Google to re-authenticate.[/red]\n\n"
+                "Refresh them by opening the browser and visiting a Google site "
+                "(e.g. https://notebooklm.google.com), then re-run this command.\n\n"
+                "If the browser is signed out, sign back in there first.\n"
+                "If you'd rather skip the browser entirely, use "
+                "[cyan]notebooklm login[/cyan] (Playwright flow)."
+            )
+        raise SystemExit(1) from None
+    except httpx.RequestError as e:
+        if not quiet:
+            console.print(
+                f"[red]Account discovery failed (network error):[/red] {e}\n"
+                "Check your internet connection and try again."
+            )
+        raise SystemExit(1) from None
+
+    if browser_profile is None:
+        return list(accounts)
+    return [
+        Account(
+            authuser=a.authuser,
+            email=a.email,
+            is_default=a.is_default,
+            browser_profile=browser_profile,
+        )
+        for a in accounts
+    ]
+
+
 def _enumerate_browser_accounts(
     browser_name: str,
     *,
     verbose: bool = True,
     include_domains: set[str] | None = None,
-) -> tuple[list[Any], list[Any]]:
+) -> tuple[dict[str | None, list[dict[str, Any]]], list[Any]]:
     """Read cookies from ``browser_name`` and discover signed-in accounts.
+
+    For chromium-family browsers with multiple populated user-data profiles
+    (``Default`` plus ``Profile 1``, ``Profile 2``, …), fans out across every
+    profile and aggregates the discovered accounts, deduping by email.
+
+    For non-chromium browsers, single-profile chromium installs, and the
+    legacy path, falls back to a single rookiepy call — preserving every
+    existing test mock and runtime behavior.
 
     Args:
         browser_name: rookiepy browser alias.
@@ -197,60 +292,144 @@ def _enumerate_browser_accounts(
             :func:`_parse_include_domains`.
 
     Returns:
-        ``(raw_cookies, accounts)`` — the original rookiepy cookies and the
-        list of :class:`notebooklm.auth.Account` records discovered via
-        per-index ``?authuser=N`` probing.
+        ``(per_profile_cookies, accounts)``:
+
+        * ``per_profile_cookies`` — dict keyed by :attr:`Account.browser_profile`
+          (e.g. ``"Default"``, ``"Profile 1"``) mapping to the raw rookiepy
+          cookies that yielded that profile's accounts. The legacy / single-jar
+          path uses ``None`` as the key.
+        * ``accounts`` — :class:`notebooklm.auth.Account` records, each tagged
+          with the originating ``browser_profile``, deduped by email (first
+          occurrence wins; later duplicates are dropped with a warning).
 
     Raises:
         SystemExit: On rookiepy failure, missing required cookies, or
-            authuser=0 not returning a signed-in account.
+            ``authuser=0`` not returning a signed-in account from every probed
+            profile.
     """
-    from ..auth import (
-        build_cookie_jar,
-        enumerate_accounts,
-        extract_cookies_with_domains,
-    )
+    from ._chromium_profiles import discover_chromium_profiles, is_chromium_browser
+
+    # Chromium multi-profile fan-out — only kicks in when discovery surfaces
+    # >1 populated profile. Single-profile installs and non-chromium browsers
+    # take the legacy path below so all existing rookiepy mocks keep working.
+    if is_chromium_browser(browser_name):
+        profiles = discover_chromium_profiles(browser_name)
+        if len(profiles) > 1:
+            return _enumerate_chromium_profiles_fanout(
+                browser_name,
+                profiles,
+                verbose=verbose,
+                include_domains=include_domains,
+            )
 
     raw_cookies = _read_browser_cookies(
         browser_name, verbose=verbose, include_domains=include_domains
     )
-    storage_state = convert_rookiepy_cookies_to_storage_state(raw_cookies)
-    try:
-        extract_cookies_from_storage(storage_state)
-    except ValueError as e:
-        console.print(
-            "[red]No valid Google authentication cookies found.[/red]\n"
-            f"{e}\n\n"
-            "Make sure you are logged into Google in your browser."
-        )
-        raise SystemExit(1) from None
+    accounts = _enumerate_one_jar(raw_cookies, browser_name, browser_profile=None)
+    return {None: raw_cookies}, accounts
 
-    cookie_map = extract_cookies_with_domains(storage_state)
-    jar = build_cookie_jar(cookies=cookie_map)
-    try:
-        accounts = run_async(enumerate_accounts(jar))
-    except ValueError:
-        # Cookies are present but Google rejected them (passive sign-in
-        # redirected to the account chooser, or RotateCookies returned 401).
-        # The on-disk cookie store the browser persists is too stale for
-        # Google to refresh server-side. User has to refresh it themselves.
+
+def _enumerate_chromium_profiles_fanout(
+    browser_name: str,
+    profiles: list[Any],
+    *,
+    verbose: bool,
+    include_domains: set[str] | None,
+) -> tuple[dict[str | None, list[dict[str, Any]]], list[Any]]:
+    """Fan out account discovery across multiple Chromium user-data profiles.
+
+    Reads cookies from each profile's own ``Cookies`` SQLite DB and probes
+    ``?authuser=N`` per profile. Aggregates accounts across profiles and
+    dedupes by email (first occurrence wins — typically ``Default``, then
+    ``Profile 1``, ``Profile 2``, … in numeric order; duplicates are dropped
+    with a console warning so the user can investigate).
+    """
+    from ._chromium_profiles import read_chromium_profile_cookies
+
+    domains = _build_google_cookie_domains(include_domains=include_domains)
+
+    if verbose:
+        names = ", ".join(f"'{p.human_name}'" for p in profiles)
         console.print(
-            f"[red]Account discovery failed: {browser_name}'s saved cookies are "
-            f"too stale for Google to re-authenticate.[/red]\n\n"
-            "Refresh them by opening the browser and visiting a Google site "
-            "(e.g. https://notebooklm.google.com), then re-run this command.\n\n"
-            "If the browser is signed out, sign back in there first.\n"
-            "If you'd rather skip the browser entirely, use "
-            "[cyan]notebooklm login[/cyan] (Playwright flow)."
+            f"[yellow]Reading cookies from {len(profiles)} {browser_name} "
+            f"user-profiles: {names}[/yellow]"
         )
-        raise SystemExit(1) from None
-    except httpx.RequestError as e:
+
+    from ..auth import Account
+
+    per_profile_cookies: dict[str | None, list[dict[str, Any]]] = {}
+    seen_emails: dict[str, str] = {}  # email -> winning browser_profile
+    aggregated: list[Any] = []
+    global_default_assigned = False
+
+    for profile in profiles:
+        try:
+            raw = read_chromium_profile_cookies(profile, domains=domains)
+        except (OSError, RuntimeError) as e:
+            # One profile failing (e.g. a locked DB) shouldn't kill discovery
+            # of the others. Surface a per-profile note and continue.
+            if verbose:
+                console.print(
+                    f"  [yellow]skipping {browser_name} profile "
+                    f"'{profile.human_name}': {e}[/yellow]"
+                )
+            continue
+
+        try:
+            accounts = _enumerate_one_jar(
+                raw,
+                browser_name,
+                browser_profile=profile.directory_name,
+                quiet=True,
+            )
+        except SystemExit:
+            # ``_enumerate_one_jar`` exits the CLI on a stale-jar / missing-cookies
+            # failure, but in fan-out mode an individual profile being signed
+            # out is normal. Catch and continue.
+            if verbose:
+                console.print(
+                    f"  [dim]no signed-in Google accounts in '{profile.human_name}'[/dim]"
+                )
+            continue
+
+        per_profile_cookies[profile.directory_name] = raw
+        for account in accounts:
+            if account.email in seen_emails:
+                if verbose:
+                    console.print(
+                        f"  [yellow]warning: {account.email} also appears in "
+                        f"'{profile.human_name}'; using cookies from "
+                        f"'{seen_emails[account.email]}'[/yellow]"
+                    )
+                continue
+            seen_emails[account.email] = profile.directory_name
+            # ``is_default`` from ``_enumerate_one_jar`` is the per-jar
+            # authuser=0 marker — every Chromium user-profile has its own.
+            # For a unified cross-profile view, only the FIRST profile's
+            # default carries the global default flag (typically Default's
+            # primary Google account, matching what the user sees when they
+            # open Chrome without explicitly picking a different profile).
+            is_default = account.is_default and not global_default_assigned
+            if is_default:
+                global_default_assigned = True
+            aggregated.append(
+                Account(
+                    authuser=account.authuser,
+                    email=account.email,
+                    is_default=is_default,
+                    browser_profile=account.browser_profile,
+                )
+            )
+
+    if not aggregated:
         console.print(
-            f"[red]Account discovery failed (network error):[/red] {e}\n"
-            "Check your internet connection and try again."
+            f"[red]No signed-in Google accounts found across {len(profiles)} "
+            f"{browser_name} user-profiles.[/red]\n"
+            "Sign in to a Google account in your browser and try again."
         )
-        raise SystemExit(1) from None
-    return raw_cookies, accounts
+        raise SystemExit(1)
+
+    return per_profile_cookies, aggregated
 
 
 def _login_browser_cookies_single(
@@ -287,7 +466,7 @@ def _login_browser_cookies_single(
 
     # Path 2: targeted extraction. We need the email to derive a profile name
     # when --profile-name is omitted.
-    raw_cookies, accounts = _enumerate_browser_accounts(
+    per_profile_cookies, accounts = _enumerate_browser_accounts(
         browser_cookies, include_domains=include_domains
     )
     selected = _select_account(accounts, account_email=account_email)
@@ -299,7 +478,7 @@ def _login_browser_cookies_single(
     target_storage = explicit_storage or get_storage_path(profile=target_profile)
 
     _write_extracted_cookies(
-        raw_cookies,
+        per_profile_cookies[selected.browser_profile],
         storage_path=target_storage,
         profile=target_profile if not explicit_storage else active_profile,
         authuser=selected.authuser,
@@ -343,7 +522,7 @@ def _login_all_accounts_from_browser(
     """Extract every signed-in Google account into its own profile."""
     from ..paths import list_profiles
 
-    raw_cookies, accounts = _enumerate_browser_accounts(
+    per_profile_cookies, accounts = _enumerate_browser_accounts(
         browser_cookies, include_domains=include_domains
     )
     if not accounts:
@@ -370,7 +549,7 @@ def _login_all_accounts_from_browser(
 
         target_storage = get_storage_path(profile=target_profile)
         _write_extracted_cookies(
-            raw_cookies,
+            per_profile_cookies[account.browser_profile],
             storage_path=target_storage,
             profile=target_profile,
             authuser=account.authuser,
@@ -515,7 +694,7 @@ def _refresh_from_browser_cookies(
     include_domains: set[str] | None = None,
 ) -> None:
     """Refresh the active profile from browser cookies, repairing account drift."""
-    raw_cookies, accounts = _enumerate_browser_accounts(
+    per_profile_cookies, accounts = _enumerate_browser_accounts(
         browser_name, verbose=not quiet, include_domains=include_domains
     )
     if not accounts:
@@ -525,7 +704,7 @@ def _refresh_from_browser_cookies(
     metadata = read_account_metadata(storage_path)
     selected = _select_refresh_account(accounts, metadata, browser_name)
     _write_extracted_cookies(
-        raw_cookies,
+        per_profile_cookies[selected.browser_profile],
         storage_path=storage_path,
         profile=profile,
         authuser=selected.authuser,
@@ -1955,16 +2134,34 @@ def register_session_commands(cli):
         ),
     )
     @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
-    def auth_inspect(browser_name, include_domains_raw, json_output):
+    @click.option(
+        "-v",
+        "--verbose",
+        "verbose",
+        is_flag=True,
+        default=False,
+        help=(
+            "Also show which browser user-profile each account's cookies came "
+            "from. Useful for Chromium-family browsers with multiple "
+            "user-profiles."
+        ),
+    )
+    def auth_inspect(browser_name, include_domains_raw, json_output, verbose):
         """List Google accounts visible to a browser's cookie store.
 
         Read-only — never writes to disk. Use this before
         ``notebooklm login --browser-cookies <browser> --account <email>`` to
         see which account emails are available.
 
+        For Chromium-family browsers (chrome, brave, edge, …) with multiple
+        user-profiles, accounts from every populated profile are surfaced and
+        deduped by email. Pass ``-v`` to see the originating user-profile per
+        account, or ``--json`` for a structured ``browser_profile`` field.
+
         \b
         Examples:
           notebooklm auth inspect --browser chrome
+          notebooklm auth inspect --browser chrome -v
           notebooklm auth inspect --browser firefox --json
         """
         include_domains = _parse_include_domains(include_domains_raw)
@@ -1975,30 +2172,44 @@ def register_session_commands(cli):
             json_output_response(
                 {
                     "browser": browser_name,
-                    "accounts": [{"email": a.email, "is_default": a.is_default} for a in accounts],
+                    "accounts": [
+                        {
+                            "email": a.email,
+                            "is_default": a.is_default,
+                            "browser_profile": a.browser_profile,
+                        }
+                        for a in accounts
+                    ],
                 }
             )
             return
         console.print(f"\n[bold]Browser:[/bold] {browser_name}")
         console.print(f"[bold]Found {len(accounts)} signed-in Google account(s):[/bold]\n")
+        show_browser_profile = verbose and any(a.browser_profile for a in accounts)
         table = Table(show_header=True, header_style="bold")
         table.add_column("email")
+        if show_browser_profile:
+            table.add_column(f"{browser_name} user")
         table.add_column("default", justify="center")
         for a in accounts:
-            table.add_row(
-                a.email,
-                "[green]✓[/green]" if a.is_default else "",
-            )
+            row = [a.email]
+            if show_browser_profile:
+                row.append(a.browser_profile or "")
+            row.append("[green]✓[/green]" if a.is_default else "")
+            table.add_row(*row)
         console.print(table)
-        console.print(
-            "\n[dim]Note: --browser-cookies <browser> reads cookies from the "
-            "browser's default user-data profile only. Accounts in other "
-            "browser profiles will not appear here.[/dim]\n"
-            "Pick one with: [cyan]notebooklm login --browser-cookies "
+        hint = (
+            f"Pick one with: [cyan]notebooklm login --browser-cookies "
             f"{browser_name} --account EMAIL[/cyan]\n"
-            "Or extract them all: [cyan]notebooklm login --browser-cookies "
+            f"Or extract them all: [cyan]notebooklm login --browser-cookies "
             f"{browser_name} --all-accounts[/cyan]"
         )
+        if not verbose and any(a.browser_profile for a in accounts):
+            hint = (
+                "[dim]Pass -v to see which browser user-profile each account "
+                "came from.[/dim]\n" + hint
+            )
+        console.print("\n" + hint)
 
     @auth_group.command("check")
     @click.option(

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -6,6 +6,29 @@ import pytest
 from click.testing import CliRunner
 
 
+@pytest.fixture(autouse=True)
+def _disable_chromium_profile_fanout(monkeypatch):
+    """Default: Chromium multi-user-profile discovery returns nothing in tests.
+
+    The session multi-account paths (``auth inspect``, ``login --account``,
+    ``login --all-accounts``, ``auth refresh``) auto-fan-out across every
+    populated Chromium user-data profile (issue #571). On a developer machine
+    with multiple real Chrome profiles, that discovery would otherwise leak
+    into tests that mock ``rookiepy.chrome`` (and ignore the new
+    ``rookiepy.any_browser`` fan-out path), making them flaky depending on
+    whoever runs the suite.
+
+    Tests that exercise the fan-out path itself override this fixture by
+    patching ``discover_chromium_profiles`` explicitly with their own list of
+    synthetic profiles — the autouse here just guarantees deterministic
+    legacy-path behavior everywhere else.
+    """
+    monkeypatch.setattr(
+        "notebooklm.cli._chromium_profiles.discover_chromium_profiles",
+        lambda *a, **kw: [],
+    )
+
+
 @pytest.fixture
 def runner():
     """Create a Click test runner."""

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -1,5 +1,6 @@
 """Tests for session CLI commands (login, use, status, clear)."""
 
+import contextlib
 import json
 import sys
 from datetime import datetime
@@ -3476,3 +3477,429 @@ class TestStaleAccountMetadataCleanup:
         # Account metadata must be gone so subsequent token fetches don't keep
         # routing to the old account, while unrelated notebook context survives.
         assert json.loads((tmp_path / "context.json").read_text()) == {"notebook_id": "nb_existing"}
+
+
+# =============================================================================
+# Chromium multi-user-profile fan-out (issue #571)
+# =============================================================================
+
+
+def _make_chromium_profile(directory_name, human_name, cookies_db):
+    """Build a synthetic ChromiumProfile for fan-out tests."""
+    from notebooklm.cli._chromium_profiles import ChromiumProfile
+
+    return ChromiumProfile(
+        browser="chrome",
+        directory_name=directory_name,
+        human_name=human_name,
+        cookies_db=cookies_db,
+    )
+
+
+def _chromium_fanout_setup(tmp_path, profile_specs):
+    """Install patches that make the chromium fan-out path deterministic.
+
+    Args:
+        tmp_path: pytest tmp_path.
+        profile_specs: list of ``(directory_name, human_name, accounts_for_profile)``
+            where ``accounts_for_profile`` is a list of dicts
+            ``{"authuser": int, "email": str, "is_default": bool}``.
+
+    Returns:
+        Tuple ``(profiles, cookies_per_profile, accounts_per_profile)`` of
+        the data structures the patches will return. Useful when a test
+        wants to assert on what was set up.
+    """
+    profiles = []
+    cookies_per_profile = {}
+    accounts_per_profile = {}
+    for dir_name, human, account_dicts in profile_specs:
+        db = tmp_path / f"{dir_name}-Cookies"
+        db.write_bytes(b"x")  # presence-only, never opened by mocks
+        profile = _make_chromium_profile(dir_name, human, db)
+        profiles.append(profile)
+        # Unique per-profile cookie value so the writer-side assertions can
+        # distinguish which profile's jar was used when writing notebooklm
+        # storage_state.json files for each account.
+        cookies_per_profile[dir_name] = [
+            {
+                "domain": ".google.com",
+                "name": "SID",
+                "value": f"SID-from-{dir_name}",
+                "path": "/",
+                "secure": True,
+                "expires": 9999,
+                "http_only": False,
+            },
+            {
+                "domain": ".google.com",
+                "name": "__Secure-1PSIDTS",
+                "value": f"SIDTS-from-{dir_name}",
+                "path": "/",
+                "secure": True,
+                "expires": 9999,
+                "http_only": False,
+            },
+        ]
+        accounts_per_profile[dir_name] = account_dicts
+    return profiles, cookies_per_profile, accounts_per_profile
+
+
+@contextlib.contextmanager
+def _install_chromium_fanout_patches(profiles, cookies_per_profile, accounts_per_profile):
+    """Context manager that installs all fan-out patches for the test body.
+
+    Patches discovery, per-profile cookie reads, ``rookiepy`` (so the
+    optional-dep import inside ``read_chromium_profile_cookies`` succeeds),
+    and ``enumerate_accounts`` so each profile yields its own account list.
+    """
+    from notebooklm.auth import Account
+
+    def fake_discover(browser_name):
+        return profiles if browser_name.lower() == "chrome" else []
+
+    def fake_read(profile, *, domains):
+        return cookies_per_profile[profile.directory_name]
+
+    pending = {p.directory_name: list(accounts_per_profile[p.directory_name]) for p in profiles}
+
+    async def fake_enumerate(jar, *args, **kwargs):
+        # ``_enumerate_one_jar`` builds a jar from the cookies it just read,
+        # so the SID value (unique per profile in our setup) identifies which
+        # profile this call corresponds to.
+        sid = jar.get("SID", default="")
+        for dir_name in pending:
+            if sid == f"SID-from-{dir_name}":
+                spec = pending.pop(dir_name)
+                return [
+                    Account(authuser=a["authuser"], email=a["email"], is_default=a["is_default"])
+                    for a in spec
+                ]
+        raise AssertionError(f"unexpected enumerate_accounts call (SID={sid!r})")
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.dict("sys.modules", {"rookiepy": MagicMock()}))
+        stack.enter_context(
+            patch(
+                "notebooklm.cli._chromium_profiles.discover_chromium_profiles",
+                side_effect=fake_discover,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "notebooklm.cli._chromium_profiles.read_chromium_profile_cookies",
+                side_effect=fake_read,
+            )
+        )
+        stack.enter_context(patch("notebooklm.auth.enumerate_accounts", side_effect=fake_enumerate))
+        yield
+
+
+class TestChromiumFanoutAuthInspect:
+    """``auth inspect`` aggregates accounts across Chrome user-profiles (#571)."""
+
+    def test_lists_accounts_across_profiles_email_only_by_default(self, runner, tmp_path):
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "bob@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 2",
+                    "Side",
+                    [{"authuser": 0, "email": "carol@ws.com", "is_default": True}],
+                ),
+            ],
+        )
+        with _install_chromium_fanout_patches(profiles, cookies, accounts):
+            result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome"])
+        assert result.exit_code == 0, result.output
+        assert "alice@gmail.com" in result.output
+        assert "bob@gmail.com" in result.output
+        assert "carol@ws.com" in result.output
+        # The result table is email-primary — no per-row browser-profile column
+        # by default. The "Reading cookies from N profiles…" status line may
+        # mention profile names, but the table rows don't repeat them.
+        table_lines = [line for line in result.output.splitlines() if "@" in line]
+        for row in table_lines:
+            assert "Default" not in row
+            assert "Profile 1" not in row
+            assert "Personal" not in row
+            assert "Work" not in row
+        # And the help text nudges the user toward -v.
+        assert "-v" in result.output
+
+    def test_verbose_shows_browser_user_profile_column(self, runner, tmp_path):
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "bob@gmail.com", "is_default": True}],
+                ),
+            ],
+        )
+        with _install_chromium_fanout_patches(profiles, cookies, accounts):
+            result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome", "-v"])
+        assert result.exit_code == 0, result.output
+        assert "Default" in result.output
+        assert "Profile 1" in result.output
+
+    def test_json_output_includes_browser_profile(self, runner, tmp_path):
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "bob@gmail.com", "is_default": True}],
+                ),
+            ],
+        )
+        with _install_chromium_fanout_patches(profiles, cookies, accounts):
+            result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        emails = {a["email"]: a["browser_profile"] for a in data["accounts"]}
+        assert emails == {
+            "alice@gmail.com": "Default",
+            "bob@gmail.com": "Profile 1",
+        }
+
+    def test_duplicate_email_across_profiles_deduped_first_wins(self, runner, tmp_path):
+        # Same email signed in to two Chrome user-profiles. Default wins
+        # (it's iterated first) and the second occurrence is dropped.
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+            ],
+        )
+        with _install_chromium_fanout_patches(profiles, cookies, accounts):
+            result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert [a["email"] for a in data["accounts"]] == ["alice@gmail.com"]
+        assert data["accounts"][0]["browser_profile"] == "Default"
+
+
+class TestChromiumFanoutAllAccounts:
+    """``login --browser-cookies chrome --all-accounts`` writes one profile per
+    unique Google account across every Chrome user-profile (#571)."""
+
+    def test_all_accounts_writes_profile_per_browser_user_profile(self, runner, tmp_path):
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "bob@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 2",
+                    "Side",
+                    [{"authuser": 0, "email": "carol@ws.com", "is_default": True}],
+                ),
+            ],
+        )
+        target_root = tmp_path / "profiles"
+
+        def fake_get_storage_path(profile=None):
+            return target_root / (profile or "default") / "storage_state.json"
+
+        def fake_list_profiles():
+            if not target_root.exists():
+                return []
+            return sorted(p.name for p in target_root.iterdir() if p.is_dir())
+
+        with (
+            _install_chromium_fanout_patches(profiles, cookies, accounts),
+            patch("notebooklm.cli.session.get_storage_path", side_effect=fake_get_storage_path),
+            patch("notebooklm.paths.list_profiles", side_effect=fake_list_profiles),
+            patch(
+                "notebooklm.cli.session.fetch_tokens_with_domains",
+                new_callable=AsyncMock,
+                return_value=("csrf", "sess"),
+            ),
+        ):
+            result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--all-accounts"])
+
+        assert result.exit_code == 0, result.output
+        assert (target_root / "alice" / "context.json").exists()
+        assert (target_root / "bob" / "context.json").exists()
+        assert (target_root / "carol" / "context.json").exists()
+        # Cookies written for "bob" must come from Profile 1, not Default —
+        # this is the core bug the fan-out fixes.
+        bob_storage = json.loads((target_root / "bob" / "storage_state.json").read_text())
+        sid_cookie = next(c for c in bob_storage["cookies"] if c["name"] == "SID")
+        assert sid_cookie["value"] == "SID-from-Profile 1"
+        # And alice@gmail.com's cookies come from Default.
+        alice_storage = json.loads((target_root / "alice" / "storage_state.json").read_text())
+        alice_sid = next(c for c in alice_storage["cookies"] if c["name"] == "SID")
+        assert alice_sid["value"] == "SID-from-Default"
+
+    def test_all_accounts_handles_profile_with_no_signed_in_account(self, runner, tmp_path):
+        # Profile 2 has a Cookies DB but no signed-in Google account
+        # (rookiepy decrypt succeeds, but enumerate_accounts rejects the jar).
+        # The remaining two profiles' accounts should still be written.
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                ("Profile 1", "Work", []),  # empty → signals signed-out below
+                (
+                    "Profile 2",
+                    "Side",
+                    [{"authuser": 0, "email": "carol@ws.com", "is_default": True}],
+                ),
+            ],
+        )
+
+        # Override the enumerate_accounts handler to SystemExit for Profile 1,
+        # mimicking ``_enumerate_one_jar`` exiting on a missing-SID jar.
+        from notebooklm.auth import Account
+
+        async def fake_enumerate(jar, *args, **kwargs):
+            sid = jar.get("SID", default="")
+            if sid == "SID-from-Profile 1":
+                # ``_enumerate_one_jar`` catches this and converts to a
+                # SystemExit, which the fan-out then catches as "signed out".
+                raise ValueError("no signed-in account at authuser=0")
+            for dir_name, spec in accounts.items():
+                if sid == f"SID-from-{dir_name}" and spec:
+                    return [
+                        Account(
+                            authuser=a["authuser"], email=a["email"], is_default=a["is_default"]
+                        )
+                        for a in spec
+                    ]
+            raise AssertionError(f"unexpected SID {sid!r}")
+
+        target_root = tmp_path / "profiles"
+
+        def fake_get_storage_path(profile=None):
+            return target_root / (profile or "default") / "storage_state.json"
+
+        def fake_list_profiles():
+            if not target_root.exists():
+                return []
+            return sorted(p.name for p in target_root.iterdir() if p.is_dir())
+
+        def fake_read(profile, *, domains):
+            return cookies[profile.directory_name]
+
+        def fake_discover(browser_name):
+            return profiles if browser_name.lower() == "chrome" else []
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": MagicMock()}),
+            patch(
+                "notebooklm.cli._chromium_profiles.discover_chromium_profiles",
+                side_effect=fake_discover,
+            ),
+            patch(
+                "notebooklm.cli._chromium_profiles.read_chromium_profile_cookies",
+                side_effect=fake_read,
+            ),
+            patch("notebooklm.auth.enumerate_accounts", side_effect=fake_enumerate),
+            patch("notebooklm.cli.session.get_storage_path", side_effect=fake_get_storage_path),
+            patch("notebooklm.paths.list_profiles", side_effect=fake_list_profiles),
+            patch(
+                "notebooklm.cli.session.fetch_tokens_with_domains",
+                new_callable=AsyncMock,
+                return_value=("csrf", "sess"),
+            ),
+        ):
+            result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--all-accounts"])
+
+        assert result.exit_code == 0, result.output
+        assert (target_root / "alice" / "context.json").exists()
+        assert (target_root / "carol" / "context.json").exists()
+        # No profile written for the signed-out Profile 1.
+        assert not any(p.name not in {"alice", "carol"} for p in target_root.iterdir())
+
+
+class TestChromiumFanoutAccountSelector:
+    """``--account EMAIL`` picks the right cookie source even when the email
+    lives in a non-Default Chrome user-profile (#571)."""
+
+    def test_account_email_from_non_default_profile(self, runner, tmp_path):
+        profiles, cookies, accounts = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "bob@gmail.com", "is_default": True}],
+                ),
+            ],
+        )
+        target_dir = tmp_path / "profiles" / "bob"
+
+        def fake_get_storage_path(profile=None):
+            return target_dir / "storage_state.json"
+
+        with (
+            _install_chromium_fanout_patches(profiles, cookies, accounts),
+            patch("notebooklm.cli.session.get_storage_path", side_effect=fake_get_storage_path),
+            patch("notebooklm.cli.session._sync_server_language_to_config"),
+            patch(
+                "notebooklm.cli.session.fetch_tokens_with_domains",
+                new_callable=AsyncMock,
+                return_value=("csrf", "sess"),
+            ),
+        ):
+            result = runner.invoke(
+                cli,
+                ["login", "--browser-cookies", "chrome", "--account", "bob@gmail.com"],
+            )
+
+        assert result.exit_code == 0, result.output
+        storage = json.loads((target_dir / "storage_state.json").read_text())
+        sid = next(c for c in storage["cookies"] if c["name"] == "SID")
+        # Critically: bob's cookies must come from Profile 1, NOT Default.
+        # Before #571 the CLI couldn't see Profile 1 at all.
+        assert sid["value"] == "SID-from-Profile 1"

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -3903,3 +3903,104 @@ class TestChromiumFanoutAccountSelector:
         # Critically: bob's cookies must come from Profile 1, NOT Default.
         # Before #571 the CLI couldn't see Profile 1 at all.
         assert sid["value"] == "SID-from-Profile 1"
+
+
+class TestChromiumFanoutBoundaryConditions:
+    """Boundary cases around when fan-out activates vs. legacy single-jar
+    path (raised by reviewers on #580)."""
+
+    def test_single_chromium_profile_uses_legacy_single_jar_path(self, runner):
+        """When discovery surfaces exactly ONE chromium user-profile, the
+        legacy ``_read_browser_cookies`` path runs (so existing rookiepy
+        mocks keep working). The new ``read_chromium_profile_cookies`` /
+        ``any_browser`` fan-out path must NOT be invoked.
+        """
+        from notebooklm.cli._chromium_profiles import ChromiumProfile
+
+        only_default = [
+            ChromiumProfile(
+                browser="chrome",
+                directory_name="Default",
+                human_name="Default",
+                cookies_db=Path("/dev/null"),
+            )
+        ]
+
+        mock_rk = _multiaccount_rookiepy_mock()
+
+        async def _enum(*args, **kwargs):
+            from notebooklm.auth import Account
+
+            return [Account(authuser=0, email="alice@example.com", is_default=True)]
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": mock_rk}),
+            patch(
+                "notebooklm.cli._chromium_profiles.discover_chromium_profiles",
+                return_value=only_default,
+            ),
+            patch(
+                "notebooklm.cli._chromium_profiles.read_chromium_profile_cookies",
+                side_effect=AssertionError(
+                    "fan-out must NOT run when only 1 chromium profile exists"
+                ),
+            ),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+        ):
+            result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome"])
+
+        assert result.exit_code == 0, result.output
+        # Legacy path was used → mock_rk.chrome was called, not any_browser.
+        mock_rk.chrome.assert_called_once()
+        assert "alice@example.com" in result.output
+
+    def test_network_error_aborts_fanout_not_silent_skip(self, runner, tmp_path):
+        """``httpx.RequestError`` during ``enumerate_accounts`` must abort
+        the entire fan-out with a clear network error, not get caught as
+        a per-profile "signed out" skip. (CodeRabbit major on #580.)
+        """
+        profiles, cookies, _ = _chromium_fanout_setup(
+            tmp_path,
+            [
+                (
+                    "Default",
+                    "Personal",
+                    [{"authuser": 0, "email": "alice@gmail.com", "is_default": True}],
+                ),
+                (
+                    "Profile 1",
+                    "Work",
+                    [{"authuser": 0, "email": "bob@gmail.com", "is_default": True}],
+                ),
+            ],
+        )
+
+        async def fake_enumerate(jar, *args, **kwargs):
+            raise httpx.ConnectError("DNS failure: notebooklm.google.com")
+
+        def fake_discover(browser_name):
+            return profiles if browser_name.lower() == "chrome" else []
+
+        def fake_read(profile, *, domains):
+            return cookies[profile.directory_name]
+
+        with (
+            patch.dict("sys.modules", {"rookiepy": MagicMock()}),
+            patch(
+                "notebooklm.cli._chromium_profiles.discover_chromium_profiles",
+                side_effect=fake_discover,
+            ),
+            patch(
+                "notebooklm.cli._chromium_profiles.read_chromium_profile_cookies",
+                side_effect=fake_read,
+            ),
+            patch("notebooklm.auth.enumerate_accounts", side_effect=fake_enumerate),
+        ):
+            result = runner.invoke(cli, ["auth", "inspect", "--browser", "chrome"])
+
+        # Fan-out must abort with non-zero exit + a network error message —
+        # NOT silently return "No accounts found" by collapsing each profile
+        # probe into the soft signed-out skip.
+        assert result.exit_code != 0, result.output
+        assert "network" in result.output.lower()
+        assert "DNS failure" in result.output

--- a/tests/unit/test_chromium_profiles.py
+++ b/tests/unit/test_chromium_profiles.py
@@ -1,0 +1,272 @@
+"""Unit tests for Chromium-family multi-user-profile cookie discovery.
+
+These tests build a synthetic ``<user-data-dir>/{Default,Profile N}/Cookies``
+layout (plus ``Local State``) on disk and prove
+:func:`notebooklm.cli._chromium_profiles.discover_chromium_profiles` returns
+the right :class:`ChromiumProfile` records for issue #571's fan-out path.
+
+We don't exercise rookiepy decryption here — that's covered against the real
+Chrome cookie DB during local validation, and at the
+:mod:`tests.unit.cli.test_session` level via mocked ``rookiepy.any_browser``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from notebooklm.cli import _chromium_profiles
+from notebooklm.cli._chromium_profiles import (
+    discover_chromium_profiles,
+    is_chromium_browser,
+)
+
+# ---------------------------------------------------------------------------
+# is_chromium_browser
+# ---------------------------------------------------------------------------
+
+
+class TestIsChromiumBrowser:
+    @pytest.mark.parametrize(
+        "name",
+        ["chrome", "Chrome", "CHROMIUM", "brave", "edge", "arc", "vivaldi", "opera"],
+    )
+    def test_recognized(self, name):
+        assert is_chromium_browser(name) is True
+
+    @pytest.mark.parametrize("name", ["firefox", "safari", "auto", "", "librewolf"])
+    def test_unrecognized(self, name):
+        assert is_chromium_browser(name) is False
+
+
+# ---------------------------------------------------------------------------
+# discover_chromium_profiles
+# ---------------------------------------------------------------------------
+
+
+def _make_chromium_user_data(
+    root: Path,
+    *,
+    profiles: dict[str, str],
+    local_state_names: dict[str, str] | None = None,
+) -> Path:
+    """Build a synthetic Chrome user-data directory at ``root``.
+
+    Args:
+        root: Directory to populate (created if missing).
+        profiles: Map of ``directory-name -> "populated" | "empty" | "no-dir"``.
+            ``"populated"`` writes a ``Cookies`` file; ``"empty"`` creates the
+            directory but no Cookies file; ``"no-dir"`` is a no-op (used to
+            simulate a never-created profile).
+        local_state_names: Optional map of ``directory-name -> human name``
+            written into ``Local State``'s ``profile.info_cache``.
+
+    Returns:
+        The ``root`` path for convenience.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    for dir_name, state in profiles.items():
+        if state == "no-dir":
+            continue
+        prof_dir = root / dir_name
+        prof_dir.mkdir(parents=True, exist_ok=True)
+        if state == "populated":
+            (prof_dir / "Cookies").write_bytes(b"SQLite format 3\x00")
+    if local_state_names is not None:
+        local_state = {
+            "profile": {
+                "info_cache": {
+                    dir_name: {"name": human} for dir_name, human in local_state_names.items()
+                }
+            }
+        }
+        (root / "Local State").write_text(json.dumps(local_state), encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def patched_user_data_dir(tmp_path, monkeypatch):
+    """Redirect chromium user-data dir lookups at the test's tmp_path.
+
+    Returns the tmp_path the test should populate under
+    ``{browser-key}/...``. Discovery is wired so that asking about
+    ``"chrome"`` will resolve to ``tmp_path / "chrome"``.
+    """
+
+    def _fake_user_data_dir(browser_name: str) -> Path | None:
+        return tmp_path / browser_name.lower()
+
+    monkeypatch.setattr(_chromium_profiles, "_user_data_dir", _fake_user_data_dir)
+    return tmp_path
+
+
+class TestDiscoverChromiumProfiles:
+    def test_non_chromium_browser_returns_empty(self):
+        assert discover_chromium_profiles("firefox") == []
+        assert discover_chromium_profiles("safari") == []
+
+    def test_missing_user_data_dir_returns_empty(self, patched_user_data_dir):
+        # No directory created for chrome at all.
+        assert discover_chromium_profiles("chrome") == []
+
+    def test_finds_default_only_install(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        _make_chromium_user_data(chrome_root, profiles={"Default": "populated"})
+
+        profiles = discover_chromium_profiles("chrome")
+        assert len(profiles) == 1
+        assert profiles[0].directory_name == "Default"
+        assert profiles[0].browser == "chrome"
+        assert profiles[0].cookies_db == chrome_root / "Default" / "Cookies"
+        # No Local State → human_name falls back to directory_name.
+        assert profiles[0].human_name == "Default"
+
+    def test_finds_multiple_profiles_in_default_then_numeric_order(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        _make_chromium_user_data(
+            chrome_root,
+            profiles={
+                "Profile 2": "populated",
+                "Profile 10": "populated",
+                "Default": "populated",
+                "Profile 1": "populated",
+            },
+            local_state_names={
+                "Default": "Personal",
+                "Profile 1": "Work",
+                "Profile 2": "Side Project",
+                "Profile 10": "Tenth",
+            },
+        )
+        profiles = discover_chromium_profiles("chrome")
+        # Default first, then Profile 1, 2, 10 in numeric order.
+        assert [p.directory_name for p in profiles] == [
+            "Default",
+            "Profile 1",
+            "Profile 2",
+            "Profile 10",
+        ]
+        assert [p.human_name for p in profiles] == [
+            "Personal",
+            "Work",
+            "Side Project",
+            "Tenth",
+        ]
+
+    def test_skips_empty_profile_dirs_without_cookies_file(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        _make_chromium_user_data(
+            chrome_root,
+            profiles={
+                "Default": "populated",
+                "Profile 1": "empty",  # dir exists but no Cookies
+                "Profile 2": "populated",
+            },
+        )
+        profiles = discover_chromium_profiles("chrome")
+        assert [p.directory_name for p in profiles] == ["Default", "Profile 2"]
+
+    def test_skips_unrecognized_directory_names(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        chrome_root.mkdir(parents=True)
+        # System / extension / cache dirs that aren't user-data profiles.
+        for junk in ("System Profile", "Crashpad", "ShaderCache"):
+            (chrome_root / junk).mkdir()
+            (chrome_root / junk / "Cookies").write_bytes(b"x")
+        # And one real profile.
+        _make_chromium_user_data(chrome_root, profiles={"Default": "populated"})
+
+        profiles = discover_chromium_profiles("chrome")
+        assert [p.directory_name for p in profiles] == ["Default"]
+
+    def test_human_name_falls_back_when_local_state_missing(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        _make_chromium_user_data(
+            chrome_root,
+            profiles={"Default": "populated", "Profile 1": "populated"},
+            # No local_state_names → no Local State file.
+        )
+        profiles = discover_chromium_profiles("chrome")
+        assert [p.human_name for p in profiles] == ["Default", "Profile 1"]
+
+    def test_malformed_local_state_treated_as_empty(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        _make_chromium_user_data(
+            chrome_root,
+            profiles={"Default": "populated", "Profile 1": "populated"},
+        )
+        (chrome_root / "Local State").write_text("not json", encoding="utf-8")
+        profiles = discover_chromium_profiles("chrome")
+        # Falls back to directory_name; doesn't crash.
+        assert [p.human_name for p in profiles] == ["Default", "Profile 1"]
+
+    def test_browser_name_is_case_insensitive(self, patched_user_data_dir):
+        chrome_root = patched_user_data_dir / "chrome"
+        _make_chromium_user_data(chrome_root, profiles={"Default": "populated"})
+        assert len(discover_chromium_profiles("Chrome")) == 1
+        assert len(discover_chromium_profiles("CHROME")) == 1
+
+
+# ---------------------------------------------------------------------------
+# read_chromium_profile_cookies
+# ---------------------------------------------------------------------------
+
+
+class TestReadChromiumProfileCookies:
+    def test_dispatches_to_rookiepy_any_browser(self, tmp_path, monkeypatch):
+        """Confirms we use any_browser (which decrypts non-Default profiles
+        on macOS) rather than the chromium_based path that errors with
+        ``missing osx_key_service`` per #511.
+        """
+        from notebooklm.cli._chromium_profiles import (
+            ChromiumProfile,
+            read_chromium_profile_cookies,
+        )
+
+        captured: dict[str, object] = {}
+
+        class FakeRookiepy:
+            @staticmethod
+            def any_browser(db_path, domains=None):
+                captured["db_path"] = db_path
+                captured["domains"] = domains
+                return [{"name": "SID", "value": "x"}]
+
+            @staticmethod
+            def chromium_based(*a, **kw):  # pragma: no cover
+                raise AssertionError("must not be called — see #511")
+
+        monkeypatch.setitem(sys.modules, "rookiepy", FakeRookiepy)
+
+        db = tmp_path / "Profile 1" / "Cookies"
+        db.parent.mkdir(parents=True)
+        db.write_bytes(b"x")
+        profile = ChromiumProfile(
+            browser="chrome",
+            directory_name="Profile 1",
+            human_name="Work",
+            cookies_db=db,
+        )
+        result = read_chromium_profile_cookies(profile, domains=["google.com"])
+        assert result == [{"name": "SID", "value": "x"}]
+        assert captured["db_path"] == str(db)
+        assert captured["domains"] == ["google.com"]
+
+
+# ---------------------------------------------------------------------------
+# Per-platform paths (sanity check the table)
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformUserDataDirs:
+    def test_chrome_path_present_on_current_platform(self):
+        path = _chromium_profiles._user_data_dir("chrome")
+        # Every supported platform documents a Chrome path. ``None`` would
+        # indicate the platform table dropped a row.
+        assert path is not None
+
+    def test_unknown_browser_returns_none(self):
+        assert _chromium_profiles._user_data_dir("not-a-browser") is None


### PR DESCRIPTION
## Summary

Closes #571.

`notebooklm auth inspect --browser chrome` and `notebooklm login --browser-cookies chrome --all-accounts` previously read only Chrome's `Default` user-data profile (rookiepy's `chrome()` hard-codes that path), silently dropping every Google account signed in to `Profile 1`, `Profile 2`, etc.

This PR fans out across every populated Chromium user-data profile via `rookiepy.any_browser(db_path, domains=...)`, which — unlike `rookiepy.chromium_based()` — successfully decrypts non-Default Chrome cookies on macOS (the `missing osx_key_service` blocker noted in #511 only affects `chromium_based`, empirically verified).

### Behavior changes (email-primary, per the amended issue body)

- **`auth inspect --browser chrome`** now lists every account across all Chrome user-profiles, deduped by email.
  - Default output is **email-only** (no browser-profile column).
  - `-v` / `--verbose` adds a ``chrome user`` column showing the source profile.
  - `--json` always includes a `browser_profile` field on each account.
- **`login --browser-cookies chrome --all-accounts`** writes one notebooklm profile per **unique email** across all Chrome user-profiles, using each account's source profile's cookies.
- **`login --browser-cookies chrome --account <email>`** now finds emails in non-Default Chrome profiles, not just Default's.
- **Single-default semantics** preserved across the unified view: only the first profile's `authuser=0` account carries `is_default=True`.
- **Same fan-out** for `brave`, `chromium`, `edge`, `arc`, `vivaldi`, `opera`, `opera-gx` via a per-platform user-data dir table.

### Backwards compatibility

Fan-out only activates when discovery surfaces >1 populated profile. Single-profile installs and non-chromium browsers take the legacy single-jar path, preserving every existing `rookiepy.chrome` test mock and runtime behavior.

### Real-world verification (3-profile Chrome on macOS)

```
$ notebooklm auth inspect --browser chrome
Reading cookies from 3 chrome user-profiles: 'Work', 'People', 'Teng'

Browser: chrome
Found 3 signed-in Google account(s):
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ email                   ┃ default ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ teng.lin@gmail.com      │    ✓    │
│ peopleconf@gmail.com    │         │
│ teng.lin.9414@gmail.com │         │
└─────────────────────────┴─────────┘
```

vs. baseline (`main`):

```
Found 1 signed-in Google account(s):
│ teng.lin@gmail.com │    ✓    │
```

## Implementation

- **New module** `src/notebooklm/cli/_chromium_profiles.py`: per-platform user-data dir table for chrome/chromium/brave/edge/arc/vivaldi/opera/opera-gx, `ChromiumProfile` dataclass, `discover_chromium_profiles()` scanner that reads `Local State` → `profile.info_cache` for human names, and `read_chromium_profile_cookies()` (dispatches to `rookiepy.any_browser`).
- **`auth.Account`** gains an optional `browser_profile: str | None` field (defaults to `None`; non-chromium / legacy paths leave it unset).
- **`_enumerate_browser_accounts`** in `src/notebooklm/cli/session.py` refactored to return `(per_profile_cookies: dict[str|None, list[dict]], accounts: list[Account])`. Callers route writes back via `per_profile_cookies[account.browser_profile]`. Email-based dedupe is first-wins (Default → Profile 1 → Profile 2 → …) with a console warning for the rare same-email-across-profiles case.
- **`_enumerate_one_jar`** extracted so legacy and fan-out paths share the same probe + error handling. Fan-out passes `quiet=True` so signed-out profiles don't bleed red "stale cookies" panels into the table output.
- **Autouse fixture** in `tests/unit/cli/conftest.py` patches `discover_chromium_profiles` to `[]` by default — test determinism shouldn't depend on the dev machine's installed Chrome layout.

## Test plan

- [x] `uv run ruff format .` / `ruff check .` / `mypy src/notebooklm --ignore-missing-imports` all clean.
- [x] New `tests/unit/test_chromium_profiles.py` (25 tests) covers discovery: synthetic `<user-data>/{Default,Profile N}/Cookies` layouts, `Local State` name lookup, fallback when malformed, browser-name case-insensitivity, ordering, skip-empty-profiles, skip-non-profile-dirs, `is_chromium_browser`, platform table sanity.
- [x] New `TestChromiumFanout{AuthInspect,AllAccounts,AccountSelector}` classes in `tests/unit/cli/test_session.py` (7 tests) cover the fan-out: cross-profile aggregation, `-v` column, `--json` schema, duplicate-email dedupe, per-profile cookie routing for `--all-accounts` (asserts bob's cookies come from `Profile 1` not `Default` — the core regression #571 fixes), `--account EMAIL` against a non-Default profile, signed-out profile skip.
- [x] All 142 existing `test_session.py` tests still pass (no rookiepy mock changes needed thanks to the discovery-returns-empty autouse fixture + 1-profile fallback).
- [x] Real-world smoke test on macOS Chrome with 3 user-profiles confirms 3 distinct accounts are surfaced and routed correctly.
- [ ] CI verifies cross-platform — Linux/Windows paths are present in the table but tested only via the discovery unit tests (synthetic fs).

## Pre-existing CI noise

7 tests in `tests/integration/cli_vcr/test_downloads.py` fail on `origin/main` (RPC ID `wXbhsf` vs cassette's `gArtLc`). Confirmed by stashing this PR's diff and re-running; not caused by these changes.

## Follow-up

- `--update` flag for `login --all-accounts` to reuse existing notebooklm profiles by name (separate issue, requested in #571 discussion).
- Document `notebooklm auth refresh --browser-cookies <browser>` in the notebooklm skill's SKILL.md (separate task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-profile support for Chromium-family browsers (Chrome, Brave, Edge, Opera), enabling detection and management of accounts across multiple profiles
  * Added `-v/--verbose` flag to `auth inspect` command to display browser profile information for each account
  * Enhanced login flow to correctly identify and use cookies from the appropriate profile when multiple accounts exist across different profiles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/580)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->