### PR TITLE
fix(tests): add allow_no_vcr markers to 6 unmarked concurrency tests

### DIFF
--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -55,6 +55,10 @@ from notebooklm._core import ClientCore
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
 
+# T8.D11 tier-enforcement opt-out — sealed from the network via an
+# in-process ``httpx.MockTransport`` handler. No cassette required.
+pytestmark = pytest.mark.allow_no_vcr
+
 # -- Generation tagging -----------------------------------------------------
 #
 # Each "generation" of credentials is a monotonic integer N. We encode N

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -35,6 +35,11 @@ import pytest
 
 from notebooklm import NotebookLMClient
 
+# T8.D11 tier-enforcement opt-out — every test installs a custom
+# ``httpx.AsyncBaseTransport`` that returns canned responses; no
+# cassette required.
+pytestmark = pytest.mark.allow_no_vcr
+
 
 def _build_chat_response_body(answer_text: str, conversation_id: str) -> str:
     """Build a minimal streamed-chat response containing ``answer_text``.

--- a/tests/integration/concurrency/test_keepalive_path_canonicalize.py
+++ b/tests/integration/concurrency/test_keepalive_path_canonicalize.py
@@ -30,6 +30,11 @@ import pytest
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens
 
+# T8.D11 tier-enforcement opt-out — pure path-canonicalization tests
+# (no HTTP, no client construction beyond keepalive-path argument
+# parsing). No cassette required.
+pytestmark = pytest.mark.allow_no_vcr
+
 
 @pytest.fixture
 def _auth_tokens() -> AuthTokens:

--- a/tests/integration/concurrency/test_refresh_cmd_race.py
+++ b/tests/integration/concurrency/test_refresh_cmd_race.py
@@ -44,6 +44,11 @@ import pytest
 
 from notebooklm import auth as auth_mod
 
+# T8.D11 tier-enforcement opt-out — this module patches the refresh
+# subprocess and the underlying httpx transport, so the assertions are
+# fully sealed from the network. No cassette is required.
+pytestmark = pytest.mark.allow_no_vcr
+
 
 @pytest.fixture(autouse=True)
 def _clear_refresh_state():

--- a/tests/integration/concurrency/test_research_task_crosswire.py
+++ b/tests/integration/concurrency/test_research_task_crosswire.py
@@ -46,6 +46,11 @@ from notebooklm import NotebookLMClient
 from notebooklm.exceptions import ResearchTaskMismatchError
 from notebooklm.rpc import RPCMethod
 
+# T8.D11 tier-enforcement opt-out — every scenario installs a custom
+# ``httpx.AsyncBaseTransport`` that returns canned POLL_RESEARCH and
+# IMPORT_SOURCES payloads; no cassette required.
+pytestmark = pytest.mark.allow_no_vcr
+
 
 def _build_completed_task_payload(query: str, source_url: str, source_title: str) -> list:
     """Build a single ``POLL_RESEARCH`` task_info entry for a completed task.

--- a/tests/integration/concurrency/test_upload_timeout_config.py
+++ b/tests/integration/concurrency/test_upload_timeout_config.py
@@ -29,6 +29,11 @@ import pytest
 
 from notebooklm import NotebookLMClient
 
+# T8.D11 tier-enforcement opt-out — every test patches
+# ``httpx.AsyncClient`` to capture the constructor's timeout argument;
+# no real HTTP traffic, no cassette required.
+pytestmark = pytest.mark.allow_no_vcr
+
 
 @pytest.fixture
 def tmp_upload_file(tmp_path: Path) -> Path:


### PR DESCRIPTION
## Summary

The T8.D11 tier-enforcement hook (#622) blocks main CI when any \`tests/integration/\` file lacks one of \`@pytest.mark.vcr\`, \`@notebooklm_vcr.use_cassette\`, or \`@pytest.mark.allow_no_vcr\`. Six concurrency tests landed in flight with the hook tightening and lack the marker, so collection fails on every matrix entry.

| File | Origin |
|---|---|
| \`test_refresh_cmd_race.py\` | #621 (T7.F4) |
| \`test_auth_snapshot_torn_read.py\` | T7.F2 |
| \`test_chat_history_race.py\` | T7.F1 |
| \`test_keepalive_path_canonicalize.py\` | T7.G6 |
| \`test_research_task_crosswire.py\` | T7.F3 |
| \`test_upload_timeout_config.py\` | T7.H3 |

All six are mock-only (custom \`httpx.AsyncBaseTransport\` / \`httpx.MockTransport\` handlers, or \`patch(httpx.AsyncClient)\`); no real HTTP, no cassette required. \`allow_no_vcr\` is the correct opt-out — matches the sibling marked modules in this directory (\`test_download_blocks_loop.py\`, \`test_upload_blocks_loop.py\`).

## Test plan

- [x] \`uv run pytest tests/integration/concurrency/test_*\` — 21 tests pass locally.
- [x] \`uv run pytest tests/integration/ --collect-only\` — 324 tests collect cleanly, no tier-enforcement violations.
- [x] \`uv run ruff format . && uv run ruff check .\` — clean.
- [ ] CI matrix confirms the tier-enforcement error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)