### PR TITLE
docs(auth): document best-effort dedupe on warning flags (T7.G7)

### DIFF
--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -135,6 +135,25 @@ _EXTRACTION_HINT = (
 
 # Tier 2 fires per cookie-load; a single CLI run can hit it 2-3 times across
 # the four loader entry points. One warning per process is enough signal.
+#
+# Dedupe contract (T7.G7): best-effort under threads, exactly-once on a single
+# event loop. The check-then-set at the call site (``_validate_required_cookies``
+# below) reads ``_SECONDARY_BINDING_WARNED`` and sets it to ``True`` in a single
+# synchronous block with no intervening ``await``. The asyncio scheduler can
+# only switch coroutines at ``await`` points, so concurrent coroutines on one
+# loop cannot interleave between the check and the set — the warning fires
+# exactly once per process. Under genuine OS threads (which this library does
+# NOT support per the documented concurrency contract — each client is bound
+# to one event loop), the pattern is racy: two threads can both observe
+# ``False`` before either has written ``True``, causing a duplicate warning.
+# We accept that as best-effort rather than introduce an ``asyncio.Lock``
+# (would not help threads) or a ``threading.Lock`` (re-architects for a use
+# case we don't support).
+#
+# Note: ``functools.lru_cache`` and ``logging.LoggerAdapter`` are sometimes
+# suggested as drop-in dedupe primitives here. They are NOT: ``lru_cache``
+# memoizes return values, not the side-effect of ``logger.warning``;
+# ``LoggerAdapter`` only rewrites records, it does not filter duplicates.
 _SECONDARY_BINDING_WARNED = False
 
 
@@ -1725,6 +1744,19 @@ def _file_lock(lock_path: Path, *, blocking: bool, log_prefix: str) -> Iterator[
         os.close(fd)
 
 
+# Dedupe contract (T7.G7): best-effort under threads, exactly-once on a single
+# event loop. ``_file_lock_exclusive`` below reads ``_FLOCK_UNAVAILABLE_WARNED``
+# and sets it to ``True`` in one synchronous block with no intervening
+# ``await``, so concurrent coroutines on one loop cannot interleave between
+# the check and the set — the warning fires exactly once per process. Under
+# genuine OS threads (out of scope per the documented concurrency contract),
+# duplicate warnings are possible. We accept that rather than serialize a
+# logging side-effect behind a lock for an unsupported configuration.
+#
+# Note: ``functools.lru_cache`` and ``logging.LoggerAdapter`` do NOT solve
+# this — ``lru_cache`` memoizes return values, not the ``logger.warning``
+# side-effect; ``LoggerAdapter`` only rewrites records, it does not filter
+# duplicates.
 _FLOCK_UNAVAILABLE_WARNED = False
 
 

--- a/tests/unit/test_warning_dedupe.py
+++ b/tests/unit/test_warning_dedupe.py
@@ -1,0 +1,120 @@
+"""T7.G7 — exactly-once warning dedupe under a single event loop.
+
+These tests pin the **single-event-loop** case of the documented "best-effort
+under threads, exactly-once on a single loop" contract for the two module-level
+warning flags in ``notebooklm.auth``:
+
+- ``_SECONDARY_BINDING_WARNED`` (auth.py)
+- ``_FLOCK_UNAVAILABLE_WARNED`` (auth.py)
+
+Both follow the same shape: a synchronous ``if not flag: flag = True; warn()``
+block with no ``await`` between the check and the set. The asyncio scheduler
+only switches coroutines at ``await`` points, so concurrent coroutines on one
+loop cannot interleave inside that block — the warning must fire exactly once
+even under ``asyncio.gather(*[N coros])``. We assert that here with N=100.
+
+Thread-mode dedupe is intentionally NOT tested — per the documented
+concurrency contract (each client is bound to a single event loop), threading
+is out of scope and a duplicate warning under threads is accepted as
+best-effort.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from notebooklm import auth as auth_module
+
+# Cookie set that passes the Tier 1 required-cookies check but lacks any
+# secondary binding (no OSID, no APISID/SAPISID pair). This triggers the
+# ``_SECONDARY_BINDING_WARNED`` warning path in ``_validate_required_cookies``.
+_TIER1_ONLY_COOKIES = {"SID", "__Secure-1PSIDTS"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_flags() -> Iterator[None]:
+    """Reset both module-level warning flags around each test."""
+    auth_module._SECONDARY_BINDING_WARNED = False
+    auth_module._FLOCK_UNAVAILABLE_WARNED = False
+    try:
+        yield
+    finally:
+        auth_module._SECONDARY_BINDING_WARNED = False
+        auth_module._FLOCK_UNAVAILABLE_WARNED = False
+
+
+def test_secondary_binding_warns_exactly_once_under_asyncio_gather(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """100 concurrent coroutines hit the secondary-binding warning path; the
+    warning must fire exactly once on a single event loop."""
+
+    async def first_access() -> None:
+        # ``_validate_required_cookies`` is synchronous, but invoking it from
+        # inside a coroutine is the realistic shape (it's called from the
+        # async cookie loaders). The asyncio scheduler can only switch tasks
+        # at ``await`` points; since the check-and-set is a single sync block,
+        # gathered tasks cannot interleave inside it.
+        auth_module._validate_required_cookies(_TIER1_ONLY_COOKIES)
+
+    async def run_gather() -> None:
+        await asyncio.gather(*(first_access() for _ in range(100)))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm.auth"):
+        asyncio.run(run_gather())
+
+    binding_warnings = [rec for rec in caplog.records if "secondary binding" in rec.getMessage()]
+    assert len(binding_warnings) == 1, (
+        f"expected exactly one secondary-binding warning, "
+        f"got {len(binding_warnings)}: {[r.getMessage() for r in binding_warnings]}"
+    )
+    assert auth_module._SECONDARY_BINDING_WARNED is True
+
+
+def test_flock_unavailable_warns_exactly_once_under_asyncio_gather(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """100 concurrent coroutines hit the flock-unavailable warning path; the
+    warning must fire exactly once on a single event loop."""
+
+    @contextlib.contextmanager
+    def fake_file_lock(lock_path: Path, *, blocking: bool, log_prefix: str) -> Iterator[str]:
+        # Simulate the "lock infrastructure failed" branch — the inner
+        # ``_file_lock`` would yield ``"unavailable"`` on NFS without flock
+        # support, fd exhaustion, etc. ``_file_lock_exclusive`` is the only
+        # caller that emits the dedupe warning, and only on this state.
+        yield "unavailable"
+
+    monkeypatch.setattr(auth_module, "_file_lock", fake_file_lock)
+
+    lock_path = tmp_path / ".storage_state.json.lock"
+
+    async def first_access() -> None:
+        # ``_file_lock_exclusive`` is a sync context manager; entering and
+        # exiting it inside a coroutine mirrors the realistic call shape
+        # (it's invoked from the cookie-save path).
+        with auth_module._file_lock_exclusive(lock_path):
+            pass
+
+    async def run_gather() -> None:
+        await asyncio.gather(*(first_access() for _ in range(100)))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm.auth"):
+        asyncio.run(run_gather())
+
+    flock_warnings = [
+        rec for rec in caplog.records if "Cross-process file lock unavailable" in rec.getMessage()
+    ]
+    assert len(flock_warnings) == 1, (
+        f"expected exactly one flock-unavailable warning, "
+        f"got {len(flock_warnings)}: {[r.getMessage() for r in flock_warnings]}"
+    )
+    assert auth_module._FLOCK_UNAVAILABLE_WARNED is True


### PR DESCRIPTION
## Summary

- Add comment blocks above the two module-level warning flags in `auth.py` documenting the dedupe contract: **best-effort under threads, exactly-once on a single event loop**.
- Add `tests/unit/test_warning_dedupe.py` with two tests that gather 100 concurrent coroutines into each warning path and assert the warning fires exactly once.
- Architectural decision: Option B (documented best-effort) — locked in iter-1 of the plan. Threading is out of scope per the documented concurrency contract; spending a PR on exact-once cross-thread logging adds complexity without proven harm.

## Task

`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.G7` (audit §24).

## Why this is correct on a single loop

Both flags share the same shape:

```python
global _SOME_FLAG
if not _SOME_FLAG:
    _SOME_FLAG = True
    logger.warning(...)
```

The asyncio scheduler can only switch coroutines at `await` points. The check-then-set is a single synchronous block with no intervening `await`, so concurrent coroutines on one loop cannot interleave between reading `_SOME_FLAG` as `False` and writing it as `True`. Under `asyncio.gather(*[100 coros])`, the warning fires exactly once. The unit test pins this.

Under genuine OS threads (which this library does NOT support — each client is bound to one event loop), two threads can both observe `False` before either has written `True`, causing a duplicate warning. That's the "best-effort" half of the contract.

## What we explicitly did NOT do (per spec MUST NOT DO)

- No `asyncio.Lock` for a logging warning.
- No re-architecture of logger handlers.
- No Option A (real cross-thread dedupe).

The comment blocks also explicitly debunk two tempting-but-broken alternatives:

- `functools.lru_cache` memoizes return values, not the `logger.warning` **side-effect**.
- `logging.LoggerAdapter` only rewrites records, it does not filter duplicates.

## Line drift note

The phase plan referenced `auth.py:1717` for the flock flag; in current `origin/main` the flag sits at `:1728` after T7.D1 (#574) added a few lines above it. Same flag, same call site — the drift is cosmetic.

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit/test_warning_dedupe.py` — 2 tests pass
- [x] `uv run pytest tests/unit/test_auth.py` — 292 tests pass (no regressions from comment edits)
- [x] `uv run pytest tests/unit/` — 3441 passed, 8 skipped

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced inline documentation for warning deduplication behavior related to cookies and file-lock unavailability.

* **Tests**
  * Added comprehensive unit tests verifying warning deduplication under concurrent execution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/611)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->