### PR TITLE
refactor(core): add poll registry collaborator

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -27,6 +27,7 @@ from ._core_cache import (
 from ._core_cache import (
     ConversationCache,
 )
+from ._core_polling import PendingPolls, PollRegistry
 from ._env import get_default_language
 from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import (
@@ -736,22 +737,7 @@ class ClientCore:
         # clobber sibling-process writes (docs/auth-keepalive.md §3.4.1).
         # Per-instance, never module-global.
         self._loaded_cookie_snapshot: CookieSnapshot | None = None
-        # Leader/follower polling-dedupe registry for
-        # ``ArtifactsAPI.wait_for_completion`` (audit §21 / T7.E2).
-        # Keyed by ``(notebook_id, task_id)``. Each entry is a
-        # ``(future, task)`` pair: the first caller for a key is the
-        # *leader* and spawns the ``task`` (a shielded ``_poll_loop`` task);
-        # subsequent callers (*followers*) attach to ``future`` via
-        # ``asyncio.shield(future)`` so their per-caller cancellations
-        # don't propagate to the underlying poll. The task reference is
-        # kept alongside the future so the running poll task can't be
-        # GC'd if the leader is cancelled with no followers attached
-        # (Python's task-GC contract is permissive). Per-instance —
-        # never module-global, so a fresh ``ClientCore`` cannot inherit
-        # a dangling entry from a prior instance.
-        self._pending_polls: dict[
-            tuple[str, str], tuple[asyncio.Future[Any], asyncio.Task[Any]]
-        ] = {}
+        self.poll_registry: PollRegistry = PollRegistry()
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
@@ -784,6 +770,20 @@ class ClientCore:
             stacklevel=2,
         )
         self._reqid_counter_value = value
+
+    @property
+    def _pending_polls(self) -> PendingPolls:
+        """Deprecated compatibility view of ``poll_registry.pending``.
+
+        ``ArtifactsAPI.wait_for_completion`` still uses this bridge until the
+        later feature-migration slices move polling behind a public core
+        capability.
+        """
+        return self.poll_registry.pending
+
+    @_pending_polls.setter
+    def _pending_polls(self, value: PendingPolls) -> None:
+        self.poll_registry.pending = value
 
     async def next_reqid(self, step: int = 100000) -> int:
         """Atomically increment the request-id counter and return the new value.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -777,7 +777,7 @@ class ClientCore:
 
         ``ArtifactsAPI.wait_for_completion`` still uses this bridge until the
         later feature-migration slices move polling behind a public core
-        capability.
+        capability, so access intentionally does not warn yet.
         """
         return self.poll_registry.pending
 

--- a/src/notebooklm/_core_polling.py
+++ b/src/notebooklm/_core_polling.py
@@ -1,0 +1,30 @@
+"""Polling collaborators for :mod:`notebooklm._core`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+PollKey = tuple[str, str]
+PendingPoll = tuple[asyncio.Future[Any], asyncio.Task[Any]]
+PendingPolls = dict[PollKey, PendingPoll]
+
+
+class PollRegistry:
+    """Leader/follower polling-dedupe registry for artifact waits.
+
+    Keys are ``(notebook_id, task_id)`` pairs. Values stay in the legacy
+    ``(future, task)`` shape because ``ArtifactsAPI.wait_for_completion`` still
+    owns the poll loop and cleanup behavior in this phase.
+
+    The first waiter for a key is the leader and stores the shared future plus
+    the running poll task. Followers attach to that future via
+    ``asyncio.shield`` so per-caller cancellation does not cancel the shared
+    poll. The task reference is retained alongside the future so the running
+    poll cannot be garbage-collected if the leader is cancelled before
+    followers attach. This registry is per ``ClientCore`` instance, never
+    module-global.
+    """
+
+    def __init__(self, pending: PendingPolls | None = None) -> None:
+        self.pending: PendingPolls = pending if pending is not None else {}

--- a/tests/unit/test_core_polling.py
+++ b/tests/unit/test_core_polling.py
@@ -1,0 +1,105 @@
+"""Unit tests for the core polling collaborator."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm._core_polling import PendingPolls, PollRegistry
+from notebooklm.auth import AuthTokens
+
+
+def _auth_tokens() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "test"},
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+
+async def _never() -> None:
+    await asyncio.Event().wait()
+
+
+def test_poll_registry_owns_pending_mapping() -> None:
+    registry = PollRegistry()
+
+    assert registry.pending == {}
+
+
+def test_poll_registry_preserves_seeded_pending_mapping_identity() -> None:
+    pending: PendingPolls = {}
+    registry = PollRegistry(pending)
+
+    assert registry.pending is pending
+
+
+def test_client_core_exposes_poll_registry_and_pending_polls_bridge() -> None:
+    core = ClientCore(_auth_tokens())
+
+    assert isinstance(core.poll_registry, PollRegistry)
+    assert core._pending_polls is core.poll_registry.pending
+
+
+def test_client_core_pending_polls_assignment_replaces_registry_backing_mapping() -> None:
+    core = ClientCore(_auth_tokens())
+    registry = core.poll_registry
+    pending: PendingPolls = {}
+
+    core._pending_polls = pending
+
+    assert core.poll_registry is registry
+    assert core.poll_registry.pending is pending
+    assert core._pending_polls is pending
+
+
+def test_client_core_pending_polls_bridge_reflects_poll_registry_mutations() -> None:
+    core = ClientCore(_auth_tokens())
+    pending: PendingPolls = {}
+
+    core.poll_registry.pending = pending
+
+    assert core._pending_polls is pending
+
+
+@pytest.mark.asyncio
+async def test_client_core_pending_polls_bridge_preserves_entry_shape() -> None:
+    core = ClientCore(_auth_tokens())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[Any] = loop.create_future()
+    task = asyncio.create_task(_never())
+    key = ("notebook-1", "task-1")
+
+    try:
+        core._pending_polls[key] = (future, task)
+
+        assert core.poll_registry.pending[key] == (future, task)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+def test_core_polling_does_not_import_client_core_at_runtime() -> None:
+    source = (Path(__file__).resolve().parents[2] / "src/notebooklm/_core_polling.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+
+    forbidden_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in {"_core", "notebooklm._core"}:
+            forbidden_imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            forbidden_imports.extend(
+                alias.name for alias in node.names if alias.name == "notebooklm._core"
+            )
+
+    assert forbidden_imports == []


### PR DESCRIPTION
## Summary
- Add `PollRegistry` in `_core_polling.py` to own the artifact pending-poll map.
- Expose `ClientCore.poll_registry` while preserving `_pending_polls` as the compatibility bridge, including assignment.
- Add direct unit coverage for registry ownership, bridge identity, value shape, and import-cycle boundaries.

## Task
- `.sisyphus/phases/architecture-remediation/phase-3.md#t4b-core-polling`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_core_polling.py tests/unit/test_artifacts_coverage.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_quota_failure_detection.py tests/integration/concurrency/test_artifact_poll_dedupe.py tests/unit/test_init_order.py tests/unit/test_public_shims.py`
- [x] `rtk uv run ruff check src/notebooklm/_core.py src/notebooklm/_core_polling.py src/notebooklm/_artifacts.py tests/unit/test_core_polling.py tests/unit/test_artifacts_coverage.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_quota_failure_detection.py tests/integration/concurrency/test_artifact_poll_dedupe.py tests/unit/test_init_order.py`
- [x] `rtk uv run mypy src/notebooklm`

## Deferred polish findings
- None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal polling system for artifact/task operations: better deduplication, cancellation-safe handling, and centralized state management while preserving backward compatibility.

* **Tests**
  * Added comprehensive unit tests covering polling behavior, state bridging, mutation semantics, and protection against unintended runtime coupling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->