### PR TITLE
test: speed up local test suites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ uv sync --frozen --extra browser --extra dev --extra markdown
 source .venv/bin/activate
 uv run playwright install chromium
 uv run pytest
+uv run pytest -n auto --dist=worksteal  # optional faster local run
 uv run ruff check .
 uv run ruff format .
 uv run mypy src/notebooklm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest-cov>=4.0.0,<8",
     "pytest-rerunfailures>=14.0,<17",
     "pytest-timeout>=2.3.0,<3",
+    "pytest-xdist>=3.6.0,<4",
     "python-dotenv>=1.0.0,<2",
     "mypy>=1.0.0,<2",
     "pre-commit>=4.5.1,<5",

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -216,7 +216,9 @@ class TestRPCCallHTTPErrors:
 
     @pytest.mark.asyncio
     async def test_server_error_500(self, auth_tokens):
-        async with NotebookLMClient(auth_tokens) as client:
+        # Pin ``server_error_max_retries=0`` to exercise the raise-immediately
+        # mapping path. Retry/backoff behavior is covered in core transport tests.
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
             mock_response = MagicMock()
@@ -232,7 +234,9 @@ class TestRPCCallHTTPErrors:
 
     @pytest.mark.asyncio
     async def test_connect_timeout_raises_network_error(self, auth_tokens):
-        async with NotebookLMClient(auth_tokens) as client:
+        # Network errors flow through the same retry loop as 5xx responses;
+        # pin to 0 so these mapping tests don't pay backoff sleeps.
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
             with (
@@ -247,7 +251,7 @@ class TestRPCCallHTTPErrors:
 
     @pytest.mark.asyncio
     async def test_read_timeout_raises_rpc_timeout_error(self, auth_tokens):
-        async with NotebookLMClient(auth_tokens) as client:
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
             with (
@@ -262,7 +266,7 @@ class TestRPCCallHTTPErrors:
 
     @pytest.mark.asyncio
     async def test_connect_error_raises_network_error(self, auth_tokens):
-        async with NotebookLMClient(auth_tokens) as client:
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
             with (
@@ -277,7 +281,7 @@ class TestRPCCallHTTPErrors:
 
     @pytest.mark.asyncio
     async def test_generic_request_error_raises_network_error(self, auth_tokens):
-        async with NotebookLMClient(auth_tokens) as client:
+        async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
             with (

--- a/tests/integration/test_workflow_tracer_vcr.py
+++ b/tests/integration/test_workflow_tracer_vcr.py
@@ -59,6 +59,7 @@ chain is the test.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import uuid
 from pathlib import Path
@@ -89,6 +90,18 @@ _TRACER_URL = "https://en.wikipedia.org/wiki/Tracer_bullet"
 _TRACER_QUESTION = "In one sentence, what is a tracer bullet?"
 
 
+@pytest.fixture
+def fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip polling backoff during replay while preserving live record cadence."""
+    if _is_vcr_record_mode():
+        return
+
+    async def instant_sleep(_seconds: float, result: object | None = None) -> object | None:
+        return result
+
+    monkeypatch.setattr(asyncio, "sleep", instant_sleep)
+
+
 class TestWorkflowTracerBullet:
     """Records and replays the full create→add→ask→generate→download journey."""
 
@@ -103,7 +116,7 @@ class TestWorkflowTracerBullet:
         # here keeps the per-cassette ``match_on`` self-contained.
         match_on=["method", "scheme", "host", "port", "path", "rpcids", "freq"],
     )
-    async def test_full_workflow(self, tmp_path: Path) -> None:
+    async def test_full_workflow(self, tmp_path: Path, fast_sleep: None) -> None:
         """End-to-end user journey produces a downloadable report.
 
         Asserts each phase's intermediate output:

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -427,7 +427,7 @@ def test_build_synthetic_error_response_invalid_mode():
         build_synthetic_error_response("418")
 
 
-@pytest.mark.parametrize("mode", list(VALID_ERROR_MODES))
+@pytest.mark.parametrize("mode", sorted(VALID_ERROR_MODES))
 def test_synthetic_error_cassette_name_prefix(mode):
     """Cassette filenames generated through this plumbing must carry the
     canonical ``error_synthetic_`` prefix so a reader of tests/cassettes/ can

--- a/uv.lock
+++ b/uv.lock
@@ -203,6 +203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -524,6 +533,7 @@ all = [
     { name = "pytest-httpx" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -544,6 +554,7 @@ dev = [
     { name = "pytest-httpx" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -569,6 +580,7 @@ requires-dist = [
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.30.0,<0.37" },
     { name = "pytest-rerunfailures", marker = "extra == 'dev'", specifier = ">=14.0,<17" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0,<3" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0,<4" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
     { name = "rich", specifier = ">=13.0.0,<15" },
     { name = "rookiepy", marker = "extra == 'cookies'", specifier = ">=0.1.0,<1" },
@@ -752,6 +764,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- remove production retry backoff sleeps from HTTP exception mapping tests by pinning `server_error_max_retries=0`
- skip polling sleeps during workflow VCR replay while preserving record-mode cadence
- make xdist collection deterministic and add `pytest-xdist` to the dev extra

## Test plan
- `uv lock --check`
- `uv run pytest tests/unit/test_vcr_config.py -n auto -q`
- `uv run pytest tests/integration/test_core.py::TestRPCCallHTTPErrors --durations=10 --durations-min=0.05 -q`
- `uv run pytest tests/integration/test_workflow_tracer_vcr.py::TestWorkflowTracerBullet::test_full_workflow --durations=5 --durations-min=0.01 -q`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy src/notebooklm`
- `uv run pytest tests/unit -q --durations=20 --durations-min=0.05` (`4051 passed, 8 skipped in 28.87s`)
- `uv run pytest tests/integration -q --durations=40 --durations-min=0.05` (`347 passed, 4 skipped in 11.64s`)
- `uv run pytest -n auto --dist=worksteal --durations=30 --durations-min=0.05 -q` (`4398 passed, 12 skipped in 8.59s`)
- `uv run pytest -q --durations=60 --durations-min=0.05` (`4398 passed, 12 skipped in 39.22s`)
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Faster VCR replay by skipping sleeps during cassette playback
  * Integration tests exercise immediate-failure retry behavior for server/network errors
  * Stabilized a unit test by iterating error modes in deterministic order

* **Chores**
  * Added test parallelization dependency to dev extras (pytest-xdist)

* **Documentation**
  * Updated contributor checklist with an optional faster local test command

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->