### PR TITLE
refactor(artifacts): route polling through capabilities

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -25,6 +25,7 @@ import httpx
 
 from . import _mind_map
 from ._callbacks import maybe_await_callback
+from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
 from ._env import get_default_language
 from .auth import load_httpx_cookies
@@ -327,6 +328,7 @@ class ArtifactsAPI:
             storage_path: Path to storage state file for loading download cookies.
         """
         self._core = core
+        self._capabilities = ClientCoreCapabilities(core)
         # ``notes_api`` is intentionally not stored — it is accepted only
         # so that existing call sites (tests, third-party code) keep
         # working through the deprecation cycle.
@@ -1849,14 +1851,13 @@ class ArtifactsAPI:
         Uses exponential backoff for polling to reduce API load.
 
         Concurrent callers for the same ``(notebook_id, task_id)`` share a
-        single underlying poll loop via the leader/follower registry on
-        ``ClientCore._pending_polls`` (audit §21 / T7.E2). The first
-        caller is the *leader* and drives the poll loop; subsequent
-        *followers* attach to the leader's future without issuing their
-        own ``LIST_ARTIFACTS`` requests. Cancellation is per-caller —
-        only the cancelled caller's ``await`` raises ``CancelledError``;
-        the underlying poll continues and remaining followers still
-        receive the result.
+        single underlying poll loop through the ``PollRegistry`` exposed by
+        this API's capabilities. The first caller is the *leader* and drives
+        the poll loop; subsequent *followers* attach to the leader's future
+        without issuing their own ``LIST_ARTIFACTS`` requests. Cancellation is
+        per-caller — only the cancelled caller's ``await`` raises
+        ``CancelledError``; the underlying poll continues and remaining
+        followers still receive the result.
 
         Because followers attach to the leader's already-running poll,
         only the *leader's* ``initial_interval`` / ``max_interval`` /
@@ -1909,7 +1910,7 @@ class ArtifactsAPI:
             )
             initial_interval = poll_interval
 
-        pending = self._core._pending_polls
+        pending = self._capabilities.poll_registry.pending
         key = (notebook_id, task_id)
 
         existing = pending.get(key)

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -49,7 +49,7 @@ class CookieJarProvider(Protocol):
         ...
 
 
-class ClientCoreCapabilities:
+class ClientCoreCapabilities(PollRegistryProvider, AuthRouteProvider, CookieJarProvider):
     """Narrow capability adapter around a ``ClientCore``-shaped object.
 
     Construction is intentionally lazy: only store the core. Individual

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -1,0 +1,81 @@
+"""Private capability adapters for feature APIs."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import httpx
+
+from ._core_polling import PollRegistry
+from .auth import authuser_query, format_authuser_value
+
+
+class PollRegistryProvider(Protocol):
+    """Provider for the shared artifact polling registry."""
+
+    @property
+    def poll_registry(self) -> PollRegistry:
+        """Return the existing per-core poll registry."""
+        ...
+
+
+class AuthRouteProvider(Protocol):
+    """Provider for NotebookLM selected-account routing values."""
+
+    @property
+    def authuser(self) -> int:
+        """Return the integer Google authuser index."""
+        ...
+
+    @property
+    def account_email(self) -> str | None:
+        """Return the stable selected-account email, when available."""
+        ...
+
+    def authuser_query(self) -> str:
+        """Return the URL query value for NotebookLM auth routing."""
+        ...
+
+    def authuser_header(self) -> str:
+        """Return the ``x-goog-authuser`` header value."""
+        ...
+
+
+class CookieJarProvider(Protocol):
+    """Provider for the live HTTP client's cookie jar."""
+
+    def live_cookies(self) -> httpx.Cookies:
+        """Return the live HTTP-client cookies."""
+        ...
+
+
+class ClientCoreCapabilities:
+    """Narrow capability adapter around a ``ClientCore``-shaped object.
+
+    Construction is intentionally lazy: only store the core. Individual
+    capability properties and methods read the underlying core when called.
+    """
+
+    def __init__(self, core: Any) -> None:
+        self._core = core
+
+    @property
+    def poll_registry(self) -> PollRegistry:
+        return self._core.poll_registry
+
+    @property
+    def authuser(self) -> int:
+        return self._core.auth.authuser
+
+    @property
+    def account_email(self) -> str | None:
+        return self._core.auth.account_email
+
+    def authuser_query(self) -> str:
+        return authuser_query(self.authuser, self.account_email)
+
+    def authuser_header(self) -> str:
+        return format_authuser_value(self.authuser, self.account_email)
+
+    def live_cookies(self) -> httpx.Cookies:
+        return self._core.get_http_client().cookies

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -658,9 +658,9 @@ class ClientCore:
     def _pending_polls(self) -> PendingPolls:
         """Deprecated compatibility view of ``poll_registry.pending``.
 
-        ``ArtifactsAPI.wait_for_completion`` still uses this bridge until the
-        later feature-migration slices move polling behind a public core
-        capability, so access intentionally does not warn yet.
+        Feature APIs now access polling state through ``poll_registry`` or a
+        narrow capability adapter. This bridge remains for external callers and
+        tests that still read or assign ``ClientCore._pending_polls`` directly.
         """
         return self.poll_registry.pending
 

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc.decoder import RPCError
 from notebooklm.types import ArtifactDownloadError
 
@@ -21,11 +22,10 @@ def mock_artifacts_api():
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
-    # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
-    # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
-    # A MagicMock attribute would return a child Mock and confuse the
-    # ``existing is not None`` branch.
-    mock_core._pending_polls = {}
+    # Real registry backing. A MagicMock attribute would return a child Mock
+    # and confuse the ``existing is not None`` branch.
+    mock_core.poll_registry = PollRegistry()
+    mock_core._pending_polls = mock_core.poll_registry.pending
     mock_core._begin_transport_task = AsyncMock(return_value=object())
     mock_core._finish_transport_post = AsyncMock()
     mock_notes = MagicMock()

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -1,17 +1,19 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from notebooklm._artifacts import ArtifactsAPI, GenerationStatus
+from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 
 
 @pytest.fixture
 def api():
     core = MagicMock()
-    # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
-    # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
-    core._pending_polls = {}
+    # Real registry backing so wait_for_completion can ``dict.get(key)``.
+    core.poll_registry = PollRegistry()
+    core._pending_polls = core.poll_registry.pending
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     notes_api = MagicMock()
@@ -67,3 +69,70 @@ async def test_wait_for_completion_no_retry_on_auth_error(api):
 
         assert api.poll_status.call_count == 1
         assert mock_sleep.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_or_later_waiter():
+    core = MagicMock()
+    core.poll_registry = PollRegistry()
+    core._pending_polls = core.poll_registry.pending
+    core._begin_transport_task = AsyncMock(return_value=object())
+    core._finish_transport_post = AsyncMock()
+    api = ArtifactsAPI(core, MagicMock())
+
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+    status_ready = GenerationStatus(task_id="task1", status="completed")
+    poll_call_count = 0
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        nonlocal poll_call_count
+        assert (notebook_id, task_id) == ("nb1", "task1")
+        poll_call_count += 1
+        poll_started.set()
+        await release_poll.wait()
+        return status_ready
+
+    api.poll_status = AsyncMock(side_effect=poll_status)
+
+    leader = asyncio.create_task(api.wait_for_completion("nb1", "task1", timeout=60.0))
+    key = ("nb1", "task1")
+    later_waiter: asyncio.Task[GenerationStatus] | None = None
+    try:
+        await poll_started.wait()
+        for _ in range(10):
+            if key in core.poll_registry.pending:
+                break
+            await asyncio.sleep(0)
+
+        assert core._pending_polls is core.poll_registry.pending
+        assert key in core.poll_registry.pending
+
+        follower = asyncio.create_task(api.wait_for_completion("nb1", "task1", timeout=60.0))
+        await asyncio.sleep(0)
+        follower.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await follower
+
+        assert not leader.done()
+        assert key in core.poll_registry.pending
+        assert poll_call_count == 1
+
+        later_waiter = asyncio.create_task(api.wait_for_completion("nb1", "task1", timeout=60.0))
+        await asyncio.sleep(0)
+        release_poll.set()
+
+        assert await leader == status_ready
+        assert await later_waiter == status_ready
+        assert poll_call_count == 1
+        assert core.poll_registry.pending == {}
+        assert core._pending_polls == {}
+    finally:
+        release_poll.set()
+        cleanup_tasks = []
+        for task in (leader, later_waiter):
+            if task is not None and not task.done():
+                task.cancel()
+                cleanup_tasks.append(task)
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -84,6 +84,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
     release_poll = asyncio.Event()
     status_ready = GenerationStatus(task_id="task1", status="completed")
     poll_call_count = 0
+    test_timeout = 1.0
 
     async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
         nonlocal poll_call_count
@@ -99,7 +100,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
     key = ("nb1", "task1")
     later_waiter: asyncio.Task[GenerationStatus] | None = None
     try:
-        await poll_started.wait()
+        await asyncio.wait_for(poll_started.wait(), timeout=test_timeout)
         for _ in range(10):
             if key in core.poll_registry.pending:
                 break
@@ -112,7 +113,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
         await asyncio.sleep(0)
         follower.cancel()
         with pytest.raises(asyncio.CancelledError):
-            await follower
+            await asyncio.wait_for(follower, timeout=test_timeout)
 
         assert not leader.done()
         assert key in core.poll_registry.pending
@@ -122,8 +123,8 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
         await asyncio.sleep(0)
         release_poll.set()
 
-        assert await leader == status_ready
-        assert await later_waiter == status_ready
+        assert await asyncio.wait_for(leader, timeout=test_timeout) == status_ready
+        assert await asyncio.wait_for(later_waiter, timeout=test_timeout) == status_ready
         assert poll_call_count == 1
         assert core.poll_registry.pending == {}
         assert core._pending_polls == {}

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -1,0 +1,75 @@
+"""Unit tests for private feature capability adapters."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+
+from notebooklm._capabilities import ClientCoreCapabilities
+from notebooklm._core_polling import PollRegistry
+from notebooklm.auth import authuser_query, format_authuser_value
+
+
+class _ExplodingCore:
+    def __getattribute__(self, name: str) -> object:
+        raise AssertionError(f"core attribute read during construction: {name}")
+
+
+def test_client_core_capabilities_construction_is_lazy() -> None:
+    adapter = ClientCoreCapabilities(_ExplodingCore())
+
+    assert isinstance(adapter, ClientCoreCapabilities)
+
+
+def test_client_core_capabilities_returns_existing_poll_registry_and_pending_mapping() -> None:
+    pending = {}
+    registry = PollRegistry(pending)
+    core = SimpleNamespace(poll_registry=registry)
+    adapter = ClientCoreCapabilities(core)
+
+    assert adapter.poll_registry is registry
+    assert adapter.poll_registry.pending is pending
+
+
+def test_client_core_capabilities_exposes_auth_route_helpers() -> None:
+    core = SimpleNamespace(auth=SimpleNamespace(authuser=2, account_email="user+test@example.com"))
+    adapter = ClientCoreCapabilities(core)
+
+    assert adapter.authuser == 2
+    assert adapter.account_email == "user+test@example.com"
+    assert adapter.authuser_query() == authuser_query(2, "user+test@example.com")
+    assert adapter.authuser_header() == format_authuser_value(2, "user+test@example.com")
+
+
+def test_client_core_capabilities_live_cookies_come_from_http_client() -> None:
+    live_cookies = httpx.Cookies()
+    auth_cookies = httpx.Cookies()
+    core = MagicMock()
+    core.auth.cookie_jar = auth_cookies
+    core.get_http_client.return_value.cookies = live_cookies
+    adapter = ClientCoreCapabilities(core)
+
+    assert adapter.live_cookies() is live_cookies
+    assert adapter.live_cookies() is not auth_cookies
+
+
+def test_capabilities_module_does_not_import_client_core_at_runtime() -> None:
+    source = (Path(__file__).resolve().parents[2] / "src/notebooklm/_capabilities.py").read_text(
+        encoding="utf-8"
+    )
+    tree = ast.parse(source)
+
+    forbidden_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in {"_core", "notebooklm._core"}:
+            forbidden_imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            forbidden_imports.extend(
+                alias.name for alias in node.names if alias.name == "notebooklm._core"
+            )
+
+    assert forbidden_imports == []

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -31,7 +31,6 @@ SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS = {
     ("_artifacts.py", "_begin_transport_task"): 1,
     ("_artifacts.py", "_finish_transport_post"): 1,
-    ("_artifacts.py", "_pending_polls"): 1,
     ("_sources.py", "_begin_transport_post"): 1,
     ("_sources.py", "_finish_transport_post"): 1,
 }

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc.types import ArtifactStatus
 from notebooklm.types import GenerationStatus
 
@@ -30,9 +31,9 @@ def _make_api():
     core = MagicMock()
     core.rpc_call = AsyncMock()
     core.get_source_ids = AsyncMock(return_value=[])
-    # ClientCore._pending_polls (T7.E2) — real dict so the leader/follower
-    # dedupe in ``wait_for_completion`` can ``dict.get(key)`` against it.
-    core._pending_polls = {}
+    # Real registry backing so wait_for_completion can ``dict.get(key)``.
+    core.poll_registry = PollRegistry()
+    core._pending_polls = core.poll_registry.pending
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     notes = MagicMock()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a capability adapter and a shared poll registry to centralize integrations and improve polling deduplication for concurrent operations.
* **Tests**
  * Expanded coverage for capability behavior, polling contention, cancellation handling, and cleanup scenarios.
* **Documentation**
  * Clarified compatibility notes around legacy polling state access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->