### PR TITLE
Tighten profiles parameter type in _enumerate_chromium_profiles_fanout

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from rich.console import Console
 
     from ..auth import Account
+    from ._chromium_profiles import ChromiumProfile
 
 from ..auth import (
     GOOGLE_REGIONAL_CCTLDS,
@@ -346,7 +347,7 @@ def _enumerate_browser_accounts(
 
 def _enumerate_chromium_profiles_fanout(
     browser_name: str,
-    profiles: list[Any],
+    profiles: list[ChromiumProfile],
     *,
     verbose: bool,
     include_domains: set[str] | None,


### PR DESCRIPTION
The `profiles` parameter on `_enumerate_chromium_profiles_fanout` was typed as `list[Any]` even though the caller (`_enumerate_browser_accounts`) always passes a `list[ChromiumProfile]` from `discover_chromium_profiles`.

This PR adds `ChromiumProfile` to the TYPE_CHECKING import block and updates the parameter annotation to `list[ChromiumProfile]`. Pure typing cleanup with no runtime impact — makes the type story consistent end-to-end as noted in #580.

Fixes #588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and type annotation improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/598)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->