### PR TITLE
refactor(tests): globalize keepalive disable for VCR tests (I4, T8.D4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ markers = [
     "variants: parameter variant tests (skip to save quota)",
     "readonly: read-only tests against user's test notebook",
     "vcr: tests using VCR.py recorded cassettes (run with NOTEBOOKLM_VCR_RECORD=1 to record)",
+    "no_keepalive_disable: opt a VCR test out of the global NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1 autouse fixture in tests/integration/conftest.py (T8.D4)",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -50,25 +50,20 @@ def mock_context(tmp_path: Path):
 
 
 @pytest.fixture
-def mock_auth_for_vcr(monkeypatch):
+def mock_auth_for_vcr():
     """Mock authentication that works with VCR cassettes.
 
-    VCR replays recorded responses regardless of auth tokens,
-    so we use mock auth to avoid requiring real credentials.
+    VCR replays recorded responses regardless of auth tokens, so we use mock
+    auth to avoid requiring real credentials.
 
-    Also disables the layer-1 ``RotateCookies`` keepalive poke
-    (``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1``) — the documented escape hatch
-    in CHANGELOG `[0.4.1]` Fixed. Cassettes were recorded before that poke
-    was added; without disabling it here, every replay raises a cassette
-    mismatch on ``POST accounts.google.com/RotateCookies``. Previously the
-    mismatch surfaced as exit 1 via the legacy ``helpers.handle_error``
-    catch-all in ``cli/download.py``; under the typed handler (P3.T2 / I14)
-    that mismatch is correctly classified ``UNEXPECTED_ERROR`` (exit 2),
-    which is outside this helper's accepted ``(0, 1)`` range. Disabling the
-    poke aligns the test with what cassettes actually capture.
+    The layer-1 ``RotateCookies`` keepalive-poke disable that used to live
+    here (``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1``) was globalized in T8.D4 —
+    see the ``_disable_keepalive_poke_for_vcr`` autouse fixture in
+    ``tests/integration/conftest.py``. Every test that pulls this fixture
+    also carries ``@pytest.mark.vcr`` (either directly or via a module-level
+    ``pytestmark``), so the global autouse already disables the poke before
+    this fixture runs.
     """
-    monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
-
     mock_cookies = {
         "SID": "vcr_mock_sid",
         "HSID": "vcr_mock_hsid",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -123,6 +123,47 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(marker)
 
 
+# =============================================================================
+# T8.D4 — Globalize keepalive-poke disable for VCR tests
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _disable_keepalive_poke_for_vcr(request, monkeypatch):
+    """Auto-set ``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` for VCR tests.
+
+    The layer-1 ``RotateCookies`` keepalive poke (documented escape hatch in
+    CHANGELOG ``[0.4.1]`` Fixed) fires from inside ``_fetch_tokens_with_jar``
+    and is not part of any cassette recorded before that poke was added.
+    Letting it fire during VCR replay produces a cassette mismatch on
+    ``POST accounts.google.com/RotateCookies``, which under the typed CLI
+    error handler (P3.T2 / I14) surfaces as ``UNEXPECTED_ERROR`` (exit 2) —
+    outside what most VCR tests accept. Disabling the poke aligns every
+    replay with what the cassettes actually capture.
+
+    A test is treated as VCR if ``request.node.get_closest_marker("vcr")``
+    returns a marker. Every cassette-using test in this repo carries the
+    ``vcr`` mark via either a module-level ``pytestmark = [pytest.mark.vcr,
+    ...]`` or a per-test ``@pytest.mark.vcr`` decorator, so the marker check
+    alone is sufficient — no stack inspection of
+    ``@notebooklm_vcr.use_cassette`` is required. If a future test uses
+    ``use_cassette`` without the marker, add ``@pytest.mark.vcr`` to it.
+
+    Escape hatch: ``@pytest.mark.no_keepalive_disable`` opts a test out so
+    it can capture or assert on real ``RotateCookies`` traffic (e.g. a
+    future cassette that records the keepalive itself).
+
+    Markers are read at SETUP TIME via ``get_closest_marker`` —
+    ``request.applymarker()`` in the test body would be too late because the
+    env var must be set before the client constructs its HTTP layer.
+    """
+    if request.node.get_closest_marker("no_keepalive_disable"):
+        return
+    if request.node.get_closest_marker("vcr") is None:
+        return
+    monkeypatch.setenv("NOTEBOOKLM_DISABLE_KEEPALIVE_POKE", "1")
+
+
 @pytest.fixture
 def auth_tokens():
     """Create test authentication tokens for integration tests.

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -38,6 +38,22 @@ NO regex literals so we can never drift between "what the recorder scrubs" and
 here are thin wrappers that delegate to
 :func:`tests.cassette_patterns.scrub_string` and
 :func:`tests.cassette_patterns.recompute_chunk_prefix`.
+
+Keepalive-poke disable (T8.D4)
+------------------------------
+Every test that carries ``@pytest.mark.vcr`` (directly or via a module-level
+``pytestmark``) automatically runs with
+``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` via the
+``_disable_keepalive_poke_for_vcr`` autouse fixture in
+:mod:`tests.integration.conftest`. This silences the layer-1
+``accounts.google.com/RotateCookies`` keepalive — none of the cassettes
+recorded before that poke landed contain it, so leaving it enabled would
+produce a guaranteed cassette mismatch on every replay.
+
+If you need a VCR test that actually captures or asserts on ``RotateCookies``
+traffic (e.g. a future cassette recording the keepalive itself), opt out with
+the ``@pytest.mark.no_keepalive_disable`` marker — the autouse fixture will
+leave the env var alone and let the poke fire.
 """
 
 import importlib.util


### PR DESCRIPTION
## Summary
- Adds autouse `_disable_keepalive_poke_for_vcr` fixture in `tests/integration/conftest.py` that sets `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1` for any test carrying `@pytest.mark.vcr` (directly or via module-level `pytestmark`).
- Removes the now-redundant local `monkeypatch.setenv` from `mock_auth_for_vcr` in `tests/integration/cli_vcr/conftest.py`; that fixture now only stubs out auth lookups.
- Registers the `no_keepalive_disable` opt-out marker in `pyproject.toml` so future tests can capture real `RotateCookies` traffic when needed.
- Documents the new mechanism + opt-out in `tests/vcr_config.py` docstring.

## Detection rationale
Every cassette-using test in the repo carries `@pytest.mark.vcr` (directly or via `pytestmark = [pytest.mark.vcr, ...]`), so `request.node.get_closest_marker("vcr")` is sufficient — no stack inspection of `@notebooklm_vcr.use_cassette` needed. The fixture reads markers at SETUP TIME via `get_closest_marker` so the env var is set before any client constructs its HTTP layer.

## Scope guardrails (per task brief)
- Unit-test conftest `_reset_poke_state` autouse (`tests/conftest.py:12-39`) is untouched — different concern (module-state cleanup, not env var).
- `tests/integration/test_auth_refresh_vcr.py` (T8.C4) keeps its local `setenv` — already disables keepalive correctly and the brief explicitly forbids retrofitting it.

## Test plan
- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest -m vcr` — 83 passed / 4 skipped / 28 xfailed; the 7 `test_downloads.py` failures are pre-existing cassette/rpcids drift on `origin/main` (verified by re-running the same command on the pre-stashed working tree) and tracked for re-recording under phase-2 T8.B*.
- [x] Spot-checked `tests/integration/cli_vcr/test_notebooks.py::TestListCommand` — both tests pass under the global fixture without any local `setenv`.
- [x] `uv run pytest tests/unit` — 3439 passed, 8 skipped (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced VCR integration test infrastructure with automatic keepalive behavior management to prevent cassette mismatches during test replay.
  * Introduced new pytest marker to allow tests to opt out of automatic keepalive disabling when needed.
  * Refactored test fixture organization and updated test documentation for developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/609)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->