### PR TITLE
test(auth): guard auth facade compatibility

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -93,6 +93,11 @@ The architecture tests encode the current layer contract:
   names exposed by public modules. Promote needed symbols through a public
   facade (`notebooklm.types`, `notebooklm.auth`, `notebooklm.research`, etc.)
   before using them from the CLI.
+- Auth internals may move under `notebooklm._auth` during architecture work,
+  but first-party callers continue to import through `notebooklm.auth`. The
+  compatibility manifest in `tests/unit/test_public_shims.py` enforces the
+  current first-party surface for that move; it is not a broader public API
+  decision, and removing a listed name needs a separate deprecation plan.
 - `tests/unit/test_init_order.py` records the temporary baseline of feature
   APIs that still access `ClientCore` private state directly. Future capability
   migration PRs should reduce that baseline as private state moves behind

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -147,6 +147,7 @@ def test_no_private_module_imports_in_cli():
         ),
         ("import notebooklm._auth.tokens", "import notebooklm._auth.tokens"),
         ("from .._auth.tokens import AuthTokens", "from .._auth.tokens import ..."),
+        ("from .. import _auth", "from .. import _auth"),
     ],
 )
 def test_cli_boundary_blocks_auth_internal_import_shapes(source: str, expected: str) -> None:

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 import ast
 import pathlib
 
+import pytest
+
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
 
 
@@ -134,3 +136,16 @@ def test_no_private_module_imports_in_cli():
         "Promote needed symbols to a public module (config/urls/log/research/types) "
         f"and import from there.\nOffenders: {offenders}"
     )
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("from notebooklm._auth.tokens import AuthTokens", "from notebooklm._auth.tokens import ..."),
+        ("import notebooklm._auth.tokens", "import notebooklm._auth.tokens"),
+        ("from .._auth.tokens import AuthTokens", "from .._auth.tokens import ..."),
+    ],
+)
+def test_cli_boundary_blocks_auth_internal_import_shapes(source: str, expected: str) -> None:
+    """CLI auth imports must stay on notebooklm.auth, even if internals move to _auth."""
+    assert expected in _violations(ast.parse(source))

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -141,7 +141,10 @@ def test_no_private_module_imports_in_cli():
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
-        ("from notebooklm._auth.tokens import AuthTokens", "from notebooklm._auth.tokens import ..."),
+        (
+            "from notebooklm._auth.tokens import AuthTokens",
+            "from notebooklm._auth.tokens import ...",
+        ),
         ("import notebooklm._auth.tokens", "import notebooklm._auth.tokens"),
         ("from .._auth.tokens import AuthTokens", "from .._auth.tokens import ..."),
     ],

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -324,6 +324,86 @@ def test_auth_cookie_domain_constants_are_facade_exports() -> None:
     assert frozenset().union(*OPTIONAL_COOKIE_DOMAINS_BY_LABEL.values()) == OPTIONAL_COOKIE_DOMAINS
 
 
+# ---------------------------------------------------------------------------
+# PR-T3A section: notebooklm.auth first-party compatibility surface
+#
+# This is narrower than a future public API decision. It only freezes the names
+# that current first-party modules, CLI code, tests, and docs may rely on while
+# Phase 2 is free to move auth internals underneath ``notebooklm._auth``.
+# Removing one of these names from ``notebooklm.auth`` requires a separate
+# deprecation/migration plan, not an internal-module move PR.
+# ---------------------------------------------------------------------------
+
+
+_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES = [
+    "_auth_domain_priority",
+    "_find_cookie_for_storage",
+    "_is_allowed_auth_domain",
+    "_is_allowed_cookie_domain",
+    "_is_google_domain",
+    "_rotate_cookies",
+    "_run_refresh_cmd",
+    "_split_refresh_cmd",
+    "_update_cookie_input",
+    "Account",
+    "advance_cookie_snapshot_after_save",
+    "ALLOWED_COOKIE_DOMAINS",
+    "authuser_query",
+    "AuthTokens",
+    "build_cookie_jar",
+    "build_httpx_cookies_from_storage",
+    "clear_account_metadata",
+    "convert_rookiepy_cookies_to_storage_state",
+    "CookieSaveResult",
+    "CookieSnapshot",
+    "CookieSnapshotKey",
+    "CookieSnapshotValue",
+    "enumerate_accounts",
+    "extract_cookies_from_storage",
+    "extract_cookies_with_domains",
+    "extract_csrf_from_html",
+    "extract_email_from_html",
+    "extract_session_id_from_html",
+    "extract_wiz_field",
+    "fetch_tokens",
+    "fetch_tokens_with_domains",
+    "format_authuser_value",
+    "get_account_email_for_storage",
+    "get_authuser_for_storage",
+    "GOOGLE_REGIONAL_CCTLDS",
+    "KEEPALIVE_ROTATE_URL",
+    "load_auth_from_storage",
+    "load_httpx_cookies",
+    "MINIMUM_REQUIRED_COOKIES",
+    "normalize_cookie_map",
+    "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
+    "NOTEBOOKLM_REFRESH_CMD_ENV",
+    "NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
+    "OPTIONAL_COOKIE_DOMAINS",
+    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+    "read_account_metadata",
+    "REQUIRED_COOKIE_DOMAINS",
+    "save_cookies_to_storage",
+    "snapshot_cookie_jar",
+    "write_account_metadata",
+]
+
+
+@pytest.mark.parametrize("name", _AUTH_FIRST_PARTY_COMPATIBILITY_NAMES)
+def test_auth_first_party_compatibility_manifest_resolves(name: str) -> None:
+    """Phase 2 internals may move, but first-party callers keep notebooklm.auth."""
+    import notebooklm.auth as auth
+
+    assert hasattr(auth, name), f"notebooklm.auth.{name} disappeared"
+
+
+def test_auth_first_party_compatibility_manifest_has_no_duplicates() -> None:
+    """The enforced compatibility manifest should stay reviewable."""
+    assert len(_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES) == len(
+        set(_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES)
+    )
+
+
 @pytest.mark.asyncio
 async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
     """NotebookLMClient.rpc_call is a public delegator to ClientCore.rpc_call."""

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -332,6 +332,12 @@ def test_auth_cookie_domain_constants_are_facade_exports() -> None:
 # Phase 2 is free to move auth internals underneath ``notebooklm._auth``.
 # Removing one of these names from ``notebooklm.auth`` requires a separate
 # deprecation/migration plan, not an internal-module move PR.
+#
+# Underscored entries are compatibility-only for non-CLI first-party callers;
+# the CLI boundary test still forbids CLI modules from importing private names
+# out of ``notebooklm.auth``. Other auth names, such as ``flatten_cookie_map``,
+# are intentionally outside this enforced move-safety manifest unless added by
+# a separate public or first-party compatibility decision.
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Add a first-party compatibility manifest for names that must remain available from `notebooklm.auth` during Phase 2 auth internals work.
- Add an explicit CLI boundary regression blocking future `notebooklm._auth.*` imports from CLI modules.
- Document that auth internals may move under `_auth`, while callers keep using `notebooklm.auth` unless a deprecation plan exists.

## Task
Phase 2 Wave 1: `.sisyphus/phases/architecture-remediation/phase-2.md` task `t3a-auth-facade-manifest`.

## Test plan
- [x] `uv run pytest tests/unit/test_public_shims.py tests/unit/test_auth.py tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_api_coverage.py`
- [x] `uv run ruff check docs/development.md src/notebooklm/auth.py tests/unit/test_public_shims.py tests/unit/test_auth.py tests/unit/test_cli_boundary.py`
- [x] `uv run mypy src/notebooklm`

## Deferred polish findings
- External Claude CLI pre-PR lens did not return within a bounded wait; the required GitHub `@claude` review is requested on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified architecture guidance for authentication: internal reorganizations are allowed while public import paths must remain stable; removals require a deprecation plan.

* **Tests**
  * Added boundary tests that block direct imports of internal authentication components.
  * Added compatibility tests that verify the public authentication surface and check for duplicate entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->