### PR TITLE
refactor(core): extract conversation cache

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -21,6 +21,12 @@ from urllib.parse import urlencode
 import httpx
 
 from ._callbacks import maybe_await_callback
+from ._core_cache import (
+    MAX_CONVERSATION_CACHE_SIZE as _DEFAULT_CONVERSATION_CACHE_SIZE,
+)
+from ._core_cache import (
+    ConversationCache,
+)
 from ._env import get_default_language
 from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import (
@@ -66,8 +72,7 @@ class _TransportOperationToken:
     task: asyncio.Task[Any] | None
 
 
-# Maximum number of conversations to cache (FIFO eviction)
-MAX_CONVERSATION_CACHE_SIZE = 100
+MAX_CONVERSATION_CACHE_SIZE = _DEFAULT_CONVERSATION_CACHE_SIZE
 
 # Default HTTP timeouts in seconds
 DEFAULT_TIMEOUT = 30.0
@@ -699,8 +704,7 @@ class ClientCore:
         # produces hangs and ``RuntimeError`` deep in httpx instead of an
         # actionable message at the call site.
         self._bound_loop: asyncio.AbstractEventLoop | None = None
-        # OrderedDict for FIFO eviction when cache exceeds MAX_CONVERSATION_CACHE_SIZE
-        self._conversation_cache: OrderedDict[str, list[dict[str, Any]]] = OrderedDict()
+        self._conversation_cache_manager = ConversationCache()
         # Keepalive background task configuration
         self._keepalive_interval: float | None = _resolve_keepalive_interval(
             keepalive, keepalive_min_interval
@@ -2336,21 +2340,12 @@ class ClientCore:
             answer: The AI's response.
             turn_number: The turn number in the conversation.
         """
-        is_new_conversation = conversation_id not in self._conversation_cache
-
-        # Only evict when adding a NEW conversation at capacity
-        if is_new_conversation:
-            while len(self._conversation_cache) >= MAX_CONVERSATION_CACHE_SIZE:
-                # popitem(last=False) removes oldest entry (FIFO)
-                self._conversation_cache.popitem(last=False)
-            self._conversation_cache[conversation_id] = []
-
-        self._conversation_cache[conversation_id].append(
-            {
-                "query": query,
-                "answer": answer,
-                "turn_number": turn_number,
-            }
+        self._conversation_cache_manager.cache_conversation_turn(
+            conversation_id,
+            query,
+            answer,
+            turn_number,
+            max_size=MAX_CONVERSATION_CACHE_SIZE,
         )
 
     def get_cached_conversation(self, conversation_id: str) -> list[dict[str, Any]]:
@@ -2362,7 +2357,7 @@ class ClientCore:
         Returns:
             List of cached turns, or empty list if not found.
         """
-        return self._conversation_cache.get(conversation_id, [])
+        return self._conversation_cache_manager.get_cached_conversation(conversation_id)
 
     def clear_conversation_cache(self, conversation_id: str | None = None) -> bool:
         """Clear conversation cache.
@@ -2373,14 +2368,16 @@ class ClientCore:
         Returns:
             True if cache was cleared.
         """
-        if conversation_id:
-            if conversation_id in self._conversation_cache:
-                del self._conversation_cache[conversation_id]
-                return True
-            return False
-        else:
-            self._conversation_cache.clear()
-            return True
+        return self._conversation_cache_manager.clear(conversation_id)
+
+    @property
+    def _conversation_cache(self) -> OrderedDict[str, list[dict[str, Any]]]:
+        """Compatibility view of the conversation cache backing mapping."""
+        return self._conversation_cache_manager.conversations
+
+    @_conversation_cache.setter
+    def _conversation_cache(self, value: OrderedDict[str, list[dict[str, Any]]]) -> None:
+        self._conversation_cache_manager = ConversationCache(value)
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
         """Extract all source IDs from a notebook.

--- a/src/notebooklm/_core_cache.py
+++ b/src/notebooklm/_core_cache.py
@@ -1,0 +1,64 @@
+"""Conversation cache collaborator for :mod:`notebooklm._core`."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Mapping
+from typing import Any
+
+# Maximum number of conversations to cache (FIFO eviction)
+MAX_CONVERSATION_CACHE_SIZE = 100
+
+
+class ConversationCache:
+    """Synchronous FIFO cache for conversation turns."""
+
+    def __init__(
+        self,
+        conversations: Mapping[str, list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self.conversations: OrderedDict[str, list[dict[str, Any]]]
+        if isinstance(conversations, OrderedDict):
+            self.conversations = conversations
+        else:
+            self.conversations = OrderedDict(conversations or {})
+
+    def cache_conversation_turn(
+        self,
+        conversation_id: str,
+        query: str,
+        answer: str,
+        turn_number: int,
+        *,
+        max_size: int = MAX_CONVERSATION_CACHE_SIZE,
+    ) -> None:
+        """Cache a conversation turn, evicting FIFO only for new conversations."""
+        is_new_conversation = conversation_id not in self.conversations
+
+        if is_new_conversation:
+            while len(self.conversations) >= max_size:
+                self.conversations.popitem(last=False)
+            self.conversations[conversation_id] = []
+
+        self.conversations[conversation_id].append(
+            {
+                "query": query,
+                "answer": answer,
+                "turn_number": turn_number,
+            }
+        )
+
+    def get_cached_conversation(self, conversation_id: str) -> list[dict[str, Any]]:
+        """Return cached turns for ``conversation_id`` or an empty list."""
+        return self.conversations.get(conversation_id, [])
+
+    def clear(self, conversation_id: str | None = None) -> bool:
+        """Clear one cached conversation or the whole cache."""
+        if conversation_id:
+            if conversation_id in self.conversations:
+                del self.conversations[conversation_id]
+                return True
+            return False
+
+        self.conversations.clear()
+        return True

--- a/tests/unit/test_concurrency_cache_race.py
+++ b/tests/unit/test_concurrency_cache_race.py
@@ -12,11 +12,37 @@ import ast
 import asyncio
 import inspect
 import textwrap
+from contextlib import asynccontextmanager
 
 import pytest
 
-from conftest import make_core  # type: ignore[import-not-found]
 from notebooklm import _core
+from notebooklm._core_cache import ConversationCache
+from notebooklm.auth import AuthTokens
+
+
+def _assert_method_has_no_yield_points(method, label: str) -> None:
+    src = inspect.getsource(method)
+    tree = ast.parse(textwrap.dedent(src))
+    awaits = [n for n in ast.walk(tree) if isinstance(n, ast.Await)]
+    is_async = any(isinstance(n, ast.AsyncFunctionDef) for n in ast.walk(tree))
+    assert not awaits, f"{label} must not contain `await` (breaks atomicity guarantee)"
+    assert not is_async, f"{label} must not be `async def` (breaks atomicity guarantee)"
+
+
+@asynccontextmanager
+async def make_core():
+    auth = AuthTokens(
+        csrf_token="CSRF_OLD",
+        session_id="SID_OLD",
+        cookies={"SID": "old_sid_cookie"},
+    )
+    core = _core.ClientCore(auth=auth, refresh_retry_delay=0.0)
+    await core.open()
+    try:
+        yield core
+    finally:
+        await core.close()
 
 
 @pytest.mark.asyncio
@@ -41,15 +67,17 @@ def test_cache_conversation_turn_remains_synchronous():
     The cache's atomicity guarantee depends on the function having no yield
     points.
     """
-    src = inspect.getsource(_core.ClientCore.cache_conversation_turn)
-    tree = ast.parse(textwrap.dedent(src))
-    awaits = [n for n in ast.walk(tree) if isinstance(n, ast.Await)]
-    is_async = any(isinstance(n, ast.AsyncFunctionDef) for n in ast.walk(tree))
-    assert not awaits, (
-        "cache_conversation_turn must not contain `await` (breaks atomicity guarantee)"
+    _assert_method_has_no_yield_points(
+        _core.ClientCore.cache_conversation_turn,
+        "cache_conversation_turn",
     )
-    assert not is_async, (
-        "cache_conversation_turn must not be `async def` (breaks atomicity guarantee)"
+
+
+def test_conversation_cache_mutation_remains_synchronous():
+    """The collaborator mutation owns the no-yield atomicity contract."""
+    _assert_method_has_no_yield_points(
+        ConversationCache.cache_conversation_turn,
+        "ConversationCache.cache_conversation_turn",
     )
 
 

--- a/tests/unit/test_core_cache.py
+++ b/tests/unit/test_core_cache.py
@@ -1,0 +1,78 @@
+"""Unit tests for the core conversation-cache collaborator."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from notebooklm._core_cache import ConversationCache
+
+
+def test_cache_conversation_turn_appends_turns() -> None:
+    cache = ConversationCache()
+
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1)
+    cache.cache_conversation_turn("conv-1", "q2", "a2", 2)
+
+    assert cache.get_cached_conversation("conv-1") == [
+        {"query": "q1", "answer": "a1", "turn_number": 1},
+        {"query": "q2", "answer": "a2", "turn_number": 2},
+    ]
+
+
+def test_cache_conversation_turn_fifo_evicts_only_for_new_conversations() -> None:
+    cache = ConversationCache()
+
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1, max_size=2)
+    cache.cache_conversation_turn("conv-2", "q2", "a2", 1, max_size=2)
+    cache.cache_conversation_turn("conv-1", "q3", "a3", 2, max_size=2)
+    cache.cache_conversation_turn("conv-3", "q4", "a4", 1, max_size=2)
+
+    assert list(cache.conversations) == ["conv-2", "conv-3"]
+    assert cache.get_cached_conversation("conv-2") == [
+        {"query": "q2", "answer": "a2", "turn_number": 1}
+    ]
+    assert cache.get_cached_conversation("conv-3") == [
+        {"query": "q4", "answer": "a4", "turn_number": 1}
+    ]
+
+
+def test_get_cached_conversation_returns_empty_list_for_missing_conversation() -> None:
+    cache = ConversationCache()
+
+    assert cache.get_cached_conversation("missing") == []
+
+
+def test_clear_specific_and_all_conversations() -> None:
+    cache = ConversationCache()
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1)
+    cache.cache_conversation_turn("conv-2", "q2", "a2", 1)
+
+    assert cache.clear("missing") is False
+    assert cache.clear("conv-1") is True
+    assert list(cache.conversations) == ["conv-2"]
+
+    assert cache.clear() is True
+    assert cache.conversations == {}
+
+
+def test_constructor_preserves_seeded_order() -> None:
+    cache = ConversationCache(
+        OrderedDict(
+            [
+                ("conv-1", [{"query": "q1", "answer": "a1", "turn_number": 1}]),
+                ("conv-2", [{"query": "q2", "answer": "a2", "turn_number": 1}]),
+            ]
+        )
+    )
+
+    assert list(cache.conversations) == ["conv-1", "conv-2"]
+
+
+def test_constructor_keeps_ordered_dict_backing_mapping() -> None:
+    conversations: OrderedDict[str, list[dict[str, object]]] = OrderedDict()
+    cache = ConversationCache(conversations)
+
+    cache.cache_conversation_turn("conv-1", "q1", "a1", 1)
+
+    assert cache.conversations is conversations
+    assert conversations["conv-1"] == [{"query": "q1", "answer": "a1", "turn_number": 1}]


### PR DESCRIPTION
## Summary
- Add `ConversationCache` in `src/notebooklm/_core_cache.py` for synchronous FIFO conversation cache behavior.
- Keep `ClientCore` cache APIs and `_conversation_cache` compatibility delegating to the collaborator.
- Preserve `_core.MAX_CONVERSATION_CACHE_SIZE` monkeypatch behavior by passing the current `_core` value at mutation time.

## Task
- `.sisyphus/phases/architecture-remediation/phase-3.md#t4a-core-cache`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_core_cache.py tests/unit/test_concurrency_cache_race.py tests/unit/test_conversation.py tests/integration/concurrency/test_chat_history_race.py tests/integration/test_core.py::TestConversationCacheFIFOEviction tests/integration/test_core.py::TestClearConversationCacheNotFound tests/unit/test_chat_integration.py::TestChatAPI::test_get_cached_turns_empty tests/unit/test_chat_integration.py::TestChatAPI::test_clear_cache tests/unit/test_chat_integration.py::TestChatAPI::test_clear_all_cache tests/unit/test_public_shims.py`
- [x] `rtk uv run ruff check src/notebooklm/_core.py src/notebooklm/_core_cache.py tests/unit/test_core_cache.py tests/unit/test_concurrency_cache_race.py tests/unit/test_conversation.py tests/integration/concurrency/test_chat_history_race.py tests/integration/test_core.py`
- [x] `rtk uv run mypy src/notebooklm`

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured conversation caching system to use a dedicated cache manager for improved maintainability and code organization.

* **Tests**
  * Added comprehensive unit tests for conversation cache functionality including turn appending, eviction behavior, and clearing operations.
  * Added tests ensuring cache operations remain atomic during concurrent access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->