### PR TITLE
test(decoder): parametrized tests for get_error_message_for_code (I19, T8.D12)

### DIFF
--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -10,10 +10,12 @@ from notebooklm.rpc.decoder import (
     ClientError,
     RateLimitError,
     RPCError,
+    RPCErrorCode,
     UnknownRPCMethodError,
     collect_rpc_ids,
     decode_response,
     extract_rpc_result,
+    get_error_message_for_code,
     parse_chunked_response,
     strip_anti_xssi,
 )
@@ -900,3 +902,213 @@ class TestMalformedChunkResilience:
         # there.
         with pytest.raises(RPCError, match="returned null result data"):
             decode_response(raw, rpc_id)
+
+
+class TestGetErrorMessageForCode:
+    """Parametrized coverage for ``get_error_message_for_code``.
+
+    Covers every known code in ``_ERROR_CODE_MESSAGES``, the ``None``
+    sentinel, the 4xx/5xx fallback ranges, and out-of-range codes.
+    """
+
+    @pytest.mark.parametrize(
+        ("code", "expected_substring", "expected_retryable"),
+        [
+            pytest.param(
+                RPCErrorCode.INVALID_REQUEST,
+                "Invalid request parameters",
+                False,
+                id="invalid_request_400",
+            ),
+            pytest.param(
+                RPCErrorCode.UNAUTHORIZED,
+                "Authentication required",
+                False,
+                id="unauthorized_401",
+            ),
+            pytest.param(
+                RPCErrorCode.FORBIDDEN,
+                "Insufficient permissions",
+                False,
+                id="forbidden_403",
+            ),
+            pytest.param(
+                RPCErrorCode.NOT_FOUND,
+                "Requested resource not found",
+                False,
+                id="not_found_404",
+            ),
+            pytest.param(
+                RPCErrorCode.RATE_LIMITED,
+                "rate limit exceeded",
+                True,
+                id="rate_limited_429",
+            ),
+            pytest.param(
+                RPCErrorCode.SERVER_ERROR,
+                "Server error occurred",
+                True,
+                id="server_error_500",
+            ),
+        ],
+    )
+    def test_error_code_known_returns_mapped_message(
+        self, code: int, expected_substring: str, expected_retryable: bool
+    ) -> None:
+        """Every known mapped code returns its tailored message + retry flag."""
+        message, is_retryable = get_error_message_for_code(int(code))
+        assert expected_substring in message
+        assert is_retryable is expected_retryable
+
+    def test_error_code_400_invalid_request(self) -> None:
+        """400 maps to the INVALID_REQUEST table entry, not the 4xx fallback."""
+        message, is_retryable = get_error_message_for_code(400)
+        assert message == "Invalid request parameters. Check your input and try again."
+        assert is_retryable is False
+
+    def test_error_code_401_unauthorized(self) -> None:
+        message, is_retryable = get_error_message_for_code(401)
+        assert "notebooklm login" in message
+        assert is_retryable is False
+
+    def test_error_code_403_forbidden(self) -> None:
+        message, is_retryable = get_error_message_for_code(403)
+        assert message == "Insufficient permissions for this operation."
+        assert is_retryable is False
+
+    def test_error_code_404_not_found(self) -> None:
+        message, is_retryable = get_error_message_for_code(404)
+        assert message == "Requested resource not found."
+        assert is_retryable is False
+
+    def test_error_code_429_rate_limit(self) -> None:
+        message, is_retryable = get_error_message_for_code(429)
+        assert "rate limit" in message.lower()
+        assert is_retryable is True
+
+    def test_error_code_500_server_error(self) -> None:
+        message, is_retryable = get_error_message_for_code(500)
+        assert "Server error" in message
+        assert is_retryable is True
+
+    def test_error_code_none_returns_generic_unknown(self) -> None:
+        """``None`` sentinel returns the generic non-retryable message."""
+        message, is_retryable = get_error_message_for_code(None)
+        assert message == "Unknown error occurred."
+        assert is_retryable is False
+
+    @pytest.mark.parametrize(
+        ("code", "expected_message", "expected_retryable"),
+        [
+            pytest.param(
+                402,
+                "Client error 402. Check your request parameters.",
+                False,
+                id="unmapped_4xx_402",
+            ),
+            pytest.param(
+                418,
+                "Client error 418. Check your request parameters.",
+                False,
+                id="unmapped_4xx_418_teapot",
+            ),
+            pytest.param(
+                422,
+                "Client error 422. Check your request parameters.",
+                False,
+                id="unmapped_4xx_422",
+            ),
+            pytest.param(
+                499,
+                "Client error 499. Check your request parameters.",
+                False,
+                id="unmapped_4xx_499_upper_edge",
+            ),
+        ],
+    )
+    def test_error_code_unmapped_4xx_generic_client_error(
+        self, code: int, expected_message: str, expected_retryable: bool
+    ) -> None:
+        """Unknown 400-499 codes get the generic client-error fallback."""
+        message, is_retryable = get_error_message_for_code(code)
+        assert message == expected_message
+        assert is_retryable is expected_retryable
+
+    @pytest.mark.parametrize(
+        ("code", "expected_message", "expected_retryable"),
+        [
+            pytest.param(
+                501,
+                "Server error 501. This is usually temporary - try again later.",
+                True,
+                id="unmapped_5xx_501",
+            ),
+            pytest.param(
+                502,
+                "Server error 502. This is usually temporary - try again later.",
+                True,
+                id="unmapped_5xx_502_bad_gateway",
+            ),
+            pytest.param(
+                503,
+                "Server error 503. This is usually temporary - try again later.",
+                True,
+                id="unmapped_5xx_503",
+            ),
+            pytest.param(
+                599,
+                "Server error 599. This is usually temporary - try again later.",
+                True,
+                id="unmapped_5xx_599_upper_edge",
+            ),
+        ],
+    )
+    def test_error_code_unmapped_5xx_generic_server_error(
+        self, code: int, expected_message: str, expected_retryable: bool
+    ) -> None:
+        """Unknown 500-599 codes get the generic retryable server-error fallback."""
+        message, is_retryable = get_error_message_for_code(code)
+        assert message == expected_message
+        assert is_retryable is expected_retryable
+
+    @pytest.mark.parametrize(
+        ("code", "expected_message"),
+        [
+            pytest.param(0, "Error code: 0", id="zero_edge_case"),
+            pytest.param(1, "Error code: 1", id="positive_below_4xx_grpc_cancelled"),
+            pytest.param(13, "Error code: 13", id="grpc_internal_13"),
+            pytest.param(200, "Error code: 200", id="success_range_200"),
+            pytest.param(399, "Error code: 399", id="just_below_4xx_399"),
+            pytest.param(600, "Error code: 600", id="just_above_5xx_600"),
+            pytest.param(999, "Error code: 999", id="three_digit_999"),
+            pytest.param(123456, "Error code: 123456", id="very_large_code"),
+            pytest.param(-1, "Error code: -1", id="negative_code"),
+        ],
+    )
+    def test_error_code_out_of_range_generic_fallback(
+        self, code: int, expected_message: str
+    ) -> None:
+        """Codes outside 400-599 get the bare ``Error code: <n>`` fallback (non-retryable)."""
+        message, is_retryable = get_error_message_for_code(code)
+        assert message == expected_message
+        assert is_retryable is False
+
+    def test_returns_tuple_of_str_and_bool(self) -> None:
+        """Return contract: always ``tuple[str, bool]`` regardless of input."""
+        for code in (None, 0, 400, 429, 500, 502, 999, -1):
+            message, is_retryable = get_error_message_for_code(code)
+            assert isinstance(message, str)
+            assert isinstance(is_retryable, bool)
+
+    def test_every_rpc_error_code_enum_value_covered_or_fallback(self) -> None:
+        """Each ``RPCErrorCode`` enum value resolves to a non-empty message.
+
+        Belt-and-suspenders: future additions to ``RPCErrorCode`` either land
+        in ``_ERROR_CODE_MESSAGES`` or fall through to the range-based
+        fallback. Either way ``get_error_message_for_code`` must produce a
+        non-empty human-readable message.
+        """
+        for code in RPCErrorCode:
+            message, is_retryable = get_error_message_for_code(int(code))
+            assert isinstance(message, str) and message
+            assert isinstance(is_retryable, bool)


### PR DESCRIPTION
## Summary
- Add `TestGetErrorMessageForCode` to `tests/unit/test_decoder.py` with parametrized coverage for every known RPC error code (400/401/403/404/429/500), the `None` sentinel, every `RPCErrorCode` enum value, the 4xx/5xx generic fallbacks (edge values 402/418/422/499 and 501/502/503/599), and out-of-range codes (0, negative, very large, gRPC canonical, 200/399/600/999).
- Test names follow the requested `test_error_code_<code>_<short_description>` pattern.
- Achieves 100% line coverage for `get_error_message_for_code` (lines 127-148 in `src/notebooklm/rpc/decoder.py`).

## Test plan
- [x] `uv run ruff format .`
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — no issues
- [x] `uv run pytest tests/unit/test_decoder.py` — 102 passed (32 new)
- [x] `uv run pytest --cov=notebooklm.rpc.decoder` — 96% overall; `get_error_message_for_code` fully covered (all 7 missing-line ranges are outside lines 127-148)
- [x] 7 pre-existing VCR cassette failures in `tests/integration/cli_vcr/test_downloads.py` reproduce on origin/main and are unrelated to this change.

No production code modified; mappings untouched.