### PR TITLE
feat(cli): --update flag for login --all-accounts (#571 follow-up)

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -523,7 +523,13 @@ def _login_browser_cookies_single(
 
 
 def _profiles_by_account_email(profile_names: list[str]) -> dict[str, str]:
-    """Return existing profiles keyed by account metadata email."""
+    """Return existing profiles keyed by *casefolded* account metadata email.
+
+    Keys are casefolded so that mixed-casing in stored ``context.json``
+    metadata (``Alice@Gmail.com`` vs. an incoming ``alice@gmail.com``)
+    doesn't cause us to miss the match and wrongly allocate a suffixed
+    profile. Lookup callers must casefold their email key likewise.
+    """
     from ..auth import read_account_metadata
 
     profiles_by_email: dict[str, str] = {}
@@ -533,7 +539,7 @@ def _profiles_by_account_email(profile_names: list[str]) -> dict[str, str]:
         if isinstance(email, str) and email:
             # list_profiles() is sorted, so this also prefers the unsuffixed
             # profile over older duplicate suffixes such as alice-2.
-            profiles_by_email.setdefault(email, profile)
+            profiles_by_email.setdefault(email.casefold(), profile)
     return profiles_by_email
 
 
@@ -608,7 +614,7 @@ def _login_all_accounts_from_browser(
     claimed: set[str] = set()
     for account in accounts:
         base_name = email_to_profile_name(account.email)
-        target_profile = profiles_by_email.get(account.email)
+        target_profile = profiles_by_email.get(account.email.casefold())
         if target_profile is None or target_profile in claimed:
             target_profile = _resolve_all_accounts_target(
                 base_name=base_name,

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -537,6 +537,21 @@ def _profiles_by_account_email(profile_names: list[str]) -> dict[str, str]:
     return profiles_by_email
 
 
+def _profile_account_email(profile: str) -> str | None:
+    """Return the account email recorded in ``profile``'s ``context.json``.
+
+    ``None`` when the profile has no account metadata at all (hand-created
+    via plain ``notebooklm login --profile NAME``, or pre-dating the
+    account-tracking feature). Used by ``--all-accounts --update`` to
+    decide whether adopting a name-matching profile is safe.
+    """
+    from ..auth import read_account_metadata
+
+    metadata = read_account_metadata(get_storage_path(profile=profile))
+    email = metadata.get("email")
+    return email if isinstance(email, str) and email else None
+
+
 def _next_available_profile_name(base_name: str, unavailable: set[str]) -> str:
     """Return ``base_name`` or the next ``-N`` suffix not in ``unavailable``."""
     if base_name not in unavailable:
@@ -553,9 +568,24 @@ def _next_available_profile_name(base_name: str, unavailable: set[str]) -> str:
 def _login_all_accounts_from_browser(
     browser_cookies: str,
     *,
+    update: bool = False,
     include_domains: set[str] | None = None,
 ) -> None:
-    """Extract every signed-in Google account into its own profile."""
+    """Extract every signed-in Google account into its own profile.
+
+    Args:
+        browser_cookies: rookiepy browser alias forwarded to
+            :func:`_enumerate_browser_accounts`.
+        update: When True and the natural profile name for an account
+            (e.g. ``alice`` for ``alice@gmail.com``) already exists but has
+            no account metadata — or its metadata matches the same email —
+            adopt that profile in place rather than allocating a suffixed
+            ``alice-2``. Profiles whose metadata already binds a *different*
+            email are still given a suffix to avoid clobbering them. Useful
+            for users who hand-created profiles via plain ``notebooklm
+            login --profile NAME`` before extending to ``--all-accounts``.
+        include_domains: Forwarded to :func:`_enumerate_browser_accounts`.
+    """
     from ..paths import list_profiles
 
     per_profile_cookies, accounts = _enumerate_browser_accounts(
@@ -572,6 +602,7 @@ def _login_all_accounts_from_browser(
     # allocate a suffix when the desired profile name belongs to a different
     # account or a hand-created profile with no account metadata.
     existing_profiles = list_profiles()
+    existing_profiles_set = set(existing_profiles)
     profiles_by_email = _profiles_by_account_email(existing_profiles)
     unavailable: set[str] = set(existing_profiles)
     claimed: set[str] = set()
@@ -579,7 +610,14 @@ def _login_all_accounts_from_browser(
         base_name = email_to_profile_name(account.email)
         target_profile = profiles_by_email.get(account.email)
         if target_profile is None or target_profile in claimed:
-            target_profile = _next_available_profile_name(base_name, unavailable | claimed)
+            target_profile = _resolve_all_accounts_target(
+                base_name=base_name,
+                account_email=account.email,
+                existing_profiles=existing_profiles_set,
+                unavailable=unavailable,
+                claimed=claimed,
+                update=update,
+            )
         unavailable.add(target_profile)
         claimed.add(target_profile)
 
@@ -591,6 +629,34 @@ def _login_all_accounts_from_browser(
             authuser=account.authuser,
             email=account.email,
         )
+
+
+def _resolve_all_accounts_target(
+    *,
+    base_name: str,
+    account_email: str,
+    existing_profiles: set[str],
+    unavailable: set[str],
+    claimed: set[str],
+    update: bool,
+) -> str:
+    """Pick the destination profile when no email-metadata match exists.
+
+    Without ``--update`` (default): always allocate the next available
+    suffix (``alice``, ``alice-2``, …) — never touch a hand-created profile.
+
+    With ``--update``: adopt the unsuffixed ``base_name`` profile in place
+    if it exists AND has either (a) no account metadata at all or (b)
+    metadata for the same email (defensive — that should have been picked
+    up by ``profiles_by_email`` upstream, but the casefold mismatch case is
+    cheap to handle). Profiles whose metadata binds a *different* email
+    fall back to the suffix path to avoid clobbering them.
+    """
+    if update and base_name in existing_profiles and base_name not in claimed:
+        existing_email = _profile_account_email(base_name)
+        if existing_email is None or existing_email.casefold() == account_email.casefold():
+            return base_name
+    return _next_available_profile_name(base_name, unavailable | claimed)
 
 
 def _select_account(
@@ -1380,6 +1446,20 @@ def register_session_commands(cli):
         ),
     )
     @click.option(
+        "--update",
+        "update",
+        is_flag=True,
+        default=False,
+        help=(
+            "With --all-accounts: when an account's natural profile name "
+            "(e.g. 'alice' for alice@gmail.com) already exists but has no "
+            "account metadata, update that profile in place instead of "
+            "creating a suffixed 'alice-2'. Profiles that already bind a "
+            "different email are still given a suffix to avoid clobbering. "
+            "Only valid with --all-accounts."
+        ),
+    )
+    @click.option(
         "--profile-name",
         "profile_name",
         default=None,
@@ -1416,6 +1496,7 @@ def register_session_commands(cli):
         browser_cookies,
         account_email,
         all_accounts,
+        update,
         profile_name,
         fresh,
         include_domains_raw,
@@ -1470,6 +1551,9 @@ def register_session_commands(cli):
                     "and cannot be combined with --storage.[/red]"
                 )
                 raise SystemExit(1)
+            if update and not all_accounts:
+                console.print("[red]Error: --update only applies to --all-accounts.[/red]")
+                raise SystemExit(1)
 
             # Parse + validate --include-domains. Raises click.BadParameter on
             # unknown labels (Click converts that to a non-zero exit + stderr
@@ -1489,7 +1573,9 @@ def register_session_commands(cli):
                 _warn_missing_optional_domains(include_domains)
                 if all_accounts:
                     _login_all_accounts_from_browser(
-                        browser_cookies, include_domains=include_domains
+                        browser_cookies,
+                        update=update,
+                        include_domains=include_domains,
                     )
                     return
                 active_profile = ctx.obj.get("profile") if ctx.obj else None

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -3572,6 +3572,32 @@ class TestLoginAllAccountsUpdate:
         assert "--update" in result.output
         assert "--all-accounts" in result.output
 
+    def test_all_accounts_matches_existing_profile_case_insensitively(self, runner, tmp_path):
+        """Stored email metadata may differ in case from what Google returns
+        on a later probe (e.g. ``Alice@Gmail.com`` stored, ``alice@gmail.com``
+        probed). The email-keyed reuse path must casefold both sides so the
+        same profile is reused rather than allocating a suffixed duplicate.
+        Regression for CodeRabbit's review on #594.
+        """
+        # No --update — proving the case-insensitive match works on the
+        # default reuse-by-email-metadata path (not the --update name path).
+        result, root = self._run_all_accounts(
+            runner,
+            tmp_path,
+            update=False,
+            accounts=[(0, "alice@gmail.com", True)],
+            preexisting={"alice": {"account": {"authuser": 0, "email": "Alice@Gmail.com"}}},
+        )
+        assert result.exit_code == 0, result.output
+        # No alice-2 — the existing alice profile was reused despite the
+        # casing mismatch.
+        assert (root / "alice-2").exists() is False
+        # Re-stamped metadata uses the email as Google reports it now.
+        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+            "authuser": 0,
+            "email": "alice@gmail.com",
+        }
+
 
 class TestStaleAccountMetadataCleanup:
     """Default-account login must clear stale account metadata from previous targeted runs."""

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -3430,6 +3430,149 @@ class TestLoginMultiAccount:
         assert "all-accounts" in result.output.lower()
 
 
+class TestLoginAllAccountsUpdate:
+    """``--update`` lets ``--all-accounts`` adopt name-matching profiles in
+    place instead of allocating a suffixed ``alice-2`` when the natural name
+    is held by a hand-created profile with no account metadata."""
+
+    @staticmethod
+    def _run_all_accounts(
+        runner,
+        tmp_path,
+        *,
+        update: bool,
+        accounts: list[tuple[int, str, bool]],
+        preexisting: dict[str, dict | None] | None = None,
+    ):
+        """Run ``login --browser-cookies chrome --all-accounts [--update]``
+        against a mocked rookiepy + ``enumerate_accounts`` setup.
+
+        Args:
+            accounts: ``(authuser, email, is_default)`` tuples returned by the
+                mocked ``enumerate_accounts``.
+            preexisting: map of ``profile_dir -> context.json contents``
+                (``None`` = create the directory + an empty storage_state.json
+                with no context.json, i.e. a hand-created profile with no
+                account metadata).
+        """
+        mock_rk = _multiaccount_rookiepy_mock()
+
+        async def _enum(*args, **kwargs):
+            from notebooklm.auth import Account
+
+            return [Account(authuser=a, email=e, is_default=d) for a, e, d in accounts]
+
+        target_root = tmp_path / "profiles"
+        target_root.mkdir(parents=True)
+        for name, ctx in (preexisting or {}).items():
+            d = target_root / name
+            d.mkdir()
+            (d / "storage_state.json").write_text("{}")
+            if ctx is not None:
+                (d / "context.json").write_text(json.dumps(ctx))
+
+        def fake_get_storage_path(profile=None):
+            return target_root / (profile or "default") / "storage_state.json"
+
+        def fake_list_profiles():
+            return sorted(p.name for p in target_root.iterdir() if p.is_dir())
+
+        argv = ["login", "--browser-cookies", "chrome", "--all-accounts"]
+        if update:
+            argv.append("--update")
+        with (
+            patch.dict("sys.modules", {"rookiepy": mock_rk}),
+            patch("notebooklm.cli.session.get_storage_path", side_effect=fake_get_storage_path),
+            patch("notebooklm.paths.list_profiles", side_effect=fake_list_profiles),
+            patch("notebooklm.auth.enumerate_accounts", new=_enum),
+            patch(
+                "notebooklm.cli.session.fetch_tokens_with_domains",
+                new_callable=AsyncMock,
+                return_value=("csrf", "sess"),
+            ),
+        ):
+            result = runner.invoke(cli, argv)
+        return result, target_root
+
+    def test_update_adopts_unsuffixed_profile_with_no_metadata(self, runner, tmp_path):
+        # Pre-existing "alice" hand-created via `notebooklm login --profile alice`
+        # — no context.json, no email metadata. With --update, it should
+        # be adopted in place instead of getting an alice-2 suffix.
+        result, root = self._run_all_accounts(
+            runner,
+            tmp_path,
+            update=True,
+            accounts=[(0, "alice@example.com", True)],
+            preexisting={"alice": None},
+        )
+        assert result.exit_code == 0, result.output
+        assert (root / "alice" / "context.json").exists()
+        assert (root / "alice-2").exists() is False
+        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+            "authuser": 0,
+            "email": "alice@example.com",
+        }
+
+    def test_default_still_allocates_suffix_for_unsuffixed_no_metadata(self, runner, tmp_path):
+        # Same setup as above but WITHOUT --update — confirms the new flag is
+        # the only opt-in for the in-place adoption.
+        result, root = self._run_all_accounts(
+            runner,
+            tmp_path,
+            update=False,
+            accounts=[(0, "alice@example.com", True)],
+            preexisting={"alice": None},
+        )
+        assert result.exit_code == 0, result.output
+        assert (root / "alice-2" / "context.json").exists()
+        # alice still exists but unchanged (no context.json was written there).
+        assert (root / "alice" / "context.json").exists() is False
+
+    def test_update_does_not_clobber_profile_bound_to_different_email(self, runner, tmp_path):
+        # Safety guard: a profile named "alice" that already binds
+        # alice@OTHER.com must NOT be hijacked by alice@example.com just
+        # because --update is on. Falls back to the suffix path.
+        result, root = self._run_all_accounts(
+            runner,
+            tmp_path,
+            update=True,
+            accounts=[(0, "alice@example.com", True)],
+            preexisting={"alice": {"account": {"authuser": 0, "email": "alice@OTHER.com"}}},
+        )
+        assert result.exit_code == 0, result.output
+        assert (root / "alice-2" / "context.json").exists()
+        # Existing alice metadata must be untouched.
+        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+            "authuser": 0,
+            "email": "alice@OTHER.com",
+        }
+
+    def test_update_is_idempotent_when_profile_already_has_matching_metadata(
+        self, runner, tmp_path
+    ):
+        # If "alice" already binds the same email, --update changes nothing
+        # observable (re-stamps the same metadata; doesn't create alice-2).
+        result, root = self._run_all_accounts(
+            runner,
+            tmp_path,
+            update=True,
+            accounts=[(0, "alice@example.com", True)],
+            preexisting={"alice": {"account": {"authuser": 0, "email": "alice@example.com"}}},
+        )
+        assert result.exit_code == 0, result.output
+        assert sorted(p.name for p in root.iterdir()) == ["alice"]
+        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+            "authuser": 0,
+            "email": "alice@example.com",
+        }
+
+    def test_update_requires_all_accounts(self, runner):
+        result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--update"])
+        assert result.exit_code != 0
+        assert "--update" in result.output
+        assert "--all-accounts" in result.output
+
+
 class TestStaleAccountMetadataCleanup:
     """Default-account login must clear stale account metadata from previous targeted runs."""
 


### PR DESCRIPTION
## Summary

Follow-up to #580 / #571. Adds a `--update` flag to `notebooklm login --browser-cookies <browser> --all-accounts` that adopts a hand-created, name-matching profile in place instead of allocating a `-2` suffix.

## The problem

A user runs:

```bash
notebooklm login --profile alice         # hand-creates "alice" via Playwright
# ...time passes...
notebooklm login --browser-cookies chrome --all-accounts
```

The `--all-accounts` pass sees Google account `alice@gmail.com`, computes natural name `alice` via `email_to_profile_name`, finds `alice` already exists without account metadata, and creates `alice-2` so it doesn't clobber the hand-created one. Result: two profiles for the same Google account. User wanted a single `alice` profile to be adopted.

## The fix

`--update` opts the user into in-place adoption:

```bash
notebooklm login --browser-cookies chrome --all-accounts --update
```

Now `alice` (the hand-created profile) gets the account metadata stamped in place. `alice-2` is never created.

### Safety guard

If `alice` already has `context.json` binding `alice@OTHER.com`, `--update` still allocates a suffix — the existing binding is not clobbered. Tested.

### Idempotency

`--all-accounts --update` re-run is a no-op when nothing changed (re-stamps the same metadata; no new profiles created). Tested.

## CLI validation

`--update` without `--all-accounts` is rejected:

```
$ notebooklm login --browser-cookies chrome --update
Error: --update only applies to --all-accounts.
```

## Test plan

- [x] `uv run ruff format .` / `ruff check .` / `mypy src/notebooklm --ignore-missing-imports` all clean.
- [x] All 3351 existing unit tests still pass.
- [x] 5 new tests in `TestLoginAllAccountsUpdate`:
  - `test_update_adopts_unsuffixed_profile_with_no_metadata` — in-place adoption when target profile has no context.json.
  - `test_default_still_allocates_suffix_for_unsuffixed_no_metadata` — without `--update`, suffix path unchanged.
  - `test_update_does_not_clobber_profile_bound_to_different_email` — safety guard.
  - `test_update_is_idempotent_when_profile_already_has_matching_metadata` — re-run yields nothing new.
  - `test_update_requires_all_accounts` — CLI validation.

## Implementation notes

- `_resolve_all_accounts_target` (new private helper) consolidates the suffix-vs-adopt decision in one place. Default branch is unchanged; `--update` is the only opt-in for in-place adoption.
- `_profile_account_email` (new private helper) reads `context.json` for one profile, returning the email or `None` when no metadata exists. Used by the safety guard.
- Case-insensitive email comparison via `casefold()` matches the convention already used by `_select_refresh_account`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--update` option to login command (with `--browser-cookies --all-accounts`) to safely reuse existing profile names when account email addresses match.

* **Tests**
  * Added comprehensive test coverage for the new profile update functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/594)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->