### PR TITLE
fix(cli): guard run_async against nested loops + close coroutine cleanly (T7.G4)

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -107,8 +107,35 @@ def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
 
 
 def run_async(coro):
-    """Run async coroutine in sync context."""
-    return asyncio.run(coro)
+    """Run async coroutine in sync context.
+
+    Guards against being called from inside an already-running event loop.
+    ``asyncio.run`` raises ``RuntimeError`` in that case ("asyncio.run() cannot
+    be called from a running event loop"); we re-raise with a CLI-shaped
+    message and explicitly close the coroutine first so the caller does not
+    see a ``RuntimeWarning: coroutine '...' was never awaited``.
+
+    Nested event loops are intentionally not supported (no ``nest_asyncio``,
+    no ``loop.run_until_complete`` fallback): the CLI assumes a single
+    top-level ``asyncio.run`` invariant.
+    """
+    try:
+        return asyncio.run(coro)
+    except RuntimeError as exc:
+        # Distinguish "loop already running" from other RuntimeErrors (e.g.,
+        # programmer errors inside the coroutine that surface as RuntimeError).
+        # Only the running-loop case requires us to close the coroutine — in
+        # every other case ``asyncio.run`` has already driven it to completion
+        # or cancellation, and calling ``close()`` would be a no-op at best
+        # (and could mask a still-pending state at worst).
+        if "running event loop" not in str(exc):
+            raise
+        coro.close()
+        raise RuntimeError(
+            "Cannot run sync CLI command from within an existing event loop. "
+            "Use the async API (``async with NotebookLMClient(...)``) directly "
+            "instead of invoking the sync CLI helper from async code."
+        ) from exc
 
 
 def _normalize_url(url: str) -> str:

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import warnings
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1028,6 +1029,50 @@ class TestRunAsync:
 
         result = run_async(sample_coro())
         assert result == "result"
+
+    def test_nested_event_loop_raises_helpful_error(self):
+        """Calling run_async from inside a running loop raises a CLI-shaped
+        RuntimeError and does NOT leak a 'coroutine was never awaited' warning.
+
+        T7.G4: the guard wraps ``asyncio.run`` and explicitly closes the
+        coroutine before re-raising so callers see the helpful message,
+        not the noisy RuntimeWarning.
+        """
+
+        async def sample_coro():
+            return "should-never-run"
+
+        async def driver():
+            coro = sample_coro()
+            try:
+                # Filter RuntimeWarning to surface as an error so pytest's
+                # filterwarnings doesn't swallow it even in environments
+                # that downgrade it. If close() works, no warning fires.
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", RuntimeWarning)
+                    with pytest.raises(RuntimeError) as exc_info:
+                        run_async(coro)
+                return exc_info.value
+            finally:
+                # Defensive: ensure no coroutine leak even if the assertion
+                # path above changes — close() is idempotent.
+                coro.close()
+
+        err = asyncio.run(driver())
+        assert "existing event loop" in str(err)
+        assert "async API" in str(err)
+
+    def test_non_loop_runtime_error_passes_through_unchanged(self):
+        """RuntimeError raised *inside* the coroutine must propagate as-is
+        (not be rewritten into the nested-loop message). The guard is keyed
+        on the 'running event loop' substring of asyncio.run's own error.
+        """
+
+        async def boom():
+            raise RuntimeError("kaboom")
+
+        with pytest.raises(RuntimeError, match="kaboom"):
+            run_async(boom())
 
 
 class TestImportWithRetry:


### PR DESCRIPTION
## Summary
- Wrap `asyncio.run(coro)` in try/except `RuntimeError`; on the "loop already running" branch, explicitly `coro.close()` to suppress the `RuntimeWarning: coroutine '...' was never awaited`, then re-raise with a CLI-shaped message pointing users at the async API.
- Nested event loops are intentionally **not** supported (no `nest_asyncio`, no `loop.run_until_complete` fallback) — the CLI assumes a single top-level `asyncio.run` invariant.
- Unit tests cover (a) the helpful error fires on nested invocation, (b) no `RuntimeWarning` leaks (the close suppresses it), and (c) unrelated `RuntimeError` raised *inside* the coroutine passes through unchanged.

## Task
- Plan: `.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.G4`
- Audit ref: tier-7 audit §16

## Test plan
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit/cli/test_helpers.py` (177 passed)
- [x] Full unit suite (`tests/unit/`) green (3441 passed, 8 skipped) — no regressions
- [ ] CI: cassette-guard integration failures are pre-existing (Wave 2/3 lessons) and non-blocking for this PR.

## Deferred polish findings
None.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for CLI invocation from within an existing event loop, providing clearer guidance to use the async API instead and preventing resource cleanup warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/610)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->