### PR TITLE
refactor(decoder): use safe_index in WRB traversal (I1, T8.D1)

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -298,19 +298,28 @@ def collect_rpc_ids(chunks: list[Any]) -> list[str]:
     Returns:
         List of RPC method IDs found in the response.
     """
+    source = "decoder.collect_rpc_ids"
     found_ids = []
     for chunk in chunks:
         if not isinstance(chunk, list):
             continue
 
-        items = chunk if (chunk and isinstance(chunk[0], list)) else [chunk]
+        # Preserve the truthy short-circuit on an empty chunk so safe_index
+        # (which would raise under NOTEBOOKLM_STRICT_DECODE=1) is only called
+        # when the index is structurally valid.
+        if not chunk:
+            continue
+        first = safe_index(chunk, 0, method_id=None, source=source)
+        items = chunk if isinstance(first, list) else [chunk]
 
         for item in items:
             if not isinstance(item, list) or len(item) < 2:
                 continue
 
-            if item[0] in ("wrb.fr", "er") and isinstance(item[1], str):
-                found_ids.append(item[1])
+            tag = safe_index(item, 0, method_id=None, source=source)
+            rpc_id = safe_index(item, 1, method_id=None, source=source)
+            if tag in ("wrb.fr", "er") and isinstance(rpc_id, str):
+                found_ids.append(rpc_id)
 
     return found_ids
 
@@ -352,18 +361,28 @@ def _find_wrb_status(chunks: list[Any], rpc_id: str) -> tuple[int, str] | None:
     Used by ``decode_response`` to enrich the null-result error message when
     the server explicitly flagged the RPC with a status code.
     """
+    source = "decoder._find_wrb_status"
     for chunk in chunks:
         if not isinstance(chunk, list):
             continue
-        items = chunk if (chunk and isinstance(chunk[0], list)) else [chunk]
+        # Skip empty chunks before safe_index, which would raise under
+        # NOTEBOOKLM_STRICT_DECODE=1 on an out-of-bounds descent.
+        if not chunk:
+            continue
+        first = safe_index(chunk, 0, method_id=rpc_id, source=source)
+        items = chunk if isinstance(first, list) else [chunk]
         for item in items:
             if not isinstance(item, list) or len(item) < 6:
                 continue
-            if item[0] != "wrb.fr" or item[1] != rpc_id:
+            tag = safe_index(item, 0, method_id=rpc_id, source=source)
+            id_field = safe_index(item, 1, method_id=rpc_id, source=source)
+            if tag != "wrb.fr" or id_field != rpc_id:
                 continue
-            if item[2] is not None or item[5] is None:
+            result_data = safe_index(item, 2, method_id=rpc_id, source=source)
+            error_info = safe_index(item, 5, method_id=rpc_id, source=source)
+            if result_data is not None or error_info is None:
                 continue
-            status = _extract_status_code(item[5])
+            status = _extract_status_code(error_info)
             if status is not None:
                 return status
     return None
@@ -393,18 +412,27 @@ def _contains_user_displayable_error(obj: Any) -> bool:
 
 def extract_rpc_result(chunks: list[Any], rpc_id: str) -> Any:
     """Extract result data for a specific RPC ID from chunks."""
+    source = "decoder.extract_rpc_result"
     for chunk in chunks:
         if not isinstance(chunk, list):
             continue
 
-        items = chunk if (chunk and isinstance(chunk[0], list)) else [chunk]
+        # Skip empty chunks before safe_index, which would raise under
+        # NOTEBOOKLM_STRICT_DECODE=1 on an out-of-bounds descent.
+        if not chunk:
+            continue
+        first = safe_index(chunk, 0, method_id=rpc_id, source=source)
+        items = chunk if isinstance(first, list) else [chunk]
 
         for item in items:
             if not isinstance(item, list) or len(item) < 3:
                 continue
 
-            if item[0] == "er" and item[1] == rpc_id:
-                error_code = item[2] if len(item) > 2 else None
+            tag = safe_index(item, 0, method_id=rpc_id, source=source)
+            id_field = safe_index(item, 1, method_id=rpc_id, source=source)
+
+            if tag == "er" and id_field == rpc_id:
+                error_code = safe_index(item, 2, method_id=rpc_id, source=source)
 
                 # Try to get human-readable message for integer error codes
                 if isinstance(error_code, int):
@@ -425,13 +453,14 @@ def extract_rpc_result(chunks: list[Any], rpc_id: str) -> Any:
                     rpc_code=error_code,
                 )
 
-            if item[0] == "wrb.fr" and item[1] == rpc_id:
-                result_data = item[2]
+            if tag == "wrb.fr" and id_field == rpc_id:
+                result_data = safe_index(item, 2, method_id=rpc_id, source=source)
 
                 # Check for embedded UserDisplayableError when result is null
                 # This indicates rate limiting, quota exceeded, or other API restrictions
-                if result_data is None and len(item) > 5 and item[5] is not None:
-                    if _contains_user_displayable_error(item[5]):
+                if result_data is None and len(item) > 5:
+                    error_info = safe_index(item, 5, method_id=rpc_id, source=source)
+                    if error_info is not None and _contains_user_displayable_error(error_info):
                         raise RateLimitError(
                             "API rate limit or quota exceeded. Please wait before retrying.",
                             method_id=rpc_id,

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -806,3 +806,97 @@ class TestUnknownRPCMethodErrorRouting:
         # raw_response preview cap (80 chars + "..." = 83) preserved by the
         # base RPCError contract (NOTEBOOKLM_DEBUG=1 opts into full body).
         assert len(err.raw_response) <= 83
+
+
+class TestMalformedChunkResilience:
+    """T8.D1: safe_index hot-path traversal must tolerate malformed chunks.
+
+    None of these inputs should raise; the decoder API surface (collect_rpc_ids,
+    extract_rpc_result) must degrade gracefully when Google's response shape
+    drifts. This pins the soft-mode contract from rpc._safe_index: drift returns
+    None / empty rather than IndexError / TypeError bubbling up.
+    """
+
+    RPC_ID = RPCMethod.LIST_NOTEBOOKS.value
+
+    def test_collect_rpc_ids_handles_empty_chunk(self):
+        """Empty list chunk is skipped without indexing into it."""
+        assert collect_rpc_ids([[]]) == []
+
+    def test_collect_rpc_ids_handles_non_list_chunk(self):
+        """Non-list chunks (str / int / dict / None) are skipped silently."""
+        assert collect_rpc_ids(["nope", 123, None, {"k": "v"}]) == []
+
+    def test_collect_rpc_ids_handles_short_item(self):
+        """Items shorter than 2 elements are skipped before indexing item[1]."""
+        chunks: list = [["wrb.fr"]]  # missing rpc_id at index 1
+        assert collect_rpc_ids(chunks) == []
+
+    def test_collect_rpc_ids_handles_non_list_inner_item(self):
+        """Non-list items inside a nested chunk are skipped."""
+        chunks: list = [["string-item", 42, None]]
+        # First element is a string, so items becomes [chunk] (the outer list),
+        # which has len=3 and item[0]="string-item" doesn't match tags. No raise.
+        assert collect_rpc_ids(chunks) == []
+
+    def test_collect_rpc_ids_handles_deeply_nested_malformed(self):
+        """Deeply nested malformed structures do not crash the traversal."""
+        chunks: list = [[[None]], [[1, 2]], [[]], [[[]]], [["wrb.fr"]]]
+        # None of these have a (tag, rpc_id) pair with a valid string rpc_id.
+        assert collect_rpc_ids(chunks) == []
+
+    def test_extract_rpc_result_handles_empty_chunk(self):
+        """Empty chunks are skipped in extract_rpc_result."""
+        assert extract_rpc_result([[]], self.RPC_ID) is None
+
+    def test_extract_rpc_result_handles_non_list_chunk(self):
+        """Non-list chunks are skipped in extract_rpc_result."""
+        assert extract_rpc_result(["nope", 123, None], self.RPC_ID) is None
+
+    def test_extract_rpc_result_handles_missing_index_5(self):
+        """wrb.fr items with len < 6 don't trigger UserDisplayableError lookup."""
+        # Item has exactly 3 elements: tag, rpc_id, null result. No index 5.
+        chunks: list = [["wrb.fr", self.RPC_ID, None]]
+        # Should return None (the null result) without raising IndexError.
+        assert extract_rpc_result(chunks, self.RPC_ID) is None
+
+    def test_extract_rpc_result_handles_short_item(self):
+        """Items with len < 3 are skipped before any indexing."""
+        # Items shorter than 3 elements should be skipped — no IndexError.
+        chunks: list = [["wrb.fr", self.RPC_ID]]
+        assert extract_rpc_result(chunks, self.RPC_ID) is None
+
+    def test_extract_rpc_result_handles_deeply_nested_malformed(self):
+        """Pathological nesting must not raise in extract_rpc_result."""
+        chunks: list = [
+            [],
+            [[]],
+            [None, None, None],
+            [["wrb.fr"]],
+            [["wrb.fr", self.RPC_ID]],  # len < 3 — skipped
+        ]
+        assert extract_rpc_result(chunks, self.RPC_ID) is None
+
+    def test_decode_response_handles_malformed_chunk_for_status_lookup(self):
+        """_find_wrb_status (via decode_response) must not crash on malformed.
+
+        When decode_response hits the "null result data, look up status"
+        branch, the chunk list it scans may include malformed entries. None
+        of these should raise.
+        """
+        # First a malformed chunk, then the legitimate null-result entry that
+        # decode_response will report on. Use GET_NOTEBOOK to trigger the
+        # status-lookup branch.
+        rpc_id = RPCMethod.GET_NOTEBOOK.value
+        good = json.dumps(["wrb.fr", rpc_id, None, None, None, None])
+        bad_short = json.dumps(["wrb.fr"])  # malformed, len < 6
+        bad_empty = json.dumps([])
+        body = (
+            f"{len(bad_short)}\n{bad_short}\n{len(bad_empty)}\n{bad_empty}\n{len(good)}\n{good}\n"
+        )
+        raw = f")]}}'\n{body}"
+        # decode_response will still raise RPCError for the null result, but
+        # the malformed-chunk traversal must not raise IndexError on its way
+        # there.
+        with pytest.raises(RPCError, match="returned null result data"):
+            decode_response(raw, rpc_id)


### PR DESCRIPTION
## Summary
- Migrate three decoder hot paths — `collect_rpc_ids`, `_find_wrb_status`, `extract_rpc_result` — from raw indexed access to `safe_index()`, unifying drift handling under the soft-strict policy already shared by `_notebooks`/`_artifacts`.
- Keep behavior on valid responses byte-for-byte identical; add explicit empty-chunk guards so the strict-mode `safe_index` does not raise on inputs the legacy short-circuit ignored.
- Add malformed-chunk resilience tests covering empty chunks, missing `item[5]`, non-list inner items, deeply nested malformed structures, and a `decode_response` end-to-end case that mixes malformed + valid chunks through `_find_wrb_status`.

## Why
Hand-rolled `try/except IndexError` and `len(item) < N` guards were drifting away from the shared `safe_index` policy (issue I1 / T8.D1). Routing through `safe_index` means: (a) one place owns the soft/strict toggle, (b) drift logs carry a consistent `source=` and `method_id=` for diagnostics, and (c) future call sites have a single idiom to copy.

## Test plan
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit` — 3357 passed
- [x] `uv run pytest tests/integration --ignore=tests/integration/cli_vcr/test_downloads.py` — 639 passed
- [x] `NOTEBOOKLM_STRICT_DECODE=1 uv run pytest tests/unit/test_decoder.py` — 81 passed (verifies strict-mode behavior)
- [ ] Note: `tests/integration/cli_vcr/test_downloads.py` has 7 pre-existing failures on `origin/main` (VCR cassette `rpcids` mismatch — unrelated to this change; verified by re-running on the base commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)