### PR TITLE
fix(cli/tests): use notes_list_mind_maps cassette instead of audio fallback (T8.C5)

### DIFF
--- a/tests/integration/cli_vcr/test_artifacts.py
+++ b/tests/integration/cli_vcr/test_artifacts.py
@@ -45,7 +45,7 @@ class TestArtifactListByType:
             ("infographic", "artifacts_list_infographics.yaml"),
             ("slide-deck", "artifacts_list_slide_decks.yaml"),
             ("data-table", "artifacts_list_data_tables.yaml"),
-            ("mind-map", "artifacts_list_audio.yaml"),  # Uses audio cassette as fallback
+            ("mind-map", "notes_list_mind_maps.yaml"),
         ],
     )
     def test_artifact_list_by_type(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -76,7 +76,7 @@ _T8_A1_XFAIL_NODEIDS = frozenset(
         "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[infographic-artifacts_list_infographics.yaml]",
         "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[slide-deck-artifacts_list_slide_decks.yaml]",
         "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[data-table-artifacts_list_data_tables.yaml]",
-        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[mind-map-artifacts_list_audio.yaml]",
+        "tests/integration/cli_vcr/test_artifacts.py::TestArtifactListByType::test_artifact_list_by_type[mind-map-notes_list_mind_maps.yaml]",
         "tests/integration/cli_vcr/test_artifacts.py::TestArtifactSuggestionsCommand::test_artifact_suggestions",
         # test_chat.py
         "tests/integration/cli_vcr/test_chat.py::TestAskCommand::test_ask_question",


### PR DESCRIPTION
## Summary

- Wire the existing `tests/cassettes/notes_list_mind_maps.yaml` into the mind-map row of `TestArtifactListByType` (was pointing at `artifacts_list_audio.yaml` with a confusing "Uses audio cassette as fallback" comment).
- Drop the misleading inline comment now that the cassette name matches the test type.
- Update the matching XFAIL nodeid in `tests/integration/conftest.py::_T8_A1_XFAIL_NODEIDS` so the parametrize id stays consistent under the T8.A1 rpcids matcher.

Closes audit item **I16** (audio-fallback workaround at `test_artifacts.py:48`).

### Cassette correctness note

The existing `notes_list_mind_maps.yaml` correctly captures the `cFji9` (GET_NOTES_AND_MIND_MAPS) RPC — the right primary call for a mind-map fetch. The CLI command `artifact list --type mind-map` actually fans out to three RPCs (`wXbhsf` for notebook resolution + `gArtLc` for studio artifacts + `cFji9` for mind maps), so the test remains XFAIL under the T8.A1 matcher — consistent with every other parametrize row in this class. Full multi-RPC cassette coverage is follow-up work outside T8.C5's scope.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — passes
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest tests/integration/cli_vcr/test_artifacts.py` — 11 xfailed (no XPASS, no new failures)
- [x] `uv run pytest tests/unit/test_cassette_shapes.py` — 78 passed (shape lint covers the cassette)
- [x] Full `uv run pytest` — only pre-existing `test_downloads.py` failures remain (unrelated to this PR; confirmed identical on `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cassettes and fixtures for artifact listing integration tests to ensure proper test data usage for mind-map artifact type scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/583)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->