### PR TITLE
refactor(chat): extract streaming protocol helpers

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -5,36 +5,34 @@ retrieving conversation history.
 """
 
 import asyncio
-import json
 import logging
-import re
 import uuid
 import weakref
 from typing import Any
-from urllib.parse import quote, urlencode
 
+from ._chat_protocol import (
+    build_streaming_chat_request,
+    collect_texts_from_nested,
+    extract_answer_and_refs_from_chunk,
+    extract_text_passages,
+    extract_uuid_from_nested,
+    parse_citations,
+    parse_single_citation,
+    parse_streaming_chat_response,
+    raise_if_rate_limited,
+)
 from ._core import ClientCore, _AuthSnapshot
-from ._env import get_default_bl, get_default_language
 from ._logging import get_request_id, reset_request_id, set_request_id
-from .auth import format_authuser_value
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import (
     ChatGoal,
     ChatResponseLength,
     RPCMethod,
-    get_query_url,
-    nest_source_ids,
     safe_index,
 )
 from .types import AskResult, ChatMode, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
-
-# UUID pattern for validating source IDs (compiled once at module level)
-_UUID_PATTERN = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-    re.IGNORECASE,
-)
 
 
 def _extract_next_turn_content(next_turn: Any) -> str | None:
@@ -530,449 +528,50 @@ class ChatAPI:
         conversation_id: str,
         reqid: int,
     ) -> tuple[str, str, dict[str, str]]:
-        """Assemble ``(url, body, extra_headers)`` for one chat HTTP attempt.
-
-        Called by ``core.query_post`` once per attempt with a fresh
-        ``_AuthSnapshot``; on retry, a new snapshot picks up the refreshed
-        CSRF / session id / account routing so the rebuilt request matches
-        the post-refresh credentials byte-for-byte.
-
-        Args:
-            snapshot: Point-in-time auth state for this attempt. The
-                ``csrf_token`` is embedded in the body's ``at=`` field; the
-                ``session_id`` and account routing fields go into URL params.
-            notebook_id: Owning notebook id (echoed at params[7] for
-                server-side conversation persistence).
-            question: User-facing question text.
-            source_ids: Sources to scope this turn against. Encoded
-                triple-nested via :func:`nest_source_ids`.
-            conversation_history: Prior turns for follow-up Q&A, or ``None``
-                when starting a new conversation.
-            conversation_id: Stable conversation identifier. Locally minted
-                UUID for new conversations, server-assigned for follow-ups.
-            reqid: Monotonic request id from :meth:`ClientCore.next_reqid`.
-
-        Returns:
-            ``(url, body, extra_headers)``. ``extra_headers`` is empty
-            because the chat endpoint inherits Content-Type from the shared
-            httpx client.
-        """
-        sources_array = nest_source_ids(source_ids, 2)
-
-        params: list[Any] = [
-            sources_array,
-            question,
-            conversation_history,
-            [2, None, [1], [1]],
-            conversation_id,
-            None,  # [5] - always null
-            None,  # [6] - always null
-            notebook_id,  # [7] - required for server-side conversation persistence
-            1,  # [8] - always 1
-        ]
-
-        params_json = json.dumps(params, separators=(",", ":"))
-        f_req_json = json.dumps([None, params_json], separators=(",", ":"))
-        encoded_req = quote(f_req_json, safe="")
-
-        body_parts = [f"f.req={encoded_req}"]
-        if snapshot.csrf_token:
-            encoded_at = quote(snapshot.csrf_token, safe="")
-            body_parts.append(f"at={encoded_at}")
-        body = "&".join(body_parts) + "&"
-
-        url_params: dict[str, str] = {
-            "bl": get_default_bl(),
-            "hl": get_default_language(),
-            "_reqid": str(reqid),
-            "rt": "c",
-        }
-        if snapshot.session_id:
-            url_params["f.sid"] = snapshot.session_id
-        # Multi-account routing: previously omitted entirely on the chat
-        # endpoint (audit C2 / M1), which silently routed requests to the
-        # default browser account when the auth tokens were minted for a
-        # non-default profile. Mirrors the batchexecute path in
-        # ``ClientCore._build_url``.
-        if snapshot.account_email or snapshot.authuser:
-            url_params["authuser"] = format_authuser_value(
-                snapshot.authuser,
-                snapshot.account_email,
-            )
-
-        url = f"{get_query_url()}?{urlencode(url_params)}"
-        return url, body, {}
+        """Compatibility wrapper for streamed-chat request construction."""
+        return build_streaming_chat_request(
+            snapshot=snapshot,
+            notebook_id=notebook_id,
+            question=question,
+            source_ids=source_ids,
+            conversation_history=conversation_history,
+            conversation_id=conversation_id,
+            reqid=reqid,
+        )
 
     def _parse_ask_response_with_references(
         self, response_text: str
     ) -> tuple[str, list[ChatReference], str | None]:
-        """Parse the streaming response to extract answer, references, and conversation ID.
-
-        Returns:
-            Tuple of (answer_text, list of ChatReference objects, server_conversation_id).
-            server_conversation_id is None if not present in the response.
-        """
-
-        if response_text.startswith(")]}'"):
-            response_text = response_text[4:]
-
-        lines = response_text.strip().split("\n")
-        best_marked_answer = ""
-        best_marked_refs: list[ChatReference] = []
-        best_unmarked_answer = ""
-        best_unmarked_refs: list[ChatReference] = []
-        server_conv_id: str | None = None
-
-        def process_chunk(json_str: str) -> None:
-            """Process a JSON chunk, updating best answer candidates and their refs."""
-            nonlocal best_marked_answer, best_marked_refs
-            nonlocal best_unmarked_answer, best_unmarked_refs
-            nonlocal server_conv_id
-            text, is_answer, refs, conv_id = self._extract_answer_and_refs_from_chunk(json_str)
-            if text:
-                if is_answer and len(text) > len(best_marked_answer):
-                    best_marked_answer = text
-                    best_marked_refs = refs
-                elif not is_answer and len(text) > len(best_unmarked_answer):
-                    best_unmarked_answer = text
-                    best_unmarked_refs = refs
-            if conv_id:
-                server_conv_id = conv_id
-
-        i = 0
-        while i < len(lines):
-            line = lines[i].strip()
-            if not line:
-                i += 1
-                continue
-
-            try:
-                int(line)
-                i += 1
-                if i < len(lines):
-                    process_chunk(lines[i])
-                i += 1
-            except ValueError:
-                process_chunk(line)
-                i += 1
-
-        # Prefer marked answers; fall back to longest unmarked text
-        if best_marked_answer:
-            longest_answer = best_marked_answer
-            final_refs = best_marked_refs
-        elif best_unmarked_answer:
-            logger.warning(
-                "No marked answer found; falling back to longest unmarked "
-                "text (%d chars). The API response format may have changed.",
-                len(best_unmarked_answer),
-            )
-            longest_answer = best_unmarked_answer
-            final_refs = best_unmarked_refs
-        else:
-            longest_answer = ""
-            final_refs = []
-
-        if not longest_answer:
-            logger.warning(
-                "No answer extracted from response (%d lines parsed)",
-                len(lines),
-            )
-
-        # Assign citation numbers based on order of appearance
-        for idx, ref in enumerate(final_refs, start=1):
-            if ref.citation_number is None:
-                ref.citation_number = idx
-
-        return longest_answer, final_refs, server_conv_id
+        """Compatibility wrapper preserving the old tuple return shape."""
+        result = parse_streaming_chat_response(response_text)
+        return result.answer, result.references, result.conversation_id
 
     def _extract_answer_and_refs_from_chunk(
         self, json_str: str
     ) -> tuple[str | None, bool, list[ChatReference], str | None]:
-        """Extract answer text, references, and conversation ID from a response chunk.
-
-        Response structure (discovered via reverse engineering):
-        - first[0]: answer text
-        - first[1]: None
-        - first[2]: [conversation_id, numeric_hash]
-        - first[3]: None
-        - first[4]: Citation metadata
-          - first[4][0]: Per-source citation positions with text spans
-          - first[4][3]: Detailed citation array with structure:
-            - cite[0][0]: chunk ID
-            - cite[1][2]: relevance score
-            - cite[1][4]: array of [text_passage, char_positions] items
-            - cite[1][5][0][0][0]: parent SOURCE ID (this is the real source UUID)
-
-        When item[2] is null and item[5] contains a UserDisplayableError, raises
-        ChatError with a rate-limit message.
-
-        Returns:
-            Tuple of (text, is_answer, references, server_conversation_id).
-        """
-        refs: list[ChatReference] = []
-
-        try:
-            data = json.loads(json_str)
-        except json.JSONDecodeError:
-            return None, False, refs, None
-
-        if not isinstance(data, list):
-            return None, False, refs, None
-
-        for item in data:
-            if not isinstance(item, list) or len(item) < 3:
-                continue
-            if item[0] != "wrb.fr":
-                continue
-
-            inner_json = item[2]
-            if not isinstance(inner_json, str):
-                # item[2] is null — check item[5] for a server-side error payload
-                if len(item) > 5 and isinstance(item[5], list):
-                    self._raise_if_rate_limited(item[5])
-                continue
-
-            try:
-                inner_data = json.loads(inner_json)
-                if isinstance(inner_data, list) and len(inner_data) > 0:
-                    first = inner_data[0]
-                    if isinstance(first, list) and len(first) > 0:
-                        text = first[0]
-                        if not isinstance(text, str) or not text:
-                            continue
-
-                        is_answer = (
-                            len(first) > 4
-                            and isinstance(first[4], list)
-                            and len(first[4]) > 0
-                            and first[4][-1] == 1
-                        )
-
-                        # Extract the server-assigned conversation ID from first[2]
-                        server_conv_id: str | None = None
-                        if (
-                            len(first) > 2
-                            and isinstance(first[2], list)
-                            and first[2]
-                            and isinstance(first[2][0], str)
-                        ):
-                            server_conv_id = first[2][0]
-
-                        refs = self._parse_citations(first)
-                        return text, is_answer, refs, server_conv_id
-            except json.JSONDecodeError:
-                # Hot-path stream parser: skip non-JSON chunks. Guard the
-                # debug log with isEnabledFor so the redaction regex doesn't
-                # run on every chunk when DEBUG is off.
-                if logger.isEnabledFor(logging.DEBUG):
-                    logger.debug("Stream parser: non-JSON chunk skipped")
-                continue
-
-        return None, False, refs, None
+        """Compatibility wrapper for streamed-chat chunk parsing."""
+        return extract_answer_and_refs_from_chunk(json_str)
 
     def _raise_if_rate_limited(self, error_payload: list) -> None:
-        """Raise ChatError if the payload contains a UserDisplayableError.
-
-        Args:
-            error_payload: The item[5] list from a wrb.fr response chunk.
-
-        Raises:
-            ChatError: When a UserDisplayableError is detected.
-        """
-        try:
-            # Structure: [8, None, [["type.googleapis.com/.../UserDisplayableError", ...]]]
-            if len(error_payload) > 2 and isinstance(error_payload[2], list):
-                for entry in error_payload[2]:
-                    if isinstance(entry, list) and entry and isinstance(entry[0], str):
-                        if "UserDisplayableError" in entry[0]:
-                            raise ChatError(
-                                "Chat request was rate limited or rejected by the API. "
-                                "Wait a few seconds and try again."
-                            )
-        except ChatError:
-            raise
-        except Exception:
-            logger.debug(
-                "Could not parse chat error payload; continuing with empty-answer handling",
-                exc_info=True,
-            )
+        """Compatibility wrapper for streamed-chat error payload parsing."""
+        raise_if_rate_limited(error_payload)
 
     def _parse_citations(self, first: list) -> list[ChatReference]:
-        """Parse citation details from response structure.
-
-        The citation data is in first[4][3], which contains an array of citations.
-        Each citation has:
-          - cite[0][0]: chunk ID (internal reference)
-          - cite[1][4]: array of text passages with character positions
-          - cite[1][5]: nested structure containing the parent SOURCE ID (UUID)
-
-        Note:
-            This parsing relies on reverse-engineered response structures that
-            Google can change at any time. Parsing failures are logged and
-            result in graceful degradation (empty references list).
-
-        Args:
-            first: The first element of the parsed response.
-
-        Returns:
-            List of ChatReference objects with source IDs and cited text.
-        """
-        try:
-            # Validate path to citations array: first[4][3]
-            if len(first) <= 4 or not isinstance(first[4], list):
-                return []
-            type_info = first[4]
-            if len(type_info) <= 3 or not isinstance(type_info[3], list):
-                return []
-
-            refs: list[ChatReference] = []
-            for cite in type_info[3]:
-                ref = self._parse_single_citation(cite)
-                if ref is not None:
-                    refs.append(ref)
-            return refs
-        except (IndexError, TypeError, AttributeError) as e:
-            logger.debug(
-                "Citation parsing failed (API structure may have changed): %s",
-                e,
-                exc_info=True,
-            )
-            return []
+        """Compatibility wrapper for streamed-chat citation parsing."""
+        return parse_citations(first)
 
     def _parse_single_citation(self, cite: Any) -> ChatReference | None:
-        """Parse a single citation entry into a ChatReference.
-
-        Args:
-            cite: A citation entry from the citations array.
-
-        Returns:
-            ChatReference if valid source ID found, None otherwise.
-        """
-        if not isinstance(cite, list) or len(cite) < 2:
-            return None
-
-        cite_inner = cite[1]
-        if not isinstance(cite_inner, list):
-            return None
-
-        # Extract source ID from cite[1][5] - required for valid reference
-        source_id_data = cite_inner[5] if len(cite_inner) > 5 else None
-        source_id = self._extract_uuid_from_nested(source_id_data)
-        if source_id is None:
-            return None
-
-        # Extract chunk ID from cite[0][0]
-        chunk_id = None
-        if isinstance(cite[0], list) and cite[0]:
-            first_item = cite[0][0]
-            if isinstance(first_item, str):
-                chunk_id = first_item
-
-        # Extract text passages and char positions from cite[1][4]
-        cited_text, start_char, end_char = self._extract_text_passages(cite_inner)
-
-        return ChatReference(
-            source_id=source_id,
-            cited_text=cited_text,
-            start_char=start_char,
-            end_char=end_char,
-            chunk_id=chunk_id,
-        )
+        """Compatibility wrapper for single streamed-chat citation parsing."""
+        return parse_single_citation(cite)
 
     def _extract_text_passages(self, cite_inner: list) -> tuple[str | None, int | None, int | None]:
-        """Extract cited text and character positions from citation data.
-
-        Structure (discovered via analysis):
-          cite_inner[4] = [[passage_data, ...], ...]
-          passage_data = [start_char, end_char, nested_passages]
-          nested_passages contains text at varying depths
-
-        Args:
-            cite_inner: The inner citation data (cite[1]).
-
-        Returns:
-            Tuple of (cited_text, start_char, end_char).
-        """
-        if len(cite_inner) <= 4 or not isinstance(cite_inner[4], list):
-            return None, None, None
-
-        texts: list[str] = []
-        start_char: int | None = None
-        end_char: int | None = None
-
-        for passage_wrapper in cite_inner[4]:
-            if not isinstance(passage_wrapper, list) or not passage_wrapper:
-                continue
-            passage_data = passage_wrapper[0]
-            if not isinstance(passage_data, list) or len(passage_data) < 3:
-                continue
-
-            # Extract char positions from first valid passage
-            if start_char is None and isinstance(passage_data[0], int):
-                start_char = passage_data[0]
-            if isinstance(passage_data[1], int):
-                end_char = passage_data[1]
-
-            # Extract text from nested structure
-            self._collect_texts_from_nested(passage_data[2], texts)
-
-        cited_text = " ".join(texts) if texts else None
-        return cited_text, start_char, end_char
+        """Compatibility wrapper for streamed-chat citation text extraction."""
+        return extract_text_passages(cite_inner)
 
     def _collect_texts_from_nested(self, nested: Any, texts: list[str]) -> None:
-        """Collect text strings from deeply nested passage structure.
-
-        The text can appear at various levels of nesting. This walks through
-        the structure looking for [start, end, text_value] triplets.
-
-        Args:
-            nested: Nested list structure to search.
-            texts: List to append found text strings to.
-        """
-        if not isinstance(nested, list):
-            return
-
-        for nested_group in nested:
-            if not isinstance(nested_group, list):
-                continue
-            for inner in nested_group:
-                if not isinstance(inner, list) or len(inner) < 3:
-                    continue
-                text_val = inner[2]
-                if isinstance(text_val, str) and text_val.strip():
-                    texts.append(text_val.strip())
-                elif isinstance(text_val, list):
-                    for item in text_val:
-                        if isinstance(item, str) and item.strip():
-                            texts.append(item.strip())
+        """Compatibility wrapper for streamed-chat nested text collection."""
+        collect_texts_from_nested(nested, texts)
 
     def _extract_uuid_from_nested(self, data: Any, max_depth: int = 10) -> str | None:
-        """Recursively extract a UUID from nested list structures.
-
-        The API returns source IDs in deeply nested list structures that can vary.
-        This walks through the nesting to find the first valid UUID string.
-
-        Args:
-            data: Nested list data to search.
-            max_depth: Maximum recursion depth to prevent stack overflow.
-
-        Returns:
-            UUID string if found, None otherwise.
-        """
-        if max_depth <= 0:
-            logger.warning("Max recursion depth reached in UUID extraction")
-            return None
-
-        if data is None:
-            return None
-
-        if isinstance(data, str):
-            return data if _UUID_PATTERN.match(data) else None
-
-        if isinstance(data, list):
-            for item in data:
-                result = self._extract_uuid_from_nested(item, max_depth - 1)
-                if result is not None:
-                    return result
-
-        return None
+        """Compatibility wrapper for streamed-chat source UUID extraction."""
+        return extract_uuid_from_nested(data, max_depth)

--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -21,6 +21,7 @@ from .rpc.encoder import nest_source_ids
 from .rpc.types import get_query_url
 from .types import ChatReference
 
+# Deliberate: preserve the pre-extraction chat parser logger namespace.
 logger = logging.getLogger("notebooklm._chat")
 
 _UUID_PATTERN = re.compile(

--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -1,0 +1,389 @@
+"""Streamed-chat protocol mechanics for NotebookLM private chat calls.
+
+This module owns only streamed-chat wire request construction and response
+parsing. Conversation flow, caching, source resolution, and ``AskResult``
+construction stay in :mod:`notebooklm._chat`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.parse import quote, urlencode
+
+from ._env import get_default_bl, get_default_language
+from .auth import format_authuser_value
+from .exceptions import ChatError
+from .rpc.encoder import nest_source_ids
+from .rpc.types import get_query_url
+from .types import ChatReference
+
+logger = logging.getLogger("notebooklm._chat")
+
+_UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+class AuthSnapshotLike(Protocol):
+    """Structural auth snapshot accepted by streamed-chat request builders."""
+
+    @property
+    def csrf_token(self) -> str: ...
+
+    @property
+    def session_id(self) -> str: ...
+
+    @property
+    def authuser(self) -> int: ...
+
+    @property
+    def account_email(self) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class StreamingChatParseResult:
+    """Parsed streamed-chat answer payload."""
+
+    answer: str
+    references: list[ChatReference]
+    conversation_id: str | None
+
+
+def build_streaming_chat_request(
+    *,
+    snapshot: AuthSnapshotLike,
+    notebook_id: str,
+    question: str,
+    source_ids: list[str],
+    conversation_history: list | None,
+    conversation_id: str,
+    reqid: int,
+) -> tuple[str, str, dict[str, str]]:
+    """Assemble ``(url, body, extra_headers)`` for one streamed-chat attempt."""
+    sources_array = nest_source_ids(source_ids, 2)
+
+    params: list[Any] = [
+        sources_array,
+        question,
+        conversation_history,
+        [2, None, [1], [1]],
+        conversation_id,
+        None,  # [5] - always null
+        None,  # [6] - always null
+        notebook_id,  # [7] - required for server-side conversation persistence
+        1,  # [8] - always 1
+    ]
+
+    params_json = json.dumps(params, separators=(",", ":"))
+    f_req_json = json.dumps([None, params_json], separators=(",", ":"))
+    encoded_req = quote(f_req_json, safe="")
+
+    body_parts = [f"f.req={encoded_req}"]
+    if snapshot.csrf_token:
+        encoded_at = quote(snapshot.csrf_token, safe="")
+        body_parts.append(f"at={encoded_at}")
+    body = "&".join(body_parts) + "&"
+
+    url_params: dict[str, str] = {
+        "bl": get_default_bl(),
+        "hl": get_default_language(),
+        "_reqid": str(reqid),
+        "rt": "c",
+    }
+    if snapshot.session_id:
+        url_params["f.sid"] = snapshot.session_id
+    if snapshot.account_email or snapshot.authuser:
+        url_params["authuser"] = format_authuser_value(
+            snapshot.authuser,
+            snapshot.account_email,
+        )
+
+    url = f"{get_query_url()}?{urlencode(url_params)}"
+    return url, body, {}
+
+
+def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResult:
+    """Parse a streamed-chat response into answer, references, and conversation ID."""
+    if response_text.startswith(")]}'"):
+        response_text = response_text[4:]
+
+    lines = response_text.strip().split("\n")
+    best_marked_answer = ""
+    best_marked_refs: list[ChatReference] = []
+    best_unmarked_answer = ""
+    best_unmarked_refs: list[ChatReference] = []
+    server_conv_id: str | None = None
+
+    def process_chunk(json_str: str) -> None:
+        """Process a JSON chunk, updating best answer candidates and their refs."""
+        nonlocal best_marked_answer, best_marked_refs
+        nonlocal best_unmarked_answer, best_unmarked_refs
+        nonlocal server_conv_id
+        text, is_answer, refs, conv_id = extract_answer_and_refs_from_chunk(json_str)
+        if text:
+            if is_answer and len(text) > len(best_marked_answer):
+                best_marked_answer = text
+                best_marked_refs = refs
+            elif not is_answer and len(text) > len(best_unmarked_answer):
+                best_unmarked_answer = text
+                best_unmarked_refs = refs
+        if conv_id:
+            server_conv_id = conv_id
+
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if not line:
+            i += 1
+            continue
+
+        try:
+            int(line)
+            i += 1
+            if i < len(lines):
+                process_chunk(lines[i])
+            i += 1
+        except ValueError:
+            process_chunk(line)
+            i += 1
+
+    if best_marked_answer:
+        longest_answer = best_marked_answer
+        final_refs = best_marked_refs
+    elif best_unmarked_answer:
+        logger.warning(
+            "No marked answer found; falling back to longest unmarked "
+            "text (%d chars). The API response format may have changed.",
+            len(best_unmarked_answer),
+        )
+        longest_answer = best_unmarked_answer
+        final_refs = best_unmarked_refs
+    else:
+        longest_answer = ""
+        final_refs = []
+
+    if not longest_answer:
+        logger.warning(
+            "No answer extracted from response (%d lines parsed)",
+            len(lines),
+        )
+
+    for idx, ref in enumerate(final_refs, start=1):
+        if ref.citation_number is None:
+            ref.citation_number = idx
+
+    return StreamingChatParseResult(longest_answer, final_refs, server_conv_id)
+
+
+def extract_answer_and_refs_from_chunk(
+    json_str: str,
+) -> tuple[str | None, bool, list[ChatReference], str | None]:
+    """Extract answer text, references, and conversation ID from one response chunk."""
+    refs: list[ChatReference] = []
+
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError:
+        return None, False, refs, None
+
+    if not isinstance(data, list):
+        return None, False, refs, None
+
+    for item in data:
+        if not isinstance(item, list) or len(item) < 3:
+            continue
+        if item[0] != "wrb.fr":
+            continue
+
+        inner_json = item[2]
+        if not isinstance(inner_json, str):
+            # item[2] is null — check item[5] for a server-side error payload
+            if len(item) > 5 and isinstance(item[5], list):
+                raise_if_rate_limited(item[5])
+            continue
+
+        try:
+            inner_data = json.loads(inner_json)
+            if isinstance(inner_data, list) and len(inner_data) > 0:
+                first = inner_data[0]
+                if isinstance(first, list) and len(first) > 0:
+                    text = first[0]
+                    if not isinstance(text, str) or not text:
+                        continue
+
+                    is_answer = (
+                        len(first) > 4
+                        and isinstance(first[4], list)
+                        and len(first[4]) > 0
+                        and first[4][-1] == 1
+                    )
+
+                    server_conv_id: str | None = None
+                    if (
+                        len(first) > 2
+                        and isinstance(first[2], list)
+                        and first[2]
+                        and isinstance(first[2][0], str)
+                    ):
+                        server_conv_id = first[2][0]
+
+                    refs = parse_citations(first)
+                    return text, is_answer, refs, server_conv_id
+        except json.JSONDecodeError:
+            # Hot-path stream parser: skip non-JSON chunks. Guard the
+            # debug log with isEnabledFor so the redaction regex doesn't
+            # run on every chunk when DEBUG is off.
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Stream parser: non-JSON chunk skipped")
+            continue
+
+    return None, False, refs, None
+
+
+def raise_if_rate_limited(error_payload: list) -> None:
+    """Raise ``ChatError`` if the payload contains a UserDisplayableError."""
+    try:
+        # Structure: [8, None, [["type.googleapis.com/.../UserDisplayableError", ...]]]
+        if len(error_payload) > 2 and isinstance(error_payload[2], list):
+            for entry in error_payload[2]:
+                if isinstance(entry, list) and entry and isinstance(entry[0], str):
+                    if "UserDisplayableError" in entry[0]:
+                        raise ChatError(
+                            "Chat request was rate limited or rejected by the API. "
+                            "Wait a few seconds and try again."
+                        )
+    except ChatError:
+        raise
+    except Exception:
+        logger.debug(
+            "Could not parse chat error payload; continuing with empty-answer handling",
+            exc_info=True,
+        )
+
+
+def parse_citations(first: list) -> list[ChatReference]:
+    """Parse citation details from a streamed-chat response structure."""
+    try:
+        if len(first) <= 4 or not isinstance(first[4], list):
+            return []
+        type_info = first[4]
+        if len(type_info) <= 3 or not isinstance(type_info[3], list):
+            return []
+
+        refs: list[ChatReference] = []
+        for cite in type_info[3]:
+            ref = parse_single_citation(cite)
+            if ref is not None:
+                refs.append(ref)
+        return refs
+    except (IndexError, TypeError, AttributeError) as e:
+        logger.debug(
+            "Citation parsing failed (API structure may have changed): %s",
+            e,
+            exc_info=True,
+        )
+        return []
+
+
+def parse_single_citation(cite: Any) -> ChatReference | None:
+    """Parse a single citation entry into a ``ChatReference``."""
+    if not isinstance(cite, list) or len(cite) < 2:
+        return None
+
+    cite_inner = cite[1]
+    if not isinstance(cite_inner, list):
+        return None
+
+    source_id_data = cite_inner[5] if len(cite_inner) > 5 else None
+    source_id = extract_uuid_from_nested(source_id_data)
+    if source_id is None:
+        return None
+
+    chunk_id = None
+    if isinstance(cite[0], list) and cite[0]:
+        first_item = cite[0][0]
+        if isinstance(first_item, str):
+            chunk_id = first_item
+
+    cited_text, start_char, end_char = extract_text_passages(cite_inner)
+
+    return ChatReference(
+        source_id=source_id,
+        cited_text=cited_text,
+        start_char=start_char,
+        end_char=end_char,
+        chunk_id=chunk_id,
+    )
+
+
+def extract_text_passages(cite_inner: list) -> tuple[str | None, int | None, int | None]:
+    """Extract cited text and character positions from citation data."""
+    if len(cite_inner) <= 4 or not isinstance(cite_inner[4], list):
+        return None, None, None
+
+    texts: list[str] = []
+    start_char: int | None = None
+    end_char: int | None = None
+
+    for passage_wrapper in cite_inner[4]:
+        if not isinstance(passage_wrapper, list) or not passage_wrapper:
+            continue
+        passage_data = passage_wrapper[0]
+        if not isinstance(passage_data, list) or len(passage_data) < 3:
+            continue
+
+        if start_char is None and isinstance(passage_data[0], int):
+            start_char = passage_data[0]
+        if isinstance(passage_data[1], int):
+            end_char = passage_data[1]
+
+        collect_texts_from_nested(passage_data[2], texts)
+
+    cited_text = " ".join(texts) if texts else None
+    return cited_text, start_char, end_char
+
+
+def collect_texts_from_nested(nested: Any, texts: list[str]) -> None:
+    """Collect text strings from deeply nested passage structure."""
+    if not isinstance(nested, list):
+        return
+
+    for nested_group in nested:
+        if not isinstance(nested_group, list):
+            continue
+        for inner in nested_group:
+            if not isinstance(inner, list) or len(inner) < 3:
+                continue
+            text_val = inner[2]
+            if isinstance(text_val, str) and text_val.strip():
+                texts.append(text_val.strip())
+            elif isinstance(text_val, list):
+                for item in text_val:
+                    if isinstance(item, str) and item.strip():
+                        texts.append(item.strip())
+
+
+def extract_uuid_from_nested(data: Any, max_depth: int = 10) -> str | None:
+    """Recursively extract a UUID from nested list structures."""
+    if max_depth <= 0:
+        logger.warning("Max recursion depth reached in UUID extraction")
+        return None
+
+    if data is None:
+        return None
+
+    if isinstance(data, str):
+        return data if _UUID_PATTERN.match(data) else None
+
+    if isinstance(data, list):
+        for item in data:
+            result = extract_uuid_from_nested(item, max_depth - 1)
+            if result is not None:
+                return result
+
+    return None

--- a/tests/unit/test_streaming_chat_protocol.py
+++ b/tests/unit/test_streaming_chat_protocol.py
@@ -1,0 +1,447 @@
+"""Characterization tests for private streamed-chat protocol helpers."""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib
+import importlib.util
+import inspect
+import json
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from urllib.parse import parse_qs, unquote, urlparse
+
+import pytest
+
+from notebooklm._chat_protocol import (
+    StreamingChatParseResult,
+    build_streaming_chat_request,
+    collect_texts_from_nested,
+    extract_answer_and_refs_from_chunk,
+    extract_text_passages,
+    extract_uuid_from_nested,
+    parse_citations,
+    parse_single_citation,
+    parse_streaming_chat_response,
+    raise_if_rate_limited,
+)
+from notebooklm.exceptions import ChatError
+from notebooklm.rpc.types import get_query_url
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
+
+
+def _snapshot(
+    *,
+    csrf_token: str = "csrf",
+    session_id: str = "sid",
+    authuser: int = 0,
+    account_email: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        csrf_token=csrf_token,
+        session_id=session_id,
+        authuser=authuser,
+        account_email=account_email,
+    )
+
+
+def _decode_body(body: str) -> tuple[list[Any], dict[str, list[str]]]:
+    body_qs = parse_qs(body, keep_blank_values=True)
+    f_req = json.loads(unquote(body_qs["f.req"][0]))
+    params = json.loads(f_req[1])
+    return params, body_qs
+
+
+def _chunk(
+    text: str,
+    *,
+    marked: bool = True,
+    conversation_id: str | None = None,
+    citations: list[Any] | None = None,
+) -> str:
+    marker = 1 if marked else 0
+    type_info = [[], None, None, citations or [], marker]
+    conv = [conversation_id, 123] if conversation_id is not None else None
+    inner_json = json.dumps([[text, None, conv, None, type_info]])
+    return json.dumps([["wrb.fr", None, inner_json]])
+
+
+def _length_prefixed(*chunks: str, xssi: bool = True) -> str:
+    parts = [")]}'"] if xssi else []
+    for chunk in chunks:
+        parts.append(f"\n{len(chunk)}\n{chunk}")
+    parts.append("\n")
+    return "".join(parts)
+
+
+def _citation(
+    *,
+    source_id: str,
+    chunk_id: str = "chunk-1",
+    text: str = "cited passage",
+    start: int = 10,
+    end: int = 20,
+) -> list[Any]:
+    return [
+        [chunk_id],
+        [
+            None,
+            None,
+            0.9,
+            [[None]],
+            [[[start, end, [[[start, end, text]]]]]],
+            [[[source_id]]],
+            [chunk_id],
+        ],
+    ]
+
+
+def test_module_signatures_are_stable() -> None:
+    signatures = {
+        "build_streaming_chat_request": inspect.signature(build_streaming_chat_request),
+        "parse_streaming_chat_response": inspect.signature(parse_streaming_chat_response),
+        "extract_answer_and_refs_from_chunk": inspect.signature(extract_answer_and_refs_from_chunk),
+        "raise_if_rate_limited": inspect.signature(raise_if_rate_limited),
+        "parse_citations": inspect.signature(parse_citations),
+        "parse_single_citation": inspect.signature(parse_single_citation),
+        "extract_text_passages": inspect.signature(extract_text_passages),
+        "collect_texts_from_nested": inspect.signature(collect_texts_from_nested),
+        "extract_uuid_from_nested": inspect.signature(extract_uuid_from_nested),
+    }
+
+    assert list(signatures["build_streaming_chat_request"].parameters) == [
+        "snapshot",
+        "notebook_id",
+        "question",
+        "source_ids",
+        "conversation_history",
+        "conversation_id",
+        "reqid",
+    ]
+    assert signatures["build_streaming_chat_request"].parameters["snapshot"].kind is (
+        inspect.Parameter.KEYWORD_ONLY
+    )
+    assert list(signatures["parse_streaming_chat_response"].parameters) == ["response_text"]
+    assert list(signatures["extract_answer_and_refs_from_chunk"].parameters) == ["json_str"]
+    assert list(signatures["raise_if_rate_limited"].parameters) == ["error_payload"]
+    assert list(signatures["parse_citations"].parameters) == ["first"]
+    assert list(signatures["parse_single_citation"].parameters) == ["cite"]
+    assert list(signatures["extract_text_passages"].parameters) == ["cite_inner"]
+    assert list(signatures["collect_texts_from_nested"].parameters) == ["nested", "texts"]
+    assert list(signatures["extract_uuid_from_nested"].parameters) == ["data", "max_depth"]
+    assert signatures["extract_uuid_from_nested"].parameters["max_depth"].default == 10
+    assert StreamingChatParseResult("a", [], None).answer == "a"
+
+
+def test_build_request_preserves_url_body_and_param_invariants(monkeypatch) -> None:
+    monkeypatch.setenv("NOTEBOOKLM_BL", "boq_labs-custom_99999999.00_p0")
+    monkeypatch.setenv("NOTEBOOKLM_HL", "ja")
+
+    url, body, extra_headers = build_streaming_chat_request(
+        snapshot=_snapshot(account_email="me@example.com", authuser=5),
+        notebook_id="nb-123",
+        question="Q?",
+        source_ids=["s1", "s2"],
+        conversation_history=[["previous answer", None, 2], ["previous question", None, 1]],
+        conversation_id="conv-1",
+        reqid=234567,
+    )
+
+    query = parse_qs(urlparse(url).query, keep_blank_values=True)
+    params, body_qs = _decode_body(body)
+
+    assert url.startswith(f"{get_query_url()}?")
+    assert query["bl"] == ["boq_labs-custom_99999999.00_p0"]
+    assert query["hl"] == ["ja"]
+    assert query["_reqid"] == ["234567"]
+    assert query["rt"] == ["c"]
+    assert query["f.sid"] == ["sid"]
+    assert query["authuser"] == ["me@example.com"]
+    assert body_qs["at"] == ["csrf"]
+    assert body.endswith("&")
+    assert extra_headers == {}
+    assert params[0] == [[["s1"]], [["s2"]]]
+    assert len(params) == 9
+    assert params[7] == "nb-123"
+
+
+def test_build_request_omits_default_authuser_and_blank_csrf() -> None:
+    url, body, _ = build_streaming_chat_request(
+        snapshot=_snapshot(csrf_token="", authuser=0, account_email=None),
+        notebook_id="nb-123",
+        question="Q?",
+        source_ids=["s1"],
+        conversation_history=None,
+        conversation_id="conv-1",
+        reqid=1,
+    )
+
+    query = parse_qs(urlparse(url).query, keep_blank_values=True)
+    _, body_qs = _decode_body(body)
+
+    assert "authuser" not in query
+    assert "at" not in body_qs
+
+
+def test_build_request_uses_authuser_index_when_email_absent() -> None:
+    url, _, _ = build_streaming_chat_request(
+        snapshot=_snapshot(authuser=3, account_email=None),
+        notebook_id="nb-123",
+        question="Q?",
+        source_ids=["s1"],
+        conversation_history=None,
+        conversation_id="conv-1",
+        reqid=1,
+    )
+
+    assert parse_qs(urlparse(url).query)["authuser"] == ["3"]
+
+
+def test_parse_response_handles_xssi_length_prefix_raw_json_and_server_conversation_id() -> None:
+    first = _chunk("First answer.", conversation_id="server-conv")
+    second = _chunk("Raw JSON answer.", conversation_id="server-conv-2")
+    response = _length_prefixed(first) + second
+
+    result = parse_streaming_chat_response(response)
+
+    assert result.answer == "Raw JSON answer."
+    assert result.references == []
+    assert result.conversation_id == "server-conv-2"
+
+
+def test_marked_answer_beats_longer_unmarked_text() -> None:
+    marked = _chunk("Marked.", marked=True)
+    unmarked = _chunk("This unmarked text is longer than the answer marker.", marked=False)
+
+    result = parse_streaming_chat_response(_length_prefixed(unmarked, marked))
+
+    assert result.answer == "Marked."
+
+
+def test_unmarked_fallback_logs_under_chat_logger(caplog) -> None:
+    response = _length_prefixed(_chunk("Only unmarked answer.", marked=False))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response(response)
+
+    assert result.answer == "Only unmarked answer."
+    assert any(
+        record.name == "notebooklm._chat" and "No marked answer found" in record.message
+        for record in caplog.records
+    )
+
+
+def test_empty_response_returns_empty_result_and_logs_under_chat_logger(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = parse_streaming_chat_response("")
+
+    assert result == StreamingChatParseResult("", [], None)
+    assert any(
+        record.name == "notebooklm._chat" and "No answer extracted" in record.message
+        for record in caplog.records
+    )
+
+
+def test_parse_citations_extracts_multiple_references_and_assigns_numbers() -> None:
+    citations = [
+        _citation(
+            source_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            chunk_id="chunk-1",
+            text="first citation",
+            start=1,
+            end=11,
+        ),
+        _citation(
+            source_id="11111111-2222-3333-4444-555555555555",
+            chunk_id="chunk-2",
+            text="second citation",
+            start=12,
+            end=27,
+        ),
+    ]
+
+    result = parse_streaming_chat_response(_length_prefixed(_chunk("Answer.", citations=citations)))
+
+    assert [ref.citation_number for ref in result.references] == [1, 2]
+    assert [ref.source_id for ref in result.references] == [
+        "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "11111111-2222-3333-4444-555555555555",
+    ]
+    assert [ref.chunk_id for ref in result.references] == ["chunk-1", "chunk-2"]
+    assert [ref.cited_text for ref in result.references] == ["first citation", "second citation"]
+    assert [(ref.start_char, ref.end_char) for ref in result.references] == [(1, 11), (12, 27)]
+
+
+def test_missing_and_malformed_citation_shapes_degrade_without_raising() -> None:
+    assert parse_citations(["Answer", None, None, None]) == []
+    assert parse_citations(["Answer", None, None, None, [[], None, None, None, 1]]) == []
+    assert parse_single_citation(_citation(source_id="not-a-uuid")) is None
+    assert extract_text_passages([None, None, None, None, ["bad-passage"]]) == (
+        None,
+        None,
+        None,
+    )
+
+    texts: list[str] = []
+    collect_texts_from_nested([["malformed"]], texts)
+    assert texts == []
+
+
+def test_uuid_max_recursion_logs_under_chat_logger(caplog) -> None:
+    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
+        result = extract_uuid_from_nested([["aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"]], max_depth=0)
+
+    assert result is None
+    assert any(
+        record.name == "notebooklm._chat" and "Max recursion depth" in record.message
+        for record in caplog.records
+    )
+
+
+def test_non_json_inner_chunk_debug_log_is_guarded_and_uses_chat_logger(caplog) -> None:
+    bad_chunk = json.dumps([["wrb.fr", "method_id", "{not valid json}"]])
+
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
+        text, is_answer, refs, conv_id = extract_answer_and_refs_from_chunk(bad_chunk)
+
+    assert (text, is_answer, refs, conv_id) == (None, False, [], None)
+    assert any(
+        record.name == "notebooklm._chat" and "Stream parser" in record.message
+        for record in caplog.records
+    )
+
+
+def test_user_displayable_error_payload_raises_same_chat_error_message() -> None:
+    payload = [
+        8,
+        None,
+        [["type.googleapis.com/google.rpc.UserDisplayableError", "details"]],
+    ]
+
+    with pytest.raises(
+        ChatError,
+        match=(
+            "Chat request was rate limited or rejected by the API. "
+            "Wait a few seconds and try again."
+        ),
+    ):
+        raise_if_rate_limited(payload)
+
+
+def test_chat_protocol_static_import_guard() -> None:
+    forbidden = {
+        "notebooklm",
+        "notebooklm.client",
+        "notebooklm._chat",
+        "notebooklm._core",
+        "notebooklm.rpc.overrides",
+    }
+    tree = ast.parse((SRC_ROOT / "_chat_protocol.py").read_text(encoding="utf-8"))
+
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level == 1 or node.level == 2:
+                module = f"notebooklm.{module}" if module else "notebooklm"
+            imports.add(module)
+
+    assert forbidden.isdisjoint(imports)
+
+
+def test_chat_protocol_runtime_import_does_not_request_forbidden_modules(monkeypatch) -> None:
+    import notebooklm  # noqa: F401
+
+    forbidden = {
+        "notebooklm.client",
+        "notebooklm._chat",
+        "notebooklm._core",
+        "notebooklm.rpc.overrides",
+    }
+    sys.modules.pop("notebooklm._chat_protocol", None)
+    real_import = builtins.__import__
+
+    def guarded_import(
+        name: str,
+        globals_: dict[str, Any] | None = None,
+        locals_: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        resolved = name
+        if level:
+            package = globals_.get("__package__") if globals_ else None
+            if package:
+                resolved = importlib.util.resolve_name(f"{'.' * level}{name}", package)
+        if resolved in forbidden:
+            raise AssertionError(f"_chat_protocol imported forbidden module {resolved}")
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    module = importlib.import_module("notebooklm._chat_protocol")
+    assert module.__name__ == "notebooklm._chat_protocol"
+
+
+def test_chat_protocol_and_chat_smoke_import_order() -> None:
+    for name in ("notebooklm._chat", "notebooklm._chat_protocol"):
+        sys.modules.pop(name, None)
+    protocol = importlib.import_module("notebooklm._chat_protocol")
+    chat = importlib.import_module("notebooklm._chat")
+    assert protocol.__name__ == "notebooklm._chat_protocol"
+    assert chat.__name__ == "notebooklm._chat"
+
+    for name in ("notebooklm._chat", "notebooklm._chat_protocol"):
+        sys.modules.pop(name, None)
+    chat = importlib.import_module("notebooklm._chat")
+    protocol = importlib.import_module("notebooklm._chat_protocol")
+    assert chat.__name__ == "notebooklm._chat"
+    assert protocol.__name__ == "notebooklm._chat_protocol"
+
+
+def test_chat_module_keeps_only_delegating_stream_parser_wrappers() -> None:
+    tree = ast.parse((SRC_ROOT / "_chat.py").read_text(encoding="utf-8"))
+    wrapper_names = {
+        "_parse_ask_response_with_references",
+        "_extract_answer_and_refs_from_chunk",
+        "_raise_if_rate_limited",
+        "_parse_citations",
+        "_parse_single_citation",
+        "_extract_text_passages",
+        "_collect_texts_from_nested",
+        "_extract_uuid_from_nested",
+    }
+
+    wrappers = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in wrapper_names
+    }
+    assert set(wrappers) == wrapper_names
+
+    for name, node in wrappers.items():
+        constants = {child.value for child in ast.walk(node) if isinstance(child, ast.Constant)}
+        assert "wrb.fr" not in constants, f"{name} owns streamed wrb.fr parsing"
+        for child in ast.walk(node):
+            assert not (
+                isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and child.func.attr == "loads"
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == "json"
+            ), f"{name} owns JSON streamed chunk parsing"
+            assert not (
+                name == "_extract_uuid_from_nested"
+                and isinstance(child, ast.Call)
+                and isinstance(child.func, ast.Attribute)
+                and isinstance(child.func.value, ast.Name)
+                and child.func.value.id == "self"
+                and child.func.attr == "_extract_uuid_from_nested"
+            ), "_chat.py owns local UUID recursion"

--- a/tests/unit/test_streaming_chat_protocol.py
+++ b/tests/unit/test_streaming_chat_protocol.py
@@ -352,8 +352,11 @@ def test_chat_protocol_static_import_guard() -> None:
             if node.level == 1 or node.level == 2:
                 module = f"notebooklm.{module}" if module else "notebooklm"
             imports.add(module)
+            for alias in node.names:
+                imports.add(f"{module}.{alias.name}" if module else alias.name)
 
-    assert forbidden.isdisjoint(imports)
+    violations = forbidden & imports
+    assert not violations, f"_chat_protocol.py imported forbidden modules: {violations}"
 
 
 def test_chat_protocol_runtime_import_does_not_request_forbidden_modules(monkeypatch) -> None:
@@ -380,8 +383,12 @@ def test_chat_protocol_runtime_import_does_not_request_forbidden_modules(monkeyp
             package = globals_.get("__package__") if globals_ else None
             if package:
                 resolved = importlib.util.resolve_name(f"{'.' * level}{name}", package)
-        if resolved in forbidden:
-            raise AssertionError(f"_chat_protocol imported forbidden module {resolved}")
+        candidates = {resolved}
+        if fromlist:
+            candidates.update(f"{resolved}.{item}" for item in fromlist)
+        violations = forbidden & candidates
+        if violations:
+            raise AssertionError(f"_chat_protocol imported forbidden modules {violations}")
         return real_import(name, globals_, locals_, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", guarded_import)
@@ -418,6 +425,16 @@ def test_chat_module_keeps_only_delegating_stream_parser_wrappers() -> None:
         "_collect_texts_from_nested",
         "_extract_uuid_from_nested",
     }
+    expected_delegate = {
+        "_parse_ask_response_with_references": "parse_streaming_chat_response",
+        "_extract_answer_and_refs_from_chunk": "extract_answer_and_refs_from_chunk",
+        "_raise_if_rate_limited": "raise_if_rate_limited",
+        "_parse_citations": "parse_citations",
+        "_parse_single_citation": "parse_single_citation",
+        "_extract_text_passages": "extract_text_passages",
+        "_collect_texts_from_nested": "collect_texts_from_nested",
+        "_extract_uuid_from_nested": "extract_uuid_from_nested",
+    }
 
     wrappers = {
         node.name: node
@@ -429,6 +446,17 @@ def test_chat_module_keeps_only_delegating_stream_parser_wrappers() -> None:
     for name, node in wrappers.items():
         constants = {child.value for child in ast.walk(node) if isinstance(child, ast.Constant)}
         assert "wrb.fr" not in constants, f"{name} owns streamed wrb.fr parsing"
+        called_helpers = {
+            child.func.id
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        }
+        called_helpers.update(
+            child.func.attr
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
+        )
+        assert expected_delegate[name] in called_helpers, f"{name} does not delegate"
         for child in ast.walk(node):
             assert not (
                 isinstance(child, ast.Call)

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -226,10 +226,10 @@ def test_auth_context_unreadable_recovers_under_lock(tmp_path):
 
 
 def test_stream_parser_debug_guarded_by_isenabledfor(caplog):
-    """_chat.py:601 — non-JSON chunk debug log fires under DEBUG; suppressed otherwise."""
+    """_chat_protocol.py — non-JSON chunk debug log is guarded before it fires."""
 
     # Direct: ensure the module has a guarded debug call (structural check).
-    src = (SRC_ROOT / "_chat.py").read_text(encoding="utf-8")
+    src = (SRC_ROOT / "_chat_protocol.py").read_text(encoding="utf-8")
     assert "logger.isEnabledFor(logging.DEBUG)" in src
     assert "Stream parser" in src
 


### PR DESCRIPTION
## Summary
- Extract streamed-chat request construction and response parsing into private `notebooklm._chat_protocol`.
- Keep `ChatAPI` conversation behavior and private helper names as compatibility delegators.
- Add direct protocol characterization tests, logger/import-cycle guards, import-order smoke coverage, and `_chat.py` AST guard.

## Task
T7a - Streaming Chat Protocol Extraction from `.sisyphus/phases/architecture-remediation/phase-6.md`.

## Test plan
- [x] `rtk uv run pytest tests/unit/test_streaming_chat_protocol.py tests/unit/test_chat_helpers.py tests/unit/test_chat_refactor.py tests/unit/test_chat_references.py tests/unit/test_chat_integration.py tests/unit/test_chat_error_payload.py tests/unit/test_swallow_observability.py tests/unit/test_conversation.py`
- [x] `rtk uv run pytest tests/unit/test_source_selection.py`
- [x] `rtk uv run pytest tests/integration/cli_vcr/test_chat.py tests/integration/test_chat_multi_source_vcr.py tests/integration/concurrency/test_chat_history_race.py`
- [x] `rtk uv run ruff check src/notebooklm/_chat.py src/notebooklm/_chat_protocol.py tests/unit/test_streaming_chat_protocol.py tests/unit/test_chat_helpers.py tests/unit/test_chat_refactor.py tests/unit/test_chat_references.py tests/unit/test_chat_integration.py tests/unit/test_chat_error_payload.py tests/unit/test_swallow_observability.py tests/unit/test_conversation.py tests/unit/test_source_selection.py tests/integration/cli_vcr/test_chat.py tests/integration/test_chat_multi_source_vcr.py tests/integration/concurrency/test_chat_history_race.py`
- [x] `rtk uv run ruff format --check src/notebooklm/_chat.py src/notebooklm/_chat_protocol.py tests/unit/test_streaming_chat_protocol.py tests/unit/test_chat_helpers.py tests/unit/test_chat_refactor.py tests/unit/test_chat_references.py tests/unit/test_chat_integration.py tests/unit/test_chat_error_payload.py tests/unit/test_swallow_observability.py tests/unit/test_conversation.py tests/unit/test_source_selection.py tests/integration/cli_vcr/test_chat.py tests/integration/test_chat_multi_source_vcr.py tests/integration/concurrency/test_chat_history_race.py`
- [x] `rtk uv run mypy src/notebooklm`

## Deferred polish findings
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved streamed chat request/response logic into a shared protocol layer; chat flow behavior remains the same but is now maintained centrally.

* **Tests**
  * Added extensive tests for streamed chat request building, streaming response parsing, citation handling, error detection, import/import-order constraints, and debug-log guarding.

* **Chore**
  * Adjusted an observability test to target the new protocol location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->