### PR TITLE
refactor(core): extract RPC executor

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -14,7 +14,6 @@ from contextlib import AbstractAsyncContextManager, nullcontext
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
-from urllib.parse import urlencode
 
 import httpx
 
@@ -27,6 +26,7 @@ from ._core_cache import (
 )
 from ._core_cookie_persistence import CookiePersistence
 from ._core_polling import PendingPolls, PollRegistry
+from ._core_rpc import RpcExecutor
 from ._core_transport import (
     MAX_RETRY_AFTER_SECONDS as MAX_RETRY_AFTER_SECONDS,
 )
@@ -34,19 +34,19 @@ from ._core_transport import (
     AuthedTransport,
     _AuthSnapshot,
     _BuildRequest,
-    _parse_retry_after,
     _TransportAuthExpired,
     _TransportRateLimited,
     _TransportServerError,
 )
-from ._env import get_default_language
+from ._core_transport import (
+    _parse_retry_after as _parse_retry_after,
+)
 from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import (
     AuthTokens,
     CookieSnapshot,
     _rotate_cookies,
     build_cookie_jar,
-    format_authuser_value,
     save_cookies_to_storage,
 )
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
@@ -63,11 +63,7 @@ from .rpc import (
     RPCMethod,
     RPCTimeoutError,
     ServerError,
-    build_request_body,
     decode_response,
-    encode_rpc_request,
-    get_batchexecute_url,
-    resolve_rpc_id,
 )
 
 logger = logging.getLogger(__name__)
@@ -349,6 +345,14 @@ def is_auth_error(error: Exception) -> bool:
     return False
 
 
+def _decode_response_late_bound(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
+    return decode_response(raw, rpc_id, allow_null=allow_null)
+
+
+def _sleep_late_bound(seconds: float) -> Awaitable[Any]:
+    return asyncio.sleep(seconds)
+
+
 class ClientCore:
     """Core client infrastructure for HTTP and RPC operations.
 
@@ -598,6 +602,7 @@ class ClientCore:
         self.cookie_persistence = CookiePersistence(self.auth, self._keepalive_storage_path)
         self.poll_registry: PollRegistry = PollRegistry()
         self._authed_transport: AuthedTransport | None = None
+        self._rpc_executor: RpcExecutor | None = None
 
     @property
     def _save_lock(self) -> threading.Lock:
@@ -949,6 +954,26 @@ class ClientCore:
             self._authed_transport = transport
         return transport
 
+    def _get_rpc_executor(self) -> RpcExecutor:
+        """Return the RPC execution collaborator, lazily initialized.
+
+        The adapters resolve through this module at call time so existing
+        monkeypatches of ``notebooklm._core.decode_response``,
+        ``notebooklm._core.is_auth_error``, and
+        ``notebooklm._core.asyncio.sleep`` keep affecting live RPC behavior
+        after the collaborator has been constructed.
+        """
+        executor = getattr(self, "_rpc_executor", None)
+        if executor is None:
+            executor = RpcExecutor(
+                self,
+                decode_response_late_bound=_decode_response_late_bound,
+                is_auth_error=lambda exc: is_auth_error(exc),
+                sleep=_sleep_late_bound,
+            )
+            self._rpc_executor = executor
+        return executor
+
     async def open(self) -> None:
         """Open the HTTP client connection.
 
@@ -1264,48 +1289,13 @@ class ClientCore:
         source_path: str = "/",
         rpc_id_override: str | None = None,
     ) -> str:
-        """Build the batchexecute URL for an RPC call.
-
-        Args:
-            rpc_method: The RPC method to call.
-            snapshot: Frozen ``_AuthSnapshot`` captured by :meth:`_snapshot`
-                under ``_auth_snapshot_lock``. The URL is built entirely
-                from snapshot fields (``session_id``, ``authuser``,
-                ``account_email``) so the URL and body for one attempt
-                stay coherent across a concurrent refresh. Audit §12 /
-                T7.F2: pre-fix this method read ``self.auth`` LIVE on
-                each call, which let a refresh's write to
-                ``self.auth.session_id`` slip between ``_snapshot()`` and
-                ``_build_url()`` — producing a URL stamped with the new
-                generation while the body still carried the old CSRF.
-            source_path: The source path parameter (usually notebook path).
-            rpc_id_override: Optional resolved RPC id string used in the
-                ``rpcids=`` query param. When provided, the SAME string must
-                also be passed to :func:`encode_rpc_request` so the URL and
-                body stay in sync. See ``resolve_rpc_id`` for the
-                ``NOTEBOOKLM_RPC_OVERRIDES`` plumbing.
-
-        Returns:
-            Full URL with query parameters.
-        """
-        rpc_id = rpc_id_override if rpc_id_override is not None else rpc_method.value
-        params: dict[str, str] = {
-            "rpcids": rpc_id,
-            "source-path": source_path,
-            "f.sid": snapshot.session_id,
-            "hl": get_default_language(),
-            "rt": "c",
-        }
-        # Multi-account: route batchexecute to the same Google account the
-        # auth tokens were minted for. Email is preferred when known because
-        # Google's integer account indices can change as browser accounts are
-        # added or removed.
-        if snapshot.account_email or snapshot.authuser:
-            params["authuser"] = format_authuser_value(
-                snapshot.authuser,
-                snapshot.account_email,
-            )
-        return f"{get_batchexecute_url()}?{urlencode(params)}"
+        """Compatibility wrapper around :class:`RpcExecutor` URL building."""
+        return self._get_rpc_executor().build_url(
+            rpc_method,
+            snapshot,
+            source_path,
+            rpc_id_override=rpc_id_override,
+        )
 
     async def _perform_authed_post(
         self,
@@ -1564,243 +1554,31 @@ class ClientCore:
         *,
         disable_internal_retries: bool = False,
     ) -> Any:
-        # Caller (rpc_call) has already verified self._http_client is not None;
-        # re-assert for mypy narrowing through this helper.
-        assert self._http_client is not None
-        start = time.perf_counter()
-        logger.debug("RPC %s starting", method.name)
-
-        # Resolve the RPC id ONCE per logical call. ``NOTEBOOKLM_RPC_OVERRIDES``
-        # lets users self-patch when Google rotates an obfuscated method id;
-        # the resolved value MUST flow into both the URL's ``rpcids=`` query
-        # param and the request body's ``f.req`` payload (the wire format
-        # treats a mismatch as malformed). Resolving once also means decode
-        # below uses the same id we asked the server for.
-        resolved_id = resolve_rpc_id(method.name, method.value)
-
-        # ``_perform_authed_post`` calls this factory once per HTTP attempt;
-        # on retry it passes a fresh snapshot so the body is rebuilt with the
-        # refreshed CSRF and the URL with the refreshed session id /
-        # authuser. Capturing ``self.auth.csrf_token`` here directly would
-        # snapshot at outer-call time and replay a stale token on retry.
-        rpc_request = encode_rpc_request(method, params, rpc_id_override=resolved_id)
-
-        def _build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
-            # T7.F2: both the URL (via ``_build_url(snapshot, ...)``) and
-            # the body (via ``snapshot.csrf_token``) now consume the
-            # *same* frozen ``_AuthSnapshot`` captured under
-            # ``_auth_snapshot_lock``. Pre-fix this factory passed only
-            # ``snapshot.csrf_token`` to the body while ``_build_url``
-            # re-read ``self.auth.session_id`` LIVE — a torn read that
-            # let a concurrent refresh slip a new sid into the URL while
-            # the body still carried the old csrf. Now URL + body are
-            # generation-coherent for the lifetime of this attempt; cookie
-            # coherence with the snapshot is still upheld by the no-await
-            # invariant between ``_snapshot()`` returning and the
-            # ``client.post(...)`` call inside ``_perform_authed_post``
-            # (see the AST guards in
-            # ``tests/unit/test_concurrency_refresh_race.py``).
-            url = self._build_url(method, snapshot, source_path, rpc_id_override=resolved_id)
-            body = build_request_body(rpc_request, snapshot.csrf_token)
-            return url, body, {}
-
-        try:
-            response = await self._perform_authed_post(
-                build_request=_build,
-                log_label=f"RPC {method.name}",
-                disable_internal_retries=disable_internal_retries,
-            )
-        except _TransportAuthExpired as exc:
-            # Refresh callback raised. Historical contract:
-            # the *original* transport exception escapes with the refresh
-            # error attached via ``__cause__`` (already chained inside
-            # ``_perform_authed_post``). No status-code mapping happens for
-            # this path — callers that catch :class:`httpx.HTTPStatusError`
-            # see exactly what they used to see pre-extraction.
-            raise exc.original from exc.__cause__
-        except _TransportRateLimited as exc:
-            elapsed = time.perf_counter() - start
-            logger.error(
-                "RPC %s failed after %.3fs: HTTP 429",
-                method.name,
-                elapsed,
-            )
-            msg = f"API rate limit exceeded calling {method.name}"
-            if exc.retry_after:
-                msg += f". Retry after {exc.retry_after} seconds"
-            raise RateLimitError(
-                msg,
-                method_id=method.value,
-                retry_after=exc.retry_after,
-            ) from exc.original
-        except _TransportServerError as exc:
-            elapsed = time.perf_counter() - start
-            # Translate the budget-exhaustion signal back into the historical
-            # RPC error shape: 5xx → ServerError; network → NetworkError /
-            # RPCTimeoutError. ``_raise_rpc_error_from_*`` already does the
-            # right mapping for the underlying ``original`` exception.
-            if isinstance(exc.original, httpx.HTTPStatusError):
-                logger.error(
-                    "RPC %s failed after %.3fs: HTTP %s (server-error retries exhausted)",
-                    method.name,
-                    elapsed,
-                    exc.original.response.status_code,
-                )
-                self._raise_rpc_error_from_http_status(exc.original, method)
-            else:
-                # ``_perform_authed_post`` only wraps ``httpx.RequestError``
-                # into ``_TransportServerError`` on the network path; this
-                # guard keeps the contract enforced under ``python -O``
-                # (where ``assert`` would be stripped).
-                if not isinstance(exc.original, httpx.RequestError):
-                    raise TypeError(
-                        f"Unexpected _TransportServerError.original type: {type(exc.original)}"
-                    ) from exc
-                logger.error(
-                    "RPC %s failed after %.3fs: %s (server-error retries exhausted)",
-                    method.name,
-                    elapsed,
-                    exc.original,
-                )
-                self._raise_rpc_error_from_request_error(exc.original, method)
-        except httpx.HTTPStatusError as exc:
-            elapsed = time.perf_counter() - start
-            logger.error(
-                "RPC %s failed after %.3fs: HTTP %s",
-                method.name,
-                elapsed,
-                exc.response.status_code,
-            )
-            self._raise_rpc_error_from_http_status(exc, method)
-        # NOTE: bare ``httpx.RequestError`` handler was removed here because
-        # ``_perform_authed_post`` always either retries network-layer
-        # errors or wraps them in ``_TransportServerError`` (handled above),
-        # so they cannot reach this scope.
-
-        # ---------- Decode -------------------------------------------------
-        # Decode-time auth retry stays RPC-specific: Google sometimes
-        # returns a 200 with an auth-shaped RPCError payload (the body says
-        # "authentication expired" instead of a 401 status code). The chat
-        # streaming format doesn't have this pattern, so the retry lives
-        # here, not in ``_perform_authed_post``.
-        try:
-            # The server echoes back whatever RPC id we sent on the wire, so
-            # decode against the resolved id (override-aware) rather than the
-            # canonical ``method.value`` — otherwise an override would parse
-            # as "RPC id not found in response".
-            result = decode_response(response.text, resolved_id, allow_null=allow_null)
-            elapsed = time.perf_counter() - start
-            logger.debug("RPC %s completed in %.3fs", method.name, elapsed)
-            return result
-        except RPCError as e:
-            elapsed = time.perf_counter() - start
-
-            # Check if this is an auth error and we can retry
-            if not _is_retry and self._refresh_callback and is_auth_error(e):
-                refreshed = await self._try_refresh_and_retry(
-                    method,
-                    params,
-                    source_path,
-                    allow_null,
-                    e,
-                    disable_internal_retries=disable_internal_retries,
-                )
-                if refreshed is not None:
-                    return refreshed
-
-            logger.error("RPC %s failed after %.3fs", method.name, elapsed)
-            raise
-        except Exception as e:
-            elapsed = time.perf_counter() - start
-            logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, e)
-            raise RPCError(
-                f"Failed to decode response for {method.name}: {e}",
-                method_id=method.value,
-            ) from e
+        """Compatibility wrapper around :class:`RpcExecutor`."""
+        return await self._get_rpc_executor().execute(
+            method,
+            params,
+            source_path,
+            allow_null,
+            _is_retry,
+            disable_internal_retries=disable_internal_retries,
+        )
 
     def _raise_rpc_error_from_http_status(
         self,
         exc: httpx.HTTPStatusError,
         method: RPCMethod,
     ) -> NoReturn:
-        """Map an HTTP-status failure onto the RPC error hierarchy.
-
-        Centralizes the status-to-exception mapping that historically lived
-        inline in ``_rpc_call_impl``. Always raises — typed ``NoReturn`` so
-        mypy sees the caller's control flow terminates here.
-        """
-        status = exc.response.status_code
-
-        if status == 429:
-            # _perform_authed_post normally raises ``_TransportRateLimited``
-            # before reaching here. This branch covers callers that bypass
-            # the helper or a 429 surfacing after an auth retry.
-            retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
-            msg = f"API rate limit exceeded calling {method.name}"
-            if retry_after:
-                msg += f". Retry after {retry_after} seconds"
-            raise RateLimitError(msg, method_id=method.value, retry_after=retry_after) from exc
-
-        if 500 <= status < 600:
-            raise ServerError(
-                f"Server error {status} calling {method.name}: {exc.response.reason_phrase}",
-                method_id=method.value,
-                status_code=status,
-            ) from exc
-
-        if 400 <= status < 500 and status not in (401, 403):
-            raise ClientError(
-                f"Client error {status} calling {method.name}: {exc.response.reason_phrase}",
-                method_id=method.value,
-                status_code=status,
-            ) from exc
-
-        # 401/403 or other: Generic RPCError (auth retry already attempted by
-        # _perform_authed_post when a refresh callback was configured).
-        raise RPCError(
-            f"HTTP {status} calling {method.name}: {exc.response.reason_phrase}",
-            method_id=method.value,
-        ) from exc
+        """Compatibility wrapper around :class:`RpcExecutor`."""
+        self._get_rpc_executor().raise_rpc_error_from_http_status(exc, method)
 
     def _raise_rpc_error_from_request_error(
         self,
         exc: httpx.RequestError,
         method: RPCMethod,
     ) -> NoReturn:
-        """Map a non-HTTPStatus transport failure onto NetworkError/RPCTimeoutError.
-
-        Always raises — typed ``NoReturn`` so mypy treats the caller's
-        control flow as terminating here, preventing an unbound-``response``
-        warning in the decode block of ``_rpc_call_impl``.
-        """
-        # Check ConnectTimeout first (more specific than general TimeoutException)
-        if isinstance(exc, httpx.ConnectTimeout):
-            raise NetworkError(
-                f"Connection timed out calling {method.name}: {exc}",
-                method_id=method.value,
-                original_error=exc,
-            ) from exc
-
-        if isinstance(exc, httpx.TimeoutException):
-            raise RPCTimeoutError(
-                f"Request timed out calling {method.name}",
-                method_id=method.value,
-                timeout_seconds=self._timeout,
-                original_error=exc,
-            ) from exc
-
-        if isinstance(exc, httpx.ConnectError):
-            raise NetworkError(
-                f"Connection failed calling {method.name}: {exc}",
-                method_id=method.value,
-                original_error=exc,
-            ) from exc
-
-        raise NetworkError(
-            f"Request failed calling {method.name}: {exc}",
-            method_id=method.value,
-            original_error=exc,
-        ) from exc
+        """Compatibility wrapper around :class:`RpcExecutor`."""
+        self._get_rpc_executor().raise_rpc_error_from_request_error(exc, method)
 
     async def _try_refresh_and_retry(
         self,
@@ -1812,59 +1590,13 @@ class ClientCore:
         *,
         disable_internal_retries: bool = False,
     ) -> Any | None:
-        """Attempt to refresh auth tokens and retry the RPC call.
-
-        Uses a shared task pattern to ensure only one refresh operation runs
-        at a time. Concurrent callers wait on the same task, preventing
-        redundant refresh calls under high concurrency.
-
-        Args:
-            method: The RPC method to retry.
-            params: Original parameters.
-            source_path: Original source path.
-            allow_null: Original allow_null setting.
-            original_error: The auth error that triggered this retry.
-            disable_internal_retries: When True, suppress the inner 5xx /
-                429 / network retry loop on the post-refresh ``rpc_call``,
-                so transport failures are surfaced immediately for the
-                caller's idempotency wrapper to handle.
-
-        Returns:
-            The RPC result if retry succeeds, None if refresh failed.
-
-        Raises:
-            The original error (with refresh error as cause) if refresh fails.
-        """
-        logger.info(
-            "RPC %s auth error detected, attempting token refresh",
-            method.name,
-        )
-
-        # Delegate the shared-task + lock dance to ``_await_refresh`` so this
-        # decode-time retry path stays in lockstep with the transport-time
-        # path inside ``_perform_authed_post``. On refresh failure, surface
-        # the *original* RPC decode error (not the refresh error) so callers
-        # see the symptom they originally hit — refresh failure is attached
-        # as ``__cause__``.
-        try:
-            await self._await_refresh()
-        except Exception as refresh_error:
-            logger.warning("Token refresh failed: %s", refresh_error)
-            raise original_error from refresh_error
-
-        # Brief delay before retry to avoid hammering the API
-        if self._refresh_retry_delay > 0:
-            await asyncio.sleep(self._refresh_retry_delay)
-
-        logger.info("Token refresh successful, retrying RPC %s", method.name)
-
-        # Retry with refreshed tokens
-        return await self.rpc_call(
+        """Compatibility wrapper around :class:`RpcExecutor`."""
+        return await self._get_rpc_executor().try_refresh_and_retry(
             method,
             params,
             source_path,
             allow_null,
-            _is_retry=True,
+            original_error,
             disable_internal_retries=disable_internal_retries,
         )
 

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -179,8 +179,7 @@ class RpcExecutor:
                     exc,
                     disable_internal_retries=disable_internal_retries,
                 )
-                if refreshed is not None:
-                    return refreshed
+                return refreshed
 
             logger.error("RPC %s failed after %.3fs", method.name, elapsed)
             raise

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -138,17 +138,18 @@ class RpcExecutor:
                 )
                 self.raise_rpc_error_from_http_status(exc.original, method)
 
-            if not isinstance(exc.original, httpx.RequestError):
-                raise TypeError(
-                    f"Unexpected _TransportServerError.original type: {type(exc.original)}"
-                ) from exc
-            logger.error(
-                "RPC %s failed after %.3fs: %s (server-error retries exhausted)",
-                method.name,
-                elapsed,
-                exc.original,
-            )
-            self.raise_rpc_error_from_request_error(exc.original, method)
+            if isinstance(exc.original, httpx.RequestError):
+                logger.error(
+                    "RPC %s failed after %.3fs: %s (server-error retries exhausted)",
+                    method.name,
+                    elapsed,
+                    exc.original,
+                )
+                self.raise_rpc_error_from_request_error(exc.original, method)
+
+            raise TypeError(
+                f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+            ) from exc
         except httpx.HTTPStatusError as exc:
             elapsed = time.perf_counter() - start
             logger.error(

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -1,0 +1,316 @@
+"""RPC execution collaborator for NotebookLM core operations."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any, NoReturn, Protocol
+from urllib.parse import urlencode
+
+import httpx
+
+from ._core_transport import (
+    _AuthSnapshot,
+    _BuildRequest,
+    _parse_retry_after,
+    _TransportAuthExpired,
+    _TransportRateLimited,
+    _TransportServerError,
+)
+from ._env import get_default_language
+from .auth import format_authuser_value
+from .rpc import (
+    ClientError,
+    NetworkError,
+    RateLimitError,
+    RPCError,
+    RPCMethod,
+    RPCTimeoutError,
+    ServerError,
+    build_request_body,
+    encode_rpc_request,
+    get_batchexecute_url,
+    resolve_rpc_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DecodeResponse(Protocol):
+    def __call__(self, raw: str, rpc_id: str, *, allow_null: bool = False) -> Any: ...
+
+
+class RpcOwner(Protocol):
+    _timeout: float
+    _refresh_callback: Callable[[], Awaitable[Any]] | None
+    _refresh_retry_delay: float
+
+    async def _perform_authed_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        log_label: str,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response: ...
+
+    async def _await_refresh(self) -> None: ...
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any: ...
+
+
+class RpcExecutor:
+    """Owns raw batchexecute RPC encode, transport dispatch, decode, and retry."""
+
+    def __init__(
+        self,
+        owner: RpcOwner,
+        *,
+        decode_response_late_bound: DecodeResponse,
+        is_auth_error: Callable[[Exception], bool],
+        sleep: Callable[[float], Awaitable[Any]],
+    ):
+        self._owner = owner
+        self._decode_response = decode_response_late_bound
+        self._is_auth_error = is_auth_error
+        self._sleep = sleep
+
+    async def execute(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str,
+        allow_null: bool,
+        _is_retry: bool,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        start = time.perf_counter()
+        logger.debug("RPC %s starting", method.name)
+
+        # Resolve once per logical call so URL, body, and decode use the same
+        # override-aware RPC id.
+        resolved_id = resolve_rpc_id(method.name, method.value)
+        rpc_request = encode_rpc_request(method, params, rpc_id_override=resolved_id)
+
+        def _build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            url = self.build_url(method, snapshot, source_path, rpc_id_override=resolved_id)
+            body = build_request_body(rpc_request, snapshot.csrf_token)
+            return url, body, {}
+
+        try:
+            response = await self._owner._perform_authed_post(
+                build_request=_build,
+                log_label=f"RPC {method.name}",
+                disable_internal_retries=disable_internal_retries,
+            )
+        except _TransportAuthExpired as exc:
+            # Preserve the historical raw transport exception on refresh failure.
+            raise exc.original from exc.__cause__
+        except _TransportRateLimited as exc:
+            elapsed = time.perf_counter() - start
+            logger.error("RPC %s failed after %.3fs: HTTP 429", method.name, elapsed)
+            msg = f"API rate limit exceeded calling {method.name}"
+            if exc.retry_after:
+                msg += f". Retry after {exc.retry_after} seconds"
+            raise RateLimitError(
+                msg,
+                method_id=method.value,
+                retry_after=exc.retry_after,
+            ) from exc.original
+        except _TransportServerError as exc:
+            elapsed = time.perf_counter() - start
+            if isinstance(exc.original, httpx.HTTPStatusError):
+                logger.error(
+                    "RPC %s failed after %.3fs: HTTP %s (server-error retries exhausted)",
+                    method.name,
+                    elapsed,
+                    exc.original.response.status_code,
+                )
+                self.raise_rpc_error_from_http_status(exc.original, method)
+
+            if not isinstance(exc.original, httpx.RequestError):
+                raise TypeError(
+                    f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                ) from exc
+            logger.error(
+                "RPC %s failed after %.3fs: %s (server-error retries exhausted)",
+                method.name,
+                elapsed,
+                exc.original,
+            )
+            self.raise_rpc_error_from_request_error(exc.original, method)
+        except httpx.HTTPStatusError as exc:
+            elapsed = time.perf_counter() - start
+            logger.error(
+                "RPC %s failed after %.3fs: HTTP %s",
+                method.name,
+                elapsed,
+                exc.response.status_code,
+            )
+            self.raise_rpc_error_from_http_status(exc, method)
+
+        try:
+            result = self._decode_response(response.text, resolved_id, allow_null=allow_null)
+            elapsed = time.perf_counter() - start
+            logger.debug("RPC %s completed in %.3fs", method.name, elapsed)
+            return result
+        except RPCError as exc:
+            elapsed = time.perf_counter() - start
+            if (
+                not _is_retry
+                and self._owner._refresh_callback is not None
+                and self._is_auth_error(exc)
+            ):
+                refreshed = await self.try_refresh_and_retry(
+                    method,
+                    params,
+                    source_path,
+                    allow_null,
+                    exc,
+                    disable_internal_retries=disable_internal_retries,
+                )
+                if refreshed is not None:
+                    return refreshed
+
+            logger.error("RPC %s failed after %.3fs", method.name, elapsed)
+            raise
+        except Exception as exc:
+            elapsed = time.perf_counter() - start
+            logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, exc)
+            raise RPCError(
+                f"Failed to decode response for {method.name}: {exc}",
+                method_id=method.value,
+            ) from exc
+
+    def build_url(
+        self,
+        rpc_method: RPCMethod,
+        snapshot: _AuthSnapshot,
+        source_path: str = "/",
+        rpc_id_override: str | None = None,
+    ) -> str:
+        """Build the batchexecute URL from a frozen auth snapshot."""
+        rpc_id = rpc_id_override if rpc_id_override is not None else rpc_method.value
+        params: dict[str, str] = {
+            "rpcids": rpc_id,
+            "source-path": source_path,
+            "f.sid": snapshot.session_id,
+            "hl": get_default_language(),
+            "rt": "c",
+        }
+        if snapshot.account_email or snapshot.authuser:
+            params["authuser"] = format_authuser_value(
+                snapshot.authuser,
+                snapshot.account_email,
+            )
+        return f"{get_batchexecute_url()}?{urlencode(params)}"
+
+    def raise_rpc_error_from_http_status(
+        self,
+        exc: httpx.HTTPStatusError,
+        method: RPCMethod,
+    ) -> NoReturn:
+        """Map an HTTP-status failure onto the RPC error hierarchy."""
+        status = exc.response.status_code
+
+        if status == 429:
+            retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+            msg = f"API rate limit exceeded calling {method.name}"
+            if retry_after:
+                msg += f". Retry after {retry_after} seconds"
+            raise RateLimitError(msg, method_id=method.value, retry_after=retry_after) from exc
+
+        if 500 <= status < 600:
+            raise ServerError(
+                f"Server error {status} calling {method.name}: {exc.response.reason_phrase}",
+                method_id=method.value,
+                status_code=status,
+            ) from exc
+
+        if 400 <= status < 500 and status not in (401, 403):
+            raise ClientError(
+                f"Client error {status} calling {method.name}: {exc.response.reason_phrase}",
+                method_id=method.value,
+                status_code=status,
+            ) from exc
+
+        raise RPCError(
+            f"HTTP {status} calling {method.name}: {exc.response.reason_phrase}",
+            method_id=method.value,
+        ) from exc
+
+    def raise_rpc_error_from_request_error(
+        self,
+        exc: httpx.RequestError,
+        method: RPCMethod,
+    ) -> NoReturn:
+        """Map a non-status transport failure onto NetworkError/RPCTimeoutError."""
+        if isinstance(exc, httpx.ConnectTimeout):
+            raise NetworkError(
+                f"Connection timed out calling {method.name}: {exc}",
+                method_id=method.value,
+                original_error=exc,
+            ) from exc
+
+        if isinstance(exc, httpx.TimeoutException):
+            raise RPCTimeoutError(
+                f"Request timed out calling {method.name}",
+                method_id=method.value,
+                timeout_seconds=self._owner._timeout,
+                original_error=exc,
+            ) from exc
+
+        if isinstance(exc, httpx.ConnectError):
+            raise NetworkError(
+                f"Connection failed calling {method.name}: {exc}",
+                method_id=method.value,
+                original_error=exc,
+            ) from exc
+
+        raise NetworkError(
+            f"Request failed calling {method.name}: {exc}",
+            method_id=method.value,
+            original_error=exc,
+        ) from exc
+
+    async def try_refresh_and_retry(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str,
+        allow_null: bool,
+        original_error: Exception,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any | None:
+        """Refresh auth after a decode-time auth error and retry once."""
+        logger.info("RPC %s auth error detected, attempting token refresh", method.name)
+
+        try:
+            await self._owner._await_refresh()
+        except Exception as refresh_error:
+            logger.warning("Token refresh failed: %s", refresh_error)
+            raise original_error from refresh_error
+
+        if self._owner._refresh_retry_delay > 0:
+            await self._sleep(self._owner._refresh_retry_delay)
+
+        logger.info("Token refresh successful, retrying RPC %s", method.name)
+        return await self._owner.rpc_call(
+            method,
+            params,
+            source_path,
+            allow_null,
+            _is_retry=True,
+            disable_internal_retries=disable_internal_retries,
+        )

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -37,7 +37,7 @@ This file *locks* the invariant in three ways:
 
 2. ``test_build_url_does_not_read_self_auth`` — static AST guard
    against any ``self.auth.<field>`` attribute access in
-   ``ClientCore._build_url``. The method MUST consume only its
+   ``RpcExecutor.build_url``. The method MUST consume only its
    ``snapshot: _AuthSnapshot`` parameter; reverting to ``self.auth``
    would silently un-do T7.F2's atomicity fix.
 
@@ -63,6 +63,7 @@ import httpx
 import pytest
 
 from notebooklm._core import ClientCore
+from notebooklm._core_rpc import RpcExecutor
 from notebooklm._core_transport import AuthedTransport
 from notebooklm.rpc import RPCMethod
 
@@ -202,7 +203,7 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
 
 
 def test_build_url_does_not_read_self_auth():
-    """``ClientCore._build_url`` must consume only its ``snapshot`` parameter.
+    """``RpcExecutor.build_url`` must consume only its ``snapshot`` parameter.
 
     T7.F2 / audit §12: pre-fix, ``_build_url`` reached into ``self.auth``
     on every call to read ``session_id``, ``authuser``, and
@@ -223,7 +224,7 @@ def test_build_url_does_not_read_self_auth():
     rooted at ``self.auth``. Forbidden: any ``self.auth.<field>``
     attribute access, regardless of which field.
     """
-    src = textwrap.dedent(inspect.getsource(ClientCore._build_url))
+    src = textwrap.dedent(inspect.getsource(RpcExecutor.build_url))
     tree = ast.parse(src)
     # ``_build_url`` is a sync method, not async.
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
@@ -239,7 +240,7 @@ def test_build_url_does_not_read_self_auth():
             forbidden.append((node.lineno, ast.dump(node)))
 
     assert not forbidden, (
-        f"_build_url reads self.auth — torn-read regression (T7.F2 / audit §12). "
+        f"RpcExecutor.build_url reads self.auth — torn-read regression (T7.F2 / audit §12). "
         f"Read every auth scalar off the ``snapshot`` parameter instead. "
         f"Occurrences: {forbidden}"
     )

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -60,6 +60,7 @@ class _Owner:
         self.perform_calls: list[dict[str, Any]] = []
         self.refresh_calls = 0
         self.rpc_retry_calls: list[dict[str, Any]] = []
+        self.rpc_retry_result: Any = {"retried": True}
         self.response = _ok_response()
         self.snapshot = _AuthSnapshot(
             csrf_token="CSRF_SNAPSHOT",
@@ -110,7 +111,7 @@ class _Owner:
                 "disable_internal_retries": disable_internal_retries,
             }
         )
-        return {"retried": True}
+        return self.rpc_retry_result
 
 
 def _executor(
@@ -364,6 +365,35 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
             "disable_internal_retries": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_decode_time_auth_retry_preserves_none_result() -> None:
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback)
+    owner.rpc_retry_result = None
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise RPCError("authentication expired")
+
+    result = await _executor(
+        owner,
+        decode_response_late_bound=decode,
+        is_auth_error=lambda exc: True,
+    ).execute(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/",
+        True,
+        False,
+    )
+
+    assert result is None
+    assert owner.refresh_calls == 1
+    assert owner.rpc_retry_calls[0]["allow_null"] is True
+    assert owner.rpc_retry_calls[0]["_is_retry"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import ast
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm._core_rpc import RpcExecutor
+from notebooklm._core_transport import _AuthSnapshot
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import (
+    ClientError,
+    NetworkError,
+    RateLimitError,
+    RPCError,
+    RPCMethod,
+    RPCTimeoutError,
+    ServerError,
+)
+
+
+def _auth_tokens() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "sid_cookie"},
+        csrf_token="CSRF",
+        session_id="SID",
+    )
+
+
+def _ok_response(text: str = "raw") -> httpx.Response:
+    return httpx.Response(
+        200,
+        text=text,
+        request=httpx.Request("POST", "https://example.test/rpc"),
+    )
+
+
+def _status_error(status_code: int, *, retry_after: str | None = None) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://example.test/rpc")
+    headers = {"retry-after": retry_after} if retry_after is not None else {}
+    response = httpx.Response(status_code, request=request, headers=headers)
+    return httpx.HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
+
+
+class _Owner:
+    def __init__(
+        self,
+        *,
+        timeout: float = 30.0,
+        refresh_callback: Callable[[], Awaitable[Any]] | None = None,
+        refresh_retry_delay: float = 0.0,
+    ):
+        self._timeout = timeout
+        self._refresh_callback = refresh_callback
+        self._refresh_retry_delay = refresh_retry_delay
+        self.perform_calls: list[dict[str, Any]] = []
+        self.refresh_calls = 0
+        self.rpc_retry_calls: list[dict[str, Any]] = []
+        self.response = _ok_response()
+        self.snapshot = _AuthSnapshot(
+            csrf_token="CSRF_SNAPSHOT",
+            session_id="SID_SNAPSHOT",
+            authuser=1,
+            account_email="user@example.test",
+        )
+
+    async def _perform_authed_post(
+        self,
+        *,
+        build_request,
+        log_label: str,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response:
+        url, body, headers = build_request(self.snapshot)
+        self.perform_calls.append(
+            {
+                "log_label": log_label,
+                "disable_internal_retries": disable_internal_retries,
+                "url": url,
+                "body": body,
+                "headers": headers,
+            }
+        )
+        return self.response
+
+    async def _await_refresh(self) -> None:
+        self.refresh_calls += 1
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        self.rpc_retry_calls.append(
+            {
+                "method": method,
+                "params": params,
+                "source_path": source_path,
+                "allow_null": allow_null,
+                "_is_retry": _is_retry,
+                "disable_internal_retries": disable_internal_retries,
+            }
+        )
+        return {"retried": True}
+
+
+def _executor(
+    owner: _Owner,
+    *,
+    decode_response_late_bound: Callable[..., Any] | None = None,
+    is_auth_error: Callable[[Exception], bool] | None = None,
+    sleep: Callable[[float], Awaitable[Any]] | None = None,
+) -> RpcExecutor:
+    async def _no_sleep(_: float) -> None:
+        return None
+
+    def _decode(_: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+        return {"rpc_id": rpc_id, "allow_null": allow_null}
+
+    return RpcExecutor(
+        owner,
+        decode_response_late_bound=decode_response_late_bound or _decode,
+        is_auth_error=is_auth_error or (lambda exc: False),
+        sleep=sleep or _no_sleep,
+    )
+
+
+def test_core_rpc_has_no_runtime_core_imports() -> None:
+    path = Path(__file__).parents[2] / "src/notebooklm/_core_rpc.py"
+    tree = ast.parse(path.read_text())
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    def inside_type_checking(node: ast.AST) -> bool:
+        while node in parents:
+            node = parents[node]
+            if isinstance(node, ast.If) and ast.unparse(node.test) == "TYPE_CHECKING":
+                return True
+        return False
+
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if inside_type_checking(node):
+            continue
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "notebooklm._core" or alias.name.endswith("._core"):
+                    violations.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in {"notebooklm._core", "_core"} or module.endswith("._core"):
+                violations.append((node.lineno, module))
+
+    assert not violations
+
+
+@pytest.mark.asyncio
+async def test_client_core_rpc_wrappers_delegate_to_rpc_executor(monkeypatch) -> None:
+    core = ClientCore(_auth_tokens())
+    snapshot = _AuthSnapshot(
+        csrf_token="csrf",
+        session_id="session",
+        authuser=0,
+        account_email=None,
+    )
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    class FakeExecutor:
+        async def execute(self, *args: Any, **kwargs: Any) -> str:
+            calls.append(("execute", args, kwargs))
+            return "executed"
+
+        def build_url(self, *args: Any, **kwargs: Any) -> str:
+            calls.append(("build_url", args, kwargs))
+            return "url"
+
+        def raise_rpc_error_from_http_status(self, *args: Any, **kwargs: Any) -> None:
+            calls.append(("http_status", args, kwargs))
+            raise RuntimeError("http status")
+
+        def raise_rpc_error_from_request_error(self, *args: Any, **kwargs: Any) -> None:
+            calls.append(("request_error", args, kwargs))
+            raise RuntimeError("request error")
+
+        async def try_refresh_and_retry(self, *args: Any, **kwargs: Any) -> str:
+            calls.append(("try_refresh", args, kwargs))
+            return "retried"
+
+    executor = FakeExecutor()
+    monkeypatch.setattr(core, "_get_rpc_executor", lambda: executor)
+
+    assert (
+        await core._rpc_call_impl(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+            disable_internal_retries=True,
+        )
+        == "executed"
+    )
+    assert core._build_url(RPCMethod.LIST_NOTEBOOKS, snapshot, "/source") == "url"
+    with pytest.raises(RuntimeError, match="http status"):
+        core._raise_rpc_error_from_http_status(_status_error(500), RPCMethod.LIST_NOTEBOOKS)
+    with pytest.raises(RuntimeError, match="request error"):
+        core._raise_rpc_error_from_request_error(
+            httpx.ConnectError("boom"),
+            RPCMethod.LIST_NOTEBOOKS,
+        )
+    assert (
+        await core._try_refresh_and_retry(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            RPCError("auth"),
+            disable_internal_retries=True,
+        )
+        == "retried"
+    )
+
+    assert [name for name, _, _ in calls] == [
+        "execute",
+        "build_url",
+        "http_status",
+        "request_error",
+        "try_refresh",
+    ]
+    assert calls[0][2] == {"disable_internal_retries": True}
+    assert calls[1][2] == {"rpc_id_override": None}
+    assert calls[-1][2] == {"disable_internal_retries": True}
+
+
+@pytest.mark.asyncio
+async def test_core_decode_response_monkeypatch_after_executor_construction(monkeypatch) -> None:
+    core = ClientCore(_auth_tokens())
+    executor = core._get_rpc_executor()
+
+    async def fake_perform_authed_post(
+        *,
+        build_request,
+        log_label: str,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response:
+        return _ok_response("wire")
+
+    decode_calls: list[dict[str, Any]] = []
+
+    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+        decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
+        return {"decoded": rpc_id}
+
+    monkeypatch.setattr(core, "_perform_authed_post", fake_perform_authed_post)
+    monkeypatch.setattr("notebooklm._core.decode_response", fake_decode)
+
+    result = await core._rpc_call_impl(
+        RPCMethod.LIST_NOTEBOOKS,
+        [],
+        "/notebook/abc",
+        True,
+        False,
+    )
+
+    assert core._get_rpc_executor() is executor
+    assert result == {"decoded": RPCMethod.LIST_NOTEBOOKS.value}
+    assert decode_calls == [
+        {
+            "raw": "wire",
+            "rpc_id": RPCMethod.LIST_NOTEBOOKS.value,
+            "allow_null": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_threads_override_source_allow_null_and_retry_flag(monkeypatch) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_RPC_OVERRIDES", '{"LIST_NOTEBOOKS": "OverrideRpc"}')
+    owner = _Owner()
+    decode_calls: list[dict[str, Any]] = []
+
+    def decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict[str, Any]:
+        decode_calls.append({"raw": raw, "rpc_id": rpc_id, "allow_null": allow_null})
+        return {"ok": True}
+
+    result = await _executor(owner, decode_response_late_bound=decode).execute(
+        RPCMethod.LIST_NOTEBOOKS,
+        [["param"]],
+        "/notebook/abc",
+        True,
+        False,
+        disable_internal_retries=True,
+    )
+
+    assert result == {"ok": True}
+    assert owner.perform_calls[0]["log_label"] == "RPC LIST_NOTEBOOKS"
+    assert owner.perform_calls[0]["disable_internal_retries"] is True
+    url = httpx.URL(owner.perform_calls[0]["url"])
+    assert url.params["rpcids"] == "OverrideRpc"
+    assert url.params["source-path"] == "/notebook/abc"
+    assert url.params["f.sid"] == "SID_SNAPSHOT"
+    assert url.params["authuser"] == "user@example.test"
+    body = httpx.QueryParams(owner.perform_calls[0]["body"])
+    assert body["at"] == "CSRF_SNAPSHOT"
+    assert '"OverrideRpc"' in body["f.req"]
+    assert decode_calls == [{"raw": "raw", "rpc_id": "OverrideRpc", "allow_null": True}]
+
+
+@pytest.mark.asyncio
+async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
+    async def refresh_callback() -> object:
+        return object()
+
+    owner = _Owner(refresh_callback=refresh_callback, refresh_retry_delay=0.25)
+    sleep_calls: list[float] = []
+    is_auth_error_calls: list[Exception] = []
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise RPCError("not matched by the built-in auth detector")
+
+    def is_auth_error(exc: Exception) -> bool:
+        is_auth_error_calls.append(exc)
+        return True
+
+    async def sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    result = await _executor(
+        owner,
+        decode_response_late_bound=decode,
+        is_auth_error=is_auth_error,
+        sleep=sleep,
+    ).execute(
+        RPCMethod.LIST_NOTEBOOKS,
+        ["param"],
+        "/notebook/abc",
+        True,
+        False,
+        disable_internal_retries=True,
+    )
+
+    assert result == {"retried": True}
+    assert owner.refresh_calls == 1
+    assert sleep_calls == [0.25]
+    assert len(is_auth_error_calls) == 1
+    assert owner.rpc_retry_calls == [
+        {
+            "method": RPCMethod.LIST_NOTEBOOKS,
+            "params": ["param"],
+            "source_path": "/notebook/abc",
+            "allow_null": True,
+            "_is_retry": True,
+            "disable_internal_retries": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_core_sleep_monkeypatch_after_executor_construction(monkeypatch) -> None:
+    async def refresh_callback() -> AuthTokens:
+        return _auth_tokens()
+
+    core = ClientCore(
+        _auth_tokens(),
+        refresh_callback=refresh_callback,
+        refresh_retry_delay=0.5,
+    )
+    executor = core._get_rpc_executor()
+    refresh_calls = 0
+    sleep_calls: list[float] = []
+
+    async def fake_await_refresh() -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+
+    async def fake_rpc_call(
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> dict[str, bool]:
+        assert method is RPCMethod.LIST_NOTEBOOKS
+        assert params == ["param"]
+        assert source_path == "/notebook/abc"
+        assert allow_null is True
+        assert _is_retry is True
+        assert disable_internal_retries is True
+        return {"ok": True}
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(core, "_await_refresh", fake_await_refresh)
+    monkeypatch.setattr(core, "rpc_call", fake_rpc_call)
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+
+    result = await core._try_refresh_and_retry(
+        RPCMethod.LIST_NOTEBOOKS,
+        ["param"],
+        "/notebook/abc",
+        True,
+        RPCError("auth"),
+        disable_internal_retries=True,
+    )
+
+    assert core._get_rpc_executor() is executor
+    assert result == {"ok": True}
+    assert refresh_calls == 1
+    assert sleep_calls == [0.5]
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_type", "expected_attr"),
+    [
+        (_status_error(429, retry_after="7"), RateLimitError, ("retry_after", 7)),
+        (_status_error(404), ClientError, ("status_code", 404)),
+        (_status_error(502), ServerError, ("status_code", 502)),
+        (_status_error(401), RPCError, ("method_id", RPCMethod.LIST_NOTEBOOKS.value)),
+    ],
+)
+def test_http_status_error_mapper_parity(
+    exc: httpx.HTTPStatusError,
+    expected_type: type[Exception],
+    expected_attr: tuple[str, Any],
+) -> None:
+    executor = _executor(_Owner())
+
+    with pytest.raises(expected_type) as raised:
+        executor.raise_rpc_error_from_http_status(exc, RPCMethod.LIST_NOTEBOOKS)
+
+    attr, value = expected_attr
+    assert getattr(raised.value, attr) == value
+
+
+def test_request_error_mapper_uses_owner_timeout_seconds() -> None:
+    executor = _executor(_Owner(timeout=12.5))
+
+    with pytest.raises(RPCTimeoutError) as raised:
+        executor.raise_rpc_error_from_request_error(
+            httpx.ReadTimeout("slow"),
+            RPCMethod.LIST_NOTEBOOKS,
+        )
+
+    assert raised.value.timeout_seconds == 12.5
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_type"),
+    [
+        (httpx.ConnectTimeout("connect slow"), NetworkError),
+        (httpx.ConnectError("connect failed"), NetworkError),
+        (httpx.ReadError("read failed"), NetworkError),
+    ],
+)
+def test_request_error_mapper_parity(
+    exc: httpx.RequestError, expected_type: type[Exception]
+) -> None:
+    executor = _executor(_Owner())
+
+    with pytest.raises(expected_type):
+        executor.raise_rpc_error_from_request_error(exc, RPCMethod.LIST_NOTEBOOKS)

--- a/tests/unit/test_refresh_lock_lazy_init.py
+++ b/tests/unit/test_refresh_lock_lazy_init.py
@@ -15,13 +15,23 @@ Pins two behaviors:
 from __future__ import annotations
 
 import asyncio
+import importlib.util
+from pathlib import Path
 
 import pytest
 
-from conftest import make_core  # type: ignore[import-not-found]
 from notebooklm._core import ClientCore
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import AuthError, RPCMethod
+
+_UNIT_CONFTEST_SPEC = importlib.util.spec_from_file_location(
+    "unit_conftest_make_core",
+    Path(__file__).resolve().parent / "conftest.py",
+)
+assert _UNIT_CONFTEST_SPEC is not None and _UNIT_CONFTEST_SPEC.loader is not None
+_unit_conftest = importlib.util.module_from_spec(_UNIT_CONFTEST_SPEC)
+_UNIT_CONFTEST_SPEC.loader.exec_module(_unit_conftest)
+make_core = _unit_conftest.make_core
 
 EVENT_TIMEOUT_S = 5.0
 


### PR DESCRIPTION
## Summary
- Add `RpcExecutor` in `_core_rpc.py` for RPC encode/dispatch/decode, decode-time auth retry, URL construction, and RPC error mapping.
- Keep `ClientCore.rpc_call(...)` as the outer request-id/metrics/telemetry wrapper and retain private compatibility wrappers.
- Add direct collaborator coverage for delegation, late-bound monkeypatch behavior, retry propagation, error mapping, and the extracted URL guard.

## Task
- `.sisyphus/phases/architecture-remediation/phase-3.md#t4e-core-rpc`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_core_rpc.py tests/unit/test_observability.py tests/unit/test_logging_correlation.py tests/unit/test_client.py tests/integration/test_auto_refresh.py tests/integration/test_core.py tests/unit/test_rpc_overrides.py tests/integration/concurrency/test_idempotency_create.py tests/unit/test_public_shims.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_core_transport.py tests/unit/test_refresh_state_machine.py tests/unit/test_refresh_lock_lazy_init.py tests/unit/test_env_base_url.py`
- [x] `rtk uv run pytest tests/unit/test_core_reqid.py tests/unit/test_core_reqid_concurrent.py tests/integration/test_auth_refresh_vcr.py tests/integration/test_error_paths_vcr.py`
- [x] `rtk uv run ruff check src/notebooklm/_core.py src/notebooklm/_core_rpc.py tests/unit/test_core_rpc.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_refresh_lock_lazy_init.py`
- [x] `rtk uv run mypy src/notebooklm`
- [x] `rtk uv run ruff format --check src/notebooklm/_core.py src/notebooklm/_core_rpc.py tests/unit/test_core_rpc.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_refresh_lock_lazy_init.py`
- [x] `rtk git diff --check`

## Deferred polish findings
None. Codex-native polish completed; Gemini CLI review did not return usable output in this terminal session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Core RPC routing, URL and error handling consolidated into a dedicated executor to improve reliability, error mapping, and auth-retry behavior.

* **Tests**
  * Added comprehensive tests for RPC execution, decode-time auth refresh & retry, error-to-exception mapping, timeout handling, and concurrency/invariant checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->