### PR TITLE
refactor(core): lazy-init _refresh_lock to match _reqid_lock (T7.G1)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -401,7 +401,19 @@ class ClientCore:
         # ``NotebookLMClient`` instances in the same process have
         # independent upload budgets.
         self._upload_semaphore: asyncio.Semaphore | None = None
-        self._refresh_lock: asyncio.Lock | None = asyncio.Lock() if refresh_callback else None
+        # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
+        # Python versions, and ``ClientCore`` can be constructed outside one
+        # (e.g. a sync-mode ``NotebookLMClient(...)`` instantiation before the
+        # caller's ``asyncio.run``). Use :meth:`_get_refresh_lock` to fetch
+        # the live lock on demand. Mirrors the ``_reqid_lock`` /
+        # ``_auth_snapshot_lock`` lazy-init pattern (audit §13 / T7.G1).
+        # The lock gates single-flight refresh-task creation in
+        # :meth:`_await_refresh` — the assert on ``_refresh_callback is not
+        # None`` there is the real precondition; this lock is allocated on
+        # first refresh attempt regardless of whether a callback was wired,
+        # because asyncio is single-threaded and the check-then-assign in
+        # ``_get_refresh_lock`` is race-free without an outer lock.
+        self._refresh_lock: asyncio.Lock | None = None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
         # Request ID counter for chat API (must be unique per request).
@@ -853,6 +865,23 @@ class ClientCore:
             self._auth_snapshot_lock = asyncio.Lock()
         return self._auth_snapshot_lock
 
+    def _get_refresh_lock(self) -> asyncio.Lock:
+        """Return the lazily-initialised ``_refresh_lock``.
+
+        ``asyncio.Lock()`` needs a running loop in some Python versions, so
+        ``ClientCore.__init__`` leaves the field as ``None`` (audit §13 /
+        T7.G1). Callers must be inside an async context — the only call site
+        is :meth:`_await_refresh`, which is itself a coroutine. The
+        check-then-assign is safe without an outer lock because asyncio is
+        single-threaded: no other coroutine can execute between the
+        ``is None`` check and the assignment unless we ``await``, so every
+        concurrent caller resolves to the *same* lock instance and the
+        single-flight refresh dedupe is preserved.
+        """
+        if self._refresh_lock is None:
+            self._refresh_lock = asyncio.Lock()
+        return self._refresh_lock
+
     async def _snapshot(self) -> _AuthSnapshot:
         """Capture the current auth headers as a frozen snapshot.
 
@@ -1192,9 +1221,12 @@ class ClientCore:
         refresh wave once the current task transitions to ``done()``.
         """
         assert self._refresh_callback is not None
-        assert self._refresh_lock is not None
 
-        async with self._refresh_lock:
+        # Lazy-init the lock on first refresh attempt (audit §13 / T7.G1).
+        # Every concurrent caller resolves to the same instance because
+        # ``_get_refresh_lock`` runs synchronously in a single-threaded
+        # asyncio loop, so single-flight task creation below is preserved.
+        async with self._get_refresh_lock():
             if self._refresh_task is not None and not self._refresh_task.done():
                 refresh_task = self._refresh_task
                 logger.debug("Joining existing refresh task")

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -29,7 +29,11 @@ class TestAutoRefreshIntegration:
         # Bound methods aren't identical, so compare underlying function
         assert client._core._refresh_callback is not None
         assert client._core._refresh_callback.__func__ is NotebookLMClient.refresh_auth
-        assert client._core._refresh_lock is not None
+        # ``_refresh_lock`` is lazily created on first ``_await_refresh``
+        # (T7.G1). At construction time it is ``None`` so the client can
+        # be instantiated outside a running loop; the helper allocates the
+        # lock on demand inside the async refresh path.
+        assert client._core._refresh_lock is None
 
     @pytest.mark.asyncio
     async def test_full_refresh_flow_http_error(self):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -453,8 +453,15 @@ class TestClientCoreRefreshCallback:
         core = ClientCore(auth)
         assert core._refresh_callback is None
 
-    def test_refresh_lock_created_when_callback_provided(self):
-        """ClientCore should create refresh lock when callback provided."""
+    def test_refresh_lock_lazy_at_construction(self):
+        """Refresh lock is ``None`` at construction regardless of callback (T7.G1).
+
+        Lazy-init mirrors ``_reqid_lock`` / ``_auth_snapshot_lock`` so the
+        client can be constructed outside a running event loop. The lock
+        is allocated on first ``_await_refresh`` call. See
+        ``test_refresh_state_machine_lazy_lock.py`` for the construction-
+        outside-loop and first-refresh-creates-lock guarantees.
+        """
         auth = AuthTokens(
             cookies={"SID": "test", "__Secure-1PSIDTS": "test_1psidts"},
             csrf_token="csrf",
@@ -464,21 +471,15 @@ class TestClientCoreRefreshCallback:
         async def mock_refresh():
             pass
 
-        core = ClientCore(auth, refresh_callback=mock_refresh)
-        assert core._refresh_lock is not None
-        assert isinstance(core._refresh_lock, asyncio.Lock)
+        # With callback: lazy — lock is None until first refresh attempt.
+        core_with_cb = ClientCore(auth, refresh_callback=mock_refresh)
+        assert core_with_cb._refresh_lock is None
+        assert core_with_cb._refresh_callback is mock_refresh
 
-    def test_no_refresh_lock_when_no_callback(self):
-        """ClientCore should NOT create refresh lock when no callback."""
-
-        auth = AuthTokens(
-            cookies={"SID": "test", "__Secure-1PSIDTS": "test_1psidts"},
-            csrf_token="csrf",
-            session_id="sid",
-        )
-
-        core = ClientCore(auth)
-        assert core._refresh_lock is None
+        # Without callback: also None (unchanged behavior on this axis).
+        core_without_cb = ClientCore(auth)
+        assert core_without_cb._refresh_lock is None
+        assert core_without_cb._refresh_callback is None
 
 
 # =============================================================================

--- a/tests/unit/test_refresh_lock_lazy_init.py
+++ b/tests/unit/test_refresh_lock_lazy_init.py
@@ -1,0 +1,189 @@
+"""T7.G1 — regression tests for ``ClientCore._refresh_lock`` lazy-init.
+
+Pins two behaviors:
+
+1. ``ClientCore`` can be constructed outside a running event loop even when
+   a ``refresh_callback`` is wired. Before T7.G1 the constructor created
+   ``asyncio.Lock()`` eagerly, which fails under some Python versions when
+   no loop is running.
+
+2. The lock is allocated on the first ``_await_refresh`` and that refresh
+   succeeds — i.e. lazy-init does not regress the single-flight dedupe
+   contract pinned by ``test_refresh_state_machine.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from conftest import make_core  # type: ignore[import-not-found]
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import AuthError, RPCMethod
+
+EVENT_TIMEOUT_S = 5.0
+
+
+def _auth_tokens() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "test_sid"},
+        csrf_token="test_csrf",
+        session_id="test_session",
+    )
+
+
+async def _noop_refresh() -> AuthTokens:
+    """Throwaway callback — never invoked by the construction test."""
+    return _auth_tokens()
+
+
+# --------------------------------------------------------------------------- #
+# (1) Construction outside an event loop
+# --------------------------------------------------------------------------- #
+
+
+def test_construct_outside_event_loop_with_callback() -> None:
+    """``ClientCore(refresh_callback=...)`` must succeed with no running loop.
+
+    Pre-T7.G1 the eager ``asyncio.Lock()`` in ``__init__`` could raise
+    ``RuntimeError: no running event loop`` on some interpreters / asyncio
+    versions when the client was constructed from sync code. Lazy-init
+    moves that allocation to the first ``_await_refresh`` call.
+
+    Sanity check: ``asyncio.get_running_loop()`` must currently raise. If a
+    plugin (e.g. ``pytest-asyncio``) sneaks a loop in for sync tests, this
+    test's premise is invalid and we want to know — fail loudly rather
+    than silently pass.
+    """
+    with pytest.raises(RuntimeError, match="no running event loop"):
+        asyncio.get_running_loop()
+
+    # Eager construction would have blown up under the prior code path.
+    core_with_cb = ClientCore(auth=_auth_tokens(), refresh_callback=_noop_refresh)
+    assert core_with_cb._refresh_lock is None, (
+        "Lazy-init contract: lock must remain None until first refresh."
+    )
+    assert core_with_cb._refresh_callback is _noop_refresh
+
+    # And the no-callback path stays the same (also lazy / also None).
+    core_without_cb = ClientCore(auth=_auth_tokens())
+    assert core_without_cb._refresh_lock is None
+    assert core_without_cb._refresh_callback is None
+
+
+# --------------------------------------------------------------------------- #
+# (2) Refresh works on first await
+# --------------------------------------------------------------------------- #
+
+
+async def _trigger_refresh(core: ClientCore) -> object:
+    """Drive ``_try_refresh_and_retry`` with throwaway args (matches the
+    helper in ``test_refresh_state_machine.py`` so this test pins the same
+    code path)."""
+    return await core._try_refresh_and_retry(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        False,
+        AuthError("simulated"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_lock_allocated_on_first_await() -> None:
+    """First ``_await_refresh`` allocates the lock and completes successfully.
+
+    Proves the lazy-init wiring: lock starts ``None`` after construction
+    (verified inside the running loop here too), is non-``None`` after the
+    first refresh, and refresh-task succeeded (single-flight contract
+    unchanged — see ``test_refresh_state_machine.py`` for the deeper
+    dedupe pinning).
+    """
+    call_count = 0
+    core_box: list[ClientCore] = []
+
+    async def cb() -> AuthTokens:
+        nonlocal call_count
+        call_count += 1
+        tokens = AuthTokens(
+            csrf_token="CSRF_REFRESHED",
+            session_id="SID_REFRESHED",
+            cookies={"SID": "post_refresh"},
+        )
+        # Mirror real-world callback behavior: update core.auth in place so
+        # ``_try_refresh_and_retry``'s subsequent ``rpc_call`` retry sees
+        # the new tokens.
+        core_box[0].auth.csrf_token = tokens.csrf_token
+        core_box[0].auth.session_id = tokens.session_id
+        return tokens
+
+    async with make_core(refresh_callback=cb) as core:
+        core_box.append(core)
+
+        # Stub out the retry so the test stays focused on the refresh-lock
+        # allocation path — matches the pattern in
+        # ``test_refresh_state_machine.py::test_concurrent_callers_share_single_refresh``.
+        async def fake_retry(*args: object, **kwargs: object) -> str:
+            return "ok"
+
+        core.rpc_call = fake_retry  # type: ignore[method-assign]
+
+        # Pre-refresh invariant: lock is unallocated even after ``open()``.
+        assert core._refresh_lock is None, (
+            "Lock must remain unallocated until the first refresh attempt."
+        )
+
+        result = await asyncio.wait_for(_trigger_refresh(core), EVENT_TIMEOUT_S)
+
+        assert result == "ok"
+        assert call_count == 1, f"Refresh callback must fire exactly once, got {call_count}"
+        # Post-refresh invariant: lock is now allocated and is a real asyncio.Lock.
+        assert core._refresh_lock is not None, (
+            "Lock must be allocated by the first ``_await_refresh`` call."
+        )
+        assert isinstance(core._refresh_lock, asyncio.Lock)
+        # And the refresh task ran to completion, matching the single-flight
+        # state-machine pinning in ``test_refresh_state_machine.py``.
+        assert core._refresh_task is not None
+        assert core._refresh_task.done()
+        assert core.auth.csrf_token == "CSRF_REFRESHED"
+
+
+@pytest.mark.asyncio
+async def test_refresh_lock_instance_stable_across_calls() -> None:
+    """Repeated refreshes resolve to the SAME lock instance.
+
+    Single-flight depends on every caller acquiring the same lock; this
+    test pins that ``_get_refresh_lock`` is idempotent — important because
+    a buggy lazy-init that re-creates the lock on each call would silently
+    break dedupe (each caller would enter its own critical section in
+    parallel).
+    """
+
+    async def cb() -> AuthTokens:
+        return AuthTokens(
+            csrf_token="R",
+            session_id="S",
+            cookies={"SID": "sid"},
+        )
+
+    async with make_core(refresh_callback=cb) as core:
+
+        async def fake_retry(*args: object, **kwargs: object) -> str:
+            return "ok"
+
+        core.rpc_call = fake_retry  # type: ignore[method-assign]
+
+        await _trigger_refresh(core)
+        first_lock = core._refresh_lock
+        assert first_lock is not None
+
+        await _trigger_refresh(core)
+        second_lock = core._refresh_lock
+
+        assert second_lock is first_lock, (
+            "Lazy-init must be idempotent — same lock instance across refreshes "
+            "to preserve single-flight dedupe."
+        )


### PR DESCRIPTION
## Summary

- Lazy-init `ClientCore._refresh_lock` so the client can be constructed outside a running event loop, mirroring the existing `_reqid_lock` / `_auth_snapshot_lock` pattern (audit §13).
- New `_get_refresh_lock()` helper structurally identical to `_get_auth_snapshot_lock()` (T7.F2). Single-flight refresh dedupe semantics are **unchanged** — every concurrent caller still resolves to the same lock instance because the check-then-assign is race-free in single-threaded asyncio.
- Three existing tests updated to reflect the new lazy contract; a new regression file (`test_refresh_lock_lazy_init.py`) pins construction-outside-loop + first-await-allocates-lock + lock-instance-stable.

## Task

`T7.G1` in [`.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.G1`](.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.G1).

## What changed

- `ClientCore.__init__` (around line 401): eager `asyncio.Lock() if refresh_callback else None` → lazy `None`, with a comment matching the `_reqid_lock` "needs running loop" idiom.
- New `_get_refresh_lock()` near `_get_auth_snapshot_lock()`.
- `_await_refresh()`: dropped `assert self._refresh_lock is not None`; uses `async with self._get_refresh_lock():`. The real precondition guard (`assert self._refresh_callback is not None`) is unchanged.
- Tests:
  - `tests/unit/test_client.py`: replaced `test_refresh_lock_created_when_callback_provided` + `test_no_refresh_lock_when_no_callback` with one `test_refresh_lock_lazy_at_construction` covering the lazy contract for both callback / no-callback paths.
  - `tests/integration/test_auto_refresh.py::test_client_has_refresh_callback_wired`: assertion flipped from `_refresh_lock is not None` → `_refresh_lock is None` with a comment explaining the lazy contract.
  - **New**: `tests/unit/test_refresh_lock_lazy_init.py` — three regression tests (construction outside loop, first-await allocation, instance stability).

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — no issues in 60 source files
- [x] Spec verify gate: `uv run pytest tests/integration/concurrency/ tests/unit/test_refresh_state_machine.py tests/unit/test_refresh_lock_lazy_init.py` — 66 passed (3 pre-existing tier-enforcement failures outside this task's scope are ignored via `--ignore`)
- [x] Full suite (sans 3 pre-existing tier-enforcement violators + 7 pre-existing CLI VCR cassette mismatches, both reproducible on clean `origin/main`): 4117 passed, 12 skipped, 28 xfailed

## Refresh dedupe semantics — unchanged

The only behavioral change is **when** the lock is allocated (first `_await_refresh` instead of `__init__`). Once allocated, the single-flight task-creation block inside `async with self._get_refresh_lock():` is byte-identical to the prior code. Tests in `test_refresh_state_machine.py` (3 dedupe-contract pinning tests) all pass unchanged.

## Deferred polish findings

None — change is surgical (35 lines net in `_core.py`).

References: audit §13 / T7.G1

[Plan tracker](.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.G1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refresh token handling now uses lazy initialization, creating resources only when needed during the first refresh attempt rather than upfront during client construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/627)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->