### PR TITLE
fix(ci): unblock 4 Windows test failures via thread-id assertions

### DIFF
--- a/tests/integration/cli_vcr/test_settings.py
+++ b/tests/integration/cli_vcr/test_settings.py
@@ -38,18 +38,18 @@ class TestLanguageSetCommand:
     def test_language_set(self, runner, mock_auth_for_vcr, tmp_path, monkeypatch):
         """``language set en`` writes locally and syncs the single SET RPC.
 
-        Redirects ``HOME`` to ``tmp_path`` so the test never touches the real
-        user's ``~/.notebooklm/config.json``. ``get_config_path`` derives the
-        config path from ``get_home_dir`` which respects ``$HOME``, so the
-        ``set_language(code)`` write lands inside ``tmp_path/.notebooklm/``.
+        Redirects ``NOTEBOOKLM_HOME`` to ``tmp_path`` so the test never touches
+        the real user's ``~/.notebooklm/config.json``. ``get_home_dir`` honors
+        ``$NOTEBOOKLM_HOME`` first; using ``HOME`` would be a no-op on Windows
+        where ``Path.home()`` consults ``%USERPROFILE%`` instead.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
         with notebooklm_vcr.use_cassette("cli_settings_set_language.yaml"):
             result = runner.invoke(cli, ["language", "set", "en"])
             assert_command_success(result, allow_no_context=False)
 
         # The local config should now hold the chosen language.
-        config_path = tmp_path / ".notebooklm" / "config.json"
+        config_path = tmp_path / "config.json"
         assert config_path.exists(), "language set must persist config.json locally"
         import json as _json
 
@@ -58,7 +58,7 @@ class TestLanguageSetCommand:
 
     def test_language_set_json(self, runner, mock_auth_for_vcr, tmp_path, monkeypatch):
         """``language set en --json`` emits machine-readable success payload."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
         with notebooklm_vcr.use_cassette("cli_settings_set_language.yaml"):
             result = runner.invoke(cli, ["language", "set", "en", "--json"])
             assert_command_success(result, allow_no_context=False)
@@ -78,7 +78,7 @@ class TestLanguageSetCommand:
         command ever regresses and tries to sync, VCR (in ``record_mode="none"``)
         will raise on the unmatched POST, failing the test loudly.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
         # No ``with notebooklm_vcr.use_cassette(...):`` — any HTTP traffic here
         # is a regression. CliRunner traps the exception and surfaces it via
         # ``result.exception`` / non-zero exit code.

--- a/tests/integration/concurrency/test_add_file_toctou.py
+++ b/tests/integration/concurrency/test_add_file_toctou.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 import os
+import sys
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -71,6 +72,18 @@ pytestmark = pytest.mark.allow_no_vcr
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "POSIX rename-over-open-FD semantics. The test swaps the path via "
+        "os.replace while a validated FD is held; on Windows that raises "
+        "PermissionError because Python opens files without FILE_SHARE_DELETE, "
+        "so the file with an open handle cannot be the rename target. The "
+        "TOCTOU attack vector this guards against is also POSIX-specific — "
+        "Windows itself blocks the rename. POSIX matrix entries cover the "
+        "regression."
+    ),
+)
 async def test_add_file_holds_validated_fd_across_swap(
     auth_tokens,
     tmp_path: Path,

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -12,50 +12,44 @@ must execute via ``asyncio.to_thread`` (or an equivalent offload) so a
 slow filesystem cannot freeze sibling coroutines for the duration of
 the call.
 
-Methodology — heartbeat-gap detection
--------------------------------------
-We do NOT try to prove the call is *exactly* on a thread; we prove the
-**observable consequence** — that a 200 ms blocking sync stub does not
-stall a concurrent heartbeat coroutine for more than ``MAX_GAP_MS``.
+Assertion methodology — thread-id capture
+-----------------------------------------
 
-A heartbeat task fires roughly every 10 ms via ``asyncio.sleep(0.01)``
-for the duration of the download. If the download blocked the loop,
-the gap between consecutive heartbeat timestamps spikes to >= the
-stub's sleep duration. With the fix in place the stub runs in a worker
-thread and the heartbeat keeps ticking at ~10 ms intervals.
+Each test patches the production call site (either the ``to_thread``
+target itself or a method called from inside the ``to_thread``
+closure) with a recording stub that captures ``threading.get_ident()``.
+After the download runs, the test asserts the captured thread id
+differs from the loop thread id. If the production wrap
+(``await asyncio.to_thread(...)``) is in place, the stub runs on the
+default ThreadPoolExecutor and the ids differ. If a regression removes
+the wrap, the stub runs on the loop thread and the ids match.
 
-Important detail — post-block settling
-......................................
-The heartbeat records ``time.monotonic()`` *before* its ``await
-asyncio.sleep(0.01)``. When the loop is blocked by a sync sleep, no
-new samples are recorded *during* the block; the very next sample
-appears only when the loop wakes and the heartbeat schedules its next
-iteration. We therefore yield (``await asyncio.sleep(SETTLE_S)``)
-*after* the download completes and *before* setting the stop event so
-the heartbeat has a fair chance to record a post-block sample. Without
-that yield the heartbeat could be terminated before it ever recorded
-the "after" timestamp, and the gap detector would see only pre-block
-samples and report a misleadingly small gap.
+Why not measure scheduler responsiveness directly (heartbeat-gap)
+.................................................................
 
-``MAX_GAP_MS`` is set to 100 ms (10x the nominal heartbeat). CI
-scheduling jitter on green runs has been observed up to ~55 ms on
-slower runners (macos-3.14 GHA); the 200 ms blocking stub produces
-gaps >> 200 ms post-regression. 100 ms gives a 2x margin over
-observed jitter while staying clearly below the regression signal.
+An earlier version of these tests fired a 10 ms heartbeat coroutine
+during the download and asserted the max gap between heartbeat ticks
+stayed below a threshold. That pattern proved flaky on shared CI:
 
-Tightness note: the spec named 50 ms as an example bound, but the
-first CI cycle on PR #579 surfaced a 55 ms green-run jitter on
-macos-3.14. We assert ``max_gap_ms < MAX_GAP_MS`` rather than a
-percentile because a single >= 200 ms gap is the signal we're hunting
-— a too-tight bound trades false positives against detection delta,
-and at 100 ms the regression signal is still 2x above the bound.
+* macOS 3.14:    ~55 ms green-run jitter (the original tuning point).
+* Ubuntu 3.11:   170.8 ms green-run jitter (PR #621 run 25928433246).
+* Windows 3.10-14: 170-220 ms typical, 2594 ms outlier on Win 3.11.
+
+A 200 ms regression signal sits inside the 170-220 ms baseline noise
+on Linux + Windows runners — no single threshold can discriminate
+"offloaded" from "regressed." Widening the stub trades wall time for
+the same problem at the next jitter level.
+
+The thread-id check is a *positive* assertion of the property the
+heartbeat-gap was inferring. It needs no threshold, no scheduler
+timing, and survives every matrix entry uniformly.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
-import time
+import threading
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -68,52 +62,36 @@ from notebooklm.types import ArtifactDownloadError
 # Opt out of the tier-enforcement hook in tests/integration/conftest.py.
 pytestmark = pytest.mark.allow_no_vcr
 
-# A "slow filesystem" or "slow auth store" simulation. 200 ms is well
-# above any plausible scheduler hiccup on CI and far above the
-# ``MAX_GAP_MS`` assertion bound, so a regression where the call
-# moves back onto the loop is unambiguous (the gap balloons to
-# ~200 ms+ post-regression).
-BLOCKING_SLEEP_S = 0.2
-# Heartbeat-gap regression threshold. Picking a tight bound:
-#   - heartbeat ticks at 10 ms cadence
-#   - the macos-3.14 GHA runner observed 55 ms scheduling jitter on
-#     a green run (PR #579 first CI cycle) — so 50 ms is too tight
-#     for that runner
-#   - 100 ms gives a 2x safety margin over the worst observed jitter
-#     while still leaving a 100 ms gap below the regression signal
-#     (~200 ms). The two regimes (40-60 ms jitter vs. 200 ms block)
-#     stay clearly separated.
-MAX_GAP_MS = 100.0
-# Time we yield to the loop after the download completes so the heartbeat
-# can record at least one post-block timestamp before we stop it. Must be
-# (a) larger than the heartbeat's 10 ms tick interval and (b) much smaller
-# than ``BLOCKING_SLEEP_S`` so it can't be confused with the block itself.
-SETTLE_S = 0.05
 
+def _assert_offloaded_to_worker_thread(
+    captured_thread_id: int | None,
+    loop_thread_id: int,
+    *,
+    call_site: str,
+    wrap_target: str,
+) -> None:
+    """Assert ``captured_thread_id`` came from a worker thread, not the loop.
 
-async def _heartbeat(stop: asyncio.Event, samples: list[float]) -> None:
-    """Tick every 10 ms until ``stop`` is set; record monotonic timestamps.
-
-    Each ``asyncio.sleep(0.01)`` is a yield point. If anything monopolizes
-    the loop for >>10 ms between yields, the gap between consecutive
-    ``samples`` entries will reflect the stall.
+    Args:
+        captured_thread_id: The thread id observed inside the patched stub,
+            or ``None`` if the stub never ran.
+        loop_thread_id: ``threading.get_ident()`` captured on the loop
+            thread before the download was awaited.
+        call_site: Human-readable name of the production async function
+            being tested (e.g. ``"_download_url"``), used in the failure
+            message so the diagnostic points at the right code.
+        wrap_target: Human-readable name of the synchronous call that
+            must be offloaded (e.g. ``"load_httpx_cookies"``).
     """
-    while not stop.is_set():
-        samples.append(time.monotonic())
-        await asyncio.sleep(0.01)
-
-
-def _max_gap_ms(samples: list[float]) -> float:
-    """Return the largest gap between consecutive heartbeat timestamps, in ms.
-
-    Returns 0.0 if fewer than two samples were recorded (the download
-    finished before the heartbeat could tick; treat as no observable
-    stall — failing the test on that would be a false positive).
-    """
-    if len(samples) < 2:
-        return 0.0
-    gaps_ms = [(samples[i] - samples[i - 1]) * 1000.0 for i in range(1, len(samples))]
-    return max(gaps_ms)
+    assert captured_thread_id is not None, (
+        f"{call_site}'s {wrap_target} stub never ran — check the patch target."
+    )
+    assert captured_thread_id != loop_thread_id, (
+        f"{call_site} ran {wrap_target} on the event-loop thread "
+        f"(thread id {captured_thread_id}). It must be wrapped in "
+        "asyncio.to_thread so slow synchronous I/O cannot stall "
+        "concurrent tasks (T7.D4, audit §30)."
+    )
 
 
 @pytest.fixture
@@ -134,17 +112,19 @@ def mock_artifacts_api() -> tuple[ArtifactsAPI, MagicMock]:
 
 
 @pytest.mark.asyncio
-async def test_download_report_does_not_block_event_loop(
+async def test_download_report_runs_write_off_loop_thread(
     mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
     tmp_path: Path,
 ) -> None:
-    """``download_report`` must offload its ``write_text`` to a thread.
+    """``download_report`` must offload its ``Path.write_text`` to a thread.
 
-    We patch ``Path.write_text`` to sleep ``BLOCKING_SLEEP_S`` seconds
-    synchronously. Pre-fix, that ``time.sleep`` runs on the event-loop
-    thread and freezes the heartbeat for ~200 ms. Post-fix the write
-    runs via ``asyncio.to_thread`` so the loop stays responsive and
-    the maximum heartbeat gap is well under ``MAX_GAP_MS``.
+    The production path wraps ``output.write_text(...)`` inside an
+    ``asyncio.to_thread(_write_markdown)`` closure. We patch
+    ``Path.write_text`` with a recording stub that captures the thread
+    id on which it runs and still performs the real write (so the
+    file-exists sanity check at the end stays meaningful). If a
+    regression removes the wrap, the recording stub runs on the loop
+    thread and the assertion fires.
     """
     api, _ = mock_artifacts_api
     output_path = tmp_path / "report.md"
@@ -165,72 +145,50 @@ async def test_download_report_does_not_block_event_loop(
         ]
     ]
 
+    loop_thread_id = threading.get_ident()
     original_write_text = Path.write_text
+    captured: list[int] = []
 
-    def slow_write_text(self: Path, *args: object, **kwargs: object) -> int:
-        # Simulate slow disk. ``time.sleep`` is the right primitive here:
-        # pre-fix this runs on the loop and stalls every concurrent task;
-        # post-fix it runs in a worker thread (``asyncio.to_thread``) and
-        # the loop's heartbeat keeps ticking.
-        time.sleep(BLOCKING_SLEEP_S)
+    def recording_write_text(self: Path, *args: object, **kwargs: object) -> int:
+        captured.append(threading.get_ident())
         return original_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
 
-    samples: list[float] = []
-    stop = asyncio.Event()
-    heartbeat = asyncio.create_task(_heartbeat(stop, samples))
-
-    # Warm-up: yield to the heartbeat so it records pre-block samples
-    # before the download starts. Without this, a fast download could
-    # finish before the heartbeat ticked once, leaving fewer than 2
-    # samples and tripping the "treat as no observable stall" branch
-    # in ``_max_gap_ms`` — a false negative.
-    await asyncio.sleep(SETTLE_S)
-
-    try:
-        with (
-            patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
-            patch.object(Path, "write_text", slow_write_text),
-        ):
-            mock_list.return_value = report_artifact_list
-            result = await api.download_report("nb_t7d4", str(output_path))
-        # Yield so the heartbeat records at least one post-download
-        # timestamp before we stop it; see module docstring "post-block
-        # settling" note.
-        await asyncio.sleep(SETTLE_S)
-    finally:
-        stop.set()
-        await heartbeat
+    with (
+        patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
+        patch.object(Path, "write_text", recording_write_text),
+    ):
+        mock_list.return_value = report_artifact_list
+        result = await api.download_report("nb_t7d4", str(output_path))
 
     assert result == str(output_path)
     assert output_path.exists(), "download_report should still produce the file"
 
-    gap_ms = _max_gap_ms(samples)
-    assert gap_ms < MAX_GAP_MS, (
-        f"download_report blocked the event loop for {gap_ms:.1f} ms "
-        f"(threshold {MAX_GAP_MS} ms). "
-        f"The Path.write_text call must be wrapped in asyncio.to_thread."
+    _assert_offloaded_to_worker_thread(
+        captured[0] if captured else None,
+        loop_thread_id,
+        call_site="download_report",
+        wrap_target="Path.write_text",
     )
 
 
 @pytest.mark.asyncio
-async def test_download_mind_map_does_not_block_event_loop(
+async def test_download_mind_map_runs_write_off_loop_thread(
     mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
     tmp_path: Path,
 ) -> None:
     """``download_mind_map`` must offload its JSON write to a thread.
 
-    Same heartbeat methodology as the report test. The production path
-    in ``download_mind_map`` calls ``json.dump(json_data, fp, ...)``
-    inside the ``asyncio.to_thread`` callable. We patch *both*
-    ``json.dump`` (post-fix call site) and ``Path.write_text`` (legacy
-    call site) with slow stubs so the test catches a regression
-    regardless of which write API the implementation uses. If neither
-    is invoked, the gap stays small — but if either runs on the loop
-    thread the heartbeat will stall.
+    The production path wraps ``json.dump(...)`` inside an
+    ``asyncio.to_thread(_write_json)`` closure. A legacy alternative
+    that used ``Path.write_text`` is also patched, so a refactor that
+    rewrites the write API in either direction is still covered. We
+    require AT LEAST ONE of the two write APIs to fire (the production
+    path uses ``json.dump``; ``Path.write_text`` is the fallback) and
+    that the firing site ran on a worker thread, not the loop.
 
-    Pointed out by coderabbit on PR #579: the original test only
-    patched ``Path.write_text``, which the post-fix code no longer
-    invokes for mind maps. Patching both APIs is the robust fix.
+    Originally pointed out by coderabbit on PR #579: patching only
+    ``Path.write_text`` would silently miss the production ``json.dump``
+    path.
     """
     import notebooklm._artifacts as artifacts_module
 
@@ -250,79 +208,63 @@ async def test_download_mind_map_does_not_block_event_loop(
         ]
     ]
 
+    loop_thread_id = threading.get_ident()
     original_json_dump = json.dump
     original_write_text = Path.write_text
+    captured_json: list[int] = []
+    captured_write: list[int] = []
 
-    def slow_json_dump(*args: object, **kwargs: object) -> None:
-        time.sleep(BLOCKING_SLEEP_S)
+    def recording_json_dump(*args: object, **kwargs: object) -> None:
+        captured_json.append(threading.get_ident())
         return original_json_dump(*args, **kwargs)  # type: ignore[arg-type]
 
-    def slow_write_text(self: Path, *args: object, **kwargs: object) -> int:
-        time.sleep(BLOCKING_SLEEP_S)
+    def recording_write_text(self: Path, *args: object, **kwargs: object) -> int:
+        captured_write.append(threading.get_ident())
         return original_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
 
-    samples: list[float] = []
-    stop = asyncio.Event()
-    heartbeat = asyncio.create_task(_heartbeat(stop, samples))
-
-    # Warm-up: yield to the heartbeat so it records pre-block samples
-    # before the download starts. Without this, a fast download could
-    # finish before the heartbeat ticked once, leaving fewer than 2
-    # samples and tripping the "treat as no observable stall" branch
-    # in ``_max_gap_ms`` — a false negative.
-    await asyncio.sleep(SETTLE_S)
-
-    try:
-        with (
-            patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
-                new=AsyncMock(return_value=mind_map_rows),
-            ),
-            # Patch the `json` module as imported by `_artifacts` so the
-            # closure inside `download_mind_map` resolves to the stub.
-            patch.object(artifacts_module.json, "dump", slow_json_dump),
-            # Cover the legacy ``Path.write_text``-based path too so a
-            # rewrite either direction is caught by this test.
-            patch.object(Path, "write_text", slow_write_text),
-        ):
-            result = await api.download_mind_map("nb_t7d4", str(output_path))
-        await asyncio.sleep(SETTLE_S)  # let heartbeat record a post-block sample
-    finally:
-        stop.set()
-        await heartbeat
+    with (
+        patch(
+            "notebooklm._artifacts._mind_map.list_mind_maps",
+            new=AsyncMock(return_value=mind_map_rows),
+        ),
+        # Patch the `json` module as imported by `_artifacts` so the
+        # closure inside `download_mind_map` resolves to the stub.
+        patch.object(artifacts_module.json, "dump", recording_json_dump),
+        # Cover the legacy ``Path.write_text``-based path too so a
+        # rewrite either direction is caught by this test.
+        patch.object(Path, "write_text", recording_write_text),
+    ):
+        result = await api.download_mind_map("nb_t7d4", str(output_path))
 
     assert result == str(output_path)
     assert output_path.exists(), "download_mind_map should still produce the file"
 
-    gap_ms = _max_gap_ms(samples)
-    assert gap_ms < MAX_GAP_MS, (
-        f"download_mind_map blocked the event loop for {gap_ms:.1f} ms "
-        f"(threshold {MAX_GAP_MS} ms). "
-        f"The json.dump/write call must be wrapped in asyncio.to_thread."
+    # Require the firing write site to have run off-loop. The production
+    # code uses json.dump; if a future refactor swaps to Path.write_text
+    # the other capture list catches it.
+    captured = captured_json or captured_write
+    wrap_target = "json.dump" if captured_json else "Path.write_text"
+    _assert_offloaded_to_worker_thread(
+        captured[0] if captured else None,
+        loop_thread_id,
+        call_site="download_mind_map",
+        wrap_target=wrap_target,
     )
 
 
 @pytest.mark.asyncio
-async def test_concurrent_downloads_keep_loop_responsive(
+async def test_concurrent_downloads_both_offload_writes(
     mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
     tmp_path: Path,
 ) -> None:
-    """End-to-end fan-out: report + mind-map concurrently must not block.
+    """End-to-end fan-out: report + mind-map concurrently must both offload.
 
-    This is the integration-flavored cousin of the two single-call tests
-    above. It fans out one ``download_report`` and one ``download_mind_map``
-    against the same heartbeat. With the fix in place neither one steals
-    the loop and the heartbeat stays smooth across both calls.
-
-    A single overall ``MAX_GAP_MS`` bound is asserted: even with two
-    concurrent slow-stubbed writes the loop must not stall.
-
-    Implementation note (per coderabbit PR #579 review): we patch
-    *both* of the actual production blocking call sites — ``Path.write_text``
-    for ``download_report`` and ``json.dump`` (as imported by the
-    ``_artifacts`` module) for ``download_mind_map`` — so each path
-    is genuinely stalled by ``BLOCKING_SLEEP_S`` and the heartbeat
-    assertion actually covers both downloads.
+    Integration-flavored cousin of the two single-call tests above. We
+    fan out one ``download_report`` and one ``download_mind_map`` under
+    ``asyncio.gather`` and require BOTH write sites — ``Path.write_text``
+    (report) and ``json.dump`` (mind-map) — to have run on a worker
+    thread. A regression on either path leaves its capture matching the
+    loop thread and fails the assertion.
     """
     import notebooklm._artifacts as artifacts_module
 
@@ -352,205 +294,132 @@ async def test_concurrent_downloads_keep_loop_responsive(
         ]
     ]
 
+    loop_thread_id = threading.get_ident()
     original_write_text = Path.write_text
     original_json_dump = json.dump
+    captured_write: list[int] = []
+    captured_json: list[int] = []
 
-    def slow_write_text(self: Path, *args: object, **kwargs: object) -> int:
-        time.sleep(BLOCKING_SLEEP_S)
+    def recording_write_text(self: Path, *args: object, **kwargs: object) -> int:
+        captured_write.append(threading.get_ident())
         return original_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
 
-    def slow_json_dump(*args: object, **kwargs: object) -> None:
-        time.sleep(BLOCKING_SLEEP_S)
+    def recording_json_dump(*args: object, **kwargs: object) -> None:
+        captured_json.append(threading.get_ident())
         return original_json_dump(*args, **kwargs)  # type: ignore[arg-type]
 
-    samples: list[float] = []
-    stop = asyncio.Event()
-    heartbeat = asyncio.create_task(_heartbeat(stop, samples))
-
-    # Warm-up: yield to the heartbeat so it records pre-block samples
-    # before the download starts. Without this, a fast download could
-    # finish before the heartbeat ticked once, leaving fewer than 2
-    # samples and tripping the "treat as no observable stall" branch
-    # in ``_max_gap_ms`` — a false negative.
-    await asyncio.sleep(SETTLE_S)
-
-    try:
-        with (
-            patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
-            patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
-                new=AsyncMock(return_value=mind_map_rows),
-            ),
-            patch.object(Path, "write_text", slow_write_text),
-            patch.object(artifacts_module.json, "dump", slow_json_dump),
-        ):
-            mock_list.return_value = report_artifact_list
-            report_result, mindmap_result = await asyncio.gather(
-                api.download_report("nb_t7d4", str(report_path)),
-                api.download_mind_map("nb_t7d4", str(mindmap_path)),
-            )
-        await asyncio.sleep(SETTLE_S)  # let heartbeat record a post-block sample
-    finally:
-        stop.set()
-        await heartbeat
+    with (
+        patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
+        patch(
+            "notebooklm._artifacts._mind_map.list_mind_maps",
+            new=AsyncMock(return_value=mind_map_rows),
+        ),
+        patch.object(Path, "write_text", recording_write_text),
+        patch.object(artifacts_module.json, "dump", recording_json_dump),
+    ):
+        mock_list.return_value = report_artifact_list
+        report_result, mindmap_result = await asyncio.gather(
+            api.download_report("nb_t7d4", str(report_path)),
+            api.download_mind_map("nb_t7d4", str(mindmap_path)),
+        )
 
     assert report_result == str(report_path)
     assert mindmap_result == str(mindmap_path)
     assert report_path.exists()
     assert mindmap_path.exists()
 
-    gap_ms = _max_gap_ms(samples)
-    assert gap_ms < MAX_GAP_MS, (
-        f"Concurrent download_report + download_mind_map blocked the event loop "
-        f"for {gap_ms:.1f} ms (threshold {MAX_GAP_MS} ms). "
-        f"Both write paths must be wrapped in asyncio.to_thread."
+    _assert_offloaded_to_worker_thread(
+        captured_write[0] if captured_write else None,
+        loop_thread_id,
+        call_site="download_report (concurrent)",
+        wrap_target="Path.write_text",
+    )
+    _assert_offloaded_to_worker_thread(
+        captured_json[0] if captured_json else None,
+        loop_thread_id,
+        call_site="download_mind_map (concurrent)",
+        wrap_target="json.dump",
     )
 
 
 @pytest.mark.asyncio
-async def test_download_urls_batch_cookie_load_does_not_block_event_loop(
+async def test_download_urls_batch_cookie_load_runs_off_loop_thread(
     mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
     tmp_path: Path,
 ) -> None:
     """``_download_urls_batch`` must offload its ``load_httpx_cookies`` call.
 
-    Mirror of the ``_download_url`` test, but exercises the batch
-    sibling. The batch helper is reachable from ``download_audio`` /
-    ``download_video`` / ``download_image`` so its cookie-load path
-    also needs the offload. We patch the imported symbol to sleep
-    ``BLOCKING_SLEEP_S`` seconds and assert the heartbeat stayed
-    alive while the cookies were "loading".
-
-    The batch then proceeds into the HTTP path. We pass an EMPTY URL
-    list so the per-URL loop exits immediately and the test stays
-    sealed from the network — the only work between the cookie load
-    and the return is opening + closing an ``httpx.AsyncClient``,
-    which doesn't touch the network until the first request.
-
-    Added in response to PR #579 review feedback from claude[bot]:
-    each of the four T7.D4 wrap sites should have a direct regression
-    test, not just three of them.
+    Empty URL list keeps the test sealed from the network — the only
+    work between the cookie load and the return is opening + closing
+    an ``httpx.AsyncClient``, which doesn't touch the network until
+    the first request.
     """
     api, _ = mock_artifacts_api
     api._storage_path = tmp_path / "fake_storage_state.json"
 
-    def slow_load_httpx_cookies(path: object = None) -> dict:
-        time.sleep(BLOCKING_SLEEP_S)
+    loop_thread_id = threading.get_ident()
+    captured: list[int] = []
+
+    def recording_load_httpx_cookies(path: object = None) -> dict:
+        captured.append(threading.get_ident())
         return {}
 
-    samples: list[float] = []
-    stop = asyncio.Event()
-    heartbeat = asyncio.create_task(_heartbeat(stop, samples))
-
-    # Warm-up: let the heartbeat record pre-block samples.
-    await asyncio.sleep(SETTLE_S)
-
-    try:
-        # Use ``new=`` (direct function replacement) instead of
-        # ``side_effect=`` so the patched symbol is a plain Python
-        # function. On Windows CI we observed MagicMock-with-side_effect
-        # produce 200 ms loop blocks even when wrapped in
-        # ``asyncio.to_thread`` — the Mock invocation machinery (lock
-        # acquisition, attribute access) appears to leak back onto the
-        # event-loop thread under the GIL on some Python/OS combos.
-        # A plain function in the worker thread is the simplest fix and
-        # produces consistent behavior across all matrix entries.
-        with patch(
-            "notebooklm._artifacts.load_httpx_cookies",
-            new=slow_load_httpx_cookies,
-        ):
-            # Empty URL list: the cookie-load runs (the thing we're
-            # measuring), then the per-URL ``for`` loop exits without
-            # ever issuing a request.
-            result = await api._download_urls_batch([])
-        await asyncio.sleep(SETTLE_S)  # let heartbeat record a post-block sample
-    finally:
-        stop.set()
-        await heartbeat
+    with patch(
+        "notebooklm._artifacts.load_httpx_cookies",
+        new=recording_load_httpx_cookies,
+    ):
+        result = await api._download_urls_batch([])
 
     # Sanity: empty input → empty result, no failures fabricated.
     assert result.succeeded == []
     assert result.failed == []
 
-    gap_ms = _max_gap_ms(samples)
-    assert gap_ms < MAX_GAP_MS, (
-        f"_download_urls_batch's load_httpx_cookies blocked the event loop "
-        f"for {gap_ms:.1f} ms (threshold {MAX_GAP_MS} ms). "
-        f"The load_httpx_cookies call must be wrapped in asyncio.to_thread."
+    _assert_offloaded_to_worker_thread(
+        captured[0] if captured else None,
+        loop_thread_id,
+        call_site="_download_urls_batch",
+        wrap_target="load_httpx_cookies",
     )
 
 
 @pytest.mark.asyncio
-async def test_download_url_cookie_load_does_not_block_event_loop(
+async def test_download_url_cookie_load_runs_off_loop_thread(
     mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
     tmp_path: Path,
 ) -> None:
     """``_download_url`` must offload its ``load_httpx_cookies`` call.
 
-    Pre-fix, the synchronous ``load_httpx_cookies(path=...)`` call —
-    which can do a real ``Path.read_text`` + ``json.loads`` on the
-    storage-state file — runs on the loop thread before the streaming
-    download begins. We patch the imported symbol to sleep
-    ``BLOCKING_SLEEP_S`` seconds and confirm the heartbeat is not
-    starved while the cookies are "loading".
-
-    We don't have to actually complete a download here — the cookie
-    load happens before any HTTP work — so we let the subsequent
-    streaming call raise (an ``ArtifactDownloadError``) and just
-    assert the heartbeat stayed alive through the cookie-load phase.
+    The subsequent network call against an unreachable URL fails with
+    ``ArtifactDownloadError`` (intentional — the test only needs the
+    pre-network cookie-load probe), but the thread-id capture has
+    already happened by then.
     """
     api, _ = mock_artifacts_api
     api._storage_path = tmp_path / "fake_storage_state.json"
     output_path = tmp_path / "download.bin"
 
-    def slow_load_httpx_cookies(path: object = None) -> dict:
-        # Simulate a slow storage-state read. Returning {} is fine —
-        # the test never reaches the HTTP transport.
-        time.sleep(BLOCKING_SLEEP_S)
+    loop_thread_id = threading.get_ident()
+    captured: list[int] = []
+
+    def recording_load_httpx_cookies(path: object = None) -> dict:
+        captured.append(threading.get_ident())
         return {}
 
-    samples: list[float] = []
-    stop = asyncio.Event()
-    heartbeat = asyncio.create_task(_heartbeat(stop, samples))
+    with (
+        patch(
+            "notebooklm._artifacts.load_httpx_cookies",
+            new=recording_load_httpx_cookies,
+        ),
+        pytest.raises(ArtifactDownloadError),
+    ):
+        await api._download_url(
+            "https://storage.googleapis.com/never-resolved-t7d4.bin",
+            str(output_path),
+        )
 
-    # Warm-up: yield to the heartbeat so it records pre-block samples
-    # before the download starts. Without this, a fast download could
-    # finish before the heartbeat ticked once, leaving fewer than 2
-    # samples and tripping the "treat as no observable stall" branch
-    # in ``_max_gap_ms`` — a false negative.
-    await asyncio.sleep(SETTLE_S)
-
-    try:
-        # Use an obviously-unreachable but trusted-domain URL so the
-        # request scheme + domain checks pass and we get all the way
-        # to the cookie load; the subsequent network call fails with
-        # ``ArtifactDownloadError`` (transport error), but that's fine —
-        # we only need the heartbeat data from the pre-network phase.
-        #
-        # Use ``new=`` instead of ``side_effect=`` for the same reason
-        # the batch test above does — MagicMock + side_effect can stall
-        # the event loop on Windows CI even when wrapped in
-        # ``asyncio.to_thread`` (see the comment block on the batch
-        # test for the full rationale).
-        with (
-            patch(
-                "notebooklm._artifacts.load_httpx_cookies",
-                new=slow_load_httpx_cookies,
-            ),
-            pytest.raises(ArtifactDownloadError),
-        ):
-            await api._download_url(
-                "https://storage.googleapis.com/never-resolved-t7d4.bin",
-                str(output_path),
-            )
-        await asyncio.sleep(SETTLE_S)  # let heartbeat record a post-block sample
-    finally:
-        stop.set()
-        await heartbeat
-
-    gap_ms = _max_gap_ms(samples)
-    assert gap_ms < MAX_GAP_MS, (
-        f"_download_url's load_httpx_cookies blocked the event loop for "
-        f"{gap_ms:.1f} ms (threshold {MAX_GAP_MS} ms). "
-        f"The load_httpx_cookies call must be wrapped in asyncio.to_thread."
+    _assert_offloaded_to_worker_thread(
+        captured[0] if captured else None,
+        loop_thread_id,
+        call_site="_download_url",
+        wrap_target="load_httpx_cookies",
     )

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -386,17 +386,30 @@ async def test_download_urls_batch_cookie_load_runs_off_loop_thread(
 async def test_download_url_cookie_load_runs_off_loop_thread(
     mock_artifacts_api: tuple[ArtifactsAPI, MagicMock],
     tmp_path: Path,
+    httpx_mock,
 ) -> None:
     """``_download_url`` must offload its ``load_httpx_cookies`` call.
 
-    The subsequent network call against an unreachable URL fails with
-    ``ArtifactDownloadError`` (intentional — the test only needs the
-    pre-network cookie-load probe), but the thread-id capture has
-    already happened by then.
+    The subsequent HTTP request is intercepted by ``httpx_mock`` with a
+    404 so ``_download_url`` raises ``ArtifactDownloadError`` (and the
+    test stays sealed from the real network — the URL must still match
+    the production trusted-domain whitelist to clear validation, but no
+    bytes hit the wire). The thread-id capture has already happened by
+    the time the HTTP step runs.
     """
     api, _ = mock_artifacts_api
     api._storage_path = tmp_path / "fake_storage_state.json"
     output_path = tmp_path / "download.bin"
+
+    # URL must clear the production trusted-domain check
+    # (``.googleapis.com``) BEFORE ``load_httpx_cookies`` runs — the
+    # validation happens first, and a rejected URL would raise
+    # ``ArtifactDownloadError("Untrusted download domain")`` before the
+    # cookie load and leave ``captured`` empty (turning this test into
+    # a false negative). The path is arbitrary because ``httpx_mock``
+    # intercepts the request before it leaves the process.
+    url = "https://storage.googleapis.com/never-resolved-t7d4.bin"
+    httpx_mock.add_response(url=url, status_code=404)
 
     loop_thread_id = threading.get_ident()
     captured: list[int] = []
@@ -412,10 +425,7 @@ async def test_download_url_cookie_load_runs_off_loop_thread(
         ),
         pytest.raises(ArtifactDownloadError),
     ):
-        await api._download_url(
-            "https://storage.googleapis.com/never-resolved-t7d4.bin",
-            str(output_path),
-        )
+        await api._download_url(url, str(output_path))
 
     _assert_offloaded_to_worker_thread(
         captured[0] if captured else None,


### PR DESCRIPTION
## Summary

Fixes the 4 Windows-specific CI failures from [run 25926796742](https://github.com/teng-lin/notebooklm-py/actions/runs/25926796742). The companion marker-fix work (formerly bundled here) has been superseded by #629 — only the Windows test fixes remain in this PR.

## Root causes

| Failing test | Root cause | Fix |
|---|---|---|
| `test_settings.py::test_language_set` | `monkeypatch.setenv("HOME", tmp_path)` is a no-op on Windows — `Path.home()` reads `%USERPROFILE%`. The redirect didn't take effect; CLI wrote to the real user home; the assertion `config_path.exists()` failed. | Switch all three `TestLanguageSetCommand` tests to `NOTEBOOKLM_HOME` (which `get_home_dir` honors directly). |
| `test_add_file_toctou.py::test_add_file_holds_validated_fd_across_swap` | `os.replace` on a path whose FD is held open. POSIX allows; Windows raises `PermissionError` because Python opens files without `FILE_SHARE_DELETE`. The TOCTOU attack vector is POSIX-specific. | Skip on Windows with rationale. |
| Two `test_download_blocks_loop.py` cookie tests + three write-path heartbeat tests | The heartbeat-gap pattern uses scheduler responsiveness as a proxy for "did this call offload?" — but observed CI green-run jitter is 55 ms macOS / 170 ms Linux / 170-220 ms typical Windows / 2594 ms Win 3.11 outlier. A 200 ms regression signal sits inside the noise band — no threshold can discriminate. | Replace all 5 heartbeat tests with **thread-id assertions**: capture `threading.get_ident()` inside the patched stub and require it to differ from the loop-thread id. Direct, deterministic, no scheduler reliance. Removed `BLOCKING_SLEEP_S`, `MAX_GAP_MS`, `SETTLE_S`, `_heartbeat`, `_max_gap_ms`, `time` import, and the per-platform skip. File wall time drops from ~3 s to ~0.3 s. |

Sanity-verified the thread-id assertion catches regressions by monkeypatching `asyncio.to_thread` to run callables inline on the loop — every test fires the expected `ran ... on the event-loop thread` failure.

## History

- Originally shipped as a multi-commit chain (test fixes + thread-id migration + write-path conversion); each iteration received Claude bot LGTM.
- Briefly bundled with marker fixes for unmarked concurrency tests (since #628 was in flight) when the matrix entries showed a dependency cycle.
- After #629 landed and added the same markers to main, the marker-fix commits became redundant — they auto-resolved as empty during the final rebase. This PR is now just the 4 Windows test fixes.

## Test plan

- [x] `uv run pytest tests/integration/cli_vcr/test_settings.py tests/integration/concurrency/test_add_file_toctou.py tests/integration/concurrency/test_download_blocks_loop.py` — 14/14 pass locally.
- [x] `uv run ruff format . && uv run ruff check .` — clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- [x] Synthetic regression check: monkeypatching `asyncio.to_thread` to run inline on the loop produces expected thread-id assertion failures.
- [ ] CI matrix on this PR (post-rebase) confirms all 15 matrix entries are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test isolation by redirecting config resolution via an environment override to avoid touching real user config.
  * Added platform-specific skips for tests that rely on POSIX rename semantics (Windows excluded).
  * Refactored concurrency regression tests to use deterministic, thread-based assertions rather than timing/heartbeat checks to verify work is offloaded from the event loop.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/623)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->