### PR TITLE
refactor(chat): named extractor for next_turn parsing (I2, T8.D2b)

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -16,7 +16,14 @@ from ._env import get_default_bl, get_default_language
 from ._logging import reset_request_id, set_request_id
 from .auth import format_authuser_value
 from .exceptions import ChatError, NetworkError, ValidationError
-from .rpc import ChatGoal, ChatResponseLength, RPCMethod, get_query_url, nest_source_ids
+from .rpc import (
+    ChatGoal,
+    ChatResponseLength,
+    RPCMethod,
+    get_query_url,
+    nest_source_ids,
+    safe_index,
+)
 from .types import AskResult, ChatMode, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
@@ -26,6 +33,50 @@ _UUID_PATTERN = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
+
+
+def _extract_next_turn_content(next_turn: Any) -> str | None:
+    """Extract the response content from a streaming-chat next_turn frame.
+
+    The ``khqZz`` (``GET_CONVERSATION_TURNS``) response packs each AI answer
+    as ``turn[4][0][0]`` — three nested wrappers around the answer text. This
+    helper delegates the inner-most descent to :func:`safe_index` so soft-mode
+    shape drift (``NOTEBOOKLM_STRICT_DECODE`` unset) logs a structured warning
+    and returns ``None`` instead of raising; strict-decode mode still lets
+    :func:`safe_index` raise ``UnknownRPCMethodError`` so callers fail fast.
+
+    Args:
+        next_turn: The candidate answer turn (a ``turn[2] == 2`` row from the
+            ``khqZz`` payload). Caller has already validated this is a list
+            with ``len(next_turn) > 4`` and ``next_turn[2] == 2``.
+
+    Returns:
+        The answer-text string on success. ``None`` when the inner
+        ``[4][0][0]`` chain drifts or the leaf is not a string — callers
+        should fall back to an empty-answer pair so chat history rendering
+        degrades gracefully rather than crashing.
+    """
+    content = safe_index(
+        next_turn,
+        4,
+        0,
+        0,
+        method_id=RPCMethod.GET_CONVERSATION_TURNS.value,
+        source="_chat._extract_next_turn_content",
+    )
+    if content is None:
+        return None
+    if not isinstance(content, str):
+        # The schema-drift contract returns ``None`` for non-string leaves so
+        # the caller's empty-answer fallback fires uniformly. A non-string
+        # leaf is rare enough to warrant a debug breadcrumb but not a warning
+        # (safe_index already emitted one for genuine descent failures).
+        logger.debug(
+            "next_turn content is not a string (type=%s); treating as drift",
+            type(content).__name__,
+        )
+        return None
+    return content
 
 
 class ChatAPI:
@@ -294,16 +345,12 @@ class ChatAPI:
                 if i + 1 < len(turns):
                     next_turn = turns[i + 1]
                     if isinstance(next_turn, list) and len(next_turn) > 4 and next_turn[2] == 2:
-                        try:
-                            a = str(next_turn[4][0][0] or "")
-                        except (IndexError, TypeError) as e:
-                            # next_turn[4] is unguarded — this except is
-                            # reachable when the answer payload shape drifts.
-                            logger.warning(
-                                "QA-pair parse: answer turn shape unexpected (schema drift?): %s",
-                                e,
-                                exc_info=True,
-                            )
+                        # Named extractor folds the previous ``try/except`` —
+                        # ``safe_index`` handles schema-drift logging and
+                        # returns ``None`` so the empty-answer fallback fires
+                        # uniformly. Strict-decode mode still raises through.
+                        content = _extract_next_turn_content(next_turn)
+                        a = str(content or "")
                         i += 1  # skip the answer turn
                 pairs.append((q, a))
             i += 1

--- a/tests/unit/test_chat_helpers.py
+++ b/tests/unit/test_chat_helpers.py
@@ -1,0 +1,108 @@
+"""Unit tests for module-level helpers in ``notebooklm._chat``.
+
+Focuses on ``_extract_next_turn_content`` — the named extractor that
+replaces the raw ``next_turn[4][0][0]`` deep-index chain in
+:meth:`ChatAPI._parse_turns_to_qa_pairs`. These tests pin the soft-mode
+contract (returns ``None`` on shape drift, never raises) and exercise the
+happy path plus two canonical drift shapes, as required by T8.D2b.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from notebooklm._chat import ChatAPI, _extract_next_turn_content
+
+# ---------------------------------------------------------------------------
+# _extract_next_turn_content — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_extract_next_turn_content_happy_path() -> None:
+    """Well-formed khqZz answer turn: returns the inner answer string."""
+    # An AI answer turn from ``khqZz`` (GET_CONVERSATION_TURNS): turn[2] == 2,
+    # turn[4] == [[answer_text]]. The first four slots (id/?/type/?) match
+    # the schema documented in _chat.get_conversation_turns.
+    next_turn = [None, None, 2, None, [["AI answer text."]]]
+
+    result = _extract_next_turn_content(next_turn)
+
+    assert result == "AI answer text."
+
+
+# ---------------------------------------------------------------------------
+# _extract_next_turn_content — drift shapes (must NOT raise)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_next_turn_content_missing_inner_list(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``turn[4]`` exists but is an empty list — descent stops at index 0."""
+    next_turn = [None, None, 2, None, []]
+
+    with caplog.at_level(logging.WARNING):
+        result = _extract_next_turn_content(next_turn)
+
+    assert result is None
+    # safe_index emits the structured drift warning; we don't assert on the
+    # exact wording to keep the test resilient to log-format tweaks.
+    assert any("safe_index" in rec.message or "drift" in rec.message for rec in caplog.records)
+
+
+def test_extract_next_turn_content_wrong_type_at_level(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``turn[4][0]`` is a string instead of a list — descent must fail soft."""
+    # The inner wrapper is a scalar, so descending to index ``[0]`` of a
+    # string would succeed (yielding 'n'), but descending again would not —
+    # safe_index normalises this to ``None`` via its TypeError/IndexError
+    # catch and the helper's ``isinstance(..., str)`` check rejects single
+    # characters that are not the expected wrapper shape… here we use a
+    # non-string non-list scalar to force the safe_index drift path.
+    next_turn = [None, None, 2, None, [42]]
+
+    with caplog.at_level(logging.WARNING):
+        result = _extract_next_turn_content(next_turn)
+
+    assert result is None
+
+
+def test_extract_next_turn_content_non_string_leaf() -> None:
+    """Leaf at ``[4][0][0]`` is a scalar instead of a string — returns ``None``.
+
+    This guards the explicit ``isinstance(content, str)`` normalisation
+    branch in ``_extract_next_turn_content`` — distinct from the soft-mode
+    ``safe_index`` drift path, which only triggers when descent itself
+    fails.
+    """
+    next_turn = [None, None, 2, None, [[12345]]]
+
+    result = _extract_next_turn_content(next_turn)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Regression: _parse_turns_to_qa_pairs still degrades gracefully
+# ---------------------------------------------------------------------------
+
+
+def test_parse_turns_to_qa_pairs_drift_yields_empty_answer() -> None:
+    """Answer turn with broken inner shape yields an empty answer string.
+
+    Pins the contract that the named extractor preserves the previous
+    empty-answer fallback semantics of :meth:`_parse_turns_to_qa_pairs`.
+    """
+    turns_data = [
+        [
+            [None, None, 1, "Question?"],
+            [None, None, 2, None, []],  # empty inner — drift via safe_index
+        ]
+    ]
+
+    result = ChatAPI._parse_turns_to_qa_pairs(turns_data)
+
+    assert result == [("Question?", "")]


### PR DESCRIPTION
## Summary

- Replace raw `next_turn[4][0][0]` deep-index access in `ChatAPI._parse_turns_to_qa_pairs` with a private, named helper `_extract_next_turn_content`
- Inner-most descent goes through `safe_index`, so soft-mode shape drift logs a structured warning and returns `None`; strict-decode mode (`NOTEBOOKLM_STRICT_DECODE=1`) still raises `UnknownRPCMethodError`
- The existing empty-answer fallback in `_parse_turns_to_qa_pairs` is preserved — drifted answer turns yield an empty answer string in the (question, answer) pair, so the `get_history` public surface is unchanged

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] New unit tests in `tests/unit/test_chat_helpers.py` pass (happy path + 2 drift shapes + non-string leaf + `_parse_turns_to_qa_pairs` regression)
- [x] All existing chat tests still pass (`tests/unit/test_chat_*.py` deltas are pre-existing `ChromiumProfile` collection errors in `session.py`, unrelated to this change)

## Notes

Test file is named `test_chat_helpers.py` rather than `test_chat.py` to avoid a basename collision with `tests/integration/test_chat.py`, `tests/e2e/test_chat.py`, and `tests/unit/cli/test_chat.py` — pytest cannot disambiguate same-basename test modules without `__init__.py` files in the test packages, the same gotcha addressed in T8.D2a (#604).

🤖 Generated with [Claude Code](https://claude.com/claude-code)