### PR TITLE
feat(client): add observability hooks and drain API

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -469,6 +469,41 @@ before doubling), matching the 5xx path. Set either to `0` to restore
 the pre-T7.H2 behavior of raising `RateLimitError` / `ServerError`
 immediately.
 
+**Observability hooks.** The client exposes stdlib-only observability so
+applications can choose their own metrics backend:
+
+```python
+from notebooklm import correlation_id
+
+events = []
+
+async with await NotebookLMClient.from_storage(on_rpc_event=events.append) as client:
+    with correlation_id("batch-import-42"):
+        await client.notebooks.list()
+
+    snapshot = client.metrics_snapshot()
+    print(snapshot.rpc_calls_succeeded, snapshot.rpc_queue_wait_seconds_max)
+```
+
+`on_rpc_event` receives a `RpcTelemetryEvent` for each logical RPC
+completion. `metrics_snapshot()` returns cumulative counters for RPC
+success/failure, retry counts, semaphore queue waits, upload queue waits,
+and internal lock wait time. The package does not depend on Prometheus or
+OpenTelemetry; forward these values to whichever backend your service uses.
+
+**Graceful shutdown.** Long-lived services can stop admitting new client
+operations and wait for in-flight operations before closing:
+
+```python
+await client.close(drain=True, drain_timeout=30.0)
+```
+
+`client.drain(timeout=...)` is also available when your framework owns
+transport shutdown separately. Once drain starts, new operations raise
+`RuntimeError`; if the timeout expires, the client remains in draining mode.
+`close(drain=True, ...)` still closes the transport after a drain timeout and
+then re-raises the timeout.
+
 **Upload-timeout configuration** (T7.H3). `client.sources.add_file(...)`
 and the related upload entry points accept an `upload_timeout` argument
 that is decoupled from the global `timeout`. A long-running upload of
@@ -670,7 +705,7 @@ print(url)
 | `get_guide(notebook_id, source_id)` | `str, str` | `dict` | Get AI-generated summary and keywords |
 | `add_url(notebook_id, url, wait=False, wait_timeout=120.0)` | `str, str, bool, float` | `Source` | Add URL source (autodetects YouTube URLs and routes them appropriately) |
 | `add_text(notebook_id, title, content, wait=False, wait_timeout=120.0)` | `str, str, str, bool, float` | `Source` | Add text content |
-| `add_file(notebook_id, file_path, mime_type=None, wait=False, wait_timeout=120.0, *, title=None)` | `str, str \| Path, str \| None, bool, float, *, str \| None` | `Source` | Upload file. `mime_type` is **deprecated** and ignored (server infers from filename); passing non-`None` raises `DeprecationWarning`. `title` (keyword-only) sets the display name via a post-upload `UPDATE_SOURCE` and forces a brief registration wait even when `wait=False`. |
+| `add_file(notebook_id, file_path, mime_type=None, wait=False, wait_timeout=120.0, *, title=None, on_progress=None)` | `str, str \| Path, str \| None, bool, float, *, str \| None, Callable \| None` | `Source` | Upload file. `mime_type` is **deprecated** and ignored (server infers from filename); passing non-`None` raises `DeprecationWarning`. `title` (keyword-only) sets the display name via a post-upload `UPDATE_SOURCE` and forces a brief registration wait even when `wait=False`. `on_progress(bytes_sent, total_bytes)` may be sync or async. |
 | `add_drive(notebook_id, file_id, title, mime_type)` | `str, str, str, str` | `Source` | Add Google Drive doc |
 | `rename(notebook_id, source_id, new_title)` | `str, str, str` | `Source` | Rename source |
 | `refresh(notebook_id, source_id)` | `str, str` | `bool` | Refresh URL/Drive source |
@@ -745,7 +780,7 @@ print(f"Keywords: {guide['keywords']}")
 | `delete(notebook_id, artifact_id)` | `str, str` | `bool` | Delete artifact |
 | `rename(notebook_id, artifact_id, new_title)` | `str, str, str` | `None` | Rename artifact |
 | `poll_status(notebook_id, task_id)` | `str, str` | `GenerationStatus` | Check generation status |
-| `wait_for_completion(notebook_id, task_id, ...)` | `str, str, ...` | `GenerationStatus` | Wait for generation |
+| `wait_for_completion(notebook_id, task_id, ...)` | `str, str, ...` | `GenerationStatus` | Wait for generation. Pass `on_status_change(status)` for sync or async progress callbacks. |
 
 #### Type-Specific List Methods
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -473,7 +473,7 @@ immediately.
 applications can choose their own metrics backend:
 
 ```python
-from notebooklm import correlation_id
+from notebooklm import NotebookLMClient, correlation_id
 
 events = []
 

--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -20,7 +20,13 @@ _check_python_version()
 del _check_python_version
 
 # Configure logging (must run before other imports that create loggers)
-from ._logging import configure_logging
+from ._logging import (
+    configure_logging,
+    correlation_id,
+    get_request_id,
+    reset_request_id,
+    set_request_id,
+)
 
 configure_logging()
 
@@ -103,6 +109,7 @@ from .types import (
     ChatReference,
     ChatResponseLength,
     CitedSourceSelection,
+    ClientMetricsSnapshot,
     ConnectionLimits,
     ConversationTurn,
     DriveMimeType,
@@ -119,6 +126,7 @@ from .types import (
     QuizQuantity,
     ReportFormat,
     ReportSuggestion,
+    RpcTelemetryEvent,
     ShareAccess,
     SharedUser,
     SharePermission,
@@ -145,10 +153,17 @@ __all__ = [
     "NotebookLMClient",
     # Auth
     "AuthTokens",
+    # Observability
+    "correlation_id",
+    "get_request_id",
+    "set_request_id",
+    "reset_request_id",
     # Types
     "AccountLimits",
     "AccountTier",
     "ConnectionLimits",
+    "ClientMetricsSnapshot",
+    "RpcTelemetryEvent",
     "Notebook",
     "NotebookDescription",
     "NotebookMetadata",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -23,6 +24,7 @@ from urllib.parse import urlparse
 import httpx
 
 from . import _mind_map
+from ._callbacks import maybe_await_callback
 from ._core import ClientCore
 from ._env import get_default_language
 from .auth import load_httpx_cookies
@@ -1840,6 +1842,7 @@ class ArtifactsAPI:
         poll_interval: float | None = None,  # Deprecated, use initial_interval
         max_not_found: int = 5,
         min_not_found_window: float = 10.0,
+        on_status_change: Callable[[GenerationStatus], object] | None = None,
     ) -> GenerationStatus:
         """Wait for a generation task to complete.
 
@@ -1884,6 +1887,10 @@ class ArtifactsAPI:
                 run triggers failure.  This avoids false positives on
                 slow or unreliable networks.  Defaults to 10.0.
                 (Leader only.)
+            on_status_change: Optional sync or async callback invoked with a
+                ``GenerationStatus`` when the leader observes a new status.
+                Followers that attach to an existing poll receive only the
+                final status through this callback.
 
         Returns:
             Final GenerationStatus.
@@ -1910,7 +1917,10 @@ class ArtifactsAPI:
             # Follower path. ``asyncio.shield`` ensures that *this* caller's
             # cancellation does not propagate into the shared future; the
             # leader's poll task continues on behalf of every other follower.
-            return await asyncio.shield(existing[0])
+            result = await asyncio.shield(existing[0])
+            if on_status_change is not None:
+                await maybe_await_callback(on_status_change, result)
+            return result
 
         # Leader path. Create the shared future, spawn the poll task,
         # register the pair so any follower can attach. Both the future
@@ -1944,6 +1954,7 @@ class ArtifactsAPI:
                 timeout=timeout,
                 max_not_found=max_not_found,
                 min_not_found_window=min_not_found_window,
+                on_status_change=on_status_change,
             ),
             name=f"artifact-poll-{notebook_id}-{task_id}",
         )
@@ -1994,6 +2005,7 @@ class ArtifactsAPI:
         timeout: float,
         max_not_found: int,
         min_not_found_window: float,
+        on_status_change: Callable[[GenerationStatus], object] | None,
     ) -> GenerationStatus:
         """The actual polling loop. Driven by the leader's shielded task.
 
@@ -2008,6 +2020,7 @@ class ArtifactsAPI:
         poll_retry_count = 0
         first_not_found_time: float | None = None
         last_status: str | None = None
+        last_emitted_status: str | None = None
 
         while True:
             try:
@@ -2035,6 +2048,10 @@ class ArtifactsAPI:
 
             poll_retry_count = 0  # reset on success
             last_status = status.status
+            if status.status != last_emitted_status:
+                last_emitted_status = status.status
+                if on_status_change is not None:
+                    await maybe_await_callback(on_status_change, status)
 
             if status.is_complete or status.is_failed:
                 return status
@@ -2076,7 +2093,7 @@ class ArtifactsAPI:
                         trigger,
                         f"elapsed={not_found_elapsed:.1f}s",
                     )
-                    return GenerationStatus(
+                    failed_status = GenerationStatus(
                         task_id=task_id,
                         status="failed",
                         error=(
@@ -2086,6 +2103,9 @@ class ArtifactsAPI:
                             "Try again later."
                         ),
                     )
+                    if on_status_change is not None and last_emitted_status != "failed":
+                        await maybe_await_callback(on_status_change, failed_status)
+                    return failed_status
             else:
                 consecutive_not_found = 0
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1958,10 +1958,27 @@ class ArtifactsAPI:
             ),
             name=f"artifact-poll-{notebook_id}-{task_id}",
         )
+        try:
+            poll_operation_token = await self._core._begin_transport_task(
+                poll_task,
+                f"artifact wait {task_id}",
+            )
+        except BaseException:
+            poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await poll_task
+            raise
 
         pending[key] = (future, poll_task)
 
+        async def _finish_poll_operation() -> None:
+            try:
+                await self._core._finish_transport_post(poll_operation_token)
+            except Exception as exc:  # noqa: BLE001 - cleanup should not mask poll result
+                logger.warning("Artifact poll drain bookkeeping failed: %s", exc)
+
         def _on_poll_done(task: asyncio.Task[GenerationStatus]) -> None:
+            asyncio.create_task(_finish_poll_operation())
             # Pop the registry entry first so a follower that arrives
             # concurrently with completion either (a) attaches to the
             # already-resolved future and gets the cached result, or

--- a/src/notebooklm/_callbacks.py
+++ b/src/notebooklm/_callbacks.py
@@ -1,0 +1,14 @@
+"""Internal helpers for user-supplied callbacks."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+
+async def maybe_await_callback(callback: Callable[..., Any], *args: Any) -> None:
+    """Invoke a sync or async callback and await its result when needed."""
+    result = callback(*args)
+    if inspect.isawaitable(result):
+        await result

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -15,7 +15,7 @@ from urllib.parse import quote, urlencode
 
 from ._core import ClientCore, _AuthSnapshot
 from ._env import get_default_bl, get_default_language
-from ._logging import reset_request_id, set_request_id
+from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import format_authuser_value
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import (
@@ -234,14 +234,15 @@ class ChatAPI:
             # duplicate inline. The request-id context lives here so retries
             # inside the helper share the same ``[req=<id>]`` log prefix as the
             # initial attempt.
-            reqid_token = set_request_id()
+            reqid_token = None if get_request_id() is not None else set_request_id()
             try:
                 response = await self._core.query_post(
                     build_request=build_request,
                     parse_label="chat.ask",
                 )
             finally:
-                reset_request_id(reqid_token)
+                if reqid_token is not None:
+                    reset_request_id(reqid_token)
 
             answer_text, references, server_conv_id = self._parse_ask_response_with_references(
                 response.text

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -939,6 +939,24 @@ class ClientCore:
             self._in_flight_posts += 1
         return _TransportOperationToken(task=task)
 
+    async def _begin_transport_task(
+        self,
+        task: asyncio.Task[Any],
+        log_label: str,
+    ) -> _TransportOperationToken:
+        """Admit an internally-spawned task as part of the current operation."""
+        condition = self._get_drain_condition()
+        current_depth = self._current_operation_depth(asyncio.current_task())
+        async with condition:
+            if self._draining and current_depth == 0:
+                raise RuntimeError(
+                    "NotebookLMClient is draining; new client operations are not accepted "
+                    f"({log_label})."
+                )
+            self._operation_depths[task] = self._operation_depths.get(task, 0) + 1
+            self._in_flight_posts += 1
+        return _TransportOperationToken(task=task)
+
     async def _finish_transport_post(self, token: _TransportOperationToken) -> None:
         condition = self._get_drain_condition()
         async with condition:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -7,10 +7,11 @@ import random
 import threading
 import time
 import warnings
+import weakref
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, nullcontext
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -19,8 +20,9 @@ from urllib.parse import urlencode
 
 import httpx
 
+from ._callbacks import maybe_await_callback
 from ._env import get_default_language
-from ._logging import reset_request_id, set_request_id
+from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import (
     AuthTokens,
     CookieSaveResult,
@@ -32,6 +34,7 @@ from .auth import (
     save_cookies_to_storage,
     snapshot_cookie_jar,
 )
+from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
 if TYPE_CHECKING:
     from .types import ConnectionLimits
@@ -53,6 +56,15 @@ from .rpc import (
 )
 
 logger = logging.getLogger(__name__)
+_OBSERVABILITY_INIT_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class _TransportOperationToken:
+    """Token for one accepted transport operation on a specific asyncio task."""
+
+    task: asyncio.Task[Any] | None
+
 
 # Maximum number of conversations to cache (FIFO eviction)
 MAX_CONVERSATION_CACHE_SIZE = 100
@@ -483,6 +495,7 @@ class ClientCore:
         limits: "ConnectionLimits | None" = None,
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
         max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
+        on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
     ):
         """Initialize the core client.
 
@@ -558,6 +571,10 @@ class ClientCore:
                 the ``NotebookLMClient`` boundary (so the constraint
                 applies whether ``limits`` is explicit or auto-defaulted
                 inside ``ClientCore``).
+            on_rpc_event: Optional callback invoked after each logical
+                ``rpc_call`` succeeds or fails. The callback receives a
+                backend-agnostic :class:`RpcTelemetryEvent`; exceptions raised
+                by the callback are logged and never mask the RPC result.
 
         Raises:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a
@@ -638,6 +655,15 @@ class ClientCore:
         self._refresh_lock: asyncio.Lock | None = None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
+        self._on_rpc_event = on_rpc_event
+        self._metrics_lock = threading.Lock()
+        self._metrics = ClientMetricsSnapshot()
+        self._draining = False
+        self._in_flight_posts = 0
+        self._drain_condition: asyncio.Condition | None = None
+        self._operation_depths: weakref.WeakKeyDictionary[asyncio.Task[Any], int] = (
+            weakref.WeakKeyDictionary()
+        )
         # Request ID counter for chat API (must be unique per request).
         # Access via the ``next_reqid()`` async method, which guards mutation
         # under ``_reqid_lock``. Direct mutation through the ``_reqid_counter``
@@ -785,9 +811,165 @@ class ClientCore:
             # Lazy init — safe to construct here because we're already in an
             # async context (caller is awaiting us).
             self._reqid_lock = asyncio.Lock()
-        async with self._reqid_lock:
+        wait_start = time.perf_counter()
+        await self._reqid_lock.acquire()
+        self._record_lock_wait(time.perf_counter() - wait_start)
+        try:
             self._reqid_counter_value += step
             return self._reqid_counter_value
+        finally:
+            self._reqid_lock.release()
+
+    def metrics_snapshot(self) -> ClientMetricsSnapshot:
+        """Return cumulative observability counters for this client instance."""
+        self._ensure_observability_state()
+        with self._metrics_lock:
+            return replace(self._metrics)
+
+    def _ensure_observability_state(self) -> None:
+        """Backfill observability fields for tests that construct via ``__new__``."""
+        if (
+            hasattr(self, "_on_rpc_event")
+            and hasattr(self, "_metrics_lock")
+            and hasattr(self, "_metrics")
+            and hasattr(self, "_draining")
+            and hasattr(self, "_in_flight_posts")
+            and hasattr(self, "_drain_condition")
+            and hasattr(self, "_operation_depths")
+        ):
+            return
+        with _OBSERVABILITY_INIT_LOCK:
+            if not hasattr(self, "_on_rpc_event"):
+                self._on_rpc_event = None
+            if not hasattr(self, "_metrics_lock"):
+                self._metrics_lock = threading.Lock()
+            if not hasattr(self, "_metrics"):
+                self._metrics = ClientMetricsSnapshot()
+            if not hasattr(self, "_draining"):
+                self._draining = False
+            if not hasattr(self, "_in_flight_posts"):
+                self._in_flight_posts = 0
+            if not hasattr(self, "_drain_condition"):
+                self._drain_condition = None
+            if not hasattr(self, "_operation_depths"):
+                self._operation_depths = weakref.WeakKeyDictionary()
+
+    def _increment_metrics(self, **increments: int | float) -> None:
+        """Increment numeric metrics fields under the metrics lock."""
+        self._ensure_observability_state()
+        with self._metrics_lock:
+            values = {
+                field_name: getattr(self._metrics, field_name) + increment
+                for field_name, increment in increments.items()
+            }
+            self._metrics = replace(self._metrics, **values)
+
+    def _record_rpc_queue_wait(self, wait_seconds: float) -> None:
+        self._ensure_observability_state()
+        with self._metrics_lock:
+            self._metrics = replace(
+                self._metrics,
+                rpc_queue_wait_seconds_total=(
+                    self._metrics.rpc_queue_wait_seconds_total + wait_seconds
+                ),
+                rpc_queue_wait_seconds_max=max(
+                    self._metrics.rpc_queue_wait_seconds_max,
+                    wait_seconds,
+                ),
+            )
+
+    def record_upload_queue_wait(self, wait_seconds: float) -> None:
+        """Record time spent waiting for the upload semaphore."""
+        self._ensure_observability_state()
+        with self._metrics_lock:
+            self._metrics = replace(
+                self._metrics,
+                upload_queue_wait_seconds_total=(
+                    self._metrics.upload_queue_wait_seconds_total + wait_seconds
+                ),
+                upload_queue_wait_seconds_max=max(
+                    self._metrics.upload_queue_wait_seconds_max,
+                    wait_seconds,
+                ),
+            )
+
+    def _record_lock_wait(self, wait_seconds: float) -> None:
+        self._ensure_observability_state()
+        with self._metrics_lock:
+            self._metrics = replace(
+                self._metrics,
+                lock_wait_seconds_total=self._metrics.lock_wait_seconds_total + wait_seconds,
+                lock_wait_seconds_max=max(self._metrics.lock_wait_seconds_max, wait_seconds),
+            )
+
+    async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
+        """Invoke the optional telemetry callback without affecting RPC behavior."""
+        self._ensure_observability_state()
+        if self._on_rpc_event is None:
+            return
+        try:
+            await maybe_await_callback(self._on_rpc_event, event)
+        except Exception as exc:  # noqa: BLE001 - observability must not alter behavior
+            logger.warning("RPC telemetry callback failed: %s", exc)
+
+    def _get_drain_condition(self) -> asyncio.Condition:
+        self._ensure_observability_state()
+        if self._drain_condition is None:
+            self._drain_condition = asyncio.Condition()
+        return self._drain_condition
+
+    def _current_operation_depth(self, task: asyncio.Task[Any] | None) -> int:
+        if task is None:
+            return 0
+        return self._operation_depths.get(task, 0)
+
+    async def _begin_transport_post(self, log_label: str) -> _TransportOperationToken:
+        """Reject new top-level transport work once graceful drain has started."""
+        condition = self._get_drain_condition()
+        task = asyncio.current_task()
+        depth = self._current_operation_depth(task)
+        async with condition:
+            if self._draining and depth == 0:
+                raise RuntimeError(
+                    "NotebookLMClient is draining; new client operations are not accepted "
+                    f"({log_label})."
+                )
+            if task is not None:
+                self._operation_depths[task] = depth + 1
+            self._in_flight_posts += 1
+        return _TransportOperationToken(task=task)
+
+    async def _finish_transport_post(self, token: _TransportOperationToken) -> None:
+        condition = self._get_drain_condition()
+        async with condition:
+            if token.task is not None:
+                depth = self._operation_depths.get(token.task, 0)
+                if depth <= 1:
+                    self._operation_depths.pop(token.task, None)
+                else:
+                    self._operation_depths[token.task] = depth - 1
+            self._in_flight_posts -= 1
+            if self._in_flight_posts == 0:
+                condition.notify_all()
+
+    async def drain(self, timeout: float | None = None) -> None:
+        """Stop accepting new client operations and wait for in-flight ones to finish.
+
+        If ``timeout`` expires, ``TimeoutError`` is raised and the client
+        remains in draining mode so shutdown callers do not accidentally admit
+        new work after a missed deadline.
+        """
+        if timeout is not None and timeout < 0:
+            raise ValueError(f"timeout must be >= 0 or None, got {timeout!r}")
+        condition = self._get_drain_condition()
+        async with condition:
+            self._draining = True
+            if self._in_flight_posts == 0:
+                return
+            await asyncio.wait_for(
+                condition.wait_for(lambda: self._in_flight_posts == 0),
+                timeout=timeout,
+            )
 
     def get_upload_semaphore(self) -> asyncio.Semaphore:
         """Return the per-instance upload semaphore, creating it on first use.
@@ -865,6 +1047,7 @@ class ClientCore:
             # built so the binding is consistent with the loop that owns
             # every primitive constructed below (T7.G2 / audit §14).
             self._bound_loop = asyncio.get_running_loop()
+            self._draining = False
             # Use granular timeouts: shorter connect timeout helps detect network issues
             # faster, while longer read/write timeouts accommodate slow responses
             timeout = httpx.Timeout(
@@ -1203,7 +1386,9 @@ class ClientCore:
         each other; the no-await rule keeps the cookie axis aligned with
         them.
         """
+        wait_start = time.perf_counter()
         async with self._get_auth_snapshot_lock():
+            self._record_lock_wait(time.perf_counter() - wait_start)
             return _AuthSnapshot(
                 csrf_token=self.auth.csrf_token,
                 session_id=self.auth.session_id,
@@ -1390,7 +1575,10 @@ class ClientCore:
         # through this same critical section on its post-refresh retry
         # iteration — that's the contract callers depend on.
         # ---------------------------------------------------------------
-        async with self._get_rpc_semaphore():
+        semaphore = self._get_rpc_semaphore()
+        queue_wait_start = time.perf_counter()
+        async with semaphore:
+            self._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
             while True:
                 snapshot = await self._snapshot()
                 url, body, headers = build_request(snapshot)
@@ -1429,6 +1617,7 @@ class ClientCore:
                             await asyncio.sleep(self._refresh_retry_delay)
                         logger.info("Token refresh successful, retrying %s", log_label)
                         refreshed_this_call = True
+                        self._increment_metrics(rpc_auth_retries=1)
                         # Loop around: next iteration takes a FRESH snapshot,
                         # rebuilds the request body with the new csrf/sid, and
                         # re-POSTs.
@@ -1469,6 +1658,7 @@ class ClientCore:
                             )
                             await asyncio.sleep(sleep_seconds)
                             rate_limit_retries += 1
+                            self._increment_metrics(rpc_rate_limit_retries=1)
                             continue
                         raise _TransportRateLimited(
                             f"{log_label} rate-limited (HTTP 429)",
@@ -1523,6 +1713,7 @@ class ClientCore:
                             )
                             await asyncio.sleep(backoff)
                             server_error_retries += 1
+                            self._increment_metrics(rpc_server_error_retries=1)
                             continue
                         if is_server_error:
                             status_error = cast(httpx.HTTPStatusError, exc)
@@ -1576,7 +1767,11 @@ class ClientCore:
         # Every concurrent caller resolves to the same instance because
         # ``_get_refresh_lock`` runs synchronously in a single-threaded
         # asyncio loop, so single-flight task creation below is preserved.
-        async with self._get_refresh_lock():
+        lock = self._get_refresh_lock()
+        wait_start = time.perf_counter()
+        await lock.acquire()
+        self._record_lock_wait(time.perf_counter() - wait_start)
+        try:
             if self._refresh_task is not None and not self._refresh_task.done():
                 refresh_task = self._refresh_task
                 logger.debug("Joining existing refresh task")
@@ -1584,6 +1779,8 @@ class ClientCore:
                 coro = cast(Coroutine[Any, Any, AuthTokens], self._refresh_callback())
                 self._refresh_task = asyncio.create_task(coro)
                 refresh_task = self._refresh_task
+        finally:
+            lock.release()
 
         await asyncio.shield(refresh_task)
 
@@ -1613,60 +1810,64 @@ class ClientCore:
         # this module's siblings.
         from .exceptions import ChatError, NetworkError
 
+        operation_token = await self._begin_transport_post(parse_label)
         try:
-            return await self._perform_authed_post(
-                build_request=build_request,
-                log_label=parse_label,
-            )
-        except _TransportAuthExpired as exc:
-            raise ChatError(
-                f"{parse_label} failed: authentication expired and refresh did not recover"
-            ) from exc
-        except _TransportRateLimited as exc:
-            raise ChatError(
-                f"{parse_label} rate-limited (HTTP 429)."
-                + (
-                    f" Retry after {exc.retry_after} seconds."
-                    if exc.retry_after is not None
-                    else ""
+            try:
+                return await self._perform_authed_post(
+                    build_request=build_request,
+                    log_label=parse_label,
                 )
-            ) from exc
-        except _TransportServerError as exc:
-            if isinstance(exc.original, httpx.HTTPStatusError):
+            except _TransportAuthExpired as exc:
                 raise ChatError(
-                    f"{parse_label} failed with HTTP {exc.original.response.status_code} "
-                    f"after retries: {exc.original}"
+                    f"{parse_label} failed: authentication expired and refresh did not recover"
                 ) from exc
-            # Network-layer failure (RequestError / Timeout).
-            # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
-            # ``_TransportServerError`` on the network path; this guard keeps
-            # the contract enforced under ``python -O`` (where ``assert``
-            # would be stripped) and gives a clear diagnostic if the
-            # invariant ever drifts.
-            if not isinstance(exc.original, httpx.RequestError):
-                raise TypeError(
-                    f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+            except _TransportRateLimited as exc:
+                raise ChatError(
+                    f"{parse_label} rate-limited (HTTP 429)."
+                    + (
+                        f" Retry after {exc.retry_after} seconds."
+                        if exc.retry_after is not None
+                        else ""
+                    )
                 ) from exc
-            # Preserve the timeout-specific message: TimeoutException is a
-            # subclass of RequestError, so without this branch read/connect
-            # timeouts would surface as a generic "network error after
-            # retries" line and lose the "timed out" signal callers rely on.
-            if isinstance(exc.original, httpx.TimeoutException):
+            except _TransportServerError as exc:
+                if isinstance(exc.original, httpx.HTTPStatusError):
+                    raise ChatError(
+                        f"{parse_label} failed with HTTP {exc.original.response.status_code} "
+                        f"after retries: {exc.original}"
+                    ) from exc
+                # Network-layer failure (RequestError / Timeout).
+                # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
+                # ``_TransportServerError`` on the network path; this guard keeps
+                # the contract enforced under ``python -O`` (where ``assert``
+                # would be stripped) and gives a clear diagnostic if the
+                # invariant ever drifts.
+                if not isinstance(exc.original, httpx.RequestError):
+                    raise TypeError(
+                        f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                    ) from exc
+                # Preserve the timeout-specific message: TimeoutException is a
+                # subclass of RequestError, so without this branch read/connect
+                # timeouts would surface as a generic "network error after
+                # retries" line and lose the "timed out" signal callers rely on.
+                if isinstance(exc.original, httpx.TimeoutException):
+                    raise NetworkError(
+                        f"{parse_label} timed out after retries: {exc.original}",
+                        original_error=exc.original,
+                    ) from exc
                 raise NetworkError(
-                    f"{parse_label} timed out after retries: {exc.original}",
+                    f"{parse_label} network error after retries: {exc.original}",
                     original_error=exc.original,
                 ) from exc
-            raise NetworkError(
-                f"{parse_label} network error after retries: {exc.original}",
-                original_error=exc.original,
-            ) from exc
-        except httpx.HTTPStatusError as exc:
-            # Non-5xx / non-401 / non-429 status errors fall through
-            # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
-            # or unhandled 4xx).
-            raise ChatError(
-                f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
-            ) from exc
+            except httpx.HTTPStatusError as exc:
+                # Non-5xx / non-401 / non-429 status errors fall through
+                # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
+                # or unhandled 4xx).
+                raise ChatError(
+                    f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
+                ) from exc
+        finally:
+            await self._finish_transport_post(operation_token)
         # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
         # handlers were removed here because ``_perform_authed_post`` always
         # either retries those errors or wraps them in
@@ -1731,9 +1932,13 @@ class ClientCore:
                 disable_internal_retries=disable_internal_retries,
             )
 
-        _reqid_token = set_request_id()
+        method_name = getattr(method, "name", str(method))
+        operation_token = await self._begin_transport_post(f"RPC {method_name}")
+        self._increment_metrics(rpc_calls_started=1)
+        start = time.perf_counter()
+        _reqid_token = None if get_request_id() is not None else set_request_id()
         try:
-            return await self._rpc_call_impl(
+            result = await self._rpc_call_impl(
                 method,
                 params,
                 source_path,
@@ -1741,8 +1946,35 @@ class ClientCore:
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
             )
+        except Exception as exc:
+            elapsed = time.perf_counter() - start
+            self._increment_metrics(rpc_calls_failed=1, rpc_latency_seconds_total=elapsed)
+            await self._emit_rpc_event(
+                RpcTelemetryEvent(
+                    method=method_name,
+                    status="error",
+                    elapsed_seconds=elapsed,
+                    request_id=get_request_id(),
+                    error_type=type(exc).__name__,
+                )
+            )
+            raise
+        else:
+            elapsed = time.perf_counter() - start
+            self._increment_metrics(rpc_calls_succeeded=1, rpc_latency_seconds_total=elapsed)
+            await self._emit_rpc_event(
+                RpcTelemetryEvent(
+                    method=method_name,
+                    status="success",
+                    elapsed_seconds=elapsed,
+                    request_id=get_request_id(),
+                )
+            )
+            return result
         finally:
-            reset_request_id(_reqid_token)
+            if _reqid_token is not None:
+                reset_request_id(_reqid_token)
+            await self._finish_transport_post(operation_token)
 
     async def _rpc_call_impl(
         self,

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -20,7 +20,8 @@ import logging
 import os
 import re
 import uuid
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from typing import Any
 
@@ -29,6 +30,7 @@ __all__ = [
     "RedactingFormatter",
     "apply_redaction",
     "configure_logging",
+    "correlation_id",
     "get_request_id",
     "install_redaction",
     "reset_request_id",
@@ -63,6 +65,23 @@ def reset_request_id(token: Token[str | None]) -> None:
 def get_request_id() -> str | None:
     """Return the current correlation id, or None if unset."""
     return _current_request_id.get()
+
+
+@contextmanager
+def correlation_id(req_id: str | None = None) -> Iterator[str]:
+    """Scope log records and RPC telemetry under a caller-chosen correlation id.
+
+    Pass ``req_id=None`` to generate a fresh 8-character id. Nested scopes
+    restore the previous id on exit.
+    """
+    token = set_request_id(req_id)
+    try:
+        current = get_request_id()
+        # ``set_request_id(None)`` always generates a string; the fallback keeps
+        # static checkers happy if that implementation ever changes.
+        yield current or ""
+    finally:
+        reset_request_id(token)
 
 
 # Patterns are immutable. Adding a new pattern requires a unit test.

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import warnings
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from time import monotonic
@@ -14,6 +15,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 
+from ._callbacks import maybe_await_callback
 from ._core import ClientCore
 from ._env import get_base_url
 from ._idempotency import idempotent_create
@@ -674,6 +676,7 @@ class SourcesAPI:
         wait_timeout: float = 120.0,
         *,
         title: str | None = None,
+        on_progress: Callable[[int, int], object] | None = None,
     ) -> Source:
         """Add a file source to a notebook using resumable upload.
 
@@ -731,6 +734,10 @@ class SourcesAPI:
                 that wait returns on the first PROCESSING/READY poll so it
                 completes in seconds for typical sources regardless of this
                 value. Default: 120.
+            on_progress: Optional sync or async callback invoked as
+                ``on_progress(bytes_sent, total_bytes)`` during the streaming
+                upload body. Callback exceptions propagate and abort the
+                upload, matching normal application callback semantics.
 
         Returns:
             The created Source object. If wait=False, status may be PROCESSING.
@@ -781,7 +788,9 @@ class SourcesAPI:
         # hold more than ``max_concurrent_uploads`` open FDs at once. The
         # semaphore is per-instance; see ClientCore.get_upload_semaphore.
         upload_sem = self._core.get_upload_semaphore()
+        upload_wait_start = monotonic()
         async with upload_sem:
+            self._core.record_upload_queue_wait(monotonic() - upload_wait_start)
             # Open the file ONCE here. The FD lives across:
             #   - the os.fstat() size check (so the size we send to
             #     ``_start_resumable_upload`` matches the bytes we will
@@ -814,12 +823,16 @@ class SourcesAPI:
             # the ``finally`` below).
             file_obj = open(file_path, "rb")  # noqa: SIM115
             handed_off = False
+            operation_token = None
             try:
                 # ``os.fstat(fd.fileno())`` reads inode metadata via the
                 # FD itself, not the path — even if the path has been
                 # relinked since ``open()``, this returns the inode we're
                 # about to upload.
                 file_size = os.fstat(file_obj.fileno()).st_size
+                operation_token = await self._core._begin_transport_post(
+                    f"source upload {filename}"
+                )
 
                 # Step 1: Register source intent with RPC → get SOURCE_ID
                 source_id = await self._register_file_source(notebook_id, filename)
@@ -836,12 +849,20 @@ class SourcesAPI:
                 # post-finalize cancel branch). ``handed_off=True``
                 # prevents the local ``finally`` from double-closing.
                 handed_off = True
-                await self._upload_file_streaming(upload_url, file_obj, filename=filename)
+                await self._upload_file_streaming(
+                    upload_url,
+                    file_obj,
+                    filename=filename,
+                    on_progress=on_progress,
+                    total_bytes=file_size,
+                )
             finally:
                 # Close locally ONLY if ownership never transferred —
                 # i.e. ``_upload_file_streaming`` was never invoked
                 # (size-check or RPC raised). After hand-off the
                 # streaming helper owns the close.
+                if operation_token is not None:
+                    await self._core._finish_transport_post(operation_token)
                 if not handed_off:
                     file_obj.close()
 
@@ -1528,6 +1549,8 @@ class SourcesAPI:
         file_obj: IO[bytes] | Path,
         *,
         filename: str | None = None,
+        on_progress: Callable[[int, int], object] | None = None,
+        total_bytes: int | None = None,
     ) -> None:
         """Stream upload file content to the resumable upload URL.
 
@@ -1580,6 +1603,11 @@ class SourcesAPI:
                 ``add_file``.
             filename: Optional filename used for diagnostic logging.
                 Defaults to ``"<file>"`` when not supplied.
+            on_progress: Optional sync or async callback invoked as
+                ``on_progress(bytes_sent, total_bytes)`` as chunks are yielded.
+            total_bytes: Total bytes expected. Required for the add_file FD
+                path; inferred from the path for legacy direct-call tests when
+                omitted.
         """
         # Discriminate: caller passed an open FD (the T7.D3 add_file path),
         # or a Path (legacy direct-call test path — opens locally). The
@@ -1610,6 +1638,13 @@ class SourcesAPI:
             }
             diag_name = filename or (path_fallback.name if path_fallback is not None else "<file>")
             logger.debug("Streaming upload to %s for %s", upload_url, diag_name)
+            if total_bytes is None and path_fallback is not None:
+                total_bytes = path_fallback.stat().st_size
+            progress_total = total_bytes if total_bytes is not None else 0
+            uploaded_bytes = 0
+
+            if on_progress is not None:
+                await maybe_await_callback(on_progress, uploaded_bytes, progress_total)
 
             # Stream the file content instead of loading it all into memory.
             # When the caller passed an FD, we read directly from it (single
@@ -1617,6 +1652,7 @@ class SourcesAPI:
             # (legacy direct-call), we open here as a one-off helper whose
             # ``with`` closes the locally-opened FD when the generator ends.
             async def file_stream():
+                nonlocal uploaded_bytes
                 # T7.D2 / audit §22: chunk reads are synchronous file I/O.
                 # On slow storage (network FS, encrypted home, large PDFs
                 # served from a cold cache) a bare ``f.read(65536)`` from
@@ -1629,6 +1665,11 @@ class SourcesAPI:
                 if path_fallback is not None:
                     with open(path_fallback, "rb") as f:
                         while chunk := await asyncio.to_thread(f.read, 65536):  # 64KB chunks
+                            uploaded_bytes += len(chunk)
+                            if on_progress is not None:
+                                await maybe_await_callback(
+                                    on_progress, uploaded_bytes, progress_total
+                                )
                             yield chunk
                     return
                 # FD path: caller transferred ownership to this helper; we
@@ -1638,6 +1679,9 @@ class SourcesAPI:
                 # cancel.
                 assert not isinstance(file_obj, Path)  # narrowed by branch above
                 while chunk := await asyncio.to_thread(file_obj.read, 65536):  # 64KB chunks
+                    uploaded_bytes += len(chunk)
+                    if on_progress is not None:
+                        await maybe_await_callback(on_progress, uploaded_bytes, progress_total)
                     yield chunk
 
             # `finalize_started` flips after the local ``httpx.AsyncClient``

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -861,10 +861,12 @@ class SourcesAPI:
                 # i.e. ``_upload_file_streaming`` was never invoked
                 # (size-check or RPC raised). After hand-off the
                 # streaming helper owns the close.
-                if operation_token is not None:
-                    await self._core._finish_transport_post(operation_token)
-                if not handed_off:
-                    file_obj.close()
+                try:
+                    if operation_token is not None:
+                        await self._core._finish_transport_post(operation_token)
+                finally:
+                    if not handed_off:
+                        file_obj.close()
 
         # Step 4: Ensure the source is registered server-side BEFORE renaming.
         # The UPDATE_SOURCE RPC silently no-ops against an unregistered source

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -19,9 +19,12 @@ Example:
         result = await client.chat.ask(notebook_id, "What is this about?")
 """
 
+from __future__ import annotations
+
 import dataclasses
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
 from typing import TYPE_CHECKING
@@ -29,7 +32,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 if TYPE_CHECKING:
-    from .types import ConnectionLimits
+    from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
 from ._artifacts import ArtifactsAPI
 from ._chat import ChatAPI
@@ -98,10 +101,11 @@ class NotebookLMClient:
         keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
         rate_limit_max_retries: int = 3,
         server_error_max_retries: int = 3,
-        limits: "ConnectionLimits | None" = None,
+        limits: ConnectionLimits | None = None,
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
         max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
         upload_timeout: httpx.Timeout | None = None,
+        on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
     ):
         """Initialize the NotebookLM client.
 
@@ -177,6 +181,11 @@ class NotebookLMClient:
                 fields will fall back to httpx's own 5.0s defaults rather
                 than the original 10.0s connect. Defaults are NOT changed
                 silently for back-compat (audit §20 / T7.H3).
+            on_rpc_event: Optional sync or async callback invoked after each
+                logical RPC succeeds or fails. The callback receives a
+                backend-agnostic ``RpcTelemetryEvent`` so applications can
+                forward telemetry to logging, Prometheus, OpenTelemetry, or
+                another metrics backend without this package depending on one.
         """
         # Normalize the effective storage path onto the auth object so every
         # downstream code path (refresh_auth, ClientCore.close on-close save,
@@ -246,6 +255,7 @@ class NotebookLMClient:
             limits=limits,
             max_concurrent_uploads=max_concurrent_uploads,
             max_concurrent_rpcs=max_concurrent_rpcs,
+            on_rpc_event=on_rpc_event,
         )
 
         # Initialize sub-client APIs.
@@ -266,7 +276,7 @@ class NotebookLMClient:
         """Get the authentication tokens."""
         return self._core.auth
 
-    async def __aenter__(self) -> "NotebookLMClient":
+    async def __aenter__(self) -> NotebookLMClient:
         """Open the client connection."""
         logger.debug("Opening NotebookLM client")
         await self._core.open()
@@ -289,7 +299,7 @@ class NotebookLMClient:
         """
         logger.debug("Closing NotebookLM client")
         try:
-            await self._core.close()
+            await self.close()
         except BaseException as close_exc:
             if exc_val is not None:
                 logger.warning(
@@ -298,6 +308,35 @@ class NotebookLMClient:
                 )
                 return
             raise
+
+    async def drain(self, timeout: float | None = None) -> None:
+        """Stop accepting new operations and wait for in-flight operations to finish."""
+        await self._core.drain(timeout=timeout)
+
+    async def close(
+        self,
+        *,
+        drain: bool = False,
+        drain_timeout: float | None = None,
+    ) -> None:
+        """Close the client.
+
+        Pass ``drain=True`` to stop accepting new operations and wait for
+        in-flight operations to finish before closing the transport. If the
+        drain deadline is exceeded, the transport is still closed and the
+        timeout is re-raised.
+        """
+        if drain:
+            try:
+                await self.drain(timeout=drain_timeout)
+            finally:
+                await self._core.close()
+            return
+        await self._core.close()
+
+    def metrics_snapshot(self) -> ClientMetricsSnapshot:
+        """Return cumulative observability counters for this client."""
+        return self._core.metrics_snapshot()
 
     @property
     def is_connected(self) -> bool:
@@ -314,11 +353,12 @@ class NotebookLMClient:
         keepalive_min_interval: float = DEFAULT_KEEPALIVE_MIN_INTERVAL,
         rate_limit_max_retries: int = 3,
         server_error_max_retries: int = 3,
-        limits: "ConnectionLimits | None" = None,
+        limits: ConnectionLimits | None = None,
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
         max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
         upload_timeout: httpx.Timeout | None = None,
-    ) -> "NotebookLMClient":
+        on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+    ) -> NotebookLMClient:
         """Create a client from Playwright storage state file.
 
         This is the recommended way to create a client for programmatic use.
@@ -360,6 +400,8 @@ class NotebookLMClient:
                 POST. ``None`` (default) preserves the original hardcoded
                 values for back-compat. See :class:`NotebookLMClient` for
                 full semantics.
+            on_rpc_event: Optional sync or async callback invoked after each
+                logical RPC succeeds or fails.
 
         Returns:
             NotebookLMClient instance (not yet connected).
@@ -397,6 +439,7 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
             max_concurrent_rpcs=max_concurrent_rpcs,
             upload_timeout=upload_timeout,
+            on_rpc_event=on_rpc_event,
         )
 
     async def refresh_auth(self) -> AuthTokens:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -329,9 +329,20 @@ class NotebookLMClient:
         if drain:
             try:
                 await self.drain(timeout=drain_timeout)
-            finally:
+            except TimeoutError as drain_exc:
+                try:
+                    await self._core.close()
+                except Exception as close_exc:
+                    logger.warning(
+                        "Suppressing close() error after drain timeout to preserve timeout "
+                        "signal: %s",
+                        close_exc,
+                    )
+                    raise drain_exc from close_exc
+                raise
+            else:
                 await self._core.close()
-            return
+                return
         await self._core.close()
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -13,7 +13,7 @@ import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 if TYPE_CHECKING:
     import httpx
@@ -112,6 +112,41 @@ class ConnectionLimits:
             max_keepalive_connections=self.max_keepalive_connections,
             keepalive_expiry=self.keepalive_expiry,
         )
+
+
+@dataclass(frozen=True)
+class RpcTelemetryEvent:
+    """One logical RPC completion event emitted by ``NotebookLMClient``.
+
+    The event is intentionally backend-agnostic: applications can forward it
+    to Prometheus, OpenTelemetry, logs, or a custom counter without this
+    package taking a dependency on any metrics framework.
+    """
+
+    method: str
+    status: Literal["success", "error"]
+    elapsed_seconds: float
+    request_id: str | None = None
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class ClientMetricsSnapshot:
+    """Cumulative in-process observability counters for a client instance."""
+
+    rpc_calls_started: int = 0
+    rpc_calls_succeeded: int = 0
+    rpc_calls_failed: int = 0
+    rpc_rate_limit_retries: int = 0
+    rpc_server_error_retries: int = 0
+    rpc_auth_retries: int = 0
+    rpc_latency_seconds_total: float = 0.0
+    rpc_queue_wait_seconds_total: float = 0.0
+    rpc_queue_wait_seconds_max: float = 0.0
+    upload_queue_wait_seconds_total: float = 0.0
+    upload_queue_wait_seconds_max: float = 0.0
+    lock_wait_seconds_total: float = 0.0
+    lock_wait_seconds_max: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -463,6 +498,8 @@ __all__ = [
     # Dataclasses
     "CitedSourceSelection",
     "ConnectionLimits",
+    "ClientMetricsSnapshot",
+    "RpcTelemetryEvent",
     "Notebook",
     "NotebookDescription",
     "NotebookMetadata",

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -102,6 +102,9 @@ def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
     cookie_jar = MagicMock(name="cookie_jar")
     core.auth.cookie_jar = cookie_jar
     core.get_http_client.return_value.cookies = cookie_jar
+    core._begin_transport_post = AsyncMock(return_value=object())
+    core._finish_transport_post = AsyncMock()
+    core.record_upload_queue_wait = MagicMock()
     return SourcesAPI(core), core
 
 

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -26,6 +26,8 @@ def mock_artifacts_api():
     # A MagicMock attribute would return a child Mock and confuse the
     # ``existing is not None`` branch.
     mock_core._pending_polls = {}
+    mock_core._begin_transport_task = AsyncMock(return_value=object())
+    mock_core._finish_transport_post = AsyncMock()
     mock_notes = MagicMock()
     mock_notes.list_mind_maps = AsyncMock(return_value=[])
     mock_note = MagicMock()

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -12,6 +12,8 @@ def api():
     # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
     # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
     core._pending_polls = {}
+    core._begin_transport_task = AsyncMock(return_value=object())
+    core._finish_transport_post = AsyncMock()
     notes_api = MagicMock()
     return ArtifactsAPI(core, notes_api)
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from notebooklm import (
+    ClientMetricsSnapshot,
+    NotebookLMClient,
+    RpcTelemetryEvent,
+    correlation_id,
+    get_request_id,
+)
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._core import ClientCore
+from notebooklm._sources import SourcesAPI
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import GenerationStatus
+
+
+@pytest.mark.asyncio
+async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) -> None:
+    events: list[RpcTelemetryEvent] = []
+    core = ClientCore(auth_tokens, on_rpc_event=events.append)
+    core._http_client = AsyncMock(spec=httpx.AsyncClient)
+    seen_request_ids: list[str | None] = []
+
+    async def fake_impl(*args: object, **kwargs: object) -> dict[str, bool]:
+        seen_request_ids.append(get_request_id())
+        return {"ok": True}
+
+    core._rpc_call_impl = fake_impl  # type: ignore[method-assign]
+
+    with correlation_id("batch-42"):
+        result = await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb_123"])
+
+    assert result == {"ok": True}
+    assert seen_request_ids == ["batch-42"]
+    assert get_request_id() is None
+
+    snapshot = core.metrics_snapshot()
+    assert isinstance(snapshot, ClientMetricsSnapshot)
+    assert snapshot.rpc_calls_started == 1
+    assert snapshot.rpc_calls_succeeded == 1
+    assert snapshot.rpc_calls_failed == 0
+    assert snapshot.rpc_latency_seconds_total >= 0
+
+    assert len(events) == 1
+    assert events[0].method == "GET_NOTEBOOK"
+    assert events[0].status == "success"
+    assert events[0].request_id == "batch-42"
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_new_work_and_waits_for_in_flight(auth_tokens: AuthTokens) -> None:
+    core = ClientCore(auth_tokens)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def in_flight() -> None:
+        operation_token = await core._begin_transport_post("test")
+        started.set()
+        try:
+            await release.wait()
+        finally:
+            await core._finish_transport_post(operation_token)
+
+    task = asyncio.create_task(in_flight())
+    await started.wait()
+
+    drain_task = asyncio.create_task(core.drain(timeout=1.0))
+    await asyncio.sleep(0)
+
+    assert not drain_task.done()
+    with pytest.raises(RuntimeError, match="draining"):
+        await core._begin_transport_post("new")
+
+    release.set()
+    await drain_task
+    await task
+
+
+@pytest.mark.asyncio
+async def test_drain_allows_nested_work_inside_accepted_operation(
+    auth_tokens: AuthTokens,
+) -> None:
+    core = ClientCore(auth_tokens)
+    outer_token = await core._begin_transport_post("source upload")
+    try:
+        drain_task = asyncio.create_task(core.drain(timeout=1.0))
+        await asyncio.sleep(0)
+
+        nested_token = await core._begin_transport_post("RPC ADD_SOURCE")
+        await core._finish_transport_post(nested_token)
+
+        assert not drain_task.done()
+    finally:
+        await core._finish_transport_post(outer_token)
+
+    await drain_task
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_child_task_spawned_from_accepted_operation(
+    auth_tokens: AuthTokens,
+) -> None:
+    core = ClientCore(auth_tokens)
+    outer_token = await core._begin_transport_post("source upload")
+    try:
+        drain_task = asyncio.create_task(core.drain(timeout=1.0))
+        await asyncio.sleep(0)
+
+        async def child_work() -> None:
+            child_token = await core._begin_transport_post("child task")
+            await core._finish_transport_post(child_token)
+
+        with pytest.raises(RuntimeError, match="draining"):
+            await asyncio.create_task(child_work())
+    finally:
+        await core._finish_transport_post(outer_token)
+
+    await drain_task
+
+
+@pytest.mark.asyncio
+async def test_close_with_drain_closes_transport_after_timeout(auth_tokens: AuthTokens) -> None:
+    client = NotebookLMClient(auth_tokens)
+    calls: list[str] = []
+
+    async def drain_timeout(timeout: float | None = None) -> None:
+        calls.append(f"drain:{timeout}")
+        raise TimeoutError("deadline")
+
+    async def close_transport() -> None:
+        calls.append("close")
+
+    client._core.drain = drain_timeout  # type: ignore[method-assign]
+    client._core.close = close_transport  # type: ignore[method-assign]
+
+    with pytest.raises(TimeoutError, match="deadline"):
+        await client.close(drain=True, drain_timeout=0.1)
+
+    assert calls == ["drain:0.1", "close"]
+
+
+@pytest.mark.asyncio
+async def test_upload_progress_callback_receives_byte_counts(
+    auth_tokens: AuthTokens,
+    tmp_path,
+) -> None:
+    core = ClientCore(auth_tokens)
+    await core.open()
+    try:
+        api = SourcesAPI(core)
+        test_file = tmp_path / "upload.txt"
+        content = b"hello progress"
+        test_file.write_bytes(content)
+        events: list[tuple[int, int]] = []
+
+        async def on_progress(sent: int, total: int) -> None:
+            events.append((sent, total))
+
+        async def consume_post(*args: object, **kwargs: object) -> MagicMock:
+            async for _chunk in kwargs["content"]:
+                pass
+            response = MagicMock()
+            response.raise_for_status.return_value = None
+            return response
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.side_effect = consume_post
+            mock_client_cls.return_value = mock_client
+
+            await api._upload_file_streaming(
+                "https://upload.example.com/session",
+                test_file,
+                on_progress=on_progress,
+            )
+
+        assert events == [(0, len(content)), (len(content), len(content))]
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_status_change_callback(auth_tokens: AuthTokens) -> None:
+    core = ClientCore(auth_tokens)
+    api = ArtifactsAPI(core)
+    statuses = [
+        GenerationStatus(task_id="task_1", status="in_progress"),
+        GenerationStatus(task_id="task_1", status="completed", url="https://example.test/out"),
+    ]
+    seen: list[str] = []
+
+    async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        return statuses.pop(0)
+
+    api.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+    result = await api.wait_for_completion(
+        "nb_123",
+        "task_1",
+        initial_interval=0.0,
+        timeout=1.0,
+        on_status_change=lambda status: seen.append(status.status),
+    )
+
+    assert result.status == "completed"
+    assert seen == ["in_progress", "completed"]

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -126,6 +126,52 @@ async def test_drain_rejects_child_task_spawned_from_accepted_operation(
 
 
 @pytest.mark.asyncio
+async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> None:
+    core = ClientCore(auth_tokens)
+    api = ArtifactsAPI(core)
+    first_poll_started = asyncio.Event()
+    release_first_poll = asyncio.Event()
+    poll_count = 0
+
+    async def fake_poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        nonlocal poll_count
+        operation_token = await core._begin_transport_post("poll_status")
+        try:
+            poll_count += 1
+            if poll_count == 1:
+                first_poll_started.set()
+                await release_first_poll.wait()
+                return GenerationStatus(task_id=task_id, status="in_progress")
+            return GenerationStatus(task_id=task_id, status="completed")
+        finally:
+            await core._finish_transport_post(operation_token)
+
+    api.poll_status = fake_poll_status  # type: ignore[method-assign]
+
+    wait_task = asyncio.create_task(
+        api.wait_for_completion(
+            "nb_123",
+            "task_1",
+            initial_interval=0.0,
+            max_interval=0.0,
+            timeout=1.0,
+        )
+    )
+    await first_poll_started.wait()
+
+    drain_task = asyncio.create_task(core.drain(timeout=1.0))
+    await asyncio.sleep(0)
+    assert not drain_task.done()
+
+    release_first_poll.set()
+    result = await wait_task
+    await drain_task
+
+    assert result.status == "completed"
+    assert poll_count == 2
+
+
+@pytest.mark.asyncio
 async def test_close_with_drain_closes_transport_after_timeout(auth_tokens: AuthTokens) -> None:
     client = NotebookLMClient(auth_tokens)
     calls: list[str] = []
@@ -144,6 +190,27 @@ async def test_close_with_drain_closes_transport_after_timeout(auth_tokens: Auth
         await client.close(drain=True, drain_timeout=0.1)
 
     assert calls == ["drain:0.1", "close"]
+
+
+@pytest.mark.asyncio
+async def test_close_with_invalid_drain_does_not_close_transport(auth_tokens: AuthTokens) -> None:
+    client = NotebookLMClient(auth_tokens)
+    calls: list[str] = []
+
+    async def invalid_drain(timeout: float | None = None) -> None:
+        calls.append(f"drain:{timeout}")
+        raise ValueError("bad deadline")
+
+    async def close_transport() -> None:
+        calls.append("close")
+
+    client._core.drain = invalid_drain  # type: ignore[method-assign]
+    client._core.close = close_transport  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="bad deadline"):
+        await client.close(drain=True, drain_timeout=-1.0)
+
+    assert calls == ["drain:-1.0"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -33,6 +33,8 @@ def _make_api():
     # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
     # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
     core._pending_polls = {}
+    core._begin_transport_task = AsyncMock(return_value=object())
+    core._finish_transport_post = AsyncMock()
     notes = MagicMock()
     notes.list_mind_maps = AsyncMock(return_value=[])
     notes.create = AsyncMock(return_value=MagicMock(id="note_1"))

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -24,6 +24,9 @@ def mock_core():
     cookie_jar = MagicMock(name="cookie_jar")
     core.auth.cookie_jar = cookie_jar
     core.get_http_client.return_value.cookies = cookie_jar
+    core._begin_transport_post = AsyncMock(return_value=object())
+    core._finish_transport_post = AsyncMock()
+    core.record_upload_queue_wait = MagicMock()
     return core
 
 


### PR DESCRIPTION
## Summary
- Adds stdlib-only observability primitives: RPC telemetry events, cumulative metrics snapshots, and public correlation IDs.
- Adds graceful client drain/close APIs for long-lived services.
- Adds upload progress and artifact wait status-change callbacks.

## Task
Closes #513

## Test plan
- [x] uv run ruff format .
- [x] uv run ruff check .
- [x] uv run mypy src/notebooklm --ignore-missing-imports
- [x] uv run pytest tests/unit/test_observability.py tests/unit/test_logging_correlation.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_sources_upload.py -q
- [x] uv run pytest tests/integration/concurrency/test_add_file_toctou.py tests/integration/concurrency/test_upload_cancel_dangling_session.py tests/integration/concurrency/test_upload_blocks_loop.py -q
- [x] uv run pytest --ignore=tests/integration/cli_vcr/test_downloads.py

## Known local issue
- tests/integration/cli_vcr/test_downloads.py fails locally due existing cassette replay drift: missing recorded LIST_NOTEBOOKS / artifact-download RPCs in record mode none. The broad suite passes when that stale cassette file is excluded.

## Deferred polish findings
- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RPC telemetry events and client metrics snapshots for observability
  * Progress callbacks for file uploads (sync or async)
  * Status-change callbacks for artifact generation (report progress)
  * Graceful shutdown: drain and close with optional draining behavior
  * Request/correlation ID tracking and scoped correlation context

* **Documentation**
  * Updated API reference documenting observability, callbacks, and lifecycle controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->