### PR TITLE
refactor(tests): extract _is_vcr_record_mode helper (CONSISTENCY 191, T8.E11)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,11 +1,27 @@
 """Shared fixtures for integration tests."""
 
-import os
+import importlib.util
 from pathlib import Path
 
 import pytest
 
 from notebooklm.auth import AuthTokens
+
+# Load ``tests/vcr_config.py`` by file path — the ``tests`` directory is not a
+# package (no ``__init__.py``), so ``from tests.vcr_config import ...`` only
+# works when the repo root happens to be on ``sys.path``. That holds in a
+# fresh REPL but NOT inside pytest's per-module import. Loading by file path
+# bypasses ``sys.path`` and is the same idiom used inside ``vcr_config.py``
+# itself for its sibling ``cassette_patterns.py`` import.
+_vcr_config_spec = importlib.util.spec_from_file_location(
+    "tests_vcr_config", Path(__file__).resolve().parent.parent / "vcr_config.py"
+)
+assert _vcr_config_spec is not None and _vcr_config_spec.loader is not None, (
+    "Could not load tests/vcr_config.py from tests/integration/conftest.py"
+)
+_vcr_config = importlib.util.module_from_spec(_vcr_config_spec)
+_vcr_config_spec.loader.exec_module(_vcr_config)
+_is_vcr_record_mode = _vcr_config._is_vcr_record_mode
 
 # =============================================================================
 # VCR Cassette Availability Check
@@ -31,7 +47,7 @@ _real_cassettes = (
 )
 
 # Skip VCR tests if no real cassettes exist (unless in record mode)
-_vcr_record_mode = os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower() in ("1", "true", "yes")
+_vcr_record_mode = _is_vcr_record_mode()
 _cassettes_available = bool(_real_cassettes) or _vcr_record_mode
 
 # Marker for skipping VCR tests when cassettes are not available

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -93,6 +93,20 @@ recompute_chunk_prefix = _cassette_patterns.recompute_chunk_prefix
 scrub_string = _cassette_patterns.scrub_string
 
 
+def _is_vcr_record_mode() -> bool:
+    """Return True if VCR record mode is enabled via environment.
+
+    Reads ``NOTEBOOKLM_VCR_RECORD`` and treats the case-insensitive values
+    ``"1"``, ``"true"``, and ``"yes"`` as enabling record mode. Any other
+    value (including unset/empty) returns False.
+
+    Single source of truth for record-mode env-var parsing — both this
+    module's VCR-instance config and ``tests/integration/conftest.py``
+    consume this helper to avoid drift between the two checks.
+    """
+    return os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower() in ("1", "true", "yes")
+
+
 def scrub_request(request: Any) -> Any:
     """Scrub sensitive data from recorded HTTP request.
 
@@ -292,8 +306,7 @@ def _freq_body_matcher(r1: Any, r2: Any) -> bool:
 
 # Determine record mode from environment
 # Set NOTEBOOKLM_VCR_RECORD=1 (or =true, =yes) to record new cassettes
-_record_env = os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower()
-_record_mode = "new_episodes" if _record_env in ("1", "true", "yes") else "none"
+_record_mode = "new_episodes" if _is_vcr_record_mode() else "none"
 
 # Main VCR instance for notebooklm-py tests
 notebooklm_vcr = vcr.VCR(


### PR DESCRIPTION
## Summary
Single source of truth for VCR record-mode env-var parsing. Replaces two inline `.lower() in ("1","true","yes")` checks with `_is_vcr_record_mode()` defined in `tests/vcr_config.py`.

Closes audit CONSISTENCY finding line 191 (duplicate record-mode parsing).

## Plan
`.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-5.md#T8.E11`

## Test plan
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest` — full suite green modulo pre-existing cassette-drift in `cli_vcr/test_downloads.py` (also fails on `main`; unrelated to this refactor)
- [x] `grep -rn "NOTEBOOKLM_VCR_RECORD" tests/ | grep -v _is_vcr_record_mode` shows zero stale inline checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test configuration for improved maintainability.
  * Centralized VCR record mode detection logic.

* **Chores**
  * Optimized internal test setup dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/631)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->