### PR TITLE
test(cli): VCR coverage for doctor + profile commands (T8.D8)

### DIFF
--- a/tests/cassettes/cli_doctor.yaml
+++ b/tests/cassettes/cli_doctor.yaml
@@ -1,0 +1,12 @@
+# VCR cassette for `notebooklm doctor` CLI integration tests (T8.D8).
+#
+# The doctor command is a local-only diagnostic — it reads filesystem state
+# (profile dir, storage_state.json, config.json) and makes NO HTTP requests.
+# This cassette is therefore intentionally empty: the matched test exists to
+# guard that `notebooklm doctor` never starts emitting HTTP traffic in a
+# future refactor (VCR in record_mode='none' raises on any unmatched
+# request). If a network call is ever added to `doctor`, the cli_vcr test
+# will fail loudly with a CannotOverwriteExistingCassetteException and force
+# the author to re-record this cassette intentionally.
+interactions: []
+version: 1

--- a/tests/cassettes/cli_profile.yaml
+++ b/tests/cassettes/cli_profile.yaml
@@ -1,0 +1,14 @@
+# VCR cassette for `notebooklm profile` CLI integration tests (T8.D8).
+#
+# The profile command group (list / create / switch / rename / delete) is a
+# local-only profile manager — every subcommand operates on
+# ``$NOTEBOOKLM_HOME/profiles/`` and ``$NOTEBOOKLM_HOME/config.json`` and
+# makes NO HTTP requests. This cassette is therefore intentionally empty:
+# the matched tests exist to guard that ``notebooklm profile`` never starts
+# emitting HTTP traffic in a future refactor (VCR in record_mode='none'
+# raises on any unmatched request). If a network call is ever added to a
+# ``profile`` subcommand, the cli_vcr test will fail loudly with a
+# CannotOverwriteExistingCassetteException and force the author to
+# re-record this cassette intentionally.
+interactions: []
+version: 1

--- a/tests/integration/cli_vcr/test_doctor.py
+++ b/tests/integration/cli_vcr/test_doctor.py
@@ -1,0 +1,122 @@
+"""CLI integration tests for ``notebooklm doctor`` (T8.D8).
+
+The ``doctor`` command is a local-only diagnostic — it inspects
+``$NOTEBOOKLM_HOME`` (profile directory, ``storage_state.json``,
+``config.json``) and makes **no** HTTP requests. The matched cassette
+``cli_doctor.yaml`` is therefore intentionally empty (``interactions: []``).
+
+Why register an empty cassette at all?
+    With ``record_mode="none"`` (the default for CI replay), VCR raises on
+    any unmatched request. Pinning ``doctor`` to an empty cassette turns
+    "future refactor accidentally adds a network call" into a loud test
+    failure (``CannotOverwriteExistingCassetteException``) — the author
+    must then re-record the cassette intentionally. This closes audit I10
+    (CLI VCR coverage gap) without recording fake traffic.
+
+Both tests run inside an isolated ``NOTEBOOKLM_HOME`` (``tmp_path``) so the
+real user's profile / config / storage is never touched, and the existing
+``notebooklm.paths`` module caches are reset before each test so the
+sandbox env var actually takes effect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from notebooklm import paths
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import notebooklm_vcr, skip_no_cassettes
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``NOTEBOOKLM_HOME`` into ``tmp_path`` and clear module caches.
+
+    Mirrors the ``isolated_notebooklm_home`` autouse fixture in
+    ``tests/unit/cli/test_doctor.py`` but lives here so the cli_vcr suite
+    doesn't have to depend on a unit-test conftest.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+    yield tmp_path
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+
+
+def _make_profile(home: Path, name: str = "default") -> Path:
+    """Create a profile directory at ``home/profiles/<name>`` with 0o700 perms."""
+    profile_dir = home / "profiles" / name
+    profile_dir.mkdir(parents=True)
+    # chmod is a no-op on Windows; the doctor command tolerates that already.
+    try:
+        profile_dir.chmod(0o700)
+    except (OSError, NotImplementedError):
+        pass
+    return profile_dir
+
+
+def _write_storage(profile_dir: Path, cookies: list[dict[str, str]]) -> None:
+    (profile_dir / "storage_state.json").write_text(
+        json.dumps({"cookies": cookies}), encoding="utf-8"
+    )
+
+
+class TestDoctorCommand:
+    """``notebooklm doctor`` — local diagnostic, no HTTP."""
+
+    @pytest.mark.parametrize("json_flag", [False, True])
+    @notebooklm_vcr.use_cassette("cli_doctor.yaml")
+    def test_doctor_happy_path(self, runner, isolated_home: Path, json_flag: bool) -> None:
+        """Doctor with a clean profile + SID cookie reports all checks pass.
+
+        Asserts:
+          * exit code 0
+          * No HTTP traffic emitted (empty cassette would trip on a request).
+          * ``--json`` output, when requested, is parseable and reports
+            ``auth.status == "pass"``.
+        """
+        profile_dir = _make_profile(isolated_home)
+        _write_storage(profile_dir, [{"name": "SID", "value": "fixture-sid"}])
+        (isolated_home / "config.json").write_text(
+            json.dumps({"default_profile": "default"}), encoding="utf-8"
+        )
+
+        args = ["doctor"]
+        if json_flag:
+            args.append("--json")
+
+        result = runner.invoke(cli, args)
+
+        assert result.exit_code == 0, result.output
+        if json_flag:
+            data = json.loads(result.output)
+            assert data["profile"] == "default"
+            assert data["checks"]["auth"]["status"] == "pass"
+
+    @notebooklm_vcr.use_cassette("cli_doctor.yaml")
+    def test_doctor_reports_missing_auth(self, runner, isolated_home: Path) -> None:
+        """Doctor with no ``storage_state.json`` reports auth failure cleanly.
+
+        The auth-failure path is the second axis the task acceptance asks
+        for. Even on the failure path the command still exits 0 (it's a
+        diagnostic — ``doctor`` reports failures rather than exiting
+        non-zero) and emits no HTTP requests.
+        """
+        _make_profile(isolated_home)
+        # Deliberately no storage_state.json written.
+
+        result = runner.invoke(cli, ["doctor", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["checks"]["auth"]["status"] == "fail"
+        assert data["checks"]["auth"]["detail"] == "not authenticated"

--- a/tests/integration/cli_vcr/test_profile.py
+++ b/tests/integration/cli_vcr/test_profile.py
@@ -1,0 +1,166 @@
+"""CLI integration tests for ``notebooklm profile`` (T8.D8).
+
+The ``profile`` command group (``list`` / ``create`` / ``switch`` /
+``rename``) is a local-only profile manager — every subcommand operates on
+``$NOTEBOOKLM_HOME/profiles/`` and ``$NOTEBOOKLM_HOME/config.json`` and
+makes **no** HTTP requests. The matched cassette ``cli_profile.yaml`` is
+intentionally empty (``interactions: []``).
+
+Why register an empty cassette at all?
+    With ``record_mode="none"`` (the default for CI replay), VCR raises on
+    any unmatched request. Pinning each ``profile`` subcommand to an empty
+    cassette turns "future refactor accidentally adds a network call" into
+    a loud test failure (``CannotOverwriteExistingCassetteException``).
+    This closes audit I10 (CLI VCR coverage gap) without recording fake
+    traffic.
+
+Coverage scope (per task MUST-NOT: no destructive operations):
+    * ``profile list``           — happy path + empty path (no profiles)
+    * ``profile create <name>``  — happy path + duplicate-name failure
+    * ``profile switch <name>``  — happy path + missing-target failure
+    * ``profile rename a b``     — happy path
+
+Every test runs inside an isolated ``NOTEBOOKLM_HOME`` (``tmp_path``) and
+resets ``notebooklm.paths`` module caches so the sandbox env var actually
+takes effect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from notebooklm import paths
+from notebooklm.notebooklm_cli import cli
+
+from .conftest import notebooklm_vcr, skip_no_cassettes
+
+pytestmark = [pytest.mark.vcr, skip_no_cassettes]
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``NOTEBOOKLM_HOME`` into ``tmp_path`` and clear module caches."""
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
+    monkeypatch.delenv("NOTEBOOKLM_PROFILE", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+    yield tmp_path
+    paths.set_active_profile(None)
+    paths._reset_config_cache()
+
+
+def _make_profile(home: Path, name: str) -> Path:
+    """Create a profile directory under ``home/profiles/<name>``."""
+    profile_dir = home / "profiles" / name
+    profile_dir.mkdir(parents=True)
+    return profile_dir
+
+
+class TestProfileListCommand:
+    """``notebooklm profile list`` — pure filesystem read, no HTTP."""
+
+    @pytest.mark.parametrize("json_flag", [False, True])
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_list_with_profiles(self, runner, isolated_home: Path, json_flag: bool) -> None:
+        """List enumerates existing profile directories.
+
+        Asserts:
+          * exit code 0
+          * No HTTP traffic emitted.
+          * ``--json`` output exposes the populated ``profiles`` list and
+            the resolved ``active`` profile name.
+        """
+        _make_profile(isolated_home, "default")
+        _make_profile(isolated_home, "work")
+
+        args = ["profile", "list"]
+        if json_flag:
+            args.append("--json")
+
+        result = runner.invoke(cli, args)
+
+        assert result.exit_code == 0, result.output
+        if json_flag:
+            data = json.loads(result.output)
+            assert {p["name"] for p in data["profiles"]} == {"default", "work"}
+            assert data["active"] == "default"
+        else:
+            # Rich table contains both profile names verbatim.
+            assert "default" in result.output
+            assert "work" in result.output
+
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_list_empty(self, runner, isolated_home: Path) -> None:
+        """With no profile directories the CLI prints a friendly hint."""
+        result = runner.invoke(cli, ["profile", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "No profiles found" in result.output
+
+
+class TestProfileCreateCommand:
+    """``notebooklm profile create`` — mkdir + perms, no HTTP."""
+
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_create_new_profile(self, runner, isolated_home: Path) -> None:
+        """Create writes a new profile directory under ``profiles/``."""
+        result = runner.invoke(cli, ["profile", "create", "work"])
+
+        assert result.exit_code == 0, result.output
+        assert (isolated_home / "profiles" / "work").is_dir()
+        assert "Profile 'work' created" in result.output
+
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_create_duplicate_fails(self, runner, isolated_home: Path) -> None:
+        """Creating an existing profile is rejected with a clean error."""
+        _make_profile(isolated_home, "work")
+
+        result = runner.invoke(cli, ["profile", "create", "work"])
+
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+
+class TestProfileSwitchCommand:
+    """``notebooklm profile switch`` — config.json write, no HTTP."""
+
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_switch_to_existing_profile(self, runner, isolated_home: Path) -> None:
+        """Switch updates ``default_profile`` in ``config.json``."""
+        _make_profile(isolated_home, "default")
+        _make_profile(isolated_home, "work")
+
+        result = runner.invoke(cli, ["profile", "switch", "work"])
+
+        assert result.exit_code == 0, result.output
+        config = json.loads((isolated_home / "config.json").read_text(encoding="utf-8"))
+        assert config["default_profile"] == "work"
+
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_switch_missing_profile_fails(self, runner, isolated_home: Path) -> None:
+        """Switching to a profile that doesn't exist is rejected."""
+        _make_profile(isolated_home, "default")
+
+        result = runner.invoke(cli, ["profile", "switch", "no-such-profile"])
+
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestProfileRenameCommand:
+    """``notebooklm profile rename`` — directory rename, no HTTP."""
+
+    @notebooklm_vcr.use_cassette("cli_profile.yaml")
+    def test_rename_profile(self, runner, isolated_home: Path) -> None:
+        """Rename moves the profile directory and reports success."""
+        _make_profile(isolated_home, "work")
+
+        result = runner.invoke(cli, ["profile", "rename", "work", "work-archive"])
+
+        assert result.exit_code == 0, result.output
+        assert not (isolated_home / "profiles" / "work").exists()
+        assert (isolated_home / "profiles" / "work-archive").is_dir()


### PR DESCRIPTION
## Summary

Adds `cli_vcr` integration tests for `notebooklm doctor` and
`notebooklm profile` — the two CLI commands flagged by audit **I10** as
lacking VCR coverage. Closes the coverage gap that `T8.D8` was filed for.

Both commands are **local-only** (filesystem reads/writes only; no HTTP),
so the matched cassettes are intentionally empty (`interactions: []`).
With `record_mode='none'` on replay, an empty cassette turns any future
accidental network call into a loud `CannotOverwriteExistingCassetteException`,
giving us defense-in-depth without recording synthetic traffic.

## Coverage

* `doctor`
  * happy path (parametrized over `--json`)
  * missing-auth path (no `storage_state.json`)
* `profile`
  * `list` — happy + empty
  * `create` — happy + duplicate-name failure
  * `switch` — happy + missing-target failure
  * `rename` — happy

All tests use an isolated `NOTEBOOKLM_HOME=tmp_path` and reset
`notebooklm.paths` module caches so the sandbox is fully self-contained.

## Files

* `tests/integration/cli_vcr/test_doctor.py` (NEW, 3 tests)
* `tests/integration/cli_vcr/test_profile.py` (NEW, 8 tests)
* `tests/cassettes/cli_doctor.yaml` (NEW, empty stub)
* `tests/cassettes/cli_profile.yaml` (NEW, empty stub)

## Test plan

- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/integration/cli_vcr/test_doctor.py tests/integration/cli_vcr/test_profile.py` — 11 passed
- [x] `uv run python tests/scripts/check_cassettes_clean.py` — 78 cassettes scanned, 0 leaks
- [x] `uv run pytest tests/unit/test_cassette_shapes.py` — 85 passed (incl. both new cassettes)
- [x] Full suite (`uv run pytest`) — only pre-existing `test_downloads.py` failures (present on `origin/main`); all other 4100 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added integration tests for the `doctor` command, verifying offline operation and authentication status reporting.
* Added integration tests for the `profile` command, ensuring profile management operations function correctly across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/615)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->