### PR TITLE
docs(skill): document auth refresh + auth inspect (#571 follow-up)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -87,7 +87,12 @@ Before starting workflows, verify auth is in place. **Use `--test --json` (not b
 2. `notebooklm list --json` → expect valid JSON (may be empty for new accounts).
 3. **If auth fails or is missing → run `notebooklm login` first.** This is the primary auth path: opens a browser, the user signs in to Google once, and the resulting `storage_state.json` is reused on every subsequent run. Works on any environment with a display.
    - For headless contexts where opening a browser is not feasible, use `notebooklm login --browser-cookies <browser>` instead — extracts the user's already-logged-in cookies from Chrome/Firefox/etc. (requires the `[cookies]` extra; rookiepy may not install on Python 3.13+).
+   - To survey signed-in Google accounts before picking one: `notebooklm auth inspect --browser <browser>` (read-only; pass `-v` to see which Chromium user-profile each account came from, or `--json` for tooling).
    - Re-run step 1 after login to confirm.
+4. **If auth was working but cookies went stale** (Google rotated SIDTS, or you signed in fresh in the browser) **→ refresh the active profile in place instead of full re-login:**
+   - `notebooklm auth refresh` — server-side SIDTS refresh against the existing `storage_state.json`. Cheap and silent; safe to run on a schedule (cron / launchd / systemd) at 15–20 min cadence to keep an unattended profile warm.
+   - `notebooklm auth refresh --browser-cookies <browser>` — re-extract cookies from a running browser and match them back to the profile's recorded email in `context.json`. Use when the on-disk `storage_state.json` is too stale for the server-side refresh path but you've just signed back into Google in the browser. For Chromium-family browsers with multiple user-profiles (Chrome's `Default`, `Profile 1`, …), refresh fans out across all profiles to find the email — same path as `auth inspect` (issue #571).
+   - Both forms preserve the same `--profile` (no new profile is created).
 
 > **Note:** `notebooklm status` reports *context state* (selected notebook); do not use it to verify auth.
 
@@ -112,6 +117,9 @@ Before starting workflows, verify auth is in place. **Use `--test --json` (not b
 **Run automatically (no confirmation):**
 - `notebooklm status` - check context
 - `notebooklm auth check` - diagnose auth issues
+- `notebooklm auth inspect` - list Google accounts visible to a browser (read-only)
+- `notebooklm auth refresh` - server-side SIDTS refresh of the active profile (no new profile, no destructive writes)
+- `notebooklm auth refresh --browser-cookies <browser>` - re-extract cookies from a browser into the active profile (rebuilds `storage_state.json` for the same `--profile`, not a new one)
 - `notebooklm list` - list notebooks
 - `notebooklm source list` - list sources
 - `notebooklm artifact list` - list artifacts
@@ -147,8 +155,13 @@ Before starting workflows, verify auth is in place. **Use `--test --json` (not b
 | Task | Command |
 |------|---------|
 | Authenticate | `notebooklm login` |
+| Authenticate from browser cookies | `notebooklm login --browser-cookies <browser>` |
+| Import every signed-in account into its own profile | `notebooklm login --browser-cookies <browser> --all-accounts` |
+| Inspect signed-in accounts (read-only, by email) | `notebooklm auth inspect --browser <browser>` |
 | Diagnose auth issues | `notebooklm auth check` |
 | Diagnose auth (full) | `notebooklm auth check --test` |
+| Refresh active profile in place (server-side) | `notebooklm auth refresh` |
+| Refresh active profile from a re-signed-in browser | `notebooklm auth refresh --browser-cookies <browser>` |
 | One-shot cookie keepalive (for cron) | `notebooklm auth refresh --quiet` |
 | List notebooks | `notebooklm list` |
 | Create notebook | `notebooklm create "Title"` |


### PR DESCRIPTION
## Summary

Documentation-only follow-up to #580 / #571. SKILL.md surfaced \`notebooklm login\` and \`auth refresh --quiet\` (cron keepalive) but not the in-place refresh paths that agents need for recovery, nor \`auth inspect\` for read-only account survey.

This PR adds:

- **Setup verification step 4** covering both \`auth refresh\` variants (server-side SIDTS refresh vs. \`--browser-cookies <browser>\` re-extract from a re-signed-in browser), the cron cadence (15–20 min), and the issue #571 fan-out behavior for multi-Chrome-profile setups.
- **\`auth inspect --browser <browser>\`** mention in step 3 so agents can survey accounts before picking one with \`--account EMAIL\`.
- **Quick-reference rows** for the new commands plus the existing \`--all-accounts\` and \`--browser-cookies\` flows that weren't in the table.
- **Autonomy-rules entries** for the read-only / non-destructive auth commands (\`inspect\`, \`refresh\`, \`refresh --browser-cookies\`) so agents can run them without prompting.

No code changes. Closes the user request raised during #571 review: "we need to document how to refresh the cookie using notebooklm auth refresh --browser-cookie browser".

## Test plan

- [x] \`uv run pytest tests/unit/test_claude_md_freshness.py\` passes (the doc-freshness regression tests).
- [x] Diff is +13 / -0 lines, no removed content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)