### PR TITLE
test(auth): record stale-CSRF refresh cassette (T8.C4)

### DIFF
--- a/tests/cassettes/auth_rotate_cookies_refresh.yaml
+++ b/tests/cassettes/auth_rotate_cookies_refresh.yaml
@@ -1,0 +1,89 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22wXbhsf%22%2C%22%5Bnull%2C1%2Cnull%2C%5B2%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=INVALID_CSRF_FOR_TEST&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '118'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - SID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=wXbhsf&source-path=%2F&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: ")]}'\n\n59\n[[\"wrb.fr\",\"wXbhsf\",\"[\\\"INVALID_CREDENTIALS\\\"]\",null,null]]\n"
+    headers:
+      Content-Type:
+      - application/json+protobuf; charset=UTF-8
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - SID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: GET
+    uri: https://notebooklm.google.com/
+  response:
+    body:
+      string: "<!doctype html><html lang=\"en\"><head><title>Google NotebookLM</title></head><body><script
+        data-id=\"_gd\">window.WIZ_global_data = {\"SNlM0e\":\"SCRUBBED_CSRF\",\"FdrFJe\":\"SCRUBBED_SESSION\"};</script></body></html>"
+    headers:
+      Content-Type:
+      - text/html; charset=utf-8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: f.req=%5B%5B%5B%22wXbhsf%22%2C%22%5Bnull%2C1%2Cnull%2C%5B2%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - SID=SCRUBBED; HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=wXbhsf&source-path=%2F&f.sid=SCRUBBED_SESSION&hl=en&rt=c
+  response:
+    body:
+      string: ")]}'\n\n38\n[[\"wrb.fr\",\"wXbhsf\",\"[[]]\",null,null]]\n"
+    headers:
+      Content-Type:
+      - application/json+protobuf; charset=UTF-8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -34,7 +34,6 @@ we substitute synthetic ``AuthTokens`` for the same reason, mirroring the
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -44,7 +43,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent))
 
-from conftest import skip_no_cassettes  # noqa: E402
+from conftest import _vcr_record_mode, skip_no_cassettes  # noqa: E402
 from notebooklm import NotebookLMClient  # noqa: E402
 from notebooklm.auth import AuthTokens  # noqa: E402
 from vcr_config import notebooklm_vcr  # noqa: E402
@@ -53,12 +52,6 @@ CASSETTE_NAME = "auth_rotate_cookies_refresh.yaml"
 
 # Skip when no cassettes are available and we're not recording.
 pytestmark = [pytest.mark.vcr, skip_no_cassettes]
-
-_VCR_RECORD_MODE = os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower() in (
-    "1",
-    "true",
-    "yes",
-)
 
 
 async def _build_client_for_test() -> NotebookLMClient:
@@ -76,7 +69,7 @@ async def _build_client_for_test() -> NotebookLMClient:
         the actual token values are irrelevant because VCR matches on
         method + path + ``rpcids`` (see ``vcr_config.notebooklm_vcr``).
     """
-    if _VCR_RECORD_MODE:
+    if _vcr_record_mode:
         # ``from_storage`` performs a live homepage GET. Keep this OUT of the
         # cassette context so the recording captures only the refresh path.
         return await NotebookLMClient.from_storage()
@@ -95,108 +88,97 @@ async def _build_client_for_test() -> NotebookLMClient:
     return NotebookLMClient(synthetic_auth)
 
 
-class TestAuthRefreshVCR:
-    """End-to-end stale-CSRF → 400 → refresh_auth → retry under VCR."""
+@pytest.mark.asyncio
+async def test_stale_csrf_triggers_refresh_and_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 400 from a stale-CSRF batchexecute round-trips through refresh_auth.
 
-    @pytest.mark.asyncio
-    async def test_stale_csrf_triggers_refresh_and_retry(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A 400 from a stale-CSRF batchexecute round-trips through refresh_auth.
+    The cassette captures three interactions in order:
 
-        The cassette captures three interactions in order:
+    1. POST ``batchexecute?rpcids=wXbhsf`` with the invalidated CSRF →
+       HTTP 400.
+    2. GET ``https://notebooklm.google.com/`` → 200 with a fresh
+       ``SNlM0e`` (CSRF) and ``FdrFJe`` (session) inside the WIZ_global_data
+       page chrome.
+    3. POST ``batchexecute?rpcids=wXbhsf`` with the refreshed CSRF →
+       HTTP 200 with the normal ``LIST_NOTEBOOKS`` ``wrb.fr`` envelope.
 
-        1. POST ``batchexecute?rpcids=wXbhsf`` with the invalidated CSRF →
-           HTTP 400.
-        2. GET ``https://notebooklm.google.com/`` → 200 with a fresh
-           ``SNlM0e`` (CSRF) and ``FdrFJe`` (session) inside the WIZ_global_data
-           page chrome.
-        3. POST ``batchexecute?rpcids=wXbhsf`` with the refreshed CSRF →
-           HTTP 200 with the normal ``LIST_NOTEBOOKS`` ``wrb.fr`` envelope.
+    The 400 → refresh → retry sequence is what the ``rpc_call`` layer
+    promises in the docstring at ``_core.py:864-894``. Asserting both
+    that the call returned a value (the retry succeeded) AND that a
+    refresh happened (token mutated mid-call) gives us a fail-loud
+    guard against a regression where the retry path silently no-ops.
+    """
+    # Disable the layer-1 RotateCookies keepalive poke so its POST is not
+    # captured into this cassette (recorded cassettes predate that poke;
+    # keeping it on would surface as a cassette mismatch on replay).
+    monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
 
-        The 400 → refresh → retry sequence is what the ``rpc_call`` layer
-        promises in the docstring at ``_core.py:864-894``. Asserting both
-        that the call returned a value (the retry succeeded) AND that a
-        refresh happened (token mutated mid-call) gives us a fail-loud
-        guard against a regression where the retry path silently no-ops.
-        """
-        # Disable the layer-1 RotateCookies keepalive poke so its POST is not
-        # captured into this cassette (recorded cassettes predate that poke;
-        # keeping it on would surface as a cassette mismatch on replay).
-        monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
+    client = await _build_client_for_test()
+    # Eliminate the post-refresh retry delay so the test runs fast.
+    client._core._refresh_retry_delay = 0
 
-        client = await _build_client_for_test()
-        # Eliminate the post-refresh retry delay so the test runs fast.
-        client._core._refresh_retry_delay = 0
+    # Track whether refresh_auth ran. We wrap the bound method so the
+    # mutation is observable from outside the test. Using ``list[object]``
+    # keeps the counter intent obvious without overspecifying element type.
+    refresh_calls: list[object] = []
+    original_refresh = client.refresh_auth
 
-        # Track whether refresh_auth ran. We wrap the bound method so the
-        # mutation is observable from outside the client.
-        refresh_calls: list[None] = []
-        original_refresh = client.refresh_auth
+    async def tracking_refresh() -> AuthTokens:
+        refresh_calls.append(None)
+        return await original_refresh()
 
-        async def tracking_refresh() -> AuthTokens:
-            refresh_calls.append(None)
-            return await original_refresh()
+    # The refresh callback is captured by ClientCore at construction;
+    # patch it on the core so the wrapper is what the retry loop sees.
+    client._core._refresh_callback = tracking_refresh
 
-        # The refresh callback is captured by ClientCore at construction;
-        # patch it on the core so the wrapper is what the retry loop sees.
-        client._core._refresh_callback = tracking_refresh
+    with notebooklm_vcr.use_cassette(CASSETTE_NAME) as cassette:
+        async with client:
+            # Deliberately corrupt the in-memory CSRF so the first
+            # batchexecute is guaranteed to draw a 400 from Google (the
+            # documented stale-CSRF response per ``_core.py:245-252``).
+            # The ``update_auth_headers`` call is what actually plumbs the
+            # new value into the live ``httpx.AsyncClient``'s default
+            # header set.
+            client._core.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
+            client._core.update_auth_headers()
 
-        with notebooklm_vcr.use_cassette(CASSETTE_NAME) as cassette:
-            async with client:
-                # Snapshot the CSRF, then deliberately corrupt it so the
-                # first batchexecute is guaranteed to draw a 400 from
-                # Google (the documented stale-CSRF response per
-                # ``_core.py:245-252``). The ``update_auth_headers`` call
-                # is what actually plumbs the new value into the live
-                # ``httpx.AsyncClient``'s default header set.
-                original_csrf = client._core.auth.csrf_token
-                client._core.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
-                client._core.update_auth_headers()
+            # This call's first attempt MUST 400; the rpc_call layer
+            # then awaits refresh_auth (interaction 2 in the cassette)
+            # and retries (interaction 3). A successful return here
+            # means the whole pipeline replayed correctly.
+            notebooks = await client.notebooks.list()
 
-                # This call's first attempt MUST 400; the rpc_call layer
-                # then awaits refresh_auth (interaction 2 in the cassette)
-                # and retries (interaction 3). A successful return here
-                # means the whole pipeline replayed correctly.
-                notebooks = await client.notebooks.list()
+            # The retry path mutated the in-memory token away from
+            # the corrupted value. Asserting the change makes this
+            # test fail loudly if a future refactor accidentally
+            # short-circuits the retry to "return the 400 unchanged".
+            assert client._core.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
+                "csrf_token should have been refreshed mid-call"
+            )
 
-                # The retry path mutated the in-memory token away from
-                # the corrupted value. Asserting the change makes this
-                # test fail loudly if a future refactor accidentally
-                # short-circuits the retry to "return the 400 unchanged".
-                assert client._core.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
-                    "csrf_token should have been refreshed mid-call"
-                )
+    # The retry contract is: at most ONE refresh per ``rpc_call``. The
+    # state machine guards this via ``refreshed_this_call`` in
+    # ``_perform_authed_post``. Asserting equality (not >=) catches a
+    # regression where the loop runs twice on the same call.
+    assert len(refresh_calls) == 1, (
+        f"refresh_auth should run exactly once for one stale-CSRF call; got {len(refresh_calls)}"
+    )
 
-        # The retry contract is: at most ONE refresh per ``rpc_call``. The
-        # state machine guards this via ``refreshed_this_call`` in
-        # ``_perform_authed_post``. Asserting equality (not >=) catches a
-        # regression where the loop runs twice on the same call.
-        assert len(refresh_calls) == 1, (
-            f"refresh_auth should run exactly once for one stale-CSRF call; "
-            f"got {len(refresh_calls)}"
-        )
+    # Cassette played EXACTLY three interactions: failing POST, homepage
+    # GET, retried POST. Asserting on ``play_count`` ties the test to the
+    # on-wire shape of the refresh handshake — if a future refactor stops
+    # issuing the homepage GET (e.g. cached token) or adds an extra round-
+    # trip (e.g. a second refresh probe), this assertion fails immediately
+    # rather than silently passing.
+    assert cassette.play_count == 3, (
+        f"Expected exactly 3 cassette interactions to play "
+        f"(failing POST, homepage GET, retried POST); got {cassette.play_count}"
+    )
 
-        # Cassette played EXACTLY three interactions: failing POST,
-        # homepage GET, retried POST. Asserting on ``play_count`` ties the
-        # test to the on-wire shape of the refresh handshake — if a future
-        # refactor stops issuing the homepage GET (e.g. cached token) or
-        # adds an extra round-trip (e.g. a second refresh probe), this
-        # assertion fails immediately rather than silently passing.
-        assert cassette.play_count == 3, (
-            f"Expected exactly 3 cassette interactions to play "
-            f"(failing POST, homepage GET, retried POST); got {cassette.play_count}"
-        )
-
-        # ``notebooks.list()`` returns a list (possibly empty). The exact
-        # contents come from the recorded response and are not the
-        # subject of this test — what matters is that the call returned
-        # at all instead of raising the original 400.
-        assert isinstance(notebooks, list)
-
-        # Silence the unused-variable lint without coupling the test to a
-        # specific pre-refresh value. The recorded HTML's SNlM0e is what
-        # ``refresh_auth`` plumbed in, scrubbed to ``SCRUBBED_CSRF`` by
-        # ``cassette_patterns.scrub_string`` (see T8.A4) — we don't
-        # compare it directly.
-        del original_csrf
+    # ``notebooks.list()`` returns a list (possibly empty). The exact
+    # contents come from the recorded response and are not the subject
+    # of this test — what matters is that the call returned at all
+    # instead of raising the original 400.
+    assert isinstance(notebooks, list)

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -1,0 +1,202 @@
+"""End-to-end stale-CSRF refresh path under VCR (T8.C4).
+
+This module records and replays the **full three-leg** auth-refresh flow that
+``test_auto_refresh.py`` covers only at the httpx-mock layer:
+
+1. **Failing batchexecute** — the client makes a ``LIST_NOTEBOOKS`` POST with a
+   deliberately invalidated CSRF token; Google returns HTTP **400** (not 401 —
+   stale CSRF is documented at ``_core.py:245-252``).
+2. **Homepage GET** — ``_perform_authed_post`` classifies the 400 as an auth
+   error via :func:`is_auth_error` and awaits ``refresh_auth``, which fetches
+   the NotebookLM homepage to re-extract ``SNlM0e`` + ``FdrFJe``.
+3. **Retried batchexecute** — the same RPC is replayed with the fresh CSRF and
+   the server returns a normal 200 ``wrb.fr`` envelope.
+
+Why this complements ``test_auto_refresh.py``
+---------------------------------------------
+The unit-style test in ``test_auto_refresh.py`` proves the retry-loop wiring
+fires by swapping in a fake ``http_client.post`` and a fake refresh callback.
+This VCR-backed test exercises the SAME state machine through the REAL httpx
+client and the REAL ``refresh_auth`` implementation, using a recorded
+homepage HTML so the regex extractor for ``SNlM0e`` / ``FdrFJe`` also runs.
+The two layers catch different defect classes (mock-shape drift vs. extractor
+drift); keep both.
+
+Recording note
+--------------
+The client construction (``NotebookLMClient.from_storage(...)``) makes its
+own homepage GET to mint the initial tokens. That GET is **outside** the
+cassette context in record mode so the cassette captures EXACTLY the three
+interactions of the refresh path — no auth-bootstrap noise. In replay mode
+we substitute synthetic ``AuthTokens`` for the same reason, mirroring the
+``mock_auth_for_vcr`` pattern in ``tests/integration/cli_vcr/conftest.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add tests directory to path for vcr_config + conftest helpers.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from conftest import skip_no_cassettes  # noqa: E402
+from notebooklm import NotebookLMClient  # noqa: E402
+from notebooklm.auth import AuthTokens  # noqa: E402
+from vcr_config import notebooklm_vcr  # noqa: E402
+
+CASSETTE_NAME = "auth_rotate_cookies_refresh.yaml"
+
+# Skip when no cassettes are available and we're not recording.
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+_VCR_RECORD_MODE = os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+
+async def _build_client_for_test() -> NotebookLMClient:
+    """Build the client without polluting the cassette with auth-bootstrap traffic.
+
+    Record mode:
+        Load real auth via ``NotebookLMClient.from_storage()``. This makes a
+        live homepage GET to mint the initial CSRF/session tokens, but that
+        call happens OUTSIDE the cassette context (the caller decorates only
+        the stale-CSRF section) so the cassette stays at exactly the three
+        interactions of the refresh path.
+
+    Replay mode:
+        Use synthetic ``AuthTokens``. The cassette has recorded responses;
+        the actual token values are irrelevant because VCR matches on
+        method + path + ``rpcids`` (see ``vcr_config.notebooklm_vcr``).
+    """
+    if _VCR_RECORD_MODE:
+        # ``from_storage`` performs a live homepage GET. Keep this OUT of the
+        # cassette context so the recording captures only the refresh path.
+        return await NotebookLMClient.from_storage()
+
+    synthetic_auth = AuthTokens(
+        cookies={
+            "SID": "vcr_mock_sid",
+            "HSID": "vcr_mock_hsid",
+            "SSID": "vcr_mock_ssid",
+            "APISID": "vcr_mock_apisid",
+            "SAPISID": "vcr_mock_sapisid",
+        },
+        csrf_token="vcr_mock_initial_csrf",
+        session_id="vcr_mock_session",
+    )
+    return NotebookLMClient(synthetic_auth)
+
+
+class TestAuthRefreshVCR:
+    """End-to-end stale-CSRF → 400 → refresh_auth → retry under VCR."""
+
+    @pytest.mark.asyncio
+    async def test_stale_csrf_triggers_refresh_and_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 400 from a stale-CSRF batchexecute round-trips through refresh_auth.
+
+        The cassette captures three interactions in order:
+
+        1. POST ``batchexecute?rpcids=wXbhsf`` with the invalidated CSRF →
+           HTTP 400.
+        2. GET ``https://notebooklm.google.com/`` → 200 with a fresh
+           ``SNlM0e`` (CSRF) and ``FdrFJe`` (session) inside the WIZ_global_data
+           page chrome.
+        3. POST ``batchexecute?rpcids=wXbhsf`` with the refreshed CSRF →
+           HTTP 200 with the normal ``LIST_NOTEBOOKS`` ``wrb.fr`` envelope.
+
+        The 400 → refresh → retry sequence is what the ``rpc_call`` layer
+        promises in the docstring at ``_core.py:864-894``. Asserting both
+        that the call returned a value (the retry succeeded) AND that a
+        refresh happened (token mutated mid-call) gives us a fail-loud
+        guard against a regression where the retry path silently no-ops.
+        """
+        # Disable the layer-1 RotateCookies keepalive poke so its POST is not
+        # captured into this cassette (recorded cassettes predate that poke;
+        # keeping it on would surface as a cassette mismatch on replay).
+        monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
+
+        client = await _build_client_for_test()
+        # Eliminate the post-refresh retry delay so the test runs fast.
+        client._core._refresh_retry_delay = 0
+
+        # Track whether refresh_auth ran. We wrap the bound method so the
+        # mutation is observable from outside the client.
+        refresh_calls: list[None] = []
+        original_refresh = client.refresh_auth
+
+        async def tracking_refresh() -> AuthTokens:
+            refresh_calls.append(None)
+            return await original_refresh()
+
+        # The refresh callback is captured by ClientCore at construction;
+        # patch it on the core so the wrapper is what the retry loop sees.
+        client._core._refresh_callback = tracking_refresh
+
+        with notebooklm_vcr.use_cassette(CASSETTE_NAME) as cassette:
+            async with client:
+                # Snapshot the CSRF, then deliberately corrupt it so the
+                # first batchexecute is guaranteed to draw a 400 from
+                # Google (the documented stale-CSRF response per
+                # ``_core.py:245-252``). The ``update_auth_headers`` call
+                # is what actually plumbs the new value into the live
+                # ``httpx.AsyncClient``'s default header set.
+                original_csrf = client._core.auth.csrf_token
+                client._core.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
+                client._core.update_auth_headers()
+
+                # This call's first attempt MUST 400; the rpc_call layer
+                # then awaits refresh_auth (interaction 2 in the cassette)
+                # and retries (interaction 3). A successful return here
+                # means the whole pipeline replayed correctly.
+                notebooks = await client.notebooks.list()
+
+                # The retry path mutated the in-memory token away from
+                # the corrupted value. Asserting the change makes this
+                # test fail loudly if a future refactor accidentally
+                # short-circuits the retry to "return the 400 unchanged".
+                assert client._core.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
+                    "csrf_token should have been refreshed mid-call"
+                )
+
+        # The retry contract is: at most ONE refresh per ``rpc_call``. The
+        # state machine guards this via ``refreshed_this_call`` in
+        # ``_perform_authed_post``. Asserting equality (not >=) catches a
+        # regression where the loop runs twice on the same call.
+        assert len(refresh_calls) == 1, (
+            f"refresh_auth should run exactly once for one stale-CSRF call; "
+            f"got {len(refresh_calls)}"
+        )
+
+        # Cassette played EXACTLY three interactions: failing POST,
+        # homepage GET, retried POST. Asserting on ``play_count`` ties the
+        # test to the on-wire shape of the refresh handshake — if a future
+        # refactor stops issuing the homepage GET (e.g. cached token) or
+        # adds an extra round-trip (e.g. a second refresh probe), this
+        # assertion fails immediately rather than silently passing.
+        assert cassette.play_count == 3, (
+            f"Expected exactly 3 cassette interactions to play "
+            f"(failing POST, homepage GET, retried POST); got {cassette.play_count}"
+        )
+
+        # ``notebooks.list()`` returns a list (possibly empty). The exact
+        # contents come from the recorded response and are not the
+        # subject of this test — what matters is that the call returned
+        # at all instead of raising the original 400.
+        assert isinstance(notebooks, list)
+
+        # Silence the unused-variable lint without coupling the test to a
+        # specific pre-refresh value. The recorded HTML's SNlM0e is what
+        # ``refresh_auth`` plumbed in, scrubbed to ``SCRUBBED_CSRF`` by
+        # ``cassette_patterns.scrub_string`` (see T8.A4) — we don't
+        # compare it directly.
+        del original_csrf


### PR DESCRIPTION
## Summary

- Adds VCR cassette `tests/cassettes/auth_rotate_cookies_refresh.yaml` capturing exactly **three** interactions: failing batchexecute (HTTP 400 from stale CSRF), homepage GET (refresh_auth extracts fresh `SNlM0e` / `FdrFJe`), retried batchexecute (HTTP 200).
- Adds `tests/integration/test_auth_refresh_vcr.py` exercising the full three-leg refresh path through the **real** `refresh_auth` + httpx client. Asserts a single refresh ran, the in-memory CSRF mutated away from the corrupted value, the retry returned normally, and `cassette.play_count == 3`.
- Complements (doesn't replace) the existing httpx-mock-based `test_auto_refresh.py` — the two layers catch different defect classes (mock-shape drift vs. on-wire extractor drift). Tier-8 Phase 3 / T8.C4.

## Test plan

- [x] `uv run pytest tests/integration/test_auth_refresh_vcr.py` — new test passes
- [x] `uv run pytest tests/integration/test_auto_refresh.py` — parallel httpx-mock tests still pass
- [x] `uv run pytest tests/unit/test_cassette_shapes.py -k auth_rotate` — cassette passes shape lint
- [x] `uv run python tests/scripts/check_cassettes_clean.py tests/cassettes/auth_rotate_cookies_refresh.yaml` — clean (0 leaks)
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports` — all green
- [x] `uv run pytest` — 3912 passed; 7 pre-existing `test_downloads` failures unrelated to this change (confirmed via stash-pop on origin/main HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)