### PR TITLE
refactor(sources): route upload auth through capabilities

### DIFF
--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -16,11 +16,11 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 
 from ._callbacks import maybe_await_callback
+from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
 from ._env import get_base_url
 from ._idempotency import idempotent_create
 from ._url_utils import is_youtube_url
-from .auth import authuser_query, format_authuser_value
 from .exceptions import (
     AuthError,
     NetworkError,
@@ -152,6 +152,7 @@ class SourcesAPI:
                 avoid surprises.
         """
         self._core = core
+        self._capabilities = ClientCoreCapabilities(core)
         self._upload_timeout = upload_timeout
 
     def _resolve_upload_timeout(self, default: httpx.Timeout) -> httpx.Timeout:
@@ -1492,15 +1493,9 @@ class SourcesAPI:
         """Start a resumable upload session and get the upload URL."""
         import json
 
-        auth_route = format_authuser_value(
-            self._core.auth.authuser,
-            self._core.auth.account_email,
-        )
+        auth_route = self._capabilities.authuser_header()
         base_url = get_base_url()
-        url = (
-            f"{get_upload_url()}?"
-            f"{authuser_query(self._core.auth.authuser, self._core.auth.account_email)}"
-        )
+        url = f"{get_upload_url()}?{self._capabilities.authuser_query()}"
 
         headers = {
             "Accept": "*/*",
@@ -1532,7 +1527,7 @@ class SourcesAPI:
         # pick up SIDCC/SIDTS rotations applied during the live session. See #373.
         async with httpx.AsyncClient(
             timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=60.0)),
-            cookies=self._core.get_http_client().cookies,
+            cookies=self._capabilities.live_cookies(),
         ) as client:
             response = await client.post(url, headers=headers, content=body)
             response.raise_for_status()
@@ -1625,10 +1620,7 @@ class SourcesAPI:
         close_wired = False
         try:
             base_url = get_base_url()
-            auth_route = format_authuser_value(
-                self._core.auth.authuser,
-                self._core.auth.account_email,
-            )
+            auth_route = self._capabilities.authuser_header()
             headers = {
                 "Accept": "*/*",
                 "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
@@ -1702,7 +1694,7 @@ class SourcesAPI:
                 # OSID against host and rejects foreign-host cookies. (#373)
                 async with httpx.AsyncClient(
                     timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=300.0)),
-                    cookies=self._core.get_http_client().cookies,
+                    cookies=self._capabilities.live_cookies(),
                 ) as client:
                     finalize_started = True
                     response = await client.post(upload_url, headers=headers, content=file_stream())
@@ -1796,7 +1788,7 @@ class SourcesAPI:
         try:
             async with httpx.AsyncClient(
                 timeout=httpx.Timeout(10.0, read=10.0),
-                cookies=self._core.get_http_client().cookies,
+                cookies=self._capabilities.live_cookies(),
             ) as client:
                 await client.post(upload_url, headers=headers)
         except Exception as exc:  # noqa: BLE001 — best-effort cleanup

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -99,9 +99,10 @@ def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
     core = MagicMock()
     core.rpc_call = AsyncMock()
     core.auth = MagicMock()
-    cookie_jar = MagicMock(name="cookie_jar")
-    core.auth.cookie_jar = cookie_jar
-    core.get_http_client.return_value.cookies = cookie_jar
+    core.auth.authuser = 0
+    core.auth.account_email = None
+    core.auth.cookie_jar = MagicMock(name="auth_cookie_jar")
+    core.get_http_client.return_value.cookies = MagicMock(name="live_cookie_jar")
     core._begin_transport_post = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.record_upload_queue_wait = MagicMock()

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import httpx
+import pytest
 
 from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._core_polling import PollRegistry
@@ -35,14 +36,33 @@ def test_client_core_capabilities_returns_existing_poll_registry_and_pending_map
     assert adapter.poll_registry.pending is pending
 
 
-def test_client_core_capabilities_exposes_auth_route_helpers() -> None:
+@pytest.mark.parametrize(
+    ("authuser", "account_email"),
+    [
+        (2, None),
+        (2, "user+test@example.com"),
+        (3, " selected.account@example.com "),
+    ],
+)
+def test_client_core_capabilities_exposes_auth_route_helpers(
+    authuser: int,
+    account_email: str | None,
+) -> None:
+    core = SimpleNamespace(auth=SimpleNamespace(authuser=authuser, account_email=account_email))
+    adapter = ClientCoreCapabilities(core)
+
+    assert adapter.authuser == authuser
+    assert adapter.account_email == account_email
+    assert adapter.authuser_query() == authuser_query(authuser, account_email)
+    assert adapter.authuser_header() == format_authuser_value(authuser, account_email)
+
+
+def test_client_core_capabilities_authuser_query_url_encodes_account_email() -> None:
     core = SimpleNamespace(auth=SimpleNamespace(authuser=2, account_email="user+test@example.com"))
     adapter = ClientCoreCapabilities(core)
 
-    assert adapter.authuser == 2
-    assert adapter.account_email == "user+test@example.com"
-    assert adapter.authuser_query() == authuser_query(2, "user+test@example.com")
-    assert adapter.authuser_header() == format_authuser_value(2, "user+test@example.com")
+    assert adapter.authuser_header() == "user+test@example.com"
+    assert adapter.authuser_query() == "authuser=user%2Btest%40example.com"
 
 
 def test_client_core_capabilities_live_cookies_come_from_http_client() -> None:

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -1,7 +1,11 @@
 """Unit tests for SourcesAPI file upload pipeline and YouTube detection."""
 
+import ast
+import inspect
+import textwrap
 import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -17,13 +21,15 @@ def mock_core():
     core = MagicMock()
     core.rpc_call = AsyncMock()
     core.auth = MagicMock()
+    core.auth.authuser = 0
+    core.auth.account_email = None
     # Upload paths pass the live http client's cookie jar to httpx so cookies
-    # are scoped by Domain attribute (#373). The mock makes auth.cookie_jar and
-    # get_http_client().cookies the same sentinel so existing assertions still
-    # work against either reference.
-    cookie_jar = MagicMock(name="cookie_jar")
-    core.auth.cookie_jar = cookie_jar
-    core.get_http_client.return_value.cookies = cookie_jar
+    # are scoped by Domain attribute (#373). Keep this distinct from
+    # auth.cookie_jar so upload tests prove the live jar is used.
+    auth_cookie_jar = MagicMock(name="auth_cookie_jar")
+    live_cookie_jar = MagicMock(name="live_cookie_jar")
+    core.auth.cookie_jar = auth_cookie_jar
+    core.get_http_client.return_value.cookies = live_cookie_jar
     core._begin_transport_post = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.record_upload_queue_wait = MagicMock()
@@ -34,6 +40,63 @@ def mock_core():
 def sources_api(mock_core):
     """Create SourcesAPI with mocked core."""
     return SourcesAPI(mock_core)
+
+
+def _self_core_auth_attr_read(node: ast.AST, attr: str) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == attr
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "auth"
+        and isinstance(node.value.value, ast.Attribute)
+        and node.value.value.attr == "_core"
+        and isinstance(node.value.value.value, ast.Name)
+        and node.value.value.value.id == "self"
+    )
+
+
+def _self_core_http_client_cookies_read(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "cookies"
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "get_http_client"
+        and isinstance(node.value.func.value, ast.Attribute)
+        and node.value.func.value.attr == "_core"
+        and isinstance(node.value.func.value.value, ast.Name)
+        and node.value.func.value.value.id == "self"
+    )
+
+
+@pytest.mark.parametrize(
+    "helper",
+    [
+        SourcesAPI._start_resumable_upload,
+        SourcesAPI._upload_file_streaming,
+        SourcesAPI._cancel_upload_session,
+    ],
+)
+def test_upload_helpers_do_not_read_core_auth_or_live_cookies_directly(helper):
+    """Upload helpers must route through ClientCoreCapabilities, not broad core internals."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(helper)))
+    violations = [
+        ast.unparse(node)
+        for node in ast.walk(tree)
+        if _self_core_auth_attr_read(node, "authuser")
+        or _self_core_auth_attr_read(node, "account_email")
+        or _self_core_http_client_cookies_read(node)
+    ]
+
+    assert violations == []
+
+
+def _assert_async_client_uses_live_cookies(mock_client_cls, mock_core) -> None:
+    assert (
+        mock_client_cls.call_args.kwargs["cookies"]
+        is mock_core.get_http_client.return_value.cookies
+    )
+    assert mock_client_cls.call_args.kwargs["cookies"] is not mock_core.auth.cookie_jar
 
 
 # =============================================================================
@@ -398,7 +461,57 @@ class TestStartResumableUpload:
             # Cookie header is no longer set manually; httpx scopes cookies
             # by Domain attribute via the cookie_jar kwarg (#373).
             assert "Cookie" not in headers
-            assert mock_client_cls.call_args.kwargs["cookies"] is mock_core.auth.cookie_jar
+            _assert_async_client_uses_live_cookies(mock_client_cls, mock_core)
+
+    @pytest.mark.asyncio
+    async def test_start_resumable_upload_uses_integer_authuser_query_and_header(
+        self, sources_api, mock_core
+    ):
+        """Integer selected-account routing is preserved in URL and header."""
+        mock_core.auth.authuser = 2
+        mock_core.auth.account_email = None
+        mock_response = MagicMock()
+        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            await sources_api._start_resumable_upload("nb_123", "test.pdf", 2048, "src_789")
+
+        url = mock_client.post.call_args.args[0]
+        assert parse_qs(urlparse(url).query) == {"authuser": ["2"]}
+        assert mock_client.post.call_args.kwargs["headers"]["x-goog-authuser"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_start_resumable_upload_uses_encoded_account_email_query_and_header(
+        self, sources_api, mock_core
+    ):
+        """Account email wins over integer routing and is URL-encoded in the query."""
+        mock_core.auth.authuser = 2
+        mock_core.auth.account_email = "user+test@example.com"
+        mock_response = MagicMock()
+        mock_response.headers = {"x-goog-upload-url": "https://upload.example.com"}
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            await sources_api._start_resumable_upload("nb_123", "test.pdf", 2048, "src_789")
+
+        url = mock_client.post.call_args.args[0]
+        assert "authuser=user%2Btest%40example.com" in urlparse(url).query
+        assert parse_qs(urlparse(url).query) == {"authuser": ["user+test@example.com"]}
+        assert (
+            mock_client.post.call_args.kwargs["headers"]["x-goog-authuser"]
+            == "user+test@example.com"
+        )
 
     @pytest.mark.asyncio
     async def test_start_resumable_upload_includes_json_body(self, sources_api, mock_core):
@@ -519,7 +632,58 @@ class TestUploadFileStreaming:
             # Cookie header is no longer set manually; httpx scopes cookies
             # by Domain attribute via the cookie_jar kwarg (#373).
             assert "Cookie" not in headers
-            assert mock_client_cls.call_args.kwargs["cookies"] is mock_core.auth.cookie_jar
+            _assert_async_client_uses_live_cookies(mock_client_cls, mock_core)
+
+    @pytest.mark.asyncio
+    async def test_upload_file_streaming_preserves_authuser_header(
+        self, sources_api, mock_core, tmp_path
+    ):
+        """Finalize upload sends the same selected-account header value."""
+        mock_core.auth.authuser = 2
+        mock_core.auth.account_email = "user+test@example.com"
+        test_file = tmp_path / "test.txt"
+        test_file.write_bytes(b"content")
+        mock_response = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client.post.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            await sources_api._upload_file_streaming(
+                "https://upload.example.com/session", test_file
+            )
+
+        assert (
+            mock_client.post.call_args.kwargs["headers"]["x-goog-authuser"]
+            == "user+test@example.com"
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_upload_session_preserves_authuser_header_and_live_cookies(
+        self, sources_api, mock_core
+    ):
+        """Best-effort Scotty cancel keeps the provided auth route and live cookie jar."""
+        auth_route = "user+test@example.com"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__.return_value = mock_client
+            mock_client.__aexit__.return_value = None
+            mock_client_cls.return_value = mock_client
+
+            await sources_api._cancel_upload_session(
+                "https://upload.example.com/session",
+                "https://notebooklm.google.com",
+                auth_route,
+            )
+
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert headers["x-goog-authuser"] == auth_route
+        assert headers["x-goog-upload-command"] == "cancel"
+        _assert_async_client_uses_live_cookies(mock_client_cls, mock_core)
 
     @pytest.mark.asyncio
     async def test_upload_file_streaming_uses_generator(self, sources_api, mock_core, tmp_path):


### PR DESCRIPTION
## Summary
- Route source upload authuser query/header and live cookies through ClientCoreCapabilities.
- Preserve Scotty live-cookie behavior by passing the HTTP-client cookie jar to start, finalize, and cancel clients.
- Add regression coverage for selected-account routing, encoded account emails, cancel cookies, and narrow static guards.

## Task
T6b - Source Upload Auth And Cookie Capabilities from .sisyphus/phases/architecture-remediation/phase-5.md

## Test plan
- [x] rtk uv run pytest tests/unit/test_capabilities.py tests/unit/test_sources_upload.py tests/unit/test_source_selection.py tests/unit/test_artifacts_integration.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py
- [x] rtk uv run ruff check src/notebooklm/_capabilities.py src/notebooklm/_sources.py tests/unit/test_capabilities.py tests/unit/test_sources_upload.py tests/unit/test_source_selection.py tests/unit/test_artifacts_integration.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py
- [x] rtk uv run ruff format --check src/notebooklm/_capabilities.py src/notebooklm/_sources.py tests/unit/test_capabilities.py tests/unit/test_sources_upload.py tests/unit/test_source_selection.py tests/unit/test_artifacts_integration.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py
- [x] rtk uv run mypy src/notebooklm

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal authentication and session handling for file uploads.

* **Tests**
  * Extended test coverage for authentication routing during upload operations.
  * Added comprehensive test cases for auth credential handling across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->