### PR TITLE
refactor(artifacts): extract listing service

### DIFF
--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -1,3 +1,148 @@
-"""Private artifact listing service skeletons."""
+"""Private artifact listing and selection helpers."""
 
 from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+import httpx
+
+from .rpc import ArtifactStatus, ArtifactTypeCode, RPCError, RPCMethod
+from .types import Artifact, ArtifactNotReadyError, ArtifactType
+
+logger = logging.getLogger(__name__)
+
+RpcCall = Callable[..., Awaitable[Any]]
+ListRawCallback = Callable[[str], Awaitable[list[Any]]]
+ListMindMapsCallback = Callable[[str], Awaitable[list[Any]]]
+ListArtifactsCallback = Callable[[str], Awaitable[list[Artifact]]]
+
+
+class ArtifactListingService:
+    """List, filter, and select artifacts without depending on the facade."""
+
+    async def list_raw(self, notebook_id: str, *, rpc_call: RpcCall) -> list[Any]:
+        """Get raw studio artifact rows from NotebookLM."""
+        params = [[2], notebook_id, 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"']
+        result = await rpc_call(
+            RPCMethod.LIST_ARTIFACTS,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        if result and isinstance(result, list) and len(result) > 0:
+            return result[0] if isinstance(result[0], list) else result
+        return []
+
+    async def list_artifacts(
+        self,
+        notebook_id: str,
+        artifact_type: ArtifactType | None,
+        *,
+        list_raw: ListRawCallback,
+        list_mind_maps: ListMindMapsCallback,
+    ) -> list[Artifact]:
+        """List public artifacts from studio rows plus mind-map rows."""
+        artifacts = self._filter_studio_artifacts(await list_raw(notebook_id), artifact_type)
+
+        if artifact_type is None or artifact_type == ArtifactType.MIND_MAP:
+            try:
+                artifacts.extend(
+                    self._filter_mind_map_artifacts(
+                        await list_mind_maps(notebook_id),
+                        artifact_type,
+                    )
+                )
+            except (RPCError, httpx.HTTPError) as e:
+                # Network/API errors - log and continue with studio artifacts.
+                # This ensures users can see audio/video/reports even if the
+                # mind-map endpoint is temporarily unavailable.
+                logger.warning("Failed to fetch mind maps: %s", e)
+
+        return artifacts
+
+    async def get(
+        self,
+        notebook_id: str,
+        artifact_id: str,
+        *,
+        list_artifacts: ListArtifactsCallback,
+    ) -> Artifact | None:
+        """Get a public artifact by ID from the public artifact listing."""
+        artifacts = await list_artifacts(notebook_id)
+        for artifact in artifacts:
+            if artifact.id == artifact_id:
+                return artifact
+        return None
+
+    def select_artifact(
+        self,
+        candidates: Sequence[Any],
+        artifact_id: str | None,
+        type_name: str,
+        no_result_error_key: str,
+        *,
+        type_code: ArtifactTypeCode,
+    ) -> Any:
+        """Select an artifact from candidates by ID or return latest completed.
+
+        The error-key asymmetry is intentional: explicit-ID misses derive the
+        key from ``type_name`` while empty-filter results use
+        ``no_result_error_key`` verbatim.
+        """
+        filtered = [
+            a
+            for a in candidates
+            if isinstance(a, list)
+            and len(a) > 4
+            and a[2] == type_code
+            and a[4] == ArtifactStatus.COMPLETED
+        ]
+
+        if artifact_id:
+            artifact = next((a for a in filtered if a[0] == artifact_id), None)
+            if not artifact:
+                raise ArtifactNotReadyError(
+                    type_name.lower().replace(" ", "_"), artifact_id=artifact_id
+                )
+            return artifact
+
+        if not filtered:
+            raise ArtifactNotReadyError(no_result_error_key)
+
+        latest_first = sorted(
+            filtered,
+            key=lambda a: (
+                (a[15][0] or 0) if len(a) > 15 and isinstance(a[15], list) and a[15] else 0
+            ),
+            reverse=True,
+        )
+        return latest_first[0]
+
+    def _filter_studio_artifacts(
+        self,
+        artifacts_data: Sequence[Any],
+        artifact_type: ArtifactType | None,
+    ) -> list[Artifact]:
+        artifacts: list[Artifact] = []
+        for art_data in artifacts_data:
+            if isinstance(art_data, list) and len(art_data) > 0:
+                artifact = Artifact.from_api_response(art_data)
+                if artifact_type is None or artifact.kind == artifact_type:
+                    artifacts.append(artifact)
+        return artifacts
+
+    def _filter_mind_map_artifacts(
+        self,
+        mind_maps: Sequence[Any],
+        artifact_type: ArtifactType | None,
+    ) -> list[Artifact]:
+        artifacts: list[Artifact] = []
+        for mm_data in mind_maps:
+            if isinstance(mm_data, list):
+                mind_map_artifact = Artifact.from_mind_map(mm_data)
+                if mind_map_artifact is not None:
+                    if artifact_type is None or mind_map_artifact.kind == artifact_type:
+                        artifacts.append(mind_map_artifact)
+        return artifacts

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -118,14 +118,13 @@ class ArtifactListingService:
         if not filtered:
             raise ArtifactNotReadyError(no_result_error_key)
 
-        latest_first = sorted(
-            filtered,
+        filtered.sort(
             key=lambda a: (
                 (a[15][0] or 0) if len(a) > 15 and isinstance(a[15], list) and a[15] else 0
             ),
             reverse=True,
         )
-        return latest_first[0]
+        return filtered[0]
 
     def _filter_studio_artifacts(
         self,

--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -31,8 +31,15 @@ class ArtifactListingService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-        if result and isinstance(result, list) and len(result) > 0:
-            return result[0] if isinstance(result[0], list) else result
+        if (
+            isinstance(result, list)
+            and len(result) == 1
+            and isinstance(result[0], list)
+            and (not result[0] or isinstance(result[0][0], list))
+        ):
+            return result[0]
+        if isinstance(result, list):
+            return result
         return []
 
     async def list_artifacts(

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2139,6 +2139,8 @@ class ArtifactsAPI:
 
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw artifact list data."""
+        # Keep this facade hop so callers/tests that patch ``api._list_raw``
+        # still affect public listing paths that delegate into the service.
         return await self._listing.list_raw(notebook_id, rpc_call=self._core.rpc_call)
 
     def _select_artifact(

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 import httpx
 
 from . import _artifact_formatters, _mind_map
+from ._artifact_listing import ArtifactListingService
 from ._callbacks import maybe_await_callback
 from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
@@ -201,6 +202,7 @@ class ArtifactsAPI:
         # working through the deprecation cycle.
         del notes_api
         self._storage_path = storage_path
+        self._listing = ArtifactListingService()
 
     # =========================================================================
     # List/Get Operations
@@ -227,43 +229,12 @@ class ArtifactsAPI:
             List of Artifact objects.
         """
         logger.debug("Listing artifacts in notebook %s", notebook_id)
-        artifacts: list[Artifact] = []
-
-        # Fetch studio artifacts (audio, video, reports, etc.)
-        params = [[2], notebook_id, 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"']
-        result = await self._core.rpc_call(
-            RPCMethod.LIST_ARTIFACTS,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
+        return await self._listing.list_artifacts(
+            notebook_id,
+            artifact_type,
+            list_raw=self._list_raw,
+            list_mind_maps=self._list_mind_maps,
         )
-
-        artifacts_data: list[Any] = []
-        if result and isinstance(result, list) and len(result) > 0:
-            artifacts_data = result[0] if isinstance(result[0], list) else result
-
-        for art_data in artifacts_data:
-            if isinstance(art_data, list) and len(art_data) > 0:
-                artifact = Artifact.from_api_response(art_data)
-                if artifact_type is None or artifact.kind == artifact_type:
-                    artifacts.append(artifact)
-
-        # Fetch mind maps from notes system (if not filtering to non-mind-map type)
-        if artifact_type is None or artifact_type == ArtifactType.MIND_MAP:
-            try:
-                mind_maps = await _mind_map.list_mind_maps(self._core, notebook_id)
-                for mm_data in mind_maps:
-                    mind_map_artifact = Artifact.from_mind_map(mm_data)
-                    if mind_map_artifact is not None:  # None means deleted (status=2)
-                        if artifact_type is None or mind_map_artifact.kind == artifact_type:
-                            artifacts.append(mind_map_artifact)
-            except (RPCError, httpx.HTTPError) as e:
-                # Network/API errors - log and continue with studio artifacts
-                # This ensures users can see their audio/video/reports even if
-                # the mind maps endpoint is temporarily unavailable
-                logger.warning("Failed to fetch mind maps: %s", e)
-
-        return artifacts
 
     async def get(self, notebook_id: str, artifact_id: str) -> Artifact | None:
         """Get a specific artifact by ID.
@@ -276,11 +247,7 @@ class ArtifactsAPI:
             Artifact object, or None if not found.
         """
         logger.debug("Getting artifact %s from notebook %s", artifact_id, notebook_id)
-        artifacts = await self.list(notebook_id)
-        for artifact in artifacts:
-            if artifact.id == artifact_id:
-                return artifact
-        return None
+        return await self._listing.get(notebook_id, artifact_id, list_artifacts=self.list)
 
     async def list_audio(self, notebook_id: str) -> builtins.list[Artifact]:
         """List audio overview artifacts."""
@@ -2166,18 +2133,13 @@ class ArtifactsAPI:
         # errors and must surface to callers under strict decoding.
         return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
 
+    async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
+        """Get raw mind-map rows through the patchable module seam."""
+        return await _mind_map.list_mind_maps(self._core, notebook_id)
+
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw artifact list data."""
-        params = [[2], notebook_id, 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"']
-        result = await self._core.rpc_call(
-            RPCMethod.LIST_ARTIFACTS,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        if result and isinstance(result, list) and len(result) > 0:
-            return result[0] if isinstance(result[0], list) else result
-        return []
+        return await self._listing.list_raw(notebook_id, rpc_call=self._core.rpc_call)
 
     def _select_artifact(
         self,
@@ -2228,41 +2190,13 @@ class ArtifactsAPI:
             ArtifactNotReadyError: If artifact not found or no candidates
                 available after filtering.
         """
-        # Filter by type + completed-status. Requires at least 5 elements so
-        # we can read a[2] (type) and a[4] (status); downstream parsers raise
-        # ArtifactParseError if specific deeper indices are missing.
-        filtered = [
-            a
-            for a in candidates
-            if isinstance(a, list)
-            and len(a) > 4
-            and a[2] == type_code
-            and a[4] == ArtifactStatus.COMPLETED
-        ]
-
-        if artifact_id:
-            artifact = next((a for a in filtered if a[0] == artifact_id), None)
-            if not artifact:
-                raise ArtifactNotReadyError(
-                    type_name.lower().replace(" ", "_"), artifact_id=artifact_id
-                )
-            return artifact
-
-        if not filtered:
-            raise ArtifactNotReadyError(no_result_error_key)
-
-        # Sort by creation timestamp (descending) to get the latest.
-        # Timestamp is the raw API field at index 15, position 0. Falsy
-        # values at that position (``None``, ``0``) fall back to ``0`` so we
-        # never compare ``None`` against ``int`` during the sort.
-        filtered.sort(
-            key=lambda a: (
-                (a[15][0] or 0) if len(a) > 15 and isinstance(a[15], list) and a[15] else 0
-            ),
-            reverse=True,
+        return self._listing.select_artifact(
+            candidates,
+            artifact_id,
+            type_name,
+            no_result_error_key,
+            type_code=type_code,
         )
-
-        return filtered[0]
 
     async def _download_urls_batch(
         self, urls_and_paths: builtins.list[tuple[str, str]]

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -2135,6 +2135,8 @@ class ArtifactsAPI:
 
     async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw mind-map rows through the patchable module seam."""
+        # Resolve the module seam at call time so tests patching
+        # ``notebooklm._artifacts._mind_map`` affect public listing paths.
         return await _mind_map.list_mind_maps(self._core, notebook_id)
 
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]:

--- a/tests/unit/test_artifacts_integration.py
+++ b/tests/unit/test_artifacts_integration.py
@@ -390,6 +390,21 @@ class TestArtifactsAPI:
         )
 
     @pytest.mark.asyncio
+    async def test_list_raw_preserves_already_flat_artifact_rows(self):
+        """_list_raw must not collapse already-flat artifact rows."""
+        artifact_rows = [
+            ["art_001", "My Report", 2, None, 3],
+            ["art_002", "Audio Overview", 1, None, 3],
+        ]
+        core = MagicMock()
+        core.rpc_call = AsyncMock(return_value=artifact_rows)
+        api = ArtifactsAPI(core)
+
+        result = await api._list_raw("nb_123")
+
+        assert result == artifact_rows
+
+    @pytest.mark.asyncio
     async def test_list_uses_facade_list_raw_callback_and_mind_map_patch_seam(self):
         """list() resolves facade and mind-map seams at call time."""
         core = MagicMock()

--- a/tests/unit/test_artifacts_integration.py
+++ b/tests/unit/test_artifacts_integration.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
+from notebooklm._artifacts import ArtifactsAPI
 from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import (
     AudioFormat,
@@ -21,6 +22,7 @@ from notebooklm.rpc import (
 from notebooklm.types import (
     ArtifactNotReadyError,
     ArtifactParseError,
+    ArtifactType,
 )
 
 
@@ -369,6 +371,67 @@ class TestArtifactsAPI:
             artifacts = await client.artifacts.list("nb_123")
 
         assert isinstance(artifacts, list)
+
+    @pytest.mark.asyncio
+    async def test_list_raw_preserves_rpc_call_shape(self):
+        """_list_raw keeps the exact LIST_ARTIFACTS RPC contract."""
+        core = MagicMock()
+        core.rpc_call = AsyncMock(return_value=[[]])
+        api = ArtifactsAPI(core)
+
+        result = await api._list_raw("nb_123")
+
+        assert result == []
+        core.rpc_call.assert_awaited_once_with(
+            RPCMethod.LIST_ARTIFACTS,
+            [[2], "nb_123", 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"'],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_uses_facade_list_raw_callback_and_mind_map_patch_seam(self):
+        """list() resolves facade and mind-map seams at call time."""
+        core = MagicMock()
+        api = ArtifactsAPI(core)
+        studio_artifact = ["art_001", "My Report", 2, None, 3]
+        mind_map = [
+            "mind_map_001",
+            ["mind_map_001", '{"name":"Map"}', [1, "user", [1704067200, 0]], None, "Map"],
+        ]
+
+        with (
+            patch.object(api, "_list_raw", new=AsyncMock(return_value=[studio_artifact]))
+            as list_raw,
+            patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(return_value=[mind_map]),
+            ) as list_mind_maps,
+        ):
+            artifacts = await api.list("nb_123")
+
+        list_raw.assert_awaited_once_with("nb_123")
+        list_mind_maps.assert_awaited_once_with(core, "nb_123")
+        assert [artifact.id for artifact in artifacts] == ["art_001", "mind_map_001"]
+
+    @pytest.mark.asyncio
+    async def test_list_skips_mind_map_callback_for_non_mind_map_filter(self):
+        """Filtering to studio-only kinds must not fetch mind maps."""
+        core = MagicMock()
+        api = ArtifactsAPI(core)
+        studio_artifact = ["art_001", "My Report", 2, None, 3]
+
+        with (
+            patch.object(api, "_list_raw", new=AsyncMock(return_value=[studio_artifact])),
+            patch(
+                "notebooklm._artifacts._mind_map.list_mind_maps",
+                new=AsyncMock(),
+            ) as list_mind_maps,
+        ):
+            artifacts = await api.list("nb_123", ArtifactType.REPORT)
+
+        list_mind_maps.assert_not_awaited()
+        assert [artifact.id for artifact in artifacts] == ["art_001"]
 
     @pytest.mark.asyncio
     async def test_rename_artifact(

--- a/tests/unit/test_artifacts_integration.py
+++ b/tests/unit/test_artifacts_integration.py
@@ -450,6 +450,27 @@ class TestArtifactsAPI:
         assert [artifact.id for artifact in artifacts] == ["art_001"]
 
     @pytest.mark.asyncio
+    async def test_get_uses_public_list_callback(self):
+        """get() delegates through the public list callback."""
+        core = MagicMock()
+        api = ArtifactsAPI(core)
+        other = MagicMock()
+        other.id = "art_other"
+        found = MagicMock()
+        found.id = "art_found"
+
+        with patch.object(
+            api, "list", new=AsyncMock(return_value=[other, found])
+        ) as list_artifacts:
+            result = await api.get("nb_123", "art_found")
+            missing = await api.get("nb_123", "art_missing")
+
+        assert result is found
+        assert missing is None
+        assert list_artifacts.await_count == 2
+        list_artifacts.assert_awaited_with("nb_123")
+
+    @pytest.mark.asyncio
     async def test_rename_artifact(
         self,
         auth_tokens,

--- a/tests/unit/test_artifacts_integration.py
+++ b/tests/unit/test_artifacts_integration.py
@@ -401,8 +401,9 @@ class TestArtifactsAPI:
         ]
 
         with (
-            patch.object(api, "_list_raw", new=AsyncMock(return_value=[studio_artifact]))
-            as list_raw,
+            patch.object(
+                api, "_list_raw", new=AsyncMock(return_value=[studio_artifact])
+            ) as list_raw,
             patch(
                 "notebooklm._artifacts._mind_map.list_mind_maps",
                 new=AsyncMock(return_value=[mind_map]),


### PR DESCRIPTION
## Summary
- Move raw listing, completed-artifact selection, and public list/get filtering into `ArtifactListingService`.
- Keep `ArtifactsAPI._list_raw(...)` and `_select_artifact(...)` as patchable facade wrappers.
- Preserve the mind-map listing seam and fallback behavior when mind-map RPCs fail.

## Task
- T8c - Artifact Listing And Selection Extraction
- Plan: `.sisyphus/phases/architecture-remediation/phase-7.md#t8c-artifact-listing-selection`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_select_artifact.py tests/unit/test_artifacts_integration.py::TestArtifactsAPI tests/unit/test_artifacts_integration.py::TestListMindMapErrorHandling tests/unit/test_init_order.py`
- [x] `rtk uv run pytest tests/integration/cli_vcr/test_artifacts.py tests/integration/test_empty_results_vcr.py`
- [x] `rtk uv run ruff check src/notebooklm/_artifacts.py src/notebooklm/_artifact_listing.py tests/unit/test_select_artifact.py tests/unit/test_artifacts_integration.py tests/unit/test_init_order.py`
- [x] `rtk uv run mypy src/notebooklm`

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete artifact listing service with RPC-based raw listing, filtered artifact lists, and single-artifact lookup.
  * Merges studio and mind‑map artifacts; supports selecting by ID or the latest completed artifact and tolerates mind‑map fetch failures.

* **Tests**
  * Added integration tests for RPC listing, studio+mind‑map merging, type-based filtering, and single-artifact retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->