### PR TITLE
fix(typing): profiles: list[ChromiumProfile] in fan-out helper (closes #588)

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from rich.console import Console
 
     from ..auth import Account
+    from ._chromium_profiles import ChromiumProfile
 
 from ..auth import (
     GOOGLE_REGIONAL_CCTLDS,
@@ -346,7 +347,7 @@ def _enumerate_browser_accounts(
 
 def _enumerate_chromium_profiles_fanout(
     browser_name: str,
-    profiles: list[Any],
+    profiles: "list[ChromiumProfile]",
     *,
     verbose: bool,
     include_domains: set[str] | None,


### PR DESCRIPTION
## Summary

Closes #588 (audit follow-up from PR #580 / issue #571).

The private \`_enumerate_chromium_profiles_fanout\` was the last spot still declaring \`profiles: list[Any]\` after #580 tightened all the return types to \`list[Account]\`. The caller \`_enumerate_browser_accounts\` always passes \`list[ChromiumProfile]\` from \`discover_chromium_profiles\`, so this was purely a documentation-consistency gap.

## Change (2 lines)

* Add \`ChromiumProfile\` to \`src/notebooklm/cli/session.py\`'s \`TYPE_CHECKING\` block alongside \`Account\` (lazy; no runtime import cost).
* Change \`profiles: list[Any]\` → \`profiles: "list[ChromiumProfile]"\` (forward-reference string so the TYPE_CHECKING import stays lazy).

Pure type-system cleanup. No runtime behavior change, no new tests needed — the 175 unit tests touching the fan-out path all still pass unchanged.

## Test plan

- [x] \`uv run ruff format .\` / \`ruff check .\` / \`mypy src/notebooklm --ignore-missing-imports\` all clean.
- [x] 175 unit tests in \`test_session.py\` + \`test_chromium_profiles.py\` all pass.
- [x] No tests removed or skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)