### PR TITLE
feat(api): expose public raw RPC call

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -586,7 +586,22 @@ class NotebookLMClient:
     )
 
     async def refresh_auth(self) -> AuthTokens
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any
 ```
+
+`RPCMethod` is imported from `notebooklm.rpc` for raw-RPC calls; `Any` is
+`typing.Any`. `_is_retry` is present only to preserve parity with the core
+delegator and should normally be left as `False`.
 
 **Long-lived clients:** pass `keepalive=<seconds>` to spawn a background task
 that periodically pokes `accounts.google.com` and persists any rotated
@@ -1851,10 +1866,9 @@ For undocumented features, you can make raw RPC calls:
 from notebooklm.rpc import RPCMethod
 
 async with await NotebookLMClient.from_storage() as client:
-    # Access the core client for raw RPC. Each RPCMethod member has its own
-    # params shape (a nested list) and `source_path`; mirror the call sites in
-    # the higher-level APIs (e.g. _notebooks.py for CREATE_NOTEBOOK) when in doubt.
-    result = await client._core.rpc_call(
+    # Each RPCMethod member has its own params shape (a nested list) and
+    # source_path; mirror the higher-level APIs when in doubt.
+    result = await client.rpc_call(
         RPCMethod.CREATE_NOTEBOOK,
         params=["My Notebook", None, None, [2], [1]],
     )

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,7 +1,7 @@
 # API Stability and Versioning
 
 **Status:** Active
-**Last Updated:** 2026-05-14
+**Last Updated:** 2026-05-15
 
 This document describes the stability guarantees and versioning policy for `notebooklm-py`.
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -66,6 +66,7 @@ NotebookLMClient.research
 NotebookLMClient.notes
 NotebookLMClient.settings
 NotebookLMClient.sharing
+NotebookLMClient.rpc_call()
 
 # Types
 Notebook, Source, Artifact, Note
@@ -105,6 +106,11 @@ AuthTokens
 
 # Helpers (cookies extra) - imported from notebooklm.auth
 notebooklm.auth.convert_rookiepy_cookies_to_storage_state  # requires `pip install "notebooklm-py[cookies]"` — see docs/installation.md#optional-extras-matrix
+
+# Cookie-domain tiers - imported from notebooklm.auth
+notebooklm.auth.REQUIRED_COOKIE_DOMAINS
+notebooklm.auth.OPTIONAL_COOKIE_DOMAINS
+notebooklm.auth.OPTIONAL_COOKIE_DOMAINS_BY_LABEL
 ```
 
 ### Internal helpers exported for compatibility
@@ -128,16 +134,15 @@ StudioContentType         # ⚠️ Deprecated — use ArtifactType (see "Current
 
 ```python
 # These are NOT part of the public API:
-notebooklm.rpc.*          # RPC protocol internals
+notebooklm.rpc.*          # RPC protocol internals, except the documented RPCMethod import path for NotebookLMClient.rpc_call()
 notebooklm._core.*        # Core infrastructure
 notebooklm._*.py          # All underscore-prefixed modules
-notebooklm.auth.*         # Auth internals (except AuthTokens and convert_rookiepy_cookies_to_storage_state)
+notebooklm.auth.*         # Auth internals (except documented AuthTokens, cookie conversion, and cookie-domain constants)
 ```
 
-To use internal APIs, import them explicitly:
+For raw-RPC power-user calls, import the method enum explicitly:
 ```python
-# Explicit import for power users (may break)
-from notebooklm.rpc import RPCMethod, encode_rpc_request
+from notebooklm.rpc import RPCMethod
 ```
 
 ## Deprecation Policy
@@ -315,7 +320,8 @@ If the library breaks before we release a fix:
 4. Temporarily patch your local copy:
    ```python
    # In your code, before using the library
-   from notebooklm.rpc.types import RPCMethod
+   from notebooklm.rpc import RPCMethod
+
    RPCMethod.SOME_METHOD._value_ = "NewMethodId"
    ```
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -27,11 +27,12 @@ import os
 from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
 if TYPE_CHECKING:
+    from .rpc import RPCMethod
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
 from ._artifacts import ArtifactsAPI
@@ -348,6 +349,35 @@ class NotebookLMClient:
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client."""
         return self._core.metrics_snapshot()
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        """Make a raw NotebookLM RPC call.
+
+        This is the public escape hatch for advanced callers who need an
+        undocumented RPC before a typed API exists. Prefer the namespaced APIs
+        (``client.notebooks``, ``client.sources``, etc.) when possible. Import
+        ``RPCMethod`` from ``notebooklm.rpc``. The ``_is_retry`` parameter is
+        exposed only to mirror ``ClientCore.rpc_call`` exactly; callers should
+        leave it at the default unless they are intentionally reproducing core
+        retry behavior.
+        """
+        return await self._core.rpc_call(
+            method=method,
+            params=params,
+            source_path=source_path,
+            allow_null=allow_null,
+            _is_retry=_is_retry,
+            disable_internal_retries=disable_internal_retries,
+        )
 
     @property
     def is_connected(self) -> bool:

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -250,6 +250,37 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_client_rpc_call_forwards_default_arguments() -> None:
+    """The public delegator must preserve ClientCore.rpc_call defaults."""
+    from notebooklm import NotebookLMClient
+    from notebooklm.auth import AuthTokens
+    from notebooklm.rpc import RPCMethod
+
+    client = NotebookLMClient(
+        AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="csrf",
+            session_id="session",
+        )
+    )
+    # No async context is needed: this test replaces the core RPC coroutine
+    # before any real transport initialization can be required.
+    client._core.rpc_call = AsyncMock(return_value=[])
+
+    result = await client.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
+
+    assert result == []
+    client._core.rpc_call.assert_awaited_once_with(
+        method=RPCMethod.LIST_NOTEBOOKS,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # PR-T1.D section: __all__ contract tests for the public shim modules.
 #

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib
 from types import ModuleType
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -176,6 +177,77 @@ def test_log_shim_exposes_install_redaction():
     from notebooklm.log import install_redaction
 
     assert callable(install_redaction)
+
+
+# ---------------------------------------------------------------------------
+# PR-T1 API contract section: public raw-RPC and documented facade imports
+# ---------------------------------------------------------------------------
+
+
+def test_rpc_method_uses_documented_power_user_import_path() -> None:
+    """Raw-RPC examples use notebooklm.rpc.RPCMethod, not notebooklm.types."""
+    from notebooklm.rpc import RPCMethod
+    from notebooklm.rpc.types import RPCMethod as CanonicalRPCMethod
+
+    assert RPCMethod is CanonicalRPCMethod
+
+
+def test_rpc_method_is_not_reexported_from_notebooklm_types() -> None:
+    """RPCMethod is intentionally not part of notebooklm.types in this phase."""
+    import notebooklm.types as public_types
+
+    assert "RPCMethod" not in public_types.__all__
+    assert not hasattr(public_types, "RPCMethod")
+
+
+def test_auth_cookie_domain_constants_are_facade_exports() -> None:
+    """Cookie-domain tiers remain importable from notebooklm.auth."""
+    from notebooklm.auth import (
+        OPTIONAL_COOKIE_DOMAINS,
+        OPTIONAL_COOKIE_DOMAINS_BY_LABEL,
+        REQUIRED_COOKIE_DOMAINS,
+    )
+
+    assert isinstance(REQUIRED_COOKIE_DOMAINS, frozenset)
+    assert isinstance(OPTIONAL_COOKIE_DOMAINS, frozenset)
+    assert isinstance(OPTIONAL_COOKIE_DOMAINS_BY_LABEL, dict)
+    assert frozenset().union(*OPTIONAL_COOKIE_DOMAINS_BY_LABEL.values()) == OPTIONAL_COOKIE_DOMAINS
+
+
+@pytest.mark.asyncio
+async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
+    """NotebookLMClient.rpc_call is a public delegator to ClientCore.rpc_call."""
+    from notebooklm import NotebookLMClient
+    from notebooklm.auth import AuthTokens
+    from notebooklm.rpc import RPCMethod
+
+    client = NotebookLMClient(
+        AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="csrf",
+            session_id="session",
+        )
+    )
+    client._core.rpc_call = AsyncMock(return_value={"ok": True})
+
+    result = await client.rpc_call(
+        RPCMethod.CREATE_NOTEBOOK,
+        ["My Notebook"],
+        source_path="/notebook/abc",
+        allow_null=True,
+        _is_retry=True,
+        disable_internal_retries=True,
+    )
+
+    assert result == {"ok": True}
+    client._core.rpc_call.assert_awaited_once_with(
+        method=RPCMethod.CREATE_NOTEBOOK,
+        params=["My Notebook"],
+        source_path="/notebook/abc",
+        allow_null=True,
+        _is_retry=True,
+        disable_internal_retries=True,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add NotebookLMClient.rpc_call as the public raw-RPC delegator while preserving client._core.rpc_call
- update stability and Python API docs to point raw-RPC users at client.rpc_call and notebooklm.rpc.RPCMethod
- add public import/delegation tests for RPCMethod, auth cookie-domain constants, and the new client method

## Task
Phase 1 Wave 1: t1-api-contract from .sisyphus/phases/architecture-remediation/phase-1.md

## Test plan
- rtk uv run pytest tests/unit/test_public_shims.py tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_types.py tests/unit/test_rpc_types.py
- rtk uv run ruff check docs src/notebooklm tests/unit/test_public_shims.py tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_types.py tests/unit/test_rpc_types.py
- rtk uv run mypy src/notebooklm

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `rpc_call()` method on NotebookLMClient for advanced raw-RPC access.

* **Documentation**
  * Updated API reference and stability docs to document `rpc_call()` and expanded documented auth cookie-domain exports; refreshed stability guidance and examples.

* **Tests**
  * Added unit tests validating the public RPC delegator behavior and facade exports for RPC types and auth cookie-domain constants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->