### PR TITLE
test(architecture): add boundary guardrails

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -81,6 +81,24 @@ src/notebooklm/
 | **Core** | `_core.py` | HTTP client, request counter, RPC abstraction |
 | **RPC** | `rpc/*.py` | Protocol encoding/decoding, method IDs |
 
+### Boundary Guardrails
+
+The architecture tests encode the current layer contract:
+
+- `tests/unit/test_public_shims.py` has a documented public import manifest.
+  When a docs change adds or removes a supported import path, update the
+  manifest in the same PR so public API drift is intentional and reviewable.
+- `tests/unit/test_cli_boundary.py` parses `src/notebooklm/cli/**/*.py` and
+  rejects CLI imports from `notebooklm._*`, `notebooklm.rpc.*`, or `_private`
+  names exposed by public modules. Promote needed symbols through a public
+  facade (`notebooklm.types`, `notebooklm.auth`, `notebooklm.research`, etc.)
+  before using them from the CLI.
+- `tests/unit/test_init_order.py` records the temporary baseline of feature
+  APIs that still access `ClientCore` private state directly. Future capability
+  migration PRs should reduce that baseline as private state moves behind
+  explicit `ClientCore` methods; do not add new entries unless the PR also
+  explains the follow-up migration path.
+
 ### Key Design Decisions
 
 **Why underscore prefixes?** Files like `_notebooks.py` are internal implementation. Public API stays clean (`from notebooklm import NotebookLMClient`).

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -8,7 +8,9 @@ invariant down so the load-bearing init order can't silently come back.
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -18,6 +20,191 @@ from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._notes import NotesAPI
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
+
+# TODO(architecture-remediation): later capability-migration tasks should move
+# these feature APIs off ClientCore private state and then shrink this baseline
+# to an empty set. Until then, this guard blocks new direct private-state access
+# without failing the legitimate pre-extraction call sites.
+_ALLOWED_CORE_PRIVATE_ACCESSES = {
+    ("_artifacts.py", "_begin_transport_task"),
+    ("_artifacts.py", "_finish_transport_post"),
+    ("_artifacts.py", "_pending_polls"),
+    ("_sources.py", "_begin_transport_post"),
+    ("_sources.py", "_finish_transport_post"),
+}
+
+_CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
+    "_atomic_io.py",
+    "_callbacks.py",
+    "_core.py",
+    "_env.py",
+    "_idempotency.py",
+    "_logging.py",
+    "_mind_map.py",
+    "_url_utils.py",
+    "_version_check.py",
+}
+
+
+def _is_self_core(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "_core"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    )
+
+
+def _is_private_attr(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr.startswith("_")
+        and not node.attr.startswith("__")
+    )
+
+
+class _CorePrivateAccessVisitor(ast.NodeVisitor):
+    """Collect ``self._core._x`` and simple aliases like ``core = self._core``."""
+
+    def __init__(self, module_name: str) -> None:
+        self.module_name = module_name
+        self.observed: set[tuple[str, str]] = set()
+        self._core_alias_stack: list[set[str]] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_scope(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_scope(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_function_scope(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if _is_self_core(node.value):
+            for target in node.targets:
+                self._record_alias_target(target)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None and _is_self_core(node.value):
+            self._record_alias_target(node.target)
+        self.generic_visit(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        if _is_self_core(node.value):
+            self._record_alias_target(node.target)
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if _is_private_attr(node) and self._is_core_access_base(node.value):
+            self.observed.add((self.module_name, node.attr))
+        self.generic_visit(node)
+
+    def _visit_function_scope(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    ) -> None:
+        self._core_alias_stack.append(set())
+        self.generic_visit(node)
+        self._core_alias_stack.pop()
+
+    def _record_alias_target(self, target: ast.AST) -> None:
+        if isinstance(target, ast.Name) and self._core_alias_stack:
+            self._core_alias_stack[-1].add(target.id)
+
+    def _is_core_access_base(self, node: ast.AST) -> bool:
+        return _is_self_core(node) or (
+            isinstance(node, ast.Name)
+            and any(node.id in aliases for aliases in reversed(self._core_alias_stack))
+        )
+
+
+def _feature_modules_for_core_private_guard() -> list[Path]:
+    return [
+        path
+        for path in sorted(SRC_ROOT.glob("_*.py"))
+        if path.name not in _CORE_PRIVATE_GUARD_EXCLUDED_MODULES
+    ]
+
+
+def _collect_core_private_accesses(path: Path) -> set[tuple[str, str]]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    visitor = _CorePrivateAccessVisitor(path.name)
+    visitor.visit(tree)
+    return visitor.observed
+
+
+def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
+    """Pending guard: no new feature API reaches directly into ClientCore internals."""
+    observed: set[tuple[str, str]] = set()
+    for path in _feature_modules_for_core_private_guard():
+        observed.update(_collect_core_private_accesses(path))
+
+    unexpected = observed - _ALLOWED_CORE_PRIVATE_ACCESSES
+    assert not unexpected, (
+        "Feature APIs must not add new direct `self._core._private` accesses. "
+        "Add a public ClientCore capability first, or temporarily extend the "
+        f"TODO baseline with a migration note. New accesses: {sorted(unexpected)}"
+    )
+
+
+def test_core_private_access_guard_detects_simple_aliases() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        core = self._core
+        return core._pending_polls
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == {("example.py", "_pending_polls")}
+
+
+def test_core_private_access_guard_detects_closure_aliases() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        core = self._core
+        def nested():
+            return core._pending_polls
+        return nested()
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == {("example.py", "_pending_polls")}
+
+
+def test_core_private_access_guard_detects_direct_access() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        return self._core._pending_polls
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == {("example.py", "_pending_polls")}
+
+
+def test_core_private_access_guard_ignores_public_core_methods() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        return self._core.rpc_call(method, params)
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == set()
 
 
 @pytest.fixture

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -27,15 +28,17 @@ SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 # these feature APIs off ClientCore private state and then shrink this baseline
 # to an empty set. Until then, this guard blocks new direct private-state access
 # without failing the legitimate pre-extraction call sites.
-_ALLOWED_CORE_PRIVATE_ACCESSES = {
-    ("_artifacts.py", "_begin_transport_task"),
-    ("_artifacts.py", "_finish_transport_post"),
-    ("_artifacts.py", "_pending_polls"),
-    ("_sources.py", "_begin_transport_post"),
-    ("_sources.py", "_finish_transport_post"),
+_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS = {
+    ("_artifacts.py", "_begin_transport_task"): 1,
+    ("_artifacts.py", "_finish_transport_post"): 1,
+    ("_artifacts.py", "_pending_polls"): 1,
+    ("_sources.py", "_begin_transport_post"): 1,
+    ("_sources.py", "_finish_transport_post"): 1,
 }
 
 _CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
+    "__init__.py",
+    "__main__.py",
     "_atomic_io.py",
     "_callbacks.py",
     "_core.py",
@@ -70,7 +73,7 @@ class _CorePrivateAccessVisitor(ast.NodeVisitor):
 
     def __init__(self, module_name: str) -> None:
         self.module_name = module_name
-        self.observed: set[tuple[str, str]] = set()
+        self.observed: list[tuple[str, str]] = []
         self._core_alias_stack: list[set[str]] = []
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -83,24 +86,24 @@ class _CorePrivateAccessVisitor(ast.NodeVisitor):
         self._visit_function_scope(node)
 
     def visit_Assign(self, node: ast.Assign) -> None:
-        if _is_self_core(node.value):
+        if self._is_core_access_base(node.value):
             for target in node.targets:
                 self._record_alias_target(target)
         self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        if node.value is not None and _is_self_core(node.value):
+        if node.value is not None and self._is_core_access_base(node.value):
             self._record_alias_target(node.target)
         self.generic_visit(node)
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
-        if _is_self_core(node.value):
+        if self._is_core_access_base(node.value):
             self._record_alias_target(node.target)
         self.generic_visit(node)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
         if _is_private_attr(node) and self._is_core_access_base(node.value):
-            self.observed.add((self.module_name, node.attr))
+            self.observed.append((self.module_name, node.attr))
         self.generic_visit(node)
 
     def _visit_function_scope(
@@ -116,9 +119,13 @@ class _CorePrivateAccessVisitor(ast.NodeVisitor):
             self._core_alias_stack[-1].add(target.id)
 
     def _is_core_access_base(self, node: ast.AST) -> bool:
-        return _is_self_core(node) or (
-            isinstance(node, ast.Name)
-            and any(node.id in aliases for aliases in reversed(self._core_alias_stack))
+        return (
+            _is_self_core(node)
+            or (
+                isinstance(node, ast.Name)
+                and any(node.id in aliases for aliases in reversed(self._core_alias_stack))
+            )
+            or (isinstance(node, ast.NamedExpr) and self._is_core_access_base(node.value))
         )
 
 
@@ -130,7 +137,7 @@ def _feature_modules_for_core_private_guard() -> list[Path]:
     ]
 
 
-def _collect_core_private_accesses(path: Path) -> set[tuple[str, str]]:
+def _collect_core_private_accesses(path: Path) -> list[tuple[str, str]]:
     tree = ast.parse(path.read_text(encoding="utf-8"))
     visitor = _CorePrivateAccessVisitor(path.name)
     visitor.visit(tree)
@@ -139,15 +146,29 @@ def _collect_core_private_accesses(path: Path) -> set[tuple[str, str]]:
 
 def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
     """Pending guard: no new feature API reaches directly into ClientCore internals."""
-    observed: set[tuple[str, str]] = set()
+    observed_counts: Counter[tuple[str, str]] = Counter()
     for path in _feature_modules_for_core_private_guard():
-        observed.update(_collect_core_private_accesses(path))
+        observed_counts.update(_collect_core_private_accesses(path))
 
-    unexpected = observed - _ALLOWED_CORE_PRIVATE_ACCESSES
+    unexpected = {
+        access: count
+        for access, count in observed_counts.items()
+        if count > _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS.get(access, 0)
+    }
     assert not unexpected, (
         "Feature APIs must not add new direct `self._core._private` accesses. "
         "Add a public ClientCore capability first, or temporarily extend the "
-        f"TODO baseline with a migration note. New accesses: {sorted(unexpected)}"
+        f"TODO baseline with a migration note. New accesses: {unexpected}"
+    )
+
+    stale = {
+        access: allowed_count - observed_counts.get(access, 0)
+        for access, allowed_count in _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS.items()
+        if observed_counts.get(access, 0) < allowed_count
+    }
+    assert not stale, (
+        "Core-private access baseline has entries no longer present in code. "
+        f"Remove them from _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS: {stale}"
     )
 
 
@@ -162,7 +183,22 @@ class Example:
     )
     visitor = _CorePrivateAccessVisitor("example.py")
     visitor.visit(tree)
-    assert visitor.observed == {("example.py", "_pending_polls")}
+    assert visitor.observed == [("example.py", "_pending_polls")]
+
+
+def test_core_private_access_guard_detects_chained_aliases() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        core = self._core
+        same = core
+        return same._pending_polls
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == [("example.py", "_pending_polls")]
 
 
 def test_core_private_access_guard_detects_closure_aliases() -> None:
@@ -178,7 +214,7 @@ class Example:
     )
     visitor = _CorePrivateAccessVisitor("example.py")
     visitor.visit(tree)
-    assert visitor.observed == {("example.py", "_pending_polls")}
+    assert visitor.observed == [("example.py", "_pending_polls")]
 
 
 def test_core_private_access_guard_detects_direct_access() -> None:
@@ -191,7 +227,38 @@ class Example:
     )
     visitor = _CorePrivateAccessVisitor("example.py")
     visitor.visit(tree)
-    assert visitor.observed == {("example.py", "_pending_polls")}
+    assert visitor.observed == [("example.py", "_pending_polls")]
+
+
+def test_core_private_access_guard_counts_duplicate_call_sites() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        first = self._core._pending_polls
+        second = self._core._pending_polls
+        return first, second
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == [
+        ("example.py", "_pending_polls"),
+        ("example.py", "_pending_polls"),
+    ]
+
+
+def test_core_private_access_guard_detects_walrus_aliases() -> None:
+    tree = ast.parse(
+        """
+class Example:
+    def method(self):
+        return (core := self._core)._pending_polls
+"""
+    )
+    visitor = _CorePrivateAccessVisitor("example.py")
+    visitor.visit(tree)
+    assert visitor.observed == [("example.py", "_pending_polls")]
 
 
 def test_core_private_access_guard_ignores_public_core_methods() -> None:
@@ -204,7 +271,7 @@ class Example:
     )
     visitor = _CorePrivateAccessVisitor("example.py")
     visitor.visit(tree)
-    assert visitor.observed == set()
+    assert visitor.observed == []
 
 
 @pytest.fixture

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -123,6 +123,7 @@ def test_public_facade_imports_are_identity_reexports() -> None:
     assert notebooklm.ConnectionLimits is public_types.ConnectionLimits
     assert public_rpc.RPCMethod is rpc_types.RPCMethod
 
+
 # ---------------------------------------------------------------------------
 # PR-A section: notebooklm.research public surface
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -9,10 +9,119 @@ Plan: .sisyphus/plans/private-module-boundary.md
 from __future__ import annotations
 
 import importlib
+import warnings
 from types import ModuleType
 from unittest.mock import AsyncMock
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# PR-T2 section: documented public import manifest
+#
+# This is the public import surface documented by PR-T1. Keep this manifest
+# explicit: if docs add a new supported import path, add it here in the same PR;
+# if docs intentionally remove one, remove it here with the docs change.
+# ---------------------------------------------------------------------------
+
+
+_DOCUMENTED_PUBLIC_IMPORTS = {
+    "notebooklm": [
+        "ArtifactType",
+        "AudioFormat",
+        "AudioLength",
+        "AuthTokens",
+        "ChatGoal",
+        "ChatResponseLength",
+        "ConnectionLimits",
+        "correlation_id",
+        "ExportType",
+        "NonIdempotentRetryError",
+        "NotebookLMClient",
+        "QuizDifficulty",
+        "QuizQuantity",
+        "ReportFormat",
+        "RPCError",
+        "SharePermission",
+        "ShareViewLevel",
+        "SourceType",
+        "VideoFormat",
+        "VideoStyle",
+    ],
+    "notebooklm.auth": [
+        "AuthTokens",
+        "convert_rookiepy_cookies_to_storage_state",
+        "OPTIONAL_COOKIE_DOMAINS",
+        "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+        "REQUIRED_COOKIE_DOMAINS",
+    ],
+    "notebooklm.config": [
+        "DEFAULT_BASE_URL",
+        "get_base_url",
+    ],
+    "notebooklm.log": [
+        "install_redaction",
+    ],
+    "notebooklm.research": [
+        "extract_report_urls",
+        "normalize_url",
+        "select_cited_sources",
+    ],
+    "notebooklm.rpc": [
+        "RPCMethod",
+    ],
+    "notebooklm.types": [
+        "ConnectionLimits",
+    ],
+    "notebooklm.urls": [
+        "is_google_auth_redirect",
+        "is_youtube_url",
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    ("module_name", "public_name"),
+    [
+        pytest.param(module_name, public_name, id=f"{module_name}:{public_name}")
+        for module_name, public_names in _DOCUMENTED_PUBLIC_IMPORTS.items()
+        for public_name in public_names
+    ],
+)
+def test_documented_public_import_manifest_resolves(
+    module_name: str,
+    public_name: str,
+) -> None:
+    """Every documented public import from PR-T1 must remain importable."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        module = __import__(module_name, fromlist=[public_name])
+
+    sentinel = object()
+    assert getattr(module, public_name, sentinel) is not sentinel
+
+
+def test_public_import_manifest_has_no_duplicates() -> None:
+    """The manifest should stay reviewable and deterministic."""
+    for module_name, public_names in _DOCUMENTED_PUBLIC_IMPORTS.items():
+        assert public_names == sorted(public_names, key=str.lower), (
+            f"{module_name} manifest entries must be sorted case-insensitively"
+        )
+        assert len(public_names) == len(set(public_names)), (
+            f"{module_name} manifest contains duplicate entries"
+        )
+
+
+def test_public_facade_imports_are_identity_reexports() -> None:
+    """Compatibility facades must keep returning the canonical public objects."""
+    import notebooklm
+    import notebooklm.auth as public_auth
+    import notebooklm.rpc as public_rpc
+    import notebooklm.rpc.types as rpc_types
+    import notebooklm.types as public_types
+
+    assert notebooklm.AuthTokens is public_auth.AuthTokens
+    assert notebooklm.ConnectionLimits is public_types.ConnectionLimits
+    assert public_rpc.RPCMethod is rpc_types.RPCMethod
 
 # ---------------------------------------------------------------------------
 # PR-A section: notebooklm.research public surface


### PR DESCRIPTION
## Summary
- Add a documented public import manifest for the PR #646 API contract.
- Keep auth/types facade compatibility covered by identity checks.
- Add CLI/core boundary guardrail documentation and a pending core-private-state baseline guard that blocks new direct feature access without failing current pre-migration call sites.

## Task
Phase 1 Wave 2: t2-boundary-guardrails from .sisyphus/phases/architecture-remediation/phase-1.md.

## Test plan
- [x] rtk uv run pytest tests/unit/test_cli_boundary.py tests/unit/test_public_shims.py tests/unit/test_init_order.py tests/unit/test_api_coverage.py
- [x] rtk uv run ruff check docs src/notebooklm tests/unit/test_public_shims.py tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_types.py tests/unit/test_rpc_types.py tests/unit/test_api_coverage.py
- [x] rtk uv run mypy src/notebooklm

## Deferred polish findings
- Optional: broaden root facade identity checks as future public imports are added.
- Expected follow-up: shrink the core-private-state baseline during later capability migration tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Boundary Guardrails" section explaining how architecture tests enforce public/CLI boundary contracts and guidance for updating supported public import paths.

* **Tests**
  * Added regression guards to detect new direct accesses to private/internal core state from feature modules (including aliasing patterns).
  * Added a deterministic public-import manifest and tests to verify public import stability, ordering, and selected facade re-exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->