### PR TITLE
refactor(core): extract cookie persistence

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -27,19 +27,17 @@ from ._core_cache import (
 from ._core_cache import (
     ConversationCache,
 )
+from ._core_cookie_persistence import CookiePersistence
 from ._core_polling import PendingPolls, PollRegistry
 from ._env import get_default_language
 from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import (
     AuthTokens,
-    CookieSaveResult,
     CookieSnapshot,
     _rotate_cookies,
-    advance_cookie_snapshot_after_save,
     build_cookie_jar,
     format_authuser_value,
     save_cookies_to_storage,
-    snapshot_cookie_jar,
 )
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
@@ -716,28 +714,29 @@ class ClientCore:
             keepalive_storage_path if keepalive_storage_path is not None else auth.storage_path
         )
         self._keepalive_task: asyncio.Task[None] | None = None
-        # Serializes keepalive's worker-thread save with close()'s on-close save
-        # so that newer state always wins. Without this, an in-flight keepalive
-        # save kicked off before close() can finish *after* close()'s own save
-        # and clobber it (an older snapshot overwriting the freshest state).
-        #
-        # Contract (audit §17 / T7.G5):
-        # ``_save_lock`` is acquired ONLY inside ``_save()`` (run on a worker
-        # thread via ``asyncio.to_thread``); never held by an async context to
-        # prevent priority inversion against the event loop. A blocking
-        # ``threading.Lock`` held on the loop thread would stall every other
-        # coroutine — including the keepalive heartbeat and the cancellation
-        # path — while a sibling worker thread does file I/O. Keep all
-        # acquisitions inside the worker closure passed to ``asyncio.to_thread``.
-        # See ``tests/unit/test_save_lock_contract.py`` for the regression guard.
-        self._save_lock = threading.Lock()
-        # Open-time cookie snapshot — the input to the dirty-flag/delta merge
-        # in save_cookies_to_storage. Captured in ``open()`` and forwarded
-        # through every ``save_cookies`` call so a stale in-memory jar can't
-        # clobber sibling-process writes (docs/auth-keepalive.md §3.4.1).
-        # Per-instance, never module-global.
-        self._loaded_cookie_snapshot: CookieSnapshot | None = None
+        # Owns the in-process save lock and open-time cookie baseline while
+        # compatibility properties below keep the legacy private attribute
+        # names observable for current tests and first-party callers.
+        self.cookie_persistence = CookiePersistence(self.auth, self._keepalive_storage_path)
         self.poll_registry: PollRegistry = PollRegistry()
+
+    @property
+    def _save_lock(self) -> threading.Lock:
+        """Compatibility bridge to ``CookiePersistence``'s in-process save lock."""
+        return self.cookie_persistence.save_lock
+
+    @_save_lock.setter
+    def _save_lock(self, value: threading.Lock) -> None:
+        self.cookie_persistence.save_lock = value
+
+    @property
+    def _loaded_cookie_snapshot(self) -> CookieSnapshot | None:
+        """Compatibility bridge to the cookie save baseline."""
+        return self.cookie_persistence.loaded_cookie_snapshot
+
+    @_loaded_cookie_snapshot.setter
+    def _loaded_cookie_snapshot(self, value: CookieSnapshot | None) -> None:
+        self.cookie_persistence.loaded_cookie_snapshot = value
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
@@ -1127,12 +1126,7 @@ class ClientCore:
             # could possibly fire. When AuthTokens carries a snapshot from a
             # failed pre-client save, keep it so the unpersisted delta can be
             # retried instead of treating the already-mutated jar as clean.
-            self._loaded_cookie_snapshot = (
-                dict(self.auth.cookie_snapshot)
-                if self.auth.cookie_snapshot is not None
-                else snapshot_cookie_jar(self._http_client.cookies)
-            )
-            self.auth.cookie_snapshot = self._loaded_cookie_snapshot
+            self.cookie_persistence.capture_open_snapshot(self._http_client.cookies)
 
             # Spawn the keepalive task once the client is ready
             if self._keepalive_interval is not None:
@@ -1141,87 +1135,20 @@ class ClientCore:
                 )
 
     async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
-        """Persist a cookie jar through the shared save lock.
+        """Persist a cookie jar through the shared cookie-persistence collaborator.
 
-        Single chokepoint used by ``close()``, the keepalive loop, and
-        ``NotebookLMClient.refresh_auth``. Routes every save through:
-
-        1. **Snapshot the jar** on the event-loop thread so the worker isn't
-           iterating a live ``AsyncClient.cookies`` that may be mutating
-           (RPC redirects, the next poke iteration).
-        2. **Hold ``self._save_lock``** (a ``threading.Lock``) for the duration
-           of the off-loaded write. Multiple writers in the same process
-           serialize through this lock so the newer caller always wins.
-        3. **Off-load** the actual save to a worker thread via
-           ``asyncio.to_thread`` so disk I/O never stalls the event loop.
-        4. **Refresh the baseline snapshot** on success so that a subsequent
-           save in this client computes deltas against what we just
-           persisted — not against the open-time snapshot. Without this
-           step the same delta would re-apply on every save, silently
-           clobbering any sibling-process write that landed between two of
-           our own saves (the keepalive + close common case).
-
-        Cross-process serialization is handled at a different layer — the
-        OS-level file lock inside :func:`save_cookies_to_storage` itself.
-
-        Args:
-            jar: The cookie jar to persist. A copy is taken on the loop thread
-                before the worker reads it.
-            path: Storage path. Falls back to ``self._keepalive_storage_path``,
-                which itself falls back to ``self.auth.storage_path``. If both
-                are ``None``, the call is a no-op.
+        This remains the single chokepoint used by ``close()``, the keepalive
+        loop, and ``NotebookLMClient.refresh_auth``. The storage writer and
+        thread offload callable are resolved from this module at call time so
+        existing ``notebooklm._core`` monkeypatch paths continue to affect the
+        live save path.
         """
-        effective_path = path if path is not None else self._keepalive_storage_path
-        if effective_path is None:
-            return
-        save_path: Path = effective_path
-
-        jar_copy = httpx.Cookies(jar)
-        # Computed on the loop thread off ``jar_copy`` so the worker can refresh
-        # the baseline without re-snapshotting a jar that may have mutated in
-        # the meantime (next keepalive poke, in-flight RPC redirect).
-        post_save_snapshot = snapshot_cookie_jar(jar_copy)
-
-        def _save(
-            s: httpx.Cookies = jar_copy,
-            p: Path = save_path,
-            lock: threading.Lock = self._save_lock,
-            post: CookieSnapshot = post_save_snapshot,
-            client: ClientCore = self,
-        ) -> None:
-            """Worker-thread save: hold the in-process lock around the disk write."""
-            with lock:
-                # Read the baseline INSIDE the lock so a prior save that
-                # completed while we were queued advances ours too. Capturing
-                # this on the loop thread would let a concurrent save observe
-                # a stale baseline, compute deltas against pre-prior-save
-                # state, hit CAS rejection on every key, and silently lose
-                # the local rotation.
-                snap = client._loaded_cookie_snapshot
-                # Advance successful keys while preserving CAS-rejected ones.
-                # A silent I/O error leaves the baseline untouched; an
-                # exception does too. See class-level
-                # ``_loaded_cookie_snapshot``.
-                result = save_cookies_to_storage(
-                    s,
-                    p,
-                    original_snapshot=snap,
-                    return_result=True,
-                )
-                if isinstance(result, CookieSaveResult):
-                    if result.ok:
-                        client._loaded_cookie_snapshot = post
-                    elif result.cas_rejected_keys:
-                        client._loaded_cookie_snapshot = advance_cookie_snapshot_after_save(
-                            snap, post, result.cas_rejected_keys
-                        )
-                    if client._loaded_cookie_snapshot is not None:
-                        client.auth.cookie_snapshot = client._loaded_cookie_snapshot
-                elif result:
-                    client._loaded_cookie_snapshot = post
-                    client.auth.cookie_snapshot = post
-
-        await asyncio.to_thread(_save)
+        await self.cookie_persistence.save(
+            jar,
+            path,
+            save_cookies_to_storage=save_cookies_to_storage,
+            to_thread=asyncio.to_thread,
+        )
 
     async def close(self) -> None:
         """Close the HTTP client connection.

--- a/src/notebooklm/_core_cookie_persistence.py
+++ b/src/notebooklm/_core_cookie_persistence.py
@@ -28,8 +28,7 @@ class SaveCookiesToStorage(Protocol):
         *,
         original_snapshot: CookieSnapshot | None = None,
         return_result: bool = False,
-    ) -> bool | CookieSaveResult:
-        ...
+    ) -> bool | CookieSaveResult: ...
 
 
 ToThread = Callable[[Callable[[], None]], Awaitable[None]]

--- a/src/notebooklm/_core_cookie_persistence.py
+++ b/src/notebooklm/_core_cookie_persistence.py
@@ -1,0 +1,125 @@
+"""Cookie persistence collaborator for :mod:`notebooklm._core`."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Protocol
+
+import httpx
+
+from .auth import (
+    AuthTokens,
+    CookieSaveResult,
+    CookieSnapshot,
+    advance_cookie_snapshot_after_save,
+    snapshot_cookie_jar,
+)
+
+
+class SaveCookiesToStorage(Protocol):
+    """Callable shape for the storage writer resolved by ``ClientCore``."""
+
+    def __call__(
+        self,
+        cookie_jar: httpx.Cookies,
+        path: Path | None = None,
+        *,
+        original_snapshot: CookieSnapshot | None = None,
+        return_result: bool = False,
+    ) -> bool | CookieSaveResult:
+        ...
+
+
+ToThread = Callable[[Callable[[], None]], Awaitable[None]]
+
+
+class CookiePersistence:
+    """Owns cookie save snapshots, in-process serialization, and baseline state."""
+
+    def __init__(
+        self,
+        auth: AuthTokens,
+        default_path: Path | None,
+        *,
+        save_lock: threading.Lock | None = None,
+    ) -> None:
+        self.auth = auth
+        self.default_path = default_path
+        self.save_lock = save_lock if save_lock is not None else threading.Lock()
+        self.loaded_cookie_snapshot: CookieSnapshot | None = None
+
+    def capture_open_snapshot(self, jar: httpx.Cookies) -> CookieSnapshot:
+        """Capture and publish the baseline used for later delta saves."""
+        self.loaded_cookie_snapshot = (
+            dict(self.auth.cookie_snapshot)
+            if self.auth.cookie_snapshot is not None
+            else snapshot_cookie_jar(jar)
+        )
+        self.auth.cookie_snapshot = self.loaded_cookie_snapshot
+        return self.loaded_cookie_snapshot
+
+    async def save(
+        self,
+        jar: httpx.Cookies,
+        path: Path | None = None,
+        *,
+        save_cookies_to_storage: SaveCookiesToStorage,
+        to_thread: ToThread,
+    ) -> None:
+        """Persist ``jar`` through the shared in-process save lock.
+
+        The jar copy and post-save snapshot are taken before dispatching the
+        worker so the background thread never iterates a live
+        ``AsyncClient.cookies`` object. The blocking lock is acquired only
+        inside the worker closure passed to ``to_thread``.
+        """
+        effective_path = path if path is not None else self.default_path
+        if effective_path is None:
+            return
+        save_path: Path = effective_path
+
+        jar_copy = httpx.Cookies(jar)
+        post_save_snapshot = snapshot_cookie_jar(jar_copy)
+
+        def _save(
+            s: httpx.Cookies = jar_copy,
+            p: Path = save_path,
+            lock: threading.Lock = self.save_lock,
+            post: CookieSnapshot = post_save_snapshot,
+            persistence: CookiePersistence = self,
+        ) -> None:
+            """Worker-thread save: hold the in-process lock around the disk write."""
+            with lock:
+                snap = persistence.loaded_cookie_snapshot
+                result = save_cookies_to_storage(
+                    s,
+                    p,
+                    original_snapshot=snap,
+                    return_result=True,
+                )
+                persistence._advance_baseline_after_save(snap, post, result)
+
+        await to_thread(_save)
+
+    def _advance_baseline_after_save(
+        self,
+        original_snapshot: CookieSnapshot | None,
+        post_save_snapshot: CookieSnapshot,
+        result: bool | CookieSaveResult,
+    ) -> None:
+        if isinstance(result, CookieSaveResult):
+            if result.ok:
+                self.loaded_cookie_snapshot = post_save_snapshot
+            elif result.cas_rejected_keys:
+                self.loaded_cookie_snapshot = advance_cookie_snapshot_after_save(
+                    original_snapshot,
+                    post_save_snapshot,
+                    result.cas_rejected_keys,
+                )
+            if self.loaded_cookie_snapshot is not None:
+                self.auth.cookie_snapshot = self.loaded_cookie_snapshot
+        elif result:
+            self.loaded_cookie_snapshot = post_save_snapshot
+            self.auth.cookie_snapshot = post_save_snapshot

--- a/tests/unit/test_core_cookie_persistence.py
+++ b/tests/unit/test_core_cookie_persistence.py
@@ -1,0 +1,225 @@
+"""Unit tests for the core cookie persistence collaborator."""
+
+from __future__ import annotations
+
+import ast
+import threading
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+import notebooklm._core as core_module
+import notebooklm._core_cookie_persistence as persistence_module
+from notebooklm._core import ClientCore
+from notebooklm._core_cookie_persistence import CookiePersistence
+from notebooklm.auth import (
+    AuthTokens,
+    CookieSaveResult,
+    CookieSnapshot,
+    CookieSnapshotKey,
+    snapshot_cookie_jar,
+)
+
+
+def _auth_tokens(storage_path: Path | None = None) -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "sid", "__Secure-1PSIDTS": "psidts"},
+        csrf_token="csrf",
+        session_id="session",
+        storage_path=storage_path,
+    )
+
+
+def _jar(sid: str = "sid", psidts: str = "psidts") -> httpx.Cookies:
+    jar = httpx.Cookies()
+    jar.set("SID", sid, domain=".google.com", path="/")
+    jar.set("__Secure-1PSIDTS", psidts, domain=".google.com", path="/")
+    return jar
+
+
+def test_client_core_exposes_cookie_persistence_and_private_bridges(tmp_path: Path) -> None:
+    core = ClientCore(_auth_tokens(tmp_path / "storage_state.json"))
+    baseline = snapshot_cookie_jar(_jar())
+
+    core._loaded_cookie_snapshot = baseline
+
+    assert isinstance(core.cookie_persistence, CookiePersistence)
+    assert core._save_lock is core.cookie_persistence.save_lock
+    assert core.cookie_persistence.loaded_cookie_snapshot is baseline
+    assert core._loaded_cookie_snapshot is baseline
+
+
+@pytest.mark.asyncio
+async def test_client_core_save_cookies_uses_core_module_monkeypatches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    core = ClientCore(_auth_tokens(tmp_path / "storage_state.json"))
+    calls: list[str] = []
+
+    def fake_save(cookie_jar: httpx.Cookies, path: Path | None = None, **kwargs: Any) -> bool:
+        calls.append("save")
+        assert path == tmp_path / "storage_state.json"
+        assert "original_snapshot" in kwargs
+        return True
+
+    async def fake_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append("to_thread")
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(core_module, "save_cookies_to_storage", fake_save)
+    monkeypatch.setattr(core_module.asyncio, "to_thread", fake_to_thread)
+
+    await core.save_cookies(_jar())
+
+    assert calls == ["to_thread", "save"]
+
+
+@pytest.mark.asyncio
+async def test_cookie_persistence_snapshots_on_loop_and_writes_off_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    auth = _auth_tokens(tmp_path / "storage_state.json")
+    persistence = CookiePersistence(auth, tmp_path / "storage_state.json")
+    baseline = snapshot_cookie_jar(_jar())
+    persistence.loaded_cookie_snapshot = baseline
+    auth.cookie_snapshot = baseline
+
+    loop_thread = threading.current_thread()
+    snapshot_threads: list[threading.Thread] = []
+    writer_thread: threading.Thread | None = None
+    real_snapshot = persistence_module.snapshot_cookie_jar
+
+    def snapshot_spy(cookie_jar: httpx.Cookies) -> CookieSnapshot:
+        snapshot_threads.append(threading.current_thread())
+        return real_snapshot(cookie_jar)
+
+    async def worker_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        assert snapshot_threads == [loop_thread]
+        raised: list[BaseException] = []
+
+        def run() -> None:
+            try:
+                func(*args, **kwargs)
+            except BaseException as exc:  # pragma: no cover - re-raised on loop thread
+                raised.append(exc)
+
+        worker = threading.Thread(target=run, name="cookie-save-test-worker")
+        worker.start()
+        worker.join(timeout=5.0)
+        assert not worker.is_alive()
+        if raised:
+            raise raised[0]
+
+    def fake_save(
+        cookie_jar: httpx.Cookies,
+        path: Path | None = None,
+        *,
+        original_snapshot: CookieSnapshot | None = None,
+        return_result: bool = False,
+    ) -> bool | CookieSaveResult:
+        nonlocal writer_thread
+        writer_thread = threading.current_thread()
+        assert path == tmp_path / "storage_state.json"
+        assert original_snapshot is baseline
+        assert return_result is True
+        assert persistence.save_lock.locked()
+        return CookieSaveResult(True)
+
+    monkeypatch.setattr(persistence_module, "snapshot_cookie_jar", snapshot_spy)
+
+    await persistence.save(
+        _jar(psidts="rotated"),
+        save_cookies_to_storage=fake_save,
+        to_thread=worker_to_thread,
+    )
+
+    psidts_key = CookieSnapshotKey("__Secure-1PSIDTS", ".google.com", "/")
+    assert snapshot_threads == [loop_thread]
+    assert writer_thread is not None and writer_thread is not loop_thread
+    assert persistence.loaded_cookie_snapshot is not baseline
+    assert persistence.loaded_cookie_snapshot is auth.cookie_snapshot
+    assert persistence.loaded_cookie_snapshot[psidts_key].value == "rotated"
+
+
+@pytest.mark.asyncio
+async def test_cookie_persistence_advances_baseline_only_on_accepted_saves(
+    tmp_path: Path,
+) -> None:
+    auth = _auth_tokens(tmp_path / "storage_state.json")
+    persistence = CookiePersistence(auth, tmp_path / "storage_state.json")
+    baseline = snapshot_cookie_jar(_jar(sid="sid-old", psidts="psidts-old"))
+    persistence.loaded_cookie_snapshot = baseline
+    auth.cookie_snapshot = baseline
+
+    sid_key = CookieSnapshotKey("SID", ".google.com", "/")
+    psidts_key = CookieSnapshotKey("__Secure-1PSIDTS", ".google.com", "/")
+    results: list[CookieSaveResult] = [
+        CookieSaveResult(False),
+        CookieSaveResult(False, frozenset({psidts_key})),
+        CookieSaveResult(True),
+    ]
+
+    async def inline_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        return func(*args, **kwargs)
+
+    def fake_save(
+        cookie_jar: httpx.Cookies,
+        path: Path | None = None,
+        *,
+        original_snapshot: CookieSnapshot | None = None,
+        return_result: bool = False,
+    ) -> bool | CookieSaveResult:
+        assert original_snapshot is persistence.loaded_cookie_snapshot
+        assert return_result is True
+        return results.pop(0)
+
+    await persistence.save(
+        _jar(sid="sid-silent", psidts="psidts-silent"),
+        save_cookies_to_storage=fake_save,
+        to_thread=inline_to_thread,
+    )
+
+    assert persistence.loaded_cookie_snapshot is baseline
+    assert auth.cookie_snapshot is baseline
+
+    await persistence.save(
+        _jar(sid="sid-accepted", psidts="psidts-rejected"),
+        save_cookies_to_storage=fake_save,
+        to_thread=inline_to_thread,
+    )
+
+    assert persistence.loaded_cookie_snapshot is not None
+    assert persistence.loaded_cookie_snapshot is auth.cookie_snapshot
+    assert persistence.loaded_cookie_snapshot[sid_key].value == "sid-accepted"
+    assert persistence.loaded_cookie_snapshot[psidts_key].value == "psidts-old"
+
+    await persistence.save(
+        _jar(sid="sid-final", psidts="psidts-final"),
+        save_cookies_to_storage=fake_save,
+        to_thread=inline_to_thread,
+    )
+
+    assert persistence.loaded_cookie_snapshot is not None
+    assert persistence.loaded_cookie_snapshot is auth.cookie_snapshot
+    assert persistence.loaded_cookie_snapshot[sid_key].value == "sid-final"
+    assert persistence.loaded_cookie_snapshot[psidts_key].value == "psidts-final"
+
+
+def test_core_cookie_persistence_does_not_import_client_core_at_runtime() -> None:
+    source = (
+        Path(__file__).resolve().parents[2] / "src/notebooklm/_core_cookie_persistence.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    forbidden_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in {"_core", "notebooklm._core"}:
+            forbidden_imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            forbidden_imports.extend(
+                alias.name for alias in node.names if alias.name == "notebooklm._core"
+            )
+
+    assert forbidden_imports == []

--- a/tests/unit/test_save_lock_contract.py
+++ b/tests/unit/test_save_lock_contract.py
@@ -200,14 +200,11 @@ def test_save_lock_only_acquired_inside_save_closure() -> None:
         def _record_if_save_lock(self, expr: ast.expr) -> None:
             # Match ``self.save_lock`` directly.
             if (
-                (
-                    isinstance(expr, ast.Attribute)
-                    and expr.attr == "save_lock"
-                    and isinstance(expr.value, ast.Name)
-                    and expr.value.id == "self"
-                )
-                or (isinstance(expr, ast.Name) and expr.id == "lock")
-            ):
+                isinstance(expr, ast.Attribute)
+                and expr.attr == "save_lock"
+                and isinstance(expr.value, ast.Name)
+                and expr.value.id == "self"
+            ) or (isinstance(expr, ast.Name) and expr.id == "lock"):
                 where = ".".join(self._enclosing_func) or "<module>"
                 acquisition_sites.append((where, expr.lineno))
 

--- a/tests/unit/test_save_lock_contract.py
+++ b/tests/unit/test_save_lock_contract.py
@@ -1,17 +1,18 @@
 """Regression guard for the ``ClientCore._save_lock`` contract (T7.G5).
 
 Contract (audit §17, documented at ``_core.py`` next to the lock definition):
-``_save_lock`` is acquired ONLY inside ``_save()``, which runs on a worker
-thread via ``asyncio.to_thread``. It is never held by an async context — a
+``_save_lock`` is acquired ONLY inside ``CookiePersistence.save``'s ``_save()``
+closure, which runs on a worker thread via ``asyncio.to_thread``. It is never
+held by an async context — a
 blocking ``threading.Lock`` taken on the event-loop thread would stall every
 other coroutine (keepalive, RPCs, cancellation) while a sibling worker thread
 does file I/O. That is the priority-inversion failure mode this contract
 exists to prevent.
 
 These tests are deliberately structural: they verify the rule end-to-end
-(via the live ``save_cookies`` path) AND statically (by scanning ``_core.py``
-for any unexpected acquisition site), so a future refactor that adds an
-event-loop acquisition fails fast in CI.
+(via the live ``save_cookies`` path) AND statically (by scanning the cookie
+persistence collaborator for any unexpected acquisition site), so a future
+refactor that adds an event-loop acquisition fails fast in CI.
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ import httpx
 import pytest
 
 from notebooklm._core import ClientCore
+from notebooklm._core_cookie_persistence import CookiePersistence
 from notebooklm.auth import AuthTokens
 
 
@@ -158,29 +160,22 @@ async def test_save_lock_does_not_block_event_loop(
 
 
 def test_save_lock_only_acquired_inside_save_closure() -> None:
-    """Static guard: ``_save_lock`` has exactly one ``with`` acquisition site
-    in ``_core.py``, and it lives inside the ``_save`` closure defined in
-    ``ClientCore.save_cookies``.
+    """Static guard: the blocking lock is acquired inside the worker closure.
 
-    This catches a refactor that adds a second ``with self._save_lock:``
-    elsewhere (e.g. inside an async method) before such a change can ship —
-    static-only, so it has zero runtime cost and runs even when the async
-    test infrastructure is offline.
-
-    Known blind spot: this scan only matches ``with self._save_lock:`` —
-    aliased acquisitions like ``lock = self._save_lock; with lock: ...``
-    inside an async method are NOT caught here. Those are covered by the
-    runtime guards above, which observe the thread that actually holds the
-    lock rather than relying on syntactic structure.
+    This catches a refactor that adds a second ``with self.save_lock:`` or
+    aliased ``with lock:`` elsewhere (e.g. inside an async method) before such
+    a change can ship — static-only, so it has zero runtime cost and runs even
+    when the async test infrastructure is offline.
     """
-    import notebooklm._core as core_module
 
-    source_path = Path(inspect.getsourcefile(core_module) or "")
-    assert source_path.is_file(), f"could not locate _core.py source: {source_path!r}"
+    source_path = Path(inspect.getsourcefile(CookiePersistence) or "")
+    assert source_path.is_file(), (
+        f"could not locate _core_cookie_persistence.py source: {source_path!r}"
+    )
     tree = ast.parse(source_path.read_text())
 
-    # Find every ``with <X>._save_lock:`` (or aliased ``with lock:`` whose
-    # binding is ``self._save_lock``) by walking the AST.
+    # Find every ``with self.save_lock:`` or closure-aliased ``with lock:`` by
+    # walking the collaborator AST.
     acquisition_sites: list[tuple[str, int]] = []
 
     class _Visitor(ast.NodeVisitor):
@@ -203,12 +198,15 @@ def test_save_lock_only_acquired_inside_save_closure() -> None:
             self._enclosing_func.pop()
 
         def _record_if_save_lock(self, expr: ast.expr) -> None:
-            # Match ``self._save_lock`` directly.
+            # Match ``self.save_lock`` directly.
             if (
-                isinstance(expr, ast.Attribute)
-                and expr.attr == "_save_lock"
-                and isinstance(expr.value, ast.Name)
-                and expr.value.id == "self"
+                (
+                    isinstance(expr, ast.Attribute)
+                    and expr.attr == "save_lock"
+                    and isinstance(expr.value, ast.Name)
+                    and expr.value.id == "self"
+                )
+                or (isinstance(expr, ast.Name) and expr.id == "lock")
             ):
                 where = ".".join(self._enclosing_func) or "<module>"
                 acquisition_sites.append((where, expr.lineno))
@@ -227,18 +225,14 @@ def test_save_lock_only_acquired_inside_save_closure() -> None:
 
     _Visitor().visit(tree)
 
-    # We don't enforce a single acquisition site (the closure uses a captured
-    # ``lock`` parameter, not ``self._save_lock`` directly, so the visitor
-    # finds zero ``self._save_lock`` ``with`` sites in steady state). What we
-    # DO enforce: no ``with self._save_lock:`` appears OUTSIDE the ``_save``
-    # closure. Any such site is a contract violation by construction.
     offenders = [
         (where, lineno) for (where, lineno) in acquisition_sites if "_save" not in where.split(".")
     ]
     assert offenders == [], (
-        "_save_lock contract violation: ``with self._save_lock:`` found "
+        "_save_lock contract violation: blocking lock acquisition found "
         f"outside the ``_save`` closure: {offenders!r}. The lock must "
         "ONLY be acquired inside ``_save()`` (run via asyncio.to_thread). "
-        "See ``_core.py`` docstring above ``self._save_lock`` "
+        "See ``_core_cookie_persistence.py`` "
         "and audit §17 / T7.G5."
     )
+    assert acquisition_sites, "expected CookiePersistence.save to acquire the save lock"


### PR DESCRIPTION
## Summary
- Add `CookiePersistence` to own cookie snapshotting, worker-thread save coordination, save-lock usage, and baseline advancement.
- Keep `ClientCore.save_cookies` as the compatibility chokepoint and preserve `_core.save_cookies_to_storage` / `_core.asyncio.to_thread` monkeypatch paths.
- Add direct collaborator coverage for loop-thread snapshots, off-thread writes, partial CAS baseline advancement, silent failures, and core bridge exposure.

## Task
`.sisyphus/phases/architecture-remediation/phase-3.md#t4c-core-cookie-persistence`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_core_cookie_persistence.py tests/unit/test_save_lock_contract.py tests/unit/test_client_keepalive.py tests/unit/test_auth_cookie_save_race.py tests/integration/test_core.py::TestClientInitialization::test_close_does_not_sync_in_memory_auth_to_default_storage tests/integration/test_core.py::TestClientInitialization::test_close_closes_http_client_when_cookie_sync_fails`
- [x] `rtk uv run ruff check src/notebooklm/_core.py src/notebooklm/_core_cookie_persistence.py tests/unit/test_core_cookie_persistence.py tests/unit/test_save_lock_contract.py tests/unit/test_client_keepalive.py tests/unit/test_auth_cookie_save_race.py`
- [x] `rtk uv run mypy src/notebooklm`
- [x] polish fallback: local simplification/review plus Gemini review; no findings

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revamped cookie persistence into a dedicated collaborator for safer, thread-aware cookie saves and reliable baseline snapshot management; maintained compatibility so existing client behavior is preserved.

* **Tests**
  * Added comprehensive tests for cookie persistence, snapshot semantics, off-thread storage writes, baseline advancement rules, and a test-only synthetic error transport to support deterministic recording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->