### PR TITLE
fix(audit): T7.D4 review fallout — new= patch on download_url cookie test

### DIFF
--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -522,10 +522,16 @@ async def test_download_url_cookie_load_does_not_block_event_loop(
         # to the cookie load; the subsequent network call fails with
         # ``ArtifactDownloadError`` (transport error), but that's fine —
         # we only need the heartbeat data from the pre-network phase.
+        #
+        # Use ``new=`` instead of ``side_effect=`` for the same reason
+        # the batch test above does — MagicMock + side_effect can stall
+        # the event loop on Windows CI even when wrapped in
+        # ``asyncio.to_thread`` (see the comment block on the batch
+        # test for the full rationale).
         with (
             patch(
                 "notebooklm._artifacts.load_httpx_cookies",
-                side_effect=slow_load_httpx_cookies,
+                new=slow_load_httpx_cookies,
             ),
             pytest.raises(ArtifactDownloadError),
         ):


### PR DESCRIPTION
## Summary

Post-merge audit of #579 surfaced an orphan CodeRabbit thread ([review comment 3248421812](https://github.com/teng-lin/notebooklm-py/pull/579#discussion_r3248421812), marked Major). In #579's commits `545d241` / `de4a262` I switched the batch cookie-load test from `side_effect=slow_load_httpx_cookies` to `new=slow_load_httpx_cookies` to avoid a `MagicMock`-call-chain issue that stalls the event loop on Windows CI — but I missed the mirror fix in the single-download cookie-load test (`test_download_url_cookie_load_does_not_block_event_loop`).

This PR applies the same `new=` swap to the single-download test so both cookie-load tests use the identical patching strategy.

## Task

- Spec: post-merge audit of T7.D4 (#579)
- CodeRabbit thread: line 528 of `tests/integration/concurrency/test_download_blocks_loop.py`

## Test plan

- [x] `uv run ruff format .` + `uv run ruff check .` clean
- [x] `uv run pytest tests/integration/concurrency/test_download_blocks_loop.py` — 5/5 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)