### PR TITLE
feat(sources): configurable upload timeouts (T7.H3)

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -129,13 +129,32 @@ class SourcesAPI:
             await client.sources.rename(notebook_id, new_src.id, "Better Title")
     """
 
-    def __init__(self, core: ClientCore):
+    def __init__(
+        self,
+        core: ClientCore,
+        upload_timeout: httpx.Timeout | None = None,
+    ):
         """Initialize the sources API.
 
         Args:
             core: The core client infrastructure.
+            upload_timeout: Optional override for the ``httpx.Timeout`` used
+                by the resumable-upload start handshake and the finalize
+                POST. ``None`` (default) preserves the original hardcoded
+                values (10.0s connect / 60.0s read for start; 10.0s connect
+                / 300.0s read for finalize). The supplied ``Timeout`` is
+                used wholesale at both sites — supplying ``httpx.Timeout(read=600.0)``
+                leaves ``connect``/``write``/``pool`` at httpx's own 5.0s
+                defaults, NOT the original 10.0s. Specify all components
+                explicitly (e.g. ``httpx.Timeout(10.0, read=600.0)``) to
+                avoid surprises.
         """
         self._core = core
+        self._upload_timeout = upload_timeout
+
+    def _resolve_upload_timeout(self, default: httpx.Timeout) -> httpx.Timeout:
+        """Return the configured upload timeout, or ``default`` if unset."""
+        return self._upload_timeout if self._upload_timeout is not None else default
 
     @staticmethod
     def _handle_malformed_list_response(
@@ -1489,7 +1508,7 @@ class SourcesAPI:
         # Using get_http_client().cookies (instead of auth.cookie_jar) so we
         # pick up SIDCC/SIDTS rotations applied during the live session. See #373.
         async with httpx.AsyncClient(
-            timeout=httpx.Timeout(10.0, read=60.0),
+            timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=60.0)),
             cookies=self._core.get_http_client().cookies,
         ) as client:
             response = await client.post(url, headers=headers, content=body)
@@ -1636,7 +1655,7 @@ class SourcesAPI:
                 # httpx scopes cookies per Domain attribute. Scotty validates
                 # OSID against host and rejects foreign-host cookies. (#373)
                 async with httpx.AsyncClient(
-                    timeout=httpx.Timeout(10.0, read=300.0),
+                    timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=300.0)),
                     cookies=self._core.get_http_client().cookies,
                 ) as client:
                     finalize_started = True

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -26,6 +26,8 @@ from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING
 
+import httpx
+
 if TYPE_CHECKING:
     from .types import ConnectionLimits
 
@@ -97,6 +99,7 @@ class NotebookLMClient:
         server_error_max_retries: int = 3,
         limits: "ConnectionLimits | None" = None,
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
+        upload_timeout: httpx.Timeout | None = None,
     ):
         """Initialize the NotebookLM client.
 
@@ -140,6 +143,17 @@ class NotebookLMClient:
                 Independent of the RPC pool sizing (uploads use their own
                 ``httpx.AsyncClient`` against the Scotty endpoint and
                 don't share the RPC connection pool).
+            upload_timeout: Optional override for the ``httpx.Timeout`` used
+                by the resumable-upload start handshake and the finalize
+                POST in ``client.sources.add_file``. ``None`` (default)
+                preserves the original hardcoded values (10.0s connect /
+                60.0s read for start; 10.0s connect / 300.0s read for
+                finalize). The supplied ``Timeout`` is used wholesale at
+                both upload sites — specify all components explicitly
+                (e.g. ``httpx.Timeout(10.0, read=600.0)``), or partial
+                fields will fall back to httpx's own 5.0s defaults rather
+                than the original 10.0s connect. Defaults are NOT changed
+                silently for back-compat (audit §20 / T7.H3).
         """
         # Normalize the effective storage path onto the auth object so every
         # downstream code path (refresh_auth, ClientCore.close on-close save,
@@ -173,7 +187,7 @@ class NotebookLMClient:
         # module for mind-map primitives, so their construction order is
         # not significant (see T6.F).
         self.notebooks = NotebooksAPI(self._core)
-        self.sources = SourcesAPI(self._core)
+        self.sources = SourcesAPI(self._core, upload_timeout=upload_timeout)
         self.artifacts = ArtifactsAPI(self._core, storage_path=storage_path)
         self.notes = NotesAPI(self._core)
         self.chat = ChatAPI(self._core)
@@ -236,6 +250,7 @@ class NotebookLMClient:
         server_error_max_retries: int = 3,
         limits: "ConnectionLimits | None" = None,
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
+        upload_timeout: httpx.Timeout | None = None,
     ) -> "NotebookLMClient":
         """Create a client from Playwright storage state file.
 
@@ -266,6 +281,11 @@ class NotebookLMClient:
                 ``None`` resolves to the default. See :class:`NotebookLMClient`
                 for full semantics (FD-exhaustion guard, independence from
                 the RPC pool).
+            upload_timeout: Optional override for the ``httpx.Timeout`` used
+                by the resumable-upload start handshake and the finalize
+                POST. ``None`` (default) preserves the original hardcoded
+                values for back-compat. See :class:`NotebookLMClient` for
+                full semantics.
 
         Returns:
             NotebookLMClient instance (not yet connected).
@@ -301,6 +321,7 @@ class NotebookLMClient:
             server_error_max_retries=server_error_max_retries,
             limits=limits,
             max_concurrent_uploads=max_concurrent_uploads,
+            upload_timeout=upload_timeout,
         )
 
     async def refresh_auth(self) -> AuthTokens:

--- a/tests/integration/concurrency/test_upload_timeout_config.py
+++ b/tests/integration/concurrency/test_upload_timeout_config.py
@@ -1,0 +1,168 @@
+"""Regression test for T7.H3 — configurable upload timeouts.
+
+Audit item #20 (`thread-safety-concurrency-audit.md` §20):
+Pre-fix, the resumable-upload `_start_resumable_upload` helper and the
+finalize POST in `_upload_file_streaming` instantiated
+`httpx.AsyncClient(timeout=httpx.Timeout(...))` with hardcoded values
+(10.0s connect / 60.0s read for start, 10.0s connect / 300.0s read for
+finalize). Callers uploading very large files on slow networks (or
+testing with deliberately short timeouts) had no way to override.
+
+Post-fix (T7.H3): `NotebookLMClient.__init__` / `from_storage` accept
+`upload_timeout: httpx.Timeout | None = None`, threaded to
+`SourcesAPI`, and used at both hardcoded sites. ``None`` (default)
+preserves the original hardcoded values for back-compat — defaults
+are NOT changed silently.
+
+The test asserts the timeout passed to ``httpx.AsyncClient`` at the
+upload sites matches the configured value, and that the default
+unchanged when no override is supplied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from notebooklm import NotebookLMClient
+
+
+@pytest.fixture
+def tmp_upload_file(tmp_path: Path) -> Path:
+    """Tiny payload for streaming uploads — content doesn't matter."""
+    path = tmp_path / "upload.txt"
+    path.write_bytes(b"x" * 256)
+    return path
+
+
+def _make_capturing_async_client(
+    captured: list[httpx.Timeout | None],
+) -> type[httpx.AsyncClient]:
+    """Build an ``httpx.AsyncClient`` subclass that records the ``timeout`` kwarg.
+
+    Returns a class so ``async with httpx.AsyncClient(...)`` continues to
+    work — replacing only the constructor argument capture, not the
+    instance behavior.
+    """
+    real_async_client = httpx.AsyncClient
+
+    class CapturingClient(real_async_client):  # type: ignore[misc, valid-type]
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            captured.append(kwargs.get("timeout"))  # type: ignore[arg-type]
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+
+    return CapturingClient
+
+
+async def test_custom_upload_timeout_propagates_to_start(
+    auth_tokens, tmp_upload_file: Path
+) -> None:
+    """``upload_timeout=Timeout(5.0, read=10.0)`` reaches ``_start_resumable_upload``."""
+    custom = httpx.Timeout(5.0, read=10.0)
+    captured: list[httpx.Timeout | None] = []
+    capturing = _make_capturing_async_client(captured)
+
+    async with NotebookLMClient(auth_tokens, upload_timeout=custom) as client:
+        with patch("notebooklm._sources.httpx.AsyncClient", capturing):
+            # Call the helper directly — exercises the start-resumable-upload
+            # site in isolation. The actual network call will fail (no real
+            # server), but we only care that the timeout kwarg was captured
+            # at construction time, before any I/O.
+            with pytest.raises((httpx.HTTPError, OSError)):
+                await client.sources._start_resumable_upload(
+                    notebook_id="nb-test",
+                    filename=tmp_upload_file.name,
+                    file_size=tmp_upload_file.stat().st_size,
+                    source_id="src-test",
+                )
+
+    assert captured, "Expected at least one httpx.AsyncClient construction"
+    timeout = captured[0]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.connect == 5.0
+    assert timeout.read == 10.0
+
+
+async def test_default_upload_timeout_preserves_back_compat_start(auth_tokens) -> None:
+    """No override -> ``_start_resumable_upload`` still uses the original 10.0/60.0 hardcode."""
+    captured: list[httpx.Timeout | None] = []
+    capturing = _make_capturing_async_client(captured)
+
+    async with NotebookLMClient(auth_tokens) as client:  # no upload_timeout
+        with patch("notebooklm._sources.httpx.AsyncClient", capturing):
+            with pytest.raises((httpx.HTTPError, OSError)):
+                await client.sources._start_resumable_upload(
+                    notebook_id="nb-test",
+                    filename="dummy.txt",
+                    file_size=256,
+                    source_id="src-test",
+                )
+
+    assert captured
+    timeout = captured[0]
+    assert isinstance(timeout, httpx.Timeout)
+    assert timeout.connect == 10.0
+    assert timeout.read == 60.0
+
+
+async def test_custom_upload_timeout_propagates_to_finalize(
+    auth_tokens, tmp_upload_file: Path
+) -> None:
+    """``upload_timeout=Timeout(5.0, read=10.0)`` reaches the finalize POST site."""
+    custom = httpx.Timeout(5.0, read=10.0)
+    captured: list[httpx.Timeout | None] = []
+    capturing = _make_capturing_async_client(captured)
+
+    async with NotebookLMClient(auth_tokens, upload_timeout=custom) as client:
+        with patch("notebooklm._sources.httpx.AsyncClient", capturing):
+            with pytest.raises((httpx.HTTPError, OSError)):
+                await client.sources._upload_file_streaming(
+                    upload_url="https://example.invalid/upload/abc",
+                    file_obj=tmp_upload_file,
+                )
+
+    assert captured, "Expected at least one httpx.AsyncClient construction"
+    finalize_timeout = captured[-1]
+    assert isinstance(finalize_timeout, httpx.Timeout)
+    assert finalize_timeout.connect == 5.0
+    assert finalize_timeout.read == 10.0
+
+
+async def test_default_upload_timeout_preserves_back_compat_finalize(
+    auth_tokens, tmp_upload_file: Path
+) -> None:
+    """No override -> finalize POST still uses the original 10.0/300.0 hardcode."""
+    captured: list[httpx.Timeout | None] = []
+    capturing = _make_capturing_async_client(captured)
+
+    async with NotebookLMClient(auth_tokens) as client:  # no upload_timeout
+        with patch("notebooklm._sources.httpx.AsyncClient", capturing):
+            with pytest.raises((httpx.HTTPError, OSError)):
+                await client.sources._upload_file_streaming(
+                    upload_url="https://example.invalid/upload/abc",
+                    file_obj=tmp_upload_file,
+                )
+
+    assert captured
+    finalize_timeout = captured[-1]
+    assert isinstance(finalize_timeout, httpx.Timeout)
+    assert finalize_timeout.connect == 10.0
+    assert finalize_timeout.read == 300.0
+
+
+async def test_from_storage_accepts_upload_timeout(monkeypatch, auth_tokens) -> None:
+    """``from_storage`` honors the ``upload_timeout`` kwarg and threads it to SourcesAPI."""
+    from notebooklm import auth as auth_module
+
+    async def _fake_from_storage(*args: object, **kwargs: object):
+        return auth_tokens
+
+    monkeypatch.setattr(auth_module.AuthTokens, "from_storage", _fake_from_storage)
+
+    custom = httpx.Timeout(7.0, read=14.0)
+    client = await NotebookLMClient.from_storage(upload_timeout=custom)
+
+    assert client.sources._upload_timeout is custom

--- a/tests/integration/concurrency/test_upload_timeout_config.py
+++ b/tests/integration/concurrency/test_upload_timeout_config.py
@@ -163,6 +163,9 @@ async def test_from_storage_accepts_upload_timeout(monkeypatch, auth_tokens) -> 
     monkeypatch.setattr(auth_module.AuthTokens, "from_storage", _fake_from_storage)
 
     custom = httpx.Timeout(7.0, read=14.0)
+    # Context not entered — only inspecting constructor-level wiring.
+    # ``__aenter__`` / ``ClientCore.open()`` never run, so there are no
+    # background tasks or open sockets to clean up.
     client = await NotebookLMClient.from_storage(upload_timeout=custom)
 
     assert client.sources._upload_timeout is custom


### PR DESCRIPTION
## Summary

Audit §20 / T7.H3 — small surgical task.

- Add `upload_timeout: httpx.Timeout | None = None` to `NotebookLMClient.__init__` and `from_storage`.
- Thread through `SourcesAPI.__init__` to both hardcoded upload sites in `_sources.py`:
  - `_start_resumable_upload` (was `Timeout(10.0, read=60.0)`)
  - `_upload_file_streaming` finalize POST (was `Timeout(10.0, read=300.0)`)
- `None` (default) preserves original hardcoded values — defaults NOT changed silently for back-compat.
- Tiny `_resolve_upload_timeout(default)` helper DRYs the fallback ternary across both sites.

## Spec / Task

`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.H3`

## Design notes / accepted tradeoffs (raised in polish review)

- **Single knob covers both sites** (start + finalize). Per spec; callers wanting asymmetric tuning can supply a wider read that's safe for both phases. Documented in docstrings.
- **`httpx.Timeout` is technically mutable**. Per spec, NOT wrapped in a custom dataclass — `httpx.Timeout` is a stable httpx type and the B3 `ConnectionLimits` wrapper precedent does NOT apply. Callers passing a shared `httpx.Timeout` should treat it as effectively immutable.
- **Partial `httpx.Timeout`** (e.g. `Timeout(read=600.0)`) falls back to httpx's own 5.0s defaults for `connect`/`write`/`pool` — NOT the original 10.0s. Docstrings call this out explicitly.
- **`_cancel_upload_session` (line ~1733)** is intentionally left on a fixed 10.0/10.0 timeout. It's a fire-and-forget best-effort cleanup, not user-driven I/O. Spec explicitly scopes to start + finalize.

## Test plan

- [x] Red-then-green TDD via `tests/integration/concurrency/test_upload_timeout_config.py` (5 tests):
  - custom timeout propagates to `_start_resumable_upload`
  - default (None) preserves 10.0/60.0 at start
  - custom timeout propagates to finalize POST
  - default (None) preserves 10.0/300.0 at finalize
  - `from_storage` accepts and threads `upload_timeout` to `SourcesAPI`
- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest tests/integration/concurrency/ tests/integration/test_sources.py` — all green (171 passed, 3 skipped).

## Deferred polish findings

- `docs/python-api.md` not updated for the new `upload_timeout` kwarg — small-task scope; can be batched with G3 (concurrency-contract docs) once Wave 5 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable upload timeout support. Users can now specify custom timeout values when creating a client or using the factory method, allowing for better control over upload behavior in various network conditions.

* **Tests**
  * Added comprehensive tests to validate upload timeout configuration propagation and backward compatibility with existing default timeout values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/618)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->