### PR TITLE
refactor(artifacts): extract artifact formatters

### DIFF
--- a/src/notebooklm/_artifact_formatters.py
+++ b/src/notebooklm/_artifact_formatters.py
@@ -1,3 +1,255 @@
-"""Private artifact formatting service skeletons."""
+"""Private artifact formatting helpers."""
 
 from __future__ import annotations
+
+import html
+import json
+import logging
+import re
+from collections.abc import Callable
+from typing import Any
+
+from .rpc import RPCMethod, safe_index
+from .types import ArtifactParseError
+
+__all__ = [
+    "_extract_app_data",
+    "_extract_cell_text",
+    "_extract_data_table_rows",
+    "_format_flashcards_markdown",
+    "_format_interactive_content",
+    "_format_quiz_markdown",
+    "_parse_data_table",
+]
+
+logger = logging.getLogger("notebooklm._artifacts")
+
+
+def _extract_app_data(html_content: str) -> dict:
+    """Extract JSON from data-app-data HTML attribute.
+
+    The quiz/flashcard HTML embeds JSON in a data-app-data attribute
+    with HTML-encoded content (e.g., &quot; for quotes).
+    """
+    match = re.search(r'data-app-data="([^"]+)"', html_content)
+    if not match:
+        raise ArtifactParseError(
+            "quiz/flashcard",
+            details="No data-app-data attribute found in HTML",
+        )
+
+    encoded_json = match.group(1)
+    decoded_json = html.unescape(encoded_json)
+    return json.loads(decoded_json)
+
+
+def _format_quiz_markdown(title: str, questions: list[dict]) -> str:
+    """Format quiz as markdown."""
+    lines = [f"# {title}", ""]
+    for i, q in enumerate(questions, 1):
+        lines.append(f"## Question {i}")
+        lines.append(q.get("question", ""))
+        lines.append("")
+        for opt in q.get("answerOptions", []):
+            marker = "[x]" if opt.get("isCorrect") else "[ ]"
+            lines.append(f"- {marker} {opt.get('text', '')}")
+        if q.get("hint"):
+            lines.append("")
+            lines.append(f"**Hint:** {q['hint']}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _format_flashcards_markdown(title: str, cards: list[dict]) -> str:
+    """Format flashcards as markdown."""
+    lines = [f"# {title}", ""]
+    for i, card in enumerate(cards, 1):
+        front = card.get("f", "")
+        back = card.get("b", "")
+        lines.extend(
+            [
+                f"## Card {i}",
+                "",
+                f"**Q:** {front}",
+                "",
+                f"**A:** {back}",
+                "",
+                "---",
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _format_interactive_content(
+    app_data: dict,
+    title: str,
+    output_format: str,
+    html_content: str,
+    is_quiz: bool,
+    quiz_markdown_formatter: Callable[[str, list[dict]], str] | None = None,
+    flashcards_markdown_formatter: Callable[[str, list[dict]], str] | None = None,
+) -> str:
+    """Format quiz or flashcard content for output.
+
+    Args:
+        app_data: Parsed data from HTML.
+        title: Artifact title.
+        output_format: Output format - json, markdown, or html.
+        html_content: Original HTML content.
+        is_quiz: True for quiz, False for flashcards.
+        quiz_markdown_formatter: Optional formatter used by compatibility wrappers.
+        flashcards_markdown_formatter: Optional formatter used by compatibility wrappers.
+
+    Returns:
+        Formatted content string.
+    """
+    if output_format == "html":
+        return html_content
+
+    if is_quiz:
+        questions = app_data.get("quiz", [])
+        if output_format == "markdown":
+            if quiz_markdown_formatter is None:
+                quiz_markdown_formatter = _format_quiz_markdown
+            return quiz_markdown_formatter(title, questions)
+        return json.dumps({"title": title, "questions": questions}, indent=2)
+
+    cards = app_data.get("flashcards", [])
+    if output_format == "markdown":
+        if flashcards_markdown_formatter is None:
+            flashcards_markdown_formatter = _format_flashcards_markdown
+        return flashcards_markdown_formatter(title, cards)
+    normalized = [{"front": c.get("f", ""), "back": c.get("b", "")} for c in cards]
+    return json.dumps({"title": title, "cards": normalized}, indent=2)
+
+
+def _extract_cell_text(cell: Any) -> str:
+    """Recursively extract text from a nested cell structure.
+
+    Data table cells have deeply nested arrays with position markers (integers)
+    and text content (strings). This function traverses the structure and
+    concatenates all text fragments found.
+    """
+    if isinstance(cell, str):
+        return cell
+    if isinstance(cell, int):
+        return ""
+    if isinstance(cell, list):
+        return "".join(text for item in cell if (text := _extract_cell_text(item)))
+    return ""
+
+
+def _extract_data_table_rows(raw_data: Any) -> list[Any]:
+    """Extract data-table rows from the LIST_ARTIFACTS (gArtLc) response shape.
+
+    Navigates the rich-text wrapper at ``raw_data[0][0][0][0][4][2]`` to reach
+    the rows array. The first four ``[0]`` hops are wrapper layers; ``[4]`` is
+    the table content section ``[type, flags, rows_array]``, and ``[2]`` is
+    the rows array itself.
+
+    Inner-most access goes through :func:`safe_index` so a soft-mode shape
+    drift logs a structured warning and returns ``[]`` instead of raising.
+    Strict-decode mode (``NOTEBOOKLM_STRICT_DECODE=1``) lets ``safe_index``
+    raise ``UnknownRPCMethodError`` so we fail fast.
+
+    Returns:
+        The rows array on success, or ``[]`` on shape drift / non-list inner
+        value. NEVER raises for soft-mode drift — callers (e.g.
+        :func:`_parse_data_table`) are responsible for converting an empty
+        result into a domain-level :class:`ArtifactParseError`.
+    """
+    rows_array = safe_index(
+        raw_data,
+        0,
+        0,
+        0,
+        0,
+        4,
+        2,
+        method_id=RPCMethod.LIST_ARTIFACTS.value,
+        source="_artifacts._extract_data_table_rows",
+    )
+    if not isinstance(rows_array, list):
+        # safe_index returns None on soft-mode drift, and the upstream shape
+        # is also occasionally seen as a non-list scalar — normalise both to
+        # the empty-list sentinel so the caller's "empty data table" path
+        # handles them uniformly.
+        if rows_array is not None:
+            logger.warning(
+                "data table rows_array is not a list (type=%s); treating as empty",
+                type(rows_array).__name__,
+            )
+        return []
+    return rows_array
+
+
+def _parse_data_table(
+    raw_data: list,
+    rows_extractor: Callable[[Any], list[Any]] | None = None,
+    cell_text_extractor: Callable[[Any], str] | None = None,
+) -> tuple[list[str], list[list[str]]]:
+    """Parse rich-text data table into headers and rows.
+
+    Data tables from NotebookLM have a complex nested structure with position
+    markers. This function delegates inner-most navigation to
+    :func:`_extract_data_table_rows` and then extracts text from each cell.
+
+    Each row has format: ``[start_pos, end_pos, [cell_array]]``.
+    Each cell is deeply nested: ``[pos, pos, [[pos, pos, [[pos, pos, [["text"]]]]]]]``.
+
+    Returns:
+        Tuple of (headers, rows) where headers is a list of column names
+        and rows is a list of row data (each row is a list of cell strings).
+
+    Raises:
+        ArtifactParseError: If the data structure cannot be parsed or is empty.
+    """
+    try:
+        if rows_extractor is None:
+            rows_extractor = _extract_data_table_rows
+        if cell_text_extractor is None:
+            cell_text_extractor = _extract_cell_text
+
+        rows_array = rows_extractor(raw_data)
+        if not rows_array:
+            # Covers both genuinely-empty tables and soft-mode shape drift
+            # (where ``_extract_data_table_rows`` returns ``[]``). The caller
+            # converts this into ArtifactParseError so the download_data_table
+            # surface stays unchanged.
+            raise ArtifactParseError("data_table", details="Empty data table")
+
+        headers: list[str] = []
+        rows: list[list[str]] = []
+
+        for i, row_section in enumerate(rows_array):
+            # Each row_section is [start_pos, end_pos, cell_array]
+            if not isinstance(row_section, list) or len(row_section) < 3:
+                continue
+
+            cell_array = row_section[2]
+            if not isinstance(cell_array, list):
+                continue
+
+            row_values = [cell_text_extractor(cell) for cell in cell_array]
+
+            if i == 0:
+                headers = row_values
+            else:
+                rows.append(row_values)
+
+        # Validate we extracted usable data
+        if not headers:
+            raise ArtifactParseError(
+                "data_table",
+                details="Failed to extract headers from data table",
+            )
+
+        return headers, rows
+
+    except (IndexError, TypeError, KeyError) as e:
+        raise ArtifactParseError(
+            "data_table",
+            details=f"Failed to parse data table structure: {e}",
+            cause=e,
+        ) from e

--- a/src/notebooklm/_artifact_formatters.py
+++ b/src/notebooklm/_artifact_formatters.py
@@ -22,6 +22,7 @@ __all__ = [
     "_parse_data_table",
 ]
 
+# Preserve the pre-extraction logger so existing log filters keep helper diagnostics.
 logger = logging.getLogger("notebooklm._artifacts")
 
 

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -9,11 +9,9 @@ import asyncio
 import builtins
 import contextlib
 import csv
-import html
 import json
 import logging
 import os
-import re
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -23,7 +21,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from . import _mind_map
+from . import _artifact_formatters, _mind_map
 from ._callbacks import maybe_await_callback
 from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
@@ -110,182 +108,51 @@ class DownloadResult:
         return bool(self.succeeded) and bool(self.failed)
 
 
+# Backward-compatible private helper wrappers.
 def _extract_app_data(html_content: str) -> dict:
-    """Extract JSON from data-app-data HTML attribute.
-
-    The quiz/flashcard HTML embeds JSON in a data-app-data attribute
-    with HTML-encoded content (e.g., &quot; for quotes).
-    """
-    match = re.search(r'data-app-data="([^"]+)"', html_content)
-    if not match:
-        raise ArtifactParseError(
-            "quiz/flashcard",
-            details="No data-app-data attribute found in HTML",
-        )
-
-    encoded_json = match.group(1)
-    decoded_json = html.unescape(encoded_json)
-    return json.loads(decoded_json)
+    return _artifact_formatters._extract_app_data(html_content)
 
 
 def _format_quiz_markdown(title: str, questions: list[dict]) -> str:
-    """Format quiz as markdown."""
-    lines = [f"# {title}", ""]
-    for i, q in enumerate(questions, 1):
-        lines.append(f"## Question {i}")
-        lines.append(q.get("question", ""))
-        lines.append("")
-        for opt in q.get("answerOptions", []):
-            marker = "[x]" if opt.get("isCorrect") else "[ ]"
-            lines.append(f"- {marker} {opt.get('text', '')}")
-        if q.get("hint"):
-            lines.append("")
-            lines.append(f"**Hint:** {q['hint']}")
-        lines.append("")
-    return "\n".join(lines)
+    return _artifact_formatters._format_quiz_markdown(title, questions)
 
 
 def _format_flashcards_markdown(title: str, cards: list[dict]) -> str:
-    """Format flashcards as markdown."""
-    lines = [f"# {title}", ""]
-    for i, card in enumerate(cards, 1):
-        front = card.get("f", "")
-        back = card.get("b", "")
-        lines.extend(
-            [
-                f"## Card {i}",
-                "",
-                f"**Q:** {front}",
-                "",
-                f"**A:** {back}",
-                "",
-                "---",
-                "",
-            ]
-        )
-    return "\n".join(lines)
+    return _artifact_formatters._format_flashcards_markdown(title, cards)
 
 
 def _extract_cell_text(cell: Any) -> str:
-    """Recursively extract text from a nested cell structure.
-
-    Data table cells have deeply nested arrays with position markers (integers)
-    and text content (strings). This function traverses the structure and
-    concatenates all text fragments found.
-    """
-    if isinstance(cell, str):
-        return cell
-    if isinstance(cell, int):
-        return ""
-    if isinstance(cell, list):
-        return "".join(text for item in cell if (text := _extract_cell_text(item)))
-    return ""
+    return _artifact_formatters._extract_cell_text(cell)
 
 
 def _extract_data_table_rows(raw_data: Any) -> list[Any]:
-    """Extract data-table rows from the LIST_ARTIFACTS (gArtLc) response shape.
-
-    Navigates the rich-text wrapper at ``raw_data[0][0][0][0][4][2]`` to reach
-    the rows array. The first four ``[0]`` hops are wrapper layers; ``[4]`` is
-    the table content section ``[type, flags, rows_array]``, and ``[2]`` is
-    the rows array itself.
-
-    Inner-most access goes through :func:`safe_index` so a soft-mode shape
-    drift logs a structured warning and returns ``[]`` instead of raising.
-    Strict-decode mode (``NOTEBOOKLM_STRICT_DECODE=1``) lets ``safe_index``
-    raise ``UnknownRPCMethodError`` so we fail fast.
-
-    Returns:
-        The rows array on success, or ``[]`` on shape drift / non-list inner
-        value. NEVER raises for soft-mode drift — callers (e.g.
-        :func:`_parse_data_table`) are responsible for converting an empty
-        result into a domain-level :class:`ArtifactParseError`.
-    """
-    rows_array = safe_index(
-        raw_data,
-        0,
-        0,
-        0,
-        0,
-        4,
-        2,
-        method_id=RPCMethod.LIST_ARTIFACTS.value,
-        source="_artifacts._extract_data_table_rows",
-    )
-    if not isinstance(rows_array, list):
-        # safe_index returns None on soft-mode drift, and the upstream shape
-        # is also occasionally seen as a non-list scalar — normalise both to
-        # the empty-list sentinel so the caller's "empty data table" path
-        # handles them uniformly.
-        if rows_array is not None:
-            logger.warning(
-                "data table rows_array is not a list (type=%s); treating as empty",
-                type(rows_array).__name__,
-            )
-        return []
-    return rows_array
+    return _artifact_formatters._extract_data_table_rows(raw_data)
 
 
 def _parse_data_table(raw_data: list) -> tuple[list[str], list[list[str]]]:
-    """Parse rich-text data table into headers and rows.
+    return _artifact_formatters._parse_data_table(
+        raw_data,
+        rows_extractor=_extract_data_table_rows,
+        cell_text_extractor=_extract_cell_text,
+    )
 
-    Data tables from NotebookLM have a complex nested structure with position
-    markers. This function delegates inner-most navigation to
-    :func:`_extract_data_table_rows` and then extracts text from each cell.
 
-    Each row has format: ``[start_pos, end_pos, [cell_array]]``.
-    Each cell is deeply nested: ``[pos, pos, [[pos, pos, [[pos, pos, [["text"]]]]]]]``.
-
-    Returns:
-        Tuple of (headers, rows) where headers is a list of column names
-        and rows is a list of row data (each row is a list of cell strings).
-
-    Raises:
-        ArtifactParseError: If the data structure cannot be parsed or is empty.
-    """
-    try:
-        rows_array = _extract_data_table_rows(raw_data)
-        if not rows_array:
-            # Covers both genuinely-empty tables and soft-mode shape drift
-            # (where ``_extract_data_table_rows`` returns ``[]``). The caller
-            # converts this into ArtifactParseError so the download_data_table
-            # surface stays unchanged.
-            raise ArtifactParseError("data_table", details="Empty data table")
-
-        headers: list[str] = []
-        rows: list[list[str]] = []
-
-        for i, row_section in enumerate(rows_array):
-            # Each row_section is [start_pos, end_pos, cell_array]
-            if not isinstance(row_section, list) or len(row_section) < 3:
-                continue
-
-            cell_array = row_section[2]
-            if not isinstance(cell_array, list):
-                continue
-
-            row_values = [_extract_cell_text(cell) for cell in cell_array]
-
-            if i == 0:
-                headers = row_values
-            else:
-                rows.append(row_values)
-
-        # Validate we extracted usable data
-        if not headers:
-            raise ArtifactParseError(
-                "data_table",
-                details="Failed to extract headers from data table",
-            )
-
-        return headers, rows
-
-    except (IndexError, TypeError, KeyError) as e:
-        raise ArtifactParseError(
-            "data_table",
-            details=f"Failed to parse data table structure: {e}",
-            cause=e,
-        ) from e
+def _format_interactive_content(
+    app_data: dict,
+    title: str,
+    output_format: str,
+    html_content: str,
+    is_quiz: bool,
+) -> str:
+    return _artifact_formatters._format_interactive_content(
+        app_data,
+        title,
+        output_format,
+        html_content,
+        is_quiz,
+        quiz_markdown_formatter=_format_quiz_markdown,
+        flashcards_markdown_formatter=_format_flashcards_markdown,
+    )
 
 
 class ArtifactsAPI:
@@ -1502,20 +1369,7 @@ class ArtifactsAPI:
         Returns:
             Formatted content string.
         """
-        if output_format == "html":
-            return html_content
-
-        if is_quiz:
-            questions = app_data.get("quiz", [])
-            if output_format == "markdown":
-                return _format_quiz_markdown(title, questions)
-            return json.dumps({"title": title, "questions": questions}, indent=2)
-
-        cards = app_data.get("flashcards", [])
-        if output_format == "markdown":
-            return _format_flashcards_markdown(title, cards)
-        normalized = [{"front": c.get("f", ""), "back": c.get("b", "")} for c in cards]
-        return json.dumps({"title": title, "cards": normalized}, indent=2)
+        return _format_interactive_content(app_data, title, output_format, html_content, is_quiz)
 
     async def download_report(
         self,

--- a/tests/unit/test_artifacts_helpers.py
+++ b/tests/unit/test_artifacts_helpers.py
@@ -155,6 +155,42 @@ def test_parse_data_table_wrapper_honors_artifacts_private_helper_seams(
     assert rows == [["text:value_cell"]]
 
 
+@pytest.mark.parametrize(
+    ("app_data", "is_quiz", "patched_name", "expected_items"),
+    [
+        ({"quiz": [{"question": "Q"}]}, True, "_format_quiz_markdown", [{"question": "Q"}]),
+        ({"flashcards": [{"f": "front"}]}, False, "_format_flashcards_markdown", [{"f": "front"}]),
+    ],
+)
+def test_format_interactive_content_wrapper_honors_artifacts_markdown_seams(
+    monkeypatch: pytest.MonkeyPatch,
+    app_data: dict,
+    is_quiz: bool,
+    patched_name: str,
+    expected_items: list[dict],
+) -> None:
+    """Interactive markdown wrappers keep sibling formatter monkeypatch seams intact."""
+    captured: dict[str, object] = {}
+
+    def formatter(title: str, items: list[dict]) -> str:
+        captured["title"] = title
+        captured["items"] = items
+        return "patched markdown"
+
+    monkeypatch.setattr(artifacts_module, patched_name, formatter)
+
+    result = artifacts_module._format_interactive_content(
+        app_data,
+        "Patched Title",
+        "markdown",
+        "<html></html>",
+        is_quiz,
+    )
+
+    assert result == "patched markdown"
+    assert captured == {"title": "Patched Title", "items": expected_items}
+
+
 def test_parse_data_table_happy_path() -> None:
     """End-to-end sanity: helper + parser still produce the expected CSV shape."""
     rows_payload = [

--- a/tests/unit/test_artifacts_helpers.py
+++ b/tests/unit/test_artifacts_helpers.py
@@ -13,6 +13,7 @@ import logging
 
 import pytest
 
+import notebooklm._artifacts as artifacts_module
 from notebooklm._artifacts import (
     _extract_data_table_rows,
     _parse_data_table,
@@ -126,6 +127,32 @@ def test_parse_data_table_raises_on_empty_rows() -> None:
 
     with pytest.raises(ArtifactParseError, match="Empty data table"):
         _parse_data_table(raw_data)
+
+
+def test_parse_data_table_wrapper_honors_artifacts_private_helper_seams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The _artifacts wrapper keeps sibling helper monkeypatch seams intact."""
+    rows_payload = [
+        [0, 5, ["header_cell"]],
+        [5, 10, ["value_cell"]],
+    ]
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "_extract_data_table_rows",
+        lambda raw_data: rows_payload,
+    )
+    monkeypatch.setattr(
+        artifacts_module,
+        "_extract_cell_text",
+        lambda cell: f"text:{cell}",
+    )
+
+    headers, rows = artifacts_module._parse_data_table(["patched raw data"])
+
+    assert headers == ["text:header_cell"]
+    assert rows == [["text:value_cell"]]
 
 
 def test_parse_data_table_happy_path() -> None:


### PR DESCRIPTION
## Summary
- Move quiz, flashcard, interactive, and data-table formatter helpers into `src/notebooklm/_artifact_formatters.py`.
- Keep `_artifacts.py` private helper wrappers for existing imports and monkeypatch seams.
- Preserve data-table `safe_index` strict/soft behavior and source label `_artifacts._extract_data_table_rows`.

## Task
`.sisyphus/phases/architecture-remediation/phase-7.md#t8b-artifact-formatters`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_artifacts_helpers.py tests/unit/test_artifacts_integration.py::TestDownloadQuizFlashcardParsing tests/integration/cli_vcr/test_downloads.py`
- [x] `rtk uv run ruff check src/notebooklm/_artifacts.py src/notebooklm/_artifact_formatters.py tests/unit/test_artifacts_helpers.py`
- [x] `rtk uv run mypy src/notebooklm`

## Deferred polish findings
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated interactive-artifact formatting/parsing into a single, unified implementation and wrapper so formatting behavior is consistent.

* **Bug Fixes**
  * Improved reliability and normalization when extracting embedded app data, nested cell text, and data-table rows; clearer parse errors on failures.

* **Tests**
  * Added and updated tests to cover wrapper behavior and ensure formatter/parsing seams are honored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->