### PR TITLE
refactor(notebooks): named extractors for summary+topics deep access (I2, T8.D2c)

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -25,6 +25,98 @@ def build_create_notebook_params(title: str) -> list[Any]:
     return [title, None, None, [2], [1]]
 
 
+def _extract_summary(outer: Any) -> str:
+    """Extract the summary string from a SUMMARIZE ``result[0]`` payload.
+
+    The expected shape is ``[[summary_string, ...], ...]`` — i.e. the summary
+    lives at ``outer[0][0]``. ``safe_index`` is used for the inner-most
+    descent so drift is logged with method_id + source rather than raising
+    ``IndexError`` from a raw subscript.
+
+    Returns:
+        The summary string, or ``""`` when the payload is missing the
+        expected slot (the caller is responsible for treating an empty
+        summary as "no description available").
+    """
+    summary_val = safe_index(
+        outer,
+        0,
+        0,
+        method_id=RPCMethod.SUMMARIZE.value,
+        source="_notebooks._extract_summary",
+    )
+    if summary_val is None:
+        return ""
+    return str(summary_val)
+
+
+def _extract_suggested_topics(outer: Any) -> list[SuggestedTopic]:
+    """Extract suggested topics from a SUMMARIZE ``result[0]`` payload.
+
+    The expected shape is ``[..., [[[question, prompt, ...], ...], ...], ...]``
+    — the topics list lives at ``outer[1][0]``, and each topic is itself a
+    list whose first two entries are ``question`` and ``prompt``.
+
+    The outer ``[1]`` slot is treated as routinely-optional (a notebook with
+    no topics legitimately omits it, so missing-slot is not "drift"); the
+    inner ``[0]`` descent goes through ``safe_index`` so genuine schema
+    drift surfaces with method_id + source. Per-topic shape checks log a
+    debug diagnostic and skip malformed entries rather than abort, because
+    a partial response (some valid topics + some drift) is more useful to
+    callers than an empty list.
+
+    Returns:
+        List of :class:`SuggestedTopic`. Empty when the payload omits the
+        slot or when every topic entry fails shape validation.
+    """
+    # outer[1] is routinely absent/empty when a notebook has no topics;
+    # use a plain guard rather than safe_index so that case doesn't log
+    # a drift warning on every healthy "no topics" response. Still log
+    # a DEBUG record so partial descriptions remain observable to anyone
+    # tailing logs while diagnosing a notebook with missing topics.
+    if not isinstance(outer, list) or len(outer) < 2:
+        logger.debug("_extract_suggested_topics: Partial description — no outer[1] slot")
+        return []
+
+    topics_container = outer[1]
+    if not isinstance(topics_container, list) or len(topics_container) == 0:
+        logger.debug(
+            "_extract_suggested_topics: Partial description — outer[1] is empty or non-list"
+        )
+        return []
+
+    topics_list = safe_index(
+        topics_container,
+        0,
+        method_id=RPCMethod.SUMMARIZE.value,
+        source="_notebooks._extract_suggested_topics",
+    )
+    if not isinstance(topics_list, list):
+        if topics_list is not None:
+            logger.debug(
+                "_extract_suggested_topics: expected list at outer[1][0], got %s",
+                type(topics_list).__name__,
+            )
+        return []
+
+    topics: list[SuggestedTopic] = []
+    for index, topic in enumerate(topics_list):
+        if not isinstance(topic, list) or len(topic) < 2:
+            logger.debug(
+                "_extract_suggested_topics: skipping malformed topic at index %d (type=%s)",
+                index,
+                type(topic).__name__,
+            )
+            continue
+        topics.append(
+            SuggestedTopic(
+                question=str(topic[0]) if topic[0] else "",
+                prompt=str(topic[1]) if topic[1] else "",
+            )
+        )
+    return topics
+
+
 class NotebooksAPI:
     """Operations on NotebookLM notebooks.
 
@@ -355,33 +447,14 @@ class NotebooksAPI:
         suggested_topics: list[SuggestedTopic] = []
 
         # Response structure: [[[summary_string], [[topics]], ...]]
-        # Summary is at result[0][0][0], topics at result[0][1][0]
-        if result and isinstance(result, list):
-            try:
-                outer = result[0]
-
-                # Summary at outer[0][0]
-                summary_val = outer[0][0]
-                summary = str(summary_val) if summary_val else ""
-
-                # Suggested topics at outer[1][0]
-                topics_list = outer[1][0]
-                if isinstance(topics_list, list):
-                    for topic in topics_list:
-                        if isinstance(topic, list) and len(topic) >= 2:
-                            suggested_topics.append(
-                                SuggestedTopic(
-                                    question=str(topic[0]) if topic[0] else "",
-                                    prompt=str(topic[1]) if topic[1] else "",
-                                )
-                            )
-            except (IndexError, TypeError) as e:
-                # A partial result (e.g. summary but no topics) is possible.
-                logger.debug(
-                    "Partial description for notebook %s (no topics?): %s",
-                    notebook_id,
-                    e,
-                )
+        # Summary is at result[0][0][0], topics at result[0][1][0].
+        # The outer descent and per-slot extraction live in named helpers
+        # (`_extract_summary` / `_extract_suggested_topics`) so the deep
+        # index access stays auditable when Google's shape drifts.
+        if result and isinstance(result, list) and len(result) > 0:
+            outer = result[0]
+            summary = _extract_summary(outer)
+            suggested_topics = _extract_suggested_topics(outer)
 
         return NotebookDescription(summary=summary, suggested_topics=suggested_topics)
 

--- a/tests/unit/test_notebooks_extractors.py
+++ b/tests/unit/test_notebooks_extractors.py
@@ -1,0 +1,161 @@
+"""Unit tests for named extraction helpers in ``_notebooks.py``.
+
+These cover ``_extract_summary`` and ``_extract_suggested_topics`` — the
+named wrappers that replaced raw ``outer[0][0]`` / ``outer[1][0]`` deep
+index access in ``NotebooksAPI.get_description``. Each helper gets a
+happy-path case plus two drift cases (missing index, wrong type).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from notebooklm._notebooks import _extract_suggested_topics, _extract_summary
+from notebooklm.types import SuggestedTopic
+
+
+class TestExtractSummary:
+    """Happy path + drift coverage for ``_extract_summary``."""
+
+    def test_happy_path_returns_summary_string(self) -> None:
+        # Real shape: result[0] = [["the summary"], [[...topics...]]]
+        outer = [["the summary"], [[["Q", "P"]]]]
+
+        assert _extract_summary(outer) == "the summary"
+
+    def test_drift_missing_inner_index_returns_empty_string(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # outer[0] is an empty list — outer[0][0] would IndexError.
+        outer: list = [[], [[["Q", "P"]]]]
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            result = _extract_summary(outer)
+
+        assert result == ""
+        # safe_index logs at WARNING in soft-decode mode when descent fails.
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "safe_index drift" in r.message
+        ]
+        assert warning_records, "expected safe_index drift WARNING on missing index"
+        assert any(
+            "_extract_summary" in str(r.args) or "_extract_summary" in r.message
+            for r in warning_records
+        )
+
+    def test_drift_wrong_type_at_outer_zero_returns_empty_string(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # outer[0] is an int — outer[0][0] raises TypeError.
+        outer = [42, [[["Q", "P"]]]]
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm"):
+            result = _extract_summary(outer)
+
+        assert result == ""
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "safe_index drift" in r.message
+        ]
+        assert warning_records, "expected safe_index drift WARNING on wrong type"
+
+
+class TestExtractSuggestedTopics:
+    """Happy path + drift coverage for ``_extract_suggested_topics``."""
+
+    def test_happy_path_returns_typed_topics(self) -> None:
+        outer = [
+            ["summary text"],
+            [
+                [
+                    ["What is X?", "Explain X"],
+                    ["How does Y work?", "Describe Y"],
+                ]
+            ],
+        ]
+
+        topics = _extract_suggested_topics(outer)
+
+        assert topics == [
+            SuggestedTopic(question="What is X?", prompt="Explain X"),
+            SuggestedTopic(question="How does Y work?", prompt="Describe Y"),
+        ]
+
+    def test_drift_missing_outer_one_returns_empty_with_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # outer has only the summary slot — no outer[1].
+        outer = [["summary only"]]
+
+        with caplog.at_level(logging.DEBUG, logger="notebooklm"):
+            topics = _extract_suggested_topics(outer)
+
+        assert topics == []
+        debug_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "Partial description" in r.message
+        ]
+        assert debug_records, "expected DEBUG diagnostic when outer[1] is absent"
+        # And no WARNING should be emitted for this legitimate "no topics" case.
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+
+    def test_drift_wrong_type_at_outer_one_returns_empty(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # outer[1] is a string instead of a list — should not parse topics.
+        outer = [["summary text"], "not-a-list"]
+
+        with caplog.at_level(logging.DEBUG, logger="notebooklm"):
+            topics = _extract_suggested_topics(outer)
+
+        assert topics == []
+        debug_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "Partial description" in r.message
+        ]
+        assert debug_records, "expected DEBUG diagnostic when outer[1] is wrong type"
+
+    def test_inner_drift_at_topics_zero_logs_and_returns_empty(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # outer[1] is a non-empty list whose [0] is not a list — safe_index
+        # descent succeeds (returns the value) but isinstance check rejects it.
+        outer = [["summary text"], ["not-a-topic-list"]]
+
+        with caplog.at_level(logging.DEBUG, logger="notebooklm"):
+            topics = _extract_suggested_topics(outer)
+
+        assert topics == []
+        debug_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "expected list at outer[1][0]" in r.message
+        ]
+        assert debug_records, "expected DEBUG when outer[1][0] is wrong type"
+
+    def test_malformed_topic_entries_are_skipped(self) -> None:
+        # Mixed: one valid topic, one too-short, one wrong-type. Only the
+        # valid entry should make it into the result; the rest are dropped
+        # rather than aborting the whole list.
+        outer = [
+            ["summary"],
+            [
+                [
+                    ["Valid question", "Valid prompt"],
+                    ["Only question"],  # too short
+                    "not a list",  # wrong type
+                ]
+            ],
+        ]
+
+        topics = _extract_suggested_topics(outer)
+
+        assert topics == [SuggestedTopic(question="Valid question", prompt="Valid prompt")]


### PR DESCRIPTION
## Summary

- Replace raw `outer[0][0]` / `outer[1][0]` deep-index access in `NotebooksAPI.get_description` with two private helpers (`_extract_summary`, `_extract_suggested_topics`) so the fragility of Google's undocumented SUMMARIZE response shape stays auditable when it drifts.
- Both helpers funnel inner-most descent through `safe_index` from `rpc/_safe_index.py` so drift surfaces with `method_id` + caller `source` instead of silently raising `IndexError`.
- The optional `outer[1]` slot is treated as routinely-empty (no drift warning for "notebook has no topics") and only falls back to `safe_index` once the slot is known to be a non-empty list — preserving the existing partial-result tolerance and the `Partial description` DEBUG signal that `tests/unit/test_swallow_observability.py` asserts on.

Lines 65 (`list()`) and 167 (quota-error path) were inspected per the task — both only contain single-level indexing, so they are left alone per the "only wrap if ≥2 levels of un-named indexing" guard. No public API changes.

## Test plan
- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] New `tests/unit/test_notebooks_extractors.py` (8 cases: happy path + missing-index + wrong-type per helper, plus inner-drift and malformed-entry coverage) — all green
- [x] Existing `get_description` integration tests in `tests/integration/test_notebooks.py` (happy path, empty topics, malformed topics, no `outer[1]`, `outer[1]` empty, `outer[1]` not list) — all still pass
- [x] `tests/unit/test_swallow_observability.py::test_description_partial_summary_logs_debug` — still asserts `Partial description` DEBUG line + no warnings
- [x] Full suite (excluding pre-existing flaky `tests/integration/cli_vcr/test_downloads.py` failures unrelated to this change): 3993 passed

## Notes

The current `origin/main` HEAD (post #598) has a `NameError: ChromiumProfile` collection error in `src/notebooklm/cli/session.py:350` that blocks the test suite from collecting. This branch is therefore based on `c77e8d6` (the commit just before the regression). Rebase to current `main` once #598's regression is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced notebook description extraction with improved handling of incomplete or malformed data payloads.
  * Optimized suggested topics extraction with better payload validation.

* **Tests**
  * Added comprehensive unit tests for extraction helpers, covering both standard parsing and edge cases with missing or invalid data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/605)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->