### PR TITLE
fix(sources): offload upload chunk reads to thread (T7.D2)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -1598,9 +1598,18 @@ class SourcesAPI:
             # (legacy direct-call), we open here as a one-off helper whose
             # ``with`` closes the locally-opened FD when the generator ends.
             async def file_stream():
+                # T7.D2 / audit §22: chunk reads are synchronous file I/O.
+                # On slow storage (network FS, encrypted home, large PDFs
+                # served from a cold cache) a bare ``f.read(65536)`` from
+                # an ``async`` context stalls the entire event loop for
+                # the duration of each chunk read. Wrap each read with
+                # ``asyncio.to_thread`` so the blocking syscall runs on
+                # the default thread executor and sibling tasks (auth
+                # refresh, heartbeats, the cancellation watchdog above)
+                # keep making progress while bytes stream in.
                 if path_fallback is not None:
                     with open(path_fallback, "rb") as f:
-                        while chunk := f.read(65536):  # 64KB chunks
+                        while chunk := await asyncio.to_thread(f.read, 65536):  # 64KB chunks
                             yield chunk
                     return
                 # FD path: caller transferred ownership to this helper; we
@@ -1609,7 +1618,7 @@ class SourcesAPI:
                 # background task can still read from it under post-finalize
                 # cancel.
                 assert not isinstance(file_obj, Path)  # narrowed by branch above
-                while chunk := file_obj.read(65536):  # 64KB chunks
+                while chunk := await asyncio.to_thread(file_obj.read, 65536):  # 64KB chunks
                     yield chunk
 
             # `finalize_started` flips after the local ``httpx.AsyncClient``

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -1,0 +1,300 @@
+"""Regression test for T7.D2 — upload chunk reads must not block the event loop.
+
+Audit item §22 (``thread-safety-concurrency-audit.md`` §22):
+
+    ``_upload_file_streaming`` streams the upload body via an
+    ``async def file_stream()`` generator that does
+    ``while chunk := f.read(65536):  yield chunk``. The ``f.read(...)``
+    call is a *synchronous* filesystem syscall executed directly on the
+    event-loop thread. For each 64 KiB chunk, slow storage (a FUSE
+    mount, a network filesystem under contention, an encrypted home,
+    or a large PDF served from a cold cache) stalls every other
+    concurrent task — auth refresh, the cancellation watchdog, the
+    sibling RPC the caller fired in parallel — for the full read
+    latency.
+
+Post-fix (T7.D2) — each chunk read wraps the synchronous ``f.read``
+with ``await asyncio.to_thread(f.read, 65536)`` so the blocking
+syscall runs on the default thread executor and the loop keeps
+ticking sibling tasks. Stdlib only — no ``aiofiles``.
+
+Methodology — heartbeat-gap detection
+-------------------------------------
+We do NOT try to prove the call is *exactly* on a thread; we prove
+the **observable consequence** — that a slow synchronous chunk read
+does not stall a concurrent heartbeat coroutine.
+
+A heartbeat task fires roughly every 10 ms via ``asyncio.sleep(0.01)``
+for the duration of the upload. The upload's first chunk read takes
+``SLEEP_S`` seconds (we inject a ``time.sleep`` inside the file-like
+object's ``.read``). If the upload blocked the loop, the gap between
+consecutive heartbeat timestamps spikes to ``>= SLEEP_S * 1000`` ms.
+With the fix in place the read runs on a worker thread and the
+heartbeat keeps ticking at ~10 ms intervals.
+
+This module pins TWO call sites — both must remain off-loop:
+
+1. ``test_upload_file_streaming_fd_path_does_not_block_event_loop``
+   The production path: ``add_file`` opens the FD once, transfers
+   ownership to ``_upload_file_streaming`` via the ``file_obj``
+   argument, and the helper drives ``file_obj.read(65536)`` from the
+   generator. We pass a file-like object whose ``.read`` does
+   ``time.sleep`` so the regression signal is unmistakable.
+
+2. ``test_upload_file_streaming_path_fallback_does_not_block_event_loop``
+   The legacy direct-call path retained for the existing
+   ``test_sources_upload.py`` unit tests. ``_upload_file_streaming``
+   accepts a ``Path``, opens it itself, and reads via
+   ``f.read(65536)`` from the ``with open(...)`` block. We
+   monkey-patch ``builtins.open`` (scoped to our temp file) so the
+   returned file object's ``.read`` is the slow one; the bare
+   ``open()`` call inside the helper falls through to the patch.
+
+Both branches must be wrapped; a regression on either path fails
+this suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from notebooklm._sources import SourcesAPI
+
+# How long the injected synchronous ``.read`` blocks for. 200 ms is well
+# above the asyncio scheduler resolution and comfortably above CI jitter,
+# but short enough to keep the test fast.
+SLEEP_S = 0.2
+
+# Heartbeat interval. ~20 ticks fit inside the SLEEP_S window, giving us
+# plenty of headroom over the ``MIN_HEARTBEATS`` threshold.
+HEARTBEAT_INTERVAL_S = 0.01
+
+# Minimum heartbeat samples we must observe during the slow read. Pre-fix
+# the synchronous sleep freezes the loop and we typically see 0–1
+# samples. Post-fix the read runs on a worker thread and we see ~20.
+# 5 leaves a 4x margin over the regression signal while staying clearly
+# below the post-fix expectation.
+MIN_HEARTBEATS = 5
+
+
+def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
+    """Build a SourcesAPI with a minimal mocked core.
+
+    Mirrors ``tests/unit/test_sources_upload.py``'s ``mock_core`` /
+    ``sources_api`` fixture pair. We don't import them because they are
+    module-local; copying the four-line setup here keeps the test
+    self-contained and avoids a conftest cross-dependency between
+    unit/ and integration/concurrency/.
+    """
+    core = MagicMock()
+    core.rpc_call = AsyncMock()
+    core.auth = MagicMock()
+    cookie_jar = MagicMock(name="cookie_jar")
+    core.auth.cookie_jar = cookie_jar
+    core.get_http_client.return_value.cookies = cookie_jar
+    return SourcesAPI(core), core
+
+
+class _SlowReadFile:
+    """File-like object whose ``.read`` does a real synchronous sleep.
+
+    Behaves like ``io.BytesIO`` over a fixed payload but injects
+    ``time.sleep(SLEEP_S)`` on the FIRST call to ``.read``. Subsequent
+    reads return promptly (we only need ONE slow read to demonstrate
+    the loop is blocked / not-blocked; further sleeps would just make
+    the test slower without sharpening the signal).
+    """
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self._pos = 0
+        self._first_read = True
+
+    def read(self, size: int = -1) -> bytes:
+        # The first read is the one whose duration the heartbeat
+        # measures. Subsequent reads (and the empty terminator read at
+        # EOF that closes the generator) skip the sleep so we don't pay
+        # for them.
+        if self._first_read:
+            self._first_read = False
+            time.sleep(SLEEP_S)
+        if size < 0:
+            chunk = self._payload[self._pos :]
+            self._pos = len(self._payload)
+            return chunk
+        chunk = self._payload[self._pos : self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+    def close(self) -> None:
+        # The FD-branch done-callback closes the file; provide a no-op
+        # so it doesn't error.
+        pass
+
+    # Context-manager support so the Path branch's
+    # ``with open(path_fallback, "rb") as f:`` accepts the slow stub
+    # returned by the monkey-patched ``builtins.open``.
+    def __enter__(self) -> _SlowReadFile:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[no-untyped-def]
+        self.close()
+
+
+async def _run_with_heartbeat(coro_factory):
+    """Drive ``coro_factory()`` while a heartbeat counts loop ticks.
+
+    Returns the heartbeat count observed during the awaited coroutine.
+    A pre-fix synchronous sleep inside the coroutine produces a count
+    near zero; a post-fix off-loop sleep lets the heartbeat tick at
+    its nominal cadence.
+    """
+    heartbeats = 0
+    stop = asyncio.Event()
+
+    async def _heartbeat() -> None:
+        nonlocal heartbeats
+        while not stop.is_set():
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=HEARTBEAT_INTERVAL_S)
+            except asyncio.TimeoutError:
+                heartbeats += 1
+
+    heartbeat_task = asyncio.create_task(_heartbeat())
+    try:
+        # Yield once so the heartbeat task has a chance to start before
+        # the upload kicks off.
+        await asyncio.sleep(0)
+        await coro_factory()
+    finally:
+        stop.set()
+        await heartbeat_task
+
+    return heartbeats
+
+
+def _patch_async_client(mock_client_cls: MagicMock) -> MagicMock:
+    """Wire a ``patch('httpx.AsyncClient')`` mock to consume the body generator.
+
+    The fix lives inside the ``file_stream`` generator, but the
+    generator is only consumed when the mocked POST iterates the
+    ``content=...`` kwarg. The default ``AsyncMock`` mock just records
+    the call and never touches ``content``, which means the generator
+    is never driven and our slow ``read`` is never hit. We replace the
+    POST with a side-effect that fully consumes the generator before
+    returning a 200 response — that's what httpx does in production
+    and it's what we need to surface the regression signal.
+    """
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    async def fake_post(*args: object, **kwargs: object) -> MagicMock:
+        content = kwargs.get("content")
+        if content is not None and hasattr(content, "__aiter__"):
+            async for _chunk in content:
+                # Drain the generator so every chunk read is exercised.
+                pass
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        return response
+
+    mock_client.post.side_effect = fake_post
+    mock_client_cls.return_value = mock_client
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_upload_file_streaming_fd_path_does_not_block_event_loop() -> None:
+    """FD branch: ``file_obj.read(65536)`` must run via ``asyncio.to_thread``.
+
+    Pre-fix: the synchronous ``time.sleep`` inside ``_SlowReadFile.read``
+    executes on the event-loop thread and freezes the heartbeat for
+    ``SLEEP_S`` seconds, so the count comes back at or near 0.
+
+    Post-fix: the read is dispatched to the default thread executor
+    via ``await asyncio.to_thread(file_obj.read, 65536)``; the
+    heartbeat keeps ticking and we observe ``>= MIN_HEARTBEATS``
+    samples.
+    """
+    sources_api, _core = _make_sources_api()
+    file_obj = _SlowReadFile(b"x" * 4096)
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        _patch_async_client(mock_client_cls)
+
+        async def _upload() -> None:
+            await sources_api._upload_file_streaming(
+                "https://upload.example.com/session",
+                file_obj,
+                filename="slow.bin",
+            )
+
+        heartbeats = await _run_with_heartbeat(_upload)
+
+    assert heartbeats >= MIN_HEARTBEATS, (
+        f"Event loop was blocked during _upload_file_streaming FD-branch read: "
+        f"only {heartbeats} heartbeats fired during a {SLEEP_S}s synchronous read "
+        f"(expected >= {MIN_HEARTBEATS}). The synchronous f.read(65536) is "
+        f"still running on the event-loop thread — wrap it with "
+        f"asyncio.to_thread."
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_file_streaming_path_fallback_does_not_block_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Path branch: ``f.read(65536)`` inside ``with open(...)`` must offload too.
+
+    The legacy ``Path`` overload (kept for the direct-call unit tests
+    in ``tests/unit/test_sources_upload.py``) opens the file inside
+    the helper. We monkey-patch ``builtins.open`` so that opening our
+    specific test file returns a ``_SlowReadFile`` — every other
+    ``open()`` call passes through untouched.
+    """
+    sources_api, _core = _make_sources_api()
+    test_file = tmp_path / "slow.bin"
+    test_file.write_bytes(b"x" * 4096)
+
+    real_open = builtins.open
+
+    def _patched_open(file, mode="r", *args, **kwargs):  # type: ignore[no-untyped-def]
+        # Match by resolved path so partial-path / cwd-relative
+        # spellings inside other code (logging, etc.) don't get
+        # accidentally diverted to the slow stub.
+        try:
+            same = Path(file).resolve() == test_file.resolve()
+        except (TypeError, ValueError):
+            same = False
+        if same and "b" in mode:
+            return _SlowReadFile(test_file.read_bytes())
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _patched_open)
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        _patch_async_client(mock_client_cls)
+
+        async def _upload() -> None:
+            await sources_api._upload_file_streaming(
+                "https://upload.example.com/session",
+                test_file,
+            )
+
+        heartbeats = await _run_with_heartbeat(_upload)
+
+    assert heartbeats >= MIN_HEARTBEATS, (
+        f"Event loop was blocked during _upload_file_streaming Path-branch read: "
+        f"only {heartbeats} heartbeats fired during a {SLEEP_S}s synchronous read "
+        f"(expected >= {MIN_HEARTBEATS}). The synchronous f.read(65536) is "
+        f"still running on the event-loop thread — wrap it with "
+        f"asyncio.to_thread."
+    )


### PR DESCRIPTION
## Summary

- Wraps the two synchronous `f.read(65536)` chunk-reads inside `_upload_file_streaming.file_stream()` with `await asyncio.to_thread(f.read, 65536)`. Covers both the FD branch used by `add_file` (post-T7.D3) and the legacy `Path` fallback retained for direct-call unit tests.
- Pre-fix, each chunk read was a synchronous filesystem syscall executed on the event-loop thread; slow storage (FUSE / NFS / encrypted home / cold-cache large PDFs) stalled every other concurrent task for the full read latency.
- Stdlib only — no `aiofiles` dependency added.

## Task

- Spec: `.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-3.md#T7.D2`
- Audit item: §22

## Test plan

Adds `tests/integration/concurrency/test_upload_blocks_loop.py` with two heartbeat-gap regression tests — one per branch (FD path and Path fallback). Each test injects a synchronous `time.sleep(0.2)` inside the file object's `.read`, drives `_upload_file_streaming` with a mocked `httpx.AsyncClient` whose POST drains the body generator, and asserts a 10 ms-cadence heartbeat task ticks `>= 5` times during the read window. The heartbeat sits at ~0–1 ticks pre-fix and ~20 post-fix, so the 5-tick threshold gives a comfortable margin over CI scheduler jitter.

Verified red→green:

- [x] Both tests fail (1 heartbeat each) when the `asyncio.to_thread` wraps are reverted.
- [x] Both tests pass (>= 5 heartbeats each) with the wraps in place.
- [x] `uv run ruff format .` — clean.
- [x] `uv run ruff check .` — clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues across 60 files.
- [x] `uv run pytest tests/integration/concurrency/ tests/integration/test_sources.py` — 169 passed (spec gate).
- [x] `uv run pytest tests/unit/test_sources_upload.py` — 66 passed (existing direct-call Path-branch coverage).
- [x] Wider sweep: `tests/integration/{concurrency,test_sources,test_core,test_notebooks,test_chat,test_artifacts}` — 449 passed.

## Notes for reviewers

- **CI matrix cassette leaks**: the cross-platform matrix has pre-existing cassette failures in `notebooks_list.yaml` and `real_api_list_notebooks.yaml` (Drive AONS tokens) — Tier-8 scope, not introduced by this PR. No required status checks are configured, so they do not block merge.
- **CLI `ChromiumProfile` collection error**: a separate pre-existing regression from PR #598 prevents `tests/integration/cli_vcr/` and several `tests/unit/` CLI-touching modules from collecting (`NameError: name 'ChromiumProfile' is not defined` — `TYPE_CHECKING`-only import used at runtime in `cli/session.py:350`). Out of scope for D2; the targeted spec gate (concurrency + sources integration) and the upload unit tests all pass.
- **Wave-3 GC pattern**: no new `asyncio.create_task` introduced, so the module-level `set` + `add_done_callback` pattern flagged on T7.C4 is not needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)