### PR TITLE
test(artifacts): record mind-map 3-RPC chain cassette (T8.C3)

### DIFF
--- a/tests/cassettes/generate_mind_map_chain.yaml
+++ b/tests/cassettes/generate_mind_map_chain.yaml
@@ -1,0 +1,2229 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=1.1.1583381276.1778846987; _ga=GA1.1.1567240762.1778846987;
+        _ga_W0LDH41ZCB=GS2.1.s1778846986$o1$g0$t1778846986$j60$l0$h0
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: GET
+    uri: https://notebooklm.google.com/
+  response:
+    body:
+      string: "<!doctype html><html lang=\"en\" dir=\"ltr\"><head><base href=\"https://notebooklm.google.com/\"><link
+        rel=\"preconnect\" href=\"//www.gstatic.com\"><meta name=\"referrer\" content=\"origin\"><title>Google
+        NotebookLM</title><link rel=\"canonical\" href=\"https://notebooklm.google.com/\"><meta
+        name=\"description\" content=\"Use the power of AI for quick summarization
+        and note taking, NotebookLM is your powerful virtual research assistant rooted
+        in information you can trust.\"><meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1, interactive-widget=resizes-content\"><meta name=\"theme-color\"
+        media=\"(prefers-color-scheme: light)\" content=\"#000000\"><meta name=\"theme-color\"
+        media=\"(prefers-color-scheme: dark)\" content=\"#ffffff\"><link rel=\"preconnect\"
+        href=\"https://fonts.googleapis.com\"><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\"><link
+        rel=\"stylesheet\" href=\"https://fonts.googleapis.com/css2?family=Google+Sans+Text:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&amp;family=Google+Sans+Code:wght@400..700&amp;display=swap\"
+        nonce=\"GLNjujGbca-mtF6r9EgIzQ\"><link rel=\"icon\" href=\"/_/static/branding/v5/light_mode/favicon/favicon.svg\"
+        media=\"(prefers-color-scheme: light)\"><link rel=\"icon\" href=\"/_/static/branding/v5/light_mode/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" media=\"(prefers-color-scheme: light)\" type=\"image/png\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/light_mode/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" media=\"(prefers-color-scheme: light)\" type=\"image/png\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/dark_mode/favicon/favicon.svg\"
+        media=\"(prefers-color-scheme: dark)\"><link rel=\"icon\" href=\"/_/static/branding/v5/dark_mode/favicon/favicon-32x32.png\"
+        sizes=\"32x32\" media=\"(prefers-color-scheme: dark)\" type=\"image/png\"><link
+        rel=\"icon\" href=\"/_/static/branding/v5/dark_mode/favicon/favicon-16x16.png\"
+        sizes=\"16x16\" media=\"(prefers-color-scheme: dark)\" type=\"image/png\"><link
+        rel=\"apple-touch-icon\" href=\"/_/static/branding/v5/light_mode/favicon/apple-touch-icon.png\"
+        sizes=\"180x180\" media=\"(prefers-color-scheme: light)\"><link rel=\"apple-touch-icon\"
+        href=\"/_/static/branding/v5/dark_mode/favicon/apple-touch-icon.png\" sizes=\"180x180\"
+        media=\"(prefers-color-scheme: dark)\"><link rel=\"manifest\" crossorigin=\"use-credentials\"
+        href=\"/_/static/branding/v5/manifest.json\"><link rel=\"preload\" href=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/js/k=boq-labs-tailwind.LabsTailwindUi.en.vqGsczK_hso.es6.O/d=1/excm=_b/ed=1/dg=0/wt=2/ujg=1/rs=ANnj5bGYPA5088LmxmvxCUc5eqkwXZTS5w/ee=Pjplud:PoEs9b;QGR0gd:Mlhmy;ScI3Yc:e7Hzgb;YIZmRd:A1yn5d;cEt90b:ws9Tlc;dowIGb:ebZ3mb/dti=1/m=_b\"
+        as=\"script\" nonce=\"w8uDqgUYYNuPfSRGbp1P7A\"><link rel=\"preload\" href=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/js/k=boq-labs-tailwind.LabsTailwindUi.en.vqGsczK_hso.es6.O/ck=boq-labs-tailwind.LabsTailwindUi.oJnRUnGRA7A.L.X.O/d=1/exm=_b/excm=_b/ed=1/wt=2/ujg=1/rs=ANnj5bGFaFd85v9f24t5x3jnbJai-WZt2A/ee=Pjplud:PoEs9b;QGR0gd:Mlhmy;ScI3Yc:e7Hzgb;YIZmRd:A1yn5d;cEt90b:ws9Tlc;dowIGb:ebZ3mb/dti=1/m=Ai5g0d\"
+        as=\"script\" nonce=\"w8uDqgUYYNuPfSRGbp1P7A\"><script data-id=\"_gd\" nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">window.WIZ_global_data
+        = {\"AfY8Hf\":false,\"B8SWKb\":\"SCRUBBED_API_KEY\",\"DpimGf\":false,\"EP1ykd\":[\"/_/*\",\"/accounts/*\"],\"FdrFJe\":\"SCRUBBED_SESSION\",\"HiPsbb\":1,\"IkJAZb\":false,\"Im6cmf\":\"/_/LabsTailwindUi\",\"Jlqnmf\":\"prod\",\"KjTSIf\":\"boq_labs-tailwind-frontend_20260513.08_p0\",\"LoQv7e\":true,\"MT7f9b\":[],\"MUE6Ne\":\"labs-tailwind-frontend\",\"PMF0Je\":true,\"QGcrse\":\"SCRUBBED_CLIENT_ID\",\"QrtxK\":\"0\",\"S06Grb\":\"SCRUBBED_USER_ID\",\"S6lZl\":96797242,\"SNlM0e\":\"SCRUBBED_CSRF\",\"TSDtV\":\"%.@.[[null,[[45733487,null,false,null,null,null,\\\"BPaxWc\\\"],[45771370,null,false,null,null,null,\\\"s1YD0e\\\"],[45776512,null,true,null,null,null,\\\"IPfj3b\\\"],[45738250,null,true,null,null,null,\\\"sCzZJe\\\"],[45752862,null,true,null,null,null,\\\"k5Gpzb\\\"],[45740073,null,false,null,null,null,\\\"wfPPIc\\\"],[45785649,null,false,null,null,null,\\\"ELEXBf\\\"],[45724026,null,null,null,null,null,\\\"czcnaf\\\",[\\\"[]\\\"]],[45684592,null,true,null,null,null,\\\"SpzUSd\\\"],[45716486,null,false,null,null,null,\\\"r0wcHb\\\"],[45781950,null,false,null,null,null,\\\"p1YEzf\\\"],[45719156,null,true,null,null,null,\\\"tjmSkf\\\"],[45698799,null,false,null,null,null,\\\"M8rvMd\\\"],[45759088,null,false,null,null,null,\\\"DhSmDc\\\"],[45759942,null,true,null,null,null,\\\"DwhXH\\\"],[106097376,null,true,null,null,null,\\\"CKbDs\\\"],[45722390,null,true,null,null,null,\\\"PZCQFc\\\"],[45715358,null,null,null,null,null,\\\"KMlRwd\\\",[\\\"[[\\\\\\\"png\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpg\\\\\\\"]]\\\"]],[45756485,null,true,null,null,null,\\\"aR2OFd\\\"],[45735128,null,true,null,null,null,\\\"wXeNQc\\\"],[45686503,null,false,null,null,null,\\\"humjFc\\\"],[45743169,null,false,null,null,null,\\\"RMhfuf\\\"],[45743456,1000,null,null,null,null,\\\"wAyMi\\\"],[45761428,null,false,null,null,null,\\\"OQwTHb\\\"],[45747054,null,true,null,null,null,\\\"gPuegc\\\"],[45708268,null,null,null,null,null,\\\"Nlyzuf\\\",[\\\"[[\\\\\\\"71669a91-d5f0-4298-913e-9193178ec62c\\\\\\\",\\\\\\\"62e5c8db-3dd2-407c-8d19-32ae4ae799db\\\\\\\"]]\\\"]],[45715763,null,false,null,null,null,\\\"G9xxqd\\\"],[45756945,null,false,null,null,null,\\\"eRtqJd\\\"],[45648591,null,true,null,null,null,\\\"Mlxxm\\\"],[45728278,null,true,null,null,null,\\\"YyUfHb\\\"],[45754913,null,true,null,null,null,\\\"JNDcub\\\"],[45678449,null,true,null,null,null,\\\"yGxKIb\\\"],[45782819,null,false,null,null,null,\\\"IPHdj\\\"],[45728059,null,false,null,null,null,\\\"Ml1gbd\\\"],[106132092,null,false,null,null,null,\\\"NGtvpd\\\"],[45701857,null,false,null,null,null,\\\"PTXWhe\\\"],[45724582,null,true,null,null,null,\\\"WNQ6ce\\\"],[45741176,null,false,null,null,null,\\\"f5Niie\\\"],[45656575,null,null,null,null,null,\\\"HFmJ5b\\\",[\\\"[[\\\\\\\"3g2\\\\\\\",\\\\\\\"3gp\\\\\\\",\\\\\\\"aac\\\\\\\",\\\\\\\"aif\\\\\\\",\\\\\\\"aifc\\\\\\\",\\\\\\\"aiff\\\\\\\",\\\\\\\"amr\\\\\\\",\\\\\\\"au\\\\\\\",\\\\\\\"avi\\\\\\\",\\\\\\\"cda\\\\\\\",\\\\\\\"m4a\\\\\\\",\\\\\\\"mid\\\\\\\",\\\\\\\"mp3\\\\\\\",\\\\\\\"mp4\\\\\\\",\\\\\\\"mpeg\\\\\\\",\\\\\\\"ogg\\\\\\\",\\\\\\\"opus\\\\\\\",\\\\\\\"ra\\\\\\\",\\\\\\\"ram\\\\\\\",\\\\\\\"snd\\\\\\\",\\\\\\\"wav\\\\\\\",\\\\\\\"wma\\\\\\\"]]\\\"]],[45732206,null,true,null,null,null,\\\"ghZtJe\\\"],[45761430,null,false,null,null,null,\\\"pi21Od\\\"],[45688086,null,true,null,null,null,\\\"hhpXGe\\\"],[45707305,null,true,null,null,null,\\\"KXRoSc\\\"],[45788787,null,true,null,null,null,\\\"ITCr5e\\\"],[45786136,null,true,null,null,null,\\\"MI8Vof\\\"],[45685058,null,true,null,null,null,\\\"Bw7zDb\\\"],[45723912,5000,null,null,null,null,\\\"Vg0Jae\\\"],[45674765,null,true,null,null,null,\\\"j6Vjze\\\"],[45759978,null,false,null,null,null,\\\"TmMW5d\\\"],[45743257,null,true,null,null,null,\\\"pcxsB\\\"],[45725988,null,true,null,null,null,\\\"yiQAJb\\\"],[45732207,null,null,null,\\\"2025-10-27\\\",null,\\\"U3MPQe\\\"],[45780978,null,false,null,null,null,\\\"K7i5wf\\\"],[45737514,null,false,null,null,null,\\\"AwWGMc\\\"],[45678177,null,true,null,null,null,\\\"kHU30e\\\"],[45693667,null,true,null,null,null,\\\"xrCHrf\\\"],[45740925,50,null,null,null,null,\\\"bu25wf\\\"],[45727858,null,true,null,null,null,\\\"FbwoGf\\\"],[45478345,null,false,null,null,null,\\\"Lwxhzb\\\"],[45702188,null,true,null,null,null,\\\"wzTuh\\\"],[45668974,null,false,null,null,null,\\\"CNhZ7\\\"],[45651050,null,true,null,null,null,\\\"ck2VTe\\\"],[45716146,null,true,null,null,null,\\\"ilD2hf\\\"],[45752997,null,true,null,null,null,\\\"Hnaefc\\\"],[45775734,null,false,null,null,null,\\\"AH2INc\\\"],[45779260,null,true,null,null,null,\\\"L7h8be\\\"],[45775855,null,false,null,null,null,\\\"jWmHQd\\\"],[45776558,null,false,null,null,null,\\\"tYLCie\\\"],[45686324,null,false,null,null,null,\\\"oTEdQe\\\"],[45741650,null,null,null,\\\"public\\\",null,\\\"IIvT6\\\"],[45707709,null,null,null,null,null,\\\"UldEOb\\\",[\\\"[[\\\\\\\"af\\\\\\\",\\\\\\\"am\\\\\\\",\\\\\\\"ar_001\\\\\\\",\\\\\\\"ar_eg\\\\\\\",\\\\\\\"az\\\\\\\",\\\\\\\"be\\\\\\\",\\\\\\\"bg\\\\\\\",\\\\\\\"bn\\\\\\\",\\\\\\\"ca\\\\\\\",\\\\\\\"ceb\\\\\\\",\\\\\\\"cs\\\\\\\",\\\\\\\"da\\\\\\\",\\\\\\\"de\\\\\\\",\\\\\\\"el\\\\\\\",\\\\\\\"en\\\\\\\",\\\\\\\"es\\\\\\\",\\\\\\\"es_419\\\\\\\",\\\\\\\"es_MX\\\\\\\",\\\\\\\"et\\\\\\\",\\\\\\\"eu\\\\\\\",\\\\\\\"fa\\\\\\\",\\\\\\\"fi\\\\\\\",\\\\\\\"fil\\\\\\\",\\\\\\\"fr\\\\\\\",\\\\\\\"fr_CA\\\\\\\",\\\\\\\"gl\\\\\\\",\\\\\\\"gu\\\\\\\",\\\\\\\"hi\\\\\\\",\\\\\\\"hr\\\\\\\",\\\\\\\"ht\\\\\\\",\\\\\\\"hu\\\\\\\",\\\\\\\"hy\\\\\\\",\\\\\\\"id\\\\\\\",\\\\\\\"is\\\\\\\",\\\\\\\"it\\\\\\\",\\\\\\\"iw\\\\\\\",\\\\\\\"ja\\\\\\\",\\\\\\\"jv\\\\\\\",\\\\\\\"ka\\\\\\\",\\\\\\\"kn\\\\\\\",\\\\\\\"ko\\\\\\\",\\\\\\\"kok\\\\\\\",\\\\\\\"la\\\\\\\",\\\\\\\"lt\\\\\\\",\\\\\\\"lv\\\\\\\",\\\\\\\"mai\\\\\\\",\\\\\\\"mk\\\\\\\",\\\\\\\"ml\\\\\\\",\\\\\\\"mr\\\\\\\",\\\\\\\"ms\\\\\\\",\\\\\\\"my\\\\\\\",\\\\\\\"nb_NO\\\\\\\",\\\\\\\"ne\\\\\\\",\\\\\\\"nl_NL\\\\\\\",\\\\\\\"nn_NO\\\\\\\",\\\\\\\"or\\\\\\\",\\\\\\\"pa\\\\\\\",\\\\\\\"pl\\\\\\\",\\\\\\\"ps\\\\\\\",\\\\\\\"pt_BR\\\\\\\",\\\\\\\"pt_PT\\\\\\\",\\\\\\\"ro\\\\\\\",\\\\\\\"ru\\\\\\\",\\\\\\\"sd\\\\\\\",\\\\\\\"si\\\\\\\",\\\\\\\"sk\\\\\\\",\\\\\\\"sl\\\\\\\",\\\\\\\"sq\\\\\\\",\\\\\\\"sr\\\\\\\",\\\\\\\"sv\\\\\\\",\\\\\\\"sw\\\\\\\",\\\\\\\"ta\\\\\\\",\\\\\\\"te\\\\\\\",\\\\\\\"th\\\\\\\",\\\\\\\"tr\\\\\\\",\\\\\\\"uk\\\\\\\",\\\\\\\"ur\\\\\\\",\\\\\\\"vi\\\\\\\",\\\\\\\"zh_Hans\\\\\\\",\\\\\\\"zh_Hant\\\\\\\"]]\\\"]],[45760001,null,true,null,null,null,\\\"JVMGdd\\\"],[45724540,null,false,null,null,null,\\\"kneAIc\\\"],[45730504,null,false,null,null,null,\\\"r4LEJf\\\"],[45724092,null,false,null,null,null,\\\"bfDVEc\\\"],[45641801,null,true,null,null,null,\\\"JeSsGe\\\"],[45727376,null,true,null,null,null,\\\"uVzPte\\\"],[45723410,null,false,null,null,null,\\\"LRVRZ\\\"],[105963886,null,true,null,null,null,\\\"HBjKGb\\\"],[45757667,null,true,null,null,null,\\\"KGR25b\\\"],[45644621,null,true,null,null,null,\\\"lDhe7d\\\"],[45692441,null,true,null,null,null,\\\"HeeGbc\\\"],[45724220,10,null,null,null,null,\\\"ncg6Ve\\\"],[45651720,null,true,null,null,null,\\\"I3MBz\\\"],[45725687,null,true,null,null,null,\\\"Sevrrc\\\"],[45760685,null,true,null,null,null,\\\"zErg6e\\\"],[45768706,null,false,null,null,null,\\\"zHFW\\\"],[45650923,null,true,null,null,null,\\\"MOu1Rc\\\"],[45681923,null,false,null,null,null,\\\"kEv01e\\\"],[45780853,null,false,null,null,null,\\\"YnfFrc\\\"],[45731113,null,null,null,null,null,\\\"ZI9cc\\\",[\\\"[[\\\\\\\"png\\\\\\\",\\\\\\\"jpg\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpe\\\\\\\",\\\\\\\"avif\\\\\\\",\\\\\\\"bmp\\\\\\\",\\\\\\\"gif\\\\\\\",\\\\\\\"ico\\\\\\\",\\\\\\\"jp2\\\\\\\",\\\\\\\"webp\\\\\\\",\\\\\\\"tif\\\\\\\",\\\\\\\"tiff\\\\\\\",\\\\\\\"heic\\\\\\\",\\\\\\\"heif\\\\\\\"]]\\\"]],[45768740,null,false,null,null,null,\\\"LjO0kf\\\"],[45755081,null,true,null,null,null,\\\"Zx4Hsd\\\"],[45771830,null,true,null,null,null,\\\"SqvtFd\\\"],[45656736,null,false,null,null,null,\\\"rKqRdd\\\"],[106265065,null,false,null,null,null,\\\"J4ELLc\\\"],[45751177,null,true,null,null,null,\\\"toafIc\\\"],[45755012,null,false,null,null,null,\\\"FwODye\\\"],[45775803,null,false,null,null,null,\\\"t7LiGb\\\"],[45732203,null,true,null,null,null,\\\"kSBWQ\\\"],[45760838,null,false,null,null,null,\\\"ZYArLe\\\"],[45732204,null,true,null,null,null,\\\"pPHMCb\\\"],[45662544,null,true,null,null,null,\\\"t6ww0\\\"],[45687890,10000,null,null,null,null,\\\"uOwq4d\\\"],[106042214,null,true,null,null,null,\\\"qDRhm\\\"],[45723756,null,true,null,null,null,\\\"yZTigd\\\"],[45752612,null,true,null,null,null,\\\"ZffjAe\\\"],[45739154,null,true,null,null,null,\\\"XF97Pb\\\"],[45727973,null,true,null,null,null,\\\"joHIze\\\"],[45759982,null,false,null,null,null,\\\"J1vQ5\\\"],[45742067,null,false,null,null,null,\\\"DbKd8\\\"],[45785088,null,false,null,null,null,\\\"IGXo0b\\\"],[45723390,null,true,null,null,null,\\\"E9Gv8e\\\"],[45738479,null,true,null,null,null,\\\"Ab1vp\\\"],[45773054,null,false,null,null,null,\\\"PVKeB\\\"],[45769519,null,false,null,null,null,\\\"vVK7Xe\\\"],[45650876,null,false,null,null,null,\\\"YnQp8e\\\"],[45725987,null,false,null,null,null,\\\"iDsH1e\\\"],[45655118,null,true,null,null,null,\\\"gRPr0e\\\"],[45780409,null,false,null,null,null,\\\"Atmqk\\\"],[45725970,null,true,null,null,null,\\\"sPU3yb\\\"],[45748239,null,true,null,null,null,\\\"JOzx6c\\\"],[45785633,null,false,null,null,null,\\\"fGEjdd\\\"],[45723440,null,true,null,null,null,\\\"f2iaWd\\\"],[45780062,null,false,null,null,null,\\\"edhUbc\\\"],[45643362,null,true,null,null,null,\\\"doKTK\\\"],[45765891,null,true,null,null,null,\\\"Ft2WAc\\\"],[45785133,null,false,null,null,null,\\\"FROnCc\\\"],[45755849,null,true,null,null,null,\\\"CDQi0\\\"],[105739227,null,false,null,null,null,\\\"RmLbJe\\\"],[45756047,null,false,null,null,null,\\\"CM3owe\\\"],[45770468,null,false,null,null,null,\\\"FjQ34e\\\"],[45725063,null,true,null,null,null,\\\"dVxE3e\\\"],[45784525,null,false,null,null,null,\\\"EEh7ue\\\"],[45699383,null,false,null,null,null,\\\"WB61ic\\\"],[45784154,null,false,null,null,null,\\\"ZckUT\\\"],[45756563,null,true,null,null,null,\\\"Lc6DMd\\\"],[45740924,5,null,null,null,null,\\\"IvF6ie\\\"],[45691822,null,true,null,null,null,\\\"y2K6ib\\\"],[45738317,null,null,null,null,null,\\\"eVvEMd\\\",[\\\"[[\\\\\\\"avif\\\\\\\",\\\\\\\"bmp\\\\\\\",\\\\\\\"gif\\\\\\\",\\\\\\\"ico\\\\\\\",\\\\\\\"jp2\\\\\\\",\\\\\\\"png\\\\\\\",\\\\\\\"webp\\\\\\\",\\\\\\\"tif\\\\\\\",\\\\\\\"tiff\\\\\\\",\\\\\\\"heic\\\\\\\",\\\\\\\"heif\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpg\\\\\\\",\\\\\\\"jpe\\\\\\\"]]\\\"]],[45743134,null,true,null,null,null,\\\"Iv2Hxe\\\"],[45749382,null,false,null,null,null,\\\"aartMe\\\"],[45746103,3900,null,null,null,null,\\\"XGM6Xe\\\"],[45682203,null,true,null,null,null,\\\"WFSam\\\"],[45739220,null,true,null,null,null,\\\"ZWjLyb\\\"],[45716774,null,false,null,null,null,\\\"rgA9If\\\"],[45766450,null,false,null,null,null,\\\"RzAbpb\\\"],[45721095,null,true,null,null,null,\\\"ywzYTd\\\"],[45673657,null,false,null,null,null,\\\"BdrTcf\\\"],[45724487,null,true,null,null,null,\\\"WG0tGf\\\"],[45759983,null,null,null,\\\"2026-03-18\\\",null,\\\"PWFRLd\\\"],[45752363,null,true,null,null,null,\\\"tvmHT\\\"],[45769063,null,true,null,null,null,\\\"C4XDze\\\"],[45746551,null,true,null,null,null,\\\"qMcOyc\\\"],[45780984,null,false,null,null,null,\\\"D3CVm\\\"],[45785134,null,false,null,null,null,\\\"dW2sIe\\\"],[45752588,null,true,null,null,null,\\\"RUnjHe\\\"],[45728277,null,true,null,null,null,\\\"yVqdQ\\\"],[45700002,null,true,null,null,null,\\\"KgtOgd\\\"],[45754531,null,false,null,null,null,\\\"PzuYid\\\"],[45696585,null,null,null,null,null,\\\"wRJHtc\\\",[\\\"[[\\\\\\\"ar_eg\\\\\\\",\\\\\\\"ar_001\\\\\\\"]]\\\"]],[45736238,null,true,null,null,null,\\\"qix6kb\\\"],[45716076,null,false,null,null,null,\\\"qN5Ni\\\"],[45750247,null,true,null,null,null,\\\"eyUGmb\\\"],[45773123,null,false,null,null,null,\\\"XaD60c\\\"],[45776084,null,false,null,null,null,\\\"rrXdsd\\\"],[45780110,null,false,null,null,null,\\\"cAVA1e\\\"],[45736793,null,false,null,null,null,\\\"SjmdKb\\\"],[45626329,10000,null,null,null,null,\\\"xAdyb\\\"],[45752350,null,false,null,null,null,\\\"X07Kbf\\\"],[45746113,null,false,null,null,null,\\\"ojDdof\\\"],[45732982,null,true,null,null,null,\\\"RNnPXd\\\"],[45741610,null,false,null,null,null,\\\"D6eTJ\\\"],[45682327,null,false,null,null,null,\\\"DcJcid\\\"],[45752619,null,false,null,null,null,\\\"rXooxd\\\"],[45744267,1000,null,null,null,null,\\\"PDdqxe\\\"],[45769622,null,false,null,null,null,\\\"EohvRe\\\"],[45712306,null,true,null,null,null,\\\"NZrIV\\\"],[45715833,null,null,null,\\\"2025-09-03\\\",null,\\\"zXsjTc\\\"],[45780686,null,false,null,null,null,\\\"rhCVeb\\\"],[45742973,null,false,null,null,null,\\\"Eltrtb\\\"],[45678526,null,false,null,null,null,\\\"TSpMx\\\"],[45711140,null,true,null,null,null,\\\"Fp3bic\\\"],[45754733,null,false,null,null,null,\\\"CVImcb\\\"],[45777056,null,true,null,null,null,\\\"AcayS\\\"],[45739119,null,false,null,null,null,\\\"u3PAZ\\\"],[45739128,null,true,null,null,null,\\\"bRZrYe\\\"],[45646319,null,false,null,null,null,\\\"XDSRxb\\\"],[45723173,null,false,null,null,null,\\\"xsupAd\\\"],[45740074,null,true,null,null,null,\\\"bhCwDf\\\"],[45642474,null,true,null,null,null,\\\"e4pHkf\\\"],[45750354,null,false,null,null,null,\\\"Pxrbt\\\"],[45620149,null,true,null,null,null,\\\"pbA7cd\\\"],[45724908,null,null,null,\\\"2025-09-19\\\",null,\\\"xFVBIb\\\"],[45677551,null,true,null,null,null,\\\"FOlkXb\\\"],[45643552,null,false,null,null,null,\\\"AVCDDf\\\"],[45743229,null,false,null,null,null,\\\"IdVLAf\\\"],[45741588,null,true,null,null,null,\\\"QVPuEd\\\"],[45634044,null,false,null,null,null,\\\"k3zu1d\\\"],[105739228,null,null,null,null,null,\\\"lJ7Wub\\\",[\\\"[[1]]\\\"]],[45745566,null,true,null,null,null,\\\"x9hO9d\\\"],[45755691,null,true,null,null,null,\\\"f9sc3\\\"],[45750441,null,false,null,null,null,\\\"rlTCJb\\\"],[45647693,null,null,null,null,null,\\\"LykTQb\\\",[\\\"[[\\\\\\\"google.com\\\\\\\",\\\\\\\".edu\\\\\\\",\\\\\\\".org\\\\\\\",\\\\\\\".net\\\\\\\",\\\\\\\".jp\\\\\\\",\\\\\\\".br\\\\\\\",\\\\\\\".tw\\\\\\\"]]\\\"]],[45667158,null,true,null,null,null,\\\"o9omF\\\"],[45739834,null,false,null,null,null,\\\"wpiqm\\\"],[45780410,null,false,null,null,null,\\\"AxYPBc\\\"],[45774869,null,false,null,null,null,\\\"MnsBhf\\\"],[45723955,null,false,null,null,null,\\\"eBBjmf\\\"],[45691662,null,true,null,null,null,\\\"EXhW4b\\\"],[45757839,null,true,null,null,null,\\\"eSoFhb\\\"],[45724967,null,true,null,null,null,\\\"vZRBce\\\"],[45740290,null,null,null,null,null,\\\"Adr4wd\\\",[\\\"[]\\\"]],[45757939,null,false,null,null,null,\\\"l32Bsf\\\"],[45782345,null,null,null,null,null,\\\"iHNes\\\",[\\\"[[\\\\\\\"pdf\\\\\\\",\\\\\\\"txt\\\\\\\",\\\\\\\"md\\\\\\\",\\\\\\\"docx\\\\\\\",\\\\\\\"csv\\\\\\\",\\\\\\\"pptx\\\\\\\",\\\\\\\"epub\\\\\\\",\\\\\\\"3g2\\\\\\\",\\\\\\\"3gp\\\\\\\",\\\\\\\"aac\\\\\\\",\\\\\\\"aif\\\\\\\",\\\\\\\"aifc\\\\\\\",\\\\\\\"aiff\\\\\\\",\\\\\\\"amr\\\\\\\",\\\\\\\"au\\\\\\\",\\\\\\\"avi\\\\\\\",\\\\\\\"cda\\\\\\\",\\\\\\\"m4a\\\\\\\",\\\\\\\"mid\\\\\\\",\\\\\\\"mp3\\\\\\\",\\\\\\\"mp4\\\\\\\",\\\\\\\"mpeg\\\\\\\",\\\\\\\"ogg\\\\\\\",\\\\\\\"opus\\\\\\\",\\\\\\\"ra\\\\\\\",\\\\\\\"ram\\\\\\\",\\\\\\\"snd\\\\\\\",\\\\\\\"wav\\\\\\\",\\\\\\\"wma\\\\\\\",\\\\\\\"avif\\\\\\\",\\\\\\\"bmp\\\\\\\",\\\\\\\"gif\\\\\\\",\\\\\\\"ico\\\\\\\",\\\\\\\"jp2\\\\\\\",\\\\\\\"png\\\\\\\",\\\\\\\"webp\\\\\\\",\\\\\\\"tif\\\\\\\",\\\\\\\"tiff\\\\\\\",\\\\\\\"heic\\\\\\\",\\\\\\\"heif\\\\\\\",\\\\\\\"jpeg\\\\\\\",\\\\\\\"jpg\\\\\\\",\\\\\\\"jpe\\\\\\\"]]\\\"]],[45665026,null,null,null,\\\"\\\",null,\\\"r5O8Ze\\\"],[45724355,null,true,null,null,null,\\\"rWadk\\\"],[45732534,null,true,null,null,null,\\\"i09X8c\\\"],[45784612,null,false,null,null,null,\\\"RKuRzc\\\"],[45777819,null,false,null,null,null,\\\"SiHPsc\\\"],[45753525,null,false,null,null,null,\\\"BgrgN\\\"],[45678961,null,true,null,null,null,\\\"QjI7hd\\\"],[45678578,null,true,null,null,null,\\\"soQo1d\\\"],[45645925,50,null,null,null,null,\\\"wv29ce\\\"],[45687600,1,null,null,null,null,\\\"sAL5Je\\\"],[45749515,null,false,null,null,null,\\\"aMVXWe\\\"],[45771702,null,true,null,null,null,\\\"DDmwWe\\\"],[45774990,null,false,null,null,null,\\\"erpoGf\\\"],[45693251,null,true,null,null,null,\\\"pPbgEf\\\"],[45747063,null,true,null,null,null,\\\"lvXPvb\\\"],[45732205,null,true,null,null,null,\\\"U2Sved\\\"],[45718005,null,true,null,null,null,\\\"kiJI4c\\\"],[45735679,null,false,null,null,null,\\\"sOvZBf\\\"],[45738347,null,true,null,null,null,\\\"xHqDbe\\\"],[45429920,null,false,null,null,null,\\\"E914fb\\\"],[45779039,null,false,null,null,null,\\\"EyWbA\\\"],[45681212,null,true,null,null,null,\\\"DiGvhc\\\"],[45739226,null,false,null,null,null,\\\"SkzECe\\\"],[45693482,null,true,null,null,null,\\\"EW61Ce\\\"],[45766028,null,true,null,null,null,\\\"pVznMc\\\"],[45644274,20,null,null,null,null,\\\"aMs4Gb\\\"],[45675685,null,true,null,null,null,\\\"x9cXUb\\\"],[45780118,null,false,null,null,null,\\\"gMeCYc\\\"],[45762225,null,true,null,null,null,\\\"T7y1cc\\\"],[118622559,null,false,null,null,null,\\\"nEG7Xe\\\"],[45742581,null,true,null,null,null,\\\"RIBLyb\\\"],[45694769,null,true,null,null,null,\\\"beJTsd\\\"],[45640342,null,true,null,null,null,\\\"gIFZhc\\\"],[45667300,null,false,null,null,null,\\\"inaRw\\\"],[45724364,null,true,null,null,null,\\\"gILkWb\\\"],[45646880,null,true,null,null,null,\\\"rKvLob\\\"],[45766074,null,false,null,null,null,\\\"SrKMZb\\\"],[45626328,10,null,null,null,null,\\\"I1V8ie\\\"],[45696584,null,true,null,null,null,\\\"Cmvzne\\\"],[45638708,null,null,null,\\\"71669a91-d5f0-4298-913e-9193178ec62c\\\",null,\\\"iQoIFf\\\"],[45709616,null,true,null,null,null,\\\"ypJDU\\\"],[45727267,null,true,null,null,null,\\\"NHdRE\\\"],[45770895,null,true,null,null,null,\\\"RgDu4c\\\"],[45768660,null,false,null,null,null,\\\"c0fhIf\\\"],[45771451,null,false,null,null,null,\\\"Db1mn\\\"],[45734729,null,false,null,null,null,\\\"Pe6YZb\\\"],[45673126,null,true,null,null,null,\\\"aM63X\\\"],[45622893,null,true,null,null,null,\\\"ZKtzR\\\"],[45692861,null,true,null,null,null,\\\"UvMGC\\\"],[45735506,null,false,null,null,null,\\\"DLUCGe\\\"],[45784613,null,false,null,null,null,\\\"x4saZe\\\"],[45765182,null,false,null,null,null,\\\"EwA9te\\\"],[45681006,null,true,null,null,null,\\\"WF6tob\\\"],[45776632,null,false,null,null,null,\\\"Y5BZef\\\"],[45765710,null,false,null,null,null,\\\"PbfpDf\\\"],[45460035,null,true,null,null,null,\\\"i6PDjc\\\"],[45753050,null,true,null,null,null,\\\"p1S3id\\\"],[45630645,1,null,null,null,null,\\\"N5wbdc\\\"],[45756887,null,false,null,null,null,\\\"CxYl7e\\\"],[45699449,null,null,null,\\\"953b658a-579b-4b3c-b280-43b3781babf3\\\",null,\\\"Uhlwjf\\\"],[45753340,null,true,null,null,null,\\\"E1daEf\\\"],[45747536,null,false,null,null,null,\\\"F67Xyc\\\"],[105739229,null,null,null,null,null,\\\"NAKK1\\\",[\\\"[]\\\"]],[45768386,null,true,null,null,null,\\\"ZxxqJe\\\"],[45784526,null,false,null,null,null,\\\"RIdkBf\\\"],[45785208,null,false,null,null,null,\\\"EN1xHe\\\"],[45679330,null,false,null,null,null,\\\"WEMP6e\\\"],[45694287,null,false,null,null,null,\\\"ytDzle\\\"],[45741764,null,true,null,null,null,\\\"Y2scZ\\\"],[45756679,null,false,null,null,null,\\\"RR1mSc\\\"],[45756579,null,true,null,null,null,\\\"pfTbee\\\"],[45740989,3000,null,null,null,null,\\\"SXDqEe\\\"],[45696586,null,null,null,null,null,\\\"hGwUE\\\",[\\\"[[\\\\\\\"\u0627\u0644\u0639\u0631\u0628\u064A\u0629
+        (\u0627\u0644\u0639\u0627\u0645\u064A\u0629 \u0627\u0644\u0645\u0635\u0631\u064A\u0629)\\\\\\\",\\\\\\\"\u0627\u0644\u0639\u0631\u0628\u064A\u0629\\\\\\\"]]\\\"]],[45725774,null,true,null,null,null,\\\"J3X1uc\\\"],[45780411,null,null,null,\\\"2026-07-01\\\",null,\\\"GmS5Ud\\\"],[45722636,null,false,null,null,null,\\\"sETgKe\\\"],[45723322,null,true,null,null,null,\\\"vSpvBb\\\"],[45639131,null,null,null,null,null,\\\"lSt5Ue\\\",[\\\"[]\\\"]],[45696007,null,true,null,null,null,\\\"hsNESc\\\"],[45650134,null,null,null,\\\"f7607d7a-584c-4f35-96fc-f6815c573a6c\\\",null,\\\"KqZKAb\\\"],[45733865,null,true,null,null,null,\\\"jKONzf\\\"],[45623036,null,true,null,null,null,\\\"uBTtH\\\"],[45651102,null,true,null,null,null,\\\"AQmbKc\\\"],[45757101,null,true,null,null,null,\\\"TEJE6d\\\"],[45786137,null,true,null,null,null,\\\"BtIFVb\\\"],[45700001,null,true,null,null,null,\\\"kQFRdd\\\"],[45714669,null,true,null,null,null,\\\"nmpRPe\\\"],[45773040,null,true,null,null,null,\\\"zw5akf\\\"],[45723127,null,true,null,null,null,\\\"zKGNYc\\\"],[45723296,null,true,null,null,null,\\\"R8Ib9c\\\"],[45545417,null,true,null,null,null,\\\"tqnO1\\\"],[45780538,null,false,null,null,null,\\\"pnD3Cb\\\"],[45683036,null,true,null,null,null,\\\"IBjb7d\\\"],[45785149,null,false,null,null,null,\\\"s5bqT\\\"],[45761661,null,true,null,null,null,\\\"C65cJe\\\"],[45716490,null,null,null,null,null,\\\"raFU8e\\\",[\\\"[[\\\\\\\"hi\\\\\\\",\\\\\\\"bn\\\\\\\",\\\\\\\"gu\\\\\\\",\\\\\\\"kn\\\\\\\",\\\\\\\"ml\\\\\\\",\\\\\\\"mr\\\\\\\",\\\\\\\"pa\\\\\\\",\\\\\\\"ta\\\\\\\",\\\\\\\"te\\\\\\\"]]\\\"]],[45735534,null,false,null,null,null,\\\"nw6yvc\\\"],[45684106,null,true,null,null,null,\\\"j23Rxe\\\"],[45761058,null,false,null,null,null,\\\"iLYIjd\\\"],[45718806,null,false,null,null,null,\\\"pELJSc\\\"],[45730877,null,true,null,null,null,\\\"rBvXZd\\\"],[45741605,null,null,null,\\\"2025-10-27\\\",null,\\\"eVX7gb\\\"],[45759979,null,null,null,\\\"2026-02-10\\\",null,\\\"zOuNxe\\\"],[45759206,null,true,null,null,null,\\\"pb1ZDf\\\"],[45478346,null,false,null,null,null,\\\"YnbJfb\\\"],[45642683,null,true,null,null,null,\\\"NTEHXd\\\"],[45720120,null,true,null,null,null,\\\"nbeCbd\\\"],[45461691,null,null,null,null,null,\\\"ws98Dd\\\",[\\\"[[\\\\\\\"application/vnd.google-apps.document\\\\\\\",\\\\\\\"application/vnd.google-apps.presentation\\\\\\\",\\\\\\\"application/pdf\\\\\\\",\\\\\\\"application/vnd.google-apps.spreadsheet\\\\\\\",\\\\\\\"application/vnd.openxmlformats-officedocument.wordprocessingml.document\\\\\\\",\\\\\\\"application/vnd.openxmlformats-officedocument.presentationml.presentation\\\\\\\",\\\\\\\"text/csv\\\\\\\",\\\\\\\"text/plain\\\\\\\"]]\\\"]],[45732186,null,true,null,null,null,\\\"fUrPrf\\\"],[45707150,null,true,null,null,null,\\\"yE41Cd\\\"],[45696727,null,false,null,null,null,\\\"A1a0Nd\\\"],[45718016,null,true,null,null,null,\\\"gdUu3d\\\"],[45723899,null,false,null,null,null,\\\"RczE3\\\"],[45691118,null,true,null,null,null,\\\"U1L54d\\\"],[45714592,null,true,null,null,null,\\\"eSw7ae\\\"],[45683617,null,false,null,null,null,\\\"zGScr\\\"],[45737496,null,true,null,null,null,\\\"UrGmDc\\\"],[45779594,1,null,null,null,null,\\\"NWXeHf\\\"],[45781087,null,false,null,null,null,\\\"FUgzab\\\"],[45657965,null,true,null,null,null,\\\"ncR2Ld\\\"],[45687798,null,null,null,null,null,\\\"M2O21b\\\",[\\\"[[\\\\\\\"af\\\\\\\",\\\\\\\"am\\\\\\\",\\\\\\\"ar_001\\\\\\\",\\\\\\\"ar_eg\\\\\\\",\\\\\\\"az\\\\\\\",\\\\\\\"be\\\\\\\",\\\\\\\"bg\\\\\\\",\\\\\\\"bn\\\\\\\",\\\\\\\"ca\\\\\\\",\\\\\\\"ceb\\\\\\\",\\\\\\\"cs\\\\\\\",\\\\\\\"da\\\\\\\",\\\\\\\"de\\\\\\\",\\\\\\\"el\\\\\\\",\\\\\\\"en\\\\\\\",\\\\\\\"es\\\\\\\",\\\\\\\"es_419\\\\\\\",\\\\\\\"es_MX\\\\\\\",\\\\\\\"et\\\\\\\",\\\\\\\"eu\\\\\\\",\\\\\\\"fa\\\\\\\",\\\\\\\"fi\\\\\\\",\\\\\\\"fil\\\\\\\",\\\\\\\"fr\\\\\\\",\\\\\\\"fr_CA\\\\\\\",\\\\\\\"gl\\\\\\\",\\\\\\\"gu\\\\\\\",\\\\\\\"hi\\\\\\\",\\\\\\\"hr\\\\\\\",\\\\\\\"ht\\\\\\\",\\\\\\\"hu\\\\\\\",\\\\\\\"hy\\\\\\\",\\\\\\\"id\\\\\\\",\\\\\\\"is\\\\\\\",\\\\\\\"it\\\\\\\",\\\\\\\"iw\\\\\\\",\\\\\\\"ja\\\\\\\",\\\\\\\"jv\\\\\\\",\\\\\\\"ka\\\\\\\",\\\\\\\"kn\\\\\\\",\\\\\\\"ko\\\\\\\",\\\\\\\"kok\\\\\\\",\\\\\\\"la\\\\\\\",\\\\\\\"lt\\\\\\\",\\\\\\\"lv\\\\\\\",\\\\\\\"mai\\\\\\\",\\\\\\\"mk\\\\\\\",\\\\\\\"ml\\\\\\\",\\\\\\\"mr\\\\\\\",\\\\\\\"ms\\\\\\\",\\\\\\\"my\\\\\\\",\\\\\\\"nb_NO\\\\\\\",\\\\\\\"ne\\\\\\\",\\\\\\\"nl_NL\\\\\\\",\\\\\\\"nn_NO\\\\\\\",\\\\\\\"or\\\\\\\",\\\\\\\"pa\\\\\\\",\\\\\\\"pl\\\\\\\",\\\\\\\"ps\\\\\\\",\\\\\\\"pt_BR\\\\\\\",\\\\\\\"pt_PT\\\\\\\",\\\\\\\"ro\\\\\\\",\\\\\\\"ru\\\\\\\",\\\\\\\"sd\\\\\\\",\\\\\\\"si\\\\\\\",\\\\\\\"sk\\\\\\\",\\\\\\\"sl\\\\\\\",\\\\\\\"sq\\\\\\\",\\\\\\\"sr\\\\\\\",\\\\\\\"sv\\\\\\\",\\\\\\\"sw\\\\\\\",\\\\\\\"ta\\\\\\\",\\\\\\\"te\\\\\\\",\\\\\\\"th\\\\\\\",\\\\\\\"tr\\\\\\\",\\\\\\\"uk\\\\\\\",\\\\\\\"ur\\\\\\\",\\\\\\\"vi\\\\\\\",\\\\\\\"zh_Hans\\\\\\\",\\\\\\\"zh_Hant\\\\\\\"]]\\\"]],[45667340,null,false,null,null,null,\\\"mhlPVb\\\"],[45726393,null,false,null,null,null,\\\"dFJRwf\\\"],[45772276,null,false,null,null,null,\\\"uXPSvd\\\"],[45477865,null,true,null,null,null,\\\"p9oeJc\\\"],[45744638,null,true,null,null,null,\\\"fsg7Cb\\\"],[45770212,null,false,null,null,null,\\\"ZxbZ6c\\\"],[45740532,null,false,null,null,null,\\\"zKRa0\\\"],[45717748,null,false,null,null,null,\\\"bomvXb\\\"],[45683096,null,false,null,null,null,\\\"SuFLEb\\\"],[45491609,null,false,null,null,null,\\\"DpoYPc\\\"],[45732022,null,true,null,null,null,\\\"QQKUfb\\\"],[45716515,null,true,null,null,null,\\\"b4dT9e\\\"],[45779333,null,false,null,null,null,\\\"ouJIg\\\"],[45766132,null,false,null,null,null,\\\"vzdSec\\\"],[45715089,null,true,null,null,null,\\\"T6tAvf\\\"],[45684753,null,false,null,null,null,\\\"ywxfCd\\\"],[45756578,null,true,null,null,null,\\\"Ww5qde\\\"],[45731112,null,null,null,null,null,\\\"RmGjKd\\\",[\\\"[[\\\\\\\"3g2\\\\\\\",\\\\\\\"3gp\\\\\\\",\\\\\\\"aac\\\\\\\",\\\\\\\"aif\\\\\\\",\\\\\\\"aifc\\\\\\\",\\\\\\\"aiff\\\\\\\",\\\\\\\"amr\\\\\\\",\\\\\\\"au\\\\\\\",\\\\\\\"avi\\\\\\\",\\\\\\\"cda\\\\\\\",\\\\\\\"m4a\\\\\\\",\\\\\\\"mid\\\\\\\",\\\\\\\"midi\\\\\\\",\\\\\\\"mp3\\\\\\\",\\\\\\\"mp4\\\\\\\",\\\\\\\"mpeg\\\\\\\",\\\\\\\"ogg\\\\\\\",\\\\\\\"opus\\\\\\\",\\\\\\\"ra\\\\\\\",\\\\\\\"ram\\\\\\\",\\\\\\\"snd\\\\\\\",\\\\\\\"wav\\\\\\\",\\\\\\\"weba\\\\\\\",\\\\\\\"wma\\\\\\\"]]\\\"]],[45759628,null,false,null,null,null,\\\"K60E2d\\\"],[45782746,null,false,null,null,null,\\\"WFShIe\\\"],[45727591,null,true,null,null,null,\\\"ygidy\\\"],[45786491,null,true,null,null,null,\\\"D9EcSc\\\"],[45728338,null,false,null,null,null,\\\"wma0md\\\"],[45734733,null,true,null,null,null,\\\"V5bj7\\\"],[45722828,null,false,null,null,null,\\\"bbwVdc\\\"],[45719885,null,false,null,null,null,\\\"YHdrU\\\"],[45696338,null,true,null,null,null,\\\"lJ1Uyd\\\"],[45724529,null,true,null,null,null,\\\"xYPCFf\\\"],[45745829,null,false,null,null,null,\\\"wRuQ3b\\\"],[105788761,null,true,null,null,null,\\\"mQeJ7d\\\"],[45689034,null,false,null,null,null,\\\"rDyR6c\\\"],[45703804,null,true,null,null,null,\\\"aW5U0\\\"],[45680123,null,true,null,null,null,\\\"DGuzo\\\"],[45658718,null,true,null,null,null,\\\"e9CJhe\\\"],[45730447,null,true,null,null,null,\\\"FQyCl\\\"],[45784287,null,false,null,null,null,\\\"hvS30d\\\"],[45723784,5000,null,null,null,null,\\\"PJ8nYd\\\"],[45750328,null,true,null,null,null,\\\"YlIlw\\\"],[45768739,null,false,null,null,null,\\\"gQZlW\\\"],[45743839,null,false,null,null,null,\\\"pnWyHf\\\"],[45761743,null,true,null,null,null,\\\"Tl7gib\\\"],[45727720,null,true,null,null,null,\\\"vD09Ne\\\"],[45719155,null,true,null,null,null,\\\"YVpG5e\\\"],[45751068,null,true,null,null,null,\\\"dpCKWd\\\"],[45757554,null,true,null,null,null,\\\"Esjauf\\\"],[45767299,null,false,null,null,null,\\\"vFPzPd\\\"],[45667626,null,true,null,null,null,\\\"GQQefc\\\"],[45736777,null,false,null,null,null,\\\"RyJDpe\\\"]],\\\"CAMStAEdtgb5uc0pBp4IBvrdGgak+g4Gqq8FBsL6sAQGicMGBt2sBAbmFQb2vQUG0AwG1jkGgDEGyCIGrSkG9wMGzAMWjpEGBvENBsWFBAbNvwYGoVwGgHwGoZkGpAyacwSZJYqnBgawKAbq9AYG+aAGBL4TBrzbBgb0EgbPQASiMAaMMgbpdga0AAFF7AipyAYEunwG1CUG4Q8G8QsG3hACnDYGtBEGsSoGqjcCmZsEBthrBY+BBQY\\\\u003d\\\"]]]\",\"UUFaWc\":\"%.@.null,1000,2]\",\"VqImj\":\"SCRUBBED_API_KEY\",\"Vvafkd\":false,\"W3Yyqf\":\"SCRUBBED_USER_ID\",\"WZsZ1e\":\"tZv2oajJBylnxx80/AQlJBYD9FPT3EE60S\",\"b5W2zf\":\"default_LabsTailwindUi\",\"cEM4oc\":\"prod\",\"cfb2h\":\"boq_labs-tailwind-frontend_20260513.08_p0\",\"ei5RBc\":\"labs\",\"eptZe\":\"/_/LabsTailwindUi/\",\"fPDxwd\":[105739272],\"fWyqL\":false,\"gGcLoe\":true,\"gnD3ee\":\"%.@.null,null,null,\\\"https://drive.google.com/viewer/main\\\"]\",\"hsFLT\":\"%.@.null,10,3]\",\"iCzhFc\":false,\"iQJtYd\":\"SCRUBBED_PROJECT_ID\",\"k76Vlc\":[\"G-W0LDH41ZCB\"],\"kHV6Kd\":false,\"mXaIFf\":true,\"nQyAE\":{},\"oPEP7c\":\"SCRUBBED_EMAIL\",\"p9hQne\":\"https://www.gstatic.com/_/boq-labs-tailwind/_/r/\",\"pEkTQ\":false,\"qDCSke\":\"SCRUBBED_USER_ID\",\"qwAQke\":\"LabsTailwindUi\",\"rtQCxc\":240,\"u4g7r\":\"%.@.null,1,3]\",\"vJQk6\":false,\"wAdwcc\":\"https://docs.google.com/picker\",\"xnI9P\":false,\"xwAfE\":true,\"y2FhP\":\"prod\",\"yFnxrf\":1957,\"zChJod\":\"%.@.]\",\"zgYTbd\":false,\"znAqjf\":\"%.@.null,null,\\\"CKTckcSxu5QDFQMxeQYd2doKYQ\\\",1778851311283749,[105980695,106128821,106014345,105613385,1714246,105927974,106194680,105758482,105860432,105844678,97785988,106229058,106102937,105670538,97480363,106181588,105987608,105901406,105727286,97691418,105739272,98341696,105588280,106037388,106116806,105938333,106104594,106097370,105732104,106052915,106101808,106052922,106122623,105959190,105809360,105712344,97689470,105710846,105759883,105921900,106107636,106051965,105668134,105882141,105897019,106114101,105982600,105738037,105901316,106030590,106195510,98379632,105832989,105720364,106113936,105983317,106114110,106011539,106081560,106023508,105738664,98178204,105980699,106128815,106014347,105613387,105927976,106194682,105758484,105860434,105844680,97785970,106229060,106102939,105670540,106181590,105987610,105727288,97691420,105739254,98341698,105588282,106037390,106116808,105938335,106104596,106097372,105732106,106052989,106101810,106055017,106122625,105959192,105809362,105712346,97689472,105710848,105759885,105921902,106107630,106051967,105668136,105880697,105897023,106114103,105982602,105738039,106030592,106195513,98379634,105832991,105720366,106113938,105983319,106114112,106011541,106081564,106023512,105738666,98178202],1]\"};</script><script
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">window[\"_F_toggles_default_LabsTailwindUi\"]
+        = [0x1c02008, ];</script><script nonce=\"w8uDqgUYYNuPfSRGbp1P7A\"></script><script
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">var _F_cssRowKey = 'boq-labs-tailwind.LabsTailwindUi.oJnRUnGRA7A.L.X.O';var
+        _F_combinedSignature = 'ANnj5bGFaFd85v9f24t5x3jnbJai-WZt2A';function _DumpException(e)
+        {throw e;}</script><style data-href=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/ss/k=boq-labs-tailwind.LabsTailwindUi.oJnRUnGRA7A.L.X.O/am=CCDAAQ/d=1/ed=1/rs=ANnj5bGe68e0FZ12qj89NoDDnu4wkwCwcQ/m=_b\"
+        nonce=\"GLNjujGbca-mtF6r9EgIzQ\">.boqHighlightVe [jslog]{-webkit-box-shadow:0
+        0 0 5px #7fffd4;box-shadow:0 0 0 5px #7fffd4}.glue-cookie-notification-bar{-webkit-box-shadow:0
+        2px 3px 0 rgba(60,64,67,.3),0 6px 10px 4px rgba(60,64,67,.15);box-shadow:0
+        2px 3px 0 rgba(60,64,67,.3),0 6px 10px 4px rgba(60,64,67,.15);background:#fff;bottom:0;-webkit-box-sizing:border-box;box-sizing:border-box;display:grid;font-size:1rem;grid-gap:8px;grid-template-columns:auto
+        auto;left:0;padding:8px;position:fixed;width:100%;z-index:1000}.glue-cookie-notification-bar[aria-hidden=true]{display:none}@media
+        (min-width:600px){.glue-cookie-notification-bar{grid-template-columns:1fr
+        auto;justify-items:flex-end}}@media (min-width:1024px){.glue-cookie-notification-bar{grid-template-columns:1fr
+        auto auto}}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar{border-top:1px
+        solid transparent}}@media print{.glue-cookie-notification-bar{display:none}}.glue-cookie-notification-bar__text{font-family:Google
+        Sans Text,Roboto,Arial,Helvetica,sans-serif;font-size:1.125em;line-height:1.5555555556;font-weight:400;letter-spacing:normal;align-self:center;color:#5f6368;grid-column:span
+        2;justify-self:flex-start;margin:0;padding:4px 12px}[lang=ar] .glue-cookie-notification-bar__text{font-family:Google
+        Sans Text,Google Sans Arabic,Roboto,Arial,Helvetica,sans-serif}[lang=ja] .glue-cookie-notification-bar__text{font-family:Google
+        Sans Text,Google Sans Japanese,Noto Sans JP,Roboto,Arial,Helvetica,sans-serif}[lang=ko]
+        .glue-cookie-notification-bar__text{font-family:Google Sans Text,Google Sans
+        Korean,Noto Sans KR,Roboto,Arial,Helvetica,sans-serif}[lang=zh-CN] .glue-cookie-notification-bar__text{font-family:Google
+        Sans Text,Google Sans Simplified Chinese,Noto Sans SC,Roboto,Arial,Helvetica,sans-serif}[lang=zh-TW]
+        .glue-cookie-notification-bar__text{font-family:Google Sans Text,Google Sans
+        Traditional Chinese,Noto Sans TC,Roboto,Arial,Helvetica,sans-serif}@media
+        (min-width:1024px){.glue-cookie-notification-bar__text{grid-column:span 1}}.glue-cookie-notification-bar__text,.glue-cookie-notification-bar__text
+        *{-moz-osx-font-smoothing:initial;-webkit-font-smoothing:initial;text-rendering:auto}.glue-cookie-notification-bar__more{background:transparent;border-radius:4px;color:#1a73e8;display:inline;overflow:hidden;text-decoration:underline;-webkit-transition:background-color
+        .2s,color .2s;transition:background-color .2s,color .2s;border-bottom:0;font-weight:inherit;letter-spacing:inherit}.glue-cookie-notification-bar__more:active,.glue-cookie-notification-bar__more:focus,.glue-cookie-notification-bar__more:hover{color:#174ea6}.glue-cookie-notification-bar__more:visited{color:#681da8}.glue-cookie-notification-bar__more:active,.glue-cookie-notification-bar__more:focus,.glue-cookie-notification-bar__more:hover{cursor:pointer;outline:none}.glue-cookie-notification-bar__more:hover{background-color:rgba(26,115,232,.04)}.glue-cookie-notification-bar__more:focus{outline:2px
+        solid transparent;background-color:rgba(26,115,232,.12);-webkit-box-shadow:0
+        0 0 2px #1a73e8;box-shadow:0 0 0 2px #1a73e8;z-index:1}.glue-cookie-notification-bar__more:active{background-color:rgba(26,115,232,.1);-webkit-box-shadow:none;box-shadow:none;outline:2px
+        auto Highlight;outline:5px auto -webkit-focus-ring-color}.glue-cookie-notification-bar__more
+        img{border:0}.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{font-size:1rem;line-height:1.5;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility;-webkit-align-content:center;align-content:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-align-self:flex-start;align-self:flex-start;border:1px
+        solid transparent;border-radius:48px;display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap;font-family:Google Sans,Arial,Helvetica,sans-serif;font-weight:500;-webkit-justify-content:space-around;justify-content:space-around;letter-spacing:.5px;margin:8px
+        0;max-width:380px;min-height:48px;min-width:96px;overflow:hidden;padding:12px
+        24px 12px 24px;text-align:center;text-decoration:none;-webkit-transition:background-color
+        .2s,color .2s,-webkit-box-shadow .2s;transition:background-color .2s,color
+        .2s,-webkit-box-shadow .2s;transition:background-color .2s,box-shadow .2s,color
+        .2s;transition:background-color .2s,box-shadow .2s,color .2s,-webkit-box-shadow
+        .2s;vertical-align:middle;background-color:#1a73e8;color:#fff;font-size:1em;cursor:pointer;margin:auto
+        0 0;max-width:unset}[lang=ar] .glue-cookie-notification-bar__accept,[lang=ar]
+        .glue-cookie-notification-bar__reject{font-family:Google Sans,Google Sans
+        Arabic,Arial,Helvetica,sans-serif}[lang=ja] .glue-cookie-notification-bar__accept,[lang=ja]
+        .glue-cookie-notification-bar__reject{font-family:Google Sans,Google Sans
+        Japanese,Noto Sans JP,Arial,Helvetica,sans-serif}[lang=ko] .glue-cookie-notification-bar__accept,[lang=ko]
+        .glue-cookie-notification-bar__reject{font-family:Google Sans,Google Sans
+        Korean,Noto Sans KR,Arial,Helvetica,sans-serif}[lang=zh-CN] .glue-cookie-notification-bar__accept,[lang=zh-CN]
+        .glue-cookie-notification-bar__reject{font-family:Google Sans,Google Sans
+        Simplified Chinese,Noto Sans SC,Arial,Helvetica,sans-serif}[lang=zh-TW] .glue-cookie-notification-bar__accept,[lang=zh-TW]
+        .glue-cookie-notification-bar__reject{font-family:Google Sans,Google Sans
+        Traditional Chinese,Noto Sans TC,Arial,Helvetica,sans-serif}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{-webkit-transition:none;transition:none}}.glue-cookie-notification-bar__accept:focus,.glue-cookie-notification-bar__reject:focus{outline:2px
+        solid transparent;-webkit-transition:none;transition:none}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept,.glue-cookie-notification-bar__reject{forced-color-adjust:none;background:buttonText;border-color:buttonFace;color:buttonFace}.glue-cookie-notification-bar__accept
+        svg,.glue-cookie-notification-bar__reject svg{fill:buttonFace}}.glue-cookie-notification-bar__accept:visited,.glue-cookie-notification-bar__reject:visited{background-color:#1a73e8;color:#fff}@media
+        (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:visited,.glue-cookie-notification-bar__reject:visited{forced-color-adjust:none;background:buttonText;border-color:buttonFace;color:buttonFace}.glue-cookie-notification-bar__accept:visited
+        svg,.glue-cookie-notification-bar__reject:visited svg{fill:buttonFace}}.glue-cookie-notification-bar__accept:hover,.glue-cookie-notification-bar__reject:hover{background-color:#185abc;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15)}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:hover,.glue-cookie-notification-bar__reject:hover{forced-color-adjust:none;background:buttonFace;border-color:buttonText;color:buttonText}.glue-cookie-notification-bar__accept:hover
+        svg,.glue-cookie-notification-bar__reject:hover svg{fill:buttonText}}.glue-cookie-notification-bar__accept:focus,.glue-cookie-notification-bar__reject:focus{background-color:#185abc;border-color:#fff;-webkit-box-shadow:0
+        0 0 2px #185abc;box-shadow:0 0 0 2px #185abc}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:focus,.glue-cookie-notification-bar__reject:focus{forced-color-adjust:none;background:buttonFace;border-color:buttonText;color:buttonText;outline:2px
+        solid highlight}.glue-cookie-notification-bar__accept:focus svg,.glue-cookie-notification-bar__reject:focus
+        svg{fill:buttonText}}.glue-cookie-notification-bar__accept:active,.glue-cookie-notification-bar__reject:active{background-color:#185abc;border:1px
+        solid transparent;-webkit-box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0 2px 6px
+        2px rgba(60,64,67,.15);box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0 2px 6px
+        2px rgba(60,64,67,.15)}@media (-ms-high-contrast:active),(forced-colors:active){.glue-cookie-notification-bar__accept:active,.glue-cookie-notification-bar__reject:active{forced-color-adjust:none;background:buttonFace;border-color:buttonText;color:buttonText}.glue-cookie-notification-bar__accept:active
+        svg,.glue-cookie-notification-bar__reject:active svg{fill:buttonText}}.glue-cookie-notification-bar__accept:last-child{grid-column:span
+        2}.glue-cookie-notification-bar-control[aria-hidden=true]{display:none}button.glue-cookie-notification-bar-control.glue-footer__link{-moz-appearance:none;-webkit-appearance:none;appearance:none;border:0;border-radius:4px;padding:0}@media
+        (-ms-high-contrast:active),(forced-colors:active){button.glue-cookie-notification-bar-control.glue-footer__link{color:linkText}button.glue-cookie-notification-bar-control.glue-footer__link:focus{outline:2px
+        solid transparent}}.glue-footer__global-links-list-item[aria-hidden=true],.h-c-footer__global-links-list-item[aria-hidden=true]{display:none}.picker-api-container,.picker-iframe-container{height:100%;width:100%;position:relative}.picker-close-button{position:absolute;z-index:100;top:12px;right:14px;width:36px;height:36px;border-radius:18px;border-width:0;background-color:rgba(0,0,0,0)}.picker-close-button:hover{background-color:rgba(60,64,67,.04)}.picker-close-button:active{background-color:rgba(60,64,67,.12)}.picker-close-button-svg{fill:#616161}.content-library
+        .picker-close-button-svg{color:var(--dt-on-neutral-container,rgb(60,64,67))}.content-library
+        .picker-loading-container{position:absolute;height:100%;width:100%;background-color:var(--dt-surface-container,#fff);-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:space-evenly;-webkit-justify-content:space-evenly;justify-content:space-evenly;display:none}.content-library.loading
+        .picker-loading-container{display:-webkit-box;display:-webkit-flex;display:flex;background-color:#f0f4f9}.content-library.loaded
+        .picker-loading-container,.content-library.loading .picker-iframe-container,.content-library.loading-timed-out
+        .picker-loading-container{display:none}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressWrapper{position:relative}.javascriptMaterialdesignGm3WizCircularProgressCircularProgress{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;position:relative;line-height:0;overflow:hidden}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressContainer{position:absolute;width:100%;height:100%;-webkit-transform:rotate(-90deg);-ms-transform:rotate(-90deg);transform:rotate(-90deg)}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressCircleGraphic{height:100%;width:100%;fill:transparent}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke:var(--yPTsAb,var(--gm3-sys-color-primary,#0b57d0));stroke-width:var(--EscQs,4px);stroke-linecap:round}@media
+        (forced-colors:active){.javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke:CanvasText}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke:var(--Sewh0e,var(--gm3-sys-color-secondary-container,#c2e7ff));stroke-width:var(--EscQs,4px);stroke-linecap:round}@media
+        (forced-colors:active){.javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke:Canvas;stroke-width:calc(var(--EscQs,
+        4px) - 2px);-webkit-filter:drop-shadow(-1px 0 0 CanvasText) drop-shadow(1px
+        0 0 CanvasText) drop-shadow(0 -1px 0 CanvasText) drop-shadow(0 1px 0 CanvasText);filter:drop-shadow(-1px
+        0 0 CanvasText) drop-shadow(1px 0 0 CanvasText) drop-shadow(0 -1px 0 CanvasText)
+        drop-shadow(0 1px 0 CanvasText)}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressAlmostComplete
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressClosed
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressClosed
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressComplete
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack,.javascriptMaterialdesignGm3WizCircularProgressCircularProgressUnopened
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke-width:0}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate{-webkit-animation:gm3-cpi-rotate
+        6s linear infinite;animation:gm3-cpi-rotate 6s linear infinite}@-webkit-keyframes
+        gm3-cpi-rotate{0%{-webkit-transform:rotate(-90deg);transform:rotate(-90deg)}to{-webkit-transform:rotate(990deg);transform:rotate(990deg)}}@keyframes
+        gm3-cpi-rotate{0%{-webkit-transform:rotate(-90deg);transform:rotate(-90deg)}to{-webkit-transform:rotate(990deg);transform:rotate(990deg)}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressContainer{-webkit-animation:gm3-cpi-container-rotate
+        6s ease infinite;animation:gm3-cpi-container-rotate 6s ease infinite}@-webkit-keyframes
+        gm3-cpi-container-rotate{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}8.3333333333%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}25%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}33.3333333333%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}50%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}58.3333333333%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}75%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}83.3333333333%{-webkit-transform:rotate(1turn);transform:rotate(1turn)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        gm3-cpi-container-rotate{0%{-webkit-transform:rotate(0deg);transform:rotate(0deg)}8.3333333333%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}25%{-webkit-transform:rotate(90deg);transform:rotate(90deg)}33.3333333333%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}50%{-webkit-transform:rotate(180deg);transform:rotate(180deg)}58.3333333333%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}75%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}83.3333333333%{-webkit-transform:rotate(1turn);transform:rotate(1turn)}to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgress{height:calc(var(--EkrYwf,
+        40px));width:calc(var(--EkrYwf, 40px))}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{-webkit-transition:stroke-dasharray
+        .5s cubic-bezier(0,0,.2,1) 0s,stroke-width .25s cubic-bezier(.4,0,.6,1) 0s;transition:stroke-dasharray
+        .5s cubic-bezier(0,0,.2,1) 0s,stroke-width .25s cubic-bezier(.4,0,.6,1) 0s;cx:calc(var(--EkrYwf,
+        40px)/2);cy:calc(var(--EkrYwf, 40px)/2);r:calc((var(--EkrYwf, 40px) - var(--EscQs,
+        4px))/2);stroke-dasharray:calc(var(--progress-value, 0)*(6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px)) - var(--EscQs, 4px)) calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - var(--progress-value, 0)*(6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px)) + var(--EscQs, 4px))}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{-webkit-transition:stroke-dasharray
+        .5s cubic-bezier(0,0,.2,1) 0s,stroke-dashoffset .5s cubic-bezier(0,0,.2,1)
+        0s,stroke-width .25s cubic-bezier(.4,0,.6,1) 0s;transition:stroke-dasharray
+        .5s cubic-bezier(0,0,.2,1) 0s,stroke-dashoffset .5s cubic-bezier(0,0,.2,1)
+        0s,stroke-width .25s cubic-bezier(.4,0,.6,1) 0s;cx:calc(var(--EkrYwf, 40px)/2);cy:calc(var(--EkrYwf,
+        40px)/2);r:calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))/2);stroke-dasharray:min((1
+        - var(--progress-value,0)) * (6.2831852 * (var(--EkrYwf,40px) - var(--EscQs,4px))/2
+        - var(--XJrZW,4px)) - var(--XJrZW,4px) - var(--EscQs,4px),6.2831852 * (var(--EkrYwf,40px)
+        - var(--EscQs,4px))/2 - var(--XJrZW,4px) - var(--XJrZW,4px) - 2 * var(--EscQs,4px))
+        calc(6.2831852 * (var(--EkrYwf, 40px) - var(--EscQs, 4px)) / 2 - min((1 -
+        var(--progress-value, 0)) * (6.2831852 * (var(--EkrYwf, 40px) - var(--EscQs,
+        4px)) / 2 - var(--XJrZW, 4px)) - var(--XJrZW, 4px) - var(--EscQs, 4px), 6.2831852
+        * (var(--EkrYwf, 40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW, 4px) - var(--XJrZW,
+        4px) - 2 * var(--EscQs, 4px)));stroke-dashoffset:calc(min((1 - var(--progress-value,
+        0)) * (6.2831852 * (var(--EkrYwf, 40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW,
+        4px)) - var(--XJrZW, 4px) - var(--EscQs, 4px), 6.2831852 * (var(--EkrYwf,
+        40px) - var(--EscQs, 4px)) / 2 - var(--XJrZW, 4px) - var(--XJrZW, 4px) - 2
+        * var(--EscQs, 4px)) + var(--XJrZW, 4px) + var(--EscQs, 4px))}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressComplete
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{stroke-dasharray:calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2)}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressUnopened
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{stroke-dasharray:calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2) 0}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressActiveIndicator{-webkit-animation:gm3-cpi-active-grow
+        6s ease infinite;animation:gm3-cpi-active-grow 6s ease infinite}@-webkit-keyframes
+        gm3-cpi-active-grow{0%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}}@keyframes
+        gm3-cpi-active-grow{0%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.87 + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 - var(--EscQs, 4px)),calc((var(--EkrYwf,
+        40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf, 40px) -
+        var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.16 + var(--EscQs, 4px))}}.javascriptMaterialdesignGm3WizCircularProgressCircularProgressIndeterminate
+        .javascriptMaterialdesignGm3WizCircularProgressCircularProgressTrack{-webkit-animation:gm3-cpi-track-grow
+        6s ease infinite;animation:gm3-cpi-track-grow 6s ease infinite}@-webkit-keyframes
+        gm3-cpi-track-grow{0%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px) - var(--EscQs,
+        4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2 - (6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 + var(--XJrZW, 4px)
+        + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf, 40px)
+        - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px) - var(--EscQs,
+        4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}}@keyframes gm3-cpi-track-grow{0%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}50%{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.13 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}to{stroke-dasharray:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px)),calc((var(--EkrYwf, 40px) - var(--EscQs, 4px))*6.2831852/2
+        - (6.2831852*(var(--EkrYwf, 40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84
+        + var(--XJrZW, 4px) + var(--EscQs, 4px));stroke-dashoffset:calc((6.2831852*(var(--EkrYwf,
+        40px) - var(--EscQs, 4px))/2 - var(--XJrZW, 4px))*.84 - var(--XJrZW, 4px)
+        - var(--EscQs, 4px) + var(--XJrZW, 4px) + var(--EscQs, 4px))}}.mdc-circular-progress__determinate-circle,.mdc-circular-progress__indeterminate-circle-graphic{stroke:#6200ee;stroke:var(--mdc-theme-primary,#6200ee)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.mdc-circular-progress__determinate-circle,.mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.mdc-circular-progress__determinate-track{stroke:transparent}@-webkit-keyframes
+        mdc-circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        mdc-circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@-webkit-keyframes
+        mdc-circular-progress-spinner-layer-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@keyframes
+        mdc-circular-progress-spinner-layer-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@-webkit-keyframes
+        mdc-circular-progress-color-1-fade-in-out{0%{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}to{opacity:.99}}@keyframes
+        mdc-circular-progress-color-1-fade-in-out{0%{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}to{opacity:.99}}@-webkit-keyframes
+        mdc-circular-progress-color-2-fade-in-out{0%{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}to{opacity:0}}@keyframes
+        mdc-circular-progress-color-2-fade-in-out{0%{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}to{opacity:0}}@-webkit-keyframes
+        mdc-circular-progress-color-3-fade-in-out{0%{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}to{opacity:0}}@keyframes
+        mdc-circular-progress-color-3-fade-in-out{0%{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}to{opacity:0}}@-webkit-keyframes
+        mdc-circular-progress-color-4-fade-in-out{0%{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}to{opacity:0}}@keyframes
+        mdc-circular-progress-color-4-fade-in-out{0%{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}to{opacity:0}}@-webkit-keyframes
+        mdc-circular-progress-left-spin{0%{-webkit-transform:rotate(265deg);transform:rotate(265deg)}50%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}to{-webkit-transform:rotate(265deg);transform:rotate(265deg)}}@keyframes
+        mdc-circular-progress-left-spin{0%{-webkit-transform:rotate(265deg);transform:rotate(265deg)}50%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}to{-webkit-transform:rotate(265deg);transform:rotate(265deg)}}@-webkit-keyframes
+        mdc-circular-progress-right-spin{0%{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}50%{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}to{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}}@keyframes
+        mdc-circular-progress-right-spin{0%{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}50%{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}to{-webkit-transform:rotate(-265deg);transform:rotate(-265deg)}}.mdc-circular-progress{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;position:relative;direction:ltr;line-height:0;overflow:hidden;-webkit-transition:opacity
+        .25s cubic-bezier(.4,0,.6,1) 0s;transition:opacity .25s cubic-bezier(.4,0,.6,1)
+        0s}.mdc-circular-progress__determinate-container,.mdc-circular-progress__indeterminate-circle-graphic,.mdc-circular-progress__indeterminate-container,.mdc-circular-progress__spinner-layer{position:absolute;width:100%;height:100%}.mdc-circular-progress__determinate-container{-webkit-transform:rotate(-90deg);-ms-transform:rotate(-90deg);transform:rotate(-90deg)}.mdc-circular-progress__indeterminate-container{font-size:0;letter-spacing:0;white-space:nowrap;opacity:0}.mdc-circular-progress__determinate-circle-graphic,.mdc-circular-progress__indeterminate-circle-graphic{fill:transparent}.mdc-circular-progress__determinate-circle{-webkit-transition:stroke-dashoffset
+        .5s cubic-bezier(0,0,.2,1) 0s;transition:stroke-dashoffset .5s cubic-bezier(0,0,.2,1)
+        0s}.mdc-circular-progress__gap-patch{position:absolute;top:0;left:47.5%;-webkit-box-sizing:border-box;box-sizing:border-box;width:5%;height:100%;overflow:hidden}.mdc-circular-progress__gap-patch
+        .mdc-circular-progress__indeterminate-circle-graphic{left:-900%;width:2000%;-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);transform:rotate(180deg)}.mdc-circular-progress__circle-clipper{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;position:relative;width:50%;height:100%;overflow:hidden}.mdc-circular-progress__circle-clipper
+        .mdc-circular-progress__indeterminate-circle-graphic{width:200%}.mdc-circular-progress__circle-right
+        .mdc-circular-progress__indeterminate-circle-graphic{left:-100%}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__determinate-container{opacity:0}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__indeterminate-container{opacity:1}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__indeterminate-container{-webkit-animation:mdc-circular-progress-container-rotate
+        1.5682352941176s linear infinite;animation:mdc-circular-progress-container-rotate
+        1.5682352941176s linear infinite}.mdc-circular-progress--indeterminate .mdc-circular-progress__spinner-layer{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-1{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-1-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-1-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-2{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-2-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-2-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-3{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-3-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-3-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__color-4{-webkit-animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-4-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-spinner-layer-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,mdc-circular-progress-color-4-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__circle-left .mdc-circular-progress__indeterminate-circle-graphic{-webkit-animation:mdc-circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--indeterminate
+        .mdc-circular-progress__circle-right .mdc-circular-progress__indeterminate-circle-graphic{-webkit-animation:mdc-circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:mdc-circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.mdc-circular-progress--closed{opacity:0}.GmCircularProgress{position:relative}.GmCircularProgress
+        .mdc-circular-progress__determinate-circle,.GmCircularProgress .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(66,133,244)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__determinate-circle,.GmCircularProgress .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-1 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(66,133,244)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-1 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-2 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(234,67,53)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-2 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-3 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(251,188,4)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-3 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__color-4 .mdc-circular-progress__indeterminate-circle-graphic{stroke:rgb(52,168,83)}@media
+        (-ms-high-contrast:active),screen and (forced-colors:active){.GmCircularProgress
+        .mdc-circular-progress__color-4 .mdc-circular-progress__indeterminate-circle-graphic{stroke:CanvasText}}.GmCircularProgress
+        .mdc-circular-progress__accessible-label{height:100%;width:100%;position:absolute;opacity:0;overflow:hidden;z-index:-1}.materialdesignWizIconSvgsSvgIcon{fill:currentColor;-webkit-flex-shrink:0;flex-shrink:0}[dir=rtl]
+        .materialdesignWizIconSvgsRtlIcon{-webkit-transform:scaleX(-1);-ms-transform:scaleX(-1);transform:scaleX(-1)}.peopleKitStyleGm3{--pkw-background:var(--gm3-sys-color-background,#fff);--pkw-outline:var(--gm3-sys-color-outline,#747775);--pkw-outline-variant:var(--gm3-sys-color-outline-variant,#c4c7c5);--pkw-scrim:rgba(0,0,0,0.32);--pkw-primary:var(--gm3-sys-color-primary,#0b57d0);--pkw-secondary-container:var(--gm3-sys-color-secondary-container,#c2e7ff);--pkw-on-secondary-container:var(--gm3-sys-color-on-secondary-container,#001d35);--pkw-error:var(--gm3-sys-color-error,#b3261e);--pkw-on-error:var(--gm3-sys-color-on-error,#fff);--pkw-error-container:var(--gm3-sys-color-error-container,#f9dedc);--pkw-error-container-low:rgb(255,237,234);--pkw-on-error-container:var(--gm3-sys-color-on-error-container,#410e0b);--pkw-caution:rgb(125,88,0);--pkw-caution-container:rgb(255,222,169);--pkw-caution-container-low:rgb(255,239,212);--pkw-on-caution-container:rgb(39,25,0);--pkw-on-surface:var(--gm3-sys-color-on-surface,#1f1f1f);--pkw-on-surface-variant:var(--gm3-sys-color-on-surface-variant,#444746);--pkw-surface-container:var(--gm3-sys-color-surface-container,#f0f4f9);--pkw-surface-container-high:var(--gm3-sys-color-surface-container-high,#e9eef6);--pkw-inverse-surface:var(--gm3-sys-color-inverse-surface,#303030);--pkw-inverse-on-surface:var(--gm3-sys-color-inverse-on-surface,#f2f2f2)}.peoplekitThemeDark
+        .peopleKitStyleGm3{--pkw-background:var(--gm3-sys-color-background,#131314);--pkw-outline:var(--gm3-sys-color-outline,#8e918f);--pkw-outline-variant:var(--gm3-sys-color-outline-variant,#444746);--pkw-scrim:rgba(0,0,0,0.32);--pkw-primary:var(--gm3-sys-color-primary,#a8c7fa);--pkw-secondary-container:var(--gm3-sys-color-secondary-container,#004a77);--pkw-on-secondary-container:var(--gm3-sys-color-on-secondary-container,#c2e7ff);--pkw-error:var(--gm3-sys-color-error,#f2b8b5);--pkw-on-error:var(--gm3-sys-color-on-error,#601410);--pkw-error-container:var(--gm3-sys-color-error-container,#8c1d18);--pkw-error-container-low:rgb(65,0,1);--pkw-on-error-container:var(--gm3-sys-color-on-error-container,#f9dedc);--pkw-caution:rgb(255,186,40);--pkw-caution-container:rgb(94,65,0);--pkw-caution-container-low:rgb(80,55,0);--pkw-on-caution-container:rgb(255,222,169);--pkw-on-surface:var(--gm3-sys-color-on-surface,#e3e3e3);--pkw-on-surface-variant:var(--gm3-sys-color-on-surface-variant,#c4c7c5);--pkw-surface-container:var(--gm3-sys-color-surface-container,#1e1f20);--pkw-surface-container-high:var(--gm3-sys-color-surface-container-high,#282a2c);--pkw-inverse-surface:var(--gm3-sys-color-inverse-surface,#e3e3e3);--pkw-inverse-on-surface:var(--gm3-sys-color-inverse-on-surface,#303030)}.peoplekitComponentsAvatarImplAvatarContainer{position:relative}.peoplekitComponentsAvatarImplAvatar{border-radius:50%;outline:1px
+        solid transparent;overflow:hidden}.peoplekitComponentsAvatarImplBadgeIconImage{margin:auto;display:block;height:100%;width:100%}.peoplekitComponentsAvatarImplAvatarBadge{position:absolute;bottom:0;right:0;display:none;height:30%;width:30%;min-height:30%;min-width:30%;-o-object-fit:cover;object-fit:cover;overflow:hidden}.peoplekitComponentsAvatarImplAvatarBadge.visible{display:inline}.isSelected
+        .peoplekitComponentsAvatarImplAvatarBadge{display:none}.peoplekitComponentsAvatarImplContainer{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;height:inherit;width:inherit}.peoplekitComponentsAvatarImplColumn{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-flex:1;-webkit-flex:1;flex:1;overflow:hidden;height:inherit;-webkit-box-align:stretch;-webkit-align-items:stretch;align-items:stretch}.peoplekitComponentsAvatarImplRow{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:1;-webkit-flex:1;flex:1;overflow:hidden}.peoplekitComponentsAvatarImplDivider{margin:1px}.peoplekitComponentsAvatarImplImageRoot{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-flex:1;-webkit-flex:auto;flex:auto;-webkit-box-align:center;-webkit-align-items:center;align-items:center;justify-items:center;-webkit-transition:background
+        50ms ease-in-out;transition:background 50ms ease-in-out}.peoplekitComponentsAvatarImplImageRoot.isLoading{background-clip:padding-box;background-color:var(--pkw-on-surface-variant,rgb(189,193,198))}.peoplekitComponentsAvatarImplDefaultAvatarImage{display:none}.isNotLoaded
+        .peoplekitComponentsAvatarImplDefaultAvatarImage{display:block;fill:var(--pkw-on-surface-variant,rgb(95,99,104))}.peoplekitThemeDark
+        .isNotLoaded .peoplekitComponentsAvatarImplDefaultAvatarImage{fill:var(--pkw-on-surface-variant,rgb(154,160,166))}.peoplekitComponentsAvatarImplImage{opacity:1;display:block;-webkit-transition:opacity
+        50ms ease-in-out;transition:opacity 50ms ease-in-out}.isLoading .peoplekitComponentsAvatarImplImage{opacity:0}.isNotLoaded
+        .peoplekitComponentsAvatarImplImage{display:none}.peoplekitComponentsChipChip{background:var(--pkw-background,#fff);border-radius:50vh;-webkit-box-shadow:0
+        0 0 1px var(--pkw-outline,rgb(218,220,224)) inset;box-shadow:0 0 0 1px var(--pkw-outline,rgb(218,220,224))
+        inset;color:var(--pkw-on-surface-variant,rgb(95,99,104));cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;display:inline-block;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;margin:4px;min-width:1px;outline:1px
+        solid transparent;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitComponentsChipChip:hover{background:var(--pkw-background,rgb(248,249,250));color:var(--pkw-on-surface-variant,rgb(32,33,36))}.peoplekitComponentsChipChip.isActive{background:var(--pkw-secondary-container,rgb(232,240,254));-webkit-box-shadow:none;box-shadow:none;color:var(--pkw-on-secondary-container,rgb(25,103,210));outline-width:2px}.peoplekitComponentsChipChip.isActive:hover{background:var(--pkw-secondary-container,rgb(210,227,252));color:var(--pkw-on-secondary-container,rgb(23,78,166))}.peoplekitComponentsChipChip.isSpotlit{-webkit-box-shadow:0
+        0 0 2px var(--pkw-primary,rgb(102,157,246)) inset;box-shadow:0 0 0 2px var(--pkw-primary,rgb(102,157,246))
+        inset;outline-width:3px}.peoplekitComponentsChipChip.isWarning{background:var(--pkw-caution-container-low,rgb(254,247,224));-webkit-box-shadow:0
+        0 0 1px var(--pkw-caution,rgb(251,188,4)) inset;box-shadow:0 0 0 1px var(--pkw-caution,rgb(251,188,4))
+        inset;color:var(--pkw-caution,rgb(95,99,104))}.peoplekitComponentsChipChip.isWarning.isActive{background:var(--pkw-caution-container,rgb(253,214,99));color:var(--pkw-on-caution-container,rgb(60,64,67));-webkit-box-shadow:none;box-shadow:none}.peoplekitComponentsChipChip.isWarning.isActive:hover{background:var(--pkw-caution-container,rgb(252,201,52));color:var(--pkw-on-caution-container,rgb(32,33,36))}.peoplekitComponentsChipChip.isWarning.isSpotlit{-webkit-box-shadow:0
+        0 0 2px var(--pkw-on-caution-container,rgb(32,33,36)) inset;box-shadow:0 0
+        0 2px var(--pkw-on-caution-container,rgb(32,33,36)) inset}.peoplekitComponentsChipChip.isWarning:hover{background:var(--pkw-caution-container,rgb(254,239,195));color:var(--pkw-caution,rgb(32,33,36))}.peoplekitComponentsChipChip.isError{background:var(--pkw-error-container-low,#fff);-webkit-box-shadow:0
+        0 0 1px var(--pkw-error,rgb(234,67,53)) inset;box-shadow:0 0 0 1px var(--pkw-error,rgb(234,67,53))
+        inset;color:var(--pkw-error,rgb(197,34,31))}.peoplekitComponentsChipChip.isError.isActive{background:var(--pkw-error-container,rgba(217,48,37,.2));color:var(--pkw-on-error-container,rgb(165,14,14));-webkit-box-shadow:none;box-shadow:none}.peoplekitComponentsChipChip.isError.isActive:hover{background:var(--pkw-error-container,rgba(217,48,37,.24));color:var(--pkw-on-error-container,rgb(165,14,14))}.peoplekitComponentsChipChip.isError.isSpotlit{-webkit-box-shadow:0
+        0 0 2px var(--pkw-on-error-container,rgb(165,14,14)) inset;box-shadow:0 0
+        0 2px var(--pkw-on-error-container,rgb(165,14,14)) inset}.peoplekitComponentsChipChip.isError:hover{background:var(--pkw-error-container,rgb(250,210,207));color:var(--pkw-error,rgb(165,14,14))}.peoplekitComponentsChipChip.isDragged,.peoplekitComponentsChipChip.isDragged.isActive,.peoplekitComponentsChipChip.isDragged.isError,.peoplekitComponentsChipChip.isDragged.isSpotlit,.peoplekitComponentsChipChip.isDragged.isWarning{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitComponentsChipChip.isDragged.isActive
+        .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged.isError .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged.isSpotlit
+        .mdc-elevation-overlay,.peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isActive,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isSpotlit,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitComponentsChipChip.isDragged
+        .mdc-elevation-overlay,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive
+        .mdc-elevation-overlay,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError
+        .mdc-elevation-overlay,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit
+        .mdc-elevation-overlay,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning
+        .mdc-elevation-overlay{opacity:0}.peoplekitComponentsChipChip.isDragged.peopleKitStyleGm3{-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15)}.peoplekitComponentsChipChip.isDisabled,.peoplekitComponentsChipChip.isDisabled:hover{cursor:default;opacity:.5}.peoplekitComponentsChipChip.isDeletionDisabled
+        .peoplekitComponentsChipDeleteButton{display:none}.peoplekitThemeDark .peoplekitComponentsChipChip{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);border-radius:50vh;-webkit-box-shadow:0
+        0 0 1px var(--pkw-outline,rgb(95,99,104)) inset;box-shadow:0 0 0 1px var(--pkw-outline,rgb(95,99,104))
+        inset;color:var(--pkw-on-surface-variant,rgb(154,160,166));cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;display:inline-block;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;margin:4px;min-width:1px;outline:1px
+        solid transparent;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitThemeDark
+        .peoplekitComponentsChipChip:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.04),rgba(232,234,237,.04)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-surface-variant,rgb(232,234,237))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isActive{background:var(--pkw-secondary-container,linear-gradient(0deg,rgba(138,180,248,.24),rgba(138,180,248,.24)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);-webkit-box-shadow:none;box-shadow:none;color:var(--pkw-on-secondary-container,rgb(210,227,252));outline-width:2px}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isActive:hover{background:var(--pkw-secondary-container,linear-gradient(0deg,rgba(138,180,248,.32),rgba(138,180,248,.32)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-secondary-container,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isSpotlit{-webkit-box-shadow:0 0 0 2px var(--pkw-primary,rgb(174,203,250))
+        inset;box-shadow:0 0 0 2px var(--pkw-primary,rgb(174,203,250)) inset;outline-width:3px}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning{background:var(--pkw-caution-container-low,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);-webkit-box-shadow:0
+        0 0 1px var(--pkw-caution,rgb(253,214,99)) inset;box-shadow:0 0 0 1px var(--pkw-caution,rgb(253,214,99))
+        inset;color:var(--pkw-caution,rgb(253,214,99))}.peoplekitThemeDark .peoplekitComponentsChipChip.isWarning.isActive{background:var(--pkw-caution-container,linear-gradient(0deg,rgba(253,214,99,.24),rgba(253,214,99,.24)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-caution-container,rgb(254,239,195));-webkit-box-shadow:none;box-shadow:none}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning.isActive:hover{background:var(--pkw-caution-container,linear-gradient(0deg,rgba(253,214,99,.36),rgba(253,214,99,.36)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-caution-container,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning.isSpotlit{-webkit-box-shadow:0 0 0
+        2px var(--pkw-on-caution-container,rgb(232,234,237)) inset;box-shadow:0 0
+        0 2px var(--pkw-on-caution-container,rgb(232,234,237)) inset}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isWarning:hover{background:var(--pkw-caution-container,linear-gradient(0deg,rgba(253,214,99,.04),rgba(253,214,99,.04)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-caution,rgb(254,239,195))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isError{background:var(--pkw-error-container-low,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);-webkit-box-shadow:0
+        0 0 1px var(--pkw-error,rgb(242,139,130)) inset;box-shadow:0 0 0 1px var(--pkw-error,rgb(242,139,130))
+        inset;color:var(--pkw-error,rgb(242,139,130))}.peoplekitThemeDark .peoplekitComponentsChipChip.isError.isActive{background:var(--pkw-error-container,linear-gradient(0deg,rgba(242,139,130,.24),rgba(242,139,130,.24)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-error-container,rgb(250,210,207));-webkit-box-shadow:none;box-shadow:none}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isError.isActive:hover{background:var(--pkw-error-container,linear-gradient(0deg,rgba(242,139,130,.36),rgba(242,139,130,.36)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-error-container,rgb(252,232,230))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isError.isSpotlit{-webkit-box-shadow:0 0 0 2px
+        var(--pkw-on-error-container,rgb(250,210,207)) inset;box-shadow:0 0 0 2px
+        var(--pkw-on-error-container,rgb(250,210,207)) inset}.peoplekitThemeDark .peoplekitComponentsChipChip.isError:hover{background:var(--pkw-error-container,linear-gradient(0deg,rgba(242,139,130,.04),rgba(242,139,130,.04)),linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-error,rgb(250,210,207))}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isError,.peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isWarning{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isActive .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isError .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isSpotlit .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning{border-width:0;-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 2px 6px 2px rgba(60,64,67,.15)}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isActive .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isError .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isSpotlit .mdc-elevation-overlay,.peoplekitThemeDark
+        .peoplekitThemeDark .peoplekitComponentsChipChip.isDragged.isWarning .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDragged.peopleKitStyleGm3{-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15)}.peoplekitThemeDark .peoplekitComponentsChipChip.isDisabled,.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDisabled:hover{cursor:default;opacity:.5}.peoplekitThemeDark
+        .peoplekitComponentsChipChip.isDeletionDisabled .peoplekitComponentsChipDeleteButton{display:none}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip{position:relative}.peopleKitStyleGm3 .peoplekitComponentsChipChip:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50vh;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsChipChip:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip:hover:before{opacity:.08}.peopleKitStyleGm3 .peoplekitComponentsChipChip.isActive:hover:before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isWarning:hover:before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isWarning.isActive:hover:before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isError:hover:before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsChipChip.isError.isActive:hover:before{opacity:.1}.peoplekitComponentsChipChipRow{-webkit-box-align:stretch;-webkit-align-items:stretch;align-items:stretch;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap;padding:2px}.peoplekitComponentsChipLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsChipCenter{-webkit-box-align:stretch;-webkit-align-items:stretch;align-items:stretch;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:1;-webkit-flex:auto;flex:auto;justify-items:stretch;overflow:hidden}.peoplekitComponentsChipRight{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsChipLabelContainer{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-flow:column
+        nowrap;flex-flow:column nowrap;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;margin-left:8px;margin-right:8px;overflow:hidden}.peoplekitComponentsChipLabelRow{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsChipLabel{letter-spacing:.0214285714em;font-family:Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;line-height:unset;max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:-webkit-box;display:-webkit-flex;display:flex}.peopleKitStyleGm3
+        .peoplekitComponentsChipLabel{font-family:Google Sans Text,Google Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsChipDisambiguationLabel.hasDisambiguationLabel{margin-left:4px}.peoplekitComponentsChipDisplayLabel{-webkit-box-flex:1;-webkit-flex:1
+        0 auto;flex:1 0 auto;overflow:hidden;text-overflow:ellipsis;max-width:100%}.peoplekitComponentsChipDisambiguationLabel{overflow:hidden;text-overflow:ellipsis}.peoplekitComponentsChipAvatar{position:relative}.peoplekitComponentsChipAvatarContainer{height:inherit;width:inherit;position:relative}.peoplekitComponentsChipAvatarExclamationOverlay{border-radius:50%;height:100%;left:0;outline:1px
+        solid transparent;position:absolute;top:0;width:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center}.peoplekitComponentsChipAvatarExclamationOverlay.isError{background-color:var(--pkw-error,rgb(197,34,31))}.peoplekitThemeDark
+        .peoplekitComponentsChipAvatarExclamationOverlay.isError{background-color:var(--pkw-error,rgb(242,139,130))}.peoplekitComponentsChipExclamationIcon{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;height:85%;width:85%}.peoplekitComponentsChipExclamationIcon.isError{fill:var(--pkw-on-error,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsChipExclamationIcon.isError{fill:var(--pkw-on-error,rgb(32,33,36))}@media
+        (forced-colors:active){.peoplekitComponentsChipExclamationIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsChipDeleteButton{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;height:100%;max-height:24px;margin-left:-3px;margin-right:1px;width:24px;z-index:1}.peoplekitComponentsChipDeleteIcon{display:block;fill:currentcolor;margin:0
+        auto}.peoplekitComponentsChipPlaceholderAvatarPlaceholder{border-radius:50%;background-color:var(--pkw-secondary-fixed-dim,rgb(174,203,250))}.peoplekitComponentsChipPlaceholderLabelPlaceholder{-webkit-align-self:center;align-self:center;background-color:var(--pkw-secondary-fixed-dim,rgb(174,203,250));border-radius:8px;height:16px;margin-left:8px;margin-right:8px;width:150px}.peoplekitComponentsChipPlaceholderShimmer{-webkit-animation:fadeinout
+        1.4s cubic-bezier(.5,0,.5,1) infinite;animation:fadeinout 1.4s cubic-bezier(.5,0,.5,1)
+        infinite}@-webkit-keyframes fadeinout{0%{opacity:.75}50%{opacity:1}to{opacity:.75}}@keyframes
+        fadeinout{0%{opacity:.75}50%{opacity:1}to{opacity:.75}}.peoplekitComponentsTooltipImplTooltip{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400;background-color:var(--pkw-inverse-surface,rgb(60,64,67));color:var(--pkw-inverse-on-surface,rgb(241,243,244));border-radius:5px;-webkit-box-sizing:border-box;box-sizing:border-box;font-weight:700;line-height:16px;min-width:40px;max-width:200px;min-height:24px;max-height:40vh;overflow:hidden;padding:4px
+        8px;position:absolute;outline:1px solid transparent;text-align:center;width:-webkit-max-content;width:-moz-max-content;width:max-content;z-index:9}.peoplekitThemeDark
+        .peoplekitComponentsTooltipImplTooltip{background-color:var(--pkw-inverse-surface,rgb(60,64,67));color:var(--pkw-inverse-on-surface,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsTooltipImplTooltip{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem;border-radius:4px}.peoplekitComponentsButtonIconIconButton{background:none;border:none;border-radius:50%;cursor:pointer}.peoplekitComponentsButtonIconIconButton:hover{background-color:var(--pkw-background,rgb(218,220,224))}.peoplekitComponentsButtonIconIconButton:active{background-color:var(--pkw-background,rgb(189,193,198))}.peoplekitComponentsButtonIconIconButton::-moz-focus-inner{border:0}.peoplekitComponentsButtonIconIconButton.isFocused{background-color:var(--pkw-background,rgb(218,220,224));outline:3px
+        solid transparent}.peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity{height:40px;padding:8px;width:40px}.peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:24px;width:24px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity{height:32px;padding:6px;width:32px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:20px;width:20px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity{height:28px;padding:5px;width:28px}.peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:18px;width:18px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton{background:none;border:none;border-radius:50%;cursor:pointer}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton:hover{background-color:var(--pkw-background,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton:active{background-color:var(--pkw-background,rgb(128,134,139))}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton::-moz-focus-inner{border:0}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.isFocused{background-color:var(--pkw-background,rgb(95,99,104));outline:3px
+        solid transparent}.peoplekitThemeDark .peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity{height:40px;padding:8px;width:40px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.googleMaterialDefaultDensity .peoplekitComponentsButtonIconAdaptableIcon{height:24px;width:24px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity{height:32px;padding:6px;width:32px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialComfortableDensity
+        .peoplekitComponentsButtonIconAdaptableIcon{height:20px;width:20px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity{height:28px;padding:5px;width:28px}.peoplekitThemeDark
+        .peoplekitComponentsButtonIconIconButton.workspaceMaterialCompactDensity .peoplekitComponentsButtonIconAdaptableIcon{height:18px;width:18px}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50%;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsButtonIconIconButton:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton:hover:before{opacity:.16}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton:active:before{opacity:.2}.peopleKitStyleGm3
+        .peoplekitComponentsButtonIconIconButton.isFocused:before{opacity:.2}@media
+        (forced-colors:none){.peopleKitStyleGm3 .peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0)
+        saturate(100%) invert(25%) sepia(11%) saturate(129%) hue-rotate(109deg) brightness(93%)
+        contrast(86%);filter:brightness(0) saturate(100%) invert(25%) sepia(11%) saturate(129%)
+        hue-rotate(109deg) brightness(93%) contrast(86%)}.peoplekitThemeDark .peopleKitStyleGm3
+        .peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0) saturate(100%)
+        invert(88%) sepia(2%) saturate(246%) hue-rotate(87deg) brightness(92%) contrast(88%);filter:brightness(0)
+        saturate(100%) invert(88%) sepia(2%) saturate(246%) hue-rotate(87deg) brightness(92%)
+        contrast(88%)}}@media (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsButtonIconAdaptableIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsResultlistitemResultListItem{background:var(--pkw-background,#fff);display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;cursor:pointer}.peoplekitComponentsResultlistitemResultListItem:hover{background:var(--pkw-background,rgba(10,10,10,.04))}.peoplekitComponentsResultlistitemResultListItem:hover
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgb(241,243,244))}.peoplekitComponentsResultlistitemResultListItem.isActive{background:var(--pkw-background,rgba(10,10,10,.12));outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitComponentsResultlistitemResultListItem.isActive
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgb(241,243,244))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;cursor:pointer}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.14),rgba(232,234,237,.14)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem:hover .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgba(241,243,244,.14))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem.isActive{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124);outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitThemeDark .peoplekitComponentsResultlistitemResultListItem.isActive
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgba(241,243,244,.14))}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsResultlistitemResultListItem:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem:hover:before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.isActive:before{opacity:.1}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity{min-height:64px}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:400}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:0;font-weight:400}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemWhiteCheckSvg{width:24px;height:24px}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemMetaIcon{width:25px;height:25px}.peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity
+        .peoplekitComponentsResultlistitemResultListItemRow{padding:8px 16px}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.googleMaterialDefaultDensity{min-height:72px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity{min-height:52px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Roboto,Arial,sans-serif;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400;line-height:1.25rem}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Roboto,Arial,sans-serif;font-size:.75rem;letter-spacing:.025em;font-weight:400;line-height:1rem}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemWhiteCheckSvg{width:19px;height:19px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemMetaIcon{width:20px;height:20px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialComfortableDensity
+        .peoplekitComponentsResultlistitemResultListItemRow{padding-left:12px;padding-right:12px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity{min-height:44px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400;line-height:1.125}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemLabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400;line-height:.875rem}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemWhiteCheckSvg{width:17px;height:17px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemMetaIcon{width:20px;height:20px}.peoplekitComponentsResultlistitemResultListItem.workspaceMaterialCompactDensity
+        .peoplekitComponentsResultlistitemResultListItemRow{padding-left:12px;padding-right:12px}.peoplekitComponentsResultlistitemResultListItem.isDisabled{cursor:default}.peoplekitComponentsResultlistitemResultListItem.isDisabled
+        .peoplekitComponentsResultlistitemLabel,.peoplekitComponentsResultlistitemResultListItem.isDisabled
+        .peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface,rgb(60,64,67));opacity:.38}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem.isDisabled .peoplekitComponentsResultlistitemLabel,.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemResultListItem.isDisabled .peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface,rgb(232,234,237))}.peoplekitComponentsResultlistitemResultListItem.isDisabled
+        .peoplekitComponentsResultlistitemAvatar{opacity:.5}.peoplekitComponentsResultlistitemResultListItem.isSelected
+        .peoplekitComponentsResultlistitemAvatarSelectionOverlay{opacity:1;-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1)}.peoplekitComponentsResultlistitemResultListItem.isOutOfOffice{background-color:var(--pkw-caution-container-low,papayawhip)}.peoplekitComponentsResultlistitemResultListItemRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap}.peoplekitComponentsResultlistitemLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsResultlistitemCenter{-webkit-box-flex:1;-webkit-flex:auto;flex:auto;overflow:hidden}.peoplekitComponentsResultlistitemRight{display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsResultlistitemLabelContainer{-webkit-align-content:flex-start;align-content:flex-start;-webkit-box-align:start;-webkit-align-items:flex-start;align-items:flex-start;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-flow:column
+        nowrap;flex-flow:column nowrap;margin-right:0}.peopleKitStyleGm3 .peoplekitComponentsResultlistitemLabelContainer{margin-left:16px}.peoplekitComponentsResultlistitemLabelContainer{margin-left:12px}.peoplekitComponentsResultlistitemLabelRow{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;width:100%}.peoplekitComponentsResultlistitemLabel{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitComponentsResultlistitemLabelText{color:var(--pkw-on-surface,rgb(60,64,67));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemLabelText{color:var(--pkw-on-surface,rgb(232,234,237))}.peoplekitComponentsResultlistitemTags{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;-webkit-box-align:center;-webkit-align-items:center;align-items:center}.peoplekitComponentsResultlistitemSublabel{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface-variant,rgb(95,99,104));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemSublabelText{color:var(--pkw-on-surface-variant,rgb(154,160,166))}.peoplekitComponentsResultlistitemAvatar{position:relative}.peoplekitComponentsResultlistitemAvatarContainer{height:inherit;width:inherit;position:relative}.peoplekitComponentsResultlistitemAvatarSelectionOverlay{background-color:var(--pkw-primary,rgb(26,115,232));border-radius:50%;height:100%;left:0;opacity:0;outline:1px
+        solid transparent;position:absolute;top:0;-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);-webkit-transition:-webkit-transform
+        .15s ease-out;transition:-webkit-transform .15s ease-out;transition:transform
+        .15s ease-out;transition:transform .15s ease-out,-webkit-transform .15s ease-out;width:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemAvatarSelectionOverlay{background-color:var(--pkw-primary,rgb(138,180,248))}.peoplekitComponentsResultlistitemWhiteCheck{fill:var(--pkw-background,#fff);display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemWhiteCheck{fill:var(--pkw-background,rgb(32,33,36))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsResultlistitemWhiteCheck{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsResultlistitemWhiteCheck{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsResultlistitemOutOfOffice{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400;color:var(--pkw-on-surface-variant,rgb(95,99,104));overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:none}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemOutOfOffice{color:var(--pkw-on-surface-variant,rgb(154,160,166))}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemOutOfOffice{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsResultlistitemMetaIcon{margin-left:16px}.peoplekitComponentsResultlistitemMetaIcon[src=\"\"]{display:none}.peoplekitComponentsListImplList{list-style:none;margin:0;padding:0}.peoplekitComponentsListImplList:focus{outline:none}.peoplekitComponentsResultListCoreGroupSectionListContainer{overflow:hidden;-webkit-transform-origin:top;-ms-transform-origin:top;transform-origin:top;-webkit-transition:all
+        .5s cubic-bezier(.05,.7,.1,1);transition:all .5s cubic-bezier(.05,.7,.1,1)}.peoplekitComponentsResultListCoreGroupSectionListContainer.collapsed{height:0;-webkit-transform:scaleY(0);-ms-transform:scaleY(0);transform:scaleY(0);-webkit-transition:all
+        .2s cubic-bezier(.3,0,.8,.15);transition:all .2s cubic-bezier(.3,0,.8,.15)}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:hover{background:var(--pkw-background,rgba(10,10,10,.04))}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:active{background:var(--pkw-background,rgba(10,10,10,.12))}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.isSpotlit{background:var(--pkw-background,rgba(10,10,10,.12));outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.rotate{-webkit-transform:rotate(-180deg);-ms-transform:rotate(-180deg);transform:rotate(-180deg)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.14),rgba(232,234,237,.14)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:active{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.isSpotlit{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124);outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.rotate{-webkit-transform:rotate(-180deg);-ms-transform:rotate(-180deg);transform:rotate(-180deg)}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50%;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:hover:before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer:active:before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderCollapsibleChevronContainer.isSpotlit:before{opacity:.1}.peoplekitComponentsGroupingHeaderCollapsibleChevron{fill:var(--pkw-on-surface-variant,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderCollapsibleChevron{fill:var(--pkw-on-surface-variant,rgb(241,243,244))}.peoplekitComponentsButtonLabelLabelButton{font-family:Google
+        Sans,Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0178571429em;font-weight:500;-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:none;border:none;border-radius:4px;color:var(--pkw-primary,rgb(26,115,232));display:-webkit-box;display:-webkit-flex;display:flex;height:36px;line-height:unset;outline:1px
+        solid transparent;padding:0 8px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitComponentsButtonLabelLabelButton:hover{background-color:var(--pkw-surface-container-high,rgba(26,115,232,.04));color:var(--pkw-primary,rgb(23,78,166));cursor:pointer}.peoplekitComponentsButtonLabelLabelButton:focus{background-color:var(--pkw-surface-container-high,rgba(26,115,232,.12));color:var(--pkw-primary,rgb(23,78,166));cursor:pointer;outline-width:3px}.peoplekitComponentsButtonLabelLabelButton::-moz-focus-inner{border:0}.peoplekitComponentsButtonLabelLabelButton.isDisabled{color:var(--pkw-on-surface,rgb(60,64,67));opacity:.38}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton{-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:none;border:none;border-radius:4px;color:var(--pkw-primary,rgb(138,180,248));display:-webkit-box;display:-webkit-flex;display:flex;height:36px;line-height:unset;outline:1px
+        solid transparent;padding:0 8px;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton:hover{background-color:var(--pkw-surface-container-high,rgba(138,180,248,.04));color:var(--pkw-primary,rgb(210,227,252));cursor:pointer}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton:focus{background-color:var(--pkw-surface-container-high,rgba(138,180,248,.12));color:var(--pkw-primary,rgb(210,227,252));cursor:pointer;outline-width:3px}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton::-moz-focus-inner{border:0}.peoplekitThemeDark
+        .peoplekitComponentsButtonLabelLabelButton.isDisabled{color:var(--pkw-on-surface,rgb(232,234,237));opacity:.38}.peopleKitStyleGm3
+        .peoplekitComponentsButtonLabelLabelButton{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem;border-radius:20px;height:40px;padding:0
+        24px;position:relative}.peopleKitStyleGm3 .peoplekitComponentsButtonLabelLabelButton:before{background:var(--pkw-primary,var(--gm3-sys-color-primary,#0b57d0));border-radius:20px;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsButtonLabelLabelButton:before{background:var(--pkw-primary,var(--gm3-sys-color-primary,#a8c7fa))}.peopleKitStyleGm3
+        .peoplekitComponentsButtonLabelLabelButton:hover:before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsButtonLabelLabelButton:focus:before{opacity:.1}.peoplekitComponentsDialogImplScrim{background:var(--pkw-scrim,rgba(32,33,36,.6));-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-sizing:border-box;box-sizing:border-box;display:-webkit-box;display:-webkit-flex;display:flex;height:100%;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;left:0;position:fixed;top:0;width:100%;z-index:999999}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplScrim{background:var(--pkw-scrim,rgba(32,33,36,.6))}.peoplekitComponentsDialogImplDialog{border-width:0;-webkit-box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);background:var(--pkw-surface-container-high,#fff);text-wrap-mode:wrap;border-radius:8px;max-width:300px;outline:1px
+        solid transparent;overflow:hidden}.peoplekitComponentsDialogImplDialog .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplDialog{background:var(--pkw-surface-container-high,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peoplekitComponentsDialogImplDialog.peopleKitStyleGm3{-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);border-radius:28px;padding:24px}.peoplekitComponentsDialogImplAvatarHeader{background:var(--pkw-surface-container-high,#fff);border-bottom:1px
+        solid var(--pkw-outline-variant,rgb(218,220,224));display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;padding:12px}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplAvatarHeader{background:var(--pkw-surface-container-high,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);border-bottom:1px
+        solid var(--pkw-outline-variant,rgb(128,134,139))}.peopleKitStyleGm3 .peoplekitComponentsDialogImplAvatarHeader{padding:0
+        0 8px}.peoplekitComponentsDialogImplTextHeader{font-family:Google Sans,Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:500;background:var(--pkw-surface-container-high,#fff);color:var(--pkw-on-surface,rgb(32,33,36));margin:24px
+        24px 20px}.peoplekitThemeDark .peoplekitComponentsDialogImplTextHeader{background:var(--pkw-surface-container-high,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-surface,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplTextHeader{font-family:Google Sans,Roboto,Arial,sans-serif;font-size:1.5rem;font-weight:400;letter-spacing:0;line-height:2rem;margin:0}.peoplekitComponentsDialogImplHeaderRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap}.peoplekitComponentsDialogImplLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsDialogImplCenter{-webkit-box-flex:1;-webkit-flex:auto;flex:auto;overflow:hidden}.peoplekitComponentsDialogImplAvatar{position:relative}.peoplekitComponentsDialogImplAvatarContainer{height:inherit;position:relative;width:inherit}.peoplekitComponentsDialogImplLabelContainer{-webkit-align-content:flex-start;align-content:flex-start;-webkit-box-align:start;-webkit-align-items:flex-start;align-items:flex-start;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-flow:column
+        nowrap;flex-flow:column nowrap;margin-left:12px;margin-right:0}.peoplekitComponentsDialogImplLabelRow{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;width:100%}.peoplekitComponentsDialogImplLabel{font-family:Google
+        Sans,Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0178571429em;font-weight:500;color:var(--pkw-on-surface,rgb(32,33,36));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplLabel{color:var(--pkw-on-surface,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplLabel{font-family:Google Sans Text,Google Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsDialogImplSublabel{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400;color:var(--pkw-on-surface-variant,rgb(60,64,67));overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.peoplekitThemeDark
+        .peoplekitComponentsDialogImplSublabel{color:var(--pkw-on-surface-variant,rgb(154,160,166))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplSublabel{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:500;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsDialogImplContent{font-family:Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:400;color:var(--pkw-on-surface-variant,rgb(60,64,67));margin:24px
+        24px 20px}.peoplekitThemeDark .peoplekitComponentsDialogImplContent{color:var(--pkw-on-surface-variant,rgb(232,234,237))}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplContent{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem;margin:0;padding-top:16px;padding-bottom:24px}.peoplekitComponentsDialogImplActions{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-pack:end;-webkit-justify-content:flex-end;justify-content:flex-end;padding:8px}.peopleKitStyleGm3
+        .peoplekitComponentsDialogImplActions{padding:0}.peoplekitComponentsDialogImplActionDivider{width:8px}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer:hover{background:var(--pkw-background,rgba(10,10,10,.04))}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer:active{background:var(--pkw-background,rgba(10,10,10,.12))}.peoplekitComponentsGroupingHeaderInfoInfoIconContainer.isSpotlit{background:var(--pkw-background,rgba(10,10,10,.12));outline:3px
+        solid transparent;outline-offset:-3px}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderInfoInfoIconContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;border-radius:50%;cursor:pointer;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-transition:-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1);transition:-webkit-transform 365ms cubic-bezier(.4,0,.2,1);transition:transform
+        365ms cubic-bezier(.4,0,.2,1);transition:transform 365ms cubic-bezier(.4,0,.2,1),-webkit-transform
+        365ms cubic-bezier(.4,0,.2,1)}.peoplekitThemeDark .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:hover{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.14),rgba(232,234,237,.14)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:active{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer.isSpotlit{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.19),rgba(232,234,237,.19)),#202124);outline:3px
+        solid transparent;outline-offset:-3px}.peopleKitStyleGm3 .peoplekitComponentsGroupingHeaderInfoInfoIconContainer{position:relative}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#444746));border-radius:50%;content:\"\";height:100%;left:0;opacity:0;position:absolute;top:0;width:100%}.peoplekitThemeDark
+        .peopleKitStyleGm3 .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:before{background:var(--pkw-on-surface-variant,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:hover:before{opacity:.08}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer:active:before{opacity:.1}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderInfoInfoIconContainer.isSpotlit:before{opacity:.1}.peoplekitComponentsGroupingHeaderInfoLearnMoreLink{color:var(--pkw-primary,rgb(26,115,232));text-decoration:underline}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoLearnMoreLink{color:var(--pkw-primary,rgb(138,180,248))}.peoplekitComponentsGroupingHeaderInfoLearnMoreLink:visited{color:var(--pkw-primary,rgb(26,115,232))}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoLearnMoreLink:visited{color:var(--pkw-primary,rgb(138,180,248))}.peoplekitComponentsGroupingHeaderInfoInfoIcon{fill:var(--pkw-on-surface-variant,rgb(95,99,104));height:16px;padding:5px;width:16px}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderInfoInfoIcon{fill:var(--pkw-on-surface-variant,rgb(241,243,244))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsGroupingHeaderInfoInfoIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsGroupingHeaderInfoInfoIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitComponentsGroupingHeaderGroupingHeader{background:var(--pkw-background,#fff)}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderGroupingHeader{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peoplekitComponentsGroupingHeaderGroupingHeaderRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-flow:row
+        nowrap;flex-flow:row nowrap;padding-left:16px;padding-right:16px}.peoplekitComponentsGroupingHeaderHeader{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.6875rem;letter-spacing:.0727272727em;font-weight:500;text-transform:uppercase;color:var(--pkw-on-surface-variant,rgb(95,99,104));padding-bottom:11px;padding-top:13px}.peoplekitThemeDark
+        .peoplekitComponentsGroupingHeaderHeader{color:var(--pkw-on-surface-variant,rgb(241,243,244))}.peopleKitStyleGm3
+        .peoplekitComponentsGroupingHeaderHeader{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem;text-transform:none;padding:6px
+        0}.peoplekitComponentsGroupingHeaderAction{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1}.peoplekitComponentsGroupingHeaderActionRow{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between}.peoplekitComponentsGroupingHeaderLeft{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial}.peoplekitComponentsGroupingHeaderRight{-webkit-box-flex:initial;-webkit-flex:initial;flex:initial;margin-left:16px;margin-right:4px}.peoplekitComponentsTagTag{background:rgb(241,243,244);color:rgb(32,33,36);display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:horizontal;-webkit-box-direction:normal;-webkit-flex-direction:row;flex-direction:row;-webkit-box-align:center;-webkit-align-items:center;align-items:center;margin-left:8px;border-radius:4px;outline:1px
+        solid transparent;overflow:hidden;position:relative}.peoplekitComponentsTagTag.isWarning{background:#fbbc04;color:rgb(32,33,36)}.peopleKitStyleGm3
+        .peoplekitComponentsTagTag{background:var(--gm3-sys-color-surface-container-high,#e9eef6);color:var(--gm3-sys-color-on-surface-variant,#444746)}.peopleKitStyleGm3
+        .peoplekitComponentsTagTag.isWarning{background:#ffbb29;color:var(--gm3-sys-color-on-surface,#1f1f1f)}@media
+        (forced-colors:none){.peopleKitStyleGm3 .peoplekitComponentsTagIcon.isWarning{-webkit-filter:brightness(0)
+        saturate(100%) invert(0) sepia(7%) saturate(1357%) hue-rotate(335deg) brightness(112%)
+        contrast(76%);filter:brightness(0) saturate(100%) invert(0) sepia(7%) saturate(1357%)
+        hue-rotate(335deg) brightness(112%) contrast(76%)}}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagTag{height:20px;min-width:20px}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagTag,.workspaceMaterialCompactDensity .peoplekitComponentsTagTag{height:16px;min-width:16px}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagIcon{width:16px;height:16px;margin-left:2px;font-size:16px}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagIcon,.workspaceMaterialCompactDensity .peoplekitComponentsTagIcon{width:14px;height:14px;margin-left:1px;font-size:14px}.peoplekitComponentsTagUnrollingAltText{max-width:0;overflow:hidden;-webkit-transition:max-width
+        .3s;transition:max-width .3s}.peoplekitComponentsTagTag:hover .peoplekitComponentsTagUnrollingAltText{max-width:1000px}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsTagIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}.peoplekitComponentsTagText{margin-left:4px;margin-right:4px}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagText{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0178571429em;font-weight:500}.googleMaterialDefaultDensity
+        .peoplekitComponentsTagText.peopleKitStyleGm3{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagText{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400}.workspaceMaterialComfortableDensity
+        .peoplekitComponentsTagText.peopleKitStyleGm3{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.workspaceMaterialCompactDensity
+        .peoplekitComponentsTagText{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.75rem;letter-spacing:.025em;font-weight:400}.workspaceMaterialCompactDensity
+        .peoplekitComponentsTagText.peopleKitStyleGm3{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.75rem;font-weight:400;letter-spacing:.00625rem;line-height:1rem}.peoplekitComponentsResultlistitemDisabledDisableReasonContainer{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex}.peoplekitComponentsResultlistitemDisabledTextIndicator{font-family:Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:400;color:var(--pkw-on-surface,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemDisabledTextIndicator{color:var(--pkw-on-surface,#fff)}.peopleKitStyleGm3
+        .peoplekitComponentsResultlistitemDisabledTextIndicator{font-family:Google
+        Sans Text,Google Sans,Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:0;font-weight:400}.peoplekitComponentsResultlistitemDisabledIconIndicator{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;background:var(--pkw-background,rgb(241,243,244));border-radius:50px;width:32px;height:32px;margin-left:16px;margin-right:4px}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemDisabledIconIndicator{background:var(--pkw-background,rgba(241,243,244,.14))}.peoplekitComponentsResultlistitemDisabledSelectedIcon{fill:var(--pkw-on-surface-variant,rgb(95,99,104))}.peoplekitThemeDark
+        .peoplekitComponentsResultlistitemDisabledSelectedIcon{fill:var(--pkw-on-surface-variant,rgb(232,234,237))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.peoplekitComponentsResultlistitemDisabledSelectedIcon{-webkit-filter:brightness(0)
+        invert(1);filter:brightness(0) invert(1)}}@media (forced-colors:active) and
+        (prefers-color-scheme:light){.peoplekitComponentsResultlistitemDisabledSelectedIcon{-webkit-filter:brightness(0);filter:brightness(0)}}.peoplekitUiResultlistHeader{font-family:Roboto,Arial,sans-serif;line-height:1rem;font-size:.6875rem;letter-spacing:.0727272727em;font-weight:500;text-transform:uppercase;background:var(--pkw-background,#fff);color:var(--pkw-on-surface-variant,rgb(95,99,104));padding-bottom:12px;padding-left:16px;padding-top:12px}.peoplekitThemeDark
+        .peoplekitUiResultlistHeader{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124);color:var(--pkw-on-surface-variant,rgb(241,243,244))}.peopleKitStyleGm3
+        .peoplekitUiResultlistHeader{font-family:Google Sans Text,Google Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:500;letter-spacing:0;line-height:1.25rem;text-transform:none}.peoplekitComponentsAutocompleteInlineContainer{background:var(--pkw-background,#fff);height:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;overflow:hidden;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peoplekitThemeDark
+        .peoplekitComponentsAutocompleteInlineContainer{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineListContainer,.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineNoResultsContainer{display:none}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineCircularProgress{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center;height:100%}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineCircularProgress:before{-webkit-box-flex:1;-webkit-flex:auto;flex:auto}.peoplekitComponentsAutocompleteInlineContainer.isLoading
+        .peoplekitComponentsAutocompleteInlineCircularProgress:after{-webkit-box-flex:1;-webkit-flex:auto;flex:auto}.peoplekitComponentsAutocompleteInlineContainer.noResults
+        .peoplekitComponentsAutocompleteInlineCircularProgress,.peoplekitComponentsAutocompleteInlineContainer.noResults
+        .peoplekitComponentsAutocompleteInlineListContainer{display:none}.peoplekitComponentsAutocompleteInlineContainer.noResults
+        .peoplekitComponentsAutocompleteInlineNoResultsContainer{display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;-webkit-box-pack:start;-webkit-justify-content:flex-start;justify-content:flex-start;-webkit-box-align:center;-webkit-align-items:center;align-items:center;height:100%;overflow:auto}.peoplekitComponentsAutocompleteInlineListContainer{height:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;overflow:hidden}.peoplekitComponentsAutocompleteInlineCircularProgress,.peoplekitComponentsAutocompleteInlineNoResultsContainer{display:none}.peoplekitComponentsCircularprogressCircularProgress{display:inline-block;height:40px;position:relative;width:40px;direction:ltr}.peoplekitComponentsCircularprogressMessageContainer{height:0;overflow:hidden;position:absolute;width:0}.peoplekitComponentsCircularprogressCircularProgressContainer{width:100%;height:100%}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressContainer{-webkit-animation:circular-progress-container-rotate
+        1568ms linear infinite;animation:circular-progress-container-rotate 1568ms
+        linear infinite}.peoplekitComponentsCircularprogressCircularProgressLayer{height:100%;opacity:0;position:absolute;width:100%}.peoplekitComponentsCircularprogressColorOne{border-color:#4285f4}.peoplekitComponentsCircularprogressColorTwo{border-color:#ea4335}.peoplekitComponentsCircularprogressColorThree{border-color:#fbbc04}.peoplekitComponentsCircularprogressColorFour{border-color:#34a853}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorOne{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-blue-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-blue-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorTwo{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-red-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-red-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorThree{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-yellow-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-yellow-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircularProgressLayer.peoplekitComponentsCircularprogressColorFour{-webkit-animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-green-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-fill-unfill-rotate
+        5332ms cubic-bezier(.4,0,.2,1) infinite both,circular-progress-green-fade-in-out
+        5332ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressGapPatch{position:absolute;-webkit-box-sizing:border-box;box-sizing:border-box;top:0;left:45%;width:10%;height:100%;overflow:hidden;border-color:inherit}.peoplekitComponentsCircularprogressGapPatch
+        .peoplekitComponentsCircularprogressCircle{width:1000%;left:-450%}.peoplekitComponentsCircularprogressCircleClipper{display:inline-block;position:relative;width:50%;height:100%;overflow:hidden;border-color:inherit}.peoplekitComponentsCircularprogressCircleClipper
+        .peoplekitComponentsCircularprogressCircle{width:200%}.peoplekitComponentsCircularprogressCircle{position:absolute;top:0;right:0;bottom:0;left:0;-webkit-box-sizing:border-box;box-sizing:border-box;height:100%;border-width:3px;border-style:solid;border-color:inherit;border-bottom-color:transparent;border-radius:50%;-webkit-animation:none;animation:none}.peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressLeft
+        .peoplekitComponentsCircularprogressCircle{border-right-color:transparent;-webkit-transform:rotate(129deg);-ms-transform:rotate(129deg);transform:rotate(129deg)}.peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressRight
+        .peoplekitComponentsCircularprogressCircle{left:-100%;border-left-color:transparent;-webkit-transform:rotate(-129deg);-ms-transform:rotate(-129deg);transform:rotate(-129deg)}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressLeft
+        .peoplekitComponentsCircularprogressCircle{-webkit-animation:circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-left-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isActive
+        .peoplekitComponentsCircularprogressCircleClipper.peoplekitComponentsCircularprogressRight
+        .peoplekitComponentsCircularprogressCircle{-webkit-animation:circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both;animation:circular-progress-right-spin
+        1333ms cubic-bezier(.4,0,.2,1) infinite both}.peoplekitComponentsCircularprogressCircularProgress.isWarmdown
+        .peoplekitComponentsCircularprogressCircularProgressContainer{-webkit-animation:circular-progress-container-rotate
+        1568ms linear infinite,circular-progress-fade-out .4s cubic-bezier(.4,0,.2,1);animation:circular-progress-container-rotate
+        1568ms linear infinite,circular-progress-fade-out .4s cubic-bezier(.4,0,.2,1)}@-webkit-keyframes
+        circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        circular-progress-container-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@-webkit-keyframes
+        circular-progress-fill-unfill-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@keyframes
+        circular-progress-fill-unfill-rotate{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@-webkit-keyframes
+        circular-progress-blue-fade-in-out{0%{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}to{opacity:.99}}@keyframes
+        circular-progress-blue-fade-in-out{0%{opacity:.99}25%{opacity:.99}26%{opacity:0}89%{opacity:0}90%{opacity:.99}to{opacity:.99}}@-webkit-keyframes
+        circular-progress-red-fade-in-out{0%{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}}@keyframes
+        circular-progress-red-fade-in-out{0%{opacity:0}15%{opacity:0}25%{opacity:.99}50%{opacity:.99}51%{opacity:0}}@-webkit-keyframes
+        circular-progress-yellow-fade-in-out{0%{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}}@keyframes
+        circular-progress-yellow-fade-in-out{0%{opacity:0}40%{opacity:0}50%{opacity:.99}75%{opacity:.99}76%{opacity:0}}@-webkit-keyframes
+        circular-progress-green-fade-in-out{0%{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}to{opacity:0}}@keyframes
+        circular-progress-green-fade-in-out{0%{opacity:0}65%{opacity:0}75%{opacity:.99}90%{opacity:.99}to{opacity:0}}@-webkit-keyframes
+        circular-progress-left-spin{0%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}50%{-webkit-transform:rotate(-5deg);transform:rotate(-5deg)}to{-webkit-transform:rotate(130deg);transform:rotate(130deg)}}@keyframes
+        circular-progress-left-spin{0%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}50%{-webkit-transform:rotate(-5deg);transform:rotate(-5deg)}to{-webkit-transform:rotate(130deg);transform:rotate(130deg)}}@-webkit-keyframes
+        circular-progress-right-spin{0%{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}50%{-webkit-transform:rotate(5deg);transform:rotate(5deg)}to{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}}@keyframes
+        circular-progress-right-spin{0%{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}50%{-webkit-transform:rotate(5deg);transform:rotate(5deg)}to{-webkit-transform:rotate(-130deg);transform:rotate(-130deg)}}@-webkit-keyframes
+        circular-progress-fade-out{0%{opacity:.99}to{opacity:0}}@keyframes circular-progress-fade-out{0%{opacity:.99}to{opacity:0}}.peoplekitComponentsScrollboxScrollbar{border:none;outline:none;overflow:auto}.peoplekitComponentsNoResultsMessageNoResultsMessage{color:var(--pkw-on-surface,rgb(95,99,104));padding:2em;text-align:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center}.peoplekitThemeDark
+        .peoplekitComponentsNoResultsMessageNoResultsMessage{color:var(--pkw-on-surface,rgb(154,160,166))}.peoplekitComponentsNoResultsMessageHeader{font-family:Google
+        Sans,Roboto,Arial,sans-serif;line-height:1.5rem;font-size:1rem;letter-spacing:.00625em;font-weight:500}.peopleKitStyleGm3
+        .peoplekitComponentsNoResultsMessageHeader{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:1rem;font-weight:500;letter-spacing:0;line-height:1.5rem}.peoplekitComponentsNoResultsMessageExplanation{font-family:Roboto,Arial,sans-serif;line-height:1.25rem;font-size:.875rem;letter-spacing:.0142857143em;font-weight:400}.peopleKitStyleGm3
+        .peoplekitComponentsNoResultsMessageExplanation{font-family:Google Sans Text,Google
+        Sans,Roboto,Arial,sans-serif;font-size:.875rem;font-weight:400;letter-spacing:0;line-height:1.25rem}.peoplekitComponentsNoResultsMessageLearnMoreLink{color:inherit;text-decoration:underline;white-space:nowrap}.peoplekitComponentsAutocompletePopupContainer{border-width:0;-webkit-box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);background:var(--pkw-background,#fff);border-radius:4px;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;outline:2px
+        solid transparent;padding-bottom:8px;padding-top:8px;position:absolute;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;z-index:999999}.peoplekitComponentsAutocompletePopupContainer
+        .mdc-elevation-overlay{opacity:0}.peoplekitThemeDark .peoplekitComponentsAutocompletePopupContainer{background:var(--pkw-background,linear-gradient(0deg,rgba(232,234,237,.08),rgba(232,234,237,.08)),#202124)}.peopleKitStyleGm3
+        .peoplekitComponentsAutocompletePopupContainer{-webkit-box-shadow:0 2px 6px
+        2px rgba(0,0,0,.15),0 1px 2px 0 rgba(0,0,0,.3);box-shadow:0 2px 6px 2px rgba(0,0,0,.15),0
+        1px 2px 0 rgba(0,0,0,.3)}.peopleShareKitThemesThemes{--md-sys-color-background:#fff;--md-sys-color-error:#b3261e;--md-sys-color-error-container:#f9dedc;--md-sys-color-inverse-on-surface:#f2f2f2;--md-sys-color-inverse-primary:#a8c7fa;--md-sys-color-inverse-surface:#303030;--md-sys-color-on-background:#1f1f1f;--md-sys-color-on-error:#fff;--md-sys-color-on-error-container:#410e0b;--md-sys-color-on-primary:#fff;--md-sys-color-on-primary-container:#041e49;--md-sys-color-on-primary-fixed:#041e49;--md-sys-color-on-primary-fixed-variant:#0842a0;--md-sys-color-on-secondary:#fff;--md-sys-color-on-secondary-container:#001d35;--md-sys-color-on-secondary-fixed:#001d35;--md-sys-color-on-secondary-fixed-variant:#004a77;--md-sys-color-on-surface:#1f1f1f;--md-sys-color-on-surface-variant:#444746;--md-sys-color-on-tertiary:#fff;--md-sys-color-on-tertiary-container:#072711;--md-sys-color-on-tertiary-fixed:#072711;--md-sys-color-on-tertiary-fixed-variant:#0f5223;--md-sys-color-outline:#747775;--md-sys-color-outline-variant:#c4c7c5;--md-sys-color-primary:#0b57d0;--md-sys-color-primary-container:#d3e3fd;--md-sys-color-primary-fixed:#d3e3fd;--md-sys-color-primary-fixed-dim:#a8c7fa;--md-sys-color-scrim:#000;--md-sys-color-secondary:#00639b;--md-sys-color-secondary-container:#c2e7ff;--md-sys-color-secondary-fixed:#c2e7ff;--md-sys-color-secondary-fixed-dim:#7fcfff;--md-sys-color-shadow:#000;--md-sys-color-surface:#fff;--md-sys-color-surface-bright:#fff;--md-sys-color-surface-container:#f0f4f9;--md-sys-color-surface-container-high:#e9eef6;--md-sys-color-surface-container-highest:#dde3ea;--md-sys-color-surface-container-low:#f8fafd;--md-sys-color-surface-container-lowest:#fff;--md-sys-color-surface-dim:#d3dbe5;--md-sys-color-surface-tint:#6991d6;--md-sys-color-surface-variant:#e1e3e1;--md-sys-color-tertiary:#146c2e;--md-sys-color-tertiary-container:#c4eed0;--md-sys-color-tertiary-fixed:#c4eed0;--md-sys-color-tertiary-fixed-dim:#6dd58c;--md-ref-typeface-brand:Google
+        Sans;--md-ref-typeface-plain:\"Google Sans Text\",\"Google Sans\";--md-ref-typeface-weight-bold:700;--md-ref-typeface-weight-medium:500;--md-ref-typeface-weight-regular:400;--md-sys-typescale-body-large-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-body-large-line-height:1.5rem;--md-sys-typescale-body-large-size:1rem;--md-sys-typescale-body-large-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-body-medium-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-body-medium-line-height:1.25rem;--md-sys-typescale-body-medium-size:0.875rem;--md-sys-typescale-body-medium-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-body-small-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-body-small-line-height:1rem;--md-sys-typescale-body-small-size:0.75rem;--md-sys-typescale-body-small-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-display-large-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-display-large-line-height:4rem;--md-sys-typescale-display-large-size:3.5625rem;--md-sys-typescale-display-large-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-display-medium-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-display-medium-line-height:3.25rem;--md-sys-typescale-display-medium-size:2.8125rem;--md-sys-typescale-display-medium-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-display-small-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-display-small-line-height:2.75rem;--md-sys-typescale-display-small-size:2.25rem;--md-sys-typescale-display-small-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-headline-large-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-headline-large-line-height:2.5rem;--md-sys-typescale-headline-large-size:2rem;--md-sys-typescale-headline-large-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-headline-medium-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-headline-medium-line-height:2.25rem;--md-sys-typescale-headline-medium-size:1.75rem;--md-sys-typescale-headline-medium-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-headline-small-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-headline-small-line-height:2rem;--md-sys-typescale-headline-small-size:1.5rem;--md-sys-typescale-headline-small-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-label-large-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-label-large-line-height:1.25rem;--md-sys-typescale-label-large-size:0.875rem;--md-sys-typescale-label-large-weight:var(--md-ref-typeface-weight-medium,500);--md-sys-typescale-label-large-weight-prominent:var(--md-ref-typeface-weight-bold,700);--md-sys-typescale-label-medium-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-label-medium-line-height:1rem;--md-sys-typescale-label-medium-size:0.75rem;--md-sys-typescale-label-medium-weight:var(--md-ref-typeface-weight-medium,500);--md-sys-typescale-label-medium-weight-prominent:var(--md-ref-typeface-weight-bold,700);--md-sys-typescale-label-small-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-label-small-line-height:1rem;--md-sys-typescale-label-small-size:0.6875rem;--md-sys-typescale-label-small-weight:var(--md-ref-typeface-weight-medium,500);--md-sys-typescale-title-large-font:var(--md-ref-typeface-brand,Google
+        Sans);--md-sys-typescale-title-large-line-height:1.75rem;--md-sys-typescale-title-large-size:1.375rem;--md-sys-typescale-title-large-weight:var(--md-ref-typeface-weight-regular,400);--md-sys-typescale-title-medium-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-title-medium-line-height:1.5rem;--md-sys-typescale-title-medium-size:1rem;--md-sys-typescale-title-medium-weight:var(--md-ref-typeface-weight-medium,500);--md-sys-typescale-title-small-font:var(--md-ref-typeface-plain,\"Google
+        Sans Text\",\"Google Sans\");--md-sys-typescale-title-small-line-height:1.25rem;--md-sys-typescale-title-small-size:0.875rem;--md-sys-typescale-title-small-weight:var(--md-ref-typeface-weight-medium,500);--ski-color-primary:var(--skw-color-primary,var(--md-sys-color-primary));--ski-color-surface-tint:var(\n
+        \   --skw-color-surface-tint,var(--md-sys-color-surface-tint)\n  );--ski-color-on-primary:var(\n
+        \   --skw-color-on-primary,var(--md-sys-color-on-primary)\n  );--ski-color-primary-container:var(\n
+        \   --skw-color-primary-container,var(--md-sys-color-primary-container)\n
+        \ );--ski-color-on-primary-container:var(\n    --skw-color-on-primary-container,var(--md-sys-color-on-primary-container)\n
+        \ );--ski-color-secondary:var(\n    --skw-color-secondary,var(--md-sys-color-secondary)\n
+        \ );--ski-color-on-secondary:var(\n    --skw-color-on-secondary,var(--md-sys-color-on-secondary)\n
+        \ );--ski-color-secondary-container:var(\n    --skw-color-secondary-container,var(--md-sys-color-secondary-container)\n
+        \ );--ski-color-on-secondary-container:var(\n    --skw-color-on-secondary-container,var(--md-sys-color-on-secondary-container)\n
+        \ );--ski-color-tertiary:var(--skw-color-tertiary,var(--md-sys-color-tertiary));--ski-color-on-tertiary:var(\n
+        \   --skw-color-on-tertiary,var(--md-sys-color-on-tertiary)\n  );--ski-color-tertiary-container:var(\n
+        \   --skw-color-tertiary-container,var(--md-sys-color-tertiary-container)\n
+        \ );--ski-color-on-tertiary-container:var(\n    --skw-color-on-tertiary-container,var(--md-sys-color-on-tertiary-container)\n
+        \ );--ski-color-error:var(--skw-color-error,var(--md-sys-color-error));--ski-color-on-error:var(--skw-color-on-error,var(--md-sys-color-on-error));--ski-color-error-container:var(\n
+        \   --skw-color-error-container,var(--md-sys-color-error-container)\n  );--ski-color-on-error-container:var(\n
+        \   --skw-color-on-error-container,var(--md-sys-color-on-error-container)\n
+        \ );--ski-color-background:var(\n    --skw-color-background,var(--md-sys-color-background)\n
+        \ );--ski-color-on-background:var(\n    --skw-color-on-background,var(--md-sys-color-on-background)\n
+        \ );--ski-color-surface:var(--skw-color-surface,var(--md-sys-color-surface));--ski-color-surface1:var(\n
+        \   --skw-color-surface1,var(--md-sys-color-surface-container-low)\n  );--ski-color-on-surface:var(\n
+        \   --skw-color-on-surface,var(--md-sys-color-on-surface)\n  );--ski-color-surface-variant:var(\n
+        \   --skw-color-surface-variant,var(--md-sys-color-surface-variant)\n  );--ski-color-on-surface-variant:var(\n
+        \   --skw-color-on-surface-variant,var(--md-sys-color-on-surface-variant)\n
+        \ );--ski-color-outline:var(--skw-color-outline,var(--md-sys-color-outline));--ski-color-outline-variant:var(\n
+        \   --skw-color-outline-variant,var(--md-sys-color-outline-variant)\n  );--ski-color-tonal-outline:var(\n
+        \   --skw-color-tonal-outline,var(--md-sys-color-inverse-primary)\n  );--ski-color-shadow:var(--skw-color-shadow,var(--md-sys-color-shadow));--ski-color-scrim:var(--skw-color-scrim,var(--md-sys-color-scrim));--ski-color-inverse-surface:var(\n
+        \   --skw-color-inverse-surface,var(--md-sys-color-inverse-surface)\n  );--ski-color-inverse-on-surface:var(\n
+        \   --skw-color-inverse-on-surface,var(--md-sys-color-inverse-on-surface)\n
+        \ );--ski-color-inverse-primary:var(\n    --skw-color-inverse-primary,var(--md-sys-color-inverse-primary)\n
+        \ );--ski-color-primary-fixed:var(\n    --skw-color-primary-fixed,var(--md-sys-color-primary-fixed)\n
+        \ );--ski-color-on-primary-fixed:var(\n    --skw-color-on-primary-fixed,var(--md-sys-color-on-primary-fixed)\n
+        \ );--ski-color-primary-fixed-dim:var(\n    --skw-color-primary-fixed-dim,var(--md-sys-color-primary-fixed-dim)\n
+        \ );--ski-color-on-primary-fixed-variant:var(\n    --skw-color-on-primary-fixed-variant,var(--md-sys-color-on-primary-fixed-variant)\n
+        \ );--ski-color-secondary-fixed:var(\n    --skw-color-secondary-fixed,var(--md-sys-color-secondary-fixed)\n
+        \ );--ski-color-on-secondary-fixed:var(\n    --skw-color-on-secondary-fixed,var(--md-sys-color-on-secondary-fixed)\n
+        \ );--ski-color-secondary-fixed-dim:var(\n    --skw-color-secondary-fixed-dim,var(--md-sys-color-secondary-fixed-dim)\n
+        \ );--ski-color-on-secondary-fixed-variant:var(\n    --skw-color-on-secondary-fixed-variant,var(--md-sys-color-on-secondary-fixed-variant)\n
+        \ );--ski-color-tertiary-fixed:var(\n    --skw-color-tertiary-fixed,var(--md-sys-color-tertiary-fixed)\n
+        \ );--ski-color-on-tertiary-fixed:var(\n    --skw-color-on-tertiary-fixed,var(--md-sys-color-on-tertiary-fixed)\n
+        \ );--ski-color-tertiary-fixed-dim:var(\n    --skw-color-tertiary-fixed-dim,var(--md-sys-color-tertiary-fixed-dim)\n
+        \ );--ski-color-on-tertiary-fixed-variant:var(\n    --skw-color-on-tertiary-fixed-variant,var(--md-sys-color-on-tertiary-fixed-variant)\n
+        \ );--ski-color-surface-dim:var(\n    --skw-color-surface-dim,var(--md-sys-color-surface-dim)\n
+        \ );--ski-color-surface-bright:var(\n    --skw-color-surface-bright,var(--md-sys-color-surface-bright)\n
+        \ );--ski-color-surface-container-lowest:var(\n    --skw-color-surface-container-lowest,var(--md-sys-color-surface-container-lowest)\n
+        \ );--ski-color-surface-container-low:var(\n    --skw-color-surface-container-low,var(--md-sys-color-surface-container-low)\n
+        \ );--ski-color-surface-container:var(\n    --skw-color-surface-container,var(--md-sys-color-surface-container)\n
+        \ );--ski-color-surface-container-high:var(\n    --skw-color-surface-container-high,var(--md-sys-color-surface-container-high)\n
+        \ );--ski-color-surface-container-highest:var(\n    --skw-color-surface-container-highest,var(--md-sys-color-surface-container-highest)\n
+        \ );--ski-typescale-title-small-font:var(\n    --skw-font,var(--md-sys-typescale-title-small-font)\n
+        \ );--ski-typescale-title-small-size:var(--md-sys-typescale-title-small-size);--ski-typescale-title-small-weight:var(\n
+        \   --md-sys-typescale-title-small-weight\n  );--ski-typescale-title-small-line-height:var(\n
+        \   --md-sys-typescale-title-small-line-height\n  );--ski-typescale-title-small:var(--ski-typescale-title-small-weight)
+        var(--ski-typescale-title-small-size) /var(--ski-typescale-title-small-line-height)
+        var(--ski-typescale-title-small-font);--ski-typescale-title-medium-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-title-medium-font)\n  );--ski-typescale-title-medium-size:var(--md-sys-typescale-title-medium-size);--ski-typescale-title-medium-weight:var(\n
+        \   --md-sys-typescale-title-medium-weight\n  );--ski-typescale-title-medium-line-height:var(\n
+        \   --md-sys-typescale-title-medium-line-height\n  );--ski-typescale-title-medium:var(--ski-typescale-title-medium-weight)
+        var(--md-sys-typescale-title-medium-size) /var(--md-sys-typescale-title-medium-line-height)
+        var(--ski-typescale-title-medium-font);--ski-typescale-title-large-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-title-large-font)\n  );--ski-typescale-title-large-size:var(--md-sys-typescale-title-large-size);--ski-typescale-title-large-weight:var(\n
+        \   --md-sys-typescale-title-large-weight\n  );--ski-typescale-title-large-line-height:var(\n
+        \   --md-sys-typescale-title-large-line-height\n  );--ski-typescale-title-large:var(--ski-typescale-title-large-weight)
+        var(--md-sys-typescale-title-large-size) /var(--md-sys-typescale-title-large-line-height)
+        var(--ski-typescale-title-large-font);--ski-typescale-label-small-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-label-small-font)\n  );--ski-typescale-label-small-size:var(--md-sys-typescale-label-small-size);--ski-typescale-label-small-weight:var(\n
+        \   --md-sys-typescale-label-small-weight\n  );--ski-typescale-label-small-line-height:var(\n
+        \   --md-sys-typescale-label-small-line-height\n  );--ski-typescale-label-small:var(--ski-typescale-label-small-weight)
+        var(--md-sys-typescale-label-small-size) /var(--md-sys-typescale-label-small-line-height)
+        var(--ski-typescale-label-small-font);--ski-typescale-label-medium-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-label-medium-font)\n  );--ski-typescale-label-medium-size:var(--md-sys-typescale-label-medium-size);--ski-typescale-label-medium-weight:var(\n
+        \   --md-sys-typescale-label-medium-weight\n  );--ski-typescale-label-medium-line-height:var(\n
+        \   --md-sys-typescale-label-medium-line-height\n  );--ski-typescale-label-medium:var(--ski-typescale-label-medium-weight)
+        var(--md-sys-typescale-label-medium-size) /var(--md-sys-typescale-label-medium-line-height)
+        var(--ski-typescale-label-medium-font);--ski-typescale-label-large-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-label-large-font)\n  );--ski-typescale-label-large-size:var(--md-sys-typescale-label-large-size);--ski-typescale-label-large-weight:var(\n
+        \   --md-sys-typescale-label-large-weight\n  );--ski-typescale-label-large-line-height:var(\n
+        \   --md-sys-typescale-label-large-line-height\n  );--ski-typescale-label-large:var(--ski-typescale-label-large-weight)
+        var(--md-sys-typescale-label-large-size) /var(--md-sys-typescale-label-large-line-height)
+        var(--ski-typescale-label-large-font);--ski-typescale-body-extra-small:400
+        0.6875rem/1rem var(--skw-font,var(--md-sys-typescale-body-small-font));--ski-typescale-body-small-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-body-small-font)\n  );--ski-typescale-body-small-size:var(--md-sys-typescale-body-small-size);--ski-typescale-body-small-weight:var(--md-sys-typescale-body-small-weight);--ski-typescale-body-small-line-height:var(\n
+        \   --md-sys-typescale-body-small-line-height\n  );--ski-typescale-body-small:var(--ski-typescale-body-small-weight)
+        var(--md-sys-typescale-body-small-size) /var(--md-sys-typescale-body-small-line-height)
+        var(--ski-typescale-body-small-font);--ski-typescale-body-regular:400 0.8125rem/1.25rem
+        var(--skw-font,var(--md-sys-typescale-body-small-font));--ski-typescale-body-medium-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-body-medium-font)\n  );--ski-typescale-body-medium-size:var(--md-sys-typescale-body-medium-size);--ski-typescale-body-medium-weight:var(\n
+        \   --md-sys-typescale-body-medium-weight\n  );--ski-typescale-body-medium-line-height:var(\n
+        \   --md-sys-typescale-body-medium-line-height\n  );--ski-typescale-body-medium:var(--ski-typescale-body-medium-weight)
+        var(--md-sys-typescale-body-medium-size) /var(--md-sys-typescale-body-medium-line-height)
+        var(--ski-typescale-body-medium-font);--ski-typescale-body-large-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-body-large-font)\n  );--ski-typescale-body-large-size:var(--md-sys-typescale-body-large-size);--ski-typescale-body-large-weight:var(--md-sys-typescale-body-large-weight);--ski-typescale-body-large-line-height:var(\n
+        \   --md-sys-typescale-body-large-line-height\n  );--ski-typescale-body-large:var(--ski-typescale-body-large-weight)
+        var(--md-sys-typescale-body-large-size) /var(--md-sys-typescale-body-large-line-height)
+        var(--skw-font,var(--md-sys-typescale-body-large-font));--ski-typescale-headline-small:var(--md-sys-typescale-headline-small-weight)
+        var(--md-sys-typescale-headline-small-size) /var(--md-sys-typescale-headline-small-line-height)
+        var(--skw-font,var(--md-sys-typescale-headline-small-font));--ski-typescale-headline-small-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-headline-small-font)\n  );--ski-typescale-headline-small-size:var(\n
+        \   --md-sys-typescale-headline-small-size\n  );--ski-typescale-headline-small-weight:var(\n
+        \   --md-sys-typescale-headline-small-weight\n  );--ski-typescale-headline-small-line-height:var(\n
+        \   --md-sys-typescale-headline-small-line-height\n  );--ski-typescale-headline-medium:var(\n
+        \     --md-sys-typescale-headline-medium-weight\n    ) var(--md-sys-typescale-headline-medium-size)
+        /var(--md-sys-typescale-headline-medium-line-height) var(--skw-font,var(--md-sys-typescale-headline-medium-font));--ski-typescale-headline-medium-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-headline-medium-font)\n  );--ski-typescale-headline-medium-size:var(\n
+        \   --md-sys-typescale-headline-medium-size\n  );--ski-typescale-headline-medium-weight:var(\n
+        \   --md-sys-typescale-headline-medium-weight\n  );--ski-typescale-headline-medium-line-height:var(\n
+        \   --md-sys-typescale-headline-medium-line-height\n  );--ski-typescale-headline-large:var(--md-sys-typescale-headline-large-weight)
+        var(--md-sys-typescale-headline-large-size) /var(--md-sys-typescale-headline-large-line-height)
+        var(--skw-font,var(--md-sys-typescale-headline-large-font));--ski-typescale-headline-large-font:var(\n
+        \   --skw-font,var(--md-sys-typescale-headline-large-font)\n  );--ski-typescale-headline-large-size:var(\n
+        \   --md-sys-typescale-headline-large-size\n  );--ski-typescale-headline-large-weight:var(\n
+        \   --md-sys-typescale-headline-large-weight\n  );--ski-typescale-headline-large-line-height:var(\n
+        \   --md-sys-typescale-headline-large-line-height\n  );--ski-actions-right-gap:1rem;--ski-app-sharing-container-background:initial;--ski-app-sharing-icon-background-color:initial;--ski-app-sharing-icon-color:initial;--ski-applicant-request-review-container-header-padding:0
+        1.5rem 0.75rem;--ski-applicant-request-review-info-label-font:initial;--ski-applicant-request-review-info-sublabel-font:initial;--ski-applicant-request-review-label-title-typescale:initial;--ski-button-container-height:initial;--ski-button-hover-elevation:1;--ski-button-leading-icon-leading-space:initial;--ski-button-leading-icon-trailing-space:initial;--ski-button-leading-space:initial;--ski-button-trailing-space:initial;--ski-internal-button-container-height:2.5rem;--ski-internal-button-leading-space:0.75rem;--ski-internal-button-trailing-space:0.75rem;--ski-outlined-button-outline-color:initial;--ski-container-footer-components-border-top:none;--ski-container-footer-components-scroll-border-top:none;--ski-container-footer-components-padding:1.5rem;--ski-container-footer-components-background:initial;--ski-container-footer-components-scroll-background:initial;--ski-container-header-components-border-bottom:none;--ski-container-header-components-scroll-border-bottom:none;--ski-container-header-components-box-shadow:0px
+        1px 3px 1px rgba(60,64,67,0.15),0px 1px 2px 0px rgba(60,64,67,0.3);--ski-container-header-components-padding-bottom:0.375rem;--ski-container-header-components-padding-inline:1.5rem
+        1.25rem;--ski-container-header-components-padding-top:1.375rem;--ski-container-height:max-content;--ski-container-max-height:80vh;--ski-container-min-height:initial;--ski-container-scrollable-components-gap:initial;--ski-container-scrollable-components-no-header-padding:1.5rem
+        0;--ski-container-scrollable-components-padding:0 0 1.5rem;--ski-container-scrollable-components-grid-template-columns:1fr;--ski-copy-link-bar-button-text-color:initial;--ski-copy-link-bar-container-background:initial;--ski-copy-link-bar-container-margin:1rem
+        1.5rem 0;--ski-copy-link-bar-container-padding:0.75rem 0;--ski-copy-link-bar-content-background:initial;--ski-copy-link-bar-content-margin:0
+        1rem;--ski-copy-link-bar-content-padding:0.5rem;--ski-description-container-margin:0
+        1.5rem;--ski-description-placeholder-height:initial;--ski-dialog-background-color:initial;--ski-dialog-border-radius:1.75rem;--ski-dialog-container-width:27.5rem;--ski-embedded-container-padding-horizontal:1.5rem;--ski-embedded-container-padding-vertical:1.5rem;--ski-group-preview-group-width:23rem;--ski-header-button-container-gap:1rem;--ski-header-icon-button-icon-color:initial;--ski-header-icon-button-icon-size:1.5rem;--ski-header-icon-button-size:2rem;--ski-header-menu-button-container-width:2.5rem;--ski-header-title-font:initial;--ski-link-copy-container-background:initial;--ski-link-copy-container-border-radius:1.25rem;--ski-link-copy-container-gap:1rem;--ski-link-copy-container-justify-content:start;--ski-link-copy-container-padding:1rem;--ski-link-copy-container-shape:1.25rem;--ski-link-copy-focus-icon-color:initial;--ski-link-copy-focus-label-color:initial;--ski-link-copy-hover-icon-color:initial;--ski-link-copy-hover-label-color:initial;--ski-link-copy-hover-state-layer-color:initial;--ski-link-copy-icon-color:initial;--ski-link-copy-label-color:initial;--ski-link-copy-margin-top:0.5rem;--ski-link-copy-padding:1rem;--ski-link-copy-pressed-icon-color:initial;--ski-link-copy-pressed-label-color:initial;--ski-link-copy-pressed-state-layer-color:initial;--ski-link-preview-container-padding-vertical:1.5rem;--ski-membership-preview-avatar-height:2.5rem;--ski-membership-preview-avatar-width:2.5rem;--ski-membership-preview-container-gap:1rem;--ski-membership-preview-container-padding:0.5rem
+        0;--ski-membership-preview-label-font:initial;--ski-menu-bottom-space:initial;--ski-menu-container-color:var(\n
+        \   --skw-color-surface-container,var(--md-sys-color-surface-container)\n
+        \ );--ski-menu-container-shape:0.25rem;--ski-menu-min-width:fit-content;--ski-menu-top-space:initial;--ski-menu-item-bottom-space:initial;--ski-menu-item-label-text-line-height:initial;--ski-menu-item-label-text-size:initial;--ski-menu-item-label-text-weight:initial;--ski-menu-item-one-line-container-height:initial;--ski-menu-item-top-space:initial;--ski-mobile-container-max-height:100vh;--ski-notification-dialog-container-color:initial;--ski-notification-dialog-container-shape:0.75rem;--ski-notification-dialog-content-font:initial;--ski-notification-dialog-scrim-opacity:32%;--ski-notification-dialog-title-font:initial;--ski-notification-dialog-width:fit-content;--ski-people-with-access-container-header-padding:0
+        1.5rem 0.75rem;--ski-people-with-access-container-padding:0;--ski-people-with-access-info-label-font:initial;--ski-people-with-access-info-sublabel-font:initial;--ski-people-with-access-label-title-typescale:initial;--ski-circular-progress-active-indicator-color:var(--md-sys-color-primary);--ski-circular-progress-size:3rem;--ski-circular-progress-thickness:initial;--ski-circular-progress-in-container-size:2.25rem;--ski-circular-progress-in-button-size:1.35rem;--ski-status-manager-container-background:initial;--ski-status-manager-container-border-radius:1.25rem;--ski-status-manager-container-margin:1rem
+        1.5rem 0;--ski-status-manager-container-padding:0.75rem 0;--ski-status-manager-content-margin:0
+        1rem;--ski-status-manager-content-padding:0.5rem;--ski-status-manager-current-status-color:initial;--ski-status-manager-edit-status-button-color:initial}@media
+        (prefers-color-scheme:dark){.peopleShareKitThemesThemes{--md-sys-color-background:#131314;--md-sys-color-error:#f2b8b5;--md-sys-color-error-container:#8c1d18;--md-sys-color-inverse-on-surface:#303030;--md-sys-color-inverse-primary:#0b57d0;--md-sys-color-inverse-surface:#e3e3e3;--md-sys-color-on-background:#e3e3e3;--md-sys-color-on-error:#601410;--md-sys-color-on-error-container:#f9dedc;--md-sys-color-on-primary:#062e6f;--md-sys-color-on-primary-container:#d3e3fd;--md-sys-color-on-primary-fixed:#041e49;--md-sys-color-on-primary-fixed-variant:#0842a0;--md-sys-color-on-secondary:#035;--md-sys-color-on-secondary-container:#c2e7ff;--md-sys-color-on-secondary-fixed:#001d35;--md-sys-color-on-secondary-fixed-variant:#004a77;--md-sys-color-on-surface:#e3e3e3;--md-sys-color-on-surface-variant:#c4c7c5;--md-sys-color-on-tertiary:#0a3818;--md-sys-color-on-tertiary-container:#c4eed0;--md-sys-color-on-tertiary-fixed:#072711;--md-sys-color-on-tertiary-fixed-variant:#0f5223;--md-sys-color-outline:#8e918f;--md-sys-color-outline-variant:#444746;--md-sys-color-primary:#a8c7fa;--md-sys-color-primary-container:#0842a0;--md-sys-color-primary-fixed:#d3e3fd;--md-sys-color-primary-fixed-dim:#a8c7fa;--md-sys-color-scrim:#000;--md-sys-color-secondary:#7fcfff;--md-sys-color-secondary-container:#004a77;--md-sys-color-secondary-fixed:#c2e7ff;--md-sys-color-secondary-fixed-dim:#7fcfff;--md-sys-color-shadow:#000;--md-sys-color-surface:#131314;--md-sys-color-surface-bright:#37393b;--md-sys-color-surface-container:#1e1f20;--md-sys-color-surface-container-high:#282a2c;--md-sys-color-surface-container-highest:#333537;--md-sys-color-surface-container-low:#1b1b1b;--md-sys-color-surface-container-lowest:#0e0e0e;--md-sys-color-surface-dim:#131314;--md-sys-color-surface-tint:#d1e1ff;--md-sys-color-surface-variant:#444746;--md-sys-color-tertiary:#6dd58c;--md-sys-color-tertiary-container:#0f5223;--md-sys-color-tertiary-fixed:#c4eed0;--md-sys-color-tertiary-fixed-dim:#6dd58c}}.peopleSharekitUiCommonButtonsButton{--md-focus-ring-color:var(--ski-color-secondary);--md-elevated-button-container-color:var(--ski-color-surface);--md-elevated-button-container-shadow-color:var(--ski-color-shadow);--md-elevated-button-disabled-container-color:var(--ski-color-on-surface);--md-elevated-button-disabled-label-text-color:var(--ski-color-on-surface);--md-elevated-button-focus-label-text-color:var(--ski-color-primary);--md-elevated-button-focus-state-layer-color:var(--ski-color-primary);--md-elevated-button-hover-label-text-color:var(--ski-color-primary);--md-elevated-button-hover-state-layer-color:var(--ski-color-primary);--md-elevated-button-label-text-color:var(--ski-color-primary);--md-elevated-button-label-text-font:var(--ski-typescale-label-large-font);--md-elevated-button-pressed-label-text-color:var(--ski-color-primary);--md-elevated-button-pressed-state-layer-color:var(--ski-color-primary);--md-elevated-button-with-icon-disabled-icon-color:var(\n
+        \   --ski-color-on-surface\n  );--md-elevated-button-with-icon-focus-icon-color:var(--ski-color-primary);--md-elevated-button-with-icon-hover-icon-color:var(--ski-color-primary);--md-elevated-button-with-icon-icon-color:var(--ski-color-primary);--md-elevated-button-with-icon-pressed-icon-color:var(--ski-color-primary);--md-filled-button-container-color:var(--ski-color-primary);--md-filled-button-container-height:var(--ski-button-container-height);--md-filled-button-container-shadow-color:var(--ski-color-shadow);--md-filled-button-disabled-container-color:var(--ski-color-on-surface);--md-filled-button-disabled-label-text-color:var(--ski-color-on-surface);--md-filled-button-focus-label-text-color:var(--ski-color-on-primary);--md-filled-button-focus-state-layer-color:var(--ski-color-on-primary);--md-filled-button-hover-container-elevation:var(\n
+        \   --ski-button-hover-elevation\n  );--md-filled-button-hover-label-text-color:var(--ski-color-on-primary);--md-filled-button-hover-state-layer-color:var(--ski-color-on-primary);--md-filled-button-label-text-color:var(--ski-color-on-primary);--md-filled-button-label-text-font:var(--ski-typescale-label-large-font);--md-filled-button-label-text-size:var(--ski-typescale-label-large-size);--md-filled-button-leading-space:var(--ski-button-leading-space);--md-filled-button-trailing-space:var(--ski-button-trailing-space);--md-filled-button-pressed-label-text-color:var(--ski-color-on-primary);--md-filled-button-pressed-state-layer-color:var(--ski-color-on-primary);--md-filled-button-disabled-icon-color:var(--ski-color-on-surface);--md-filled-button-icon-color:var(--ski-color-on-primary);--md-filled-button-focus-icon-color:var(--ski-color-on-primary);--md-filled-button-hover-icon-color:var(--ski-color-on-primary);--md-filled-button-pressed-icon-color:var(--ski-color-on-primary);--md-filled-button-with-icon-disabled-icon-color:var(\n
+        \   --ski-color-on-surface\n  );--md-filled-button-with-icon-focus-icon-color:var(--ski-color-on-primary);--md-filled-button-with-icon-hover-icon-color:var(--ski-color-on-primary);--md-filled-button-with-icon-icon-color:var(--ski-color-on-primary);--md-filled-button-with-icon-pressed-icon-color:var(\n
+        \   --ski-color-on-primary\n  );--md-filled-tonal-button-container-color:var(\n
+        \   --ski-color-secondary-container\n  );--md-filled-tonal-button-container-height:var(\n
+        \   --ski-button-container-height\n  );--md-filled-tonal-button-container-shadow-color:var(--ski-color-shadow);--md-filled-tonal-button-disabled-container-color:var(\n
+        \   --ski-color-on-surface\n  );--md-filled-tonal-button-disabled-label-text-color:var(\n
+        \   --ski-color-on-surface\n  );--md-filled-tonal-button-focus-label-text-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-focus-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-hover-container-elevation:var(\n
+        \   --ski-button-hover-elevation\n  );--md-filled-tonal-button-hover-label-text-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-hover-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-label-text-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-label-text-font:var(\n
+        \   --ski-typescale-label-large-font\n  );--md-filled-tonal-button-label-text-size:var(\n
+        \   --ski-typescale-label-large-size\n  );--md-filled-tonal-button-leading-space:var(--ski-button-leading-space);--md-filled-tonal-button-trailing-space:var(--ski-button-trailing-space);--md-filled-tonal-button-pressed-label-text-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-pressed-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-with-icon-disabled-icon-color:var(\n
+        \   --ski-color-on-surface\n  );--md-filled-tonal-button-with-icon-focus-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-with-icon-hover-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-with-icon-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-button-with-icon-pressed-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-container-color:var(\n
+        \   --ski-color-secondary-container\n  );--md-filled-tonal-icon-button-disabled-container-color:var(\n
+        \   --ski-color-on-surface\n  );--md-filled-tonal-icon-button-disabled-icon-color:var(\n
+        \   --ski-color-on-surface\n  );--md-filled-tonal-icon-button-focus-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-focus-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-hover-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-hover-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-pressed-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-pressed-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-selected-container-color:var(\n
+        \   --ski-color-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-focus-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-focus-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-hover-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-hover-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-pressed-icon-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-selected-pressed-state-layer-color:var(\n
+        \   --ski-color-on-secondary-container\n  );--md-filled-tonal-icon-button-toggle-unselected-focus-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-focus-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-hover-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-hover-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-pressed-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-pressed-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-tonal-icon-button-toggle-unselected-container-color:var(\n
+        \   --ski-color-surface-container-highest\n  );--md-outlined-button-container-height:var(--ski-button-container-height);--md-outlined-button-disabled-label-text-color:var(--ski-color-on-surface);--md-outlined-button-disabled-outline-color:var(--ski-color-on-surface);--md-outlined-button-focus-label-text-color:var(--ski-color-primary);--md-outlined-button-focus-outline-color:var(--ski-color-outline);--md-outlined-button-focus-state-layer-color:var(--ski-color-primary);--md-outlined-button-hover-label-text-color:var(--ski-color-primary);--md-outlined-button-hover-outline-color:var(--ski-color-outline);--md-outlined-button-hover-state-layer-color:var(--ski-color-primary);--md-outlined-button-label-text-color:var(--ski-color-primary);--md-outlined-button-label-text-font:var(--ski-typescale-label-large-font);--md-outlined-button-label-text-size:var(--ski-typescale-label-large-size);--md-outlined-button-leading-space:var(--ski-button-leading-space);--md-outlined-button-trailing-space:var(--ski-button-trailing-space);--md-outlined-button-outline-color:var(\n
+        \   --ski-outlined-button-outline-color,var(--ski-color-outline)\n  );--md-outlined-button-pressed-label-text-color:var(--ski-color-primary);--md-outlined-button-pressed-outline-color:var(\n
+        \   --ski-outlined-button-outline-color,var(--ski-color-outline)\n  );--md-outlined-button-pressed-state-layer-color:var(--ski-color-primary);--md-outlined-button-with-leading-icon-leading-space:var(\n
+        \   --ski-button-leading-icon-leading-space\n  );--md-outlined-button-with-leading-icon-trailing-space:var(\n
+        \   --ski-button-leading-icon-trailing-space\n  );--md-outlined-button-disabled-icon-color:var(--ski-color-on-surface);--md-outlined-button-focus-icon-color:var(--ski-color-primary);--md-outlined-button-hover-icon-color:var(--ski-color-primary);--md-outlined-button-icon-color:var(--ski-color-primary);--md-outlined-button-pressed-icon-color:var(--ski-color-primary);--md-text-button-disabled-label-text-color:var(--ski-color-on-surface);--md-text-button-focus-label-text-color:var(--ski-color-primary);--md-text-button-focus-state-layer-color:var(--ski-color-primary);--md-text-button-hover-label-text-color:var(--ski-color-primary);--md-text-button-hover-state-layer-color:var(--ski-color-primary);--md-text-button-label-text-color:var(--ski-color-primary);--md-text-button-label-text-font:var(--ski-typescale-label-large-font);--md-text-button-pressed-label-text-color:var(--ski-color-primary);--md-text-button-pressed-state-layer-color:var(--ski-color-primary);--md-text-button-with-icon-disabled-icon-color:var(--ski-color-on-surface);--md-text-button-with-icon-focus-icon-color:var(--ski-color-primary);--md-text-button-with-icon-hover-icon-color:var(--ski-color-primary);--md-text-button-with-icon-icon-color:var(--ski-color-primary);--md-text-button-with-icon-pressed-icon-color:var(--ski-color-primary);--md-text-button-icon-color:var(--ski-color-primary);--md-text-button-disabled-icon-color:var(--ski-color-on-surface);--md-text-button-focus-icon-color:var(--ski-color-primary);--md-text-button-hover-icon-color:var(--ski-color-primary);--md-text-button-pressed-icon-color:var(--ski-color-primary);--md-icon-button-icon-color:var(--ski-color-on-surface-variant);--md-icon-button-disabled-icon-color:var(--ski-color-on-surface);--md-icon-button-focus-icon-color:var(--ski-color-on-surface-variant);--md-icon-button-hover-icon-color:var(--ski-color-on-surface-variant);--md-icon-button-pressed-icon-color:var(--ski-color-on-surface-variant);--md-icon-button-focus-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-icon-button-hover-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-icon-button-pressed-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );display:-webkit-box;display:-webkit-flex;display:flex}.peopleSharekitUiCommonButtonsIconButton{--md-focus-ring-outward-offset:-0.125rem;--md-focus-ring-width:0.125rem}.peopleSharekitUiCommonSnackbarSnackbar{bottom:0;display:grid;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;left:0;margin:1.5rem;position:fixed;right:0;z-index:9999999}.peopleSharekitUiCommonSnackbarSnackbarSurface{-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:var(--ski-color-inverse-surface);border-radius:4px;-webkit-box-shadow:0
+        1px 3px 0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);box-shadow:0 1px 3px
+        0 rgba(0,0,0,.3),0 4px 8px 3px rgba(0,0,0,.15);display:grid;gap:.25rem;grid-auto-flow:column;height:3rem;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;outline:1px
+        solid transparent;padding:.25rem .5rem .25rem 1rem;width:min(21.5rem,90vw)}.peopleSharekitUiCommonSnackbarSnackbarMessage{color:var(--ski-color-inverse-on-surface);font:var(--ski-typescale-body-medium,initial)}.peopleSharekitUiCommonSnackbarSnackbarButtonsContainer{display:grid;grid-auto-flow:column}.peopleSharekitUiCommonSnackbarSnackbarButton{--md-text-button-focus-label-text-color:var(--ski-color-inverse-primary);--md-text-button-hover-label-text-color:var(--ski-color-inverse-primary);--md-text-button-hover-state-layer-color:var(--ski-color-inverse-primary);--md-text-button-label-text-color:var(--ski-color-inverse-primary);--md-text-button-pressed-label-text-color:var(--ski-color-inverse-primary);--md-text-button-pressed-state-layer-color:var(--ski-color-inverse-primary)}.peopleSharekitContainerContainer{border-radius:var(--ski-dialog-border-radius);display:grid;outline:none;overflow:hidden}.peopleSharekitContainerComponents{display:grid;grid-template-rows:auto
+        1fr auto;height:var(--ski-container-height);max-height:var(--ski-container-max-height);min-height:var(--ski-container-min-height)}@media
+        screen and (max-width:520px){.peopleSharekitContainerComponentsMobile{max-height:var(--ski-mobile-container-max-height)}}.peopleSharekitContainerHeaderComponents{border-bottom:var(--ski-container-header-components-border-bottom);padding-bottom:var(--ski-container-header-components-padding-bottom);padding-inline:var(--ski-container-header-components-padding-inline);padding-top:var(--ski-container-header-components-padding-top)}.peopleSharekitContainerHeaderComponentsHidden{visibility:hidden}.peopleSharekitContainerHeaderComponentsScroll{border-bottom:var(--ski-container-header-components-scroll-border-bottom);-webkit-box-shadow:var(--ski-container-header-components-box-shadow);box-shadow:var(--ski-container-header-components-box-shadow)}.peopleSharekitContainerScrollableComponents{-webkit-align-content:start;align-content:start;display:grid;grid-template-columns:var(--ski-container-scrollable-components-grid-template-columns);gap:var(--ski-container-scrollable-components-gap);overflow:hidden
+        auto}.peopleSharekitContainerScrollableComponentsHidden{visibility:hidden}.peopleSharekitContainerScrollableComponentsPadding{padding:var(--ski-container-scrollable-components-padding)}.peopleSharekitContainerScrollableComponentsNoHeaderPadding{padding:var(--ski-container-scrollable-components-no-header-padding)}.peopleSharekitContainerScrollableComponentsAdaptiveSize{grid-template-columns:1fr}.peopleSharekitContainerFooterComponents{background:var(--ski-container-footer-components-background);border-top:var(--ski-container-footer-components-border-top);padding:var(--ski-container-footer-components-padding)}.peopleSharekitContainerFooterComponentsScroll{background:var(--ski-container-footer-components-scroll-background,var(--ski-color-surface-container-high));border-top:var(--ski-container-footer-components-scroll-border-top)}.peopleSharekitContainerFooterComponentsHidden{visibility:hidden}.peopleSharekitNotificationCircularProgress{border-radius:var(--ski-dialog-border-radius);left:0;overflow:hidden;position:absolute;top:0;width:100%;z-index:9999;display:grid;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:var(--ski-dialog-background-color,var(--ski-color-surface-container-low))}.peopleSharekitNotificationCircularProgressShowHeader{height:calc(100%
+        - 4.5rem);margin-top:4.5rem}.peopleSharekitNotificationCircularProgressHideHeader{height:100%}.peopleSharekitNotificationCircularSpinner{height:2.25rem;width:2.25rem;--md-circular-progress-size:2.25rem}.peopleSharekitNotificationLinearProgress{border-radius:var(--ski-dialog-border-radius);height:100%;left:0;overflow:hidden;position:absolute;top:0;width:100%;z-index:9999;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column}.peopleSharekitNotificationLinearScrim{background:var(--ski-dialog-background-color,var(--ski-color-surface-container-low));opacity:.2;-webkit-flex-basis:100%;flex-basis:100%}.peopleSharekitUiCommonProgressProgress{display:grid;--md-circular-progress-active-indicator-color:var(\n
+        \   --ski-circular-progress-active-indicator-color\n  )}.peopleSharekitUiCommonProgressLinear{width:100%;--md-linear-progress-track-color:var(\n
+        \   --ski-color-surface-container-highest\n  );--md-linear-progress-active-indicator-color:var(--ski-color-primary)}.peopleSharekitUiCommonLoadingButtonsButtonHidden{visibility:hidden;grid-area:1/1}.peopleSharekitUiCommonLoadingButtonsButtonLoading{grid-area:1/1;height:var(--ski-button-container-height);width:auto;--md-circular-progress-size:2rem}.peopleSharekitUiCommonLoadingButtonsContainer{display:grid}.peopleSharekitUiCommonLoadingButtonsFilledLoadingButton{border-radius:9999px;outline:1px
+        solid transparent;--md-filled-icon-button-disabled-container-color:var(--ski-color-primary);--md-filled-icon-button-disabled-container-opacity:1;--md-filled-icon-button-disabled-icon-opacity:1;--md-filled-icon-button-icon-size:1.35rem}.peopleSharekitUiCommonLoadingButtonsFilledLoadingButtonProgress{--md-circular-progress-active-indicator-color:var(\n
+        \   --ski-color-on-primary\n  )}.peopleSharekitUiCommonLoadingButtonsOutlinedLoadingButton{--md-outlined-icon-button-disabled-icon-opacity:1;--md-outlined-icon-button-disabled-outline-color:var(\n
+        \   --ski-outlined-button-outline-color,var(--ski-color-outline)\n  );--md-outlined-icon-button-disabled-outline-opacity:1;--md-outlined-icon-button-icon-size:1.35rem}.peopleSharekitUiCommonLoadingButtonsOutlinedLoadingButtonProgress{--md-circular-progress-active-indicator-color:var(--ski-color-primary)}.peopleSharekitUiCommonLoadingButtonsTonalLoadingButton{border-radius:9999px;outline:1px
+        solid transparent;--md-filled-tonal-icon-button-disabled-container-color:var(\n
+        \   --ski-color-secondary-container\n  );--md-filled-tonal-icon-button-disabled-container-opacity:1;--md-filled-tonal-icon-button-disabled-icon-opacity:1;--md-filled-tonal-icon-button-icon-size:1.35rem}.peopleSharekitUiCommonLoadingButtonsTonalLoadingButtonProgress{--md-circular-progress-active-indicator-color:var(\n
+        \   --ski-color-on-secondary-container\n  )}.peopleSharekitUiCommonLoadingButtonsIconLoadingButton{border-radius:9999px;outline:1px
+        solid transparent;--md-icon-button-disabled-icon-opacity:1;--md-icon-button-icon-size:1.35rem}.peopleSharekitUiCommonLoadingButtonsIconLoadingButtonProgress{--md-circular-progress-active-indicator-color:var(\n
+        \   --ski-color-on-primary\n  )}.peopleSharekitUiCommonDialogDialog{display:inherit;width:var(--ski-notification-dialog-width);--md-dialog-action-focus-label-text-color:var(--ski-color-primary);--md-dialog-action-focus-state-layer-color:var(--ski-color-primary);--md-dialog-action-hover-label-text-color:var(--ski-color-primary);--md-dialog-action-hover-state-layer-color:var(--ski-color-primary);--md-dialog-action-label-text-color:var(--ski-color-primary);--md-dialog-action-pressed-label-text-color:var(--ski-color-primary);--md-dialog-action-pressed-state-layer-color:var(--ski-color-primary);--md-dialog-container-color:var(\n
+        \   --ski-notification-dialog-container-color,var(--ski-color-surface-container)\n
+        \ );--md-dialog-container-shape:var(--ski-notification-dialog-container-shape);--md-dialog-headline-color:var(--ski-color-on-surface);--md-dialog-headline-font:var(--ski-typescale-headline-small-font);--md-dialog-supporting-text-color:var(--ski-color-on-surface-variant);--md-dialog-supporting-text-font:var(--ski-typescale-body-medium-font);--md-dialog-with-icon-icon-color:var(--ski-color-secondary);--md-divider-color:var(--ski-color-primary-container)}.peopleSharekitUiCommonDialogHeader{padding:1.25rem
+        1.25rem 0}.peopleSharekitUiCommonDialogTitle{color:var(--ski-color-on-surface);font:var(--ski-notification-dialog-title-font)}.peopleSharekitUiCommonDialogContent{color:var(--ski-color-on-surface-variant);font:var(--ski-notification-dialog-content-font)}.peopleSharekitUiCommonDialogContentContainer{padding:.5rem
+        1.25rem}.peopleSharekitUiCommonDialogLink{color:var(--ski-color-primary);text-decoration:underline;text-underline-position:under}.peopleSharekitUiCommonDialogButtonsContainer{padding:.5rem
+        1.25rem 1.25rem}.peopleSharekitUiDialogScrim{-webkit-box-align:center;-webkit-align-items:center;align-items:center;background:color-mix(in
+        srgb,var(--ski-color-scrim) 32%,var(--ski-color-scrim) 32%);-webkit-box-sizing:border-box;box-sizing:border-box;display:-webkit-box;display:-webkit-flex;display:flex;height:max(100%,100vh);-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;left:0;position:fixed;top:0;width:100%;z-index:999999}.peopleSharekitUiDialogContainer{border-width:0;-webkit-box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);box-shadow:0
+        1px 3px 0 rgba(60,64,67,.3),0 4px 8px 3px rgba(60,64,67,.15);background:var(--ski-dialog-background-color,var(--ski-color-surface-container-low));border-radius:var(--ski-dialog-border-radius);-webkit-box-shadow:0
+        .25rem .5rem .1875rem rgba(0,0,0,.15),0 .0625rem .1875rem 0 rgba(0,0,0,.3);box-shadow:0
+        .25rem .5rem .1875rem rgba(0,0,0,.15),0 .0625rem .1875rem 0 rgba(0,0,0,.3);-webkit-box-sizing:border-box;box-sizing:border-box;outline:1px
+        solid transparent;position:relative;width:var(--ski-dialog-container-width)}.peopleSharekitUiDialogContainer
+        .mdc-elevation-overlay{opacity:0}@-webkit-keyframes slideUp{0%{-webkit-transform:translateY(100%);transform:translateY(100%);opacity:0}to{-webkit-transform:translateY(0);transform:translateY(0);opacity:1}}@keyframes
+        slideUp{0%{-webkit-transform:translateY(100%);transform:translateY(100%);opacity:0}to{-webkit-transform:translateY(0);transform:translateY(0);opacity:1}}@media
+        screen and (max-width:520px){.peopleSharekitUiDialogContainerMobile{position:fixed;bottom:0;border-bottom-left-radius:0;border-bottom-right-radius:0;max-height:100%;max-width:100%;-webkit-animation:slideUp
+        .5s ease-in-out forwards;animation:slideUp .5s ease-in-out forwards;-webkit-transform:translateY(100%);-ms-transform:translateY(100%);transform:translateY(100%)}}.peopleSharekitUiDialogContainerAdaptiveSize{width:auto;height:auto}.peopleSharekitUiCommonInternalButtonButtonContent{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;gap:.5rem;grid-area:1/1;-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;min-width:calc(4rem
+        - var(--ski-internal-button-leading-space) - var(--ski-internal-button-trailing-space));text-decoration:none;text-wrap:nowrap;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;white-space:nowrap;width:100%}.peopleSharekitUiCommonInternalButtonButtonContentIsLoading{visibility:hidden}.peopleSharekitUiCommonInternalButtonProgressContainer{--ski-circular-progress-thickness:0.15rem;display:grid;grid-area:1/1;place-items:center}.peopleSharekitUiCommonInternalButtonFilled{background-color:var(--ski-color-primary);color:var(--ski-color-on-primary)}.peopleSharekitUiCommonInternalButtonFilled:hover{background-color:color-mix(in
+        srgb,var(--ski-color-on-primary) 8%,var(--ski-color-primary))}.peopleSharekitUiCommonInternalButtonFilled:active{background-color:color-mix(in
+        srgb,var(--ski-color-on-primary) 12%,var(--ski-color-primary))}.peopleSharekitUiCommonInternalButtonFilled:disabled{background:color-mix(in
+        srgb,var(--ski-color-on-surface) 12%,transparent);color:color-mix(in srgb,var(--ski-color-on-surface)
+        38%,transparent)}.peopleSharekitUiCommonInternalButtonFilledLoading:disabled{background:var(--ski-color-primary)}.peopleSharekitUiCommonInternalButtonFilledProgress{--ski-circular-progress-size:var(--ski-circular-progress-in-button-size);--ski-circular-progress-active-indicator-color:var(\n
+        \   --ski-color-on-primary\n  )}.peopleSharekitUiCommonInternalButtonOutlined{background:transparent;color:var(--ski-color-primary)}.peopleSharekitUiCommonInternalButtonOutlined:after{border-radius:inherit;content:\"\";inset:0;outline:var(--ski-color-outline)
+        1px solid;position:absolute}.peopleSharekitUiCommonInternalButtonOutlined:hover{background:color-mix(in
+        srgb,var(--ski-color-primary) 8%,transparent)}.peopleSharekitUiCommonInternalButtonOutlined:active{background:color-mix(in
+        srgb,var(--ski-color-primary) 12%,transparent)}.peopleSharekitUiCommonInternalButtonOutlined:disabled{color:color-mix(in
+        srgb,var(--ski-color-on-surface) 38%,transparent)}.peopleSharekitUiCommonInternalButtonOutlined:disabled:after{outline:color-mix(in
+        srgb,var(--ski-color-on-surface) 12%,transparent) 1px solid}.peopleSharekitUiCommonInternalButtonOutlinedLoading:disabled:after{outline:var(--ski-color-outline)
+        1px solid}.peopleSharekitUiCommonInternalButtonOutlinedProgress{--ski-circular-progress-active-indicator-color:var(--ski-color-primary);--ski-circular-progress-size:var(--ski-circular-progress-in-button-size)}.peopleSharekitUiCommonInternalButtonsSharedButton{-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:grid;border:none;border-radius:6.25rem;cursor:pointer;font:var(--ski-typescale-label-large);height:var(--ski-internal-button-container-height);-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;outline:none;padding-inline:var(--ski-internal-button-leading-space)
+        var(--ski-internal-button-trailing-space);position:relative}.peopleSharekitUiCommonInternalButtonsSharedButton:disabled{pointer-events:none}.peopleSharekitUiCommonInternalButtonsSharedButton:focus-visible{inset:0;outline:.188rem
+        solid var(--ski-color-secondary);outline-offset:.125rem}.peopleSharekitUiCommonInternalButtonText{background:transparent;color:var(--ski-color-primary)}.peopleSharekitUiCommonInternalButtonText:hover{background:color-mix(in
+        srgb,var(--ski-color-primary) 8%,transparent)}.peopleSharekitUiCommonInternalButtonText:active{background:color-mix(in
+        srgb,var(--ski-color-primary) 12%,transparent)}.peopleSharekitUiCommonInternalButtonText:disabled{color:color-mix(in
+        srgb,var(--ski-color-on-surface) 38%,transparent)}.peopleSharekitUiCommonInternalButtonTextProgress{--ski-circular-progress-active-indicator-color:var(--ski-color-primary);--ski-circular-progress-size:var(--ski-circular-progress-in-button-size)}.peopleSharekitUiCommonInternalButtonTonal{background:var(--ski-color-secondary-container);color:var(--ski-color-on-secondary-container)}.peopleSharekitUiCommonInternalButtonTonal:hover{background:color-mix(in
+        srgb,var(--ski-color-on-secondary-container) 8%,var(--ski-color-secondary-container))}.peopleSharekitUiCommonInternalButtonTonal:active{background:color-mix(in
+        srgb,var(--ski-color-on-secondary-container) 12%,var(--ski-color-secondary-container))}.peopleSharekitUiCommonInternalButtonTonal:disabled{background:color-mix(in
+        srgb,var(--ski-color-on-surface) 12%,transparent);color:color-mix(in srgb,var(--ski-color-on-surface)
+        38%,transparent)}.peopleSharekitUiCommonInternalButtonTonalLoading:disabled{background:var(--ski-color-secondary-container)}.peopleSharekitUiCommonInternalButtonTonalProgress{--ski-circular-progress-size:var(--ski-circular-progress-in-button-size);--ski-circular-progress-active-indicator-color:var(\n
+        \   --ski-color-on-secondary-container\n  )}.sharekitUiCommonInternalProgressCircle{-webkit-animation-duration:1333ms;animation-duration:1333ms;-webkit-animation-fill-mode:both;animation-fill-mode:both;-webkit-animation-iteration-count:infinite;animation-iteration-count:infinite;-webkit-animation-name:expand-arc;animation-name:expand-arc;-webkit-animation-timing-function:cubic-bezier(.4,0,.2,1);animation-timing-function:cubic-bezier(.4,0,.2,1);border:solid
+        var(--ski-circular-progress-thickness,calc((var(--ski-circular-progress-size)
+        - .5rem)*.1));border-color:var(--ski-circular-progress-active-indicator-color)
+        var(--ski-circular-progress-active-indicator-color) transparent transparent;border-radius:50%;-webkit-box-sizing:border-box;box-sizing:border-box;position:absolute}.sharekitUiCommonInternalProgressIndeterminate{-webkit-animation:linear-rotate
+        1.5682352941176s linear infinite;animation:linear-rotate 1.5682352941176s
+        linear infinite}.sharekitUiCommonInternalProgressLeft{inset:0 50% 0 0;overflow:hidden;position:absolute}.sharekitUiCommonInternalProgressLeft
+        .sharekitUiCommonInternalProgressCircle{inset:0 -100% 0 0;rotate:135deg}.sharekitUiCommonInternalProgressProgress{-webkit-box-align:center;-webkit-align-items:center;align-items:center;contain:strict;content-visibility:auto;display:-webkit-inline-box;display:-webkit-inline-flex;display:inline-flex;height:var(--ski-circular-progress-size);-webkit-box-pack:center;-webkit-justify-content:center;justify-content:center;position:relative;vertical-align:middle;width:var(--ski-circular-progress-size)}.sharekitUiCommonInternalProgressProgressLayer{-webkit-align-self:stretch;align-self:stretch;-webkit-box-flex:1;-webkit-flex:1;flex:1;inset:0;margin:.25rem;position:absolute}.sharekitUiCommonInternalProgressRight{inset:0
+        0 0 50%;overflow:hidden;position:absolute}.sharekitUiCommonInternalProgressRight
+        .sharekitUiCommonInternalProgressCircle{-webkit-animation-delay:-.6665s,0s;animation-delay:-.6665s,0s;inset:0
+        0 0 -100%;rotate:100deg}.sharekitUiCommonInternalProgressSpinner{-webkit-animation:rotate-arc
+        5332ms cubic-bezier(.4,0,.2,1) infinite both;animation:rotate-arc 5332ms cubic-bezier(.4,0,.2,1)
+        infinite both;inset:0;position:absolute}@-webkit-keyframes expand-arc{0%{-webkit-transform:rotate(265deg);transform:rotate(265deg)}50%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}to{-webkit-transform:rotate(265deg);transform:rotate(265deg)}}@keyframes
+        expand-arc{0%{-webkit-transform:rotate(265deg);transform:rotate(265deg)}50%{-webkit-transform:rotate(130deg);transform:rotate(130deg)}to{-webkit-transform:rotate(265deg);transform:rotate(265deg)}}@-webkit-keyframes
+        rotate-arc{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@keyframes
+        rotate-arc{12.5%{-webkit-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);transform:rotate(945deg)}to{-webkit-transform:rotate(3turn);transform:rotate(3turn)}}@-webkit-keyframes
+        linear-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}@keyframes
+        linear-rotate{to{-webkit-transform:rotate(1turn);transform:rotate(1turn)}}.peopleSharekitUiCommonInternalIconsIcon{display:grid;place-items:center;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.peopleSharekitUiCopyLinkBarCopyLinkBarContainer{background:var(--ski-copy-link-bar-container-background,var(--ski-color-surface-container-high));border-radius:1.25rem;display:grid;margin:var(--ski-copy-link-bar-container-margin);padding:var(--ski-copy-link-bar-container-padding);position:relative;outline:1px
+        solid transparent}.peopleSharekitUiCopyLinkBarCopyLinkBarContent{-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-align-self:center;align-self:center;border-radius:.75rem;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1;margin:var(--ski-copy-link-bar-content-margin);min-height:2.5rem;padding:var(--ski-copy-link-bar-content-padding)}.peopleSharekitUiCopyLinkBarCopyLinkBarContentWithLink{background-color:var(--ski-copy-link-bar-content-background,var(--ski-color-surface-container-low));color:var(--ski-color-on-surface);font:var(--ski-typescale-body-medium,initial);-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;outline:1px
+        solid transparent;outline-offset:-1px;overflow:hidden;position:relative;text-align:start}.peopleSharekitUiCopyLinkBarShareLink{color:var(--ski-color-secondary);max-width:70%;min-width:0;overflow:hidden;padding-left:.25rem;text-overflow:ellipsis;white-space:nowrap}.peopleSharekitUiCopyLinkBarCopyLinkButton{color:var(--ski-copy-link-bar-button-text-color,var(--ski-color-on-secondary-container));display:-webkit-box;display:-webkit-flex;display:flex;min-width:5rem;padding:.75rem
+        1rem;width:-webkit-fit-content;width:-moz-fit-content;width:fit-content}.peopleSharekitUiCopyLinkBarCopyLinkButton:only-child{-webkit-box-flex:1;-webkit-flex-grow:1;flex-grow:1}.peopleSharekitUiCommonInternalIconButtonIcon{background-color:transparent;height:2.5rem;padding:0;width:2.5rem}.peopleSharekitUiCommonInternalIconButtonIconDefault{color:var(--ski-color-on-surface-variant)}.peopleSharekitUiCommonInternalIconButtonIconDefault:hover{background:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 8%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconDefault:active{background:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 12%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconDefault:disabled{color:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 38%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconOutlined{color:var(--ski-color-on-surface-variant)}.peopleSharekitUiCommonInternalIconButtonIconOutlined:after{content:\"\";border-radius:inherit;inset:0;outline:var(--ski-color-outline)
+        1px solid;position:absolute}.peopleSharekitUiCommonInternalIconButtonIconOutlined:hover{background:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 8%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconOutlined:active{background:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 12%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconOutlined:disabled{color:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 38%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconOutlined:disabled:after{outline:color-mix(in
+        srgb,var(--ski-color-on-surface) 12%,transparent) 1px solid}.peopleSharekitUiCommonInternalIconButtonIconTonal{background:var(--ski-color-secondary-container);color:var(--ski-color-on-secondary-container)}.peopleSharekitUiCommonInternalIconButtonIconTonal:hover{background:color-mix(in
+        srgb,var(--ski-color-on-secondary-container) 8%,var(--ski-color-secondary-container))}.peopleSharekitUiCommonInternalIconButtonIconTonal:active{background:color-mix(in
+        srgb,var(--ski-color-on-secondary-container) 12%,var(--ski-color-secondary-container))}.peopleSharekitUiCommonInternalIconButtonIconTonal:disabled{background:color-mix(in
+        srgb,var(--ski-color-on-surface) 12%,transparent);color:color-mix(in srgb,var(--ski-color-on-surface)
+        38%,transparent)}.peopleSharekitUiCommonInternalIconButtonIconFilled{background:var(--ski-color-primary);color:var(--ski-color-on-primary)}.peopleSharekitUiCommonInternalIconButtonIconFilled:hover{background:color-mix(in
+        srgb,var(--ski-color-on-primary) 8%,var(--ski-color-primary))}.peopleSharekitUiCommonInternalIconButtonIconFilled:active{background:color-mix(in
+        srgb,var(--ski-color-on-primary) 12%,var(--ski-color-primary))}.peopleSharekitUiCommonInternalIconButtonIconFilled:disabled{background:color-mix(in
+        srgb,var(--ski-color-on-surface) 12%,transparent);color:color-mix(in srgb,var(--ski-color-on-surface)
+        38%,transparent)}.peopleSharekitUiCommonMenuMenu{--md-menu-bottom-space:var(--ski-menu-bottom-space);--md-menu-container-color:var(--ski-menu-container-color);--md-menu-container-shape:var(--ski-menu-container-shape);--md-menu-min-width:var(--ski-menu-min-width);--md-menu-top-space:var(--ski-menu-top-space);--md-menu-item-container-color:var(--ski-color-surface-container);--md-menu-item-hover-state-layer-color:var(--ski-color-on-surface);--md-menu-item-selected-container-color:var(\n
+        \   --ski-color-secondary-container\n  );--md-menu-item-label-text-line-height:var(\n
+        \   --ski-menu-item-label-text-line-height\n  );--md-menu-item-label-text-font:var(--ski-typescale-body-large-font);--md-menu-item-label-text-color:var(--ski-color-on-surface);--md-menu-item-label-text-size:var(--ski-menu-item-label-text-size);--md-menu-item-label-text-weight:var(--ski-menu-item-label-text-weight);--md-menu-item-bottom-space:var(--ski-menu-item-bottom-space);--md-menu-item-top-space:var(--ski-menu-item-top-space);--md-menu-item-one-line-container-height:var(\n
+        \   --ski-menu-item-one-line-container-height\n  );display:grid;min-width:var(--ski-menu-min-width)}.peopleSharekitUiCommonMenuMenuItem{display:grid}.peopleSharekitUiHeaderContainer{display:grid;grid-auto-flow:column;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;-webkit-box-align:center;-webkit-align-items:center;align-items:center}.peopleSharekitUiHeaderLeftSection{-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-column-gap:.125rem;-moz-column-gap:.125rem;column-gap:.125rem;display:grid;grid-auto-flow:column}.peopleSharekitUiHeaderLeftSectionInternalButtonAdjustment{-webkit-column-gap:.31rem;-moz-column-gap:.31rem;column-gap:.31rem}.peopleSharekitUiHeaderTitle{color:var(--ski-color-on-surface);display:-webkit-box;font:var(--ski-header-title-font,var(--ski-typescale-title-large));overflow:hidden;text-overflow:ellipsis;-webkit-box-orient:vertical;-webkit-line-clamp:2}.peopleSharekitUiHeaderButtonContainer{display:grid;gap:var(--ski-header-button-container-gap);grid-auto-flow:column}.peopleSharekitUiHeaderMenuButtonContainer{position:relative;width:var(--ski-header-menu-button-container-width)}.peopleSharekitUiHeaderIconButton{border-radius:50%;color:var(--ski-header-icon-button-icon-color,var(--ski-color-on-surface));width:var(--ski-header-icon-button-size);height:var(--ski-header-icon-button-size);outline:1px
+        solid transparent;--md-icon-button-icon-size:var(--ski-header-icon-button-icon-size)}.peopleSharekitUiHeaderMenuButton{width:var(--ski-header-icon-button-size);height:var(--ski-header-icon-button-size);--md-filled-icon-button-focus-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-icon-button-hover-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-icon-button-icon-size:var(--ski-header-icon-button-icon-size);--md-filled-icon-button-icon-color:var(--ski-color-on-surface-variant);--md-filled-icon-button-pressed-icon-color:var(\n
+        \   --ski-color-on-surface-variant\n  )}.peopleSharekitUiHeaderMenuButtonHideMenu{--md-filled-icon-button-container-color:transparent;--md-filled-icon-button-hover-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  );--md-filled-icon-button-pressed-state-layer-color:var(\n
+        \   --ski-color-on-surface-variant\n  )}.peopleSharekitUiHeaderMenuButtonShowMenu{--md-filled-icon-button-container-color:color-mix(in
+        srgb,var(--ski-color-on-surface-variant) 20%,var(\n      --ski-dialog-background-color,var(--ski-color-surface-container-low)\n
+        \   ));--md-filled-icon-button-hover-state-layer-color:transparent;--md-filled-icon-button-pressed-state-layer-color:transparent}.peopleSharekitUiStatusManagerStatusManagerContainer{background:var(--ski-status-manager-container-background,var(--ski-color-surface-container-high));border-radius:var(--ski-status-manager-container-border-radius);display:grid;margin:var(--ski-status-manager-container-margin);padding:var(--ski-status-manager-container-padding);position:relative;outline:1px
+        solid transparent}.peopleSharekitUiStatusManagerStatusManagerContent{-webkit-box-align:start;-webkit-align-items:flex-start;align-items:flex-start;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;flex-direction:column;gap:.5rem;padding:var(--ski-status-manager-content-padding);margin:var(--ski-status-manager-content-margin)}.peopleSharekitUiStatusManagerCurrentStatus{color:var(--ski-status-manager-current-status-color,var(--ski-color-on-surface));font:var(--ski-typescale-body-medium)}.peopleSharekitUiStatusManagerEditStatusButton{background:none;border:none;color:var(--ski-status-manager-edit-status-button-color,var(--ski-color-primary));font:var(--ski-typescale-label-large);padding:0;text-align:start}.peopleSharekitUiStatusManagerEditStatusButton:hover{cursor:pointer;text-decoration:underline}.peopleShareKitNotebooklmArtifactSharingThemes{--ski-container-header-components-padding-top:1.25rem;--ski-container-header-components-padding-bottom:1.25rem;--ski-container-header-components-padding-inline:1.5rem;--ski-container-footer-components-background:var(\n
+        \   --ski-color-secondary-container\n  );--ski-container-footer-components-padding:1.5rem;--ski-container-footer-components-scroll-background:var(\n
+        \   --ski-color-secondary-container\n  );--ski-container-scrollable-components-padding:0
+        0 0.75rem;--ski-header-icon-button-icon-color:var(--ski-color-on-surface);--ski-dialog-border-radius:0;--ski-copy-link-bar-container-background:transparent;--ski-copy-link-bar-container-padding:0.5rem
+        1.5rem 1.5rem 1.5rem;--ski-copy-link-bar-container-margin:0;--ski-copy-link-bar-content-padding:0;--ski-copy-link-bar-content-margin:0;--ski-copy-link-bar-button-text-color:var(--ski-color-tertiary);--ski-status-manager-container-background:transparent;--ski-status-manager-container-border-radius:0;--ski-status-manager-container-padding:0;--ski-status-manager-container-margin:0;--ski-status-manager-content-padding:0;--ski-status-manager-content-margin:0;--ski-status-manager-current-status-color:var(--ski-color-on-secondary);--ski-status-manager-edit-status-button-color:var(--ski-color-secondary)}.picker-api-container,.picker-iframe-container{height:100%;width:100%;position:relative}.picker-close-button{position:absolute;z-index:100;top:12px;right:14px;width:36px;height:36px;border-radius:18px;border-width:0;background-color:rgba(0,0,0,0)}.picker-close-button:hover{background-color:rgba(60,64,67,.04)}.picker-close-button:active{background-color:rgba(60,64,67,.12)}.picker-close-button-svg{fill:#616161}.content-library
+        .picker-close-button-svg{color:var(--dt-on-neutral-container,rgb(60,64,67))}.content-library
+        .picker-loading-container{position:absolute;height:100%;width:100%;background-color:var(--dt-surface-container,#fff);-webkit-box-align:center;-webkit-align-items:center;align-items:center;-webkit-box-pack:space-evenly;-webkit-justify-content:space-evenly;justify-content:space-evenly;display:none}.content-library.loading
+        .picker-loading-container{display:-webkit-box;display:-webkit-flex;display:flex;background-color:#f0f4f9}.content-library.loaded
+        .picker-loading-container,.content-library.loading .picker-iframe-container,.content-library.loading-timed-out
+        .picker-loading-container{display:none}.goog-modalpopup,.modal-dialog{-webkit-box-shadow:0
+        4px 16px rgba(0,0,0,.2);box-shadow:0 4px 16px rgba(0,0,0,.2);background:#fff;background-clip:padding-box;border:1px
+        solid #acacac;border:1px solid rgba(0,0,0,.333);outline:0;position:absolute}.goog-modalpopup-bg,.modal-dialog-bg{background:#fff;left:0;position:absolute;top:0}div.goog-modalpopup-bg,div.modal-dialog-bg{filter:alpha(opacity=75);opacity:.75}.modal-dialog{color:#000;padding:30px
+        42px}.modal-dialog-title{background-color:#fff;color:#000;cursor:default;font-size:16px;font-weight:400;line-height:24px;margin:0
+        0 16px}.modal-dialog-title-close{height:11px;opacity:.7;padding:17px;position:absolute;right:0;top:0;width:11px}.modal-dialog-title-close:after{content:\"\";background:url(https://ssl.gstatic.com/ui/v1/dialog/close-x.png);position:absolute;height:11px;width:11px;right:17px}.modal-dialog-title-close:hover{opacity:1}.modal-dialog-content{background-color:#fff;line-height:1.4em;word-wrap:break-word}.modal-dialog-buttons{margin-top:16px}.modal-dialog-buttons
+        button{border-radius:2px;background-color:#f5f5f5;background-image:-webkit-linear-gradient(top,#f5f5f5,#f1f1f1);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#f5f5f5),to(#f1f1f1));background-image:linear-gradient(top,#f5f5f5,#f1f1f1);border:1px
+        solid #dcdcdc;border:1px solid rgba(0,0,0,.1);color:#444;cursor:default;font-family:inherit;font-size:11px;font-weight:700;height:29px;line-height:27px;margin:0
+        16px 0 0;min-width:72px;outline:0;padding:0 8px}.modal-dialog-buttons button:active,.modal-dialog-buttons
+        button:hover{-webkit-box-shadow:0 1px 1px rgba(0,0,0,.1);box-shadow:0 1px
+        1px rgba(0,0,0,.1);background-color:#f8f8f8;background-image:-webkit-linear-gradient(top,#f8f8f8,#f1f1f1);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#f8f8f8),to(#f1f1f1));background-image:linear-gradient(top,#f8f8f8,#f1f1f1);border:1px
+        solid #c6c6c6;color:#333}.modal-dialog-buttons button:active{-webkit-box-shadow:inset
+        0 1px 2px rgba(0,0,0,.1);box-shadow:inset 0 1px 2px rgba(0,0,0,.1)}.modal-dialog-buttons
+        button:focus{border:1px solid #4d90fe}.modal-dialog-buttons button[disabled]{-webkit-box-shadow:none;box-shadow:none;background:#fff;background-image:none;border:1px
+        solid #f3f3f3;border:1px solid rgba(0,0,0,.05);color:#b8b8b8}.modal-dialog-buttons
+        .goog-buttonset-action{background-color:#4d90fe;background-image:-webkit-linear-gradient(top,#4d90fe,#4787ed);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#4d90fe),to(#4787ed));background-image:linear-gradient(top,#4d90fe,#4787ed);border:1px
+        solid #3079ed;color:#fff}.modal-dialog-buttons .goog-buttonset-action:active,.modal-dialog-buttons
+        .goog-buttonset-action:hover{background-color:#357ae8;background-image:-webkit-linear-gradient(180deg,#4d90fe,#357ae8);background-image:-webkit-gradient(linear,left
+        top,left bottom,from(#4d90fe),to(#357ae8));background-image:-webkit-linear-gradient(top,#4d90fe,#357ae8);background-image:linear-gradient(180deg,#4d90fe,#357ae8);border:1px
+        solid #2f5bb7;color:#fff}.modal-dialog-buttons .goog-buttonset-action:active{-webkit-box-shadow:inset
+        0 1px 2px rgba(0,0,0,.3);box-shadow:inset 0 1px 2px rgba(0,0,0,.3)}.modal-dialog-buttons
+        .goog-buttonset-action:focus{-webkit-box-shadow:inset 0 0 0 1px #fff;box-shadow:inset
+        0 0 0 1px #fff;border:1px solid #fff;border:1px solid rgba(0,0,0,0);outline:1px
+        solid #4d90fe;outline:0 rgba(0,0,0,0)}.modal-dialog-buttons .goog-buttonset-action[disabled]{-webkit-box-shadow:none;box-shadow:none;background:#4d90fe;color:#fff;filter:alpha(opacity=50);opacity:.5}.jfk-alert,.jfk-confirm,.jfk-prompt{width:512px}.google-picker.modal-dialog{background-color:var(--dt-surface-container-high,#fff);border:none;padding:0;-webkit-transition:top
+        .5s ease-in-out;transition:top .5s ease-in-out;z-index:1004;border-radius:24px;-webkit-box-shadow:0
+        4px 8px 3px rgba(60,64,67,.15),0 1px 3px rgba(60,64,67,.3);box-shadow:0 4px
+        8px 3px rgba(60,64,67,.15),0 1px 3px rgba(60,64,67,.3);overflow:hidden;right:auto;bottom:auto}.google-picker.modal-dialog
+        .picker-close-button{top:20px;right:18px}.google-picker.modal-dialog-bg{background-color:var(--dt-scrim,rgba(32,33,36,.6));z-index:1003;border:none;bottom:auto;right:auto}.google-picker.transparent-picker.modal-dialog{background-color:transparent;border:none;-webkit-box-shadow:none;box-shadow:none;padding:0}.google-picker.transparent-picker.modal-dialog-content{background-color:transparent}.note-card
+        .ql-indent-1:not(.ql-direction-rtl){-webkit-margin-start:27px;margin-inline-start:27px}.note-card
+        .ql-indent-1.ql-direction-rtl.ql-align-right{-webkit-margin-end:27px;margin-inline-end:27px}.note-card
+        li.ql-indent-1.ql-direction-rtl.ql-align-right{-webkit-margin-end:40px;margin-inline-end:40px}.note-card
+        li.ql-indent-1:not(.ql-direction-rtl){-webkit-margin-start:40px;margin-inline-start:40px}.note-card
+        .ql-indent-2:not(.ql-direction-rtl){-webkit-margin-start:54px;margin-inline-start:54px}.note-card
+        .ql-indent-2.ql-direction-rtl.ql-align-right{-webkit-margin-end:54px;margin-inline-end:54px}.note-card
+        li.ql-indent-2.ql-direction-rtl.ql-align-right{-webkit-margin-end:80px;margin-inline-end:80px}.note-card
+        li.ql-indent-2:not(.ql-direction-rtl){-webkit-margin-start:80px;margin-inline-start:80px}.note-card
+        .ql-indent-3:not(.ql-direction-rtl){-webkit-margin-start:81px;margin-inline-start:81px}.note-card
+        .ql-indent-3.ql-direction-rtl.ql-align-right{-webkit-margin-end:81px;margin-inline-end:81px}.note-card
+        li.ql-indent-3.ql-direction-rtl.ql-align-right{-webkit-margin-end:120px;margin-inline-end:120px}.note-card
+        li.ql-indent-3:not(.ql-direction-rtl){-webkit-margin-start:120px;margin-inline-start:120px}.note-card
+        .ql-indent-4:not(.ql-direction-rtl){-webkit-margin-start:108px;margin-inline-start:108px}.note-card
+        .ql-indent-4.ql-direction-rtl.ql-align-right{-webkit-margin-end:108px;margin-inline-end:108px}.note-card
+        li.ql-indent-4.ql-direction-rtl.ql-align-right{-webkit-margin-end:160px;margin-inline-end:160px}.note-card
+        li.ql-indent-4:not(.ql-direction-rtl){-webkit-margin-start:160px;margin-inline-start:160px}.note-card
+        .ql-indent-5:not(.ql-direction-rtl){-webkit-margin-start:135px;margin-inline-start:135px}.note-card
+        .ql-indent-5.ql-direction-rtl.ql-align-right{-webkit-margin-end:135px;margin-inline-end:135px}.note-card
+        li.ql-indent-5.ql-direction-rtl.ql-align-right{-webkit-margin-end:200px;margin-inline-end:200px}.note-card
+        li.ql-indent-5:not(.ql-direction-rtl){-webkit-margin-start:200px;margin-inline-start:200px}.note-card
+        .ql-indent-6:not(.ql-direction-rtl){-webkit-margin-start:162px;margin-inline-start:162px}.note-card
+        .ql-indent-6.ql-direction-rtl.ql-align-right{-webkit-margin-end:162px;margin-inline-end:162px}.note-card
+        li.ql-indent-6.ql-direction-rtl.ql-align-right{-webkit-margin-end:240px;margin-inline-end:240px}.note-card
+        li.ql-indent-6:not(.ql-direction-rtl){-webkit-margin-start:240px;margin-inline-start:240px}.note-card
+        .ql-indent-7:not(.ql-direction-rtl){-webkit-margin-start:189px;margin-inline-start:189px}.note-card
+        .ql-indent-7.ql-direction-rtl.ql-align-right{-webkit-margin-end:189px;margin-inline-end:189px}.note-card
+        li.ql-indent-7.ql-direction-rtl.ql-align-right{-webkit-margin-end:280px;margin-inline-end:280px}.note-card
+        li.ql-indent-7:not(.ql-direction-rtl){-webkit-margin-start:280px;margin-inline-start:280px}.note-card
+        .ql-indent-8:not(.ql-direction-rtl){-webkit-margin-start:216px;margin-inline-start:216px}.note-card
+        .ql-indent-8.ql-direction-rtl.ql-align-right{-webkit-margin-end:216px;margin-inline-end:216px}.note-card
+        li.ql-indent-8.ql-direction-rtl.ql-align-right{-webkit-margin-end:320px;margin-inline-end:320px}.note-card
+        li.ql-indent-8:not(.ql-direction-rtl){-webkit-margin-start:320px;margin-inline-start:320px}.note-card
+        .ql-indent-9:not(.ql-direction-rtl){-webkit-margin-start:243px;margin-inline-start:243px}.note-card
+        .ql-indent-9.ql-direction-rtl.ql-align-right{-webkit-margin-end:243px;margin-inline-end:243px}.note-card
+        li.ql-indent-9.ql-direction-rtl.ql-align-right{-webkit-margin-end:360px;margin-inline-end:360px}.note-card
+        li.ql-indent-9:not(.ql-direction-rtl){-webkit-margin-start:360px;margin-inline-start:360px}html{--mat-snack-bar-container-color:var(--nlm-ctas-buttons-secondary);--mat-snack-bar-container-shape:16px}.mat-mdc-snack-bar-container{--mat-focus-indicator-border-color:var(--nlm-strong-focus-indicator-reverse);--mat-focus-indicator-display:block}.mat-mdc-snack-bar-container
+        .mat-mdc-standard-chip .mat-mdc-chip-action-label,.mat-mdc-snack-bar-container
+        .mat-mdc-standard-chip .mdc-evolution-chip__action--primary,.mat-mdc-snack-bar-container
+        .mat-mdc-standard-chip .mdc-evolution-chip__cell--primary{overflow:visible}.outset-focus-ring
+        .mat-focus-indicator:before{inset:-8px}body,html{isolation:isolate;margin-block:0;margin-inline:0;block-size:100%;-webkit-font-smoothing:antialiased;-webkit-text-size-adjust:calc(100%*env(preferred-text-scale,
+        1));-moz-text-size-adjust:calc(100%*env(preferred-text-scale, 1));-ms-text-size-adjust:calc(100%*env(preferred-text-scale,
+        1));text-size-adjust:calc(100%*env(preferred-text-scale, 1))}::-webkit-scrollbar{inline-size:12px}::-webkit-scrollbar-corner{background:transparent}::-webkit-scrollbar-thumb{background-color:var(--nlm-stroke-default);border-start-start-radius:20px;border-start-end-radius:20px;border-end-start-radius:20px;border-end-end-radius:20px;border-block:3px
+        solid transparent;border-inline:3px solid transparent;background-clip:content-box}.boqOnegoogleliteOgbOneGoogleBar{position:absolute;inset-inline-end:.5rem;block-size:4rem;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-align:center;-webkit-align-items:center;align-items:center;z-index:999}[data-ogsr-up]>div[style*=\"visibility:
+        hidden\"]:empty{display:none}strong{font-weight:600}a{color:var(--nlm-ctas-text-and-icon)}.rounded-bottom-sheet
+        mat-bottom-sheet-container{border-start-start-radius:1rem;border-start-end-radius:1rem}.bottom-sheet-overflow-hidden
+        mat-bottom-sheet-container{overflow:hidden}.mat-display-large,h1{font:var(--mat-sys-display-large);letter-spacing:var(--mat-sys-display-large-tracking);margin-inline:0;margin-block:0
+        .5em;color:var(--nlm-text-titles-and-labels)}.mat-display-medium,h2{font:var(--mat-sys-display-medium);letter-spacing:var(--mat-sys-display-medium-tracking);margin-inline:0;margin-block:0
+        .5em;color:var(--nlm-text-titles-and-labels)}.mat-display-small,h3{font:var(--mat-sys-display-small);letter-spacing:var(--mat-sys-display-small-tracking);margin-inline:0;margin-block:0
+        .5em;color:var(--nlm-text-titles-and-labels)}.mat-headline-large,h4{font:var(--mat-sys-headline-large);letter-spacing:var(--mat-sys-headline-large-tracking);margin-inline:0;margin-block:0
+        .5em;color:var(--nlm-text-titles-and-labels)}.mat-headline-medium,h5{font:var(--mat-sys-headline-medium);letter-spacing:var(--mat-sys-headline-medium-tracking);margin-inline:0;margin-block:0
+        .5em;color:var(--nlm-text-titles-and-labels)}.mat-headline-small,h6{font:var(--mat-sys-headline-small);letter-spacing:var(--mat-sys-headline-small-tracking);margin-inline:0;margin-block:0
+        .5em;color:var(--nlm-text-titles-and-labels)}.mat-title-xlarge{font:var(--mat-sys-title-large);letter-spacing:var(--mat-sys-title-large-tracking);font-size:1.75rem;line-height:2.25rem;color:var(--nlm-text-titles-and-labels)}.mat-title-large{font:var(--mat-sys-title-large);letter-spacing:var(--mat-sys-title-large-tracking);line-height:2.25rem;color:var(--nlm-text-titles-and-labels)}.mat-title-medium{font:var(--mat-sys-title-medium);letter-spacing:var(--mat-sys-title-medium-tracking);line-height:2rem;font-weight:500;color:var(--nlm-text-titles-and-labels)}.mat-title-small{font:var(--mat-sys-title-small);letter-spacing:var(--mat-sys-title-small-tracking);line-height:1.5rem;font-weight:500;color:var(--nlm-text-titles-and-labels)}.mat-body-large{font:var(--mat-sys-body-large);letter-spacing:var(--mat-sys-body-large-tracking);color:var(--nlm-text-body-text)}.mat-body-large
+        p{margin-inline:0;margin-block:0 .75em}.mat-body-medium{font:var(--mat-sys-body-medium);letter-spacing:var(--mat-sys-body-medium-tracking);line-height:1.5rem;color:var(--nlm-text-body-text)}.mat-body-medium
+        p{margin-inline:0;margin-block:0 .75em}.mat-body-medium-condensed{font:var(--mat-sys-body-medium);letter-spacing:var(--mat-sys-body-medium-tracking);color:var(--nlm-text-body-text)}.mat-body-medium-condensed
+        p{margin-inline:0;margin-block:0 .75em}.mat-body-small{font:var(--mat-sys-body-small);letter-spacing:var(--mat-sys-body-small-tracking);line-height:1.25rem;color:var(--nlm-text-body-text)}.mat-body-small
+        p{margin-inline:0;margin-block:0 .75em}.mat-label-xlarge{font:var(--mat-sys-label-large);letter-spacing:var(--mat-sys-label-large-tracking);font-size:1rem;line-height:1.5rem;font-weight:500;color:var(--nlm-text-titles-and-labels)}.mat-label-large{font:var(--mat-sys-label-large);letter-spacing:var(--mat-sys-label-large-tracking);font-weight:400;color:var(--nlm-text-titles-and-labels)}.mat-label-medium{font:var(--mat-sys-label-medium);letter-spacing:var(--mat-sys-label-medium-tracking);color:var(--nlm-text-titles-and-labels)}.mat-label-small{font:var(--mat-sys-label-small);letter-spacing:var(--mat-sys-label-small-tracking);color:var(--nlm-text-titles-and-labels)}:where(:root):root{color-scheme:light;--xap-color-surface:var(--mat-sys-surface);--xap-color-on-surface:var(--mat-sys-on-surface);background:var(--mat-sys-background);color:var(--mat-sys-on-background);--mat-sys-background:#fff;--mat-sys-error:#b3261e;--mat-sys-error-container:#f9dedc;--mat-sys-inverse-on-surface:#f2f2f2;--mat-sys-inverse-primary:#a8c7fa;--mat-sys-inverse-surface:#303030;--mat-sys-on-background:#1f1f1f;--mat-sys-on-error:#fff;--mat-sys-on-error-container:#8c1d18;--mat-sys-on-primary:#fff;--mat-sys-on-primary-container:#0842a0;--mat-sys-on-primary-fixed:#041e49;--mat-sys-on-primary-fixed-variant:#0842a0;--mat-sys-on-secondary:#fff;--mat-sys-on-secondary-container:#004a77;--mat-sys-on-secondary-fixed:#001d35;--mat-sys-on-secondary-fixed-variant:#004a77;--mat-sys-on-surface:#1f1f1f;--mat-sys-on-surface-variant:#444746;--mat-sys-on-tertiary:#fff;--mat-sys-on-tertiary-container:#0842a0;--mat-sys-on-tertiary-fixed:#041e49;--mat-sys-on-tertiary-fixed-variant:#0842a0;--mat-sys-outline:#747775;--mat-sys-outline-variant:#c4c7c5;--mat-sys-primary:#0b57d0;--mat-sys-primary-container:#d3e3fd;--mat-sys-primary-fixed:#d3e3fd;--mat-sys-primary-fixed-dim:#a8c7fa;--mat-sys-scrim:#000;--mat-sys-secondary:#00639b;--mat-sys-secondary-container:#c2e7ff;--mat-sys-secondary-fixed:#c2e7ff;--mat-sys-secondary-fixed-dim:#7fcfff;--mat-sys-shadow:#000;--mat-sys-surface:#fff;--mat-sys-surface-bright:#fff;--mat-sys-surface-container:#f0f4f9;--mat-sys-surface-container-high:#e9eef6;--mat-sys-surface-container-highest:#dde3ea;--mat-sys-surface-container-low:#f8fafd;--mat-sys-surface-container-lowest:#fff;--mat-sys-surface-dim:#d3dbe5;--mat-sys-surface-tint:#6991d6;--mat-sys-surface-variant:#e1e3e1;--mat-sys-tertiary:#0b57d0;--mat-sys-tertiary-container:#d3e3fd;--mat-sys-tertiary-fixed:#d3e3fd;--mat-sys-tertiary-fixed-dim:#a8c7fa;--mat-sys-info:#1157ce;--mat-sys-on-info:#fff;--mat-sys-info-container:#d0e4ff;--mat-sys-on-info-container:#04409f;--mat-sys-success:#006c35;--mat-sys-on-success:#fff;--mat-sys-success-container:#beefbb;--mat-sys-on-success-container:#00522c;--mat-sys-warning:#8f4e06;--mat-sys-on-warning:#fff;--mat-sys-warning-container:#ffe07c;--mat-sys-on-warning-container:#6d3a01;--mat-sys-link:#1157ce;--mat-sys-link-hover:#04409f;--mat-sys-link-visited:#7438d2;--mat-sys-blue:#1157ce;--mat-sys-on-blue:#fff;--mat-sys-blue-container:#d0e4ff;--mat-sys-on-blue-container:#04409f;--mat-sys-red:#b3251e;--mat-sys-on-red:#fff;--mat-sys-red-container:#ffdadc;--mat-sys-on-red-container:#8a1a16;--mat-sys-yellow:#8f4e06;--mat-sys-on-yellow:#fff;--mat-sys-yellow-container:#ffe07c;--mat-sys-on-yellow-container:#6d3a01;--mat-sys-green:#006c35;--mat-sys-on-green:#fff;--mat-sys-green-container:#beefbb;--mat-sys-on-green-container:#00522c;--mat-sys-orange:#9a4600;--mat-sys-on-orange:#fff;--mat-sys-orange-container:#ffdcc3;--mat-sys-on-orange-container:#753403;--mat-sys-pink:#b60d6e;--mat-sys-on-pink:#fff;--mat-sys-pink-container:#ffd8ef;--mat-sys-on-pink-container:#8d0053;--mat-sys-purple:#7438d2;--mat-sys-on-purple:#fff;--mat-sys-purple-container:#eedcfe;--mat-sys-on-purple-container:#5629a4;--mat-sys-cyan:#00687c;--mat-sys-on-cyan:#fff;--mat-sys-cyan-container:#acedff;--mat-sys-on-cyan-container:#004e5d;--mat-sys-grey:#5e5e5e;--mat-sys-on-grey:#fff;--mat-sys-grey-container:#e3e3e3;--mat-sys-on-grey-container:#474747;--mat-sys-neutral-variant20:#2d312f;--mat-sys-neutral10:#1f1f1f;--mat-sys-level0:0px
+        0px 0px 0px rgba(0,0,0,0.2),0px 0px 0px 0px rgba(0,0,0,0.14),0px 0px 0px 0px
+        rgba(0,0,0,0.12);--mat-sys-level1:0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px
+        1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);--mat-sys-level2:0px
+        3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px
+        0px rgba(0,0,0,0.12);--mat-sys-level3:0px 3px 5px -1px rgba(0,0,0,0.2),0px
+        6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);--mat-sys-level4:0px
+        5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px
+        2px rgba(0,0,0,0.12);--mat-sys-level5:0px 7px 8px -4px rgba(0,0,0,0.2),0px
+        12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);--mat-sys-body-large:400
+        1rem/1.5rem Google Sans Text;--mat-sys-body-large-font:Google Sans Text;--mat-sys-body-large-line-height:1.5rem;--mat-sys-body-large-size:1rem;--mat-sys-body-large-tracking:0;--mat-sys-body-large-weight:400;--mat-sys-body-medium:400
+        0.875rem/1.25rem Google Sans Text;--mat-sys-body-medium-font:Google Sans Text;--mat-sys-body-medium-line-height:1.25rem;--mat-sys-body-medium-size:0.875rem;--mat-sys-body-medium-tracking:0;--mat-sys-body-medium-weight:400;--mat-sys-body-small:400
+        0.75rem/1rem Google Sans Text;--mat-sys-body-small-font:Google Sans Text;--mat-sys-body-small-line-height:1rem;--mat-sys-body-small-size:0.75rem;--mat-sys-body-small-tracking:0.006rem;--mat-sys-body-small-weight:400;--mat-sys-display-large:400
+        3.562rem/4rem Google Sans;--mat-sys-display-large-font:Google Sans;--mat-sys-display-large-line-height:4rem;--mat-sys-display-large-size:3.562rem;--mat-sys-display-large-tracking:0;--mat-sys-display-large-weight:400;--mat-sys-display-medium:400
+        2.812rem/3.25rem Google Sans;--mat-sys-display-medium-font:Google Sans;--mat-sys-display-medium-line-height:3.25rem;--mat-sys-display-medium-size:2.812rem;--mat-sys-display-medium-tracking:0;--mat-sys-display-medium-weight:400;--mat-sys-display-small:400
+        2.25rem/2.75rem Google Sans;--mat-sys-display-small-font:Google Sans;--mat-sys-display-small-line-height:2.75rem;--mat-sys-display-small-size:2.25rem;--mat-sys-display-small-tracking:0;--mat-sys-display-small-weight:400;--mat-sys-headline-large:400
+        2rem/2.5rem Google Sans;--mat-sys-headline-large-font:Google Sans;--mat-sys-headline-large-line-height:2.5rem;--mat-sys-headline-large-size:2rem;--mat-sys-headline-large-tracking:0;--mat-sys-headline-large-weight:400;--mat-sys-headline-medium:400
+        1.75rem/2.25rem Google Sans;--mat-sys-headline-medium-font:Google Sans;--mat-sys-headline-medium-line-height:2.25rem;--mat-sys-headline-medium-size:1.75rem;--mat-sys-headline-medium-tracking:0;--mat-sys-headline-medium-weight:400;--mat-sys-headline-small:400
+        1.5rem/2rem Google Sans;--mat-sys-headline-small-font:Google Sans;--mat-sys-headline-small-line-height:2rem;--mat-sys-headline-small-size:1.5rem;--mat-sys-headline-small-tracking:0;--mat-sys-headline-small-weight:400;--mat-sys-label-large:500
+        0.875rem/1.25rem Google Sans Text;--mat-sys-label-large-font:Google Sans Text;--mat-sys-label-large-line-height:1.25rem;--mat-sys-label-large-size:0.875rem;--mat-sys-label-large-tracking:0;--mat-sys-label-large-weight:500;--mat-sys-label-large-weight-prominent:700;--mat-sys-label-medium:500
+        0.75rem/1rem Google Sans Text;--mat-sys-label-medium-font:Google Sans Text;--mat-sys-label-medium-line-height:1rem;--mat-sys-label-medium-size:0.75rem;--mat-sys-label-medium-tracking:0.006rem;--mat-sys-label-medium-weight:500;--mat-sys-label-medium-weight-prominent:700;--mat-sys-label-small:500
+        0.688rem/1rem Google Sans Text;--mat-sys-label-small-font:Google Sans Text;--mat-sys-label-small-line-height:1rem;--mat-sys-label-small-size:0.688rem;--mat-sys-label-small-tracking:0.006rem;--mat-sys-label-small-weight:500;--mat-sys-title-large:400
+        1.375rem/1.75rem Google Sans;--mat-sys-title-large-font:Google Sans;--mat-sys-title-large-line-height:1.75rem;--mat-sys-title-large-size:1.375rem;--mat-sys-title-large-tracking:0;--mat-sys-title-large-weight:400;--mat-sys-title-medium:500
+        1rem/1.5rem Google Sans Text;--mat-sys-title-medium-font:Google Sans Text;--mat-sys-title-medium-line-height:1.5rem;--mat-sys-title-medium-size:1rem;--mat-sys-title-medium-tracking:0;--mat-sys-title-medium-weight:500;--mat-sys-title-small:500
+        0.875rem/1.25rem Google Sans Text;--mat-sys-title-small-font:Google Sans Text;--mat-sys-title-small-line-height:1.25rem;--mat-sys-title-small-size:0.875rem;--mat-sys-title-small-tracking:0;--mat-sys-title-small-weight:500;--mat-sys-corner-extra-large:28px;--mat-sys-corner-extra-large-top:28px
+        28px 0 0;--mat-sys-corner-extra-small:4px;--mat-sys-corner-extra-small-top:4px
+        4px 0 0;--mat-sys-corner-full:9999px;--mat-sys-corner-large:16px;--mat-sys-corner-large-end:0
+        16px 16px 0;--mat-sys-corner-large-start:16px 0 0 16px;--mat-sys-corner-large-top:16px
+        16px 0 0;--mat-sys-corner-medium:12px;--mat-sys-corner-none:0;--mat-sys-corner-small:8px;--mat-sys-dragged-state-layer-opacity:0.16;--mat-sys-focus-state-layer-opacity:0.12;--mat-sys-hover-state-layer-opacity:0.08;--mat-sys-pressed-state-layer-opacity:0.12;--nlm-grey-0:#000;--nlm-grey-5:undefined;--nlm-grey-10:#1b1b1c;--nlm-grey-20:#303030;--nlm-grey-30:#474747;--nlm-grey-40:#5e5e5e;--nlm-grey-50:#777;--nlm-grey-60:#919191;--nlm-grey-70:#ababab;--nlm-grey-80:#c7c7c7;--nlm-grey-90:#e3e3e3;--nlm-grey-95:#f2f2f2;--nlm-grey-98:#f9f9f9;--nlm-grey-99:undefined;--nlm-grey-100:#fff;--nlm-blue-0:undefined;--nlm-blue-2:#17181c;--nlm-blue-5:#1d1e26;--nlm-blue-10:#232740;--nlm-blue-20:#2a3163;--nlm-blue-30:#2f3a8e;--nlm-blue-40:#384acf;--nlm-blue-50:#4259ff;--nlm-blue-60:#596cf7;--nlm-blue-70:#7c8bf3;--nlm-blue-80:#94a0f4;--nlm-blue-90:#c3cafc;--nlm-blue-95:#dbdfff;--nlm-blue-98:#edeffa;--nlm-blue-99:undefined;--nlm-blue-100:#fff;--nlm-green-0:undefined;--nlm-green-5:undefined;--nlm-green-10:undefined;--nlm-green-20:undefined;--nlm-green-30:undefined;--nlm-green-40:undefined;--nlm-green-50:#45ec6d;--nlm-green-60:#6df88e;--nlm-green-70:#9efab4;--nlm-green-80:#cefdd9;--nlm-green-90:undefined;--nlm-green-95:undefined;--nlm-green-98:undefined;--nlm-green-99:undefined;--nlm-green-100:#fff;--nlm-brand-black:#000;--nlm-brand-white:#fff;--nlm-brand-green:#45ec6d;--nlm-brand-blue:#4259ff;--nlm-brand-light-blue:#edeffa;--nlm-brand-dark-blue:#2f334b;--nlm-red-50:#db372d}:where(:root):root
+        .mat-icon.filled{font-variation-settings:\"FILL\" 1}:where(:root):root{--mat-sys-background:var(--nlm-fills-surface-landing);--mat-sys-on-background:var(--nlm-text-body-text);--mat-dialog-container-max-width:90vw;--mat-dialog-container-shape:1rem;--mat-button-filled-container-color:var(--nlm-ctas-buttons-primary);--mat-button-filled-label-text-color:var(--nlm-cta-text-and-icon-primary);--mat-button-filled-container-height:2.5rem;--mat-button-filled-container-shape:6rem;--mat-button-filled-hover-state-layer-opacity:0.08;--mat-button-filled-focus-state-layer-opacity:0.1;--mat-button-filled-disabled-label-text-color:var(--nlm-text-secondary-text);--mat-button-tonal-container-color:var(--nlm-ctas-buttons-secondary);--mat-button-tonal-label-text-color:var(--nlm-text-cta-text-secondary);--mat-button-tonal-container-height:2.5rem;--mat-button-tonal-container-shape:6rem;--mat-button-tonal-hover-state-layer-opacity:0.08;--mat-button-tonal-focus-state-layer-opacity:0.1;--mat-button-tonal-disabled-label-text-color:var(--nlm-text-secondary-text);--mat-button-outlined-label-text-color:var(--nlm-text-cta-text-tertiary);--mat-button-outlined-outline-color:var(--nlm-stroke-default);--mat-button-outlined-container-height:2.5rem;--mat-button-outlined-container-shape:6rem;--mat-button-outlined-hover-state-layer-opacity:0.08;--mat-button-outlined-focus-state-layer-opacity:0.1;--mat-button-outlined-disabled-label-text-color:var(--nlm-text-secondary-text);--mat-button-text-label-text-color:var(--nlm-text-cta-text-tertiary);--mat-button-text-hover-state-layer-opacity:0.08;--mat-button-text-focus-state-layer-opacity:0.1;--mat-button-text-disabled-label-text-color:var(--nlm-text-secondary-text);--mat-icon-button-disabled-icon-color:var(--nlm-text-secondary-text);--mat-radio-checked-ripple-color:var(--nlm-ctas-text-and-icon);--mat-radio-disabled-selected-icon-color:var(--nlm-text-secondary-text);--mat-radio-disabled-unselected-icon-color:var(--nlm-text-secondary-text);--mat-radio-ripple-color:var(--nlm-text-titles-and-labels);--mat-radio-selected-focus-icon-color:var(--nlm-ctas-text-and-icon);--mat-radio-selected-hover-icon-color:var(--nlm-ctas-text-and-icon);--mat-radio-selected-icon-color:var(--nlm-ctas-text-and-icon);--mat-radio-selected-pressed-icon-color:var(--nlm-ctas-text-and-icon);--mat-radio-unselected-focus-icon-color:var(--nlm-text-titles-and-labels);--mat-radio-unselected-hover-icon-color:var(--nlm-text-titles-and-labels);--mat-radio-unselected-icon-color:var(--nlm-text-secondary-text);--mat-radio-unselected-pressed-icon-color:var(--nlm-text-titles-and-labels);--mat-menu-container-color:var(--nlm-fills-surface-panel);--mat-menu-container-shape:0.5rem;--mat-menu-item-label-text-color:var(--nlm-text-cta-text-tertiary);--mat-menu-item-hover-state-layer-color:var(--nlm-states-on-tertiary-hover);--nlm-states-on-primary-hover:light-dark(rgba(0,0,0,0.08),rgba(255,255,255,0.08));--nlm-states-on-primary-focus:light-dark(rgba(0,0,0,0.12),rgba(255,255,255,0.12));--nlm-states-on-secondary-hover:light-dark(rgba(255,255,255,0.08),rgba(66,89,255,0.08));--nlm-states-on-secondary-focus:light-dark(rgba(255,255,255,0.12),rgba(66,89,255,0.12));--nlm-states-on-tertiary-hover:light-dark(rgba(66,89,255,0.08),rgba(255,255,255,0.08));--nlm-states-on-tertiary-focus:light-dark(rgba(66,89,255,0.12),rgba(255,255,255,0.12));--nlm-states-on-artifacts-hover:light-dark(rgba(0,0,0,0.08),rgba(255,255,255,0.08));--nlm-states-surface-panel-0:light-dark(rgba(255,255,255,0),rgba(34,38,43,0));--nlm-states-tile-edit-button-hover:light-dark(rgba(0,0,0,0.16),rgba(255,255,255,0.16));--nlm-states-tile-edit-button-focus:light-dark(rgba(0,0,0,0.18),rgba(255,255,255,0.18));--nlm-fills-surface-panel:light-dark(#fff,#22262b);--nlm-fills-surface-panel-transparent-70:light-dark(rgba(255,255,255,0.7),rgba(34,38,43,0.7));--nlm-fills-surface-panel-transparent-80:light-dark(rgba(255,255,255,0.8),rgba(34,38,43,0.8));--nlm-fills-surface-page:light-dark(#edeffa,#1a1d22);--nlm-fills-surface-page-grey:light-dark(var(--nlm-grey-98),#1a1d22);--nlm-fills-surface-landing:light-dark(#fff,#22262b);--nlm-fills-ui-blue-fill:light-dark(#edeffa,#22262b);--nlm-fills-ui-light-grey-fill:light-dark(#f9f9f9,#1a1d22);--nlm-fills-ui-grey-fill:light-dark(#f2f2f2,#3e4a59);--nlm-fills-ui-dark-grey-fill:light-dark(#919191,#777);--nlm-fills-x-icon:light-dark(#f2f4f7,#22262b);--nlm-fills-scrim:light-dark(rgba(0,0,0,0.32),rgba(0,0,0,0.6));--nlm-text-titles-and-labels:light-dark(#1b1b1c,#f2f2f2);--nlm-text-body-text:light-dark(#303030,#c7c7c7);--nlm-text-secondary-text:light-dark(#5e5e5e,#ababab);--nlm-text-ghost-text:light-dark(#777,#919191);--nlm-cta-text-and-icon-primary:light-dark(#fff,#fff);--nlm-text-cta-text-secondary:light-dark(#fff,#22262b);--nlm-text-cta-text-tertiary:light-dark(#1b1b1c,#f2f2f2);--nlm-text-buttons-primary:light-dark(#4259ff,#c3caff);--nlm-cta-text-and-icon-blue-reverse:light-dark(#c3caff,#4259ff);--nlm-ctas-text-and-icon:light-dark(var(--nlm-blue-50),var(--nlm-blue-90));--nlm-ctas-text-and-icon-reverse:light-dark(var(--nlm-blue-90),var(--nlm-blue-50));--nlm-ctas-buttons-tertiary:var(\n
+        \   --nlm-fills-surface-panel\n  );--nlm-ctas-buttons-secondary:light-dark(var(--nlm-brand-black),var(--nlm-grey-100));--nlm-ctas-buttons-pill:light-dark(var(--nlm-blue-98),var(--nlm-blue-90));--nlm-tiles-blue:light-dark(#edeffa,#32343e);--nlm-tiles-green:light-dark(#e1f1e5,#303632);--nlm-tiles-yellow:light-dark(#f2f2e8,#3a3a2f);--nlm-tiles-orange:light-dark(#f7edeb,#3a3230);--nlm-tiles-pink:light-dark(#f0e9ef,#3a3139);--nlm-tiles-cyan:light-dark(#def1f7,#32383e);--nlm-tiles-grey:light-dark(#f2f2f2,#3e4a59);--nlm-tiles-on-blue:light-dark(#224484,#d4dafa);--nlm-tiles-on-green:light-dark(#0f5223,#cdf1d6);--nlm-tiles-on-yellow:light-dark(#796731,#f2f2ce);--nlm-tiles-on-orange:light-dark(#8c2e2a,#f7d8d2);--nlm-tiles-on-pink:light-dark(#802272,#f0cceb);--nlm-tiles-on-cyan:light-dark(#056a95,#c9eff0);--nlm-tiles-on-grey:light-dark(#f2f2f2,#3e4a59);--nlm-tiles-on-blue-hover:light-dark(rgba(34,68,132,0.08),rgba(212,218,250,0.08));--nlm-tiles-on-green-hover:light-dark(rgba(15,82,35,0.08),rgba(205,241,214,0.08));--nlm-tiles-on-yellow-hover:light-dark(rgba(121,103,49,0.08),rgba(242,242,206,0.08));--nlm-tiles-on-orange-hover:light-dark(rgba(140,46,42,0.08),rgba(247,216,210,0.08));--nlm-tiles-on-pink-hover:light-dark(rgba(128,34,114,0.08),rgba(240,204,235,0.08));--nlm-tiles-on-cyan-hover:light-dark(rgba(5,106,149,0.08),rgba(201,239,240,0.08));--nlm-tiles-on-grey-hover:light-dark(rgba(242,242,242,0.08),rgba(62,74,89,0.08));--nlm-icons-default:light-dark(#1b1b1c,#f2f2f2);--nlm-icons-blue:light-dark(#3271ea,#3271ea);--nlm-icons-yellow:light-dark(#fcbd00,#fcbd00);--nlm-icons-red:light-dark(#db372d,#db372d);--nlm-icons-pink:light-dark(#b741ff,#b741ff);--nlm-icons-green:light-dark(#128937,#128937);--nlm-icons-youtube:light-dark(#f00,#f00);--nlm-stroke-default:light-dark(#dde1eb,#37383b);--nlm-stroke-focus:light-dark(#919191,#5e5e5e);--nlm-ctas-buttons-primary:var(--nlm-blue-50);--nlm-strong-focus-indicator:light-dark(var(--nlm-ctas-buttons-primary),#c3cafc);--nlm-strong-focus-indicator-reverse:light-dark(#c3cafc,var(--nlm-ctas-buttons-primary));--nlm-pastel-purple:light-dark(#edeffa,#20222d);--nlm-pastel-green:light-dark(#e1f1e5,#1e2520);--nlm-pastel-yellow:light-dark(#f2f2e8,#29291d);--nlm-pastel-orange:light-dark(#f7edeb,#29201e);--nlm-pastel-pink:light-dark(#f0e9ef,#291f28);--nlm-pastel-blue:light-dark(#e7f0fa,#20272d);--nlm-brand-light-blue:light-dark(#edeffa,#2f334b);--nlm-loading-shimmer-highlight:light-dark(#edeffa,#2f334b);--nlm-loading-shimmer-general:light-dark(transparent,transparent);--mat-focus-indicator-border-color:var(--nlm-strong-focus-indicator);--mat-focus-indicator-display:block}:where(:root):root
+        .button-large{--mat-button-filled-container-height:3.25rem;--mat-button-outlined-container-height:3.25rem;--mat-button-tonal-container-height:3.25rem}:where(:root):root
+        .button-small{--mat-button-filled-container-height:2rem;--mat-button-outlined-container-height:2rem;--mat-button-tonal-container-height:2rem}:where(:root):root
+        .icon-button-small{--mat-icon-button-state-layer-size:2rem;--mat-icon-button-icon-size:1.125rem}:where(:root):root
+        .icon-button-small mat-icon{font-size:1.125rem;block-size:1.125rem;inline-size:1.125rem}:where(:root):root
+        .icon-button-primary.mat-mdc-icon-button{background-color:var(--nlm-ctas-buttons-primary);--mat-icon-button-icon-color:var(--nlm-cta-text-and-icon-primary);--mat-icon-button-disabled-icon-color:var(--nlm-text-secondary-text)}:where(:root):root
+        .icon-button-primary-light.mat-mdc-icon-button{background-color:var(--nlm-fills-ui-blue-fill);--mat-icon-button-icon-color:var(--nlm-icons-blue);--mat-icon-button-disabled-icon-color:var(--nlm-text-secondary-text)}:where(:root):root
+        .icon-button-tonal.mat-mdc-icon-button{background-color:var(--nlm-ctas-buttons-secondary);--mat-icon-button-icon-color:var(--nlm-text-cta-text-secondary);--mat-icon-button-disabled-icon-color:var(--nlm-text-secondary-text)}:where(:root):root
+        .icon-button-outline.mat-mdc-icon-button{border:1px solid var(--nlm-stroke-default);--mat-icon-button-icon-color:var(--nlm-text-titles-and-labels);--mat-icon-button-disabled-icon-color:var(--nlm-text-secondary-text)}:where(:root):root
+        .icon-button-outline.mat-mdc-icon-button mat-icon{inset-inline-start:-1px;inset-block-start:-1px}:where(:root):root
+        .mat-mdc-standard-chip .mat-mdc-chip-action-label,:where(:root):root .mat-mdc-standard-chip
+        .mdc-evolution-chip__action--primary,:where(:root):root .mat-mdc-standard-chip
+        .mdc-evolution-chip__cell--primary{overflow:visible}:where(:root):root .xap-inline-dialog-container{-webkit-box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);box-shadow:0
+        1px 2px 0 rgba(60,64,67,.3),0 1px 3px 1px rgba(60,64,67,.15);background:var(--xap-color-surface);color:var(--xap-color-on-surface)}:where(:root):root
+        .xap-inline-dialog-container:focus{outline-color:var(--xap-color-outline,#202124)}:where(:root):root
+        .xap-inline-dialog-container .xap-dialog-layout .xap-dialog-layout-content{max-height:none}@media
+        (forced-colors:active){:where(:root):root .xap-inline-dialog-container{outline:2px
+        solid;outline-color:var(--xap-color-outline,black)}:where(:root):root .xap-inline-dialog-container:focus{outline:3px
+        dashed}}.dark-theme{color-scheme:dark;--xap-color-surface:var(--mat-sys-surface);--xap-color-on-surface:var(--mat-sys-on-surface);background:var(--mat-sys-background);color:var(--mat-sys-on-background);--mat-sys-background:#131314;--mat-sys-error:#f2b8b5;--mat-sys-error-container:#8c1d18;--mat-sys-inverse-on-surface:#303030;--mat-sys-inverse-primary:#0b57d0;--mat-sys-inverse-surface:#e3e3e3;--mat-sys-on-background:#e3e3e3;--mat-sys-on-error:#601410;--mat-sys-on-error-container:#f9dedc;--mat-sys-on-primary:#062e6f;--mat-sys-on-primary-container:#d3e3fd;--mat-sys-on-primary-fixed:#041e49;--mat-sys-on-primary-fixed-variant:#0842a0;--mat-sys-on-secondary:#035;--mat-sys-on-secondary-container:#c2e7ff;--mat-sys-on-secondary-fixed:#001d35;--mat-sys-on-secondary-fixed-variant:#004a77;--mat-sys-on-surface:#e3e3e3;--mat-sys-on-surface-variant:#c4c7c5;--mat-sys-on-tertiary:#062e6f;--mat-sys-on-tertiary-container:#d3e3fd;--mat-sys-on-tertiary-fixed:#041e49;--mat-sys-on-tertiary-fixed-variant:#0842a0;--mat-sys-outline:#8e918f;--mat-sys-outline-variant:#444746;--mat-sys-primary:#a8c7fa;--mat-sys-primary-container:#0842a0;--mat-sys-primary-fixed:#d3e3fd;--mat-sys-primary-fixed-dim:#a8c7fa;--mat-sys-scrim:#000;--mat-sys-secondary:#7fcfff;--mat-sys-secondary-container:#004a77;--mat-sys-secondary-fixed:#c2e7ff;--mat-sys-secondary-fixed-dim:#7fcfff;--mat-sys-shadow:#000;--mat-sys-surface:#131314;--mat-sys-surface-bright:#37393b;--mat-sys-surface-container:#1e1f20;--mat-sys-surface-container-high:#282a2c;--mat-sys-surface-container-highest:#333537;--mat-sys-surface-container-low:#1b1b1b;--mat-sys-surface-container-lowest:#0e0e0e;--mat-sys-surface-dim:#131313;--mat-sys-surface-tint:#d1e1ff;--mat-sys-surface-variant:#444746;--mat-sys-tertiary:#a8c7fa;--mat-sys-tertiary-container:#0842a0;--mat-sys-tertiary-fixed:#d3e3fd;--mat-sys-tertiary-fixed-dim:#a8c7fa;--mat-sys-info:#a1c9ff;--mat-sys-on-info:#012c6f;--mat-sys-info-container:#04409f;--mat-sys-on-info-container:#d0e4ff;--mat-sys-success:#80da88;--mat-sys-on-success:#00381f;--mat-sys-success-container:#00522c;--mat-sys-on-success-container:#beefbb;--mat-sys-warning:#fcbd00;--mat-sys-on-warning:#4d2600;--mat-sys-warning-container:#6d3a01;--mat-sys-on-warning-container:#ffe07c;--mat-sys-link:#a1c9ff;--mat-sys-link-hover:#d0e4ff;--mat-sys-link-visited:#d9bafd;--mat-sys-blue:#a1c9ff;--mat-sys-on-blue:#012c6f;--mat-sys-blue-container:#04409f;--mat-sys-on-blue-container:#d0e4ff;--mat-sys-red:#ffb3ae;--mat-sys-on-red:#60150f;--mat-sys-red-container:#8a1a16;--mat-sys-on-red-container:#ffdadc;--mat-sys-yellow:#fcbd00;--mat-sys-on-yellow:#4d2600;--mat-sys-yellow-container:#6d3a01;--mat-sys-on-yellow-container:#ffe07c;--mat-sys-green:#80da88;--mat-sys-on-green:#00381f;--mat-sys-green-container:#00522c;--mat-sys-on-green-container:#beefbb;--mat-sys-orange:#ffb683;--mat-sys-on-orange:#522302;--mat-sys-orange-container:#753403;--mat-sys-on-orange-container:#ffdcc3;--mat-sys-pink:#ffaee4;--mat-sys-on-pink:#620438;--mat-sys-pink-container:#8d0053;--mat-sys-on-pink-container:#ffd8ef;--mat-sys-purple:#d9bafd;--mat-sys-on-purple:#400b84;--mat-sys-purple-container:#5629a4;--mat-sys-on-purple-container:#eedcfe;--mat-sys-cyan:#60d5f3;--mat-sys-on-cyan:#003641;--mat-sys-cyan-container:#004e5d;--mat-sys-on-cyan-container:#acedff;--mat-sys-grey:#c7c7c7;--mat-sys-on-grey:#303030;--mat-sys-grey-container:#474747;--mat-sys-on-grey-container:#e3e3e3;--mat-sys-neutral-variant20:#2d312f;--mat-sys-neutral10:#1f1f1f;--mat-sys-level0:0px
+        0px 0px 0px rgba(0,0,0,0.2),0px 0px 0px 0px rgba(0,0,0,0.14),0px 0px 0px 0px
+        rgba(0,0,0,0.12);--mat-sys-level1:0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px
+        1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);--mat-sys-level2:0px
+        3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px
+        0px rgba(0,0,0,0.12);--mat-sys-level3:0px 3px 5px -1px rgba(0,0,0,0.2),0px
+        6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);--mat-sys-level4:0px
+        5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px
+        2px rgba(0,0,0,0.12);--mat-sys-level5:0px 7px 8px -4px rgba(0,0,0,0.2),0px
+        12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);--mat-sys-body-large:400
+        1rem/1.5rem Google Sans Text;--mat-sys-body-large-font:Google Sans Text;--mat-sys-body-large-line-height:1.5rem;--mat-sys-body-large-size:1rem;--mat-sys-body-large-tracking:0;--mat-sys-body-large-weight:400;--mat-sys-body-medium:400
+        0.875rem/1.25rem Google Sans Text;--mat-sys-body-medium-font:Google Sans Text;--mat-sys-body-medium-line-height:1.25rem;--mat-sys-body-medium-size:0.875rem;--mat-sys-body-medium-tracking:0;--mat-sys-body-medium-weight:400;--mat-sys-body-small:400
+        0.75rem/1rem Google Sans Text;--mat-sys-body-small-font:Google Sans Text;--mat-sys-body-small-line-height:1rem;--mat-sys-body-small-size:0.75rem;--mat-sys-body-small-tracking:0.006rem;--mat-sys-body-small-weight:400;--mat-sys-display-large:400
+        3.562rem/4rem Google Sans;--mat-sys-display-large-font:Google Sans;--mat-sys-display-large-line-height:4rem;--mat-sys-display-large-size:3.562rem;--mat-sys-display-large-tracking:0;--mat-sys-display-large-weight:400;--mat-sys-display-medium:400
+        2.812rem/3.25rem Google Sans;--mat-sys-display-medium-font:Google Sans;--mat-sys-display-medium-line-height:3.25rem;--mat-sys-display-medium-size:2.812rem;--mat-sys-display-medium-tracking:0;--mat-sys-display-medium-weight:400;--mat-sys-display-small:400
+        2.25rem/2.75rem Google Sans;--mat-sys-display-small-font:Google Sans;--mat-sys-display-small-line-height:2.75rem;--mat-sys-display-small-size:2.25rem;--mat-sys-display-small-tracking:0;--mat-sys-display-small-weight:400;--mat-sys-headline-large:400
+        2rem/2.5rem Google Sans;--mat-sys-headline-large-font:Google Sans;--mat-sys-headline-large-line-height:2.5rem;--mat-sys-headline-large-size:2rem;--mat-sys-headline-large-tracking:0;--mat-sys-headline-large-weight:400;--mat-sys-headline-medium:400
+        1.75rem/2.25rem Google Sans;--mat-sys-headline-medium-font:Google Sans;--mat-sys-headline-medium-line-height:2.25rem;--mat-sys-headline-medium-size:1.75rem;--mat-sys-headline-medium-tracking:0;--mat-sys-headline-medium-weight:400;--mat-sys-headline-small:400
+        1.5rem/2rem Google Sans;--mat-sys-headline-small-font:Google Sans;--mat-sys-headline-small-line-height:2rem;--mat-sys-headline-small-size:1.5rem;--mat-sys-headline-small-tracking:0;--mat-sys-headline-small-weight:400;--mat-sys-label-large:500
+        0.875rem/1.25rem Google Sans Text;--mat-sys-label-large-font:Google Sans Text;--mat-sys-label-large-line-height:1.25rem;--mat-sys-label-large-size:0.875rem;--mat-sys-label-large-tracking:0;--mat-sys-label-large-weight:500;--mat-sys-label-large-weight-prominent:700;--mat-sys-label-medium:500
+        0.75rem/1rem Google Sans Text;--mat-sys-label-medium-font:Google Sans Text;--mat-sys-label-medium-line-height:1rem;--mat-sys-label-medium-size:0.75rem;--mat-sys-label-medium-tracking:0.006rem;--mat-sys-label-medium-weight:500;--mat-sys-label-medium-weight-prominent:700;--mat-sys-label-small:500
+        0.688rem/1rem Google Sans Text;--mat-sys-label-small-font:Google Sans Text;--mat-sys-label-small-line-height:1rem;--mat-sys-label-small-size:0.688rem;--mat-sys-label-small-tracking:0.006rem;--mat-sys-label-small-weight:500;--mat-sys-title-large:400
+        1.375rem/1.75rem Google Sans;--mat-sys-title-large-font:Google Sans;--mat-sys-title-large-line-height:1.75rem;--mat-sys-title-large-size:1.375rem;--mat-sys-title-large-tracking:0;--mat-sys-title-large-weight:400;--mat-sys-title-medium:500
+        1rem/1.5rem Google Sans Text;--mat-sys-title-medium-font:Google Sans Text;--mat-sys-title-medium-line-height:1.5rem;--mat-sys-title-medium-size:1rem;--mat-sys-title-medium-tracking:0;--mat-sys-title-medium-weight:500;--mat-sys-title-small:500
+        0.875rem/1.25rem Google Sans Text;--mat-sys-title-small-font:Google Sans Text;--mat-sys-title-small-line-height:1.25rem;--mat-sys-title-small-size:0.875rem;--mat-sys-title-small-tracking:0;--mat-sys-title-small-weight:500;--mat-sys-corner-extra-large:28px;--mat-sys-corner-extra-large-top:28px
+        28px 0 0;--mat-sys-corner-extra-small:4px;--mat-sys-corner-extra-small-top:4px
+        4px 0 0;--mat-sys-corner-full:9999px;--mat-sys-corner-large:16px;--mat-sys-corner-large-end:0
+        16px 16px 0;--mat-sys-corner-large-start:16px 0 0 16px;--mat-sys-corner-large-top:16px
+        16px 0 0;--mat-sys-corner-medium:12px;--mat-sys-corner-none:0;--mat-sys-corner-small:8px;--mat-sys-dragged-state-layer-opacity:0.16;--mat-sys-focus-state-layer-opacity:0.12;--mat-sys-hover-state-layer-opacity:0.08;--mat-sys-pressed-state-layer-opacity:0.12}.dark-theme{--mat-sys-background:var(--nlm-fills-surface-landing);--mat-sys-on-background:var(--nlm-text-body-text)}.dark-theme
+        .xap-inline-dialog-container{-webkit-box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0
+        1px 3px 1px rgba(60,64,67,.15);box-shadow:0 1px 2px 0 rgba(60,64,67,.3),0
+        1px 3px 1px rgba(60,64,67,.15);background:var(--xap-color-surface);color:var(--xap-color-on-surface)}.dark-theme
+        .xap-inline-dialog-container:focus{outline-color:var(--xap-color-outline,#202124)}.dark-theme
+        .xap-inline-dialog-container .xap-dialog-layout .xap-dialog-layout-content{max-height:none}@media
+        (forced-colors:active){.dark-theme .xap-inline-dialog-container{outline:2px
+        solid;outline-color:var(--xap-color-outline,black)}.dark-theme .xap-inline-dialog-container:focus{outline:3px
+        dashed}}sentinel{}</style><style data-font-stylesheet nonce=\"GLNjujGbca-mtF6r9EgIzQ\">@font-face{font-family:'Roboto';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/roboto/v18/KFOmCnqEu92Fr1Mu4mxP.ttf)format('truetype');}@font-face{font-family:'Roboto';font-style:normal;font-weight:500;src:url(https://fonts.gstatic.com/s/roboto/v18/KFOlCnqEu92Fr1MmEU9fBBc9.ttf)format('truetype');}@font-face{font-family:'Google
+        Material Icons';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlematerialicons/v144/Gw6kwdfw6UnXLJCcmafZyFRXb3BL9rvi0QZG3g.otf)format('opentype');}.google-material-icons{font-family:'Google
+        Material Icons';font-weight:normal;font-style:normal;font-size:24px;line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;white-space:nowrap;word-wrap:normal;direction:ltr;}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrwEIJllpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:500;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrw2IJllpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans';font-style:normal;font-weight:700;src:url(https://fonts.gstatic.com/s/googlesans/v62/4Ua_rENHsxJlGDuGo1OIlJfC6l_24rlCK1Yo_Iqcsih3SAyH6cAwhWdRFD48TE63OOYKtrzjJ5llpyw.ttf)format('truetype');}@font-face{font-family:'Google
+        Sans Display';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesansdisplay/v13/ea8FacM9Wef3EJPWRrHjgE4B6CnlZxHVDv79pA.ttf)format('truetype');}@font-face{font-family:'Google
+        Symbols';font-style:normal;font-weight:400;src:url(https://fonts.gstatic.com/s/googlesymbols/v428/HhzMU5Ak9u-oMExPeInvcuEmPosC9zyteYEFU68cPrjdKM1XLPTxlGmzczpgWvF1d8Yp7AudBnt3CPar1JFWjoLAUv3G-tSNljixIIGUsC62cYrKiAk.ttf)format('truetype');}.google-symbols{font-family:'Google
+        Symbols';font-weight:normal;font-style:normal;font-size:24px;line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;white-space:nowrap;word-wrap:normal;direction:ltr;}</style><script
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">(window.dataLayer=window.dataLayer||[]).push({'gtm.start':new
+        Date().getTime(),event:'gtm.js'});</script><script async src=\"https://www.googletagmanager.com/gtm.js?id=GTM-WQ7LTQ58\"
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\"></script><style nonce=\"GLNjujGbca-mtF6r9EgIzQ\">.gb_Eb{font:13px/27px
+        Roboto,Arial,sans-serif;z-index:986}.gb_Z{display:none}.gb_W{-webkit-background-size:32px
+        32px;background-size:32px 32px;border:0;border-radius:50%;display:block;margin:0px;position:relative;height:32px;width:32px;z-index:0}.gb_pb{background-color:#e8f0fe;border:1px
+        solid rgba(32,33,36,.08);position:relative}.gb_pb.gb_W{height:30px;width:30px}.gb_pb.gb_W:active,.gb_pb.gb_W:hover{-webkit-box-shadow:none;box-shadow:none}.gb_qb{background:#fff;border:none;border-radius:50%;bottom:2px;-webkit-box-shadow:0px
+        1px 2px 0px rgba(60,64,67,0.3),0px 1px 3px 1px rgba(60,64,67,0.15);box-shadow:0px
+        1px 2px 0px rgba(60,64,67,0.3),0px 1px 3px 1px rgba(60,64,67,0.15);height:14px;margin:2px;position:absolute;right:0;width:14px;line-height:normal;z-index:1}.gb_rb{color:#1f71e7;font:400
+        22px/32px Google Sans,Roboto,Helvetica,Arial,sans-serif;text-align:center;text-transform:uppercase}@media
+        (-webkit-min-device-pixel-ratio:1.25),(min-device-pixel-ratio:1.25),(min-resolution:1.25dppx){.gb_W:before,.gb_sb:before{display:inline-block;-webkit-transform:scale(.5);-ms-transform:scale(.5);transform:scale(.5);-webkit-transform-origin:left
+        0;-ms-transform-origin:left 0;transform-origin:left 0}.gb_9 .gb_sb:before{-webkit-transform:scale(scale(.416666667));-ms-transform:scale(scale(.416666667));transform:scale(scale(.416666667))}}.gb_W:focus,.gb_W:hover{-webkit-box-shadow:0
+        1px 0 rgba(0,0,0,.15);box-shadow:0 1px 0 rgba(0,0,0,.15)}.gb_W:active{-webkit-box-shadow:inset
+        0 2px 0 rgba(0,0,0,.15);box-shadow:inset 0 2px 0 rgba(0,0,0,.15)}.gb_W:active:after{background:rgba(0,0,0,.1);border-radius:50%;content:\"\";display:block;height:100%}.gb_tb{cursor:pointer;line-height:40px;min-width:30px;opacity:.75;overflow:hidden;vertical-align:middle;text-overflow:ellipsis}.gb_C.gb_tb{width:auto}.gb_tb:focus,.gb_tb:hover{opacity:.85}.gb_ub
+        .gb_tb,.gb_ub .gb_vb{line-height:26px}#gb#gb.gb_ub a.gb_tb,.gb_ub .gb_vb{font-size:11px;height:auto}.gb_wb{border-top:4px
+        solid #000;border-left:4px dashed transparent;border-right:4px dashed transparent;display:inline-block;margin-left:6px;opacity:.75;vertical-align:middle}.gb_5a:hover
+        .gb_wb{opacity:.85}.gb_3a>.gb_z{padding:3px 3px 3px 4px}.gb_xb.gb_ob{color:#fff}.gb_7
+        .gb_tb,.gb_7 .gb_wb{opacity:1}#gb#gb .gb_7.gb_7 a.gb_tb,#gb#gb.gb_7.gb_7 a.gb_tb{color:#fff}.gb_7.gb_7
+        .gb_wb{border-top-color:#fff;opacity:1}.gb_7 .gb_W:focus,.gb_7 .gb_W:hover,.gb_qa
+        .gb_W:focus,.gb_qa .gb_W:hover{-webkit-box-shadow:0 1px 0 rgba(0,0,0,0.15),0
+        1px 2px rgba(0,0,0,0.2);box-shadow:0 1px 0 rgba(0,0,0,0.15),0 1px 2px rgba(0,0,0,0.2)}.gb_yb
+        .gb_z,.gb_zb .gb_z{position:absolute;right:1px}.gb_5a.gb_6,.gb_Ab.gb_6,.gb_z.gb_6{-webkit-box-flex:0;-webkit-flex:0
+        1 auto;flex:0 1 auto}.gb_Bb.gb_Cb .gb_tb{width:30px!important}.gb_T,.gb_U{height:40px;position:absolute;right:-5px;top:-5px;width:40px}.gb_Db
+        .gb_T,.gb_Db .gb_U,.gb_Eb .gb_T,.gb_Eb .gb_U{right:0;top:0}.gb_y .gb_T,.gb_y
+        .gb_U{right:1px;top:-1px}.gb_U.gb_V{display:none}.gb_Ma a.gb_0a{border-radius:100px;background:#0b57d0;background:var(--gm3-sys-color-primary,#0b57d0);-webkit-box-sizing:border-box;box-sizing:border-box;color:#fff;color:var(--gm3-sys-color-on-primary,#fff);display:inline-block;font-size:14px;font-weight:500;min-height:40px;outline:none;padding:10px
+        24px;text-align:center;text-decoration:none;white-space:normal;line-height:18px;position:relative}.gb_Ma
+        a.gb_2a{border-radius:100px;border:1px solid;border-color:#747775;border-color:var(--gm3-sys-color-outline,#747775);background:none;-webkit-box-sizing:border-box;box-sizing:border-box;color:#0b57d0;color:var(--gm3-sys-color-primary,#0b57d0);display:inline-block;font-size:14px;font-weight:500;min-height:40px;outline:none;padding:10px
+        24px;text-align:center;text-decoration:none;white-space:normal;line-height:18px;position:relative}.gb_6a.gb_J
+        a.gb_0a,.gb_7a.gb_J a.gb_0a,.gb_8a.gb_J a.gb_0a{background:#c2e7ff;background:var(--gm3-sys-color-secondary-fixed,#c2e7ff);color:#001d35;color:var(--gm3-sys-color-on-secondary-fixed,#001d35)}.gb_Ma.gb_J
+        a.gb_2a{color:#a8c7fa;color:var(--gm3-sys-color-primary,#a8c7fa)}.gb_Ma a.gb_Td{padding:10px
+        12px;margin:12px 16px 12px 10px;min-width:85px}@media (max-width:640px){.gb_Ma
+        a.gb_Td{min-width:75px}}.gb_Jd,.gb_Ma{font-family:Google Sans Text,Roboto,Helvetica,Arial,sans-serif;font-style:normal}.gb_Ma.gb_6a{color:#1f1f1f;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_6a.gb_Ud{background:#fff;background:var(--og-bar-background,var(--gm3-sys-color-background,#fff))}.gb_Ma.gb_6a
+        .gb_ud.gb_vd,.gb_Ma.gb_6a a.gb_4,.gb_Ma.gb_6a span.gb_4{color:#1f1f1f;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_6a
+        .gb_nd .gb_Vd,.gb_Ma.gb_6a .gb_wd .gb_Vd{color:#1f1f1f;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_6a
+        svg{color:#444746;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#444746))}@media
+        (forced-colors:active) and (prefers-color-scheme:dark){.gb_Ma svg,.gb_Ma.gb_6a
+        svg,.gb_Ma.gb_J svg{color:white}}.gb_Ma.gb_J.gb_6a{color:#e3e3e3;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ma.gb_J.gb_6a.gb_Ud{background:transparent}.gb_Ma.gb_J.gb_6a
+        .gb_ud.gb_vd,.gb_Ma.gb_J.gb_6a a.gb_4,.gb_Ma.gb_J.gb_6a span.gb_4{color:#e3e3e3;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ma.gb_J.gb_6a
+        .gb_nd .gb_Vd,.gb_Ma.gb_J.gb_6a .gb_wd .gb_Vd{color:#e3e3e3;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ma.gb_J.gb_6a
+        svg{color:#c4c7c5;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.gb_Ma.gb_J.gb_6a.gb_Ud{background:#1f1f1f;background:var(--og-bar-background,var(--gm3-sys-color-background,#131314))}.gb_Ma.gb_7a{color:#1f1f1f;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_7a.gb_Ud{background:#e9eef6;background:var(--og-bar-background,var(--gm3-sys-color-surface-container-high,#e9eef6))}.gb_Ma.gb_7a
+        .gb_ud.gb_vd,.gb_Ma.gb_7a a.gb_4,.gb_Ma.gb_7a span.gb_4{color:#1f1f1f;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_7a
+        .gb_nd .gb_Vd,.gb_Ma.gb_7a .gb_wd .gb_Vd{color:#1f1f1f;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_7a
+        svg{color:#444746;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#444746))}.gb_Ma.gb_J.gb_7a{color:#e3e3e3;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ma.gb_J.gb_7a.gb_Ud{background:#282a2c;background:var(--og-bar-background,var(--gm3-sys-color-surface-container-high,#282a2c))}.gb_Ma.gb_J.gb_7a
+        .gb_ud.gb_vd,.gb_Ma.gb_J.gb_7a a.gb_4,.gb_Ma.gb_J.gb_7a span.gb_4{color:#e3e3e3;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ma.gb_J.gb_7a
+        .gb_nd .gb_Vd,.gb_Ma.gb_J.gb_7a .gb_wd .gb_Vd{color:#e3e3e3;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_Ma.gb_J.gb_7a
+        svg{color:#c4c7c5;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#c4c7c5))}.gb_Ma.gb_8a{color:#1f1f1f;color:var(--og-bar-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_8a.gb_Ud{background:transparent}.gb_Ma.gb_8a
+        .gb_ud.gb_vd,.gb_Ma.gb_8a a.gb_4,.gb_Ma.gb_8a span.gb_4{color:#1f1f1f;color:var(--og-link-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_8a
+        .gb_nd .gb_Vd,.gb_Ma.gb_8a .gb_wd .gb_Vd{color:#1f1f1f;color:var(--og-logo-color,var(--gm3-sys-color-on-surface,#1f1f1f))}.gb_Ma.gb_8a
+        svg{color:#444746;color:var(--og-svg-color,var(--gm3-sys-color-on-surface-variant,#444746))}.gb_Ma.gb_8a.gb_J.gb_Ud{background:transparent}.gb_Ma.gb_8a.gb_J
+        .gb_ud.gb_vd,.gb_Ma.gb_8a.gb_J a.gb_4,.gb_Ma.gb_8a.gb_J span.gb_4{color:white;color:var(--og-theme-color,white)}.gb_Ma.gb_8a.gb_J
+        .gb_nd .gb_Vd,.gb_Ma.gb_8a.gb_J .gb_wd .gb_Vd{color:white;color:var(--og-theme-color,white)}.gb_Ma.gb_8a.gb_J
+        svg{color:white;color:var(--og-theme-color,white)}.gb_Ma a.gb_4,.gb_Ma span.gb_4{text-decoration:none}.gb_ud{font-family:Google
+        Sans,Roboto,Helvetica,Arial,sans-serif;font-size:20px;font-weight:400;letter-spacing:.25px;line-height:48px;margin-bottom:2px;opacity:1;overflow:hidden;padding-left:16px;position:relative;text-overflow:ellipsis;vertical-align:middle;top:2px;white-space:nowrap;-webkit-box-flex:1;-webkit-flex:1
+        1 auto;flex:1 1 auto}.gb_zd{display:none}.gb_Ma.gb_eb .gb_ud{margin-bottom:0}.gb_wd.gb_xd
+        .gb_ud{padding-left:4px}.gb_Ma.gb_eb .gb_yd{position:relative;top:-2px}.gb_Ma{min-width:160px;position:relative}.gb_Ma.gb_fd{min-width:120px}.gb_Ma.gb_Wd
+        .gb_Xd{display:none}.gb_Ma.gb_Wd .gb_Pd{height:56px}header.gb_Ma{display:block}.gb_Ma
+        svg{fill:currentColor}.gb_Zd{position:fixed;top:0;width:100%}.gb_0d{-webkit-box-shadow:0
+        4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12),0 2px 4px -1px rgba(0,0,0,.2);box-shadow:0
+        4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12),0 2px 4px -1px rgba(0,0,0,.2)}.gb_1d{height:64px}.gb_Pd{-webkit-box-sizing:border-box;box-sizing:border-box;position:relative;width:100%;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-box-pack:justify;-webkit-justify-content:space-between;justify-content:space-between;min-width:-webkit-min-content;min-width:-moz-min-content;min-width:min-content}.gb_Ma:not(.gb_eb)
+        .gb_Pd{padding:8px}.gb_Ma:not(.gb_eb) .gb_Pd a.gb_2d{margin:12px 8px 12px
+        10px}.gb_Ma.gb_3d .gb_Pd{-webkit-box-flex:1;-webkit-flex:1 0 auto;flex:1 0
+        auto}.gb_Ma .gb_Pd.gb_Qd.gb_4d{min-width:0}.gb_Ma.gb_eb .gb_Pd{padding:4px;padding-left:8px;min-width:0}.gb_Ma.gb_eb
+        .gb_Pd a.gb_2d{margin:12px 8px 12px 10px}.gb_Xd{height:48px;vertical-align:middle;white-space:nowrap;-webkit-box-align:center;-webkit-align-items:center;align-items:center;display:-webkit-box;display:-webkit-flex;display:flex;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.gb_5d>.gb_Xd{display:table-cell;width:100%}.gb_wd{padding-right:25px;-webkit-box-sizing:border-box;box-sizing:border-box;-webkit-box-flex:1;-webkit-flex:1
+        0 auto;flex:1 0 auto}.gb_Ma.gb_eb .gb_wd{padding-right:14px}.gb_6d{-webkit-box-flex:1;-webkit-flex:1
+        1 100%;flex:1 1 100%}.gb_6d>:only-child{display:inline-block}.gb_7d.gb_od{padding-left:4px}.gb_7d.gb_8d,.gb_Ma.gb_3d
+        .gb_7d,.gb_Ma.gb_eb:not(.gb_Jd) .gb_7d{padding-left:0}.gb_Ma.gb_eb .gb_7d.gb_8d{padding-right:0}.gb_Ma.gb_eb
+        .gb_7d.gb_8d .gb_3a{margin-left:10px}.gb_od{display:inline}.gb_Ma.gb_Jd .gb_7d.gb_9d,.gb_Ma.gb_id
+        .gb_7d.gb_9d{padding-left:2px}.gb_ud{display:inline-block}.gb_7d{-webkit-box-sizing:border-box;box-sizing:border-box;height:48px;padding:0
+        4px;padding-left:5px;-webkit-box-flex:0;-webkit-flex:0 0 auto;flex:0 0 auto;-webkit-box-pack:end;-webkit-justify-content:flex-end;justify-content:flex-end}.gb_Jd{height:48px}.gb_Ma.gb_Jd{min-width:auto}.gb_Jd
+        .gb_7d{float:right;padding-left:32px;padding-left:var(--og-bar-parts-side-padding,32px)}.gb_Jd
+        .gb_7d.gb_ae{padding-left:0}.gb_be{font-size:14px;max-width:200px;overflow:hidden;padding:0
+        12px;text-overflow:ellipsis;white-space:nowrap;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text;user-select:text}.gb_a
+        a,.gb_bd a{color:inherit}.gb_vd{text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.gb_vd{opacity:1}.gb_ce{position:relative}.gb_Q{font-family:arial,sans-serif;line-height:normal;padding-right:15px}.gb_5{display:inline-block;padding-left:15px}.gb_5
+        .gb_4{display:inline-block;line-height:24px;vertical-align:middle}.gb_de{text-align:left}.gb_N,.gb_O{display:none}@media
+        screen and (max-width:319px){.gb_Pd .gb_K{display:none;visibility:hidden}}.gb_K
+        .gb_C,.gb_K .gb_C:focus,.gb_K .gb_C:hover{opacity:1}.gb_P{display:none}.gb_V{display:none!important}.gb_ob{visibility:hidden}@media
+        screen and (max-width:319px){.gb_Pd:not(.gb_Qd) .gb_K{display:none;visibility:hidden}}.gb_Ad{display:inline-block;vertical-align:middle}.gb_Bd
+        .gb_Z{bottom:-3px;right:-5px}@if (RTL_LANG){.gb_Bd .gb_Z{left:-5px}}.gb_Ad:first-child{padding-left:0}.gb_D{position:relative}.gb_C{display:inline-block;outline:none;vertical-align:middle;border-radius:50%;-webkit-box-sizing:border-box;box-sizing:border-box;height:40px;width:40px}#gb#gb
+        a.gb_C,.gb_C{cursor:pointer;text-decoration:none}.gb_C,a.gb_C{color:#000}x:-o-prefocus{border-bottom-color:#ccc}.gb_ra{background:#fff;border:1px
+        solid #ccc;border-color:rgba(0,0,0,.2);color:#000;-webkit-box-shadow:0 2px
+        10px rgba(0,0,0,.2);box-shadow:0 2px 10px rgba(0,0,0,.2);display:none;outline:none;overflow:hidden;position:absolute;right:0;top:54px;-webkit-animation:gb__a
+        .2s;animation:gb__a .2s;border-radius:2px;-webkit-user-select:text;-moz-user-select:text;-ms-user-select:text;user-select:text}.gb_Ad.gb_ab
+        .gb_ra,.gb_ab.gb_ra{display:block}.gb_Fd{position:absolute;right:0;top:54px;z-index:-1}.gb_ub
+        .gb_ra{margin-top:-10px}.gb_Ad:first-child{padding-left:4px}.gb_Ma.gb_Hd .gb_Ad:first-child{padding-left:0}.gb_Id{position:relative}.gb_Jd
+        .gb_Id,.gb_nd .gb_Id{float:right}.gb_C{padding:8px;cursor:pointer}.gb_C,.gb_Ld
+        button svg{border-radius:50%}.gb_Ad{padding:4px}.gb_Ma.gb_Hd .gb_Ad{padding:4px
+        2px}.gb_Ma.gb_Hd .gb_z.gb_Ad{padding-left:6px}.gb_ra{z-index:991;line-height:normal}.gb_ra.gb_Nd{left:0;right:auto}@media
+        (max-width:350px){.gb_ra.gb_Nd{left:0}}.gb_Od .gb_ra{top:56px}.gb_z .gb_C{padding:4px}.gb_X{display:none}.gb_5a:not(.gb_2d){position:relative}.gb_ge:after{content:\"\";border:1px
+        solid #202124;opacity:.13;position:absolute;top:4px;left:4px;border-radius:50%;width:30px;height:30px;-webkit-box-sizing:content-box;box-sizing:content-box}.gb_3a{-webkit-box-sizing:border-box;box-sizing:border-box;cursor:pointer;display:inline-block;height:48px;overflow:hidden;outline:none;padding:7px
+        0 0 16px;vertical-align:middle;width:142px;border-radius:28px;background-color:transparent;border:1px
+        solid;position:relative}.gb_3a .gb_5a{width:32px;height:32px;padding:0}.gb_3a
+        .gb_U{top:3px;right:5px}.gb_3a .gb_Z{bottom:-2px;right:-4px}.gb_6a .gb_3a,.gb_7a
+        .gb_3a{border-color:#747775;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-outline,#747775))}.gb_6a.gb_J
+        .gb_3a,.gb_7a.gb_J .gb_3a{border-color:#8e918f;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-outline,#8e918f))}.gb_8a
+        .gb_3a{border-color:#747775;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-outline,#747775))}.gb_8a.gb_J
+        .gb_3a{border-color:#e3e3e3;border-color:var(--og-dasher-chip-outline,var(--gm3-sys-color-on-surface,#e3e3e3))}.gb_9a{display:inherit}.gb_3a
+        .gb_9a{background:#fff;border-radius:6px;display:inline-block;left:15px;position:static;padding:2px;top:-1px;height:32px;-webkit-box-sizing:border-box;box-sizing:border-box;width:78px}.gb_bb{text-align:center}.gb_bb.gb_cb{background-color:#f1f3f4}.gb_bb
+        .gb_db{vertical-align:middle;max-height:28px;max-width:74px}.gb_Ma .gb_3a
+        .gb_z.gb_Ad{padding:0;margin-right:9px;float:right}.gb_Ma:not(.gb_eb) .gb_3a{margin-left:10px;margin-right:4px}.gb_3a
+        .gb_ge:after{left:0;top:0}@media screen and (max-width:480px){.gb_3a .gb_9a{display:none}.gb_3a{border:none;border-radius:50%;height:40px;margin:4px;outline:1px
+        solid transparent;padding:0;width:40px}.gb_Ma .gb_3a .gb_z.gb_Ad{padding:4px;margin-right:0}}sentinel{}</style><script
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">;this.gbar_={CONFIG:[[[0,\"www.gstatic.com\",\"og.qtm.en_US.Ij9Z0zRJIW8.es5.O\",\"com\",\"en\",\"666\",0,[4,2,\"\",\"\",\"\",\"913434246\",\"0\"],null,\"7x0HavbgEYCbw8cPsNqroQk\",null,0,\"og.qtm.zUExhDBu49U.L.X.O\",\"AA2YrTuOLF_SOEO2VtRxhQez40nbCUpFXg\",\"AA2YrTvPQXRoNheLgTKAV69R5MN0TmyBjg\",\"\",2,1,200,\"USA\",null,null,\"269\",\"666\",1,null,null,96797242,null,0,0,0,0],null,[1,0.1000000014901161,2,1],null,[1,0,0,null,\"0\",\"SCRUBBED_EMAIL@example.com\",\"\",\"AEV-sWyEiyKJDm4EwDqB0zAzSxwZA1AUK805p40EMO9A8ClNjPakX1sL3xHGL8E3obhRVYvRsqJQRQXOjv9EeaevyFok4x0yMg\",0,0,null,\"\"],[0,0,\"\",1,0,0,0,0,0,0,null,0,0,null,0,0,null,null,0,0,0,\"\",\"\",\"\",\"\",\"\",\"\",null,0,0,0,0,0,null,null,null,\"rgba(32,33,36,1)\",\"rgba(255,255,255,1)\",0,0,1,null,null,null,0,null,null,null,0],[\"%1$s
+        (default)\",\"Brand account\",1,\"%1$s (delegated)\",1,null,83,\"/?authuser=$authuser\\u0026pageId=$pageId\",null,null,null,1,\"https://accounts.google.com/ListAccounts?authuser=0\\u0026listPages=1\\u0026fwput=10\\u0026rdr=2\\u0026pid=666\\u0026gpsia=1\\u0026source=ogb\\u0026atic=1\\u0026mo=1\\u0026mn=1\\u0026hl=en\\u0026ts=1097\",0,\"dashboard\",null,null,null,null,\"Profile\",\"\",1,null,\"Signed
+        out\",\"https://accounts.google.com/AccountChooser?source=ogb\\u0026continue=$continue\\u0026Email=$email\\u0026ec=GAhAmgU\",\"https://accounts.google.com/RemoveLocalAccount?source=ogb\",\"Remove\",\"Sign
+        in\",0,1,1,0,1,0,0,null,null,null,\"Session expired\",null,null,null,\"Visitor\",null,\"Default\",\"Delegated\",\"Sign
+        out of all accounts\",0,null,null,0,null,null,\"myaccount.google.com\",\"https\",0,1,0],null,[\"1\",\"gci_91f30755d6a6b787dcc2a4062e6e9824.js\",\"googleapis.client:gapi.iframes\",\"0\",\"en\"],null,null,null,null,[\"m;/_/scs/abc-static/_/js/k=gapi.gapi.en.qXs1zGQX_58.O/d=1/rs=AHpOoo_d4u8TYeoS8K1_Ex78H_ckeXKOWw/m=__features__\",\"https://apis.google.com\",\"\",\"\",\"1\",\"\",null,1,\"es_plusone_gc_20260412.0_p1\",\"en\",null,0],[0.009999999776482582,\"com\",\"666\",[null,\"\",\"0\",null,1,5184000,null,null,\"\",null,null,null,null,null,0,null,0,null,1,0,0,0,null,null,0,0,null,0,0,0,0,0],null,null,null,0],[1,null,null,27043,666,\"USA\",\"en\",\"913434246.0\",8,null,1,0,null,null,null,null,\"3700949,105109531,105109534,105140909,105140912,115517798,115517801,116249040,116249043,116974618,116974621\",null,null,null,\"7x0HavbgEYCbw8cPsNqroQk\",0,0,0,null,2,5,\"gh\",109,0,0,null,null,1,96797242,0,0],[[null,null,null,\"https://www.gstatic.com/og/_/js/k=og.qtm.en_US.Ij9Z0zRJIW8.es5.O/rt=j/m=qabr,qgl,q_dnp,qdid,qbd,qapid,qads,qrcd,q_dg/exm=qaaw,qadd,qaid,qein,qhaw,qhba,qhbr,qhch,qhga,qhid,qhin/d=1/ed=1/rs=AA2YrTuOLF_SOEO2VtRxhQez40nbCUpFXg\"],[null,null,null,\"https://www.gstatic.com/og/_/ss/k=og.qtm.zUExhDBu49U.L.X.O/m=qdid,qba,d_b_gm3,d_wi_gm3,d_lo_gm3/excm=qaaw,qadd,qaid,qein,qhaw,qhba,qhbr,qhch,qhga,qhid,qhin/d=1/ed=1/ct=zgms/rs=AA2YrTvPQXRoNheLgTKAV69R5MN0TmyBjg\"]],null,null,null,null,null,[[\"mousedown\",\"touchstart\",\"touchmove\",\"wheel\",\"keydown\"],300000],[[null,null,null,\"https://accounts.google.com/RotateCookiesPage\"],3,null,null,null,0,1]]],};this.gbar_=this.gbar_||{};(function(_){var
+        window=this;\ntry{\n_._F_toggles_initialize=function(a){(typeof globalThis!==\"undefined\"?globalThis:typeof
+        self!==\"undefined\"?self:this)._F_toggles_gbar_=a||[]};(0,_._F_toggles_initialize)([]);\n/*\n\n
+        Copyright The Closure Library Authors.\n SPDX-License-Identifier: Apache-2.0\n*/\nvar
+        ia,oa,qa,ua,wa,xa,Pa,Qa,gb,kb,mb,rb,nb,ub,zb,Lb,Mb,Nb,Ob,Pb,Yb,Zb,$b,ac;_.aa=function(a,b){if(Error.captureStackTrace)Error.captureStackTrace(this,_.aa);else{var
+        c=Error().stack;c&&(this.stack=c)}a&&(this.message=String(a));b!==void 0&&(this.cause=b)};_.ba=function(a){a.Ym=!0;return
+        a};\n_.ha=function(a){var b=a;if(ca(b)){if(!/^\\s*(?:-?[1-9]\\d*|0)?\\s*$/.test(b))throw
+        Error(String(b));}else if(da(b)&&!Number.isSafeInteger(b))throw Error(String(b));return
+        ea?BigInt(a):a=fa(a)?a?\"1\":\"0\":ca(a)?a.trim()||\"0\":String(a)};ia=function(a,b){if(a.length>b.length)return!1;if(a.length<b.length||a===b)return!0;for(var
+        c=0;c<a.length;c++){var d=a[c],e=b[c];if(d>e)return!1;if(d<e)return!0}};_.ja=function(a){_.t.setTimeout(function(){throw
+        a;},0)};\n_.la=function(){return _.ka().toLowerCase().indexOf(\"webkit\")!=-1};_.ka=function(){var
+        a=_.t.navigator;return a&&(a=a.userAgent)?a:\"\"};oa=function(a){if(!ma||!na)return!1;for(var
+        b=0;b<na.brands.length;b++){var c=na.brands[b].brand;if(c&&c.indexOf(a)!=-1)return!0}return!1};_.pa=function(a){return
+        _.ka().indexOf(a)!=-1};qa=function(){return ma?!!na&&na.brands.length>0:!1};_.ra=function(){return
+        qa()?!1:_.pa(\"Opera\")};_.sa=function(){return qa()?!1:_.pa(\"Trident\")||_.pa(\"MSIE\")};\n_.ta=function(){return
+        _.pa(\"Firefox\")||_.pa(\"FxiOS\")};_.va=function(){return _.pa(\"Safari\")&&!(ua()||(qa()?0:_.pa(\"Coast\"))||_.ra()||(qa()?0:_.pa(\"Edge\"))||(qa()?oa(\"Microsoft
+        Edge\"):_.pa(\"Edg/\"))||(qa()?oa(\"Opera\"):_.pa(\"OPR\"))||_.ta()||_.pa(\"Silk\")||_.pa(\"Android\"))};ua=function(){return
+        qa()?oa(\"Chromium\"):(_.pa(\"Chrome\")||_.pa(\"CriOS\"))&&!(qa()?0:_.pa(\"Edge\"))||_.pa(\"Silk\")};wa=function(){return
+        ma?!!na&&!!na.platform:!1};xa=function(){return _.pa(\"iPhone\")&&!_.pa(\"iPod\")&&!_.pa(\"iPad\")};\n_.ya=function(){return
+        xa()||_.pa(\"iPad\")||_.pa(\"iPod\")};_.za=function(){return wa()?na.platform===\"macOS\":_.pa(\"Macintosh\")};_.Ca=function(a,b){return(0,_.Ba)(a,b)>=0};_.Da=function(a,b,c){return
+        typeof Symbol===\"function\"&&typeof Symbol()===\"symbol\"?(c===void 0?0:c)&&Symbol.for&&a?Symbol.for(a):a!=null?Symbol(a):Symbol():b};_.Ha=function(a,b){_.Ea||_.w
+        in a||Fa(a,Ga);a[_.w]|=b};_.Ia=function(a,b){_.Ea||_.w in a||Fa(a,Ga);a[_.w]=b};_.Ma=function(a){return
+        a[Ja]===Ka};\n_.Oa=function(a,b){return b===void 0?a.j!==Na&&!!(2&(a.J[_.w]|0)):!!(2&b)&&a.j!==Na};Pa=function(a){return
+        a};Qa=function(a,b){a.__closure__error__context__984382||(a.__closure__error__context__984382={});a.__closure__error__context__984382.severity=b};_.Ra=function(a){a=Error(a);Qa(a,\"warning\");return
+        a};_.Ta=function(a,b){if(a!=null){var c;var d=(c=Sa)!=null?c:Sa={};c=d[a]||0;c>=b||(d[a]=c+1,a=Error(),Qa(a,\"incident\"),_.ja(a))}};\n_.Va=function(a){if(typeof
+        a!==\"boolean\")throw Error(\"y`\"+_.Ua(a)+\"`\"+a);return a};_.Wa=function(a){if(a==null||typeof
+        a===\"boolean\")return a;if(typeof a===\"number\")return!!a};_.Ya=function(a){if(!(0,_.Xa)(a))throw
+        _.Ra(\"enum\");return a|0};_.Za=function(a){if(typeof a!==\"number\")throw
+        _.Ra(\"int32\");if(!(0,_.Xa)(a))throw _.Ra(\"int32\");return a|0};_.$a=function(a){if(a!=null&&typeof
+        a!==\"string\")throw Error();return a};_.ab=function(a){return a==null||typeof
+        a===\"string\"?a:void 0};\n_.bb=function(a,b,c){if(a!=null&&_.Ma(a))return
+        a;if(Array.isArray(a)){var d=a[_.w]|0;c=d|c&32|c&2;c!==d&&_.Ia(a,c);return
+        new b(a)}};_.eb=function(a){var b=_.cb(_.db);return b?a[b]:void 0};gb=function(a,b){b<100||_.Ta(fb,1)};\nkb=function(a,b,c,d){var
+        e=d!==void 0;d=!!d;var f=_.cb(_.db),g;!e&&_.Ea&&f&&(g=a[f])&&g.Od(gb);f=[];var
+        h=a.length;g=4294967295;var k=!1,m=!!(b&64),n=m?b&128?0:-1:void 0;if(!(b&1)){var
+        p=h&&a[h-1];p!=null&&typeof p===\"object\"&&p.constructor===Object?(h--,g=h):p=void
+        0;if(m&&!(b&128)&&!e){k=!0;var q;g=((q=ib)!=null?q:Pa)(g-n,n,a,p,void 0)+n}}b=void
+        0;for(q=0;q<h;q++){var r=a[q];if(r!=null&&(r=c(r,d))!=null)if(m&&q>=g){var
+        u=q-n,v=void 0;((v=b)!=null?v:b={})[u]=r}else f[q]=r}if(p)for(var A in p)h=p[A],\nh!=null&&(h=c(h,d))!=null&&(q=+A,r=void
+        0,m&&!Number.isNaN(q)&&(r=q+n)<g?f[r]=h:(q=void 0,((q=b)!=null?q:b={})[A]=h));b&&(k?f.push(b):f[g]=b);e&&_.cb(_.db)&&(a=_.eb(a))&&\"function\"==typeof
+        _.jb&&a instanceof _.jb&&(f[_.db]=a.i());return f};\nmb=function(a){switch(typeof
+        a){case \"number\":return Number.isFinite(a)?a:\"\"+a;case \"bigint\":return(0,_.lb)(a)?Number(a):\"\"+a;case
+        \"boolean\":return a?1:0;case \"object\":if(Array.isArray(a)){var b=a[_.w]|0;return
+        a.length===0&&b&1?void 0:kb(a,b,mb)}if(a!=null&&_.Ma(a))return nb(a);if(\"function\"==typeof
+        _.ob&&a instanceof _.ob)return a.j();return}return a};rb=function(a,b){if(b){ib=b==null||b===Pa||b[pb]!==qb?Pa:b;try{return
+        nb(a)}finally{ib=void 0}}return nb(a)};\nnb=function(a){a=a.J;return kb(a,a[_.w]|0,mb)};_.x=function(a,b,c){return
+        _.sb(a,b,c,2048)};\n_.sb=function(a,b,c,d){d=d===void 0?0:d;if(a==null){var
+        e=32;c?(a=[c],e|=128):a=[];b&&(e=e&-16760833|(b&1023)<<14)}else{if(!Array.isArray(a))throw
+        Error(\"z\");e=a[_.w]|0;if(tb&&1&e)throw Error(\"A\");2048&e&&!(2&e)&&ub();if(e&256)throw
+        Error(\"B\");if(e&64)return(e|d)!==e&&_.Ia(a,e|d),a;if(c&&(e|=128,c!==a[0]))throw
+        Error(\"C\");a:{c=a;e|=64;var f=c.length;if(f){var g=f-1,h=c[g];if(h!=null&&typeof
+        h===\"object\"&&h.constructor===Object){b=e&128?0:-1;g-=b;if(g>=1024)throw
+        Error(\"E\");for(var k in h)f=+k,f<g&&\n(c[f+b]=h[k],delete h[k]);e=e&-16760833|(g&1023)<<14;break
+        a}}if(b){k=Math.max(b,f-(e&128?0:-1));if(k>1024)throw Error(\"F\");e=e&-16760833|(k&1023)<<14}}}_.Ia(a,e|64|d);return
+        a};ub=function(){if(tb)throw Error(\"D\");_.Ta(vb,5)};\nzb=function(a,b){if(typeof
+        a!==\"object\")return a;if(Array.isArray(a)){var c=a[_.w]|0;a.length===0&&c&1?a=void
+        0:c&2||(!b||4096&c||16&c?a=_.wb(a,c,!1,b&&!(c&16)):(_.Ha(a,34),c&4&&Object.freeze(a)));return
+        a}if(a!=null&&_.Ma(a))return b=a.J,c=b[_.w]|0,_.Oa(a,c)?a:_.xb(a,b,c)?_.yb(a,b):_.wb(b,c);if(\"function\"==typeof
+        _.ob&&a instanceof _.ob)return a};_.yb=function(a,b,c){a=new a.constructor(b);c&&(a.j=Na);a.o=Na;return
+        a};\n_.wb=function(a,b,c,d){d!=null||(d=!!(34&b));a=kb(a,b,zb,d);d=32;c&&(d|=2);b=b&16769217|d;_.Ia(a,b);return
+        a};_.Ab=function(a){var b=a.J,c=b[_.w]|0;return _.Oa(a,c)?_.xb(a,b,c)?_.yb(a,b,!0):new
+        a.constructor(_.wb(b,c,!1)):a};_.Bb=function(a){if(a.j!==Na)return!1;var b=a.J;b=_.wb(b,b[_.w]|0);_.Ha(b,2048);a.J=b;a.j=void
+        0;a.o=void 0;return!0};_.Cb=function(a){if(!_.Bb(a)&&_.Oa(a,a.J[_.w]|0))throw
+        Error();};_.Db=function(a,b){b===void 0&&(b=a[_.w]|0);b&32&&!(b&4096)&&_.Ia(a,b|4096)};\n_.xb=function(a,b,c){return
+        c&2?!0:c&32&&!(c&4096)?(_.Ia(b,c|2),a.j=Na,!0):!1};_.Eb=function(a,b,c,d,e){var
+        f=c+(e?0:-1),g=a.length-1;if(g>=1+(e?0:-1)&&f>=g){var h=a[g];if(h!=null&&typeof
+        h===\"object\"&&h.constructor===Object)return h[c]=d,b}if(f<=g)return a[f]=d,b;if(d!==void
+        0){var k;g=((k=b)!=null?k:b=a[_.w]|0)>>14&1023||536870912;c>=g?d!=null&&(f={},a[g+(e?0:-1)]=(f[c]=d,f)):a[f]=d}return
+        b};\n_.Gb=function(a,b,c,d,e){var f=!1;d=_.Fb(a,d,e,function(g){var h=_.bb(g,c,b);f=h!==g&&h!=null;return
+        h});if(d!=null)return f&&!_.Oa(d)&&_.Db(a,b),d};_.Hb=function(){var a=function(){throw
+        Error();};Object.setPrototypeOf(a,a.prototype);return a};_.y=function(){this.oa=this.oa;this.X=this.X};_.Ib=function(a,b){return
+        a!=null?!!a:!!b};_.z=function(a,b){b==void 0&&(b=\"\");return a!=null?a:b};_.Jb=function(a,b,c){for(var
+        d in a)b.call(c,a[d],d,a)};_.Kb=function(a){for(var b in a)return!1;return!0};\nLb=typeof
+        Object.create==\"function\"?Object.create:function(a){var b=function(){};b.prototype=a;return
+        new b};Mb=typeof Object.defineProperties==\"function\"?Object.defineProperty:function(a,b,c){if(a==Array.prototype||a==Object.prototype)return
+        a;a[b]=c.value;return a};\nNb=function(a){a=[\"object\"==typeof globalThis&&globalThis,a,\"object\"==typeof
+        window&&window,\"object\"==typeof self&&self,\"object\"==typeof global&&global];for(var
+        b=0;b<a.length;++b){var c=a[b];if(c&&c.Math==Math)return c}throw Error(\"a\");};Ob=Nb(this);Pb=\"Int8
+        Uint8 Uint8Clamped Int16 Uint16 Int32 Uint32 Float32 Float64\".split(\" \");Ob.BigInt64Array&&(Pb.push(\"BigInt64\"),Pb.push(\"BigUint64\"));\nvar
+        Sb=function(a,b){if(b)for(var c=0;c<Pb.length;c++)Qb(Pb[c]+\"Array.prototype.\"+a,b)},Tb=function(a,b){b&&Qb(a,b)},Qb=function(a,b){var
+        c=Ob;a=a.split(\".\");for(var d=0;d<a.length-1;d++){var e=a[d];if(!(e in c))return;c=c[e]}a=a[a.length-1];d=c[a];b=b(d);b!=d&&b!=null&&Mb(c,a,{configurable:!0,writable:!0,value:b})},Ub;\nif(typeof
+        Object.setPrototypeOf==\"function\")Ub=Object.setPrototypeOf;else{var Vb;a:{var
+        Wb={a:!0},Xb={};try{Xb.__proto__=Wb;Vb=Xb.a;break a}catch(a){}Vb=!1}Ub=Vb?function(a,b){a.__proto__=b;if(a.__proto__!==b)throw
+        new TypeError(\"b`\"+a);return a}:null}Yb=Ub;\n_.B=function(a,b){a.prototype=Lb(b.prototype);a.prototype.constructor=a;if(Yb)Yb(a,b);else
+        for(var c in b)if(c!=\"prototype\")if(Object.defineProperties){var d=Object.getOwnPropertyDescriptor(b,c);d&&Object.defineProperty(a,c,d)}else
+        a[c]=b[c];a.Y=b.prototype};Zb=function(a){var b=0;return function(){return
+        b<a.length?{done:!1,value:a[b++]}:{done:!0}}};\n_.C=function(a){var b=typeof
+        Symbol!=\"undefined\"&&Symbol.iterator&&a[Symbol.iterator];if(b)return b.call(a);if(typeof
+        a.length==\"number\")return{next:Zb(a)};throw Error(\"c`\"+String(a));};$b=function(a,b){return
+        Object.prototype.hasOwnProperty.call(a,b)};ac=typeof Object.assign==\"function\"?Object.assign:function(a,b){if(a==null)throw
+        new TypeError(\"d\");a=Object(a);for(var c=1;c<arguments.length;c++){var d=arguments[c];if(d)for(var
+        e in d)$b(d,e)&&(a[e]=d[e])}return a};\nTb(\"Object.assign\",function(a){return
+        a||ac});_.bc=function(a){if(!(a instanceof Object))throw new TypeError(\"e`\"+a);};_.D=function(){this.X=!1;this.F=null;this.o=void
+        0;this.j=1;this.D=this.G=0;this.oa=this.A=null};_.D.prototype.N=function(a){this.o=a};_.D.prototype.getNextAddressJsc=function(){return
+        this.j};_.D.prototype.getYieldResultJsc=function(){return this.o};_.D.prototype.return=function(a){this.A={return:a};this.j=this.D};_.D.prototype[\"return\"]=_.D.prototype.return;\n_.D.prototype.S=function(a){this.A={na:a};this.j=this.D};_.D.prototype.jumpThroughFinallyBlocks=_.D.prototype.S;_.D.prototype.i=function(a,b){this.j=b;return{value:a}};_.D.prototype.yield=_.D.prototype.i;_.D.prototype.T=function(a,b){a=_.C(a);var
+        c=a.next();_.bc(c);if(c.done)this.o=c.value,this.j=b;else return this.F=a,this.i(c.value,b)};_.D.prototype.yieldAll=_.D.prototype.T;_.D.prototype.na=function(a){this.j=a};_.D.prototype.jumpTo=_.D.prototype.na;_.D.prototype.v=function(){this.j=0};\n_.D.prototype.jumpToEnd=_.D.prototype.v;_.D.prototype.C=function(a,b){this.G=a;b!=void
+        0&&(this.D=b)};_.D.prototype.setCatchFinallyBlocks=_.D.prototype.C;_.D.prototype.R=function(a){this.G=0;this.D=a||0};_.D.prototype.setFinallyBlock=_.D.prototype.R;_.D.prototype.K=function(a,b){this.j=a;this.G=b||0};_.D.prototype.leaveTryBlock=_.D.prototype.K;_.D.prototype.B=function(a){this.G=a||0;a=this.A.ng;this.A=null;return
+        a};_.D.prototype.enterCatchBlock=_.D.prototype.B;\n_.D.prototype.L=function(a,b,c){c?this.oa[c]=this.A:this.oa=[this.A];this.G=a||0;this.D=b||0};_.D.prototype.enterFinallyBlock=_.D.prototype.L;_.D.prototype.M=function(a,b){b=this.oa.splice(b||0)[0];(b=this.A=this.A||b)?b.Ag?this.j=this.G||this.D:b.na!=void
+        0&&this.D<b.na?(this.j=b.na,this.A=null):this.j=this.D:this.j=a};_.D.prototype.leaveFinallyBlock=_.D.prototype.M;_.D.prototype.O=function(a){return
+        new cc(a)};_.D.prototype.forIn=_.D.prototype.O;\nvar cc=function(a){this.o=a;this.i=[];for(var
+        b in a)this.i.push(b);this.i.reverse()};cc.prototype.j=function(){for(;this.i.length>0;){var
+        a=this.i.pop();if(a in this.o)return a}return null};cc.prototype.getNext=cc.prototype.j;Tb(\"globalThis\",function(a){return
+        a||Ob});Tb(\"Reflect.setPrototypeOf\",function(a){return a?a:Yb?function(b,c){try{return
+        Yb(b,c),!0}catch(d){return!1}}:null});\nTb(\"Symbol\",function(a){if(a)return
+        a;var b=function(f,g){this.i=f;Mb(this,\"description\",{configurable:!0,writable:!0,value:g})};b.prototype.toString=function(){return
+        this.i};var c=\"jscomp_symbol_\"+(Math.random()*1E9>>>0)+\"_\",d=0,e=function(f){if(this
+        instanceof e)throw new TypeError(\"g\");return new b(c+(f||\"\")+\"_\"+d++,f)};return
+        e});Tb(\"Symbol.iterator\",function(a){if(a)return a;a=Symbol(\"h\");Mb(Array.prototype,a,{configurable:!0,writable:!0,value:function(){return
+        dc(Zb(this))}});return a});\nvar dc=function(a){a={next:a};a[Symbol.iterator]=function(){return
+        this};return a};\nTb(\"Promise\",function(a){function b(){this.i=null}function
+        c(g){return g instanceof e?g:new e(function(h){h(g)})}if(a)return a;b.prototype.j=function(g){if(this.i==null){this.i=[];var
+        h=this;this.o(function(){h.A()})}this.i.push(g)};var d=Ob.setTimeout;b.prototype.o=function(g){d(g,0)};b.prototype.A=function(){for(;this.i&&this.i.length;){var
+        g=this.i;this.i=[];for(var h=0;h<g.length;++h){var k=g[h];g[h]=null;try{k()}catch(m){this.v(m)}}}this.i=null};b.prototype.v=function(g){this.o(function(){throw
+        g;\n})};var e=function(g){this.i=0;this.o=void 0;this.j=[];this.C=!1;var h=this.v();try{g(h.resolve,h.reject)}catch(k){h.reject(k)}};e.prototype.v=function(){function
+        g(m){return function(n){k||(k=!0,m.call(h,n))}}var h=this,k=!1;return{resolve:g(this.X),reject:g(this.A)}};e.prototype.X=function(g){if(g===this)this.A(new
+        TypeError(\"i\"));else if(g instanceof e)this.M(g);else{a:switch(typeof g){case
+        \"object\":var h=g!=null;break a;case \"function\":h=!0;break a;default:h=!1}h?this.K(g):this.B(g)}};e.prototype.K=\nfunction(g){var
+        h=void 0;try{h=g.then}catch(k){this.A(k);return}typeof h==\"function\"?this.N(h,g):this.B(g)};e.prototype.A=function(g){this.D(2,g)};e.prototype.B=function(g){this.D(1,g)};e.prototype.D=function(g,h){if(this.i!=0)throw
+        Error(\"j`\"+g+\"`\"+h+\"`\"+this.i);this.i=g;this.o=h;this.i===2&&this.L();this.F()};e.prototype.L=function(){var
+        g=this;d(function(){if(g.G()){var h=Ob.console;typeof h!==\"undefined\"&&h.error(g.o)}},1)};e.prototype.G=function(){if(this.C)return!1;var
+        g=Ob.CustomEvent,h=Ob.Event,\nk=Ob.dispatchEvent;if(typeof k===\"undefined\")return!0;typeof
+        g===\"function\"?g=new g(\"unhandledrejection\",{cancelable:!0}):typeof h===\"function\"?g=new
+        h(\"unhandledrejection\",{cancelable:!0}):(g=Ob.document.createEvent(\"CustomEvent\"),g.initCustomEvent(\"unhandledrejection\",!1,!0,g));g.promise=this;g.reason=this.o;return
+        k(g)};e.prototype.F=function(){if(this.j!=null){for(var g=0;g<this.j.length;++g)f.j(this.j[g]);this.j=null}};var
+        f=new b;e.prototype.M=function(g){var h=this.v();g.Ld(h.resolve,h.reject)};\ne.prototype.N=function(g,h){var
+        k=this.v();try{g.call(h,k.resolve,k.reject)}catch(m){k.reject(m)}};e.prototype.then=function(g,h){function
+        k(q,r){return typeof q==\"function\"?function(u){try{m(q(u))}catch(v){n(v)}}:r}var
+        m,n,p=new e(function(q,r){m=q;n=r});this.Ld(k(g,m),k(h,n));return p};e.prototype.catch=function(g){return
+        this.then(void 0,g)};e.prototype.Ld=function(g,h){function k(){switch(m.i){case
+        1:g(m.o);break;case 2:h(m.o);break;default:throw Error(\"k`\"+m.i);}}var m=this;this.j==null?f.j(k):\nthis.j.push(k);this.C=!0};e.resolve=c;e.reject=function(g){return
+        new e(function(h,k){k(g)})};e.race=function(g){return new e(function(h,k){for(var
+        m=_.C(g),n=m.next();!n.done;n=m.next())c(n.value).Ld(h,k)})};e.all=function(g){var
+        h=_.C(g),k=h.next();return k.done?c([]):new e(function(m,n){function p(u){return
+        function(v){q[u]=v;r--;r==0&&m(q)}}var q=[],r=0;do q.push(void 0),r++,c(k.value).Ld(p(q.length-1),n),k=h.next();while(!k.done)})};return
+        e});\nvar ec=function(a,b,c){if(a==null)throw new TypeError(\"l`\"+c);if(b
+        instanceof RegExp)throw new TypeError(\"m`\"+c);return a+\"\"};Tb(\"String.prototype.startsWith\",function(a){return
+        a?a:function(b,c){var d=ec(this,b,\"startsWith\"),e=d.length,f=b.length;c=Math.max(0,Math.min(c|0,d.length));for(var
+        g=0;g<f&&c<e;)if(d[c++]!=b[g++])return!1;return g>=f}});Tb(\"Object.setPrototypeOf\",function(a){return
+        a||Yb});Tb(\"Symbol.dispose\",function(a){return a?a:Symbol(\"n\")});\nTb(\"WeakMap\",function(a){function
+        b(){}function c(k){var m=typeof k;return m===\"object\"&&k!==null||m===\"function\"}function
+        d(k){if(!$b(k,f)){var m=new b;Mb(k,f,{value:m})}}function e(k){var m=Object[k];m&&(Object[k]=function(n){if(n
+        instanceof b)return n;Object.isExtensible(n)&&d(n);return m(n)})}if(function(){if(!a||!Object.seal)return!1;try{var
+        k=Object.seal({}),m=Object.seal({}),n=new a([[k,2],[m,3]]);if(n.get(k)!=2||n.get(m)!=3)return!1;n.delete(k);n.set(m,4);return!n.has(k)&&n.get(m)==4}catch(p){return!1}}())return
+        a;\nvar f=\"$jscomp_hidden_\"+Math.random();e(\"freeze\");e(\"preventExtensions\");e(\"seal\");var
+        g=0,h=function(k){this.i=(g+=Math.random()+1).toString();if(k){k=_.C(k);for(var
+        m;!(m=k.next()).done;)m=m.value,this.set(m[0],m[1])}};h.prototype.set=function(k,m){if(!c(k))throw
+        Error(\"o\");d(k);if(!$b(k,f))throw Error(\"p`\"+k);k[f][this.i]=m;return
+        this};h.prototype.get=function(k){return c(k)&&$b(k,f)?k[f][this.i]:void 0};h.prototype.has=function(k){return
+        c(k)&&$b(k,f)&&$b(k[f],this.i)};h.prototype.delete=function(k){return c(k)&&\n$b(k,f)&&$b(k[f],this.i)?delete
+        k[f][this.i]:!1};return h});\nTb(\"Map\",function(a){if(function(){if(!a||typeof
+        a!=\"function\"||!a.prototype.entries||typeof Object.seal!=\"function\")return!1;try{var
+        h=Object.seal({x:4}),k=new a(_.C([[h,\"s\"]]));if(k.get(h)!=\"s\"||k.size!=1||k.get({x:4})||k.set({x:4},\"t\")!=k||k.size!=2)return!1;var
+        m=k.entries(),n=m.next();if(n.done||n.value[0]!=h||n.value[1]!=\"s\")return!1;n=m.next();return
+        n.done||n.value[0].x!=4||n.value[1]!=\"t\"||!m.next().done?!1:!0}catch(p){return!1}}())return
+        a;var b=new WeakMap,c=function(h){this[0]={};this[1]=\nf();this.size=0;if(h){h=_.C(h);for(var
+        k;!(k=h.next()).done;)k=k.value,this.set(k[0],k[1])}};c.prototype.set=function(h,k){h=h===0?0:h;var
+        m=d(this,h);m.list||(m.list=this[0][m.id]=[]);m.entry?m.entry.value=k:(m.entry={next:this[1],Db:this[1].Db,head:this[1],key:h,value:k},m.list.push(m.entry),this[1].Db.next=m.entry,this[1].Db=m.entry,this.size++);return
+        this};c.prototype.delete=function(h){h=d(this,h);return h.entry&&h.list?(h.list.splice(h.index,1),h.list.length||delete
+        this[0][h.id],h.entry.Db.next=\nh.entry.next,h.entry.next.Db=h.entry.Db,h.entry.head=null,this.size--,!0):!1};c.prototype.clear=function(){this[0]={};this[1]=this[1].Db=f();this.size=0};c.prototype.has=function(h){return!!d(this,h).entry};c.prototype.get=function(h){return(h=d(this,h).entry)&&h.value};c.prototype.entries=function(){return
+        e(this,function(h){return[h.key,h.value]})};c.prototype.keys=function(){return
+        e(this,function(h){return h.key})};c.prototype.values=function(){return e(this,function(h){return
+        h.value})};c.prototype.forEach=\nfunction(h,k){for(var m=this.entries(),n;!(n=m.next()).done;)n=n.value,h.call(k,n[1],n[0],this)};c.prototype[Symbol.iterator]=c.prototype.entries;var
+        d=function(h,k){var m=k&&typeof k;m==\"object\"||m==\"function\"?b.has(k)?m=b.get(k):(m=\"\"+
+        ++g,b.set(k,m)):m=\"p_\"+k;var n=h[0][m];if(n&&$b(h[0],m))for(h=0;h<n.length;h++){var
+        p=n[h];if(k!==k&&p.key!==p.key||k===p.key)return{id:m,list:n,index:h,entry:p}}return{id:m,list:n,index:-1,entry:void
+        0}},e=function(h,k){var m=h[1];return dc(function(){if(m){for(;m.head!=\nh[1];)m=m.Db;for(;m.next!=m.head;)return
+        m=m.next,{done:!1,value:k(m)};m=null}return{done:!0,value:void 0}})},f=function(){var
+        h={};return h.Db=h.next=h.head=h},g=0;return c});\nTb(\"Set\",function(a){if(function(){if(!a||typeof
+        a!=\"function\"||!a.prototype.entries||typeof Object.seal!=\"function\")return!1;try{var
+        c=Object.seal({x:4}),d=new a(_.C([c]));if(!d.has(c)||d.size!=1||d.add(c)!=d||d.size!=1||d.add({x:4})!=d||d.size!=2)return!1;var
+        e=d.entries(),f=e.next();if(f.done||f.value[0]!=c||f.value[1]!=c)return!1;f=e.next();return
+        f.done||f.value[0]==c||f.value[0].x!=4||f.value[1]!=f.value[0]?!1:e.next().done}catch(g){return!1}}())return
+        a;var b=function(c){this.i=new Map;if(c){c=\n_.C(c);for(var d;!(d=c.next()).done;)this.add(d.value)}this.size=this.i.size};b.prototype.add=function(c){c=c===0?0:c;this.i.set(c,c);this.size=this.i.size;return
+        this};b.prototype.delete=function(c){c=this.i.delete(c);this.size=this.i.size;return
+        c};b.prototype.clear=function(){this.i.clear();this.size=0};b.prototype.has=function(c){return
+        this.i.has(c)};b.prototype.entries=function(){return this.i.entries()};b.prototype.values=function(){return
+        this.i.values()};b.prototype.keys=b.prototype.values;\nb.prototype[Symbol.iterator]=b.prototype.values;b.prototype.forEach=function(c,d){var
+        e=this;this.i.forEach(function(f){return c.call(d,f,f,e)})};return b});Tb(\"Array.from\",function(a){return
+        a?a:function(b,c,d){c=c!=null?c:function(h){return h};var e=[],f=typeof Symbol!=\"undefined\"&&Symbol.iterator&&b[Symbol.iterator];if(typeof
+        f==\"function\"){b=f.call(b);for(var g=0;!(f=b.next()).done;)e.push(c.call(d,f.value,g++))}else
+        for(f=b.length,g=0;g<f;g++)e.push(c.call(d,b[g],g));return e}});\nTb(\"Object.entries\",function(a){return
+        a?a:function(b){var c=[],d;for(d in b)$b(b,d)&&c.push([d,b[d]]);return c}});Tb(\"Number.isFinite\",function(a){return
+        a?a:function(b){return typeof b!==\"number\"?!1:!isNaN(b)&&b!==Infinity&&b!==-Infinity}});Tb(\"Number.MAX_SAFE_INTEGER\",function(){return
+        9007199254740991});Tb(\"Number.MIN_SAFE_INTEGER\",function(){return-9007199254740991});Tb(\"Number.isInteger\",function(a){return
+        a?a:function(b){return Number.isFinite(b)?b===Math.floor(b):!1}});\nTb(\"Number.isSafeInteger\",function(a){return
+        a?a:function(b){return Number.isInteger(b)&&Math.abs(b)<=Number.MAX_SAFE_INTEGER}});Tb(\"Object.is\",function(a){return
+        a?a:function(b,c){return b===c?b!==0||1/b===1/c:b!==b&&c!==c}});Tb(\"Array.prototype.includes\",function(a){return
+        a?a:function(b,c){var d=this;d instanceof String&&(d=String(d));var e=d.length;c=c||0;for(c<0&&(c=Math.max(c+e,0));c<e;c++){var
+        f=d[c];if(f===b||Object.is(f,b))return!0}return!1}});\nTb(\"String.prototype.includes\",function(a){return
+        a?a:function(b,c){return ec(this,b,\"includes\").indexOf(b,c||0)!==-1}});var
+        fc=function(a,b){a instanceof String&&(a+=\"\");var c=0,d=!1,e={next:function(){if(!d&&c<a.length){var
+        f=c++;return{value:b(f,a[f]),done:!1}}d=!0;return{done:!0,value:void 0}}};e[Symbol.iterator]=function(){return
+        e};return e};Tb(\"Array.prototype.entries\",function(a){return a?a:function(){return
+        fc(this,function(b,c){return[b,c]})}});\nTb(\"Math.trunc\",function(a){return
+        a?a:function(b){b=Number(b);if(isNaN(b)||b===Infinity||b===-Infinity||b===0)return
+        b;var c=Math.floor(Math.abs(b));return b<0?-c:c}});Tb(\"Array.prototype.find\",function(a){return
+        a?a:function(b,c){a:{var d=this;d instanceof String&&(d=String(d));for(var
+        e=d.length,f=0;f<e;f++){var g=d[f];if(b.call(c,g,f,d)){b=g;break a}}b=void
+        0}return b}});Tb(\"Object.values\",function(a){return a?a:function(b){var
+        c=[],d;for(d in b)$b(b,d)&&c.push(b[d]);return c}});\nTb(\"Number.isNaN\",function(a){return
+        a?a:function(b){return typeof b===\"number\"&&isNaN(b)}});Tb(\"Array.prototype.keys\",function(a){return
+        a?a:function(){return fc(this,function(b){return b})}});Tb(\"Array.prototype.values\",function(a){return
+        a?a:function(){return fc(this,function(b,c){return c})}});\nTb(\"Promise.prototype.finally\",function(a){return
+        a?a:function(b){return this.then(function(c){return Promise.resolve(b()).then(function(){return
+        c})},function(c){return Promise.resolve(b()).then(function(){throw c;})})}});Tb(\"Array.prototype.fill\",function(a){return
+        a?a:function(b,c,d){var e=this.length||0;c<0&&(c=Math.max(0,e+c));if(d==null||d>e)d=e;d=Number(d);d<0&&(d=Math.max(0,e+d));for(c=Number(c||0);c<d;c++)this[c]=b;return
+        this}});Sb(\"fill\",function(a){return a?a:Array.prototype.fill});\nTb(\"Array.prototype.flat\",function(a){return
+        a?a:function(b){b=b===void 0?1:b;var c=[];Array.prototype.forEach.call(this,function(d){Array.isArray(d)&&b>0?(d=Array.prototype.flat.call(d,b-1),c.push.apply(c,d)):c.push(d)});return
+        c}});var jc,kc,nc,oc;_.hc=_.hc||{};_.t=this||self;jc=function(a,b){var c=_.ic(\"WIZ_global_data.oxN3nb\");a=c&&c[a];return
+        a!=null?a:b};kc=_.t._F_toggles_gbar_||[];_.ic=function(a,b){a=a.split(\".\");b=b||_.t;for(var
+        c=0;c<a.length;c++)if(b=b[a[c]],b==null)return null;return b};_.Ua=function(a){var
+        b=typeof a;return b!=\"object\"?b:a?Array.isArray(a)?\"array\":b:\"null\"};_.lc=function(a){var
+        b=typeof a;return b==\"object\"&&a!=null||b==\"function\"};_.mc=\"closure_uid_\"+(Math.random()*1E9>>>0);\nnc=function(a,b,c){return
+        a.call.apply(a.bind,arguments)};oc=function(a,b,c){if(!a)throw Error();if(arguments.length>2){var
+        d=Array.prototype.slice.call(arguments,2);return function(){var e=Array.prototype.slice.call(arguments);Array.prototype.unshift.apply(e,d);return
+        a.apply(b,e)}}return function(){return a.apply(b,arguments)}};_.E=function(a,b,c){_.E=Function.prototype.bind&&Function.prototype.bind.toString().indexOf(\"native
+        code\")!=-1?nc:oc;return _.E.apply(null,arguments)};\n_.pc=function(a,b){var
+        c=Array.prototype.slice.call(arguments,1);return function(){var d=c.slice();d.push.apply(d,arguments);return
+        a.apply(this,d)}};_.G=function(a,b){a=a.split(\".\");for(var c=_.t,d;a.length&&(d=a.shift());)a.length||b===void
+        0?c[d]&&c[d]!==Object.prototype[d]?c=c[d]:c=c[d]={}:c[d]=b};_.cb=function(a){return
+        a};\n_.qc=function(a,b){function c(){}c.prototype=b.prototype;a.Y=b.prototype;a.prototype=new
+        c;a.prototype.constructor=a;a.Pm=function(d,e,f){for(var g=Array(arguments.length-2),h=2;h<arguments.length;h++)g[h-2]=arguments[h];return
+        b.prototype[e].apply(d,g)}};_.qc(_.aa,Error);_.aa.prototype.name=\"CustomError\";var
+        rc=!!(kc[0]>>22&1),sc=!!(kc[0]>>17&1),tc=!!(kc[0]>>24&1),uc=!!(kc[0]&1024);var
+        ma=rc?tc:jc(610401301,!1),tb=rc?sc||!uc:jc(748402147,!0);_.vc=_.ba(function(a){return
+        a!==null&&a!==void 0});var da=_.ba(function(a){return typeof a===\"number\"}),ca=_.ba(function(a){return
+        typeof a===\"string\"}),fa=_.ba(function(a){return typeof a===\"boolean\"});var
+        ea=typeof _.t.BigInt===\"function\"&&typeof _.t.BigInt(0)===\"bigint\";var
+        yc,wc,zc,xc;_.lb=_.ba(function(a){return ea?a>=wc&&a<=xc:a[0]===\"-\"?ia(a,yc):ia(a,zc)});yc=Number.MIN_SAFE_INTEGER.toString();wc=ea?BigInt(Number.MIN_SAFE_INTEGER):void
+        0;zc=Number.MAX_SAFE_INTEGER.toString();xc=ea?BigInt(Number.MAX_SAFE_INTEGER):void
+        0;_.Ac=typeof Uint8Array.prototype.slice===\"function\";_.Bc=typeof TextDecoder!==\"undefined\";_.Cc=typeof
+        String.prototype.isWellFormed===\"function\";_.Dc=typeof TextEncoder!==\"undefined\";_.Ec=String.prototype.trim?function(a){return
+        a.trim()}:function(a){return/^[\\s\\xa0]*([\\s\\S]*?)[\\s\\xa0]*$/.exec(a)[1]};var
+        na,Fc=_.t.navigator;na=Fc?Fc.userAgentData||null:null;_.Ba=Array.prototype.indexOf?function(a,b){return
+        Array.prototype.indexOf.call(a,b,void 0)}:function(a,b){if(typeof a===\"string\")return
+        typeof b!==\"string\"||b.length!=1?-1:a.indexOf(b,0);for(var c=0;c<a.length;c++)if(c
+        in a&&a[c]===b)return c;return-1};_.Gc=Array.prototype.forEach?function(a,b,c){Array.prototype.forEach.call(a,b,c)}:function(a,b,c){for(var
+        d=a.length,e=typeof a===\"string\"?a.split(\"\"):a,f=0;f<d;f++)f in e&&b.call(c,e[f],f,a)};\n_.Hc=Array.prototype.filter?function(a,b,c){return
+        Array.prototype.filter.call(a,b,c)}:function(a,b,c){for(var d=a.length,e=[],f=0,g=typeof
+        a===\"string\"?a.split(\"\"):a,h=0;h<d;h++)if(h in g){var k=g[h];b.call(c,k,h,a)&&(e[f++]=k)}return
+        e};_.Ic=Array.prototype.map?function(a,b,c){return Array.prototype.map.call(a,b,c)}:function(a,b,c){for(var
+        d=a.length,e=Array(d),f=typeof a===\"string\"?a.split(\"\"):a,g=0;g<d;g++)g
+        in f&&(e[g]=b.call(c,f[g],g,a));return e};\n_.Jc=Array.prototype.some?function(a,b){return
+        Array.prototype.some.call(a,b,void 0)}:function(a,b){for(var c=a.length,d=typeof
+        a===\"string\"?a.split(\"\"):a,e=0;e<c;e++)if(e in d&&b.call(void 0,d[e],e,a))return!0;return!1};_.Kc=function(a){_.Kc[\"
+        \"](a);return a};_.Kc[\" \"]=function(){};var Xc;_.Lc=_.ra();_.Mc=_.sa();_.Nc=_.pa(\"Edge\");_.Oc=_.pa(\"Gecko\")&&!(_.la()&&!_.pa(\"Edge\"))&&!(_.pa(\"Trident\")||_.pa(\"MSIE\"))&&!_.pa(\"Edge\");_.Pc=_.la()&&!_.pa(\"Edge\");_.Qc=_.za();_.Rc=wa()?na.platform===\"Windows\":_.pa(\"Windows\");_.Sc=wa()?na.platform===\"Android\":_.pa(\"Android\");_.Tc=xa();_.Uc=_.pa(\"iPad\");_.Vc=_.pa(\"iPod\");_.Wc=_.ya();\na:{var
+        Yc=\"\",Zc=function(){var a=_.ka();if(_.Oc)return/rv:([^\\);]+)(\\)|;)/.exec(a);if(_.Nc)return/Edge\\/([\\d\\.]+)/.exec(a);if(_.Mc)return/\\b(?:MSIE|rv)[:
+        ]([^\\);]+)(\\)|;)/.exec(a);if(_.Pc)return/WebKit\\/(\\S+)/.exec(a);if(_.Lc)return/(?:Version)[
+        \\/]?(\\S+)/.exec(a)}();Zc&&(Yc=Zc?Zc[1]:\"\");if(_.Mc){var $c,ad=_.t.document;$c=ad?ad.documentMode:void
+        0;if($c!=null&&$c>parseFloat(Yc)){Xc=String($c);break a}}Xc=Yc}_.bd=Xc;_.cd=_.ta();_.dd=xa()||_.pa(\"iPod\");_.ed=_.pa(\"iPad\");_.fd=_.pa(\"Android\")&&!(ua()||_.ta()||_.ra()||_.pa(\"Silk\"));_.gd=ua();_.hd=_.va()&&!_.ya();_.id=typeof
+        Uint8Array!==\"undefined\";_.jd=!_.Mc&&typeof btoa===\"function\";var kd,fb,vb,Ja,pb;_.Ea=typeof
+        Symbol===\"function\"&&typeof Symbol()===\"symbol\";kd=_.Da(\"jas\",void 0,!0);_.db=_.Da(void
+        0,Symbol());_.ld=_.Da(void 0,\"0ub\");fb=_.Da(void 0,\"0ubs\");_.md=_.Da(void
+        0,\"0ubsb\");vb=_.Da(void 0,\"0actk\");Ja=_.Da(\"m_m\",\"hn\",!0);pb=_.Da(void
+        0,\"vps\");_.nd=_.Da();var Ga,Fa,pd;Ga={nk:{value:0,configurable:!0,writable:!0,enumerable:!1}};Fa=Object.defineProperties;_.w=_.Ea?kd:\"nk\";pd=[];_.Ia(pd,7);_.od=Object.freeze(pd);var
+        Ka,Na;Ka={};Na={};_.qd=Object.freeze({});var qb={};var Sa=void 0;_.rd=typeof
+        BigInt===\"function\"?BigInt.asIntN:void 0;_.sd=Number.isSafeInteger;_.Xa=Number.isFinite;_.td=Math.trunc;var
+        ib;_.ud=_.ha(0);_.vd={};_.xd=function(a,b,c,d,e){b=_.Fb(a.J,b,c,e);if(b!==null||d&&a.o!==Na)return
+        b};_.Fb=function(a,b,c,d){if(b===-1)return null;var e=b+(c?0:-1),f=a.length-1;if(!(f<1+(c?0:-1))){if(e>=f){var
+        g=a[f];if(g!=null&&typeof g===\"object\"&&g.constructor===Object){c=g[b];var
+        h=!0}else if(e===f)c=g;else return}else c=a[e];if(d&&c!=null){d=d(c);if(d==null)return
+        d;if(!Object.is(d,c))return h?g[b]=d:a[e]=d,d}return c}};_.yd=function(a,b,c,d){_.Cb(a);var
+        e=a.J;_.Eb(e,e[_.w]|0,b,c,d);return a};\n_.I=function(a,b,c,d){var e=a.J,f=e[_.w]|0;b=_.Gb(e,f,b,c,d);if(b==null)return
+        b;f=e[_.w]|0;if(!_.Oa(a,f)){var g=_.Ab(b);g!==b&&(_.Bb(a)&&(e=a.J,f=e[_.w]|0),b=g,f=_.Eb(e,f,c,b,d),_.Db(e,f))}return
+        b};_.J=function(a,b,c){c==null&&(c=void 0);_.yd(a,b,c);c&&!_.Oa(c)&&_.Db(a.J);return
+        a};_.L=function(a,b,c,d){c=c===void 0?!1:c;var e;return(e=_.Wa(_.xd(a,b,d)))!=null?e:c};_.M=function(a,b,c,d){c=c===void
+        0?\"\":c;var e;return(e=_.ab(_.xd(a,b,d)))!=null?e:c};_.N=function(a,b,c){return
+        _.ab(_.xd(a,b,c,_.vd))};\n_.O=function(a,b,c,d){return _.yd(a,b,c==null?c:_.Va(c),d)};_.P=function(a,b,c){return
+        _.yd(a,b,c==null?c:_.Za(c))};_.Q=function(a,b,c,d){return _.yd(a,b,_.$a(c),d)};_.R=function(a,b,c,d){return
+        _.yd(a,b,c==null?c:_.Ya(c),d)};_.S=function(a,b,c){this.J=_.x(a,b,c)};_.S.prototype.toJSON=function(){return
+        rb(this)};_.S.prototype.ua=function(a){return JSON.stringify(rb(this,a))};_.S.prototype[Ja]=Ka;_.S.prototype.toString=function(){return
+        this.J.toString()};_.zd=_.Hb();_.Ad=_.Hb();_.Bd=_.Hb();_.Cd=Symbol();var Dd=function(a){this.J=_.x(a)};_.B(Dd,_.S);_.Ed=function(a){this.J=_.x(a)};_.B(_.Ed,_.S);_.Ed.prototype.xd=function(a){return
+        _.P(this,3,a)};_.Fd=function(a){this.J=_.x(a)};_.B(_.Fd,_.S);_.y.prototype.oa=!1;_.y.prototype.isDisposed=function(){return
+        this.oa};_.y.prototype.dispose=function(){this.oa||(this.oa=!0,this.P())};_.y.prototype[Symbol.dispose]=function(){this.dispose()};_.y.prototype.P=function(){if(this.X)for(;this.X.length;)this.X.shift()()};var
+        Gd=function(a){_.y.call(this);this.o=a;this.i=[];this.j={}};_.B(Gd,_.y);Gd.prototype.resolve=function(a){var
+        b=this.o;a=a.split(\".\");for(var c=a.length,d=0;d<c;++d)if(b[a[d]])b=b[a[d]];else
+        return null;return b instanceof Function?b:null};Gd.prototype.Ab=function(){for(var
+        a=this.i.length,b=this.i,c=[],d=0;d<a;++d){var e=b[d].i(),f=this.resolve(e);if(f&&f!=this.j[e])try{b[d].Ab(f)}catch(g){}else
+        c.push(b[d])}this.i=c.concat(b.slice(a))};var Hd=function(a){_.y.call(this);this.o=a;this.A=this.i=null;this.v=0;this.B={};this.j=!1;a=window.navigator.userAgent;a.indexOf(\"MSIE\")>=0&&a.indexOf(\"Trident\")>=0&&(a=/\\b(?:MSIE|rv)[:
+        ]([^\\);]+)(\\)|;)/.exec(a))&&a[1]&&parseFloat(a[1])<9&&(this.j=!0)};_.B(Hd,_.y);Hd.prototype.C=function(a,b){this.i=b;this.A=a;b.preventDefault?b.preventDefault():b.returnValue=!1};_.Id=function(a){this.J=_.x(a)};_.B(_.Id,_.S);var
+        Jd=function(a){this.J=_.x(a)};_.B(Jd,_.S);var Ld=function(){var a=Kd;this.i=null;_.L(a,4,!0)};Ld.prototype.log=function(a,b,c){c=c===void
+        0?new _.Ed:c;_.Md(this,a,98,c)};_.Md=function(a,b,c,d){c=c===void 0?98:c;d=d===void
+        0?new _.Ed:d;if(a.i){var e=new Dd;_.Q(e,1,b.message);_.Q(e,2,b.stack);_.P(e,3,b.lineNumber);_.R(e,5,1);_.J(d,40,e);a.i.log(c,d)}};_.Nd=function(a){this.i=a;this.j=void
+        0;this.o=[]};_.Nd.prototype.then=function(a,b,c){this.o.push(new Od(a,b,c));Pd(this)};_.Nd.prototype.resolve=function(a){if(this.i!==void
+        0||this.j!==void 0)throw Error(\"J\");this.i=a;Pd(this)};_.Nd.prototype.reject=function(a){if(this.i!==void
+        0||this.j!==void 0)throw Error(\"J\");this.j=a;Pd(this)};var Pd=function(a){if(a.o.length>0){var
+        b=a.i!==void 0,c=a.j!==void 0;if(b||c){b=b?a.v:a.A;c=a.o;a.o=[];try{_.Gc(c,b,a)}catch(d){console.error(d)}}}};\n_.Nd.prototype.v=function(a){a.j&&a.j.call(a.i,this.i)};_.Nd.prototype.A=function(a){a.o&&a.o.call(a.i,this.j)};var
+        Od=function(a,b,c){this.j=a;this.o=b;this.i=c};_.Qd=function(a){var b=\"nc\";if(a.nc&&a.hasOwnProperty(b))return
+        a.nc;b=new a;return a.nc=b};_.T=function(){this.v=new _.Nd;this.i=new _.Nd;this.D=new
+        _.Nd;this.B=new _.Nd;this.C=new _.Nd;this.A=new _.Nd;this.o=new _.Nd;this.j=new
+        _.Nd;this.G=new _.Nd;this.K=new _.Nd;this.F=new _.Nd};_.l=_.T.prototype;_.l.oj=function(){return
+        this.v};_.l.xj=function(){return this.i};_.l.Fj=function(){return this.D};_.l.wj=function(){return
+        this.B};_.l.Dj=function(){return this.C};_.l.uj=function(){return this.A};_.l.ij=function(){return
+        this.o};_.l.hj=function(){return this.j};_.l.yj=function(){return this.G};\n_.l.Gj=function(){return
+        this.F};_.T.i=function(){return _.Qd(_.T)};var Rd=function(a){this.J=_.x(a)};_.B(Rd,_.S);_.Td=function(){return
+        _.I(_.Sd,_.Fd,5)};var Ud;window.gbar_&&window.gbar_.CONFIG?Ud=window.gbar_.CONFIG[0]||{}:Ud=[];_.Sd=new
+        Rd(Ud);var Kd;Kd=_.I(_.Sd,Jd,3)||new Jd;_.Vd=new Ld;_.G(\"gbar_._DumpException\",function(a){_.Vd?_.Vd.log(a):console.error(a)});_.Wd=new
+        Hd(_.Vd);_.Xd=function(){this.i={};this.j={}};_.Zd=function(a,b){var c=_.Xd.i();if(a
+        in c.i){if(c.i[a]!=b)throw new Yd(a);}else{c.i[a]=b;if(b=c.j[a])for(var d=0,e=b.length;d<e;d++){var
+        f=b[d],g=c.i;delete f.i[a];if(_.Kb(f.i)){for(var h=f.j.length,k=Array(h),m=0;m<h;m++)k[m]=g[f.j[m]];f.o.apply(f.v,k)}}delete
+        c.j[a]}};_.Xd.i=function(){return _.Qd(_.Xd)};_.$d=function(){_.aa.call(this)};_.B(_.$d,_.aa);var
+        Yd=function(){_.aa.call(this)};_.B(Yd,_.$d);_.G(\"gbar.A\",_.Nd);_.Nd.prototype.aa=_.Nd.prototype.then;_.G(\"gbar.B\",_.T);_.T.prototype.ba=_.T.prototype.xj;_.T.prototype.bb=_.T.prototype.Fj;_.T.prototype.bd=_.T.prototype.Dj;_.T.prototype.bf=_.T.prototype.oj;_.T.prototype.bg=_.T.prototype.wj;_.T.prototype.bh=_.T.prototype.uj;_.T.prototype.bj=_.T.prototype.ij;_.T.prototype.bk=_.T.prototype.hj;_.T.prototype.bl=_.T.prototype.yj;_.T.prototype.bm=_.T.prototype.Gj;_.G(\"gbar.a\",_.T.i());window.gbar&&window.gbar.ap&&window.gbar.ap(window.gbar.a);\nvar
+        ae=new Gd(window);_.Zd(\"api\",ae);var be=_.Td()||new _.Fd,ce=window,de=_.z(_.N(be,8));ce.__PVT=de;_.Zd(\"eq\",_.Wd);\n}catch(e){_._DumpException(e)}\ntry{\n_.ee=function(a){this.J=_.x(a)};_.B(_.ee,_.S);\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        fe=function(a){this.J=_.x(a)};_.B(fe,_.S);var ge=function(){_.y.call(this);this.j=[];this.i=[]};_.B(ge,_.y);ge.prototype.o=function(a,b){this.j.push({features:a,options:b!=null?b:null})};ge.prototype.init=function(a,b,c){window.gapi={};var
+        d=window.___jsl={};d.h=_.z(_.N(a,1));_.Wa(_.xd(a,12))!=null&&(d.dpo=_.Ib(_.L(a,12)));d.ms=_.z(_.N(a,2));d.m=_.z(_.N(a,3));d.l=[];_.M(b,1)&&(a=_.N(b,3))&&this.i.push(a);_.M(c,1)&&(c=_.N(c,2))&&this.i.push(c);_.G(\"gapi.load\",(0,_.E)(this.o,this));return
+        this};var he=_.I(_.Sd,_.Id,14);if(he){var ie=_.I(_.Sd,_.ee,9)||new _.ee,je=new
+        fe,ke=new ge;ke.init(he,ie,je);_.Zd(\"gs\",ke)};\n}catch(e){_._DumpException(e)}\n})(this.gbar_);\n//
+        Google Inc.\n</script><meta property=\"og:title\" content=\"Google NotebookLM
+        | Note Taking &amp; Research Assistant Powered by AI\"><meta property=\"og:description\"
+        content=\"Use the power of AI for quick summarization and note taking, NotebookLM
+        is your powerful virtual research assistant rooted in information you can
+        trust.\"><meta property=\"og:url\" content=\"https://notebooklm.google.com/\"><meta
+        property=\"og:image\" content=\"https://notebooklm.google.com/_/static/branding/v5/og/notebook_lm_share.png\"><meta
+        property=\"og:image:width\" content=\"2400\"><meta property=\"og:image:height\"
+        content=\"1254\"><meta property=\"og:image:alt\" content=\"Google NotebookLM\"><meta
+        property=\"og:type\" content=\"website\"><meta name=\"twitter:card\" content=\"summary_large_image\"><script
+        type=\"application/ld+json\" nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">\n{\n  \"@context\"
+        : \"https://schema.org\",\n  \"@type\" : \"WebSite\",\n  \"name\" : \"Google
+        NotebookLM\",\n  \"url\" : \"https://notebooklm.google/\"\n}\n</script><script
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">var AF_initDataKeys = []; var AF_dataServiceRequests
+        = {}; var AF_initDataChunkQueue = []; var AF_initDataCallback; var AF_initDataInitializeCallback;
+        if (AF_initDataInitializeCallback) {AF_initDataInitializeCallback(AF_initDataKeys,
+        AF_initDataChunkQueue, AF_dataServiceRequests);}if (!AF_initDataCallback)
+        {AF_initDataCallback = function(chunk) {AF_initDataChunkQueue.push(chunk);};}</script></head><body><!--
+        Google Tag Manager (noscript) --><noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-WQ7LTQ58\"
+        height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript><!--
+        End Google Tag Manager (noscript) --></body><div class=\"boqOnegoogleliteOgbOneGoogleBar\"><div
+        class=\"gb_Ma gb_Jd gb_Eb gb_e gb_8a\" id=\"gb\"><div class=\"gb_7d gb_Bb
+        gb_Xd\" ng-non-bindable=\"\" data-ogsr-up=\"\"><div class=\"gb_Id\"><div class=\"gb_od\"><div
+        class=\"gb_K gb_Ad gb_6\" data-ogsr-alt=\"\" id=\"gbwa\"><div class=\"gb_D\"><a
+        class=\"gb_C\" aria-label=\"Google apps\" href=\"https://www.google.com/intl/en/about/products\"
+        aria-expanded=\"false\" role=\"button\" tabindex=\"0\"><svg class=\"gb_F\"
+        focusable=\"false\" viewbox=\"0 0 24 24\"><path d=\"M6,8c1.1,0 2,-0.9 2,-2s-0.9,-2
+        -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,20c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9
+        -2,2 0.9,2 2,2zM6,20c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM6,14c1.1,0
+        2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,14c1.1,0 2,-0.9 2,-2s-0.9,-2
+        -2,-2 -2,0.9 -2,2 0.9,2 2,2zM16,6c0,1.1 0.9,2 2,2s2,-0.9 2,-2 -0.9,-2 -2,-2
+        -2,0.9 -2,2zM12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,14c1.1,0
+        2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,20c1.1,0 2,-0.9 2,-2s-0.9,-2
+        -2,-2 -2,0.9 -2,2 0.9,2 2,2z\"></path><image src=\"https://ssl.gstatic.com/gb/images/bar/al-icon.png\"
+        alt=\"\" height=\"24\" width=\"24\" style=\"border:none;display:none \\9\"></image></svg></a></div></div></div><div
+        class=\"gb_z gb_Ad gb_Vf gb_6\"><div class=\"gb_D gb_Ab gb_Vf gb_6\"><a class=\"gb_C
+        gb_5a gb_6\" aria-expanded=\"false\" aria-label=\"Google Account: SCRUBBED_NAME\"
+        href=\"https://accounts.google.com/SignOutOptions?hl=en&amp;continue=https://notebooklm.google.com/&amp;ec=GBRAmgU\"
+        tabindex=\"0\" role=\"button\"><div class=\"gb_T\"><svg focusable=\"false\"
+        height=\"40px\" version=\"1.1\" viewbox=\"0 0 40 40\" width=\"40px\" xml:space=\"preserve\"
+        xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
+        style=\"opacity:1.0\"><path d=\"M4.02,28.27C2.73,25.8,2,22.98,2,20c0-2.87,0.68-5.59,1.88-8l-1.72-1.04C0.78,13.67,0,16.75,0,20c0,3.31,0.8,6.43,2.23,9.18L4.02,28.27z\"
+        fill=\"#F6AD01\"></path><path d=\"M32.15,33.27C28.95,36.21,24.68,38,20,38c-6.95,0-12.98-3.95-15.99-9.73l-1.79,0.91C5.55,35.61,12.26,40,20,40c5.2,0,9.93-1.98,13.48-5.23L32.15,33.27z\"
+        fill=\"#249A41\"></path><path d=\"M33.49,34.77C37.49,31.12,40,25.85,40,20c0-5.86-2.52-11.13-6.54-14.79l-1.37,1.46C35.72,9.97,38,14.72,38,20c0,5.25-2.26,9.98-5.85,13.27L33.49,34.77z\"
+        fill=\"#3174F1\"></path><path d=\"M20,2c4.65,0,8.89,1.77,12.09,4.67l1.37-1.46C29.91,1.97,25.19,0,20,0l0,0C12.21,0,5.46,4.46,2.16,10.96L3.88,12C6.83,6.08,12.95,2,20,2\"
+        fill=\"#E92D18\"></path></svg></div><span class=\"gb_ge\"><img class=\"gb_W
+        gbii\" src=\"SCRUBBED_AVATAR_URL\" srcset=\"SCRUBBED_AVATAR_URL 1x, SCRUBBED_AVATAR_URL
+        2x \" alt=\"\" aria-hidden=\"true\" data-noaft=\"\"></span><div class=\"gb_Z
+        gb_V\" aria-hidden=\"true\"><svg class=\"gb_Qa\" height=\"14\" viewBox=\"0
+        0 14 14\" width=\"14\" xmlns=\"http://www.w3.org/2000/svg\"><circle class=\"gb_Ra\"
+        cx=\"7\" cy=\"7\" r=\"7\"></circle><path class=\"gb_Ta\" d=\"M6 10H8V12H6V10ZM6
+        2H8V8H6V2Z\"></path></svg></div></a></div><div class=\"gb_Fb gb_ra gb_9 gb_Hb\"
+        aria-label=\"Account Information\" aria-hidden=\"true\"><div class=\"gb_Pb\"><div
+        class=\"gb_Qb\"><img class=\"gb_sb gbip gb_Ub gb_Xb\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\"
+        data-src=\"SCRUBBED_AVATAR_URL\" data-srcset=\"SCRUBBED_AVATAR_URL 1x, SCRUBBED_AVATAR_URL
+        2x \" title=\"Profile\" alt=\"\" aria-hidden=\"true\"><div class=\"gb_Mc\"><svg
+        height=\"88\" width=\"88\" focusable=\"false\" version=\"1.1\" viewbox=\"0
+        0 108 108\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"
+        style=\"opacity:1.0\"><path d=\"M3,54c0-8.21,1.95-15.96,5.4-22.83l-2.62-1.32c-3.67,7.29-5.74,15.51-5.74,24.23
+        c0,9.01,2.22,17.49,6.12,24.96l2.66-1.4C5.11,70.56,3,62.53,3,54z\" fill=\"#F6AD01\"></path><path
+        d=\"M90.22,94.16l-2.07-2.28C79.11,100.03,67.13,105,54,105c-19.64,0-36.67-11.1-45.19-27.37l-2.66,1.4
+        c8.53,16.34,25.17,27.76,44.58,28.93h6.6C69.95,107.21,81.4,102.12,90.22,94.16z\"
+        fill=\"#249A41\"></path><path d=\"M108,52.89c-0.33-15.31-7.02-29.05-17.55-38.68l-2.01,2.17C98.61,25.71,105,39.11,105,54
+        c0,15.03-6.51,28.54-16.85,37.88l2.07,2.28c10.66-9.63,17.45-23.47,17.78-38.89V52.89z\"
+        fill=\"#3174F1\"></path><path d=\"M8.43,31.11C16.81,14.44,34.07,3,54,3c13.28,0,25.36,5.08,34.44,13.39l2.01-2.17
+        C80.85,5.44,68.06,0.08,54.03,0.08C32.95,0.08,14.7,12.17,5.8,29.79L8.43,31.11z\"
+        fill=\"#E92D18\"></path></svg></div><div class=\"gb_Zb gb_Ub\"><a class=\"gb_0b
+        gb_Af gb_Ub gb_Ff\" aria-label=\"Change profile picture.\" href=\"https://myaccount.google.com/?utm_source=OGB\"
+        target=\"_blank\"><svg class=\"gb_1b\" enable-background=\"new 0 0 24 24\"
+        focusable=\"false\" height=\"26\" viewbox=\"0 0 24 24\" width=\"18\" xml:space=\"preserve\"
+        xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path
+        d=\"M20 5h-3.17L15 3H9L7.17 5H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0
+        2-.9 2-2V7c0-1.1-.9-2-2-2zm0 14H4V7h16v12zM12 9c-2.21 0-4 1.79-4 4s1.79 4
+        4 4 4-1.79 4-4-1.79-4-4-4z\"></path></svg></a></div></div><div class=\"gb_Rb\"><div
+        class=\"gb_2b gb_g\">SCRUBBED_NAME</div><div class=\"gb_3b\">SCRUBBED_EMAIL@example.com</div><a
+        class=\"gb_7b gb_Bf gbp1 gb_Rd gb_Kd\" href=\"https://myaccount.google.com/?utm_source=OGB&amp;utm_medium=act\"
+        target=\"_blank\">Manage your Google Account</a></div></div><div class=\"gb_m
+        gb_jc\"><div class=\"gb_If gb_Nc gb_V\"><div class=\"gb_Oc\"></div></div><div
+        class=\"gb_Ef gb_lc gb_V\" aria-hidden=\"true\"><a class=\"gb_kc gb_uc\" aria-hidden=\"true\"
+        href=\"/?authuser=0\" target=\"_blank\"><img class=\"gb_wc gb_Ub\" src=\"data:image/gif;base64,R0lGODlhAQABAIAAAP///////yH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==\"
+        data-src=\"SCRUBBED_AVATAR_URL\" alt=\"\" aria-hidden=\"true\"><div class=\"gb_nc\"><div><div
+        class=\"gb_Bc\">Default</div></div><div class=\"gb_yc\">SCRUBBED_NAME</div><div
+        class=\"gb_Ac\">SCRUBBED_EMAIL@example.com</div></div></a></div><div class=\"gb_dc\"
+        aria-hidden=\"true\"><svg class=\"gb_ec\" focusable=\"false\" height=\"20\"
+        viewbox=\"0 0 20 20\" width=\"20\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path d=\"M0 0h20v20H0V0z\" fill=\"none\"></path><path
+        d=\"M6.18 7L10 10.82 13.82 7 15 8.17l-5 5-5-5z\"></path></svg></div><a class=\"gb_Dc
+        gb_V gb_oc\" href=\"https://myaccount.google.com/brandaccounts?authuser=0&amp;continue=https://notebooklm.google.com/&amp;service=/%3Fauthuser%3D%24authuser%26pageId%3D%24pageId\"
+        aria-hidden=\"true\"><div class=\"gb_Ec\"><svg focusable=\"false\" height=\"20\"
+        viewbox=\"0 0 24 24\" width=\"20\" xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path d=\"M19 3H5c-1.11 0-2 .9-2
+        2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 2v10.79C16.52 14.37
+        13.23 14 12 14s-4.52.37-7 1.79V5h14zM5 19v-.77C6.74 16.66 10.32 16 12 16s5.26.66
+        7 2.23V19H5zm7-6c1.94 0 3.5-1.56 3.5-3.5S13.94 6 12 6 8.5 7.56 8.5 9.5 10.06
+        13 12 13zm0-5c.83 0 1.5.67 1.5 1.5S12.83 11 12 11s-1.5-.67-1.5-1.5S11.17 8
+        12 8z\" fill=\"#5F6368\"></path><path d=\"M0 0h24v24H0V0z\" fill=\"none\"></path></svg></div><div
+        class=\"gb_Hc gb_Ic\">All Brand accounts</div><svg class=\"gb_Jc\" focusable=\"false\"
+        height=\"24\" viewbox=\"0 0 24 24\" width=\"24\" xmlns=\"http://www.w3.org/2000/svg\"><path
+        d=\"M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z\" fill=\"#5F6368\"></path><path
+        d=\"M0 0h24v24H0z\" fill=\"none\"></path></svg></a></div><div class=\"gb_pc\"
+        tabindex=\"-1\"><a class=\"gb_ac gb_xf\" href=\"https://accounts.google.com/AddSession?continue=https://notebooklm.google.com/&amp;ec=GAlAmgU\"
+        target=\"_blank\"><div class=\"gb_bc\"><svg class=\"gb_cc\" enable-background=\"new
+        0 0 24 24\" focusable=\"false\" height=\"20\" viewbox=\"0 0 24 24\" width=\"20\"
+        xml:space=\"preserve\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><path
+        d=\"M9 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0-6c1.1 0 2
+        .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm0 7c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4zm6
+        5H3v-.99C3.2 16.29 6.3 15 9 15s5.8 1.29 6 2v1zm3-4v-3h-3V9h3V6h2v3h3v2h-3v3h-2z\"></path></svg></div><div
+        class=\"gb_fc\">Add another account</div></a></div><div class=\"gb_yf gb_gc\"><a
+        class=\"gb_ic gb_Cf gb_Lf gb_Rd gb_Kd\" id=\"gb_71\" href=\"https://accounts.google.com/Logout?ec=GAdAmgU\"
+        target=\"_top\">Sign out</a></div><div class=\"gb_zf gb_8b\"><a class=\"gb_9b
+        gb_t\" href=\"https://policies.google.com/privacy?hl=en\" target=\"_blank\">Privacy
+        Policy</a><span class=\"gb_xb\" aria-hidden=\"true\">&bull;</span><a class=\"gb_9b
+        gb_x\" href=\"https://myaccount.google.com/termsofservice?hl=en\" target=\"_blank\">Terms
+        of Service</a></div></div></div></div></div></div></div><script nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">this.gbar_=this.gbar_||{};(function(_){var
+        window=this;\ntry{\n_.le=function(a,b,c){if(!a.j)if(c instanceof Array){c=_.C(c);for(var
+        d=c.next();!d.done;d=c.next())_.le(a,b,d.value)}else{d=(0,_.E)(a.C,a,b);var
+        e=a.v+c;a.v++;b.dataset.eqid=e;a.B[e]=d;b&&b.addEventListener?b.addEventListener(c,d,!1):b&&b.attachEvent?b.attachEvent(\"on\"+c,d):a.o.log(Error(\"H`\"+b))}};\n}catch(e){_._DumpException(e)}\ntry{\n_.me=function(){if(!_.t.addEventListener||!Object.defineProperty)return!1;var
+        a=!1,b=Object.defineProperty({},\"passive\",{get:function(){a=!0}});try{var
+        c=function(){};_.t.addEventListener(\"test\",c,b);_.t.removeEventListener(\"test\",c,b)}catch(d){}return
+        a}();\n}catch(e){_._DumpException(e)}\ntry{\nvar ne=document.querySelector(\".gb_K
+        .gb_C\"),pe=document.querySelector(\"#gb.gb_fd\");ne&&!pe&&_.le(_.Wd,ne,\"click\");\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        gi=function(a){_.y.call(this);this.B=a;this.v=null;this.o={};this.C={};this.i={};this.j=null};_.B(gi,_.y);_.hi=function(a){if(a.v)return
+        a.v;for(var b in a.i)if(a.i[b].Me()&&a.i[b].nb())return a.i[b];return null};gi.prototype.A=function(a){this.i[a]&&(_.hi(this)&&_.hi(this).Ec()==a||this.i[a].Fd(!0))};gi.prototype.Va=function(a){this.j=a;for(var
+        b in this.i)this.i[b].Me()&&this.i[b].Va(a)};_.ii=function(a,b){a.i[b.Ec()]=b};gi.prototype.Bb=function(a){return
+        a in this.i?this.i[a]:null};var ji=new gi(_.Vd);_.Zd(\"dd\",ji);\n}catch(e){_._DumpException(e)}\ntry{\n_.Bj=function(a,b){return
+        _.O(a,36,b)};\n}catch(e){_._DumpException(e)}\ntry{\nvar Cj=document.querySelector(\".gb_z
+        .gb_C\"),Dj=document.querySelector(\"#gb.gb_fd\");Cj&&!Dj&&_.le(_.Wd,Cj,\"click\");\n}catch(e){_._DumpException(e)}\n})(this.gbar_);\n//
+        Google Inc.\n</script><body><labs-tailwind-root></labs-tailwind-root></body><script
+        src=\"https://www.gstatic.com/_/mss/boq-labs-tailwind/_/js/k=boq-labs-tailwind.LabsTailwindUi.en.vqGsczK_hso.es6.O/d=1/excm=_b/ed=1/dg=0/wt=2/ujg=1/rs=ANnj5bGYPA5088LmxmvxCUc5eqkwXZTS5w/ee=Pjplud:PoEs9b;QGR0gd:Mlhmy;ScI3Yc:e7Hzgb;YIZmRd:A1yn5d;cEt90b:ws9Tlc;dowIGb:ebZ3mb/dti=1/m=_b\"
+        id=\"base-js\" nonce=\"w8uDqgUYYNuPfSRGbp1P7A\"></script></body></html><script
+        nonce=\"w8uDqgUYYNuPfSRGbp1P7A\">this.gbar_=this.gbar_||{};(function(_){var
+        window=this;\ntry{\nvar ve=function(){_.aa.call(this)};_.B(ve,_.$d);_.we=function(a,b){if(b
+        in a.i)return a.i[b];throw new ve(b);};_.xe=function(a){return _.we(_.Xd.i(),a)};\n}catch(e){_._DumpException(e)}\ntry{\n/*\n\n
+        Copyright Google LLC\n SPDX-License-Identifier: Apache-2.0\n*/\nvar Ae,Be;_.ye=function(a){var
+        b=a.length;if(b>0){for(var c=Array(b),d=0;d<b;d++)c[d]=a[d];return c}return[]};Ae=function(a){return
+        new _.ze(function(b){return b.substr(0,a.length+1).toLowerCase()===a+\":\"})};Be=0;_.Ce=function(a){return
+        Object.prototype.hasOwnProperty.call(a,_.mc)&&a[_.mc]||(a[_.mc]=++Be)};_.De=globalThis.trustedTypes;_.Fe=function(a){this.i=a};_.Fe.prototype.toString=function(){return
+        this.i};_.Ge=new _.Fe(\"about:invalid#zClosurez\");_.ze=function(a){this.rk=a};_.He=[Ae(\"data\"),Ae(\"http\"),Ae(\"https\"),Ae(\"mailto\"),Ae(\"ftp\"),new
+        _.ze(function(a){return/^[^:]*([/?#]|$)/.test(a)})];_.Ie=function(a){this.i=a};_.Ie.prototype.toString=function(){return
+        this.i+\"\"};_.Je=new _.Ie(_.De?_.De.emptyHTML:\"\");\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        Pe,bf,ef,Oe,Qe;_.Ke=function(a){return/^[\\s\\xa0]*$/.test(a)};_.Le=function(a){return
+        a==null?a:(0,_.Xa)(a)?a|0:void 0};_.Me=function(a){if(a==null)return a;if(typeof
+        a===\"string\"&&a)a=+a;else if(typeof a!==\"number\")return;return(0,_.Xa)(a)?a|0:void
+        0};_.Ne=function(a,b){return a.lastIndexOf(b,0)==0};Pe=function(){var a=null;if(!Oe)return
+        a;try{var b=function(c){return c};a=Oe.createPolicy(\"ogb-qtm#html\",{createHTML:b,createScript:b,createScriptURL:b})}catch(c){}return
+        a};\n_.Re=function(){Qe===void 0&&(Qe=Pe());return Qe};_.Te=function(a){var
+        b=_.Re();a=b?b.createScriptURL(a):a;return new _.Se(a)};_.Ue=function(a){if(a
+        instanceof _.Se)return a.i;throw Error(\"L\");};_.Ve=function(a){if(a instanceof
+        _.Fe)return a.i;throw Error(\"L\");};_.Xe=function(a){if(We.test(a))return
+        a};_.Ye=function(a){return a instanceof _.Fe?_.Ve(a):_.Xe(a)};\n_.Ze=function(a,b){b=b===void
+        0?document:b;var c,d;b=(d=(c=b).querySelector)==null?void 0:d.call(c,a+\"[nonce]\");return
+        b==null?\"\":b.nonce||b.getAttribute(\"nonce\")||\"\"};_.$e=function(a,b,c,d){return
+        _.Le(_.xd(a,b,c,d))};_.U=function(a,b,c){return _.Wa(_.xd(a,b,c,_.vd))};_.af=function(a,b){return
+        _.Me(_.xd(a,b,void 0,_.vd))};bf=function(a){this.J=_.x(a)};_.B(bf,_.S);bf.prototype.Qb=function(a){return
+        _.Q(this,24,a)};_.cf=function(){return _.I(_.Sd,bf,1)};\n_.df=function(a){var
+        b=_.Ua(a);return b==\"array\"||b==\"object\"&&typeof a.length==\"number\"};Oe=_.De;_.Se=function(a){this.i=a};_.Se.prototype.toString=function(){return
+        this.i+\"\"};var We=/^\\s*(?!javascript:)(?:[\\w+.-]+:|[^:/?#]*(?:[/?#]|$))/i;var
+        lf,pf,ff;_.hf=function(a){return a?new ff(_.gf(a)):ef||(ef=new ff)};_.jf=function(a,b){return
+        typeof b===\"string\"?a.getElementById(b):b};_.V=function(a,b){var c=b||document;c.getElementsByClassName?a=c.getElementsByClassName(a)[0]:(c=document,a=a?(b||c).querySelector(a?\".\"+a:\"\"):_.kf(c,\"*\",a,b)[0]||null);return
+        a||null};_.kf=function(a,b,c,d){a=d||a;return(b=b&&b!=\"*\"?String(b).toUpperCase():\"\")||c?a.querySelectorAll(b+(c?\".\"+c:\"\")):a.getElementsByTagName(\"*\")};\n_.mf=function(a,b){_.Jb(b,function(c,d){d==\"style\"?a.style.cssText=c:d==\"class\"?a.className=c:d==\"for\"?a.htmlFor=c:lf.hasOwnProperty(d)?a.setAttribute(lf[d],c):_.Ne(d,\"aria-\")||_.Ne(d,\"data-\")?a.setAttribute(d,c):a[d]=c})};lf={cellpadding:\"cellPadding\",cellspacing:\"cellSpacing\",colspan:\"colSpan\",frameborder:\"frameBorder\",height:\"height\",maxlength:\"maxLength\",nonce:\"nonce\",role:\"role\",rowspan:\"rowSpan\",type:\"type\",usemap:\"useMap\",valign:\"vAlign\",width:\"width\"};\n_.nf=function(a){return
+        a?a.defaultView:window};_.qf=function(a,b){var c=b[1],d=_.of(a,String(b[0]));c&&(typeof
+        c===\"string\"?d.className=c:Array.isArray(c)?d.className=c.join(\" \"):_.mf(d,c));b.length>2&&pf(a,d,b);return
+        d};\npf=function(a,b,c){function d(h){h&&b.appendChild(typeof h===\"string\"?a.createTextNode(h):h)}for(var
+        e=2;e<c.length;e++){var f=c[e];if(!_.df(f)||_.lc(f)&&f.nodeType>0)d(f);else{a:{if(f&&typeof
+        f.length==\"number\"){if(_.lc(f)){var g=typeof f.item==\"function\"||typeof
+        f.item==\"string\";break a}if(typeof f===\"function\"){g=typeof f.item==\"function\";break
+        a}}g=!1}_.Gc(g?_.ye(f):f,d)}}};_.rf=function(a){return _.of(document,a)};\n_.of=function(a,b){b=String(b);a.contentType===\"application/xhtml+xml\"&&(b=b.toLowerCase());return
+        a.createElement(b)};_.sf=function(a){for(var b;b=a.firstChild;)a.removeChild(b)};_.tf=function(a){return
+        a&&a.parentNode?a.parentNode.removeChild(a):null};_.uf=function(a,b){if(!a||!b)return!1;if(a.contains&&b.nodeType==1)return
+        a==b||a.contains(b);if(typeof a.compareDocumentPosition!=\"undefined\")return
+        a==b||!!(a.compareDocumentPosition(b)&16);for(;b&&a!=b;)b=b.parentNode;return
+        b==a};\n_.gf=function(a){return a.nodeType==9?a:a.ownerDocument||a.document};ff=function(a){this.i=a||_.t.document||document};_.l=ff.prototype;_.l.H=function(a){return
+        _.jf(this.i,a)};_.l.Qa=function(a,b,c){return _.qf(this.i,arguments)};_.l.appendChild=function(a,b){a.appendChild(b)};_.l.yf=_.sf;_.l.mh=_.tf;_.l.kh=_.uf;\n}catch(e){_._DumpException(e)}\ntry{\n_.Ij=function(a,b){a.src=_.Ue(b).toString()};_.Jj=function(a){var
+        b=_.Ze(\"script\",a.ownerDocument);b&&a.setAttribute(\"nonce\",b)};_.Kj=function(a,b){a.src=_.Ue(b);_.Jj(a)};_.Lj=function(a){if(!a)return
+        null;a=_.N(a,4);var b;a===null||a===void 0?b=null:b=_.Te(a);return b};_.Mj=function(a,b,c){a=a.J;return
+        _.Gb(a,a[_.w]|0,b,c)!==void 0};_.Nj=function(a){this.J=_.x(a)};_.B(_.Nj,_.S);_.Oj=function(){for(var
+        a=Number(this),b=[],c=a;c<arguments.length;c++)b[c-a]=arguments[c];return
+        b};\n_.Pj=function(a,b){return(b||document).getElementsByTagName(String(a))};\n}catch(e){_._DumpException(e)}\ntry{\nvar
+        Rj=function(a,b,c){a<b?Qj(a+1,b):_.Vd.log(Error(\"oa`\"+a+\"`\"+b),{url:c})},Qj=function(a,b){if(Sj){var
+        c=_.rf(\"SCRIPT\");c.async=!0;c.type=\"text/javascript\";c.charset=\"UTF-8\";_.Kj(c,Sj);c.onerror=_.pc(Rj,a,b,c.src);_.Pj(\"HEAD\")[0].appendChild(c)}},Tj=function(a){this.J=_.x(a)};_.B(Tj,_.S);var
+        Uj=_.I(_.Sd,Tj,17)||new Tj,Vj,Sj=(Vj=_.I(Uj,_.Nj,1))?_.Lj(Vj):null,Wj,Xj=(Wj=_.I(Uj,_.Nj,2))?_.Lj(Wj):null,Yj=function(){Qj(1,2);if(Xj){var
+        a=_.rf(\"LINK\");a.setAttribute(\"type\",\"text/css\");a.href=_.Ue(Xj).toString();a.rel=\"stylesheet\";var
+        b=_.Ze(\"style\",document);b&&a.setAttribute(\"nonce\",b);_.Pj(\"HEAD\")[0].appendChild(a)}};(function(){var
+        a=_.cf();if(_.U(a,18))Yj();else{var b=_.af(a,19)||0;window.addEventListener(\"load\",function(){window.setTimeout(Yj,b)})}})();\n}catch(e){_._DumpException(e)}\n})(this.gbar_);\n//
+        Google Inc.\n</script><div ng-non-bindable=\"\"><div class=\"gb_P\">Google
+        apps</div><div class=\"gb_X\"><div class=\"gb_Xc\"><div>Google Account</div><div
+        class=\"gb_g\">SCRUBBED_NAME</div><div>SCRUBBED_EMAIL@example.com</div><div
+        class=\"gb_Wc\"></div></div></div></div>"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Security-Policy:
+      - script-src 'report-sample' 'nonce-w8uDqgUYYNuPfSRGbp1P7A' 'unsafe-inline';object-src
+        'none';base-uri 'self';report-uri /_/LabsTailwindUi/cspreport;worker-src 'self'
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - text/html; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Fri, 15 May 2026 13:21:51 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - NID=SCRUBBED; expires=Sat, 14-Nov-2026 13:21:51 GMT; path=/; domain=.google.com;
+        HttpOnly
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:51 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:51 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:51 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:51 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:51 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:51 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '331588'
+      reporting-endpoints:
+      - default="/_/LabsTailwindUi/web-reports?context=eJwNyU9IU3EAB_AX-b7JCIoxciwlMJhLnbw2NqfhH0SDmD_f-733RE8OxT8sxpvOgXhYFij4r5CkoJwIHSoK6dSpQxcR6eIYIjEWhFCHwLqESIT4PXxOH9f3i3cDPuW9s68-2CqqD8n3pqhWU8Z7oM7TS09JzVPnelntosm6b2qGYv44WuneYhxx8g_1IkDLE71YpbMKAUUV-OoSKFFjvUATRXsEYlQ5KOCiSFqgmd5OCbyjk2leVsD9WcBDKzsCj6mw0Ici1Rz14QbtXtGxR4bQYdJsXkfNKx13yjo6qOJYxxCl2gw45O83EKDNnIEturZvwEtVNyWu02K9xDL1ByUGyNsu4aP1DYlntPRaYoXsLxKDdPZDQvkpsaqYeEK5FhNzFG4z0Uo5SvaY8G6bqKbSLxNl0v6bCNELxcIGuS9Z8NBvt4W_tNZg4SlFGi00Uzt10m7Uwh7NCQuP6MOYhY90ELZxSKfjNv5R9L6NFuo6ttFN7suVfz7lC7haeL69dKH21kh6KpEaHpkOZoeTqZmkMxocz6Sd7JgzmghpoagWuR1u0mKJSe0cwCilPA"
+      x-ua-compatible:
+      - IE=edge
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22yyryJe%22%2C%22%5B%5B%5B%5B%5C%22466b9ee3-c1ce-45ef-861c-1d4bfcd939ad%5C%22%5D%5D%5D%2Cnull%2Cnull%2Cnull%2Cnull%2C%5B%5C%22interactive_mindmap%5C%22%2C%5B%5B%5C%22%5BCONTEXT%5D%5C%22%2C%5C%22%5C%22%5D%5D%2C%5C%22en%5C%22%5D%2Cnull%2C%5B2%2Cnull%2C%5B1%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778851311284&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '363'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=1.1.1583381276.1778846987; _ga=GA1.1.1567240762.1778846987;
+        _ga_W0LDH41ZCB=GS2.1.s1778846986$o1$g0$t1778846986$j60$l0$h0
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=yyryJe&source-path=%2Fnotebook%2Fbb00c9e3-656c-4fd2-b890-2b71e1cf3814&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ")]}'\n\n2937\n[[\"wrb.fr\",\"yyryJe\",\"[[\\\"{\\\\n  \\\\\\\"name\\\\\\\":
+        \\\\\\\"NotebookLM\\\\\\\",\\\\n  \\\\\\\"children\\\\\\\": [\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Description G\xE9n\xE9rale\\\\\\\",\\\\n
+        \     \\\\\\\"children\\\\\\\": [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Outil
+        de synth\xE8se de documents\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"Assistant de recherche virtuel\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"D\xE9veloppeur: Google Labs\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"Mod\xE8le: Google Gemini\\\\\\\" }\\\\n      ]\\\\n    },\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Historique\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\":
+        [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Origine: Project Tailwind (Mai
+        2023)\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Rebranding: NotebookLM
+        (2024)\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Version stable:
+        Octobre 2024\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Lancement
+        NotebookLM Plus: D\xE9cembre 2024\\\\\\\" }\\\\n      ]\\\\n    },\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Fonctionnalit\xE9s Cl\xE9s\\\\\\\",\\\\n
+        \     \\\\\\\"children\\\\\\\": [\\\\n        {\\\\n          \\\\\\\"name\\\\\\\":
+        \\\\\\\"Audio Overviews\\\\\\\",\\\\n          \\\\\\\"children\\\\\\\": [\\\\n
+        \           { \\\\\\\"name\\\\\\\": \\\\\\\"Discussion type podcast\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"H\xF4tes IA conversationnels\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Mode interactif (Join)\\\\\\\"
+        }\\\\n          ]\\\\n        },\\\\n        {\\\\n          \\\\\\\"name\\\\\\\":
+        \\\\\\\"Video Overviews\\\\\\\",\\\\n          \\\\\\\"children\\\\\\\": [\\\\n
+        \           { \\\\\\\"name\\\\\\\": \\\\\\\"R\xE9sum\xE9s visuels style diapositives\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Narration et sch\xE9mas
+        IA\\\\\\\" },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Mode cin\xE9matique\\\\\\\"
+        }\\\\n          ]\\\\n        },\\\\n        {\\\\n          \\\\\\\"name\\\\\\\":
+        \\\\\\\"Formats de sortie\\\\\\\",\\\\n          \\\\\\\"children\\\\\\\":
+        [\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Infographies\\\\\\\" },\\\\n
+        \           { \\\\\\\"name\\\\\\\": \\\\\\\"Pr\xE9sentations (Slide Deck)\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Tableaux de donn\xE9es\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Fiches de r\xE9vision\\\\\\\"
+        }\\\\n          ]\\\\n        }\\\\n      ]\\\\n    },\\\\n    {\\\\n      \\\\\\\"name\\\\\\\":
+        \\\\\\\"Sources support\xE9es\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\":
+        [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"PDF et Google Docs\\\\\\\" },\\\\n
+        \       { \\\\\\\"name\\\\\\\": \\\\\\\"Sites web\\\\\\\" },\\\\n        {
+        \\\\\\\"name\\\\\\\": \\\\\\\"Google Slides\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"Transcriptions YouTube\\\\\\\" }\\\\n      ]\\\\n    },\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Adoption et Usage\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\":
+        [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Chercheurs et \xC9tudiants\\\\\\\"
+        },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Entreprises\\\\\\\" },\\\\n
+        \       { \\\\\\\"name\\\\\\\": \\\\\\\"Spotify Wrapped 2024\\\\\\\" }\\\\n
+        \     ]\\\\n    },\\\\n    {\\\\n      \\\\\\\"name\\\\\\\": \\\\\\\"D\xE9fis
+        et Juridique\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\": [\\\\n        {
+        \\\\\\\"name\\\\\\\": \\\\\\\"Proc\xE8s David Greene (Voix IA)\\\\\\\" },\\\\n
+        \       { \\\\\\\"name\\\\\\\": \\\\\\\"Limites d'utilisation du tier gratuit\\\\\\\"
+        }\\\\n      ]\\\\n    }\\\\n  ]\\\\n}\\\",null,[\\\"eba91cb8-8599-4281-a15c-6c570262d232\\\",\\\"ef032691-866e-4f83-9f6a-3a25f79080df\\\",3220050741]]]\",null,null,null,\"generic\"]]\n57\n[[\"di\",4244],[\"af.httprm\",4244,\"7536316320012766335\",10]]\n24\n[[\"e\",4,null,null,3038]]\n"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Fri, 15 May 2026 13:21:51 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - NID=SCRUBBED; expires=Sat, 14-Nov-2026 13:21:51 GMT; path=/; domain=.google.com;
+        HttpOnly
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '3038'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22CYK0Xb%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2C%5C%22%5C%22%2C%5B1%5D%2Cnull%2C%5C%22NotebookLM%5C%22%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778851311284&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '228'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=1.1.1583381276.1778846987; _ga=GA1.1.1567240762.1778846987;
+        _ga_W0LDH41ZCB=GS2.1.s1778846986$o1$g0$t1778846986$j60$l0$h0
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=CYK0Xb&source-path=%2Fnotebook%2Fbb00c9e3-656c-4fd2-b890-2b71e1cf3814&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ')]}''
+
+
+        216
+
+        [["wrb.fr","CYK0Xb","[[\"208ac8c0-5206-4e93-ae24-4b83ce14084b\",\"\",[1,\"400237754469\",[1778851315,944236000]],null,\"NotebookLM\"]]",null,null,null,"generic"],["di",201],["af.httprm",201,"7985505495306672947",10]]
+
+        23
+
+        [["e",4,null,null,254]]
+
+        '
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Fri, 15 May 2026 13:21:55 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:55 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '254'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22cYAfTb%22%2C%22%5B%5C%22bb00c9e3-656c-4fd2-b890-2b71e1cf3814%5C%22%2C%5C%22208ac8c0-5206-4e93-ae24-4b83ce14084b%5C%22%2C%5B%5B%5B%5C%22%7B%5C%5Cn%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22NotebookLM%5C%5C%5C%22%2C%5C%5Cn%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Description%20G%5C%5Cu00e9n%5C%5Cu00e9rale%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Outil%20de%20synth%5C%5Cu00e8se%20de%20documents%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Assistant%20de%20recherche%20virtuel%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22D%5C%5Cu00e9veloppeur%3A%20Google%20Labs%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Mod%5C%5Cu00e8le%3A%20Google%20Gemini%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Historique%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Origine%3A%20Project%20Tailwind%20%28Mai%202023%29%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Rebranding%3A%20NotebookLM%20%282024%29%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Version%20stable%3A%20Octobre%202024%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Lancement%20NotebookLM%20Plus%3A%20D%5C%5Cu00e9cembre%202024%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Fonctionnalit%5C%5Cu00e9s%20Cl%5C%5Cu00e9s%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Audio%20Overviews%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Discussion%20type%20podcast%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22H%5C%5Cu00f4tes%20IA%20conversationnels%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Mode%20interactif%20%28Join%29%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Video%20Overviews%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22R%5C%5Cu00e9sum%5C%5Cu00e9s%20visuels%20style%20diapositives%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Narration%20et%20sch%5C%5Cu00e9mas%20IA%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Mode%20cin%5C%5Cu00e9matique%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Formats%20de%20sortie%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Infographies%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Pr%5C%5Cu00e9sentations%20%28Slide%20Deck%29%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Tableaux%20de%20donn%5C%5Cu00e9es%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Fiches%20de%20r%5C%5Cu00e9vision%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%20%20%20%20%7D%5C%5Cn%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Sources%20support%5C%5Cu00e9es%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22PDF%20et%20Google%20Docs%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Sites%20web%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Google%20Slides%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Transcriptions%20YouTube%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Adoption%20et%20Usage%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Chercheurs%20et%20%5C%5Cu00c9tudiants%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Entreprises%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Spotify%20Wrapped%202024%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%7D%2C%5C%5Cn%20%20%20%20%7B%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22D%5C%5Cu00e9fis%20et%20Juridique%5C%5C%5C%22%2C%5C%5Cn%20%20%20%20%20%20%5C%5C%5C%22children%5C%5C%5C%22%3A%20%5B%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Proc%5C%5Cu00e8s%20David%20Greene%20%28Voix%20IA%29%5C%5C%5C%22%20%7D%2C%5C%5Cn%20%20%20%20%20%20%20%20%7B%20%5C%5C%5C%22name%5C%5C%5C%22%3A%20%5C%5C%5C%22Limites%20d%27utilisation%20du%20tier%20gratuit%5C%5C%5C%22%20%7D%5C%5Cn%20%20%20%20%20%20%5D%5C%5Cn%20%20%20%20%7D%5C%5Cn%20%20%5D%5C%5Cn%7D%5C%22%2C%5C%22NotebookLM%5C%22%2C%5B%5D%2C0%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778851311284&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '6747'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=1.1.1583381276.1778846987; _ga=GA1.1.1567240762.1778846987;
+        _ga_W0LDH41ZCB=GS2.1.s1778846986$o1$g0$t1778846986$j60$l0$h0
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=cYAfTb&source-path=%2Fnotebook%2Fbb00c9e3-656c-4fd2-b890-2b71e1cf3814&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ")]}'\n\n2942\n[[\"wrb.fr\",\"cYAfTb\",\"[[\\\"208ac8c0-5206-4e93-ae24-4b83ce14084b\\\",\\\"{\\\\n
+        \ \\\\\\\"name\\\\\\\": \\\\\\\"NotebookLM\\\\\\\",\\\\n  \\\\\\\"children\\\\\\\":
+        [\\\\n    {\\\\n      \\\\\\\"name\\\\\\\": \\\\\\\"Description G\xE9n\xE9rale\\\\\\\",\\\\n
+        \     \\\\\\\"children\\\\\\\": [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Outil
+        de synth\xE8se de documents\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"Assistant de recherche virtuel\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"D\xE9veloppeur: Google Labs\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"Mod\xE8le: Google Gemini\\\\\\\" }\\\\n      ]\\\\n    },\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Historique\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\":
+        [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Origine: Project Tailwind (Mai
+        2023)\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Rebranding: NotebookLM
+        (2024)\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Version stable:
+        Octobre 2024\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Lancement
+        NotebookLM Plus: D\xE9cembre 2024\\\\\\\" }\\\\n      ]\\\\n    },\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Fonctionnalit\xE9s Cl\xE9s\\\\\\\",\\\\n
+        \     \\\\\\\"children\\\\\\\": [\\\\n        {\\\\n          \\\\\\\"name\\\\\\\":
+        \\\\\\\"Audio Overviews\\\\\\\",\\\\n          \\\\\\\"children\\\\\\\": [\\\\n
+        \           { \\\\\\\"name\\\\\\\": \\\\\\\"Discussion type podcast\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"H\xF4tes IA conversationnels\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Mode interactif (Join)\\\\\\\"
+        }\\\\n          ]\\\\n        },\\\\n        {\\\\n          \\\\\\\"name\\\\\\\":
+        \\\\\\\"Video Overviews\\\\\\\",\\\\n          \\\\\\\"children\\\\\\\": [\\\\n
+        \           { \\\\\\\"name\\\\\\\": \\\\\\\"R\xE9sum\xE9s visuels style diapositives\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Narration et sch\xE9mas
+        IA\\\\\\\" },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Mode cin\xE9matique\\\\\\\"
+        }\\\\n          ]\\\\n        },\\\\n        {\\\\n          \\\\\\\"name\\\\\\\":
+        \\\\\\\"Formats de sortie\\\\\\\",\\\\n          \\\\\\\"children\\\\\\\":
+        [\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Infographies\\\\\\\" },\\\\n
+        \           { \\\\\\\"name\\\\\\\": \\\\\\\"Pr\xE9sentations (Slide Deck)\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Tableaux de donn\xE9es\\\\\\\"
+        },\\\\n            { \\\\\\\"name\\\\\\\": \\\\\\\"Fiches de r\xE9vision\\\\\\\"
+        }\\\\n          ]\\\\n        }\\\\n      ]\\\\n    },\\\\n    {\\\\n      \\\\\\\"name\\\\\\\":
+        \\\\\\\"Sources support\xE9es\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\":
+        [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"PDF et Google Docs\\\\\\\" },\\\\n
+        \       { \\\\\\\"name\\\\\\\": \\\\\\\"Sites web\\\\\\\" },\\\\n        {
+        \\\\\\\"name\\\\\\\": \\\\\\\"Google Slides\\\\\\\" },\\\\n        { \\\\\\\"name\\\\\\\":
+        \\\\\\\"Transcriptions YouTube\\\\\\\" }\\\\n      ]\\\\n    },\\\\n    {\\\\n
+        \     \\\\\\\"name\\\\\\\": \\\\\\\"Adoption et Usage\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\":
+        [\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Chercheurs et \xC9tudiants\\\\\\\"
+        },\\\\n        { \\\\\\\"name\\\\\\\": \\\\\\\"Entreprises\\\\\\\" },\\\\n
+        \       { \\\\\\\"name\\\\\\\": \\\\\\\"Spotify Wrapped 2024\\\\\\\" }\\\\n
+        \     ]\\\\n    },\\\\n    {\\\\n      \\\\\\\"name\\\\\\\": \\\\\\\"D\xE9fis
+        et Juridique\\\\\\\",\\\\n      \\\\\\\"children\\\\\\\": [\\\\n        {
+        \\\\\\\"name\\\\\\\": \\\\\\\"Proc\xE8s David Greene (Voix IA)\\\\\\\" },\\\\n
+        \       { \\\\\\\"name\\\\\\\": \\\\\\\"Limites d'utilisation du tier gratuit\\\\\\\"
+        }\\\\n      ]\\\\n    }\\\\n  ]\\\\n}\\\",[1,\\\"400237754469\\\",[1778851316,308817000]],null,\\\"NotebookLM\\\"]]\",null,null,null,\"generic\"]]\n55\n[[\"di\",233],[\"af.httprm\",233,\"3691130681665002081\",10]]\n24\n[[\"e\",4,null,null,3041]]\n"
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Fri, 15 May 2026 13:21:56 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:56 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:56 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:56 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:56 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:56 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 13:21:56 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      content-length:
+      - '3041'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_mind_map_chain_vcr.py
+++ b/tests/integration/test_mind_map_chain_vcr.py
@@ -1,0 +1,164 @@
+"""Multi-interaction mind-map chain cassette (T8.C3).
+
+``ArtifactsAPI.generate_mind_map`` is one of the few public-API entry points
+that emits **multiple sequential RPCs** in a single call. The flow is:
+
+1. ``GENERATE_MIND_MAP`` (``yyryJe``) — generates the mind-map JSON but does
+   not persist it server-side.
+2. ``CREATE_NOTE`` (``CYK0Xb``) — creates an empty note row to hold the
+   mind-map content.
+3. ``UPDATE_NOTE`` (``cYAfTb``) — writes the mind-map JSON and the title
+   (derived from the mind-map ``name`` field) into the note row.
+
+A single-RPC cassette per call would not exercise the chain wiring (note-id
+plumbed from CREATE_NOTE's response into UPDATE_NOTE's params). This module
+records ALL THREE RPCs into one cassette so the integration test replays the
+full chain in order — closing the multi-interaction gap that T8.B coverage
+identified.
+
+Recording
+---------
+Pre-condition: the generation notebook (``NOTEBOOKLM_GENERATION_NOTEBOOK_ID``)
+must have at least one ready source attached. T8.B1 added a Wikipedia page
+("NotebookLM - Wikipedia") to ``bb00c9e3-656c-4fd2-b890-2b71e1cf3814``; the
+``source_ids`` list passed below is the single source UUID from that page.
+
+To re-record this cassette::
+
+    export NOTEBOOKLM_GENERATION_NOTEBOOK_ID=bb00c9e3-656c-4fd2-b890-2b71e1cf3814
+    export NOTEBOOKLM_VCR_RECORD=1
+    uv run pytest tests/integration/test_mind_map_chain_vcr.py -v
+
+Replay
+------
+The default VCR matcher includes ``rpcids`` (T8.A1) which deterministically
+disambiguates the three batchexecute POSTs by the RPC ID in the URL query
+string. No per-cassette ``match_on`` override is needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Add tests directory to path for vcr_config import (parity with the rest of
+# tests/integration/test_vcr_*.py — these files are imported by pytest with
+# the repo root NOT on sys.path).
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+from conftest import get_vcr_auth, skip_no_cassettes  # noqa: E402
+from notebooklm import NotebookLMClient  # noqa: E402
+from notebooklm.rpc import RPCMethod  # noqa: E402
+from vcr_config import notebooklm_vcr  # noqa: E402
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+# Canonical Tier-8 generation notebook (carries the Wikipedia "NotebookLM"
+# page from T8.B1). The env var override is only consulted when recording —
+# during replay the cassette drives the response regardless of notebook ID,
+# but we still need a stable value so the URL ``source-path`` query param
+# matches what was recorded.
+MUTABLE_NOTEBOOK_ID = os.environ.get(
+    "NOTEBOOKLM_GENERATION_NOTEBOOK_ID",
+    "bb00c9e3-656c-4fd2-b890-2b71e1cf3814",
+)
+
+# Source ID for the Wikipedia "NotebookLM" page attached to the generation
+# notebook. Passing this explicitly skips the implicit ``GET_NOTEBOOK`` call
+# that ``generate_mind_map`` would otherwise issue to enumerate sources —
+# keeping the cassette to the three RPCs the chain itself emits.
+_WIKIPEDIA_SOURCE_ID = "466b9ee3-c1ce-45ef-861c-1d4bfcd939ad"
+
+CASSETTE_NAME = "generate_mind_map_chain.yaml"
+CASSETTE_PATH = Path(__file__).parent.parent / "cassettes" / CASSETTE_NAME
+
+
+class TestMindMapChain:
+    """Records and replays the GENERATE_MIND_MAP → CREATE_NOTE → UPDATE_NOTE chain."""
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @notebooklm_vcr.use_cassette(CASSETTE_NAME)
+    async def test_generate_mind_map_chain(self) -> None:
+        """End-to-end mind-map chain produces a persisted note.
+
+        Asserts the public API contract: callers receive a dict with the
+        parsed ``mind_map`` payload and the ``note_id`` that holds it.
+        """
+        auth = await get_vcr_auth()
+        async with NotebookLMClient(auth) as client:
+            result = await client.artifacts.generate_mind_map(
+                MUTABLE_NOTEBOOK_ID,
+                source_ids=[_WIKIPEDIA_SOURCE_ID],
+            )
+
+        # Final note is created with mind-map content.
+        assert isinstance(result, dict)
+        assert result.get("note_id"), "generate_mind_map must persist a note"
+        assert isinstance(result["note_id"], str)
+        # Mind-map JSON should be present and shaped like a tree
+        # (either ``children`` or ``nodes`` key — both shapes are valid;
+        # mirror the heuristic used by ``_mind_map.list_mind_maps``).
+        assert result.get("mind_map") is not None
+        mind_map = result["mind_map"]
+        assert isinstance(mind_map, dict)
+        assert "children" in mind_map or "nodes" in mind_map, (
+            f"mind_map payload missing tree keys: {list(mind_map)[:5]}"
+        )
+
+    def test_cassette_records_three_rpc_chain(self) -> None:
+        """The cassette captures all three sequential RPCs in order.
+
+        This guards against two regression classes:
+
+        1. **Chain shortening** — a refactor that drops UPDATE_NOTE (e.g.
+           because the caller assumed CREATE_NOTE persists the title) would
+           reduce the cassette to two RPCs. The rpcids order check catches
+           it before the replay test silently masks the change.
+        2. **Cassette drift** — if a future re-record accidentally pins the
+           wrong source list (e.g. ``source_ids=None``), the cassette would
+           sprout an extra GET_NOTEBOOK interaction. Asserting the exact
+           ordered rpcids sequence rejects that shape too.
+
+        The cassette is the source of truth here — we parse it directly
+        rather than relying on the replay test's side effects so the
+        assertion is independent of the client implementation.
+        """
+        assert CASSETTE_PATH.exists(), (
+            f"cassette missing: {CASSETTE_PATH}. "
+            "Re-record with NOTEBOOKLM_VCR_RECORD=1 — see module docstring."
+        )
+
+        with CASSETTE_PATH.open(encoding="utf-8") as fh:
+            cassette = yaml.safe_load(fh)
+
+        interactions = cassette.get("interactions", [])
+        # Extract the rpcids query param from every batchexecute interaction
+        # in the order they were recorded. Non-batchexecute interactions
+        # (e.g. the homepage GET that bootstraps the CSRF token) are skipped.
+        from urllib.parse import parse_qs, urlparse
+
+        rpcids_sequence: list[str] = []
+        for interaction in interactions:
+            uri = interaction.get("request", {}).get("uri", "")
+            if "/batchexecute" not in uri:
+                continue
+            qs = parse_qs(urlparse(uri).query)
+            for rpc_id in qs.get("rpcids", []):
+                rpcids_sequence.append(rpc_id)
+
+        expected = [
+            RPCMethod.GENERATE_MIND_MAP.value,  # yyryJe
+            RPCMethod.CREATE_NOTE.value,  # CYK0Xb
+            RPCMethod.UPDATE_NOTE.value,  # cYAfTb
+        ]
+        assert rpcids_sequence == expected, (
+            f"Mind-map chain shape drift. Expected {expected}, got "
+            f"{rpcids_sequence}. The chain MUST be exactly GENERATE_MIND_MAP "
+            "→ CREATE_NOTE → UPDATE_NOTE; any other shape (extra RPC, "
+            "missing UPDATE_NOTE, reordering) is a regression."
+        )


### PR DESCRIPTION
## Summary

`ArtifactsAPI.generate_mind_map` is the one public-API entry point that emits THREE sequential RPCs in a single call, with state (note_id) plumbed between them:

1. `GENERATE_MIND_MAP` (`yyryJe`) — produces mind-map JSON, no server-side persistence
2. `CREATE_NOTE` (`CYK0Xb`) — creates an empty note row
3. `UPDATE_NOTE` (`cYAfTb`) — writes title + content into the new row

Single-RPC cassettes per call cannot exercise the chain wiring. This PR captures the full chain in **one** multi-interaction cassette (`tests/cassettes/generate_mind_map_chain.yaml`) and adds an integration test that replays it + verifies the exact ordered `rpcids` sequence.

## What's new

- **`tests/integration/test_mind_map_chain_vcr.py`** (new) — two-test module:
  - `test_generate_mind_map_chain` replays the cassette and asserts the public-API contract (parsed `mind_map` dict + `note_id` string).
  - `test_cassette_records_three_rpc_chain` parses the cassette YAML directly and asserts the EXACT ordered rpcids sequence `[yyryJe, CYK0Xb, cYAfTb]`. This is the regression guard: it catches both chain-shortening (dropping UPDATE_NOTE) and cassette drift (e.g. an accidental extra GET_NOTEBOOK from `source_ids=None`).
- **`tests/cassettes/generate_mind_map_chain.yaml`** (new) — 374 KB, 4 interactions: 1 homepage GET + the 3-RPC chain. Passes the cassette guard (`check_cassettes_clean.py`) and the shape lint (`tests/unit/test_cassette_shapes.py::test_cassette_shape[generate_mind_map_chain.yaml]`).

## Recording details

- **Source**: Wikipedia "NotebookLM" page (id `466b9ee3-c1ce-45ef-861c-1d4bfcd939ad`) — the source added by T8.B1 to the generation notebook `bb00c9e3-656c-4fd2-b890-2b71e1cf3814`. Confirmed via `notebooklm source list -n bb00c9e3-... --json` before recording.
- **Notebook ID**: `bb00c9e3-656c-4fd2-b890-2b71e1cf3814` (Tier-8 generation notebook, T8.A0).
- **Replay-driver**: passes `source_ids=[<wikipedia-source-uuid>]` explicitly to suppress the implicit `GET_NOTEBOOK` that `generate_mind_map` would otherwise issue. This keeps the cassette to exactly the 3-RPC chain.

## How to re-record

```
export NOTEBOOKLM_GENERATION_NOTEBOOK_ID=bb00c9e3-656c-4fd2-b890-2b71e1cf3814
export NOTEBOOKLM_VCR_RECORD=1
uv run pytest tests/integration/test_mind_map_chain_vcr.py -v
```

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success
- [x] `uv run pytest tests/integration/test_mind_map_chain_vcr.py -v` — both tests pass (replay mode)
- [x] `uv run pytest tests/unit/test_cassette_shapes.py` — 79 passed (including `[generate_mind_map_chain.yaml]`)
- [x] `uv run python tests/scripts/check_cassettes_clean.py tests/cassettes/generate_mind_map_chain.yaml` — 0 leaks
- [x] Full `uv run pytest` — only pre-existing `test_downloads.py` failures unrelated to this PR (verified by removing the new files and re-running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)