### PR TITLE
refactor(rpc): move QUERY_ENDPOINT out of RPCMethod enum (I8, T8.D6)

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -131,8 +131,6 @@ FULL_MODE_ONLY_METHODS = {
 
 # Methods always skipped (even in full mode)
 ALWAYS_SKIP_METHODS = {
-    # Not a batchexecute RPC
-    RPCMethod.QUERY_ENDPOINT,
     # Takes too long
     RPCMethod.START_DEEP_RESEARCH,
     # Not fully rolled out by Google - fails with any IDs

--- a/src/notebooklm/rpc/types.py
+++ b/src/notebooklm/rpc/types.py
@@ -5,6 +5,7 @@ import logging
 import os
 from enum import Enum
 from functools import lru_cache
+from typing import Final
 
 from .._env import DEFAULT_BASE_URL, get_base_url
 
@@ -144,14 +145,18 @@ def resolve_rpc_id(method_name: str, canonical_id: str) -> str:
     return overrides.get(method_name, canonical_id)
 
 
+# URL path for the streamed-chat endpoint. Not a batchexecute RPC ID — kept
+# as a module-level constant rather than an ``RPCMethod`` member so the enum
+# only contains real RPC IDs that ``scripts/check_rpc_health.py`` can probe.
+_QUERY_ENDPOINT_PATH: Final[str] = (
+    "/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1."
+    "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
+)
+
 # Backward-compatible default-host endpoint constants. Runtime code should use
 # the lazy get_* helpers below so NOTEBOOKLM_BASE_URL is honored after import.
 BATCHEXECUTE_URL = f"{DEFAULT_BASE_URL}/_/LabsTailwindUi/data/batchexecute"
-QUERY_URL = (
-    f"{DEFAULT_BASE_URL}/_/LabsTailwindUi/data/"
-    "google.internal.labs.tailwind.orchestration.v1."
-    "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
-)
+QUERY_URL = f"{DEFAULT_BASE_URL}{_QUERY_ENDPOINT_PATH}"
 UPLOAD_URL = f"{DEFAULT_BASE_URL}/upload/_/"
 
 
@@ -162,11 +167,7 @@ def get_batchexecute_url() -> str:
 
 def get_query_url() -> str:
     """Return the NotebookLM streamed chat endpoint for the configured host."""
-    return (
-        f"{get_base_url()}/_/LabsTailwindUi/data/"
-        "google.internal.labs.tailwind.orchestration.v1."
-        "LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
-    )
+    return f"{get_base_url()}{_QUERY_ENDPOINT_PATH}"
 
 
 def get_upload_url() -> str:
@@ -202,9 +203,6 @@ class RPCMethod(str, Enum):
     SUMMARIZE = "VfAZjd"
     GET_SOURCE_GUIDE = "tr032e"
     GET_SUGGESTED_REPORTS = "ciyUvf"  # AI-suggested report formats
-
-    # Query endpoint (not a batchexecute RPC ID)
-    QUERY_ENDPOINT = "/_/LabsTailwindUi/data/google.internal.labs.tailwind.orchestration.v1.LabsTailwindOrchestrationService/GenerateFreeFormStreamed"
 
     # Artifact operations
     CREATE_ARTIFACT = "R7cb6c"  # Generate any artifact (audio, video, report, quiz, etc.)

--- a/tests/unit/test_rpc_health_coverage.py
+++ b/tests/unit/test_rpc_health_coverage.py
@@ -96,14 +96,12 @@ MUTATING_SKIP_LIST: frozenset[str] = frozenset(
 )
 
 
-PATH_NOT_METHOD_SKIP: frozenset[str] = frozenset(
-    {
-        # QUERY_ENDPOINT holds a streamed-chat URL path, not a batchexecute
-        # RPC ID. The chat endpoint lives outside the /batchexecute RPC
-        # pipeline, so the canary cannot probe it via the same plumbing.
-        "QUERY_ENDPOINT",
-    }
-)
+# Reserved for ``RPCMethod`` members that hold a URL-path string rather than
+# a batchexecute RPC ID. None currently exist — the streamed-chat path was
+# relocated to a module-level constant in ``rpc/types.py`` (T8.D6) — but
+# this category remains so a future path-shaped entry can be classified
+# without re-introducing the whole skip-list scaffolding.
+PATH_NOT_METHOD_SKIP: frozenset[str] = frozenset()
 
 
 UNAVAILABLE_SKIP_LIST: frozenset[str] = frozenset(


### PR DESCRIPTION
## Summary

- Move the streamed-chat URL path out of ``RPCMethod`` (where it never belonged — the enum is for batchexecute RPC IDs) into a module-level ``_QUERY_ENDPOINT_PATH: Final[str]`` in ``rpc/types.py``.
- ``QUERY_URL`` and ``get_query_url()`` reference the new constant; URL string is preserved byte-for-byte.
- Drop the now-stale ``RPCMethod.QUERY_ENDPOINT`` line from ``ALWAYS_SKIP_METHODS`` in ``scripts/check_rpc_health.py`` (the canary was always skipping it anyway) and empty the matching ``PATH_NOT_METHOD_SKIP`` frozenset in the coverage test (kept as an empty set so a future path-shaped entry can be classified without re-introducing the scaffolding).
- No public API change: ``_chat.py`` already routes through ``get_query_url()``; ``QUERY_ENDPOINT`` was never re-exported from ``notebooklm.rpc``.

## Test plan

- [x] ``uv run ruff format .`` — 259 files unchanged.
- [x] ``uv run ruff check .`` — All checks passed.
- [x] ``uv run mypy src/notebooklm --ignore-missing-imports`` — no issues in 60 files.
- [x] ``uv run pytest`` — 3993 pass, 12 skip, 28 xfailed. The 7 unrelated VCR cassette failures in ``tests/integration/cli_vcr/test_downloads.py::test_download`` reproduce on a clean ``origin/main`` (``c77e8d6``) checkout with no changes, so they are pre-existing.
- [x] ``scripts/check_rpc_health.py`` imports cleanly and runs to the auth-gate exit; ``ALWAYS_SKIP_METHODS`` now contains only ``{START_DEEP_RESEARCH, DISCOVER_SOURCES}``.
- [x] Runtime sanity-check: ``_QUERY_ENDPOINT_PATH``, ``QUERY_URL``, and ``get_query_url()`` produce the exact original path; ``RPCMethod.__members__`` no longer contains ``QUERY_ENDPOINT``.

Blocks: T8.D2b (both edit ``_chat.py``).