### PR TITLE
feat(core): fail fast on cross-event-loop use (T7.G2)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -487,6 +487,20 @@ class ClientCore:
         # would re-introduce the reentrancy ambiguity T7.F2 set out to
         # avoid.
         self._auth_snapshot_lock: asyncio.Lock | None = None
+        # Event-loop affinity guard (audit §14 / T7.G2). Captured in
+        # :meth:`open` and checked in :meth:`_perform_authed_post`; a cheap
+        # ``is`` comparison fails fast when a caller drives the same
+        # ``ClientCore`` from a different loop (typical mistake: instantiating
+        # under ``asyncio.run`` in one thread, then handing the client to
+        # another thread's loop). Each client is per-loop — the asyncio
+        # primitives we hold (``_reqid_lock``, ``_refresh_lock``,
+        # ``_auth_snapshot_lock``, ``_upload_semaphore``, ``_rpc_semaphore``,
+        # the ``httpx.AsyncClient`` pool, in-flight tasks like
+        # ``_refresh_task``/``_keepalive_task``) are all bound to the loop
+        # that ``open()`` ran on; reusing them under a different loop
+        # produces hangs and ``RuntimeError`` deep in httpx instead of an
+        # actionable message at the call site.
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
         # OrderedDict for FIFO eviction when cache exceeds MAX_CONVERSATION_CACHE_SIZE
         self._conversation_cache: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
         # Keepalive background task configuration
@@ -666,8 +680,19 @@ class ClientCore:
         Called automatically by NotebookLMClient.__aenter__.
         Uses httpx.Cookies jar to properly handle cross-domain redirects
         (e.g., to accounts.google.com for auth token refresh).
+
+        Captures the running event loop in ``self._bound_loop`` so
+        :meth:`_perform_authed_post` can fail fast if the same client is
+        later driven from a different loop (audit §14 / T7.G2). Re-opening
+        on a different loop intentionally replaces the binding — ``open()``
+        is the only binding moment; ``close()`` does not unbind so an
+        accidental cross-loop call after close still raises actionably.
         """
         if self._http_client is None:
+            # Capture event-loop affinity before any awaitable resource is
+            # built so the binding is consistent with the loop that owns
+            # every primitive constructed below (T7.G2 / audit §14).
+            self._bound_loop = asyncio.get_running_loop()
             # Use granular timeouts: shorter connect timeout helps detect network issues
             # faster, while longer read/write timeouts accommodate slow responses
             timeout = httpx.Timeout(
@@ -1109,6 +1134,18 @@ class ClientCore:
         """
         assert self._http_client is not None
         client = self._http_client
+
+        # Event-loop affinity guard (audit §14 / T7.G2). Cheap ``is``
+        # comparison — no per-call list traversal, no extra await. Fails
+        # fast with an actionable message instead of a deep httpx /
+        # asyncio.Lock error when the same client is reused across loops.
+        # Placed BEFORE ``_get_rpc_semaphore()`` so a cross-loop misuse
+        # never even reserves a semaphore slot.
+        if self._bound_loop is not None and asyncio.get_running_loop() is not self._bound_loop:
+            raise RuntimeError(
+                "NotebookLMClient is bound to a different event loop. "
+                "Each client is per-loop; create a new client in the target loop."
+            )
 
         refreshed_this_call = False
         rate_limit_retries = 0

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -1,0 +1,232 @@
+"""Regression test for T7.G2 — event-loop affinity guard.
+
+Audit item §14 (`thread-safety-concurrency-audit.md` §14):
+Pre-fix, ``ClientCore`` carried asyncio primitives (``_reqid_lock``,
+``_refresh_lock``, the underlying ``httpx.AsyncClient``'s connection
+pool, and any spawned ``asyncio.Task``s) that are silently bound to
+whichever event loop was current when they were constructed or first
+awaited. A caller who instantiates a client under ``asyncio.run(...)``
+in one thread and then hands it to another thread's loop hits opaque
+``RuntimeError: ... is bound to a different event loop`` deep inside
+httpx, or — worse — a hang on a never-acquired lock that belongs to
+a dead loop.
+
+Post-fix (T7.G2): ``ClientCore.open()`` captures
+``asyncio.get_running_loop()`` in ``self._bound_loop`` and
+``_perform_authed_post`` asserts the running loop matches via a cheap
+``is`` comparison. On mismatch we raise an actionable ``RuntimeError``
+at the call site instead of letting the failure escalate into the
+httpx pool or asyncio.Lock internals.
+
+The test exercises the surgical contract:
+
+1. **Cross-loop use raises early** — open the core under one loop, then
+   call ``rpc_call`` (which routes through ``_perform_authed_post``)
+   under a *different* loop and assert the loop-affinity ``RuntimeError``
+   surfaces with the documented message. The error must come from G2's
+   guard, not from a downstream httpx symptom.
+2. **Same-loop use is unaffected** — open + dispatch under one loop and
+   confirm 100 fan-out calls succeed (no false positive on the
+   ``is`` comparison).
+3. **No binding before open()** — a freshly-constructed ``ClientCore``
+   that has never been ``open()``ed has ``_bound_loop is None``; we
+   only check inside ``_perform_authed_post`` which already asserts
+   ``self._http_client is not None``, so an "unopened client" caller
+   sees the existing assertion error, not the loop guard.
+
+Why this lives under ``tests/integration/concurrency/`` and not
+``tests/unit/``: the regression requires a real ``httpx.AsyncClient``
+that has actually been opened, so we reuse the ``ConcurrentMockTransport``
+swap-in pattern documented in ``test_harness_smoke.py``. The fix
+itself is a one-line ``is`` comparison — but verifying it requires
+two distinct event loops, which is integration-shaped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import RPCMethod
+
+from .conftest import ConcurrentMockTransport
+
+# T8.D11 — affinity-guard tests against a mock transport; no HTTP, no
+# cassette. Opt out of the tier-enforcement hook in
+# tests/integration/conftest.py.
+pytestmark = pytest.mark.allow_no_vcr
+
+
+def _make_auth() -> AuthTokens:
+    """Synthetic auth tokens — values don't matter, the mock transport
+    ignores them. Mirrors ``test_harness_smoke.py::_make_auth`` so a
+    regression in either place surfaces consistently.
+    """
+    return AuthTokens(
+        csrf_token="CSRF_TEST",
+        session_id="SID_TEST",
+        cookies={"SID": "test_sid_cookie"},
+    )
+
+
+async def _open_core_with_transport(transport: ConcurrentMockTransport) -> ClientCore:
+    """Open a ``ClientCore`` and swap in the mock transport.
+
+    Mirrors the documented pattern from ``test_harness_smoke.py``:
+    ``ClientCore.open()`` builds its own ``httpx.AsyncClient`` and we
+    can't override the transport via the constructor. So we open
+    normally — which is the moment the loop affinity is captured —
+    then close-and-replace the underlying client with one that routes
+    through our recording transport. The replacement keeps
+    ``self._bound_loop`` unchanged because we don't call ``open()``
+    again.
+    """
+    core = ClientCore(auth=_make_auth())
+    await core.open()
+    assert core._http_client is not None
+    prior_cookies = core._http_client.cookies
+    await core._http_client.aclose()
+    core._http_client = httpx.AsyncClient(
+        cookies=prior_cookies,
+        transport=transport,
+        timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+    )
+    return core
+
+
+def test_cross_loop_use_raises_actionable_runtime_error(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """Open the core under loop A, dispatch under loop B → ``RuntimeError``.
+
+    Two independent ``asyncio.run`` invocations give us two genuinely
+    distinct event loops in the same thread (each ``asyncio.run`` builds
+    a fresh loop, runs to completion, then closes it). The ``is``
+    comparison in ``_perform_authed_post`` is what we care about — these
+    two loops are not the same object, so the guard must fire.
+
+    Note: this test is intentionally *not* ``async def``. We need to own
+    the two ``asyncio.run`` calls explicitly so they construct distinct
+    loops. An ``async def`` test would run inside a single pytest-asyncio
+    loop and we'd have to spin up a second loop manually, which is
+    exactly what ``asyncio.run`` does for us.
+    """
+    transport = mock_transport_concurrent
+    # No artificial delay — the guard fires before any wire request would
+    # be issued, so the per-request stacking the smoke test relies on
+    # doesn't matter here.
+    transport.set_delay(0.0)
+
+    # Loop A: construct + open the core. The core's ``_bound_loop`` is
+    # bound to this loop. We deliberately don't ``close()`` here because
+    # ``close()`` is also async and would need yet another loop — we
+    # rely on the test's terminal ``asyncio.run`` for the second-loop
+    # close.
+    core: ClientCore = asyncio.run(_open_core_with_transport(transport))
+
+    # Loop A is now closed; loop B is the fresh loop ``asyncio.run``
+    # below will construct. Both ``open`` and ``call_under_loop_b`` must
+    # see two distinct loop objects via ``is``.
+    async def call_under_loop_b() -> None:
+        # The guard fires inside ``_perform_authed_post``. ``rpc_call``
+        # wraps transport errors into ``RPCError``-family exceptions —
+        # but our ``RuntimeError`` is not a transport error, so it
+        # propagates unchanged.
+        with pytest.raises(RuntimeError, match="bound to a different event loop"):
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+        # Confirm the actionable second sentence is in the message so
+        # users know what to do — not just that *something* went wrong.
+        try:
+            await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+        except RuntimeError as exc:
+            assert "create a new client in the target loop" in str(exc), (
+                f"loop-affinity RuntimeError should tell users how to fix it; got message: {exc!s}"
+            )
+        else:  # pragma: no cover — defensive
+            raise AssertionError("expected RuntimeError on cross-loop reuse")
+
+        # No wire requests were issued — the guard fired before any
+        # ``client.post(...)`` could run.
+        assert transport.request_count() == 0, (
+            f"expected guard to fire before any wire request; "
+            f"transport saw {transport.request_count()} request(s)"
+        )
+
+        # Tear the (now-orphaned) httpx client down on *this* loop so we
+        # don't leak the transport. We deliberately go around
+        # ``core.close()`` because that path also touches asyncio
+        # primitives bound to loop A.
+        if core._http_client is not None:
+            await core._http_client.aclose()
+            core._http_client = None
+
+    asyncio.run(call_under_loop_b())
+
+
+async def test_same_loop_use_unaffected(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """100-way fan-out on the *same* loop must complete without the guard firing.
+
+    Mirrors ``test_harness_smoke.py``'s 100-way gather to confirm the
+    cheap ``is`` comparison does not produce false positives under
+    realistic dispatch shapes. If the guard fired here, the ``rpc_call``
+    would surface ``RuntimeError`` instead of returning ``[]``.
+    """
+    transport = mock_transport_concurrent
+    transport.set_delay(0.0)  # speed only — peak-inflight isn't asserted here
+
+    core = await _open_core_with_transport(transport)
+    try:
+        results = await asyncio.gather(
+            *[core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []) for _ in range(100)]
+        )
+    finally:
+        await core.close()
+
+    assert len(results) == 100
+    assert all(r == [] for r in results)
+    assert transport.request_count() == 100
+
+
+async def test_bound_loop_captured_on_open(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """Sanity check: ``_bound_loop`` is ``None`` pre-open, set to the running loop post-open.
+
+    Pins the contract that ``open()`` is the binding moment. A future
+    refactor that moves the capture to ``__init__`` (which can be called
+    outside a running loop) would break the audit-§14 fix because the
+    construction-time loop may not be the dispatch-time loop.
+    """
+    core = ClientCore(auth=_make_auth())
+    assert core._bound_loop is None, (
+        "ClientCore must not bind to a loop at construction time — "
+        "open() is the binding moment (T7.G2)."
+    )
+
+    await core.open()
+    try:
+        assert core._bound_loop is asyncio.get_running_loop(), (
+            "open() must capture the *running* loop, not a stored or module-level reference."
+        )
+
+        # Swap in the mock transport so close() doesn't make real HTTP
+        # requests for cookie persistence (auth has no storage_path so
+        # save_cookies is already a no-op, but route everything through
+        # the recorder to keep the test deterministic).
+        assert core._http_client is not None
+        prior_cookies = core._http_client.cookies
+        await core._http_client.aclose()
+        core._http_client = httpx.AsyncClient(
+            cookies=prior_cookies,
+            transport=mock_transport_concurrent,
+            timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
+        )
+    finally:
+        await core.close()


### PR DESCRIPTION
## Summary
- Capture ``asyncio.get_running_loop()`` in ``ClientCore.open()`` (the binding moment) and assert match in ``_perform_authed_post`` via a cheap ``is`` comparison.
- On mismatch, raise ``RuntimeError("NotebookLMClient is bound to a different event loop. Each client is per-loop; create a new client in the target loop.")`` — actionable error at the call site instead of opaque httpx pool / ``asyncio.Lock`` hangs.
- Placed BEFORE ``_get_rpc_semaphore()`` so cross-loop misuse never reserves a semaphore slot.

## Task
[T7.G2 — Event-loop affinity guard](.sisyphus/plans/tier-7-thread-safety-concurrency/phase-2-wave-5.md#T7.G2). Audit §14.

## Test plan
- [x] ``test_cross_loop_use_raises_actionable_runtime_error`` — open core under one ``asyncio.run`` loop, call ``rpc_call`` under a second; the guard raises ``RuntimeError`` with the documented message; transport sees zero wire requests.
- [x] ``test_same_loop_use_unaffected`` — 100-way fan-out on same loop completes (``is`` comparison adds no false positives).
- [x] ``test_bound_loop_captured_on_open`` — pre-open ``_bound_loop is None``; post-open it binds to ``asyncio.get_running_loop()``.
- [x] ``uv run pytest tests/integration/concurrency/`` — 94 passed (G2 + all wave 2-5 regression suites).
- [x] ``uv run pytest tests/unit/test_core_reqid.py tests/unit/test_core_reqid_concurrent.py tests/unit/test_core_transport.py`` — 35 passed.
- [x] ``uv run ruff format`` / ``ruff check`` / ``mypy`` clean.

## Out-of-scope (deferred to T7.G3 docs)
- ``next_reqid()`` cross-loop hole: ``ChatAPI.ask`` calls ``next_reqid()`` BEFORE ``query_post() → _perform_authed_post``, so the first cross-loop call's ``_reqid_lock`` raises a deep asyncio ``RuntimeError``, not the friendly G2 message. T7.G3 will narrow the loop-affinity guarantee in ``docs/python-api.md`` to "authed POST hot path."
- ``close()`` cross-loop hole: ``close()`` awaits ``save_cookies`` + ``aclose``; neither routes through ``_perform_authed_post``. T7.G3 will exclude ``__aexit__/close()`` from the loop-affinity guarantee.

Both gaps will surface in T7.Z1 re-audit; if /argus flags them CRITICAL, file as tier-7-followup. Otherwise tag as documented limitations.

## Deferred polish findings
none — small surgical change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clients now detect when reused across different event loops and raise clear, actionable error messages instead of causing opaque failures.

* **Tests**
  * Added comprehensive integration tests verifying proper client behavior across different event-loop scenarios and confirming error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/633)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->