### PR TITLE
refactor(auth): delegate refresh session handling

### DIFF
--- a/src/notebooklm/_auth/session.py
+++ b/src/notebooklm/_auth/session.py
@@ -1,0 +1,71 @@
+"""Auth session refresh implementation."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from pathlib import Path
+from typing import Protocol
+
+import httpx
+
+from .._env import get_base_url
+from .._url_utils import is_google_auth_redirect
+from ..auth import AuthTokens, authuser_query, extract_wiz_field
+from ..exceptions import AuthExtractionError
+
+
+class RefreshAuthCore(Protocol):
+    """Structural core boundary required by auth session refresh."""
+
+    auth: AuthTokens
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        """Return the live HTTP client."""
+        ...
+
+    def update_auth_tokens(self, csrf: str, session_id: str) -> Awaitable[None]:
+        """Atomically update auth token scalars."""
+        ...
+
+    def update_auth_headers(self) -> None:
+        """Refresh auth-dependent HTTP state after token mutation."""
+        ...
+
+    def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> Awaitable[None]:
+        """Persist refreshed cookies."""
+        ...
+
+
+async def refresh_auth_session(core: RefreshAuthCore) -> AuthTokens:
+    """Refresh NotebookLM auth tokens through the raw homepage session path."""
+    http_client = core.get_http_client()
+    url = f"{get_base_url()}/"
+    if core.auth.account_email or core.auth.authuser:
+        url = f"{url}?{authuser_query(core.auth.authuser, core.auth.account_email)}"
+    response = await http_client.get(url)
+    response.raise_for_status()
+
+    final_url = str(response.url)
+    if is_google_auth_redirect(final_url):
+        raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
+
+    try:
+        csrf = extract_wiz_field(response.text, "SNlM0e", strict=True)
+        sid = extract_wiz_field(response.text, "FdrFJe", strict=True)
+    except AuthExtractionError as exc:
+        label = {"SNlM0e": "CSRF token", "FdrFJe": "session ID"}.get(exc.key, exc.key)
+        raise ValueError(
+            f"Failed to extract {label} ({exc.key}). "
+            "Page structure may have changed or authentication expired. "
+            f"Preview: {exc.payload_preview!r}"
+        ) from exc
+
+    # Keep the csrf/session mutation centralized so RPC snapshots cannot
+    # observe a torn token pair while refresh is in flight.
+    await core.update_auth_tokens(csrf or "", sid or "")
+    core.update_auth_headers()
+    # Persist through ClientCore.save_cookies so refresh serializes with
+    # keepalive and close saves.
+    await core.save_cookies(http_client.cookies)
+
+    return core.auth

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -559,8 +559,8 @@ class ClientCore:
         # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
         # Python versions, and this object can be constructed outside one.
         self._reqid_lock: asyncio.Lock | None = None
-        # Serializes ``_AuthSnapshot`` reads in :meth:`_snapshot` with the
-        # refresh-side mutation block in :meth:`NotebookLMClient.refresh_auth`
+        # Serializes ``_AuthSnapshot`` reads in :meth:`_snapshot` with
+        # :meth:`ClientCore.update_auth_tokens` during auth refresh
         # (audit §12 / T7.F2). The lock holds only across the four
         # ``self.auth.*`` scalar reads / two scalar writes — never across
         # an ``await`` — so RPC throughput isn't serialized to refresh
@@ -1210,8 +1210,8 @@ class ClientCore:
         ``asyncio.Lock()`` needs a running loop in some Python versions, so
         ``ClientCore.__init__`` leaves the field as ``None``. Callers must
         be inside an async context (which we are, since both
-        :meth:`_snapshot` and :meth:`NotebookLMClient.refresh_auth` are
-        coroutines). The check-then-assign is safe without an outer lock
+        :meth:`_snapshot` and :meth:`update_auth_tokens` are coroutines).
+        The check-then-assign is safe without an outer lock
         because asyncio is single-threaded — no other coroutine can
         execute between the ``is None`` check and the assignment unless
         we ``await``.

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
 from ._artifacts import ArtifactsAPI
+from ._auth.session import refresh_auth_session
 from ._chat import ChatAPI
 from ._core import (
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -44,16 +45,18 @@ from ._core import (
     DEFAULT_TIMEOUT,
     ClientCore,
 )
-from ._env import get_base_url
+from ._env import get_base_url as get_base_url
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
 from ._settings import SettingsAPI
 from ._sharing import SharingAPI
 from ._sources import SourcesAPI
-from ._url_utils import is_google_auth_redirect
-from .auth import AuthTokens, authuser_query, extract_wiz_field
-from .exceptions import AuthExtractionError
+from ._url_utils import is_google_auth_redirect as is_google_auth_redirect
+from .auth import AuthTokens
+from .auth import authuser_query as authuser_query
+from .auth import extract_wiz_field as extract_wiz_field
+from .exceptions import AuthExtractionError as AuthExtractionError
 
 logger = logging.getLogger(__name__)
 
@@ -495,61 +498,4 @@ class NotebookLMClient:
         Raises:
             ValueError: If token extraction fails (page structure may have changed).
         """
-        http_client = self._core.get_http_client()
-        url = f"{get_base_url()}/"
-        if self.auth.account_email or self.auth.authuser:
-            url = f"{url}?{authuser_query(self.auth.authuser, self.auth.account_email)}"
-        response = await http_client.get(url)
-        response.raise_for_status()
-
-        # Check for redirect to login page
-        final_url = str(response.url)
-        if is_google_auth_redirect(final_url):
-            raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
-
-        # Extract SNlM0e (CSRF token) + FdrFJe (Session ID) via the unified
-        # extract_wiz_field helper. The helper tolerates double-quoted,
-        # single-quoted, and HTML-escaped variants, and raises
-        # AuthExtractionError with a sanitized 200-char preview on drift.
-        # AuthExtractionError is wrapped in ValueError to preserve the
-        # historical contract that refresh_auth raises ValueError on
-        # extraction failure (existing callers in keepalive paths catch
-        # ValueError specifically).
-        try:
-            csrf = extract_wiz_field(response.text, "SNlM0e", strict=True)
-            sid = extract_wiz_field(response.text, "FdrFJe", strict=True)
-        except AuthExtractionError as exc:
-            # Preserve the legacy human-readable label for each token
-            # ("CSRF token" / "session ID") so existing callers and tests
-            # that match on substring keep working, while still propagating
-            # the sanitized HTML preview from the new helper.
-            label = {"SNlM0e": "CSRF token", "FdrFJe": "session ID"}.get(exc.key, exc.key)
-            raise ValueError(
-                f"Failed to extract {label} ({exc.key}). "
-                "Page structure may have changed or authentication expired. "
-                f"Preview: {exc.payload_preview!r}"
-            ) from exc
-        # ``extract_wiz_field`` returns ``Optional[str]``; with ``strict=True``
-        # it never returns None — narrow the type for mypy and tolerate the
-        # (unreachable) None branch without crashing.
-        # T7.F2: serialize the csrf_token / session_id mutation with
-        # ``ClientCore._snapshot()`` via ``ClientCore.update_auth_tokens`` so a
-        # concurrent in-flight RPC can't observe a torn ``(csrf, sid)`` pair.
-        # Keep the historical normalization where an unreachable ``None`` from
-        # strict extraction is written as an empty string.
-        await self._core.update_auth_tokens(csrf or "", sid or "")
-
-        # CRITICAL: Update the HTTP client headers with new auth tokens
-        # Without this, the client continues using stale credentials
-        self._core.update_auth_headers()
-
-        # Persist refreshed cookies back to disk so the next CLI invocation
-        # picks up the updated short-lived tokens (e.g., __Secure-1PSIDCC).
-        # Routed through ClientCore.save_cookies so it serializes with the
-        # keepalive worker and the on-close save via ``_save_lock`` — without
-        # that, refresh_auth's synchronous save can race with an in-flight
-        # keepalive save and an older snapshot can clobber the freshly
-        # refreshed tokens.
-        await self._core.save_cookies(http_client.cookies)
-
-        return self._core.auth
+        return await refresh_auth_session(self._core)

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -1,0 +1,306 @@
+"""Tests for the internal auth session refresh collaborator."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import httpx
+import pytest
+
+from notebooklm._auth.session import refresh_auth_session
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
+
+REFRESH_HTML = '"SNlM0e":"new_csrf_token_123" "FdrFJe":"new_session_id_456"'
+
+
+def _auth(**overrides: object) -> AuthTokens:
+    values = {
+        "cookies": {
+            "SID": "test_sid",
+            "__Secure-1PSIDTS": "test_1psidts",
+            "HSID": "test_hsid",
+        },
+        "csrf_token": "old_csrf",
+        "session_id": "old_session",
+    }
+    values.update(overrides)
+    return AuthTokens(**values)
+
+
+@dataclass
+class RecordingRefreshCore:
+    auth: AuthTokens
+    http_client: httpx.AsyncClient
+    operations: list[str] = field(default_factory=list)
+    saved_jars: list[httpx.Cookies] = field(default_factory=list)
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        return self.http_client
+
+    async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
+        self.operations.append("update_auth_tokens")
+        self.auth.csrf_token = csrf
+        self.auth.session_id = session_id
+
+    def update_auth_headers(self) -> None:
+        self.operations.append("update_auth_headers")
+
+    async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
+        assert path is None
+        self.operations.append("save_cookies")
+        self.saved_jars.append(jar)
+
+
+def _client(handler: httpx.MockTransport | httpx.AsyncBaseTransport) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=handler, follow_redirects=True)
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_default_account_uses_bare_base_url() -> None:
+    requests: list[httpx.URL] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.url)
+        return httpx.Response(200, text=REFRESH_HTML, request=request)
+
+    async with _client(httpx.MockTransport(handler)) as http_client:
+        core = RecordingRefreshCore(_auth(), http_client)
+
+        refreshed_auth = await refresh_auth_session(core)
+
+    assert requests == [httpx.URL("https://notebooklm.google.com/")]
+    assert refreshed_auth is core.auth
+    assert refreshed_auth.csrf_token == "new_csrf_token_123"
+    assert refreshed_auth.session_id == "new_session_id_456"
+    assert core.operations == ["update_auth_tokens", "update_auth_headers", "save_cookies"]
+    assert core.saved_jars == [http_client.cookies]
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_selected_account_uses_account_email_url() -> None:
+    requests: list[httpx.URL] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.url)
+        return httpx.Response(200, text=REFRESH_HTML, request=request)
+
+    auth = _auth(authuser=2, account_email="bob@example.com")
+    async with _client(httpx.MockTransport(handler)) as http_client:
+        core = RecordingRefreshCore(auth, http_client)
+
+        await refresh_auth_session(core)
+
+    assert requests == [httpx.URL("https://notebooklm.google.com/?authuser=bob%40example.com")]
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_selected_account_uses_authuser_url() -> None:
+    requests: list[httpx.URL] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.url)
+        return httpx.Response(200, text=REFRESH_HTML, request=request)
+
+    auth = _auth(authuser=2)
+    async with _client(httpx.MockTransport(handler)) as http_client:
+        core = RecordingRefreshCore(auth, http_client)
+
+        await refresh_auth_session(core)
+
+    assert requests == [httpx.URL("https://notebooklm.google.com/?authuser=2")]
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_detects_login_redirect() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "notebooklm.google.com":
+            return httpx.Response(
+                302,
+                headers={"Location": "https://accounts.google.com/signin/v2/identifier"},
+                request=request,
+            )
+        return httpx.Response(200, text="<html>Please sign in</html>", request=request)
+
+    async with _client(httpx.MockTransport(handler)) as http_client:
+        core = RecordingRefreshCore(_auth(), http_client)
+
+        with pytest.raises(ValueError, match="Authentication expired"):
+            await refresh_auth_session(core)
+
+    assert core.operations == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_missing_csrf_wraps_extraction_error() -> None:
+    html = '\n    <html>\n      "FdrFJe":"session_only"\n    </html>\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html, request=request)
+
+    async with _client(httpx.MockTransport(handler)) as http_client:
+        core = RecordingRefreshCore(_auth(), http_client)
+
+        with pytest.raises(ValueError) as exc_info:
+            await refresh_auth_session(core)
+
+    message = str(exc_info.value)
+    assert "Failed to extract CSRF token (SNlM0e)." in message
+    assert "Preview:" in message
+    assert "\n" not in message
+    assert core.operations == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_missing_session_id_wraps_extraction_error() -> None:
+    html = '\n    <html>\n      "SNlM0e":"csrf_only"\n    </html>\n'
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text=html, request=request)
+
+    async with _client(httpx.MockTransport(handler)) as http_client:
+        core = RecordingRefreshCore(_auth(), http_client)
+
+        with pytest.raises(ValueError) as exc_info:
+            await refresh_auth_session(core)
+
+    message = str(exc_info.value)
+    assert "Failed to extract session ID (FdrFJe)." in message
+    assert "Preview:" in message
+    assert "\n" not in message
+    assert core.operations == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_auth_session_persists_through_client_core_save_cookies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage_path = tmp_path / "storage_state.json"
+    auth = _auth(storage_path=storage_path)
+    core = ClientCore(auth)
+    calls: list[tuple[Path, bool, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text=REFRESH_HTML,
+            headers={"Set-Cookie": "SID=fresh_sid; Domain=.google.com; Path=/"},
+            request=request,
+        )
+
+    def fake_save_cookies_to_storage(
+        jar: httpx.Cookies,
+        path: Path,
+        *,
+        original_snapshot: object = None,
+        return_result: bool = False,
+    ) -> bool:
+        assert jar.get("SID") == "fresh_sid"
+        calls.append((path, return_result, original_snapshot))
+        return True
+
+    monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", fake_save_cookies_to_storage)
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        cookies=auth.cookie_jar,
+        follow_redirects=True,
+    )
+    core._http_client = http_client
+    core.cookie_persistence.capture_open_snapshot(http_client.cookies)
+    try:
+        await refresh_auth_session(core)
+    finally:
+        await http_client.aclose()
+        core._http_client = None
+
+    assert len(calls) == 1
+    path, return_result, original_snapshot = calls[0]
+    assert path == storage_path
+    assert return_result is True
+    assert original_snapshot is not None
+
+
+def test_client_refresh_auth_is_facade_only() -> None:
+    source = textwrap.dedent(inspect.getsource(NotebookLMClient.refresh_auth))
+    tree = ast.parse(source)
+    function = next(node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef))
+
+    calls_refresh_session = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "refresh_auth_session"
+        for node in ast.walk(function)
+    )
+    forbidden_names = {
+        "extract_wiz_field",
+        "is_google_auth_redirect",
+        "_get_auth_snapshot_lock",
+    }
+    forbidden_attrs = {
+        "update_auth_tokens",
+        "update_auth_headers",
+        "save_cookies",
+        "csrf_token",
+        "session_id",
+    }
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(function):
+        if isinstance(node, ast.Name) and node.id in forbidden_names:
+            violations.append((node.lineno, node.id))
+        elif isinstance(node, ast.Attribute) and node.attr in forbidden_attrs:
+            violations.append((node.lineno, node.attr))
+
+    assert calls_refresh_session
+    assert violations == []
+
+
+def test_auth_session_has_no_runtime_client_or_core_imports() -> None:
+    path = Path(__file__).parents[2] / "src/notebooklm/_auth/session.py"
+    tree = ast.parse(path.read_text())
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    def inside_type_checking(node: ast.AST) -> bool:
+        while node in parents:
+            node = parents[node]
+            if isinstance(node, ast.If) and ast.unparse(node.test) == "TYPE_CHECKING":
+                return True
+        return False
+
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if inside_type_checking(node):
+            continue
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in {"notebooklm.client", "notebooklm._core"}:
+                    violations.append((node.lineno, f"import {alias.name}"))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            imported_names = {alias.name for alias in node.names}
+            if module in {"notebooklm.client", "notebooklm._core", "client", "_core"}:
+                violations.append((node.lineno, f"from {module} import ..."))
+            if (module == "notebooklm" or (node.level > 0 and module == "")) and imported_names & {
+                "client",
+                "_core",
+            }:
+                imported = ", ".join(sorted(imported_names & {"client", "_core"}))
+                violations.append(
+                    (node.lineno, f"from {'.' * node.level}{module} import {imported}")
+                )
+            if node.level > 0 and module in {"client", "_core"}:
+                violations.append((node.lineno, f"from {'.' * node.level}{module} import ..."))
+            forbidden_type_names = {"NotebookLMClient", "ClientCore"}
+            for name in sorted(imported_names & forbidden_type_names):
+                violations.append((node.lineno, name))
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- Added `_auth/session.py` with a protocol-based auth refresh collaborator.
- Reduced `NotebookLMClient.refresh_auth()` to a facade while preserving helper aliases on `notebooklm.client`.
- Added direct auth session tests for routing, error wrapping, operation order, cookie persistence, facade shape, and import-cycle guard.

## Task
`.sisyphus/phases/architecture-remediation/phase-4.md#t5-auth-session-refresh`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_auth_session.py tests/unit/test_client.py::TestRefreshAuth tests/unit/test_client_keepalive.py::TestSaveCookiesUnification tests/unit/test_auth_cookie_save_race.py::TestRefreshAuthOnBoundSessionIsNoOp tests/unit/test_concurrency_refresh_race.py tests/unit/test_refresh_state_machine.py tests/integration/concurrency/test_auth_snapshot_torn_read.py tests/integration/concurrency/test_refresh_cancellation_propagation.py tests/integration/test_auth_refresh_vcr.py tests/integration/test_auto_refresh.py`
- [x] `rtk uv run ruff check src/notebooklm/client.py src/notebooklm/_core.py src/notebooklm/_auth/session.py tests/unit/test_auth_session.py tests/unit/test_client.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_refresh_state_machine.py tests/unit/test_client_keepalive.py tests/unit/test_auth_cookie_save_race.py tests/integration/concurrency/test_auth_snapshot_torn_read.py tests/integration/concurrency/test_refresh_cancellation_propagation.py tests/integration/test_auth_refresh_vcr.py tests/integration/test_auto_refresh.py`
- [x] `rtk uv run ruff format --check src/notebooklm/client.py src/notebooklm/_core.py src/notebooklm/_auth/session.py tests/unit/test_auth_session.py tests/unit/test_client.py tests/unit/test_concurrency_refresh_race.py tests/unit/test_refresh_state_machine.py tests/unit/test_client_keepalive.py tests/unit/test_auth_cookie_save_race.py tests/integration/concurrency/test_auth_snapshot_torn_read.py tests/integration/concurrency/test_refresh_cancellation_propagation.py tests/integration/test_auth_refresh_vcr.py tests/integration/test_auto_refresh.py`
- [x] `rtk uv run mypy src/notebooklm`

## Polish notes
- Claude review: no blocking findings; preserved auth refresh rationale comments in `_auth/session.py`.
- Gemini review: no blocking findings; suggestion to remove `notebooklm.client` helper aliases intentionally rejected because the task warns against accidentally dropping those module-level names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized authentication session refresh implementation into a cleaner, more modular architecture with improved error handling for expired sessions and better guidance for re-authentication scenarios

* **Tests**
  * Added comprehensive unit test coverage for authentication refresh functionality, including URL selection logic, redirect detection, error handling, and API contract validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/661?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->