### PR TITLE
refactor(artifacts): named extractor for data-table deep chain (I2, T8.D2a)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -179,20 +179,59 @@ def _extract_cell_text(cell: Any) -> str:
     return ""
 
 
+def _extract_data_table_rows(raw_data: Any) -> list[Any]:
+    """Extract data-table rows from the LIST_ARTIFACTS (gArtLc) response shape.
+
+    Navigates the rich-text wrapper at ``raw_data[0][0][0][0][4][2]`` to reach
+    the rows array. The first four ``[0]`` hops are wrapper layers; ``[4]`` is
+    the table content section ``[type, flags, rows_array]``, and ``[2]`` is
+    the rows array itself.
+
+    Inner-most access goes through :func:`safe_index` so a soft-mode shape
+    drift logs a structured warning and returns ``[]`` instead of raising.
+    Strict-decode mode (``NOTEBOOKLM_STRICT_DECODE=1``) lets ``safe_index``
+    raise ``UnknownRPCMethodError`` so we fail fast.
+
+    Returns:
+        The rows array on success, or ``[]`` on shape drift / non-list inner
+        value. NEVER raises for soft-mode drift — callers (e.g.
+        :func:`_parse_data_table`) are responsible for converting an empty
+        result into a domain-level :class:`ArtifactParseError`.
+    """
+    rows_array = safe_index(
+        raw_data,
+        0,
+        0,
+        0,
+        0,
+        4,
+        2,
+        method_id=RPCMethod.LIST_ARTIFACTS.value,
+        source="_artifacts._extract_data_table_rows",
+    )
+    if not isinstance(rows_array, list):
+        # safe_index returns None on soft-mode drift, and the upstream shape
+        # is also occasionally seen as a non-list scalar — normalise both to
+        # the empty-list sentinel so the caller's "empty data table" path
+        # handles them uniformly.
+        if rows_array is not None:
+            logger.warning(
+                "data table rows_array is not a list (type=%s); treating as empty",
+                type(rows_array).__name__,
+            )
+        return []
+    return rows_array
+
+
 def _parse_data_table(raw_data: list) -> tuple[list[str], list[list[str]]]:
     """Parse rich-text data table into headers and rows.
 
     Data tables from NotebookLM have a complex nested structure with position
-    markers. This function navigates to the rows array and extracts text from
-    each cell.
+    markers. This function delegates inner-most navigation to
+    :func:`_extract_data_table_rows` and then extracts text from each cell.
 
-    Structure: raw_data[0][0][0][0][4][2] contains the rows array where:
-    - [0][0][0][0] navigates through wrapper layers
-    - [4] contains the table content section [type, flags, rows_array]
-    - [2] is the actual rows array
-
-    Each row has format: [start_pos, end_pos, [cell_array]]
-    Each cell is deeply nested: [pos, pos, [[pos, pos, [[pos, pos, [["text"]]]]]]]
+    Each row has format: ``[start_pos, end_pos, [cell_array]]``.
+    Each cell is deeply nested: ``[pos, pos, [[pos, pos, [[pos, pos, [["text"]]]]]]]``.
 
     Returns:
         Tuple of (headers, rows) where headers is a list of column names
@@ -202,9 +241,12 @@ def _parse_data_table(raw_data: list) -> tuple[list[str], list[list[str]]]:
         ArtifactParseError: If the data structure cannot be parsed or is empty.
     """
     try:
-        # Navigate through nested wrappers to reach the rows array
-        rows_array = raw_data[0][0][0][0][4][2]
+        rows_array = _extract_data_table_rows(raw_data)
         if not rows_array:
+            # Covers both genuinely-empty tables and soft-mode shape drift
+            # (where ``_extract_data_table_rows`` returns ``[]``). The caller
+            # converts this into ArtifactParseError so the download_data_table
+            # surface stays unchanged.
             raise ArtifactParseError("data_table", details="Empty data table")
 
         headers: list[str] = []

--- a/tests/unit/test_artifacts_helpers.py
+++ b/tests/unit/test_artifacts_helpers.py
@@ -1,0 +1,156 @@
+"""Unit tests for module-level helpers in ``notebooklm._artifacts``.
+
+Focuses on ``_extract_data_table_rows`` — the named extractor that replaces
+the raw ``raw_data[0][0][0][0][4][2]`` deep-index chain in
+:func:`_parse_data_table`. These tests pin the soft-mode contract (returns
+``[]`` on shape drift, never raises) and exercise the four canonical drift
+shapes plus the happy path. T8.D2a.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from notebooklm._artifacts import (
+    _extract_data_table_rows,
+    _parse_data_table,
+)
+from notebooklm.types import ArtifactParseError
+
+# ---------------------------------------------------------------------------
+# _extract_data_table_rows — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_extract_data_table_rows_happy_path() -> None:
+    """Well-formed CGsXqf shape: returns the inner rows array unchanged."""
+    rows_payload = [
+        [0, 5, [[0, 5, [[0, 5, [["Col1"]]]]]]],
+        [5, 10, [[5, 10, [[5, 10, [["A"]]]]]]],
+    ]
+    # Build the nested structure: raw_data[0][0][0][0][4][2] -> rows_payload
+    raw_data = [[[[[0, 100, None, None, [6, 7, rows_payload]]]]]]
+
+    result = _extract_data_table_rows(raw_data)
+
+    assert result == rows_payload
+    # Identity matters: helper must not copy / re-wrap the inner array.
+    assert result is rows_payload
+
+
+# ---------------------------------------------------------------------------
+# _extract_data_table_rows — drift shapes (must NOT raise)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_data_table_rows_missing_inner_list(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Inner ``[4]`` slot exists but lacks the ``[2]`` rows entry."""
+    # The table-content section ([type, flags, rows_array]) is truncated to
+    # ``[type, flags]`` — descending to index 2 must miss without raising.
+    raw_data = [[[[[0, 100, None, None, [6, 7]]]]]]
+
+    with caplog.at_level(logging.WARNING):
+        result = _extract_data_table_rows(raw_data)
+
+    assert result == []
+    # safe_index emits the structured drift warning; we don't assert on the
+    # exact wording to keep the test resilient to log-format tweaks.
+    assert any("safe_index" in rec.message or "drift" in rec.message for rec in caplog.records)
+
+
+def test_extract_data_table_rows_wrong_type_at_one_level() -> None:
+    """One of the wrapper hops is a string, not a list. Must return ``[]``."""
+    # Replace the third wrapper layer with a non-indexable string.
+    raw_data = [[[["not-a-list", [[0, 100, None, None, [6, 7, []]]]]]]]
+
+    result = _extract_data_table_rows(raw_data)
+
+    assert result == []
+
+
+def test_extract_data_table_rows_truncated_structure() -> None:
+    """Outer wrapper is only 3 levels deep — descent stops well before [4][2]."""
+    raw_data: list = [[[]]]
+
+    result = _extract_data_table_rows(raw_data)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_data_table_rows — extra coverage for non-list inner value
+# ---------------------------------------------------------------------------
+
+
+def test_extract_data_table_rows_non_list_inner_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Inner ``[2]`` is a scalar (e.g. None) instead of a list. Returns ``[]``.
+
+    This guards the ``isinstance(rows_array, list)`` normalisation branch in
+    the helper, which keeps the caller's "empty data table" path uniform.
+    """
+    raw_data = [[[[[0, 100, None, None, [6, 7, None]]]]]]
+
+    with caplog.at_level(logging.WARNING):
+        result = _extract_data_table_rows(raw_data)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_data_table — fallback path still raises on drift (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_data_table_raises_artifact_parse_error_on_drift() -> None:
+    """The fallback at _artifacts.py:236-240 must still raise on shape drift.
+
+    Even though the helper returns ``[]`` on drift, ``_parse_data_table`` must
+    convert that to :class:`ArtifactParseError` so the
+    ``download_data_table`` surface is unchanged.
+    """
+    truncated: list = [[[]]]  # same shape as drift test above
+
+    with pytest.raises(ArtifactParseError):
+        _parse_data_table(truncated)
+
+
+def test_parse_data_table_raises_on_empty_rows() -> None:
+    """Genuinely-empty rows array still raises with the existing message."""
+    raw_data = [[[[[0, 100, None, None, [6, 7, []]]]]]]
+
+    with pytest.raises(ArtifactParseError, match="Empty data table"):
+        _parse_data_table(raw_data)
+
+
+def test_parse_data_table_happy_path() -> None:
+    """End-to-end sanity: helper + parser still produce the expected CSV shape."""
+    rows_payload = [
+        [
+            0,
+            20,
+            [
+                [0, 5, [[0, 5, [[0, 5, [["Col1"]]]]]]],
+                [5, 10, [[5, 10, [[5, 10, [["Col2"]]]]]]],
+            ],
+        ],
+        [
+            20,
+            40,
+            [
+                [20, 25, [[20, 25, [[20, 25, [["A"]]]]]]],
+                [25, 30, [[25, 30, [[25, 30, [["B"]]]]]]],
+            ],
+        ],
+    ]
+    raw_data = [[[[[0, 100, None, None, [6, 7, rows_payload]]]]]]
+
+    headers, rows = _parse_data_table(raw_data)
+
+    assert headers == ["Col1", "Col2"]
+    assert rows == [["A", "B"]]


### PR DESCRIPTION
## Summary

- Replace the raw `raw_data[0][0][0][0][4][2]` deep-index chain in `_parse_data_table` with a private named helper `_extract_data_table_rows` that delegates inner-most access to `safe_index`.
- Soft-mode drift (`NOTEBOOKLM_STRICT_DECODE` unset) now logs a structured warning and returns `[]` rather than raising. Strict mode still raises `UnknownRPCMethodError` via `safe_index`.
- `_parse_data_table`'s existing fallback path is preserved: empty rows (genuinely-empty table OR soft-mode drift) is converted to `ArtifactParseError`, so the `download_data_table` public surface is unchanged.

## Why

T8.D2a — the first of the deep-index parser refactors. Named helpers make schema-drift behaviour observable and testable; the next siblings (D2b/c/d) will follow the same pattern for the other parsers.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit` (3355 passed, 8 skipped — clean)
- [x] `uv run pytest tests/unit/test_artifact_downloads.py tests/unit/test_artifacts_helpers.py tests/unit/test_artifacts_coverage.py` (80 passed — adjacent flows intact)
- [x] New `tests/unit/test_artifacts_helpers.py` covers: happy path, missing inner list, wrong type at one wrapper level, truncated 3-level structure, non-list inner value, plus regression tests pinning the `_parse_data_table` fallback semantics.

## Notes

- Test file is named `test_artifacts_helpers.py` (not `test_artifacts.py`) because pytest can't disambiguate against the pre-existing `tests/integration/test_artifacts.py` when neither directory has an `__init__.py`. The basename collision causes a collection error; the suffix keeps modules unique without restructuring the test tree.
- Pre-existing VCR cassette failures in `tests/integration/cli_vcr/test_downloads.py` (7 tests, all `wXbhsf` vs `gArtLc` rpcid mismatches) reproduce on clean `origin/main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)