### PR TITLE
test(cli): coverage for login/clear/auth-logout/status (T8.C7)

### DIFF
--- a/tests/cassettes/cli_login_browser_cookies_check.yaml
+++ b/tests/cassettes/cli_login_browser_cookies_check.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - SID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED;
+        __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        OSID=SCRUBBED; __Secure-OSID=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: GET
+    uri: https://notebooklm.google.com/
+  response:
+    body:
+      string: "<!doctype html><html lang=\"en\" dir=\"ltr\"><head><base href=\"https://notebooklm.google.com/\"><title>Google\
+        \ NotebookLM</title></head><body><script nonce=\"SCRUBBED_NONCE\">window.WIZ_global_data\
+        \ = {\"SNlM0e\":\"SCRUBBED_CSRF\",\"FdrFJe\":\"SCRUBBED_SESSION\",\"qwAQke\":\"LabsTailwindUi\"\
+        ,\"S06Grb\":\"SCRUBBED_USER_ID\",\"oPEP7c\":\"SCRUBBED_EMAIL@example.com\"\
+        };</script></body></html>"
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Content-Type:
+      - text/html; charset=utf-8
+      Set-Cookie:
+      - SIDCC=SCRUBBED; expires=Thu, 21-Jan-2027 02:50:20 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Thu, 21-Jan-2027 02:50:20 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/cli_vcr/test_login_browser_cookies.py
+++ b/tests/integration/cli_vcr/test_login_browser_cookies.py
@@ -1,0 +1,193 @@
+"""CLI integration tests for ``notebooklm login --browser-cookies`` (T8.C7).
+
+The VCR cassette captures ONLY the post-import auth verification GET — the
+homepage fetch that ``_login_with_browser_cookies`` performs after
+``atomic_write_json`` lands the storage_state file. No batchexecute RPC, no
+OAuth handshake, and no RotateCookies POST is recorded.
+
+Two monkeypatches keep the recorded path narrow:
+
+1. ``_read_browser_cookies`` — patched to return a sanitized rookiepy cookie
+   set instead of opening the user's real browser DB.
+2. ``_sync_server_language_to_config`` — neutralized so it does not fire the
+   ``get_output_language`` batchexecute RPC that ``_login_with_browser_cookies``
+   normally invokes at line ``session.py:984``.
+
+``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` suppresses the layer-1 RotateCookies
+POST. ``NOTEBOOKLM_HOME`` is redirected to ``tmp_path`` so the test never
+writes outside the sandbox.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import notebooklm_vcr, skip_no_cassettes
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+
+# A sanitized rookiepy cookie payload. Required tier-1 (``SID`` +
+# ``__Secure-1PSIDTS``) plus tier-2 secondary bindings (``APISID`` + ``SAPISID``
+# and ``OSID``) so ``_has_valid_secondary_binding`` is happy and no Tier-2
+# warning is emitted during the test.
+SANITIZED_ROOKIEPY_COOKIES: list[dict] = [
+    {
+        "domain": ".google.com",
+        "name": "SID",
+        "value": "FIXTURE_SID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": False,
+    },
+    {
+        "domain": ".google.com",
+        "name": "HSID",
+        "value": "FIXTURE_HSID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "SSID",
+        "value": "FIXTURE_SSID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "APISID",
+        "value": "FIXTURE_APISID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": False,
+        "http_only": False,
+    },
+    {
+        "domain": ".google.com",
+        "name": "SAPISID",
+        "value": "FIXTURE_SAPISID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "OSID",
+        "value": "FIXTURE_OSID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "__Secure-1PSID",
+        "value": "FIXTURE_1PSID_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "__Secure-1PSIDTS",
+        "value": "FIXTURE_1PSIDTS_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+    {
+        "domain": ".google.com",
+        "name": "__Secure-3PSIDTS",
+        "value": "FIXTURE_3PSIDTS_VALUE",
+        "path": "/",
+        "expires": 2000000000,
+        "secure": True,
+        "http_only": True,
+    },
+]
+
+
+class TestLoginBrowserCookies:
+    """Test 'notebooklm login --browser-cookies' (rookiepy fast-path)."""
+
+    @notebooklm_vcr.use_cassette("cli_login_browser_cookies_check.yaml")
+    def test_browser_cookies_imports_and_verifies(self, runner, tmp_path, monkeypatch) -> None:
+        """The fast-path writes storage_state.json then verifies via homepage GET.
+
+        Asserts:
+          * exit code is 0
+          * confirmation prints ("Cookies verified successfully.")
+          * storage_state.json was written to the sandbox profile
+        """
+        # Redirect NotebookLM home into the sandbox so no real config is touched.
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+        # Suppress layer-1 RotateCookies poke (cassette doesn't capture it).
+        monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
+
+        # Replace the real browser-cookie reader with our sanitized fixture so
+        # the test never opens the user's actual browser cookie database.
+        monkeypatch.setattr(
+            "notebooklm.cli.session._read_browser_cookies",
+            lambda *a, **kw: SANITIZED_ROOKIEPY_COOKIES,
+        )
+
+        # Skip the post-verification settings RPC (line session.py:984) so the
+        # cassette only captures the homepage GET. Without this, the run would
+        # also fire a batchexecute call for ``get_output_language``.
+        monkeypatch.setattr(
+            "notebooklm.cli.session._sync_server_language_to_config",
+            lambda *a, **kw: None,
+        )
+
+        result = runner.invoke(cli, ["login", "--browser-cookies", "chrome"])
+
+        assert result.exit_code == 0, result.output
+        assert "Cookies verified successfully." in result.output
+        # The storage_state file must have been atomically written under the
+        # profile dir inside NOTEBOOKLM_HOME.
+        storage_files = list(tmp_path.glob("**/storage_state.json"))
+        assert storage_files, (
+            f"Expected storage_state.json under {tmp_path}; output was: {result.output}"
+        )
+
+    @notebooklm_vcr.use_cassette("cli_login_browser_cookies_check.yaml")
+    def test_browser_cookies_routes_to_read_helper(self, runner, tmp_path, monkeypatch) -> None:
+        """``--browser-cookies <name>`` forwards the browser name verbatim.
+
+        Regression guard: a defaults rewrite that swallowed the argument would
+        silently fall through to the Playwright path. We capture the call to
+        ``_read_browser_cookies`` and assert the browser-name positional arg
+        matches what the user passed.
+        """
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+        monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
+
+        called_with: list[str] = []
+
+        def _capture(name: str, **kwargs):
+            called_with.append(name)
+            return SANITIZED_ROOKIEPY_COOKIES
+
+        monkeypatch.setattr("notebooklm.cli.session._read_browser_cookies", _capture)
+        monkeypatch.setattr(
+            "notebooklm.cli.session._sync_server_language_to_config",
+            lambda *a, **kw: None,
+        )
+
+        result = runner.invoke(cli, ["login", "--browser-cookies", "firefox"])
+
+        assert result.exit_code == 0, result.output
+        assert called_with == ["firefox"], (
+            f"Expected --browser-cookies firefox to route through 'firefox', got: {called_with}"
+        )

--- a/tests/integration/test_cli_session_local.py
+++ b/tests/integration/test_cli_session_local.py
@@ -1,0 +1,213 @@
+"""CLI tests for local-only session commands — status / clear / auth logout.
+
+These commands never make network calls, so they need no VCR cassette. The
+tests run under ``tests/integration/`` (not ``cli_vcr/``) because they still
+exercise the full CLI surface; ``@pytest.mark.allow_no_vcr`` opts out of the
+tier-enforcement hook landing alongside this work (T8.D11).
+
+Commands covered:
+
+* ``notebooklm status`` — text mode, JSON mode, ``--paths`` mode (no context).
+* ``notebooklm clear`` — local state mutation (removes notebook context).
+* ``notebooklm auth logout`` — clears storage_state.json + browser_profile + context.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+
+# Opt out of the future tier-enforcement hook (T8.D11) — if the marker has not
+# landed yet pytest will still collect and run these tests, the unknown marker
+# is harmless on its own.
+pytestmark = pytest.mark.allow_no_vcr
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Click test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch) -> Path:
+    """Redirect NOTEBOOKLM_HOME into ``tmp_path`` so tests touch no real state.
+
+    Also clears any NOTEBOOKLM_PROFILE / NOTEBOOKLM_AUTH_JSON inherited from
+    the test runner's environment — those would otherwise short-circuit the
+    profile machinery and surface state we did not set up here.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    return tmp_path
+
+
+def _seed_storage_state(home: Path) -> Path:
+    """Write a minimal storage_state.json so ``auth logout`` has something to remove."""
+    profile_dir = home / "profiles" / "default"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    storage_path = profile_dir / "storage_state.json"
+    storage_path.write_text(
+        json.dumps({"cookies": [{"name": "SID", "value": "fake", "domain": ".google.com"}]})
+    )
+    return storage_path
+
+
+def _seed_context(home: Path, notebook_id: str = "test_nb_id", **extra) -> Path:
+    """Write context.json under the default profile so ``status``/``clear`` find it."""
+    profile_dir = home / "profiles" / "default"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    context_path = profile_dir / "context.json"
+    payload = {"notebook_id": notebook_id, **extra}
+    context_path.write_text(json.dumps(payload))
+    return context_path
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+class TestStatusCommand:
+    """``notebooklm status`` — local-only inspection of context.json."""
+
+    def test_status_no_context(self, runner: CliRunner, isolated_home: Path) -> None:
+        """With no context.json, status prints the 'no notebook selected' hint."""
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "No notebook selected" in result.output
+
+    def test_status_no_context_json(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``--json`` returns a structured envelope with ``has_context: false``."""
+        result = runner.invoke(cli, ["status", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {"has_context": False, "notebook": None, "conversation_id": None}
+
+    def test_status_with_context(self, runner: CliRunner, isolated_home: Path) -> None:
+        """With context.json, status renders the notebook ID/title in a table."""
+        _seed_context(isolated_home, notebook_id="abc123", title="Demo NB", is_owner=True)
+
+        result = runner.invoke(cli, ["status"])
+
+        assert result.exit_code == 0, result.output
+        assert "abc123" in result.output
+        assert "Demo NB" in result.output
+
+    def test_status_with_context_json(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``--json`` envelope echoes notebook id/title/is_owner + conversation_id."""
+        _seed_context(
+            isolated_home,
+            notebook_id="abc123",
+            title="Demo NB",
+            is_owner=True,
+            conversation_id="conv-99",
+        )
+
+        result = runner.invoke(cli, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["has_context"] is True
+        assert data["notebook"] == {"id": "abc123", "title": "Demo NB", "is_owner": True}
+        assert data["conversation_id"] == "conv-99"
+
+    def test_status_paths_json(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``status --paths --json`` returns the path-info envelope."""
+        result = runner.invoke(cli, ["status", "--paths", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "paths" in data
+        # Both home_dir and storage_path keys must be present and live inside
+        # our sandbox — guards against the env var being silently ignored.
+        paths = data["paths"]
+        assert str(isolated_home) in paths["home_dir"]
+        assert str(isolated_home) in paths["storage_path"]
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+class TestClearCommand:
+    """``notebooklm clear`` — local state mutation."""
+
+    def test_clear_with_context(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``clear`` wipes the notebook id from context.json."""
+        ctx_path = _seed_context(isolated_home, notebook_id="abc123", title="Demo", is_owner=True)
+
+        result = runner.invoke(cli, ["clear"])
+
+        assert result.exit_code == 0, result.output
+        assert "Context cleared" in result.output
+        # context.json should be removed (no surviving non-context fields).
+        assert not ctx_path.exists()
+
+    def test_clear_no_context_is_noop(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``clear`` with no existing context still succeeds (idempotent)."""
+        result = runner.invoke(cli, ["clear"])
+        assert result.exit_code == 0, result.output
+        assert "Context cleared" in result.output
+
+
+# ---------------------------------------------------------------------------
+# auth logout
+# ---------------------------------------------------------------------------
+
+
+class TestAuthLogoutCommand:
+    """``notebooklm auth logout`` — local-only auth file removal."""
+
+    def test_auth_logout_clears_storage(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``auth logout`` deletes the storage_state.json for the active profile."""
+        storage = _seed_storage_state(isolated_home)
+        assert storage.exists()  # pre-condition
+
+        result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert "Logged out" in result.output
+        assert not storage.exists()
+
+    def test_auth_logout_no_session(self, runner: CliRunner, isolated_home: Path) -> None:
+        """With no storage/profile/context, logout reports 'Already logged out'."""
+        result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert "Already logged out" in result.output
+
+    def test_auth_logout_also_clears_context(self, runner: CliRunner, isolated_home: Path) -> None:
+        """``auth logout`` removes context.json so post-logout commands start fresh.
+
+        Regression guard for the account-switch flow: leaving a stale notebook
+        id in context.json caused mismatched 'not found' / permission errors
+        after the user logged into a different Google account (see
+        ``_ACCOUNT_MISMATCH_HINT`` in ``rpc/decoder.py``).
+        """
+        _seed_storage_state(isolated_home)
+        ctx_path = _seed_context(isolated_home, notebook_id="abc123")
+
+        result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert not ctx_path.exists()
+
+    def test_auth_logout_warns_on_env_auth(
+        self, runner: CliRunner, isolated_home: Path, monkeypatch
+    ) -> None:
+        """``NOTEBOOKLM_AUTH_JSON`` users get a heads-up that env auth persists."""
+        _seed_storage_state(isolated_home)
+        # The fixture clears this env var; set it back specifically for this test.
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", '{"cookies":{}}')
+
+        result = runner.invoke(cli, ["auth", "logout"])
+
+        assert result.exit_code == 0, result.output
+        assert "NOTEBOOKLM_AUTH_JSON is set" in result.output


### PR DESCRIPTION
## Summary

Adds test coverage for the session CLI commands flagged by audit finding I10 — completing the Tier-8 Phase 3 C-track.

- **VCR test** (`tests/integration/cli_vcr/test_login_browser_cookies.py`) — exercises `notebooklm login --browser-cookies` through the rookiepy fast-path. Monkeypatches `_read_browser_cookies` to inject a sanitized cookie fixture and neutralizes `_sync_server_language_to_config` so the cassette captures only the post-import homepage verification GET. ``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` suppresses the layer-1 RotateCookies POST.
- **Non-VCR tests** (`tests/integration/test_cli_session_local.py`) — covers ``notebooklm status`` (text / JSON / `--paths` modes, with and without context), ``notebooklm clear``, and ``notebooklm auth logout`` (storage removal, idempotent re-logout, context cleanup, env-auth warning). Uses CliRunner + ``tmp_path`` to redirect ``NOTEBOOKLM_HOME`` and never touches real state.
- **Cassette** (`tests/cassettes/cli_login_browser_cookies_check.yaml`) — single GET against the homepage; no batchexecute, no real cookie values, sanitized HTML with ``SNlM0e``/``FdrFJe`` placeholders only.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] New tests pass: `uv run pytest tests/integration/test_cli_session_local.py tests/integration/cli_vcr/test_login_browser_cookies.py` — 13 passed
- [x] Cassette passes shape lint: `uv run pytest "tests/unit/test_cassette_shapes.py::test_cassette_shape[cli_login_browser_cookies_check.yaml]"`
- [x] Cassette passes guard: `uv run python tests/scripts/check_cassettes_clean.py tests/cassettes/cli_login_browser_cookies_check.yaml`
- [x] Full suite (excluding pre-existing `test_downloads.py` cassette drift unrelated to this PR) — 3924 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)