### PR TITLE
feat(tests): error-recording plumbing wired through client transport (Strategic 5, T8.E10)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -335,6 +335,51 @@ the result with the cassette guard before committing:
 tests/check_cassettes_clean.sh
 ```
 
+#### Synthetic error cassettes (T8.E10)
+
+> [!WARNING]
+> **Error cassettes generated through this plumbing are SYNTHETIC.** They
+> validate the client's exception-mapping branches (`RateLimitError`,
+> `ServerError`, the auth-refresh path), NOT Google's actual error response
+> shapes. If you need to validate a real-world error shape, capture a live
+> recording instead — these synthetic shapes are intentionally minimal.
+
+The `NOTEBOOKLM_VCR_RECORD_ERRORS` env var opts a recording session into
+substituting the next outgoing batchexecute RPC with a synthetic error
+response. Three modes are supported:
+
+| Mode            | HTTP status | Maps to                                         |
+|-----------------|-------------|-------------------------------------------------|
+| `429`           | 429         | `RateLimitError` (after retry budget exhausted) |
+| `5xx`           | 500         | `ServerError`   (after retry budget exhausted) |
+| `expired_csrf`  | 400         | auth-refresh path (NotebookLM uses 400, not 401)|
+
+The plumbing has three opt-in layers:
+
+1. **Env var**: `NOTEBOOKLM_VCR_RECORD_ERRORS=<mode>` activates the transport
+   wrapper inside `ClientCore.open()`.
+2. **Pytest marker**: `@pytest.mark.synthetic_error("<mode>")` sets the env
+   var for the duration of a single test (auto-reverted on teardown).
+3. **Filename prefix**: cassettes recorded under this mode MUST be named
+   `error_synthetic_<mode>_<slug>.yaml` — use
+   `tests.cassette_patterns.synthetic_error_cassette_name(mode, slug)` to
+   build the filename so reviewers can tell synthetic shapes apart from
+   real recordings at a glance.
+
+Example recording session (this is the workflow T8.E4 will use to record
+the actual error cassettes — T8.E10 itself ships only the plumbing):
+
+```bash
+NOTEBOOKLM_VCR_RECORD=1 \
+NOTEBOOKLM_VCR_RECORD_ERRORS=429 \
+  uv run pytest tests/integration/test_error_cassettes.py::test_rate_limit_records
+```
+
+Production behavior is unchanged when `NOTEBOOKLM_VCR_RECORD_ERRORS` is
+unset — the transport wrapper is only constructed when the env var resolves
+to a recognized mode, and a typo'd value resolves to `None` (the recording
+session continues without substitution).
+
 ### Per-method RPC coverage gate
 
 `tests/scripts/check_method_coverage.py` enforces, on every PR, that each

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -88,6 +88,153 @@ DEFAULT_MAX_CONCURRENT_RPCS = 16
 # so a malicious or buggy server can't force a multi-hour pause.
 MAX_RETRY_AFTER_SECONDS = 300
 
+# -----------------------------------------------------------------------------
+# T8.E10 — Test-only synthetic-error transport (opt-in via env var)
+# -----------------------------------------------------------------------------
+#
+# When ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to one of ``429`` / ``5xx`` /
+# ``expired_csrf``, the next outgoing batchexecute RPC gets a substituted
+# synthetic response that the client maps onto its own exception domain. This
+# plumbing exists so T8.E4 (and any future error-cassette PR) can record
+# cassettes whose response shapes match what the client's exception mapping
+# keys on — see ``tests/cassette_patterns.py:build_synthetic_error_response``.
+#
+# **Production behavior is unchanged when the env var is unset.** The transport
+# wrapper is only constructed when the env var resolves to a valid mode; the
+# default ``httpx.AsyncClient`` is built with no explicit transport otherwise.
+#
+# This is deliberately wired through the client's HTTP layer (not just the VCR
+# config) so the substitution sits BELOW VCR — VCR records the synthetic
+# response into the cassette as if it had come from the wire. Wiring it at the
+# VCR-config layer only would mean the substitution never ran in record mode,
+# leaving the plumbing inert (the Momus iter-1 rejection rationale).
+
+ERROR_INJECT_ENV_VAR = "NOTEBOOKLM_VCR_RECORD_ERRORS"
+
+
+def _get_error_injection_mode() -> str | None:
+    """Return the synthetic-error mode from ``NOTEBOOKLM_VCR_RECORD_ERRORS``.
+
+    Returns ``None`` when the env var is unset, empty, or carries an
+    unrecognized value (we deliberately fail open rather than crash a
+    cassette-recording run on a typo — the unit tests catch the typo path,
+    and the VCR config validates the value separately).
+
+    Recognized values are imported from ``tests.cassette_patterns`` lazily so
+    this module never depends on the test tree at import time.
+    """
+    import os
+
+    raw = os.environ.get(ERROR_INJECT_ENV_VAR, "").strip()
+    if not raw:
+        return None
+    # Lowercase-normalize so callers can use ``"5XX"`` / ``"429"`` / etc.
+    normalized = raw.lower()
+    valid = {"429", "5xx", "expired_csrf"}
+    if normalized not in valid:
+        return None
+    return normalized
+
+
+class _SyntheticErrorTransport(httpx.AsyncBaseTransport):
+    """Test-only httpx transport that substitutes a synthetic error on first use.
+
+    Wraps an inner ``httpx.AsyncBaseTransport`` and, for the FIRST outgoing
+    batchexecute POST, returns a synthetic error response built by
+    ``tests.cassette_patterns.build_synthetic_error_response``. Subsequent
+    requests pass through to the inner transport unchanged.
+
+    The "first batchexecute POST" gate is deliberate: most ``ClientCore``
+    operations make one RPC call, but a few make two (e.g. an auth refresh
+    re-issues the same RPC). We want the SAME error to fire on every retry
+    inside the recording window — so when ``always`` is True (the default for
+    record-mode use), every batchexecute POST is substituted, not just the
+    first.
+
+    Non-batchexecute traffic (Scotty uploads, ``RotateCookies`` pokes, the
+    homepage GET that extracts CSRF) passes through unchanged because none of
+    those endpoints are in scope for error-shape cassettes.
+
+    This class is OPT-IN — ``ClientCore`` only wraps the transport when
+    ``_get_error_injection_mode()`` returns a non-``None`` value, so removing
+    the env var restores byte-for-byte production behavior.
+    """
+
+    def __init__(
+        self,
+        mode: str,
+        inner: httpx.AsyncBaseTransport,
+        *,
+        always: bool = True,
+    ):
+        self._mode = mode
+        self._inner = inner
+        self._always = always
+        self._fired = False
+        # Resolved lazily on first use so this module doesn't import the test
+        # tree at module load time.
+        self._builder: Callable[[str], tuple[int, bytes, dict[str, str]]] | None = None
+
+    def _is_batchexecute(self, request: httpx.Request) -> bool:
+        # NotebookLM's batchexecute endpoint lives under
+        # ``notebooklm.google.com/_/LabsTailwindUi/data/batchexecute``. We
+        # match on the path suffix so any subdomain / region variant still
+        # triggers substitution.
+        return request.url.path.endswith("/batchexecute")
+
+    def _load_builder(
+        self,
+    ) -> Callable[[str], tuple[int, bytes, dict[str, str]]]:
+        if self._builder is not None:
+            return self._builder
+        # Import lazily and via importlib to avoid a hard dependency on the
+        # tests tree from production code. The env var that gates this whole
+        # path is itself test-only, so this import only ever runs in
+        # recording / unit-test contexts.
+        import importlib.util
+        from pathlib import Path
+
+        # Walk up from src/notebooklm/_core.py to the repo root, then dive
+        # into tests/cassette_patterns.py. This keeps the lookup robust to
+        # installed-package layouts (where ``tests/`` may not exist) — in
+        # that case we raise a clear error rather than silently no-oping.
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        target = repo_root / "tests" / "cassette_patterns.py"
+        if not target.exists():
+            raise RuntimeError(
+                f"{ERROR_INJECT_ENV_VAR} is set but "
+                f"tests/cassette_patterns.py is not available at {target}. "
+                f"This plumbing is test-only — unset {ERROR_INJECT_ENV_VAR} "
+                f"to restore normal behavior."
+            )
+        spec = importlib.util.spec_from_file_location("_notebooklm_cassette_patterns", target)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        self._builder = cast(
+            Callable[[str], tuple[int, bytes, dict[str, str]]],
+            mod.build_synthetic_error_response,
+        )
+        return self._builder
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if self._is_batchexecute(request) and (self._always or not self._fired):
+            self._fired = True
+            status_code, body, headers = self._load_builder()(self._mode)
+            response = httpx.Response(
+                status_code=status_code,
+                headers=headers,
+                content=body,
+                request=request,
+            )
+            # ``httpx.Response`` constructed this way is already "read" — VCR
+            # can serialize it directly via its standard before_record hook.
+            return response
+        return await self._inner.handle_async_request(request)
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
 
 def _parse_retry_after(value: str | None) -> int | None:
     """Parse RFC 7231 Retry-After: integer-seconds OR HTTP-date.
@@ -707,6 +854,22 @@ class ClientCore:
                 cookies=self.auth.cookies,
                 storage_path=self.auth.storage_path,
             )
+            # T8.E10 — opt-in synthetic-error transport wrapper. When the env
+            # var is unset (the default) this is a no-op and the AsyncClient
+            # is constructed exactly as before. See ``_SyntheticErrorTransport``
+            # docstring at module top.
+            error_mode = _get_error_injection_mode()
+            synthetic_transport: httpx.AsyncBaseTransport | None = None
+            if error_mode is not None:
+                inner_transport = httpx.AsyncHTTPTransport(
+                    limits=self._limits.to_httpx_limits(),
+                )
+                synthetic_transport = _SyntheticErrorTransport(error_mode, inner_transport)
+                logger.info(
+                    "T8.E10 synthetic-error injection enabled (mode=%s) — "
+                    "production paths will see substituted responses",
+                    error_mode,
+                )
             self._http_client = httpx.AsyncClient(
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -715,6 +878,7 @@ class ClientCore:
                 timeout=timeout,
                 follow_redirects=True,
                 limits=self._limits.to_httpx_limits(),
+                transport=synthetic_transport,
             )
 
             # Capture the open-time snapshot AFTER the AsyncClient is built

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -120,8 +120,14 @@ def _get_error_injection_mode() -> str | None:
     cassette-recording run on a typo — the unit tests catch the typo path,
     and the VCR config validates the value separately).
 
-    Recognized values are imported from ``tests.cassette_patterns`` lazily so
-    this module never depends on the test tree at import time.
+    The valid-mode set is hardcoded here (rather than imported from
+    ``tests.cassette_patterns``) so production import time never reaches into
+    the test tree. The same set is mirrored in
+    ``tests.cassette_patterns.VALID_ERROR_MODES`` and the
+    ``synthetic_error`` marker validator in ``tests/conftest.py``; the
+    duplication is intentional and bounded — adding a fourth mode requires
+    updating all three sites, which the unit tests in ``tests/unit/
+    test_vcr_config.py`` will surface immediately.
     """
     import os
 
@@ -137,23 +143,26 @@ def _get_error_injection_mode() -> str | None:
 
 
 class _SyntheticErrorTransport(httpx.AsyncBaseTransport):
-    """Test-only httpx transport that substitutes a synthetic error on first use.
+    """Test-only httpx transport that substitutes synthetic error responses.
 
-    Wraps an inner ``httpx.AsyncBaseTransport`` and, for the FIRST outgoing
-    batchexecute POST, returns a synthetic error response built by
-    ``tests.cassette_patterns.build_synthetic_error_response``. Subsequent
-    requests pass through to the inner transport unchanged.
+    Wraps an inner ``httpx.AsyncBaseTransport`` and substitutes a synthetic
+    error response on outgoing batchexecute POSTs, built by
+    ``tests.cassette_patterns.build_synthetic_error_response``. Non-batchexecute
+    traffic (Scotty uploads, ``RotateCookies`` pokes, the homepage GET that
+    extracts CSRF) passes through unchanged because none of those endpoints
+    are in scope for error-shape cassettes.
 
-    The "first batchexecute POST" gate is deliberate: most ``ClientCore``
-    operations make one RPC call, but a few make two (e.g. an auth refresh
-    re-issues the same RPC). We want the SAME error to fire on every retry
-    inside the recording window — so when ``always`` is True (the default for
-    record-mode use), every batchexecute POST is substituted, not just the
-    first.
+    Substitution scope is controlled by ``always``:
 
-    Non-batchexecute traffic (Scotty uploads, ``RotateCookies`` pokes, the
-    homepage GET that extracts CSRF) passes through unchanged because none of
-    those endpoints are in scope for error-shape cassettes.
+    - ``always=True`` (the default for record-mode use): every batchexecute
+      POST is substituted. This matters because the client's auth-refresh
+      path re-issues the same RPC; we want the SAME error to fire on every
+      retry inside the recording window so the cassette captures the full
+      retry-and-fail sequence rather than substituting once and then letting
+      a real response slip through on the retry.
+    - ``always=False``: only the FIRST batchexecute POST is substituted; later
+      POSTs fall through to the inner transport. Useful for tests that want
+      to assert the client recovers after a single transient failure.
 
     This class is OPT-IN — ``ClientCore`` only wraps the transport when
     ``_get_error_injection_mode()`` returns a non-``None`` value, so removing
@@ -208,7 +217,15 @@ class _SyntheticErrorTransport(httpx.AsyncBaseTransport):
                 f"to restore normal behavior."
             )
         spec = importlib.util.spec_from_file_location("_notebooklm_cassette_patterns", target)
-        assert spec is not None and spec.loader is not None
+        # NOT ``assert`` — runtime invariant must survive ``python -O``. The
+        # check is defensive (spec_from_file_location on an existing .py file
+        # virtually always succeeds) but if it ever fails the user has clear
+        # remediation via the env var.
+        if spec is None or spec.loader is None:
+            raise RuntimeError(
+                f"Failed to load module spec for {target}. "
+                f"Unset {ERROR_INJECT_ENV_VAR} to restore normal behavior."
+            )
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         self._builder = cast(
@@ -861,6 +878,11 @@ class ClientCore:
             error_mode = _get_error_injection_mode()
             synthetic_transport: httpx.AsyncBaseTransport | None = None
             if error_mode is not None:
+                # When we supply a custom ``transport=`` to ``AsyncClient``,
+                # httpx no longer constructs its own internal transport from
+                # the ``limits=`` kwarg below — those limits are consumed by
+                # the inner transport here instead, so connection-pool sizing
+                # remains identical to the no-injection path.
                 inner_transport = httpx.AsyncHTTPTransport(
                     limits=self._limits.to_httpx_limits(),
                 )
@@ -877,6 +899,12 @@ class ClientCore:
                 cookies=cookies,
                 timeout=timeout,
                 follow_redirects=True,
+                # ``limits=`` is honored when ``transport=None`` (default) —
+                # httpx builds its own default transport with these limits.
+                # When ``transport=synthetic_transport`` (T8.E10 record mode)
+                # this kwarg is ignored by httpx and the inner_transport above
+                # carries the limits instead. The redundant pass is harmless
+                # and avoids a branch on the AsyncClient construction site.
                 limits=self._limits.to_httpx_limits(),
                 transport=synthetic_transport,
             )

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -235,7 +235,15 @@ class _SyntheticErrorTransport(httpx.AsyncBaseTransport):
         return self._builder
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        if self._is_batchexecute(request) and (self._always or not self._fired):
+        # Substitute ONLY on POST batchexecute calls. Non-POST traffic on the
+        # same path (a hypothetical GET batchexecute probe, OPTIONS preflight,
+        # etc.) is out of scope for error-shape cassettes and must pass through
+        # unchanged — see CodeRabbit feedback on PR #638.
+        if (
+            request.method.upper() == "POST"
+            and self._is_batchexecute(request)
+            and (self._always or not self._fired)
+        ):
             self._fired = True
             status_code, body, headers = self._load_builder()(self._mode)
             response = httpx.Response(

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -781,3 +781,109 @@ def is_clean(text: str) -> tuple[bool, list[str]]:
         leaks.append(f"Leak (avatar URL): {match.group(0)!r}")
 
     return (not leaks, leaks)
+
+
+# =============================================================================
+# T8.E10 — Synthetic error-response builders for VCR recording
+# =============================================================================
+#
+# These helpers exist so that T8.E4 (and any future error-shape cassette PRs)
+# can generate cassettes whose responses match the shapes our client's
+# exception mapping in ``src/notebooklm/_core.py`` keys on:
+#
+#   - HTTP 429  -> ``_TransportRateLimited`` -> ``RateLimitError``
+#   - HTTP 5xx  -> ``_TransportServerError`` -> ``ServerError``
+#   - HTTP 400  -> ``is_auth_error()``       -> refresh path + ``AuthError`` on
+#                                               second failure
+#
+# The synthetic bodies are **not** captured from Google. They are deliberately
+# minimal and exist purely to validate client-side exception mapping. Documented
+# warning lives in ``docs/development.md`` under "Synthetic error cassettes".
+
+ERROR_MODE_RATE_LIMIT = "429"
+ERROR_MODE_SERVER = "5xx"
+ERROR_MODE_EXPIRED_CSRF = "expired_csrf"
+
+VALID_ERROR_MODES: frozenset[str] = frozenset(
+    {ERROR_MODE_RATE_LIMIT, ERROR_MODE_SERVER, ERROR_MODE_EXPIRED_CSRF}
+)
+
+# Filename prefix that T8.E4 (and any future error-cassette PR) MUST apply to
+# cassettes generated through this plumbing. The prefix is mechanical: it lets a
+# reader of ``tests/cassettes/`` distinguish synthetic error shapes from real
+# recordings at a glance, without having to open the YAML.
+SYNTHETIC_ERROR_CASSETTE_PREFIX = "error_synthetic_"
+
+
+def synthetic_error_cassette_name(mode: str, slug: str) -> str:
+    """Build the canonical ``error_synthetic_<mode>_<slug>.yaml`` filename.
+
+    Args:
+        mode: One of ``VALID_ERROR_MODES``.
+        slug: A short identifier for the RPC being recorded (e.g. ``"list_notebooks"``).
+
+    Raises:
+        ValueError: If ``mode`` is not a recognized synthetic-error mode.
+    """
+    if mode not in VALID_ERROR_MODES:
+        raise ValueError(
+            f"Unknown synthetic error mode {mode!r}. Valid modes: {sorted(VALID_ERROR_MODES)}"
+        )
+    return f"{SYNTHETIC_ERROR_CASSETTE_PREFIX}{mode}_{slug}.yaml"
+
+
+def build_synthetic_error_response(
+    mode: str,
+) -> tuple[int, bytes, dict[str, str]]:
+    """Return a ``(status_code, body, headers)`` triple for a synthetic error.
+
+    The shape is intentionally minimal; the client's exception mapping keys on
+    the HTTP status code (see ``_core.py:is_auth_error`` and the 429 / 5xx
+    branches in ``_perform_authed_post``), so a syntactically-valid Google
+    error-shaped body is sufficient.
+
+    For the ``expired_csrf`` mode we return HTTP 400 — not 401 — because that
+    matches the documented Google contract: NotebookLM returns 400 (not 401/403)
+    when the embedded CSRF token has expired, which is why ``is_auth_error``
+    treats 400 as an auth-refresh trigger. See ``is_auth_error`` in
+    ``src/notebooklm/_core.py``.
+
+    Args:
+        mode: One of ``VALID_ERROR_MODES``.
+
+    Returns:
+        A tuple of ``(status_code, body_bytes, headers_dict)`` suitable for
+        constructing an ``httpx.Response``.
+
+    Raises:
+        ValueError: If ``mode`` is not a recognized synthetic-error mode.
+    """
+    if mode == ERROR_MODE_RATE_LIMIT:
+        body = (
+            b'{"error": {"code": 429, "message": "Rate limited", "status": "RESOURCE_EXHAUSTED"}}'
+        )
+        # Retry-After is honored by the 429 retry loop in ``_perform_authed_post``.
+        # Setting a small value keeps the recording-time loop short.
+        headers = {
+            "Content-Type": "application/json; charset=UTF-8",
+            "Retry-After": "1",
+        }
+        return (429, body, headers)
+    if mode == ERROR_MODE_SERVER:
+        body = b'{"error": {"code": 500, "message": "Internal error"}}'
+        headers = {"Content-Type": "application/json; charset=UTF-8"}
+        return (500, body, headers)
+    if mode == ERROR_MODE_EXPIRED_CSRF:
+        # NotebookLM returns 400 (not 401/403) for expired CSRF — this matches
+        # the ``is_auth_error`` branch that treats 400/401/403 as auth-refresh
+        # triggers. The body shape echoes Google's typical "invalid request"
+        # response; the client keys on status code, not body, for this path.
+        body = (
+            b'{"error": {"code": 400, "message": "Invalid request token", '
+            b'"status": "INVALID_ARGUMENT"}}'
+        )
+        headers = {"Content-Type": "application/json; charset=UTF-8"}
+        return (400, body, headers)
+    raise ValueError(
+        f"Unknown synthetic error mode {mode!r}. Valid modes: {sorted(VALID_ERROR_MODES)}"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,13 @@ def _synthetic_error_mode(request, monkeypatch):
         raise pytest.UsageError(
             f"@pytest.mark.synthetic_error: invalid mode {mode!r}; valid modes are {sorted(valid)}."
         )
-    monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD_ERRORS", mode)
+    # Import the env-var name from the production module so a future rename
+    # in ``_core.py`` cascades automatically; the constant is also exposed
+    # from ``tests/vcr_config.py`` but going through ``_core`` is the
+    # production-faithful path.
+    from notebooklm._core import ERROR_INJECT_ENV_VAR
+
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,40 @@ def _reset_poke_state():
 
 
 @pytest.fixture(autouse=True)
+def _synthetic_error_mode(request, monkeypatch):
+    """T8.E10 — opt a test into ``NOTEBOOKLM_VCR_RECORD_ERRORS=<mode>``.
+
+    When a test (or its enclosing module/class) carries
+    ``@pytest.mark.synthetic_error("429"|"5xx"|"expired_csrf")``, this fixture
+    sets the env var for the test's lifetime via ``monkeypatch`` (so it's
+    auto-reverted on teardown). Without the marker, the env var is left
+    untouched — preserving the spec's "opt-in" contract.
+
+    Set BEFORE the client constructs its HTTP transport (markers are read at
+    setup time): the transport wrapper in ``_core.py:_get_error_injection_mode``
+    reads the env var only during ``ClientCore.open()``, so the var must be
+    in place before the fixture under test enters its ``async with`` block.
+
+    Production behavior is unchanged when the marker is absent.
+    """
+    marker = request.node.get_closest_marker("synthetic_error")
+    if marker is None:
+        return
+    if not marker.args:
+        raise pytest.UsageError(
+            "@pytest.mark.synthetic_error requires one positional arg: "
+            "the mode (429, 5xx, or expired_csrf)."
+        )
+    mode = marker.args[0]
+    valid = {"429", "5xx", "expired_csrf"}
+    if mode not in valid:
+        raise pytest.UsageError(
+            f"@pytest.mark.synthetic_error: invalid mode {mode!r}; valid modes are {sorted(valid)}."
+        )
+    monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD_ERRORS", mode)
+
+
+@pytest.fixture(autouse=True)
 def _mock_keepalive_poke(request):
     """Default-mock the auth keepalive poke so tests don't trip on it.
 
@@ -78,6 +112,13 @@ def pytest_configure(config):
         "markers",
         "no_default_keepalive_mock: skip the default accounts.google.com/RotateCookies "
         "mock so the test can register its own response",
+    )
+    config.addinivalue_line(
+        "markers",
+        "synthetic_error(mode): T8.E10 — opts a test into "
+        "NOTEBOOKLM_VCR_RECORD_ERRORS=<mode> for the duration of the test. "
+        "Used by T8.E4 (and any future error-cassette PR) to record cassettes "
+        "with synthetic error shapes. Mode must be one of: 429, 5xx, expired_csrf.",
     )
     # Disable Rich/Click formatting in tests to avoid ANSI escape codes in output
     # This ensures consistent test assertions regardless of -s flag

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -21,10 +21,20 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+import httpx
+import pytest
+
+from notebooklm._core import (
+    ERROR_INJECT_ENV_VAR,
+    _get_error_injection_mode,
+    _SyntheticErrorTransport,
+)
 
 # Load ``tests/vcr_config.py`` via ``importlib`` rather than mutating
 # ``sys.path``. The ``tests`` directory is not a package (no ``__init__.py``),
@@ -353,3 +363,349 @@ def test_scrub_response_does_not_corrupt_non_chunked_html_body():
     assert "SCRUBBED" in out
     # Structure preserved: no spurious digit prefix introduced.
     assert out.startswith("<html>")
+
+
+# ---------------------------------------------------------------------------
+# T8.E10 — synthetic-error plumbing tests
+# ---------------------------------------------------------------------------
+#
+# Three layers of coverage:
+#
+# 1. The cassette-patterns response builders return the right shapes for each
+#    valid mode and raise on invalid mode.
+# 2. The ``before_record_response`` hook in vcr_config.py performs a
+#    defense-in-depth substitution when the env var is set, and is a no-op
+#    when unset.
+# 3. The ``_core.py`` transport wrapper substitutes the FIRST batchexecute
+#    POST without touching non-batchexecute traffic, and is only constructed
+#    when the env var resolves to a valid mode.
+
+build_synthetic_error_response = _cassette_patterns.build_synthetic_error_response
+synthetic_error_cassette_name = _cassette_patterns.synthetic_error_cassette_name
+SYNTHETIC_ERROR_CASSETTE_PREFIX = _cassette_patterns.SYNTHETIC_ERROR_CASSETTE_PREFIX
+VALID_ERROR_MODES = _cassette_patterns.VALID_ERROR_MODES
+get_error_injection_mode_vcr = _vcr_config.get_error_injection_mode
+
+
+# --- (1) response builder + filename helper ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "mode,expected_status",
+    [
+        ("429", 429),
+        ("5xx", 500),
+        ("expired_csrf", 400),
+    ],
+)
+def test_build_synthetic_error_response_status_codes(mode, expected_status):
+    """Each mode returns the status code its corresponding exception path keys on.
+
+    - 429 -> RateLimitError via the 429 retry budget exhausted path.
+    - 500 -> ServerError via the 5xx retry budget exhausted path.
+    - 400 -> ``is_auth_error`` treats 400/401/403 as auth-refresh triggers
+      (NotebookLM returns 400 for expired CSRF, not 401/403).
+    """
+    status, body, headers = build_synthetic_error_response(mode)
+    assert status == expected_status
+    assert isinstance(body, bytes)
+    assert body, "body must be non-empty"
+    assert headers["Content-Type"].startswith("application/json")
+
+
+def test_build_synthetic_error_response_429_has_retry_after():
+    """The 429 shape carries a Retry-After header so the client's parser sees
+    a numeric hint to consume (parsed via ``_parse_retry_after``)."""
+    _, _, headers = build_synthetic_error_response("429")
+    assert "Retry-After" in headers
+    # Integer-seconds form so it round-trips through _parse_retry_after.
+    assert headers["Retry-After"].isdigit()
+
+
+def test_build_synthetic_error_response_invalid_mode():
+    with pytest.raises(ValueError, match="Unknown synthetic error mode"):
+        build_synthetic_error_response("418")
+
+
+@pytest.mark.parametrize("mode", list(VALID_ERROR_MODES))
+def test_synthetic_error_cassette_name_prefix(mode):
+    """Cassette filenames generated through this plumbing must carry the
+    canonical ``error_synthetic_`` prefix so a reader of tests/cassettes/ can
+    tell them apart from real recordings at a glance."""
+    name = synthetic_error_cassette_name(mode, "list_notebooks")
+    assert name.startswith(SYNTHETIC_ERROR_CASSETTE_PREFIX)
+    assert mode in name
+    assert name.endswith(".yaml")
+
+
+def test_synthetic_error_cassette_name_rejects_unknown_mode():
+    with pytest.raises(ValueError):
+        synthetic_error_cassette_name("teapot", "list_notebooks")
+
+
+# --- (2) before_record_response substitution --------------------------------
+
+
+def test_vcr_get_error_injection_mode_unset(monkeypatch):
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    assert get_error_injection_mode_vcr() is None
+
+
+@pytest.mark.parametrize("mode", ["429", "5xx", "expired_csrf"])
+def test_vcr_get_error_injection_mode_valid(monkeypatch, mode):
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
+    assert get_error_injection_mode_vcr() == mode
+
+
+def test_vcr_get_error_injection_mode_case_insensitive(monkeypatch):
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5XX")
+    assert get_error_injection_mode_vcr() == "5xx"
+
+
+def test_vcr_get_error_injection_mode_typo_returns_none(monkeypatch):
+    """A typo'd mode does not crash — it resolves to ``None`` so the rest of
+    the plumbing acts as if the env var were unset. The unit tests catch
+    typos via this same helper."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "ratelimit")
+    assert get_error_injection_mode_vcr() is None
+
+
+@pytest.mark.parametrize("mode", ["429", "5xx", "expired_csrf"])
+def test_scrub_response_substitutes_when_env_var_set(monkeypatch, mode):
+    """When the env var resolves to a valid mode, ``scrub_response`` rewrites
+    the response shape to the canonical synthetic body, regardless of what
+    came in. This is the defense-in-depth layer below the transport wrapper."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
+    incoming = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"Content-Type": ["text/plain"]},
+        "body": {"string": b"original wire response"},
+    }
+    out = scrub_response(incoming)
+    expected_status, expected_body, _ = build_synthetic_error_response(mode)
+    assert out["status"]["code"] == expected_status
+    assert expected_body in out["body"]["string"] or out["body"]["string"] == expected_body
+    # Content-Type was overlaid with the synthetic value.
+    assert any("json" in v.lower() for v in out["headers"]["Content-Type"])
+
+
+def test_scrub_response_noop_when_env_var_unset(monkeypatch):
+    """With the env var absent, ``scrub_response`` is byte-for-byte the same
+    as before T8.E10 landed — only sensitive-data scrubbing runs."""
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    incoming = {
+        "status": {"code": 200, "message": "OK"},
+        "headers": {"Content-Type": ["text/plain"]},
+        "body": {"string": b"original wire response"},
+    }
+    out = scrub_response(incoming)
+    # Substitution did NOT fire — status is preserved.
+    assert out["status"]["code"] == 200
+    # The body went through the scrub pipeline but the original payload is
+    # still recognizable.
+    assert b"original wire response" in out["body"]["string"]
+
+
+# --- (3) _core.py transport wrapper -----------------------------------------
+
+
+def test_core_get_error_injection_mode_unset(monkeypatch):
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    assert _get_error_injection_mode() is None
+
+
+@pytest.mark.parametrize("mode", ["429", "5xx", "expired_csrf"])
+def test_core_get_error_injection_mode_valid(monkeypatch, mode):
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
+    assert _get_error_injection_mode() == mode
+
+
+def test_core_get_error_injection_mode_case_insensitive(monkeypatch):
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "EXPIRED_CSRF")
+    assert _get_error_injection_mode() == "expired_csrf"
+
+
+def test_core_get_error_injection_mode_typo_returns_none(monkeypatch):
+    """A typo resolves to ``None`` rather than crashing — recording runs
+    should fail open so an operator can fix the typo without losing their
+    in-flight cassette session."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "ratelimit")
+    assert _get_error_injection_mode() is None
+
+
+class _RecordingInnerTransport(httpx.AsyncBaseTransport):
+    """Inner transport that records calls so we can assert pass-through."""
+
+    def __init__(self):
+        self.calls: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(request)
+        return httpx.Response(200, content=b"inner-response", request=request)
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode,expected_status",
+    [("429", 429), ("5xx", 500), ("expired_csrf", 400)],
+)
+async def test_synthetic_transport_substitutes_batchexecute(mode, expected_status):
+    """The wrapped transport returns a synthetic response for batchexecute
+    POSTs without ever forwarding them to the inner transport."""
+    inner = _RecordingInnerTransport()
+    wrapper = _SyntheticErrorTransport(mode, inner)
+    async with httpx.AsyncClient(transport=wrapper) as client:
+        resp = await client.post(
+            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+            content=b"f.req=...",
+        )
+    assert resp.status_code == expected_status
+    assert resp.content  # synthetic body present
+    assert inner.calls == []  # batchexecute did NOT pass through
+
+
+@pytest.mark.asyncio
+async def test_synthetic_transport_passes_non_batchexecute_through():
+    """Non-batchexecute traffic (Scotty uploads, RotateCookies pokes, the
+    homepage GET) MUST pass through unchanged — error-shape cassettes only
+    target batchexecute RPCs."""
+    inner = _RecordingInnerTransport()
+    wrapper = _SyntheticErrorTransport("429", inner)
+    async with httpx.AsyncClient(transport=wrapper) as client:
+        resp = await client.get("https://notebooklm.google.com/")
+    assert resp.status_code == 200
+    assert resp.content == b"inner-response"
+    assert len(inner.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_synthetic_transport_substitutes_every_batchexecute_call():
+    """With ``always=True`` (the default), every batchexecute POST gets the
+    synthetic response — important because the client's auth-refresh path
+    retries the same RPC and both retries must see the synthetic shape."""
+    inner = _RecordingInnerTransport()
+    wrapper = _SyntheticErrorTransport("5xx", inner, always=True)
+    async with httpx.AsyncClient(transport=wrapper) as client:
+        for _ in range(3):
+            resp = await client.post(
+                "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+                content=b"f.req=...",
+            )
+            assert resp.status_code == 500
+    assert inner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_synthetic_transport_always_false_fires_once():
+    """``always=False`` substitutes only the FIRST batchexecute POST; later
+    POSTs fall through to the inner transport. Useful for tests that want
+    to assert the client recovers after a single transient failure."""
+    inner = _RecordingInnerTransport()
+    wrapper = _SyntheticErrorTransport("5xx", inner, always=False)
+    async with httpx.AsyncClient(transport=wrapper) as client:
+        first = await client.post(
+            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+            content=b"f.req=...",
+        )
+        second = await client.post(
+            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+            content=b"f.req=...",
+        )
+    assert first.status_code == 500
+    assert second.status_code == 200  # passed through
+    assert len(inner.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_synthetic_transport_no_op_when_env_var_unset_in_clientcore(
+    monkeypatch,
+):
+    """End-to-end: when ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is unset, the
+    ``ClientCore.open()`` path constructs an ``httpx.AsyncClient`` WITHOUT
+    the synthetic transport wrapper — production behavior unchanged.
+
+    We don't actually call the network; we just inspect the underlying
+    transport stack after ``open()`` to confirm no synthetic wrapper is in
+    place. Uses a minimal ``AuthTokens`` instance to construct ``ClientCore``.
+    """
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    from notebooklm._core import ClientCore
+    from notebooklm.auth import AuthTokens
+
+    auth = AuthTokens(cookies={"SID": "t"}, csrf_token="c", session_id="s")
+    core = ClientCore(auth)
+    try:
+        await core.open()
+        assert core._http_client is not None
+        # When unset, the AsyncClient is built without our wrapper. The
+        # default httpx transport is some private class; we just assert
+        # ours isn't in the chain.
+        transport = core._http_client._transport
+        assert not isinstance(transport, _SyntheticErrorTransport)
+    finally:
+        if core._http_client is not None:
+            await core._http_client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["429", "5xx", "expired_csrf"])
+async def test_synthetic_transport_wired_when_env_var_set_in_clientcore(monkeypatch, mode):
+    """End-to-end: when the env var resolves to a valid mode,
+    ``ClientCore.open()`` builds the AsyncClient with the synthetic wrapper
+    in place. The transport's ``_mode`` attribute reflects the env var."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
+    from notebooklm._core import ClientCore
+    from notebooklm.auth import AuthTokens
+
+    auth = AuthTokens(cookies={"SID": "t"}, csrf_token="c", session_id="s")
+    core = ClientCore(auth)
+    try:
+        await core.open()
+        assert core._http_client is not None
+        transport = core._http_client._transport
+        assert isinstance(transport, _SyntheticErrorTransport)
+        assert transport._mode == mode
+    finally:
+        if core._http_client is not None:
+            await core._http_client.aclose()
+
+
+# --- (4) lazy-import resolution of the builder ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthetic_transport_lazy_loads_builder():
+    """The transport defers importing tests/cassette_patterns.py until the
+    first batchexecute POST fires. This keeps the production module
+    free of test-tree dependencies at import time."""
+    inner = _RecordingInnerTransport()
+    wrapper = _SyntheticErrorTransport("429", inner)
+    assert wrapper._builder is None  # not yet resolved
+    async with httpx.AsyncClient(transport=wrapper) as client:
+        await client.post(
+            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+            content=b"f.req=...",
+        )
+    assert wrapper._builder is not None  # resolved after first use
+
+
+# --- (5) marker plumbing in tests/conftest.py --------------------------------
+
+
+@pytest.mark.synthetic_error("429")
+def test_synthetic_error_marker_sets_env_var():
+    """The autouse fixture in tests/conftest.py applies the env var when the
+    marker is present. The teardown reverts it via monkeypatch's standard
+    cleanup."""
+    assert os.environ.get(ERROR_INJECT_ENV_VAR) == "429"
+    assert _get_error_injection_mode() == "429"
+
+
+def test_synthetic_error_marker_absent_leaves_env_alone(monkeypatch):
+    """Without the marker, the env var is whatever pytest's environment had
+    when the test started — the fixture is a strict no-op."""
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    assert _get_error_injection_mode() is None

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -484,7 +484,9 @@ def test_scrub_response_substitutes_when_env_var_set(monkeypatch, mode):
     out = scrub_response(incoming)
     expected_status, expected_body, _ = build_synthetic_error_response(mode)
     assert out["status"]["code"] == expected_status
-    assert expected_body in out["body"]["string"] or out["body"]["string"] == expected_body
+    # Byte-for-byte equality — synthetic bodies never trigger scrub patterns or
+    # chunk-prefix rewrites, so any mutation downstream is a regression.
+    assert out["body"]["string"] == expected_body
     # Content-Type was overlaid with the synthetic value.
     assert any("json" in v.lower() for v in out["headers"]["Content-Type"])
 

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -584,6 +584,29 @@ async def test_synthetic_transport_passes_non_batchexecute_through():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS", "PUT", "DELETE"])
+async def test_synthetic_transport_only_substitutes_post_on_batchexecute(method):
+    """Even on the batchexecute path, only POST requests are substituted.
+
+    Non-POST methods on /batchexecute (a hypothetical GET probe, an OPTIONS
+    preflight, etc.) are out of scope for error-shape cassettes and must
+    pass through unchanged. Closes CodeRabbit feedback on PR #638.
+    """
+    inner = _RecordingInnerTransport()
+    wrapper = _SyntheticErrorTransport("429", inner)
+    async with httpx.AsyncClient(transport=wrapper) as client:
+        resp = await client.request(
+            method,
+            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+        )
+    assert resp.status_code == 200
+    assert resp.content == b"inner-response"
+    assert len(inner.calls) == 1
+    # ``_fired`` must NOT have been flipped by a non-POST request.
+    assert wrapper._fired is False
+
+
+@pytest.mark.asyncio
 async def test_synthetic_transport_substitutes_every_batchexecute_call():
     """With ``always=True`` (the default), every batchexecute POST gets the
     synthetic response — important because the client's auth-refresh path

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -96,9 +96,12 @@ synthetic_error_cassette_name = _cassette_patterns.synthetic_error_cassette_name
 SYNTHETIC_ERROR_CASSETTE_PREFIX = _cassette_patterns.SYNTHETIC_ERROR_CASSETTE_PREFIX
 VALID_ERROR_MODES = _cassette_patterns.VALID_ERROR_MODES
 
-# T8.E10 — env var name shared with ``src/notebooklm/_core.py``. Kept in sync as
-# a local copy so the unit tests can import it from either side without taking
-# a runtime dependency on the production module.
+# T8.E10 — env var name shared with ``src/notebooklm/_core.py``. Kept in sync
+# as a local copy so the VCR-only replay path (which does not import
+# ``notebooklm._core``) can still parse the env var without dragging the
+# production module in. The unit tests in ``tests/unit/test_vcr_config.py``
+# import ``ERROR_INJECT_ENV_VAR`` directly from ``notebooklm._core`` — the
+# duplication here covers ONLY the VCR-replay path, not the unit-test path.
 ERROR_INJECT_ENV_VAR = "NOTEBOOKLM_VCR_RECORD_ERRORS"
 
 

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -91,6 +91,15 @@ def _load_sibling(module_name: str, file_name: str) -> Any:
 _cassette_patterns = _load_sibling("tests_cassette_patterns", "cassette_patterns.py")
 recompute_chunk_prefix = _cassette_patterns.recompute_chunk_prefix
 scrub_string = _cassette_patterns.scrub_string
+build_synthetic_error_response = _cassette_patterns.build_synthetic_error_response
+synthetic_error_cassette_name = _cassette_patterns.synthetic_error_cassette_name
+SYNTHETIC_ERROR_CASSETTE_PREFIX = _cassette_patterns.SYNTHETIC_ERROR_CASSETTE_PREFIX
+VALID_ERROR_MODES = _cassette_patterns.VALID_ERROR_MODES
+
+# T8.E10 — env var name shared with ``src/notebooklm/_core.py``. Kept in sync as
+# a local copy so the unit tests can import it from either side without taking
+# a runtime dependency on the production module.
+ERROR_INJECT_ENV_VAR = "NOTEBOOKLM_VCR_RECORD_ERRORS"
 
 
 def _is_vcr_record_mode() -> bool:
@@ -105,6 +114,24 @@ def _is_vcr_record_mode() -> bool:
     consume this helper to avoid drift between the two checks.
     """
     return os.environ.get("NOTEBOOKLM_VCR_RECORD", "").lower() in ("1", "true", "yes")
+
+
+def get_error_injection_mode() -> str | None:
+    """Return the active synthetic-error mode from the environment, or ``None``.
+
+    Reads ``NOTEBOOKLM_VCR_RECORD_ERRORS`` and validates the value against
+    :data:`VALID_ERROR_MODES`. Unset, empty, or unrecognized values resolve to
+    ``None`` so plumbing never crashes on a typo — the unit tests assert the
+    typo path explicitly. The value comparison is case-insensitive.
+
+    This helper mirrors ``_get_error_injection_mode`` in ``_core.py``; both
+    sides validate against the same canonical set in
+    :mod:`tests.cassette_patterns` so they cannot drift.
+    """
+    raw = os.environ.get(ERROR_INJECT_ENV_VAR, "").strip().lower()
+    if not raw:
+        return None
+    return raw if raw in VALID_ERROR_MODES else None
 
 
 def scrub_request(request: Any) -> Any:
@@ -137,6 +164,44 @@ def scrub_request(request: Any) -> Any:
     return request
 
 
+def _substitute_synthetic_error(response: dict[str, Any]) -> dict[str, Any]:
+    """T8.E10 — defense-in-depth synthetic-error substitution.
+
+    When ``NOTEBOOKLM_VCR_RECORD_ERRORS`` resolves to a valid mode (see
+    :data:`VALID_ERROR_MODES`), rewrite the response shape to the canonical
+    synthetic-error shape from :mod:`tests.cassette_patterns`.
+
+    The transport wrapper in ``src/notebooklm/_core.py`` already substitutes
+    the live response BEFORE it reaches VCR, so in normal recording this hook
+    sees the synthetic shape already. This pass exists so that:
+
+    1. Tests that bypass the production transport (e.g. direct
+       ``notebooklm_vcr.use_cassette`` with a hand-built ``httpx.AsyncClient``)
+       still record synthetic shapes when the env var is set.
+    2. The substitution is observable from cassette-only paths in CI without
+       requiring access to the production transport.
+
+    Returns ``response`` unchanged when the env var is unset or the value is
+    not a recognized mode.
+    """
+    mode = get_error_injection_mode()
+    if mode is None:
+        return response
+    status_code, body_bytes, headers = build_synthetic_error_response(mode)
+    response["status"] = {"code": status_code, "message": ""}
+    response["body"] = {"string": body_bytes}
+    # Preserve any incoming headers (e.g. Content-Length VCR fills in) but
+    # overlay our synthetic ones so the Content-Type / Retry-After hints land
+    # on the recorded shape.
+    out_headers = response.get("headers", {})
+    if not isinstance(out_headers, dict):
+        out_headers = {}
+    for k, v in headers.items():
+        out_headers[k] = [v]
+    response["headers"] = out_headers
+    return response
+
+
 def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     """Scrub sensitive data from recorded HTTP response.
 
@@ -154,7 +219,16 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     tolerance branch would log a warning on every replay. The helper is a
     no-op on bodies that don't look chunked, so it's safe to call
     unconditionally.
+
+    T8.E10: when ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to a valid mode,
+    :func:`_substitute_synthetic_error` runs FIRST so that downstream scrub
+    steps see the canonical synthetic shape rather than whatever the wire
+    produced (the transport wrapper in ``_core.py`` normally already
+    substituted, but this pass closes the loop for VCR-only test paths).
     """
+    # T8.E10 — synthetic-error substitution (no-op when env var unset).
+    response = _substitute_synthetic_error(response)
+
     # Scrub response body
     body = response.get("body", {})
     if "string" in body:


### PR DESCRIPTION
## Summary
Adds `NOTEBOOKLM_VCR_RECORD_ERRORS=<429|5xx|expired_csrf>` plumbing wired through the httpx transport in `_core.py` and the `before_record_response` hook in `vcr_config.py`. When set during recording, the next RPC has a substituted synthetic response that VCR captures into a cassette.

Cassettes generated via this plumbing are tagged with `error_synthetic_*.yaml` prefix to make their synthetic nature obvious. T8.E4 will use this plumbing to record the actual error cassettes.

Three opt-in layers:
1. **Env var** — `NOTEBOOKLM_VCR_RECORD_ERRORS=<mode>` activates the transport wrapper inside `ClientCore.open()`. The wrapper substitutes the FIRST (or every — controlled by `always=True`) batchexecute POST with the synthetic shape returned by `tests.cassette_patterns.build_synthetic_error_response`. Non-batchexecute traffic (Scotty uploads, RotateCookies pokes, the homepage GET) passes through untouched.
2. **Pytest marker** — `@pytest.mark.synthetic_error("<mode>")` sets the env var for one test's lifetime via monkeypatch (auto-reverted on teardown).
3. **Filename prefix** — `tests.cassette_patterns.synthetic_error_cassette_name(mode, slug)` builds `error_synthetic_<mode>_<slug>.yaml` filenames so reviewers can tell synthetic shapes apart from real recordings at a glance.

Production behavior is unchanged when the env var is unset — the AsyncClient is built exactly as before (no `transport=` kwarg, no test-tree import).

## Plan
`.sisyphus/plans/tier-8-rpc-vcr-remediation/phase-5.md#T8.E10`

## Test plan
- [x] `uv run ruff format .`
- [x] `uv run ruff check .`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest` — 4195 passed, 12 skipped, 28 xfailed. The 7 pre-existing `tests/integration/cli_vcr/test_downloads.py` failures replicate on pristine main and are unrelated to this PR (cassette drift queued for T8.B* re-recording).
- [x] New unit tests in `tests/unit/test_vcr_config.py` exercise each of the three modes across the response builder, the `before_record_response` hook substitution, the `_SyntheticErrorTransport` wrapper (substitution + pass-through + lazy builder import), and the conftest marker plumbing.

## Synthetic-cassette warning
Documented in `docs/development.md` under "Synthetic error cassettes": error cassettes generated via this plumbing are SYNTHETIC — they validate client exception mapping, not real Google API error shapes. A prominent callout block precedes the env-var documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guide on synthetic RPC error cassettes, supported modes (429, 5xx, expired_csrf), opt-in layers, filename prefix requirement, and recording examples; production behavior unchanged by default.

* **New Features**
  * Opt-in synthetic error injection for testing via env var and pytest marker; lazy-loaded cassette builder and controllable substitution behavior.

* **Tests**
  * Added comprehensive tests for modes, filename rules, env-var/marker plumbing, transport substitution semantics, and lazy loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/638)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->