### PR TITLE
test(artifacts): assert infographic + data-table list parsing (T8.C6)

### DIFF
--- a/tests/integration/cli_vcr/test_artifacts.py
+++ b/tests/integration/cli_vcr/test_artifacts.py
@@ -51,10 +51,47 @@ class TestArtifactListByType:
     def test_artifact_list_by_type(
         self, runner, mock_auth_for_vcr, mock_context, artifact_type, cassette
     ):
-        """List artifacts filtered by type."""
+        """List artifacts filtered by type.
+
+        For INFOGRAPHIC and DATA_TABLE we additionally assert the rendered
+        JSON output exposes the parsed ``type_id`` matching the requested
+        filter — proving the parser, not just the transport, agrees on the
+        kind. T8.C6 / audit-I21. Today the cli_vcr suite is blanket-xfailed
+        under T8.A1 because the recorded rpcids order does not match the
+        live call order; once a phase-2 PR re-records these cassettes the
+        xfail entry in ``tests/integration/conftest.py`` will be removed
+        and these assertions will become enforcing.
+        """
+        # T8.C6: only the INFOGRAPHIC + DATA_TABLE rows opt into ``--json``.
+        # The other rows stay on the table renderer to preserve their
+        # historical (xfail-masked) call sequence — the ``--json`` path
+        # makes an extra ``notebooks.get()`` RPC for the table header that
+        # several legacy cassettes do not have recorded.
+        is_target_type = artifact_type in {"infographic", "data-table"}
+        args = ["artifact", "list", "--type", artifact_type]
+        if is_target_type:
+            args.append("--json")
+
         with notebooklm_vcr.use_cassette(cassette):
-            result = runner.invoke(cli, ["artifact", "list", "--type", artifact_type])
+            result = runner.invoke(cli, args)
             assert_command_success(result)
+
+            # Parser-shape sanity check for the two types this task targets.
+            if is_target_type and result.exit_code == 0:
+                data = parse_json_output(result.output)
+                assert isinstance(data, dict)
+                artifacts = data.get("artifacts", [])
+                assert isinstance(artifacts, list)
+                # The recorded cassettes each contain one artifact of the
+                # requested kind. ``type_id`` is the user-facing string enum
+                # value (``"infographic"`` / ``"data_table"``); the CLI maps
+                # the kebab-case filter to the snake_case enum value.
+                expected_type_id = artifact_type.replace("-", "_")
+                for art in artifacts:
+                    assert art.get("type_id") == expected_type_id, (
+                        f"Parsed type_id {art.get('type_id')!r} does not match "
+                        f"filter {artifact_type!r} (cassette {cassette})"
+                    )
 
 
 class TestArtifactSuggestionsCommand:

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent))
 from conftest import get_vcr_auth, skip_no_cassettes
 from notebooklm import NotebookLMClient, ReportFormat
+from notebooklm.types import Artifact, ArtifactType
 from vcr_config import notebooklm_vcr
 
 # Skip all tests in this module if cassettes are not available
@@ -325,6 +326,67 @@ class TestArtifactsListAPI:
                 else:
                     result = await method(READONLY_NOTEBOOK_ID)
                 assert isinstance(result, list)
+                # Every element the decoder hands back must be a fully-formed
+                # Artifact with a non-empty id/title and a known status. This
+                # rejects "the call replays but the parser silently returned
+                # garbage" — the failure mode the original ``isinstance(list)``
+                # check would not catch.
+                for art in result:
+                    assert isinstance(art, Artifact)
+                    assert isinstance(art.id, str) and art.id
+                    assert isinstance(art.title, str)
+                    assert isinstance(art.status, int)
+
+    @pytest.mark.vcr
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "cassette", "expected_kind", "expected_type_code"),
+        [
+            (
+                "list_infographics",
+                "artifacts_list_infographics.yaml",
+                ArtifactType.INFOGRAPHIC,
+                7,
+            ),
+            (
+                "list_data_tables",
+                "artifacts_list_data_tables.yaml",
+                ArtifactType.DATA_TABLE,
+                9,
+            ),
+        ],
+    )
+    async def test_list_artifacts_kind_parsing(
+        self, method_name, cassette, expected_kind, expected_type_code
+    ):
+        """Parser turns INFOGRAPHIC (7) and DATA_TABLE (9) rows into the right kind.
+
+        T8.C6: closes audit finding I21. The two cassettes were already wired
+        into :data:`ARTIFACT_LIST_METHODS`, but the surrounding assertion only
+        proved the call replayed — not that the decoder mapped the integer
+        type code to the user-facing :class:`ArtifactType` enum. This test
+        asserts the full parser contract: at least one artifact is returned,
+        every artifact carries the expected ``_artifact_type`` integer, and
+        every artifact's ``.kind`` property resolves to the expected enum.
+        """
+        with notebooklm_vcr.use_cassette(cassette):
+            async with vcr_client() as client:
+                method = getattr(client.artifacts, method_name)
+                result = await method(READONLY_NOTEBOOK_ID)
+
+        assert isinstance(result, list)
+        assert len(result) >= 1, f"{cassette} should contain at least one artifact"
+        for art in result:
+            assert isinstance(art, Artifact)
+            assert art._artifact_type == expected_type_code, (
+                f"Expected raw type code {expected_type_code}, "
+                f"got {art._artifact_type} for artifact {art.id!r}"
+            )
+            assert art.kind == expected_kind, (
+                f"Expected .kind == {expected_kind!r}, got {art.kind!r} for artifact {art.id!r}"
+            )
+            # The .kind property is a str-enum so equality holds both ways.
+            assert art.kind == expected_kind.value
 
     @pytest.mark.vcr
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The audit's **I21** finding (`artifacts_list_infographics.yaml` + `artifacts_list_data_tables.yaml` missing) was stale — both cassettes have existed for some time, pass shape-lint, and are wired into the two artifact-list parametrize blocks. What was missing is **assertion strength**: existing checks proved the call replayed but not that the parser mapped raw type codes 7 (INFOGRAPHIC) and 9 (DATA_TABLE) to the right `ArtifactType` enum.

This PR closes I21 by adding parser-level assertions in both parametrize blocks. No new cassettes recorded; no parser logic touched.

```
$ ls -la tests/cassettes/artifacts_list_infographics.yaml tests/cassettes/artifacts_list_data_tables.yaml
-rw-r--r--  362K  tests/cassettes/artifacts_list_data_tables.yaml
-rw-r--r--  362K  tests/cassettes/artifacts_list_infographics.yaml
```

## Changes

- **`tests/integration/test_vcr_comprehensive.py`**
  - `test_list_artifacts` (parametrized over all 9 list methods): every element returned by the decoder must be a fully-formed `Artifact` with non-empty `id`/`title` and an integer `status`. Catches the "parser silently returned garbage" failure mode the original `isinstance(list)` would miss.
  - **New** `test_list_artifacts_kind_parsing` (parametrized over INFOGRAPHIC + DATA_TABLE): asserts at least one artifact returned, `_artifact_type` matches the expected raw code (7 / 9), and `.kind` resolves to `ArtifactType.INFOGRAPHIC` / `ArtifactType.DATA_TABLE` (and the str-enum equality holds both ways).
- **`tests/integration/cli_vcr/test_artifacts.py`**
  - `test_artifact_list_by_type` opts into `--json` only for `infographic` / `data-table` and asserts the rendered JSON `type_id` matches the requested filter. The other rows keep the table renderer to preserve their pre-existing (xfail-masked) call sequence. These assertions become enforcing once T8.A1 xfail markers are lifted in a later phase-2 cassette re-record.

## Test plan

- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (60 files)
- [x] `uv run pytest tests/unit/test_cassette_shapes.py` 82 passed — both target cassettes pass shape-lint (correct rpcids, valid f.req, no leaks)
- [x] `uv run pytest tests/integration/test_vcr_comprehensive.py::TestArtifactsListAPI` 11 passed, 1 xfailed
- [x] `uv run pytest tests/integration/cli_vcr/test_artifacts.py` 11 xfailed (legacy T8.A1 xfails preserved)
- [x] `uv run pytest` 3978 passed; 7 pre-existing `tests/integration/cli_vcr/test_downloads.py` failures unrelated to this PR (verified on `origin/main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)