### PR TITLE
fix(decoder): demote byte-count mismatch log to DEBUG (#669)

### DIFF
--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -230,11 +230,8 @@ def parse_chunked_response(response: str) -> list[Any]:
             json_str = lines[i]
             actual_byte_count = len(json_str.encode("utf-8"))
             if actual_byte_count != byte_count:
-                # Demoted to DEBUG: Google's batchexecute declares a count in a
-                # different unit than ``len(s.encode("utf-8"))`` (likely UTF-16
-                # codepoints), so every multi-chunk live response trips this on
-                # every chunk. The JSONDecodeError branch below still WARNs on
-                # real corruption.
+                # DEBUG (not WARNING): live multi-chunk responses trip this on
+                # every chunk; see the Note: block in this function's docstring.
                 logger.debug(
                     "Chunk at line %d declares %d bytes but payload is %d bytes; "
                     "parsing valid JSON payload anyway. Preview: %s",

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -193,7 +193,7 @@ def parse_chunked_response(response: str) -> list[Any]:
         logged at DEBUG and tolerated when the following payload is still
         valid JSON, because recorded and proxy-transformed streams may not
         preserve Google's original byte count and live Google responses use a
-        different unit (likely UTF-16 codepoints) than ``len(s.encode("utf-8"))``.
+        different unit (likely UTF-16 code units) than ``len(s.encode("utf-8"))``.
         A JSONDecodeError on the payload still emits a WARNING on the
         subsequent parse-failure path. If the malformed-record rate exceeds
         10%, raises RPCError as this likely indicates API changes.

--- a/src/notebooklm/rpc/decoder.py
+++ b/src/notebooklm/rpc/decoder.py
@@ -190,10 +190,13 @@ def parse_chunked_response(response: str) -> list[Any]:
     Note:
         Malformed chunks are skipped with a warning logged. A byte-count line
         without a following payload is malformed. A byte-count mismatch is
-        logged but tolerated when the following payload is still valid JSON,
-        because recorded and proxy-transformed streams may not preserve Google's
-        original byte count. If the malformed-record rate exceeds 10%, raises
-        RPCError as this likely indicates API changes.
+        logged at DEBUG and tolerated when the following payload is still
+        valid JSON, because recorded and proxy-transformed streams may not
+        preserve Google's original byte count and live Google responses use a
+        different unit (likely UTF-16 codepoints) than ``len(s.encode("utf-8"))``.
+        A JSONDecodeError on the payload still emits a WARNING on the
+        subsequent parse-failure path. If the malformed-record rate exceeds
+        10%, raises RPCError as this likely indicates API changes.
     """
     if not response or not response.strip():
         return []
@@ -227,7 +230,12 @@ def parse_chunked_response(response: str) -> list[Any]:
             json_str = lines[i]
             actual_byte_count = len(json_str.encode("utf-8"))
             if actual_byte_count != byte_count:
-                logger.warning(
+                # Demoted to DEBUG: Google's batchexecute declares a count in a
+                # different unit than ``len(s.encode("utf-8"))`` (likely UTF-16
+                # codepoints), so every multi-chunk live response trips this on
+                # every chunk. The JSONDecodeError branch below still WARNs on
+                # real corruption.
+                logger.debug(
                     "Chunk at line %d declares %d bytes but payload is %d bytes; "
                     "parsing valid JSON payload anyway. Preview: %s",
                     i + 1,

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -126,8 +126,9 @@ def recompute_chunk_prefix(body: str) -> str:
 
     1. ``test_cassette_shapes.py`` byte-count assertion failures.
     2. ``decoder.py`` to emit ``Chunk at line N declares X bytes but payload is
-       Y bytes`` warnings during replay (the JSON is still parsed — see the
-       tolerance block at decoder.py:217-237 — but the warning is noise).
+       Y bytes`` DEBUG logs during replay (the JSON is still parsed — see the
+       tolerance block at decoder.py:217-237 — but well-formed cassettes
+       shouldn't trip the log at all).
 
     This helper walks the body, identifies every digit-only "header" line that
     is immediately followed by a non-header line, and replaces the header with

--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -23,8 +23,8 @@ complementary halves:
    replaces a 21-char user ID with the 17-char ``SCRUBBED_USER_ID``
    placeholder the advertised count no longer matches the payload, so this
    helper runs as a second pass inside :func:`tests.vcr_config.scrub_response`
-   to keep cassettes self-consistent and silence the decoder's tolerance
-   warning during replay.
+   to keep cassettes self-consistent and avoid tripping the decoder's
+   byte-count-mismatch DEBUG log during replay.
 
 Why both halves live here, not split into two modules:
 
@@ -33,11 +33,12 @@ Why both halves live here, not split into two modules:
   string surgery is a separate concern and benefits from being importable
   on its own (the T8.B6 bulk re-scrub script in ``scripts/`` imports both
   ``scrub_string`` AND ``recompute_chunk_prefix`` directly).
-- Decoder tolerance behavior in ``src/notebooklm/rpc/decoder.py`` (warning
-  on byte-count mismatch but still parsing the JSON) is intentionally
-  UNCHANGED — these helpers exist so cassettes don't trigger that warning
-  during replay, not to harden the decoder against drift in production
-  responses.
+- Decoder tolerance behavior in ``src/notebooklm/rpc/decoder.py`` (still
+  parses the JSON on byte-count mismatch, now logging at DEBUG rather
+  than WARNING — see #669) is what makes the recompute pass optional for
+  correctness; these helpers exist so cassettes stay self-consistent for
+  shape-lint and don't add log noise during replay, not to harden the
+  decoder against drift in production responses.
 
 Exports
 -------
@@ -133,9 +134,11 @@ def recompute_chunk_prefix(body: str) -> str:
     This helper walks the body, identifies every digit-only "header" line that
     is immediately followed by a non-header line, and replaces the header with
     the correct count for that payload. Byte count uses ``len(payload.encode(
-    "utf-8"))`` — matching the on-wire protocol AND the
-    ``len(json_str.encode("utf-8"))`` calculation the decoder uses. For
-    ASCII-only payloads (the common case for batchexecute JSON), this is
+    "utf-8"))`` — matching the ``len(json_str.encode("utf-8"))`` calculation
+    the decoder uses (which is what the cassette shape lint validates, even
+    though Google's live framing appears to use a different unit; see the
+    Note: block on :func:`notebooklm.rpc.decoder.parse_chunked_response`).
+    For ASCII-only payloads (the common case for batchexecute JSON), this is
     identical to ``len(payload)``, so the shape-lint character-length
     assertion in ``test_cassette_shapes.py`` still passes.
 

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -137,7 +137,6 @@ class TestParseChunkedResponse:
         ]
         assert len(mismatch_records) == 1
         assert mismatch_records[0].levelno == logging.DEBUG
-        assert mismatch_records[0].levelno < logging.WARNING
         assert "payload is" in mismatch_records[0].message
 
     def test_skips_byte_count_without_payload_below_threshold(self, caplog):

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -137,20 +137,8 @@ class TestParseChunkedResponse:
         ]
         assert len(mismatch_records) == 1
         assert mismatch_records[0].levelno == logging.DEBUG
+        assert mismatch_records[0].levelno < logging.WARNING
         assert "payload is" in mismatch_records[0].message
-
-    def test_does_not_warn_on_byte_count_mismatch_with_valid_json(self, caplog):
-        """Byte-count mismatch with valid JSON must not log at WARNING or above."""
-        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
-        payload = json.dumps(["wrong-size"])
-        response = f"{valid_parts}\n{len(payload) + 1}\n{payload}\n"
-
-        with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
-            parse_chunked_response(response)
-
-        assert not any(
-            "declares" in r.message and r.levelno >= logging.WARNING for r in caplog.records
-        )
 
     def test_skips_byte_count_without_payload_below_threshold(self, caplog):
         """A trailing byte-count line without a payload is malformed and skipped."""

--- a/tests/unit/test_decoder.py
+++ b/tests/unit/test_decoder.py
@@ -1,6 +1,7 @@
 """Unit tests for RPC response decoder."""
 
 import json
+import logging
 
 import pytest
 
@@ -114,17 +115,42 @@ class TestParseChunkedResponse:
         assert chunks[0] == ["valid0"]
         assert chunks[9] == ["valid9"]
 
-    def test_warns_but_parses_mismatched_byte_count_with_valid_json(self, caplog):
-        """Mismatched byte counts are tolerated when the payload is valid JSON."""
+    def test_logs_debug_but_parses_mismatched_byte_count_with_valid_json(self, caplog):
+        """Mismatched byte counts are tolerated when the payload is valid JSON.
+
+        The mismatch is logged at DEBUG (not WARNING) because Google's
+        batchexecute declares a count in a different unit than UTF-8 bytes, so
+        every multi-chunk live response would otherwise flood CI logs.
+        """
         valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
         payload = json.dumps(["wrong-size"])
         response = f"{valid_parts}\n{len(payload) + 1}\n{payload}\n"
 
-        chunks = parse_chunked_response(response)
+        with caplog.at_level(logging.DEBUG, logger="notebooklm.rpc.decoder"):
+            chunks = parse_chunked_response(response)
 
         assert chunks == [[f"valid{i}"] for i in range(10)] + [["wrong-size"]]
-        assert "declares" in caplog.text
-        assert "payload is" in caplog.text
+        mismatch_records = [
+            r
+            for r in caplog.records
+            if r.name == "notebooklm.rpc.decoder" and "declares" in r.message
+        ]
+        assert len(mismatch_records) == 1
+        assert mismatch_records[0].levelno == logging.DEBUG
+        assert "payload is" in mismatch_records[0].message
+
+    def test_does_not_warn_on_byte_count_mismatch_with_valid_json(self, caplog):
+        """Byte-count mismatch with valid JSON must not log at WARNING or above."""
+        valid_parts = "\n".join(self._chunk_record([f"valid{i}"]) for i in range(10))
+        payload = json.dumps(["wrong-size"])
+        response = f"{valid_parts}\n{len(payload) + 1}\n{payload}\n"
+
+        with caplog.at_level(logging.WARNING, logger="notebooklm.rpc.decoder"):
+            parse_chunked_response(response)
+
+        assert not any(
+            "declares" in r.message and r.levelno >= logging.WARNING for r in caplog.records
+        )
 
     def test_skips_byte_count_without_payload_below_threshold(self, caplog):
         """A trailing byte-count line without a payload is malformed and skipped."""


### PR DESCRIPTION
## Summary

- Demotes the `Chunk at line N declares X bytes but payload is Y bytes` log in `src/notebooklm/rpc/decoder.py` from `WARNING` to `DEBUG`.
- Keeps the subsequent `JSONDecodeError` branch at `WARNING` so real payload corruption is still surfaced.
- Updates `tests/unit/test_decoder.py` to assert the new level on the captured mismatch record.

## Why

Google's batchexecute stream declares a chunk length that differs from `len(payload.encode("utf-8"))` — likely a UTF-16-code-unit count — so every multi-chunk live response was emitting 2-3 WARNING lines per request, drowning the E2E job log on https://github.com/teng-lin/notebooklm-py/actions/runs/25955275691/job/76300692322. The decoder already documents this case as tolerated; only the log level was wrong.

Closes #669.

## Test plan

- [x] `uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest` — all 4504 tests pass locally on the worktree.
- [x] `test_logs_debug_but_parses_mismatched_byte_count_with_valid_json` (renamed from the old `test_warns_but_parses_...`) asserts the mismatch record is logged at exactly `logging.DEBUG` and that the chunk still parses — any future re-promotion to WARNING will fail the test.
- [ ] Verify CI green and that the next E2E run no longer floods stderr with mismatch warnings.

## Polish trail

- Stage 1 (code-simplifier): collapsed the 5-line inline comment to a 2-line pointer to the docstring; folded the original separate negative test into the renamed positive test.
- Stage 2 (triple review): claude bot — approve; gemini-code-assist — terminology nit (UTF-16 codepoints → code units, applied); codex — same nit + stale module prose in `tests/cassette_patterns.py` (both applied); coderabbit — no actionable comments.
- Stage 3 (ultrathink): noted side-benefits (perf via deferred `%`-formatting at DEBUG; reduced PII surface in default-level logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce noisy warnings for streamed chunk byte-count mismatches: demote mismatch messages to DEBUG while continuing to tolerate and parse valid payloads.

* **Tests**
  * Strengthened tests to verify parsing still succeeds when byte-counts differ and that the mismatch is logged exactly once at DEBUG level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->