### PR TITLE
refactor(artifacts): add transport capability skeleton

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -1,0 +1,3 @@
+"""Private artifact download service skeletons."""
+
+from __future__ import annotations

--- a/src/notebooklm/_artifact_formatters.py
+++ b/src/notebooklm/_artifact_formatters.py
@@ -1,0 +1,3 @@
+"""Private artifact formatting service skeletons."""
+
+from __future__ import annotations

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -1,0 +1,3 @@
+"""Private artifact generation service skeletons."""
+
+from __future__ import annotations

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -1,0 +1,3 @@
+"""Private artifact listing service skeletons."""
+
+from __future__ import annotations

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -1,0 +1,3 @@
+"""Private artifact polling service skeletons."""
+
+from __future__ import annotations

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -1960,7 +1960,7 @@ class ArtifactsAPI:
             name=f"artifact-poll-{notebook_id}-{task_id}",
         )
         try:
-            poll_operation_token = await self._core._begin_transport_task(
+            poll_operation_token = await self._capabilities.begin_transport_task(
                 poll_task,
                 f"artifact wait {task_id}",
             )
@@ -1974,7 +1974,7 @@ class ArtifactsAPI:
 
         async def _finish_poll_operation() -> None:
             try:
-                await self._core._finish_transport_post(poll_operation_token)
+                await self._capabilities.finish_transport_post(poll_operation_token)
             except Exception as exc:  # noqa: BLE001 - cleanup should not mask poll result
                 logger.warning("Artifact poll drain bookkeeping failed: %s", exc)
 

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -51,6 +51,8 @@ class CookieJarProvider(Protocol):
 
 
 class TransportOperationProvider(Protocol):
+    """Provider for shared transport operation bookkeeping."""
+
     async def begin_transport_post(self, log_label: str) -> object: ...
     async def begin_transport_task(
         self,

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Protocol
 
 import httpx
@@ -49,7 +50,22 @@ class CookieJarProvider(Protocol):
         ...
 
 
-class ClientCoreCapabilities(PollRegistryProvider, AuthRouteProvider, CookieJarProvider):
+class TransportOperationProvider(Protocol):
+    async def begin_transport_post(self, log_label: str) -> object: ...
+    async def begin_transport_task(
+        self,
+        task: asyncio.Task[Any],
+        log_label: str,
+    ) -> object: ...
+    async def finish_transport_post(self, token: object) -> None: ...
+
+
+class ClientCoreCapabilities(
+    PollRegistryProvider,
+    AuthRouteProvider,
+    CookieJarProvider,
+    TransportOperationProvider,
+):
     """Narrow capability adapter around a ``ClientCore``-shaped object.
 
     Construction is intentionally lazy: only store the core. Individual
@@ -79,3 +95,16 @@ class ClientCoreCapabilities(PollRegistryProvider, AuthRouteProvider, CookieJarP
 
     def live_cookies(self) -> httpx.Cookies:
         return self._core.get_http_client().cookies
+
+    async def begin_transport_post(self, log_label: str) -> object:
+        return await self._core._begin_transport_post(log_label)
+
+    async def begin_transport_task(
+        self,
+        task: asyncio.Task[Any],
+        log_label: str,
+    ) -> object:
+        return await self._core._begin_transport_task(task, log_label)
+
+    async def finish_transport_post(self, token: object) -> None:
+        await self._core._finish_transport_post(token)

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
 
-from notebooklm._capabilities import ClientCoreCapabilities
+from notebooklm._capabilities import ClientCoreCapabilities, TransportOperationProvider
 from notebooklm._core_polling import PollRegistry
 from notebooklm.auth import authuser_query, format_authuser_value
 
@@ -75,6 +76,70 @@ def test_client_core_capabilities_live_cookies_come_from_http_client() -> None:
 
     assert adapter.live_cookies() is live_cookies
     assert adapter.live_cookies() is not auth_cookies
+
+
+@pytest.mark.asyncio
+async def test_client_core_capabilities_begin_transport_post_delegates_to_core() -> None:
+    token = object()
+    core = MagicMock()
+    core._begin_transport_post = AsyncMock(return_value=token)
+    adapter = ClientCoreCapabilities(core)
+
+    result = await adapter.begin_transport_post("artifact generate")
+
+    assert result is token
+    core._begin_transport_post.assert_awaited_once_with("artifact generate")
+
+
+@pytest.mark.asyncio
+async def test_client_core_capabilities_begin_transport_task_delegates_to_core() -> None:
+    token = object()
+    task: asyncio.Task[object] = asyncio.create_task(asyncio.sleep(0, result=object()))
+    core = MagicMock()
+    core._begin_transport_task = AsyncMock(return_value=token)
+    adapter = ClientCoreCapabilities(core)
+
+    try:
+        result = await adapter.begin_transport_task(task, "artifact wait task_123")
+    finally:
+        await task
+
+    assert result is token
+    core._begin_transport_task.assert_awaited_once_with(task, "artifact wait task_123")
+
+
+@pytest.mark.asyncio
+async def test_client_core_capabilities_finish_transport_post_delegates_exact_token() -> None:
+    token = object()
+    core = MagicMock()
+    core._finish_transport_post = AsyncMock(return_value=None)
+    adapter = ClientCoreCapabilities(core)
+
+    await adapter.finish_transport_post(token)
+
+    core._finish_transport_post.assert_awaited_once_with(token)
+
+
+@pytest.mark.asyncio
+async def test_transport_operation_provider_accepts_magicmock_shape() -> None:
+    post_token = object()
+    task_token = object()
+    task: asyncio.Task[object] = asyncio.create_task(asyncio.sleep(0, result=object()))
+    provider = MagicMock(spec=TransportOperationProvider)
+    provider.begin_transport_post = AsyncMock(return_value=post_token)
+    provider.begin_transport_task = AsyncMock(return_value=task_token)
+    provider.finish_transport_post = AsyncMock(return_value=None)
+
+    try:
+        assert await provider.begin_transport_post("artifact generate") is post_token
+        assert await provider.begin_transport_task(task, "artifact wait task_123") is task_token
+        await provider.finish_transport_post(task_token)
+    finally:
+        await task
+
+    provider.begin_transport_post.assert_awaited_once_with("artifact generate")
+    provider.begin_transport_task.assert_awaited_once_with(task, "artifact wait task_123")
+    provider.finish_transport_post.assert_awaited_once_with(task_token)
 
 
 def test_capabilities_module_does_not_import_client_core_at_runtime() -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -234,14 +234,11 @@ def test_capabilities_does_not_import_transport_operation_token() -> None:
 
 
 def _is_type_checking_guard(node: ast.AST) -> bool:
-    return (
-        (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING")
-        or (
-            isinstance(node, ast.Attribute)
-            and node.attr == "TYPE_CHECKING"
-            and isinstance(node.value, ast.Name)
-            and node.value.id == "typing"
-        )
+    return (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING") or (
+        isinstance(node, ast.Attribute)
+        and node.attr == "TYPE_CHECKING"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "typing"
     )
 
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -33,12 +33,6 @@ _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS = {
     ("_sources.py", "_finish_transport_post"): 1,
 }
 
-_CAPABILITIES_TRANSPORT_PRIVATE_METHODS = {
-    "_begin_transport_post",
-    "_begin_transport_task",
-    "_finish_transport_post",
-}
-
 _CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
     "__init__.py",
     "__main__.py",
@@ -199,7 +193,7 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
     )
 
 
-def test_capabilities_is_the_only_private_transport_adapter() -> None:
+def test_capabilities_private_core_access_is_limited_to_transport_adapter_calls() -> None:
     observed = _collect_core_private_accesses(SRC_ROOT / "_capabilities.py")
     observed_counts = Counter(attr for _, attr in observed)
 
@@ -210,8 +204,6 @@ def test_capabilities_is_the_only_private_transport_adapter() -> None:
             "_finish_transport_post": 1,
         }
     )
-    unexpected = set(observed_counts) - _CAPABILITIES_TRANSPORT_PRIVATE_METHODS
-    assert unexpected == set()
 
 
 def test_capabilities_does_not_import_transport_operation_token() -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -29,10 +29,14 @@ SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 # to an empty set. Until then, this guard blocks new direct private-state access
 # without failing the legitimate pre-extraction call sites.
 _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS = {
-    ("_artifacts.py", "_begin_transport_task"): 1,
-    ("_artifacts.py", "_finish_transport_post"): 1,
     ("_sources.py", "_begin_transport_post"): 1,
     ("_sources.py", "_finish_transport_post"): 1,
+}
+
+_CAPABILITIES_TRANSPORT_PRIVATE_METHODS = {
+    "_begin_transport_post",
+    "_begin_transport_task",
+    "_finish_transport_post",
 }
 
 _CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
@@ -40,6 +44,7 @@ _CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
     "__main__.py",
     "_atomic_io.py",
     "_callbacks.py",
+    "_capabilities.py",
     "_core.py",
     "_env.py",
     "_idempotency.py",
@@ -47,6 +52,29 @@ _CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
     "_mind_map.py",
     "_url_utils.py",
     "_version_check.py",
+}
+
+_ARTIFACT_SERVICE_MODULES = [
+    "_artifact_formatters.py",
+    "_artifact_listing.py",
+    "_artifact_downloads.py",
+    "_artifact_generation.py",
+    "_artifact_polling.py",
+]
+
+_FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_NAMES = {
+    "NotebookLMClient",
+    "ClientCore",
+    "ArtifactsAPI",
+}
+
+_FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES = {
+    "_artifacts",
+    "_core",
+    "client",
+    "notebooklm._artifacts",
+    "notebooklm._core",
+    "notebooklm.client",
 }
 
 
@@ -169,6 +197,97 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
         "Core-private access baseline has entries no longer present in code. "
         f"Remove them from _ALLOWED_CORE_PRIVATE_ACCESS_COUNTS: {stale}"
     )
+
+
+def test_capabilities_is_the_only_private_transport_adapter() -> None:
+    observed = _collect_core_private_accesses(SRC_ROOT / "_capabilities.py")
+    observed_counts = Counter(attr for _, attr in observed)
+
+    assert observed_counts == Counter(
+        {
+            "_begin_transport_post": 1,
+            "_begin_transport_task": 1,
+            "_finish_transport_post": 1,
+        }
+    )
+    unexpected = set(observed_counts) - _CAPABILITIES_TRANSPORT_PRIVATE_METHODS
+    assert unexpected == set()
+
+
+def test_capabilities_does_not_import_transport_operation_token() -> None:
+    tree = ast.parse((SRC_ROOT / "_capabilities.py").read_text(encoding="utf-8"))
+    forbidden_imports: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            forbidden_imports.extend(
+                alias.name for alias in node.names if alias.name == "_TransportOperationToken"
+            )
+        elif isinstance(node, ast.Import):
+            forbidden_imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name.endswith("._TransportOperationToken")
+            )
+
+    assert forbidden_imports == []
+
+
+def _is_type_checking_guard(node: ast.AST) -> bool:
+    return (
+        (isinstance(node, ast.Name) and node.id == "TYPE_CHECKING")
+        or (
+            isinstance(node, ast.Attribute)
+            and node.attr == "TYPE_CHECKING"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "typing"
+        )
+    )
+
+
+class _RuntimeImportVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.forbidden: list[str] = []
+
+    def visit_If(self, node: ast.If) -> None:
+        if _is_type_checking_guard(node.test):
+            for child in node.orelse:
+                self.visit(child)
+            return
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.forbidden.extend(
+            alias.name
+            for alias in node.names
+            if alias.name in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES
+        )
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        if module in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES:
+            self.forbidden.extend(f"{module}.{alias.name}" for alias in node.names)
+            return
+
+        self.forbidden.extend(
+            alias.name
+            for alias in node.names
+            if alias.name in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_NAMES
+            or alias.name in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES
+        )
+
+
+def test_artifact_service_modules_do_not_runtime_import_facades_or_core() -> None:
+    """Guard future artifact service extraction modules against facade/core imports."""
+    forbidden_by_module: dict[str, list[str]] = {}
+    for module_name in _ARTIFACT_SERVICE_MODULES:
+        tree = ast.parse((SRC_ROOT / module_name).read_text(encoding="utf-8"))
+        visitor = _RuntimeImportVisitor()
+        visitor.visit(tree)
+        if visitor.forbidden:
+            forbidden_by_module[module_name] = visitor.forbidden
+
+    assert forbidden_by_module == {}
 
 
 def test_core_private_access_guard_detects_simple_aliases() -> None:


### PR DESCRIPTION
## Summary
- add private artifact service skeleton modules for T8 follow-up slices
- add transport operation capability protocol and route artifact polling through it
- tighten init-order guards so only _capabilities.py can touch private transport methods

## Task
T8a - Service Skeleton And Capability Contract from .sisyphus/phases/architecture-remediation/phase-7.md

## Test plan
- [x] rtk uv run pytest tests/unit/test_capabilities.py tests/unit/test_init_order.py tests/unit/test_artifacts_integration.py tests/unit/test_source_selection.py
- [x] rtk uv run ruff check src/notebooklm/_artifacts.py src/notebooklm/_artifact_formatters.py src/notebooklm/_artifact_listing.py src/notebooklm/_artifact_downloads.py src/notebooklm/_artifact_generation.py src/notebooklm/_artifact_polling.py src/notebooklm/_capabilities.py tests/unit/test_capabilities.py tests/unit/test_init_order.py
- [x] rtk uv run mypy src/notebooklm

## Deferred polish findings
- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modularized internal artifact service components and improved transport operation bookkeeping to make artifact handling more robust.
* **Tests**
  * Added new unit and init-order regression tests to enforce transport-operation safeguards and prevent unintended runtime imports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->