### PR TITLE
refactor(auth): move cookie policy internals

### DIFF
--- a/src/notebooklm/_auth/__init__.py
+++ b/src/notebooklm/_auth/__init__.py
@@ -1,0 +1,1 @@
+"""Private authentication implementation package."""

--- a/src/notebooklm/_auth/cookie_policy.py
+++ b/src/notebooklm/_auth/cookie_policy.py
@@ -1,0 +1,440 @@
+"""Cookie-domain policy and required-cookie validation for authentication."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("notebooklm.auth")
+
+# Tier 1: cookies whose absence Google rejects deterministically.
+#
+# - ``SID``: only individually-required cookie (singleton ablation).
+# - ``__Secure-1PSIDTS``: directly accepted by Google's homepage check, OR
+#   recoverable via the RotateCookies POST when other auth cookies are intact.
+#   When neither path is viable the homepage GET 302s to login.
+#
+# See ``docs/auth-keepalive.md`` §3.5 for the ablation methodology and the full
+# 16-pair failure table backing this set.
+MINIMUM_REQUIRED_COOKIES = {"SID", "__Secure-1PSIDTS"}
+
+
+_EXTRACTION_HINT = (
+    "This typically means --browser-cookies extraction was incomplete "
+    "(Chrome 127+ App-Bound Encryption can cause silent partial reads). "
+    "Run 'notebooklm login' to re-authenticate."
+)
+
+# Tier 2 fires per cookie-load; a single CLI run can hit it 2-3 times across
+# the four loader entry points. One warning per process is enough signal.
+#
+# Dedupe contract (T7.G7): best-effort under threads, exactly-once on a single
+# event loop. The check-then-set at the call site (``_validate_required_cookies``
+# below) reads ``_SECONDARY_BINDING_WARNED`` and sets it to ``True`` in a single
+# synchronous block with no intervening ``await``. The asyncio scheduler can
+# only switch coroutines at ``await`` points, so concurrent coroutines on one
+# loop cannot interleave between the check and the set — the warning fires
+# exactly once per process. Under genuine OS threads (which this library does
+# NOT support per the documented concurrency contract — each client is bound
+# to one event loop), the pattern is racy: two threads can both observe
+# ``False`` before either has written ``True``, causing a duplicate warning.
+# We accept that as best-effort rather than introduce an ``asyncio.Lock``
+# (would not help threads) or a ``threading.Lock`` (re-architects for a use
+# case we don't support).
+#
+# Note: ``functools.lru_cache`` and ``logging.LoggerAdapter`` are sometimes
+# suggested as drop-in dedupe primitives here. They are NOT: ``lru_cache``
+# memoizes return values, not the side-effect of ``logger.warning``;
+# ``LoggerAdapter`` only rewrites records, it does not filter duplicates.
+_SECONDARY_BINDING_WARNED = False
+
+
+def _has_valid_secondary_binding(cookie_names: set[str]) -> bool:
+    """Tier 2 acceptance check (see ``MINIMUM_REQUIRED_COOKIES``).
+
+    Pair-wise ablation against a live Google session reveals that the
+    NotebookLM homepage GET requires *at least one* of two redundant
+    secondary-binding paths in addition to Tier 1:
+
+    - ``OSID`` (recent-sign-in binding), OR
+    - both ``APISID`` AND ``SAPISID`` (legacy XSSI binding pair).
+
+    Without either, Google 302s to ``accounts.google.com/v3/signin`` even when
+    ``SID`` and ``__Secure-1PSIDTS`` are present and otherwise valid.
+    """
+    if "OSID" in cookie_names:
+        return True
+    return {"APISID", "SAPISID"} <= cookie_names
+
+
+def _validate_required_cookies(
+    cookie_names: set[str],
+    *,
+    context: str = "",
+    extra_diagnostics: list[str] | None = None,
+) -> None:
+    """Enforce the Tier 1 cookie-set rule (raise) and warn on Tier 2 violation.
+
+    Hybrid rollout: Tier 1 (``MINIMUM_REQUIRED_COOKIES``) is a hard requirement
+    because its ablation evidence is unambiguous — Google rejects deterministically
+    and there is no recovery path inside the library. Tier 2 (secondary binding,
+    see ``_has_valid_secondary_binding``) is logged as a warning so partial
+    extractions surface in user logs without breaking edge-case auth flows we
+    haven't ablated yet (e.g. Workspace SSO). After one release of telemetry
+    this can be promoted to a hard raise.
+
+    Args:
+        cookie_names: Names of cookies present in the loaded set (any domain).
+        context: Optional suffix for the Tier 1 error message
+            (e.g. ``" for downloads"``).
+        extra_diagnostics: Optional extra lines inserted into the Tier 1 error
+            (e.g. observed cookies, source domains) for friendlier diagnosis.
+    """
+    missing = MINIMUM_REQUIRED_COOKIES - cookie_names
+    if missing:
+        missing_names = ", ".join(sorted(missing))
+        parts = [f"Missing required cookies{context}: {missing_names}"]
+        if extra_diagnostics:
+            parts.extend(extra_diagnostics)
+        parts.append(_EXTRACTION_HINT)
+        raise ValueError("\n".join(parts))
+
+    if not _has_valid_secondary_binding(cookie_names):
+        global _SECONDARY_BINDING_WARNED
+        if not _SECONDARY_BINDING_WARNED:
+            _SECONDARY_BINDING_WARNED = True
+            logger.warning(
+                "Cookie set lacks a secondary binding (need OSID, or both APISID "
+                "and SAPISID). Google may reject auth on the next call. %s",
+                _EXTRACTION_HINT,
+            )
+
+
+# Cookie domains we extract / accept by default.
+#
+# Empirical justification (T5.G): traced cassettes
+# (``tests/cassettes/*.yaml``) and the live auth-refresh path. Only the
+# following domains are actually exercised during login + token refresh +
+# source-add + chat-ask flows:
+#   - ``notebooklm.google.com`` (the API host — all CLI RPCs land here)
+#   - ``.google.com`` (carries ``SID``/``HSID``/``SSID``/etc.)
+#   - ``accounts.google.com`` (token refresh + ``RotateCookies`` endpoint at
+#     :data:`KEEPALIVE_ROTATE_URL`)
+#   - ``.googleusercontent.com`` (authenticated media downloads — audio /
+#     infographic / slide assets)
+#   - ``drive.google.com`` (Drive-source ingest follows redirects through
+#     here; kept in REQUIRED for source-add safety)
+#
+# YouTube / Docs / Mail / myaccount cookies do NOT appear in any traced
+# flow. They are now :data:`OPTIONAL_COOKIE_DOMAINS` — opted in via
+# ``notebooklm login --include-domains=...``. This narrows the blast
+# radius if ``storage_state.json`` is ever leaked (synthesis K15).
+#
+# REQUIRED is also fed verbatim to ``rookiepy.load(domains=...)`` by
+# ``_login_with_browser_cookies`` (via
+# :func:`notebooklm.cli.session._build_google_cookie_domains`); adding a
+# domain here automatically extends what we ask the browser for at login.
+# This is the single load-bearing T5.G control: blast-radius reduction
+# is enforced at extraction time (what rookiepy returns), not at the
+# runtime gate, which stays permissive over the REQUIRED ∪ OPTIONAL
+# union so that ``--include-domains=...`` cookies survive downstream
+# filters (see :func:`_is_allowed_cookie_domain`).
+REQUIRED_COOKIE_DOMAINS: frozenset[str] = frozenset(
+    {
+        ".google.com",
+        "google.com",  # Host-only Domain=google.com cookies (rare but possible)
+        # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
+        ".notebooklm.google.com",
+        "notebooklm.google.com",
+        ".notebooklm.cloud.google.com",
+        "notebooklm.cloud.google.com",
+        ".googleusercontent.com",
+        "accounts.google.com",  # Required for token refresh + RotateCookies
+        ".accounts.google.com",  # http.cookiejar may normalize Domain=accounts.google.com
+        # Drive-source ingest follows redirects through drive.google.com.
+        # Both dotted and non-dotted variants are listed so that
+        # http.cookiejar normalization (which can add a leading dot) doesn't
+        # drop a cookie at the next extraction; same defensive pattern as
+        # accounts.google.com above.
+        "drive.google.com",
+        ".drive.google.com",
+    }
+)
+
+# Sibling Google product domains — NOT exercised by any current code path
+# but historically extracted "for symmetry with a logged-in browser session"
+# (issue #360). Now opt-in via ``--include-domains=...`` to reduce
+# storage_state.json blast radius. The keys here (``youtube``, ``docs``,
+# ``myaccount``, ``mail``) are also the labels accepted by ``--include-domains``.
+#
+# Both dotted and non-dotted variants are listed so that http.cookiejar
+# normalization (which can add a leading dot) doesn't drop a cookie at the
+# next extraction.
+OPTIONAL_COOKIE_DOMAINS_BY_LABEL: dict[str, frozenset[str]] = {
+    "youtube": frozenset(
+        {
+            ".youtube.com",
+            "youtube.com",
+            "accounts.youtube.com",
+            ".accounts.youtube.com",
+        }
+    ),
+    "docs": frozenset({"docs.google.com", ".docs.google.com"}),
+    "myaccount": frozenset({"myaccount.google.com", ".myaccount.google.com"}),
+    "mail": frozenset({"mail.google.com", ".mail.google.com"}),
+}
+
+OPTIONAL_COOKIE_DOMAINS: frozenset[str] = frozenset().union(
+    *OPTIONAL_COOKIE_DOMAINS_BY_LABEL.values()
+)
+
+# Backward-compatible union — preserves the old constant name so external
+# imports keep working. Internal code should prefer ``REQUIRED_*`` /
+# ``OPTIONAL_*`` so the security tier is explicit at the call site.
+ALLOWED_COOKIE_DOMAINS: frozenset[str] = REQUIRED_COOKIE_DOMAINS | OPTIONAL_COOKIE_DOMAINS
+
+# Regional Google ccTLDs where Google may set auth cookies
+# Users in these regions may have SID cookies on regional domains instead of .google.com
+# Format: suffix after ".google." (e.g., "com.sg" for ".google.com.sg")
+#
+# Categories:
+# - com.XX: Country-code second-level domains (Singapore, Australia, Brazil, etc.)
+# - co.XX: Country domains using .co (UK, Japan, India, Korea, etc.)
+# - XX: Single ccTLD countries (Germany, France, Italy, etc.)
+GOOGLE_REGIONAL_CCTLDS = frozenset(
+    {
+        # .google.com.XX pattern (country-code second-level domains)
+        "com.sg",  # Singapore
+        "com.au",  # Australia
+        "com.br",  # Brazil
+        "com.mx",  # Mexico
+        "com.ar",  # Argentina
+        "com.hk",  # Hong Kong
+        "com.tw",  # Taiwan
+        "com.my",  # Malaysia
+        "com.ph",  # Philippines
+        "com.vn",  # Vietnam
+        "com.pk",  # Pakistan
+        "com.bd",  # Bangladesh
+        "com.ng",  # Nigeria
+        "com.eg",  # Egypt
+        "com.tr",  # Turkey
+        "com.ua",  # Ukraine
+        "com.co",  # Colombia
+        "com.pe",  # Peru
+        "com.sa",  # Saudi Arabia
+        "com.ae",  # UAE
+        # .google.co.XX pattern (countries using .co second-level)
+        "co.uk",  # United Kingdom
+        "co.jp",  # Japan
+        "co.in",  # India
+        "co.kr",  # South Korea
+        "co.za",  # South Africa
+        "co.nz",  # New Zealand
+        "co.id",  # Indonesia
+        "co.th",  # Thailand
+        "co.il",  # Israel
+        "co.ve",  # Venezuela
+        "co.cr",  # Costa Rica
+        "co.ke",  # Kenya
+        "co.ug",  # Uganda
+        "co.tz",  # Tanzania
+        "co.ma",  # Morocco
+        "co.ao",  # Angola
+        "co.mz",  # Mozambique
+        "co.zw",  # Zimbabwe
+        "co.bw",  # Botswana
+        # .google.XX pattern (single ccTLD countries)
+        "cn",  # China
+        "de",  # Germany
+        "fr",  # France
+        "it",  # Italy
+        "es",  # Spain
+        "nl",  # Netherlands
+        "pl",  # Poland
+        "ru",  # Russia
+        "ca",  # Canada
+        "be",  # Belgium
+        "at",  # Austria
+        "ch",  # Switzerland
+        "se",  # Sweden
+        "no",  # Norway
+        "dk",  # Denmark
+        "fi",  # Finland
+        "pt",  # Portugal
+        "gr",  # Greece
+        "cz",  # Czech Republic
+        "ro",  # Romania
+        "hu",  # Hungary
+        "ie",  # Ireland
+        "sk",  # Slovakia
+        "bg",  # Bulgaria
+        "hr",  # Croatia
+        "si",  # Slovenia
+        "lt",  # Lithuania
+        "lv",  # Latvia
+        "ee",  # Estonia
+        "lu",  # Luxembourg
+        "cl",  # Chile
+        "cat",  # Catalonia (special case - 3 letter)
+    }
+)
+
+
+def _is_google_domain(domain: str) -> bool:
+    """Check if a cookie domain is a valid Google domain.
+
+    Uses a whitelist approach to validate Google domains including:
+    - Base domain: .google.com
+    - Regional .google.com.XX: .google.com.sg, .google.com.au, etc.
+    - Regional .google.co.XX: .google.co.uk, .google.co.jp, etc.
+    - Regional .google.XX: .google.de, .google.fr, etc.
+
+    This function is used by both auth cookie extraction and download cookie
+    validation to ensure consistent domain handling across the codebase.
+
+    Args:
+        domain: Cookie domain to check (e.g., '.google.com', '.google.com.sg')
+
+    Returns:
+        True if domain is a valid Google domain.
+
+    Note:
+        Uses an explicit whitelist (GOOGLE_REGIONAL_CCTLDS) rather than regex
+        to prevent false positives from invalid or malicious domains.
+    """
+    # Base Google domain
+    if domain == ".google.com":
+        return True
+
+    # Check regional Google domains using whitelist
+    if domain.startswith(".google."):
+        suffix = domain[8:]  # Remove ".google." prefix
+        return suffix in GOOGLE_REGIONAL_CCTLDS
+
+    return False
+
+
+def _is_allowed_auth_domain(domain: str) -> bool:
+    """Check if a cookie domain is allowed for auth cookie extraction.
+
+    Thin alias of :func:`_is_allowed_cookie_domain`. Both auth-jar building
+    and download-cookie loading (and the persistence path that filters which
+    cookies get saved back) share a single allowlist policy:
+
+    1. Exact match against :data:`REQUIRED_COOKIE_DOMAINS` (covers the API
+       host, ``.google.com`` / ``accounts.google.com`` /
+       ``.googleusercontent.com`` / ``drive.google.com``, and the
+       leading-dot variants ``http.cookiejar`` may normalize to).
+    2. Regional Google ccTLDs (``.google.com.sg``, ``.google.co.uk``,
+       ``.google.de``, …) where SID cookies may be set for users in those
+       regions.
+    3. Suffix matches for Google subdomains (``lh3.google.com``,
+       ``accounts.google.com``) and ``.googleusercontent.com`` /
+       ``.usercontent.google.com`` for authenticated media downloads.
+
+    The previous strict / broad split (#334 / fea8315) created an asymmetry
+    where ``save_cookies_to_storage`` would persist cookies that the next
+    extraction would silently drop. Issue #360 collapsed both filters into
+    this single policy. T5.G narrows the *extraction* surface (rookiepy
+    only requests :data:`REQUIRED_COOKIE_DOMAINS` by default, so YouTube
+    cookies are never written to ``storage_state.json`` unless the user
+    opts in via ``--include-domains=youtube``); the runtime gate stays
+    permissive over the full :data:`ALLOWED_COOKIE_DOMAINS` union so that
+    opted-in cookies survive the downstream filters.
+
+    Args:
+        domain: Cookie domain to check (e.g., '.google.com', '.google.com.sg')
+
+    Returns:
+        True if domain is allowed for auth/download cookies.
+    """
+    return _is_allowed_cookie_domain(domain)
+
+
+def _auth_domain_priority(domain: str) -> int:
+    """Return duplicate-cookie priority for allowed auth domains.
+
+    Higher value wins. Tiers are distinct so the resolved cookie is fully
+    deterministic regardless of storage_state ordering.
+    """
+    if domain == ".google.com":
+        return 4
+    if domain == ".notebooklm.google.com":
+        return 3
+    if domain == "notebooklm.google.com":
+        return 2
+    if domain == ".notebooklm.cloud.google.com":
+        return 3
+    if domain == "notebooklm.cloud.google.com":
+        return 2
+    if _is_google_domain(domain):
+        return 1
+    # Allowlisted but unranked domains (e.g. .googleusercontent.com) fall through.
+    return 0
+
+
+def _is_allowed_cookie_domain(domain: str) -> bool:
+    """Canonical cookie-domain allowlist for both auth and downloads.
+
+    Single source of truth for "is this cookie domain one we accept at
+    runtime?". Both the auth-extraction path and the download path go
+    through here — :func:`_is_allowed_auth_domain` is a thin alias
+    preserved for call-site readability. See issue #360 for why the split
+    was collapsed.
+
+    A domain is allowed if any of the following holds:
+
+    1. Exact match against :data:`REQUIRED_COOKIE_DOMAINS` (the API host,
+       ``.google.com``, ``accounts.google.com``, ``.googleusercontent.com``,
+       ``drive.google.com``, and the leading-dot variants ``http.cookiejar``
+       may normalize to).
+    2. Valid Google domain via :func:`_is_google_domain` (regional ccTLDs:
+       ``.google.com.sg``, ``.google.co.uk``, ``.google.de``, …).
+    3. Subdomain of ``.google.com``, ``.googleusercontent.com``, or
+       ``.usercontent.google.com`` (e.g. ``lh3.google.com``,
+       ``lh3.googleusercontent.com``).
+
+    The leading-dot suffix check ensures lookalikes like ``evil-google.com``
+    are rejected.
+
+    Note (T5.G): the runtime gate consults the
+    :data:`ALLOWED_COOKIE_DOMAINS` union (REQUIRED ∪ OPTIONAL). The
+    blast-radius reduction is enforced at **extraction time** —
+    ``_build_google_cookie_domains`` defaults to
+    :data:`REQUIRED_COOKIE_DOMAINS` only, so rookiepy never returns
+    sibling-product cookies (e.g. ``.youtube.com``) unless the user
+    opts in via ``--include-domains=...``. The runtime gate must stay
+    permissive over the full union so that opted-in cookies survive
+    the downstream filters in :func:`convert_rookiepy_cookies_to_storage_state`,
+    :func:`extract_cookies_with_domains`, and
+    :func:`build_httpx_cookies_from_storage`.
+
+    Args:
+        domain: Cookie domain to check (e.g., '.google.com', 'lh3.google.com')
+
+    Returns:
+        True if domain is allowed for auth/download cookies.
+    """
+    # Exact match against the union of REQUIRED + OPTIONAL. Anything that
+    # could have been validly opted in via ``--include-domains`` at
+    # extraction time must pass this gate at runtime (T5.G).
+    if domain in ALLOWED_COOKIE_DOMAINS:
+        return True
+
+    # Check if it's a valid Google domain (base or regional)
+    # This handles .google.com, .google.com.sg, .google.co.uk, .google.de, etc.
+    if _is_google_domain(domain):
+        return True
+
+    # Suffixes for allowed download domains (leading dot provides boundary check)
+    # - Subdomains of .google.com (e.g., lh3.google.com, accounts.google.com)
+    # - googleusercontent.com domains for media downloads
+    allowed_suffixes = (
+        ".google.com",
+        ".googleusercontent.com",
+        ".usercontent.google.com",
+    )
+
+    # Check if domain is a subdomain of allowed suffixes
+    # The leading dot ensures 'evil-google.com' does NOT match
+    return any(domain.endswith(suffix) for suffix in allowed_suffixes)

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -46,6 +46,7 @@ from collections.abc import Iterator
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 from typing import Any, NamedTuple, TypeAlias
 from urllib.parse import urlencode
 
@@ -53,6 +54,7 @@ import httpx
 from filelock import FileLock
 
 from ._atomic_io import atomic_update_json, atomic_write_json
+from ._auth import cookie_policy as _cookie_policy
 from ._env import get_base_url
 from ._url_utils import contains_google_auth_redirect, is_google_auth_redirect
 from .exceptions import AuthExtractionError
@@ -115,64 +117,37 @@ class CookieSaveResult:
     cas_rejected_keys: frozenset[CookieSnapshotKey] = frozenset()
 
 
-# Tier 1: cookies whose absence Google rejects deterministically.
-#
-# - ``SID``: only individually-required cookie (singleton ablation).
-# - ``__Secure-1PSIDTS``: directly accepted by Google's homepage check, OR
-#   recoverable via the RotateCookies POST when other auth cookies are intact.
-#   When neither path is viable the homepage GET 302s to login.
-#
-# See ``docs/auth-keepalive.md`` §3.5 for the ablation methodology and the full
-# 16-pair failure table backing this set.
-MINIMUM_REQUIRED_COOKIES = {"SID", "__Secure-1PSIDTS"}
+REQUIRED_COOKIE_DOMAINS = _cookie_policy.REQUIRED_COOKIE_DOMAINS
+OPTIONAL_COOKIE_DOMAINS_BY_LABEL = _cookie_policy.OPTIONAL_COOKIE_DOMAINS_BY_LABEL
+OPTIONAL_COOKIE_DOMAINS = _cookie_policy.OPTIONAL_COOKIE_DOMAINS
+ALLOWED_COOKIE_DOMAINS = _cookie_policy.ALLOWED_COOKIE_DOMAINS
+GOOGLE_REGIONAL_CCTLDS = _cookie_policy.GOOGLE_REGIONAL_CCTLDS
+MINIMUM_REQUIRED_COOKIES = _cookie_policy.MINIMUM_REQUIRED_COOKIES
+_EXTRACTION_HINT = _cookie_policy._EXTRACTION_HINT
+_SECONDARY_BINDING_WARNED = _cookie_policy._SECONDARY_BINDING_WARNED
+_has_valid_secondary_binding = _cookie_policy._has_valid_secondary_binding
+_auth_domain_priority = _cookie_policy._auth_domain_priority
+_is_google_domain = _cookie_policy._is_google_domain
+_is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
+_is_allowed_cookie_domain = _cookie_policy._is_allowed_cookie_domain
 
 
-_EXTRACTION_HINT = (
-    "This typically means --browser-cookies extraction was incomplete "
-    "(Chrome 127+ App-Bound Encryption can cause silent partial reads). "
-    "Run 'notebooklm login' to re-authenticate."
-)
+class _AuthFacadeModule(ModuleType):
+    """Keep compatibility assignments to auth globals meaningful after moves."""
 
-# Tier 2 fires per cookie-load; a single CLI run can hit it 2-3 times across
-# the four loader entry points. One warning per process is enough signal.
-#
-# Dedupe contract (T7.G7): best-effort under threads, exactly-once on a single
-# event loop. The check-then-set at the call site (``_validate_required_cookies``
-# below) reads ``_SECONDARY_BINDING_WARNED`` and sets it to ``True`` in a single
-# synchronous block with no intervening ``await``. The asyncio scheduler can
-# only switch coroutines at ``await`` points, so concurrent coroutines on one
-# loop cannot interleave between the check and the set — the warning fires
-# exactly once per process. Under genuine OS threads (which this library does
-# NOT support per the documented concurrency contract — each client is bound
-# to one event loop), the pattern is racy: two threads can both observe
-# ``False`` before either has written ``True``, causing a duplicate warning.
-# We accept that as best-effort rather than introduce an ``asyncio.Lock``
-# (would not help threads) or a ``threading.Lock`` (re-architects for a use
-# case we don't support).
-#
-# Note: ``functools.lru_cache`` and ``logging.LoggerAdapter`` are sometimes
-# suggested as drop-in dedupe primitives here. They are NOT: ``lru_cache``
-# memoizes return values, not the side-effect of ``logger.warning``;
-# ``LoggerAdapter`` only rewrites records, it does not filter duplicates.
-_SECONDARY_BINDING_WARNED = False
+    def __setattr__(self, name: str, value: Any) -> None:
+        super().__setattr__(name, value)
+        if name == "_SECONDARY_BINDING_WARNED":
+            _cookie_policy._SECONDARY_BINDING_WARNED = bool(value)
+        elif name in {
+            "MINIMUM_REQUIRED_COOKIES",
+            "_EXTRACTION_HINT",
+            "_has_valid_secondary_binding",
+        }:
+            setattr(_cookie_policy, name, value)
 
 
-def _has_valid_secondary_binding(cookie_names: set[str]) -> bool:
-    """Tier 2 acceptance check (see ``MINIMUM_REQUIRED_COOKIES``).
-
-    Pair-wise ablation against a live Google session reveals that the
-    NotebookLM homepage GET requires *at least one* of two redundant
-    secondary-binding paths in addition to Tier 1:
-
-    - ``OSID`` (recent-sign-in binding), OR
-    - both ``APISID`` AND ``SAPISID`` (legacy XSSI binding pair).
-
-    Without either, Google 302s to ``accounts.google.com/v3/signin`` even when
-    ``SID`` and ``__Secure-1PSIDTS`` are present and otherwise valid.
-    """
-    if "OSID" in cookie_names:
-        return True
-    return {"APISID", "SAPISID"} <= cookie_names
+sys.modules[__name__].__class__ = _AuthFacadeModule
 
 
 def _validate_required_cookies(
@@ -181,212 +156,19 @@ def _validate_required_cookies(
     context: str = "",
     extra_diagnostics: list[str] | None = None,
 ) -> None:
-    """Enforce the Tier 1 cookie-set rule (raise) and warn on Tier 2 violation.
-
-    Hybrid rollout: Tier 1 (``MINIMUM_REQUIRED_COOKIES``) is a hard requirement
-    because its ablation evidence is unambiguous — Google rejects deterministically
-    and there is no recovery path inside the library. Tier 2 (secondary binding,
-    see ``_has_valid_secondary_binding``) is logged as a warning so partial
-    extractions surface in user logs without breaking edge-case auth flows we
-    haven't ablated yet (e.g. Workspace SSO). After one release of telemetry
-    this can be promoted to a hard raise.
-
-    Args:
-        cookie_names: Names of cookies present in the loaded set (any domain).
-        context: Optional suffix for the Tier 1 error message
-            (e.g. ``" for downloads"``).
-        extra_diagnostics: Optional extra lines inserted into the Tier 1 error
-            (e.g. observed cookies, source domains) for friendlier diagnosis.
-    """
-    missing = MINIMUM_REQUIRED_COOKIES - cookie_names
-    if missing:
-        missing_names = ", ".join(sorted(missing))
-        parts = [f"Missing required cookies{context}: {missing_names}"]
-        if extra_diagnostics:
-            parts.extend(extra_diagnostics)
-        parts.append(_EXTRACTION_HINT)
-        raise ValueError("\n".join(parts))
-
-    if not _has_valid_secondary_binding(cookie_names):
-        global _SECONDARY_BINDING_WARNED
-        if not _SECONDARY_BINDING_WARNED:
-            _SECONDARY_BINDING_WARNED = True
-            logger.warning(
-                "Cookie set lacks a secondary binding (need OSID, or both APISID "
-                "and SAPISID). Google may reject auth on the next call. %s",
-                _EXTRACTION_HINT,
-            )
-
-
-# Cookie domains we extract / accept by default.
-#
-# Empirical justification (T5.G): traced cassettes
-# (``tests/cassettes/*.yaml``) and the live auth-refresh path. Only the
-# following domains are actually exercised during login + token refresh +
-# source-add + chat-ask flows:
-#   - ``notebooklm.google.com`` (the API host — all CLI RPCs land here)
-#   - ``.google.com`` (carries ``SID``/``HSID``/``SSID``/etc.)
-#   - ``accounts.google.com`` (token refresh + ``RotateCookies`` endpoint at
-#     :data:`KEEPALIVE_ROTATE_URL`)
-#   - ``.googleusercontent.com`` (authenticated media downloads — audio /
-#     infographic / slide assets)
-#   - ``drive.google.com`` (Drive-source ingest follows redirects through
-#     here; kept in REQUIRED for source-add safety)
-#
-# YouTube / Docs / Mail / myaccount cookies do NOT appear in any traced
-# flow. They are now :data:`OPTIONAL_COOKIE_DOMAINS` — opted in via
-# ``notebooklm login --include-domains=...``. This narrows the blast
-# radius if ``storage_state.json`` is ever leaked (synthesis K15).
-#
-# REQUIRED is also fed verbatim to ``rookiepy.load(domains=...)`` by
-# ``_login_with_browser_cookies`` (via
-# :func:`notebooklm.cli.session._build_google_cookie_domains`); adding a
-# domain here automatically extends what we ask the browser for at login.
-# This is the single load-bearing T5.G control: blast-radius reduction
-# is enforced at extraction time (what rookiepy returns), not at the
-# runtime gate, which stays permissive over the REQUIRED ∪ OPTIONAL
-# union so that ``--include-domains=...`` cookies survive downstream
-# filters (see :func:`_is_allowed_cookie_domain`).
-REQUIRED_COOKIE_DOMAINS: frozenset[str] = frozenset(
-    {
-        ".google.com",
-        "google.com",  # Host-only Domain=google.com cookies (rare but possible)
-        # Playwright storage_state may preserve the leading dot for NotebookLM cookies.
-        ".notebooklm.google.com",
-        "notebooklm.google.com",
-        ".notebooklm.cloud.google.com",
-        "notebooklm.cloud.google.com",
-        ".googleusercontent.com",
-        "accounts.google.com",  # Required for token refresh + RotateCookies
-        ".accounts.google.com",  # http.cookiejar may normalize Domain=accounts.google.com
-        # Drive-source ingest follows redirects through drive.google.com.
-        # Both dotted and non-dotted variants are listed so that
-        # http.cookiejar normalization (which can add a leading dot) doesn't
-        # drop a cookie at the next extraction; same defensive pattern as
-        # accounts.google.com above.
-        "drive.google.com",
-        ".drive.google.com",
-    }
-)
-
-# Sibling Google product domains — NOT exercised by any current code path
-# but historically extracted "for symmetry with a logged-in browser session"
-# (issue #360). Now opt-in via ``--include-domains=...`` to reduce
-# storage_state.json blast radius. The keys here (``youtube``, ``docs``,
-# ``myaccount``, ``mail``) are also the labels accepted by ``--include-domains``.
-#
-# Both dotted and non-dotted variants are listed so that http.cookiejar
-# normalization (which can add a leading dot) doesn't drop a cookie at the
-# next extraction.
-OPTIONAL_COOKIE_DOMAINS_BY_LABEL: dict[str, frozenset[str]] = {
-    "youtube": frozenset(
-        {
-            ".youtube.com",
-            "youtube.com",
-            "accounts.youtube.com",
-            ".accounts.youtube.com",
-        }
-    ),
-    "docs": frozenset({"docs.google.com", ".docs.google.com"}),
-    "myaccount": frozenset({"myaccount.google.com", ".myaccount.google.com"}),
-    "mail": frozenset({"mail.google.com", ".mail.google.com"}),
-}
-
-OPTIONAL_COOKIE_DOMAINS: frozenset[str] = frozenset().union(
-    *OPTIONAL_COOKIE_DOMAINS_BY_LABEL.values()
-)
-
-# Backward-compatible union — preserves the old constant name so external
-# imports keep working. Internal code should prefer ``REQUIRED_*`` /
-# ``OPTIONAL_*`` so the security tier is explicit at the call site.
-ALLOWED_COOKIE_DOMAINS: frozenset[str] = REQUIRED_COOKIE_DOMAINS | OPTIONAL_COOKIE_DOMAINS
-
-# Regional Google ccTLDs where Google may set auth cookies
-# Users in these regions may have SID cookies on regional domains instead of .google.com
-# Format: suffix after ".google." (e.g., "com.sg" for ".google.com.sg")
-#
-# Categories:
-# - com.XX: Country-code second-level domains (Singapore, Australia, Brazil, etc.)
-# - co.XX: Country domains using .co (UK, Japan, India, Korea, etc.)
-# - XX: Single ccTLD countries (Germany, France, Italy, etc.)
-GOOGLE_REGIONAL_CCTLDS = frozenset(
-    {
-        # .google.com.XX pattern (country-code second-level domains)
-        "com.sg",  # Singapore
-        "com.au",  # Australia
-        "com.br",  # Brazil
-        "com.mx",  # Mexico
-        "com.ar",  # Argentina
-        "com.hk",  # Hong Kong
-        "com.tw",  # Taiwan
-        "com.my",  # Malaysia
-        "com.ph",  # Philippines
-        "com.vn",  # Vietnam
-        "com.pk",  # Pakistan
-        "com.bd",  # Bangladesh
-        "com.ng",  # Nigeria
-        "com.eg",  # Egypt
-        "com.tr",  # Turkey
-        "com.ua",  # Ukraine
-        "com.co",  # Colombia
-        "com.pe",  # Peru
-        "com.sa",  # Saudi Arabia
-        "com.ae",  # UAE
-        # .google.co.XX pattern (countries using .co second-level)
-        "co.uk",  # United Kingdom
-        "co.jp",  # Japan
-        "co.in",  # India
-        "co.kr",  # South Korea
-        "co.za",  # South Africa
-        "co.nz",  # New Zealand
-        "co.id",  # Indonesia
-        "co.th",  # Thailand
-        "co.il",  # Israel
-        "co.ve",  # Venezuela
-        "co.cr",  # Costa Rica
-        "co.ke",  # Kenya
-        "co.ug",  # Uganda
-        "co.tz",  # Tanzania
-        "co.ma",  # Morocco
-        "co.ao",  # Angola
-        "co.mz",  # Mozambique
-        "co.zw",  # Zimbabwe
-        "co.bw",  # Botswana
-        # .google.XX pattern (single ccTLD countries)
-        "cn",  # China
-        "de",  # Germany
-        "fr",  # France
-        "it",  # Italy
-        "es",  # Spain
-        "nl",  # Netherlands
-        "pl",  # Poland
-        "ru",  # Russia
-        "ca",  # Canada
-        "be",  # Belgium
-        "at",  # Austria
-        "ch",  # Switzerland
-        "se",  # Sweden
-        "no",  # Norway
-        "dk",  # Denmark
-        "fi",  # Finland
-        "pt",  # Portugal
-        "gr",  # Greece
-        "cz",  # Czech Republic
-        "ro",  # Romania
-        "hu",  # Hungary
-        "ie",  # Ireland
-        "sk",  # Slovakia
-        "bg",  # Bulgaria
-        "hr",  # Croatia
-        "si",  # Slovenia
-        "lt",  # Lithuania
-        "lv",  # Latvia
-        "ee",  # Estonia
-        "lu",  # Luxembourg
-        "cl",  # Chile
-        "cat",  # Catalonia (special case - 3 letter)
-    }
-)
+    """Delegate required-cookie validation through the compatibility facade."""
+    global _SECONDARY_BINDING_WARNED
+    _cookie_policy.MINIMUM_REQUIRED_COOKIES = MINIMUM_REQUIRED_COOKIES
+    _cookie_policy._EXTRACTION_HINT = _EXTRACTION_HINT
+    _cookie_policy._has_valid_secondary_binding = _has_valid_secondary_binding
+    try:
+        _cookie_policy._validate_required_cookies(
+            cookie_names,
+            context=context,
+            extra_diagnostics=extra_diagnostics,
+        )
+    finally:
+        _SECONDARY_BINDING_WARNED = _cookie_policy._SECONDARY_BINDING_WARNED
 
 
 @dataclass
@@ -628,99 +410,6 @@ def flatten_cookie_map(cookies: CookieInput | None) -> FlatCookieMap:
             priorities[name] = priority
 
     return flat
-
-
-def _is_google_domain(domain: str) -> bool:
-    """Check if a cookie domain is a valid Google domain.
-
-    Uses a whitelist approach to validate Google domains including:
-    - Base domain: .google.com
-    - Regional .google.com.XX: .google.com.sg, .google.com.au, etc.
-    - Regional .google.co.XX: .google.co.uk, .google.co.jp, etc.
-    - Regional .google.XX: .google.de, .google.fr, etc.
-
-    This function is used by both auth cookie extraction and download cookie
-    validation to ensure consistent domain handling across the codebase.
-
-    Args:
-        domain: Cookie domain to check (e.g., '.google.com', '.google.com.sg')
-
-    Returns:
-        True if domain is a valid Google domain.
-
-    Note:
-        Uses an explicit whitelist (GOOGLE_REGIONAL_CCTLDS) rather than regex
-        to prevent false positives from invalid or malicious domains.
-    """
-    # Base Google domain
-    if domain == ".google.com":
-        return True
-
-    # Check regional Google domains using whitelist
-    if domain.startswith(".google."):
-        suffix = domain[8:]  # Remove ".google." prefix
-        return suffix in GOOGLE_REGIONAL_CCTLDS
-
-    return False
-
-
-def _is_allowed_auth_domain(domain: str) -> bool:
-    """Check if a cookie domain is allowed for auth cookie extraction.
-
-    Thin alias of :func:`_is_allowed_cookie_domain`. Both auth-jar building
-    and download-cookie loading (and the persistence path that filters which
-    cookies get saved back) share a single allowlist policy:
-
-    1. Exact match against :data:`REQUIRED_COOKIE_DOMAINS` (covers the API
-       host, ``.google.com`` / ``accounts.google.com`` /
-       ``.googleusercontent.com`` / ``drive.google.com``, and the
-       leading-dot variants ``http.cookiejar`` may normalize to).
-    2. Regional Google ccTLDs (``.google.com.sg``, ``.google.co.uk``,
-       ``.google.de``, …) where SID cookies may be set for users in those
-       regions.
-    3. Suffix matches for Google subdomains (``lh3.google.com``,
-       ``accounts.google.com``) and ``.googleusercontent.com`` /
-       ``.usercontent.google.com`` for authenticated media downloads.
-
-    The previous strict / broad split (#334 / fea8315) created an asymmetry
-    where ``save_cookies_to_storage`` would persist cookies that the next
-    extraction would silently drop. Issue #360 collapsed both filters into
-    this single policy. T5.G narrows the *extraction* surface (rookiepy
-    only requests :data:`REQUIRED_COOKIE_DOMAINS` by default, so YouTube
-    cookies are never written to ``storage_state.json`` unless the user
-    opts in via ``--include-domains=youtube``); the runtime gate stays
-    permissive over the full :data:`ALLOWED_COOKIE_DOMAINS` union so that
-    opted-in cookies survive the downstream filters.
-
-    Args:
-        domain: Cookie domain to check (e.g., '.google.com', '.google.com.sg')
-
-    Returns:
-        True if domain is allowed for auth/download cookies.
-    """
-    return _is_allowed_cookie_domain(domain)
-
-
-def _auth_domain_priority(domain: str) -> int:
-    """Return duplicate-cookie priority for allowed auth domains.
-
-    Higher value wins. Tiers are distinct so the resolved cookie is fully
-    deterministic regardless of storage_state ordering.
-    """
-    if domain == ".google.com":
-        return 4
-    if domain == ".notebooklm.google.com":
-        return 3
-    if domain == "notebooklm.google.com":
-        return 2
-    if domain == ".notebooklm.cloud.google.com":
-        return 3
-    if domain == "notebooklm.cloud.google.com":
-        return 2
-    if _is_google_domain(domain):
-        return 1
-    # Allowlisted but unranked domains (e.g. .googleusercontent.com) fall through.
-    return 0
 
 
 def convert_rookiepy_cookies_to_storage_state(
@@ -1447,73 +1136,6 @@ def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
     """
     storage_state = _load_storage_state(path)
     return extract_cookies_from_storage(storage_state)
-
-
-def _is_allowed_cookie_domain(domain: str) -> bool:
-    """Canonical cookie-domain allowlist for both auth and downloads.
-
-    Single source of truth for "is this cookie domain one we accept at
-    runtime?". Both the auth-extraction path and the download path go
-    through here — :func:`_is_allowed_auth_domain` is a thin alias
-    preserved for call-site readability. See issue #360 for why the split
-    was collapsed.
-
-    A domain is allowed if any of the following holds:
-
-    1. Exact match against :data:`REQUIRED_COOKIE_DOMAINS` (the API host,
-       ``.google.com``, ``accounts.google.com``, ``.googleusercontent.com``,
-       ``drive.google.com``, and the leading-dot variants ``http.cookiejar``
-       may normalize to).
-    2. Valid Google domain via :func:`_is_google_domain` (regional ccTLDs:
-       ``.google.com.sg``, ``.google.co.uk``, ``.google.de``, …).
-    3. Subdomain of ``.google.com``, ``.googleusercontent.com``, or
-       ``.usercontent.google.com`` (e.g. ``lh3.google.com``,
-       ``lh3.googleusercontent.com``).
-
-    The leading-dot suffix check ensures lookalikes like ``evil-google.com``
-    are rejected.
-
-    Note (T5.G): the runtime gate consults the
-    :data:`ALLOWED_COOKIE_DOMAINS` union (REQUIRED ∪ OPTIONAL). The
-    blast-radius reduction is enforced at **extraction time** —
-    ``_build_google_cookie_domains`` defaults to
-    :data:`REQUIRED_COOKIE_DOMAINS` only, so rookiepy never returns
-    sibling-product cookies (e.g. ``.youtube.com``) unless the user
-    opts in via ``--include-domains=...``. The runtime gate must stay
-    permissive over the full union so that opted-in cookies survive
-    the downstream filters in :func:`convert_rookiepy_cookies_to_storage_state`,
-    :func:`extract_cookies_with_domains`, and
-    :func:`build_httpx_cookies_from_storage`.
-
-    Args:
-        domain: Cookie domain to check (e.g., '.google.com', 'lh3.google.com')
-
-    Returns:
-        True if domain is allowed for auth/download cookies.
-    """
-    # Exact match against the union of REQUIRED + OPTIONAL. Anything that
-    # could have been validly opted in via ``--include-domains`` at
-    # extraction time must pass this gate at runtime (T5.G).
-    if domain in ALLOWED_COOKIE_DOMAINS:
-        return True
-
-    # Check if it's a valid Google domain (base or regional)
-    # This handles .google.com, .google.com.sg, .google.co.uk, .google.de, etc.
-    if _is_google_domain(domain):
-        return True
-
-    # Suffixes for allowed download domains (leading dot provides boundary check)
-    # - Subdomains of .google.com (e.g., lh3.google.com, accounts.google.com)
-    # - googleusercontent.com domains for media downloads
-    allowed_suffixes = (
-        ".google.com",
-        ".googleusercontent.com",
-        ".usercontent.google.com",
-    )
-
-    # Check if domain is a subdomain of allowed suffixes
-    # The leading dot ensures 'evil-google.com' does NOT match
-    return any(domain.endswith(suffix) for suffix in allowed_suffixes)
 
 
 def load_httpx_cookies(path: Path | None = None) -> "httpx.Cookies":

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -9,6 +9,7 @@ Plan: .sisyphus/plans/private-module-boundary.md
 from __future__ import annotations
 
 import importlib
+import logging
 import warnings
 from types import ModuleType
 from unittest.mock import AsyncMock
@@ -343,14 +344,18 @@ def test_auth_cookie_domain_constants_are_facade_exports() -> None:
 
 _AUTH_FIRST_PARTY_COMPATIBILITY_NAMES = [
     "_auth_domain_priority",
+    "_EXTRACTION_HINT",
     "_find_cookie_for_storage",
+    "_has_valid_secondary_binding",
     "_is_allowed_auth_domain",
     "_is_allowed_cookie_domain",
     "_is_google_domain",
     "_rotate_cookies",
     "_run_refresh_cmd",
+    "_SECONDARY_BINDING_WARNED",
     "_split_refresh_cmd",
     "_update_cookie_input",
+    "_validate_required_cookies",
     "Account",
     "advance_cookie_snapshot_after_save",
     "ALLOWED_COOKIE_DOMAINS",
@@ -408,6 +413,83 @@ def test_auth_first_party_compatibility_manifest_has_no_duplicates() -> None:
     assert len(_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES) == len(
         set(_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES)
     )
+
+
+def test_auth_cookie_policy_facade_delegates_to_private_module() -> None:
+    """Policy constants/helpers live in _auth while notebooklm.auth stays compatible."""
+    import notebooklm.auth as auth
+    from notebooklm._auth import cookie_policy
+
+    assert auth.REQUIRED_COOKIE_DOMAINS is cookie_policy.REQUIRED_COOKIE_DOMAINS
+    assert auth.OPTIONAL_COOKIE_DOMAINS is cookie_policy.OPTIONAL_COOKIE_DOMAINS
+    assert auth.OPTIONAL_COOKIE_DOMAINS_BY_LABEL is cookie_policy.OPTIONAL_COOKIE_DOMAINS_BY_LABEL
+    assert auth.ALLOWED_COOKIE_DOMAINS is cookie_policy.ALLOWED_COOKIE_DOMAINS
+    assert auth.GOOGLE_REGIONAL_CCTLDS is cookie_policy.GOOGLE_REGIONAL_CCTLDS
+    assert auth.MINIMUM_REQUIRED_COOKIES is cookie_policy.MINIMUM_REQUIRED_COOKIES
+    assert auth._auth_domain_priority is cookie_policy._auth_domain_priority
+    assert auth._is_google_domain is cookie_policy._is_google_domain
+    assert auth._is_allowed_auth_domain is cookie_policy._is_allowed_auth_domain
+    assert auth._is_allowed_cookie_domain is cookie_policy._is_allowed_cookie_domain
+
+
+def test_auth_secondary_binding_reset_syncs_to_cookie_policy(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resetting notebooklm.auth._SECONDARY_BINDING_WARNED still controls validation."""
+    import notebooklm.auth as auth
+    from notebooklm._auth import cookie_policy
+
+    monkeypatch.setattr(cookie_policy, "_SECONDARY_BINDING_WARNED", True)
+    monkeypatch.setattr(auth, "_SECONDARY_BINDING_WARNED", False)
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm.auth"):
+        auth._validate_required_cookies({"SID", "__Secure-1PSIDTS"})
+
+    assert auth._SECONDARY_BINDING_WARNED is True
+    assert cookie_policy._SECONDARY_BINDING_WARNED is True
+    assert "Cookie set lacks a secondary binding" in caplog.text
+
+
+def test_auth_validation_preserves_private_warning_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Facade validation must not clobber a private validation's warning state."""
+    import notebooklm.auth as auth
+    from notebooklm._auth import cookie_policy
+
+    monkeypatch.setattr(auth, "_SECONDARY_BINDING_WARNED", False)
+    cookie_policy._validate_required_cookies({"SID", "__Secure-1PSIDTS"})
+
+    auth._validate_required_cookies({"SID", "__Secure-1PSIDTS", "OSID"})
+
+    assert auth._SECONDARY_BINDING_WARNED is True
+    assert cookie_policy._SECONDARY_BINDING_WARNED is True
+
+
+def test_auth_validation_uses_facade_policy_rebindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validation keeps auth.py monkeypatch compatibility after delegation."""
+    import notebooklm.auth as auth
+
+    monkeypatch.setattr(auth, "MINIMUM_REQUIRED_COOKIES", {"SID"})
+    monkeypatch.setattr(auth, "_has_valid_secondary_binding", lambda names: True)
+
+    auth._validate_required_cookies({"SID"})
+
+
+def test_auth_validation_uses_facade_extraction_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier-1 errors still read the compatibility facade's extraction hint."""
+    import notebooklm.auth as auth
+
+    monkeypatch.setattr(auth, "MINIMUM_REQUIRED_COOKIES", {"SID", "SIDTS"})
+    monkeypatch.setattr(auth, "_EXTRACTION_HINT", "custom extraction hint")
+
+    with pytest.raises(ValueError, match="custom extraction hint"):
+        auth._validate_required_cookies({"SID"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Move cookie-domain constants and validation helpers into private `notebooklm._auth.cookie_policy`
- Keep `notebooklm.auth` as the first-party compatibility facade for policy constants/helpers
- Preserve `_SECONDARY_BINDING_WARNED` reset semantics and facade monkeypatch behavior for validation globals

## Task
Phase 2 Wave 2: `t3b-auth-cookie-policy` from `.sisyphus/phases/architecture-remediation/phase-2.md`

## Test plan
- [x] `uv run pytest tests/unit/test_auth.py::TestMinimumRequiredCookies tests/unit/test_auth.py::TestAllowedCookieDomains tests/unit/test_auth.py::TestIsAllowedCookieDomain tests/unit/test_auth.py::TestIsGoogleDomain tests/unit/test_auth.py::TestIsAllowedAuthDomain tests/unit/test_auth.py::TestAuthDomainPriority tests/unit/test_auth.py::TestIsAllowedCookieDomainRegional tests/unit/test_auth.py::TestRookiepyDomainsCoverage tests/unit/test_cookie_domain_split.py tests/unit/test_public_shims.py tests/unit/test_cli_boundary.py`
- [x] `uv run ruff check src/notebooklm/auth.py src/notebooklm/_auth tests/unit/test_auth.py tests/unit/test_cookie_domain_split.py tests/unit/test_public_shims.py tests/unit/test_cli_boundary.py`
- [x] `uv run mypy src/notebooklm`
- [x] `uv run pytest tests/unit/test_warning_dedupe.py`

## Deferred polish findings
- Wheel build smoke check was attempted during polish but could not resolve build-system dependencies because PyPI DNS lookup failed in the environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized authentication cookie validation logic into a dedicated policy module for improved code organization and maintainability.
  * Streamlined cookie domain allowlisting and tier validation through a shared policy layer.

* **Tests**
  * Enhanced authentication compatibility tests to verify cookie policy delegation and synchronization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->