### PR TITLE
refactor(artifacts): extract generation service

### DIFF
--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -39,6 +39,8 @@ def _artifact_seams() -> Any:
     try:
         return sys.modules["notebooklm._artifacts"]
     except KeyError as e:
+        # Normal construction imports this service from _artifacts first; the
+        # lookup exists only so call sites can preserve _artifacts patch seams.
         raise RuntimeError("notebooklm._artifacts must be imported before generation runs") from e
 
 
@@ -299,6 +301,8 @@ class ArtifactGenerationService:
         """Generate a study guide report."""
         if language is None:
             language = get_default_language()
+        # Preserve the historical facade seam for callers/tests that patch
+        # ArtifactsAPI.generate_report.
         return await self._api.generate_report(
             notebook_id,
             report_format=ReportFormat.STUDY_GUIDE,
@@ -525,6 +529,8 @@ class ArtifactGenerationService:
             raise
         if result is None:
             logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
+        # Call through the facade so patches on ArtifactsAPI._parse_generation_result
+        # remain effective after extraction.
         return api._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
 
     async def generate_data_table(
@@ -690,6 +696,8 @@ class ArtifactGenerationService:
                     error_code=str(e.rpc_code) if e.rpc_code is not None else None,
                 )
             raise
+        # Call through the facade so patches on ArtifactsAPI._parse_generation_result
+        # remain effective after extraction.
         return api._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
 
     def _parse_generation_result(

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -1,3 +1,712 @@
-"""Private artifact generation service skeletons."""
+"""Private artifact generation service implementation."""
 
 from __future__ import annotations
+
+import json as json_module
+import logging
+import sys
+from typing import Any
+
+from ._env import get_default_language
+from .exceptions import ValidationError
+from .rpc import (
+    ArtifactTypeCode,
+    AudioFormat,
+    AudioLength,
+    InfographicDetail,
+    InfographicOrientation,
+    InfographicStyle,
+    QuizDifficulty,
+    QuizQuantity,
+    ReportFormat,
+    RPCError,
+    RPCMethod,
+    SlideDeckFormat,
+    SlideDeckLength,
+    VideoFormat,
+    VideoStyle,
+    artifact_status_to_str,
+    nest_source_ids,
+    safe_index,
+)
+from .types import GenerationStatus, ReportSuggestion
+
+logger = logging.getLogger(__name__)
+
+
+def _artifact_seams() -> Any:
+    """Return the facade module that legacy tests patch."""
+    try:
+        return sys.modules["notebooklm._artifacts"]
+    except KeyError as e:
+        raise RuntimeError("notebooklm._artifacts must be imported before generation runs") from e
+
+
+class ArtifactGenerationService:
+    """Artifact generation operations extracted from the public facade."""
+
+    def __init__(self, api: Any):
+        self._api = api
+
+    async def generate_audio(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+        audio_format: AudioFormat | None = None,
+        audio_length: AudioLength | None = None,
+    ) -> GenerationStatus:
+        """Generate an Audio Overview (podcast)."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
+
+        format_code = audio_format.value if audio_format else None
+        length_code = audio_length.value if audio_length else None
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.AUDIO.value,
+                source_ids_triple,
+                None,
+                None,
+                [
+                    None,
+                    [
+                        instructions,
+                        length_code,
+                        None,
+                        source_ids_double,
+                        language,
+                        None,
+                        format_code,
+                    ],
+                ],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_video(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+        video_format: VideoFormat | None = None,
+        video_style: VideoStyle | None = None,
+        style_prompt: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a Video Overview."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
+        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
+            raise ValidationError("style_prompt is not supported for cinematic videos")
+        if video_style == VideoStyle.CUSTOM and not normalized_style_prompt:
+            raise ValidationError("style_prompt is required when video_style is CUSTOM")
+        if normalized_style_prompt and video_style != VideoStyle.CUSTOM:
+            raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
+
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
+
+        format_code = video_format.value if video_format else None
+        style_code = video_style.value if video_style else None
+
+        video_config = [
+            source_ids_double,
+            language,
+            instructions,
+            None,
+            format_code,
+            style_code,
+        ]
+        if normalized_style_prompt:
+            video_config.append(normalized_style_prompt)
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.VIDEO.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                [
+                    None,
+                    None,
+                    video_config,
+                ],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_cinematic_video(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a Cinematic Video Overview."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.VIDEO.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                [
+                    None,
+                    None,
+                    [
+                        source_ids_double,
+                        language,
+                        instructions,
+                        None,
+                        VideoFormat.CINEMATIC.value,
+                    ],
+                ],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_report(
+        self,
+        notebook_id: str,
+        report_format: ReportFormat = ReportFormat.BRIEFING_DOC,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        custom_prompt: str | None = None,
+        extra_instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a report artifact."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        format_configs = {
+            ReportFormat.BRIEFING_DOC: {
+                "title": "Briefing Doc",
+                "description": "Key insights and important quotes",
+                "prompt": (
+                    "Create a comprehensive briefing document that includes an "
+                    "Executive Summary, detailed analysis of key themes, important "
+                    "quotes with context, and actionable insights."
+                ),
+            },
+            ReportFormat.STUDY_GUIDE: {
+                "title": "Study Guide",
+                "description": "Short-answer quiz, essay questions, glossary",
+                "prompt": (
+                    "Create a comprehensive study guide that includes key concepts, "
+                    "short-answer practice questions, essay prompts for deeper "
+                    "exploration, and a glossary of important terms."
+                ),
+            },
+            ReportFormat.BLOG_POST: {
+                "title": "Blog Post",
+                "description": "Insightful takeaways in readable article format",
+                "prompt": (
+                    "Write an engaging blog post that presents the key insights "
+                    "in an accessible, reader-friendly format. Include an attention-"
+                    "grabbing introduction, well-organized sections, and a compelling "
+                    "conclusion with takeaways."
+                ),
+            },
+            ReportFormat.CUSTOM: {
+                "title": "Custom Report",
+                "description": "Custom format",
+                "prompt": custom_prompt or "Create a report based on the provided sources.",
+            },
+        }
+
+        config = format_configs[report_format]
+        if extra_instructions and report_format != ReportFormat.CUSTOM:
+            config = {**config, "prompt": f"{config['prompt']}\n\n{extra_instructions}"}
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        source_ids_double = nest_source_ids(source_ids, 1)
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.REPORT.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                [
+                    None,
+                    [
+                        config["title"],
+                        config["description"],
+                        None,
+                        source_ids_double,
+                        language,
+                        config["prompt"],
+                        None,
+                        True,
+                    ],
+                ],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_study_guide(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        extra_instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a study guide report."""
+        if language is None:
+            language = get_default_language()
+        return await self._api.generate_report(
+            notebook_id,
+            report_format=ReportFormat.STUDY_GUIDE,
+            source_ids=source_ids,
+            language=language,
+            extra_instructions=extra_instructions,
+        )
+
+    async def generate_quiz(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        instructions: str | None = None,
+        quantity: QuizQuantity | None = None,
+        difficulty: QuizDifficulty | None = None,
+    ) -> GenerationStatus:
+        """Generate a quiz."""
+        api = self._api
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        quantity_code = quantity.value if quantity else None
+        difficulty_code = difficulty.value if difficulty else None
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.QUIZ_FLASHCARD.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [
+                    None,
+                    [
+                        2,
+                        None,
+                        instructions,
+                        None,
+                        None,
+                        None,
+                        None,
+                        [quantity_code, difficulty_code],
+                    ],
+                ],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_flashcards(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        instructions: str | None = None,
+        quantity: QuizQuantity | None = None,
+        difficulty: QuizDifficulty | None = None,
+    ) -> GenerationStatus:
+        """Generate flashcards."""
+        api = self._api
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        quantity_code = quantity.value if quantity else None
+        difficulty_code = difficulty.value if difficulty else None
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.QUIZ_FLASHCARD.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [
+                    None,
+                    [
+                        1,
+                        None,
+                        instructions,
+                        None,
+                        None,
+                        None,
+                        [difficulty_code, quantity_code],
+                    ],
+                ],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_infographic(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+        orientation: InfographicOrientation | None = None,
+        detail_level: InfographicDetail | None = None,
+        style: InfographicStyle | None = None,
+    ) -> GenerationStatus:
+        """Generate an infographic."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        orientation_code = orientation.value if orientation else None
+        detail_code = detail_level.value if detail_level else None
+        style_code = style.value if style else None
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.INFOGRAPHIC.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [[instructions, language, None, orientation_code, detail_code, style_code]],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_slide_deck(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+        slide_format: SlideDeckFormat | None = None,
+        slide_length: SlideDeckLength | None = None,
+    ) -> GenerationStatus:
+        """Generate a slide deck."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+        format_code = slide_format.value if slide_format else None
+        length_code = slide_length.value if slide_length else None
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.SLIDE_DECK.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [[instructions, language, format_code, length_code]],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def revise_slide(
+        self,
+        notebook_id: str,
+        artifact_id: str,
+        slide_index: int,
+        prompt: str,
+    ) -> GenerationStatus:
+        """Revise an individual slide in a completed slide deck using a prompt."""
+        api = self._api
+        if slide_index < 0:
+            raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
+
+        params = [
+            [2],
+            artifact_id,
+            [[[slide_index, prompt]]],
+        ]
+        try:
+            result = await api._core.rpc_call(
+                RPCMethod.REVISE_SLIDE,
+                params,
+                source_path=f"/notebook/{notebook_id}",
+                allow_null=True,
+            )
+        except RPCError as e:
+            if e.rpc_code == "USER_DISPLAYABLE_ERROR":
+                return GenerationStatus(
+                    task_id="",
+                    status="failed",
+                    error=str(e),
+                    error_code=str(e.rpc_code) if e.rpc_code is not None else None,
+                )
+            raise
+        if result is None:
+            logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
+        return api._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
+
+    async def generate_data_table(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+    ) -> GenerationStatus:
+        """Generate a data table."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_triple = nest_source_ids(source_ids, 2)
+
+        params = [
+            [2],
+            notebook_id,
+            [
+                None,
+                None,
+                ArtifactTypeCode.DATA_TABLE.value,
+                source_ids_triple,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                [None, [instructions, language]],
+            ],
+        ]
+        return await api._call_generate(notebook_id, params)
+
+    async def generate_mind_map(
+        self,
+        notebook_id: str,
+        source_ids: list[str] | None = None,
+        language: str | None = None,
+        instructions: str | None = None,
+    ) -> dict[str, Any]:
+        """Generate an interactive mind map and persist it as a note."""
+        api = self._api
+        if language is None:
+            language = get_default_language()
+        if source_ids is None:
+            source_ids = await api._core.get_source_ids(notebook_id)
+
+        source_ids_nested = nest_source_ids(source_ids, 2)
+
+        params = [
+            source_ids_nested,
+            None,
+            None,
+            None,
+            None,
+            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
+            None,
+            [2, None, [1]],
+        ]
+
+        result = await api._core.rpc_call(
+            RPCMethod.GENERATE_MIND_MAP,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+
+        if result and isinstance(result, list) and len(result) > 0:
+            inner = result[0]
+            if isinstance(inner, list) and len(inner) > 0:
+                mind_map_json = inner[0]
+
+                if isinstance(mind_map_json, str):
+                    try:
+                        mind_map_data = json_module.loads(mind_map_json)
+                    except json_module.JSONDecodeError:
+                        mind_map_data = mind_map_json
+                        mind_map_json = str(mind_map_json)
+                else:
+                    mind_map_data = mind_map_json
+                    mind_map_json = json_module.dumps(mind_map_json)
+
+                title = "Mind Map"
+                if isinstance(mind_map_data, dict) and "name" in mind_map_data:
+                    title = mind_map_data["name"]
+
+                note = await _artifact_seams()._mind_map.create_note(
+                    api._core,
+                    notebook_id,
+                    title=title,
+                    content=mind_map_json,
+                )
+                note_id = note.id if note else None
+
+                return {
+                    "mind_map": mind_map_data,
+                    "note_id": note_id,
+                }
+
+        return {"mind_map": None, "note_id": None}
+
+    async def suggest_reports(
+        self,
+        notebook_id: str,
+    ) -> list[ReportSuggestion]:
+        """Get AI-suggested report formats for a notebook."""
+        api = self._api
+        params = [[2], notebook_id]
+
+        result = await api._core.rpc_call(
+            RPCMethod.GET_SUGGESTED_REPORTS,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+
+        suggestions = []
+        if result and isinstance(result, list) and len(result) > 0:
+            items = result[0] if isinstance(result[0], list) else result
+            for item in items:
+                if isinstance(item, list) and len(item) >= 5:
+                    suggestions.append(
+                        ReportSuggestion(
+                            title=item[0] if isinstance(item[0], str) else "",
+                            description=item[1] if isinstance(item[1], str) else "",
+                            prompt=item[4] if isinstance(item[4], str) else "",
+                            audience_level=item[5] if len(item) > 5 else 2,
+                        )
+                    )
+
+        return suggestions
+
+    async def _call_generate(self, notebook_id: str, params: list[Any]) -> GenerationStatus:
+        """Make a generation RPC call with error handling."""
+        api = self._api
+        artifact_type = params[2][2] if len(params) > 2 and len(params[2]) > 2 else "unknown"
+        logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
+        try:
+            result = await api._core.rpc_call(
+                RPCMethod.CREATE_ARTIFACT,
+                params,
+                source_path=f"/notebook/{notebook_id}",
+                allow_null=True,
+            )
+        except RPCError as e:
+            if e.rpc_code == "USER_DISPLAYABLE_ERROR":
+                return GenerationStatus(
+                    task_id="",
+                    status="failed",
+                    error=str(e),
+                    error_code=str(e.rpc_code) if e.rpc_code is not None else None,
+                )
+            raise
+        return api._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
+
+    def _parse_generation_result(
+        self,
+        result: Any,
+        *,
+        method_id: str,
+        source: str = "_parse_generation_result",
+    ) -> GenerationStatus:
+        """Parse generation API result into GenerationStatus."""
+        artifact_id = safe_index(result, 0, 0, method_id=method_id, source=source)
+
+        if artifact_id:
+            status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
+            status = artifact_status_to_str(status_code) if status_code is not None else "pending"
+            return GenerationStatus(task_id=artifact_id, status=status)
+
+        return GenerationStatus(
+            task_id="", status="failed", error="Generation failed - no artifact_id returned"
+        )

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -16,13 +16,12 @@ from typing import TYPE_CHECKING, Any
 
 from . import _artifact_formatters, _mind_map
 from ._artifact_downloads import ArtifactDownloadService, DownloadResult
+from ._artifact_generation import ArtifactGenerationService
 from ._artifact_listing import ArtifactListingService
 from ._callbacks import maybe_await_callback
 from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
-from ._env import get_default_language
 from .auth import load_httpx_cookies
-from .exceptions import ValidationError
 from .rpc import (
     ArtifactStatus,
     ArtifactTypeCode,
@@ -36,7 +35,6 @@ from .rpc import (
     QuizDifficulty,
     QuizQuantity,
     ReportFormat,
-    RPCError,
     RPCMethod,
     RPCTimeoutError,
     ServerError,
@@ -45,8 +43,6 @@ from .rpc import (
     VideoFormat,
     VideoStyle,
     artifact_status_to_str,
-    nest_source_ids,
-    safe_index,
 )
 from .types import (
     Artifact,
@@ -186,6 +182,7 @@ class ArtifactsAPI:
         del notes_api
         self._storage_path = storage_path
         self._listing = ArtifactListingService()
+        self._generation = ArtifactGenerationService(self)
         self._downloads = ArtifactDownloadService(self)
 
     # =========================================================================
@@ -278,56 +275,15 @@ class ArtifactsAPI:
         audio_format: AudioFormat | None = None,
         audio_length: AudioLength | None = None,
     ) -> GenerationStatus:
-        """Generate an Audio Overview (podcast).
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Custom instructions for the podcast hosts.
-            audio_format: DEEP_DIVE, BRIEF, CRITIQUE, or DEBATE.
-            audio_length: SHORT, DEFAULT, or LONG.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        format_code = audio_format.value if audio_format else None
-        length_code = audio_length.value if audio_length else None
-
-        params = [
-            [2],
+        """Generate an Audio Overview (podcast)."""
+        return await self._generation.generate_audio(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.AUDIO.value,
-                source_ids_triple,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        instructions,
-                        length_code,
-                        None,
-                        source_ids_double,
-                        language,
-                        None,
-                        format_code,
-                    ],
-                ],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
+            audio_format=audio_format,
+            audio_length=audio_length,
+        )
 
     async def generate_video(
         self,
@@ -339,72 +295,16 @@ class ArtifactsAPI:
         video_style: VideoStyle | None = None,
         style_prompt: str | None = None,
     ) -> GenerationStatus:
-        """Generate a Video Overview.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Custom instructions for video generation.
-            video_format: EXPLAINER or BRIEF.
-            video_style: AUTO_SELECT, CLASSIC, WHITEBOARD, etc.
-            style_prompt: Custom visual style instructions. Requires
-                ``video_style=VideoStyle.CUSTOM``.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
-        if video_format == VideoFormat.CINEMATIC and normalized_style_prompt:
-            raise ValidationError("style_prompt is not supported for cinematic videos")
-        if video_style == VideoStyle.CUSTOM and not normalized_style_prompt:
-            raise ValidationError("style_prompt is required when video_style is CUSTOM")
-        if normalized_style_prompt and video_style != VideoStyle.CUSTOM:
-            raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
-
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        format_code = video_format.value if video_format else None
-        style_code = video_style.value if video_style else None
-
-        video_config = [
-            source_ids_double,
-            language,
-            instructions,
-            None,
-            format_code,
-            style_code,
-        ]
-        if normalized_style_prompt:
-            video_config.append(normalized_style_prompt)
-
-        params = [
-            [2],
+        """Generate a Video Overview."""
+        return await self._generation.generate_video(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.VIDEO.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    None,
-                    video_config,
-                ],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
+            video_format=video_format,
+            video_style=video_style,
+            style_prompt=style_prompt,
+        )
 
     async def generate_cinematic_video(
         self,
@@ -413,64 +313,13 @@ class ArtifactsAPI:
         language: str | None = None,
         instructions: str | None = None,
     ) -> GenerationStatus:
-        """Generate a Cinematic Video Overview.
-
-        Cinematic videos use AI-generated documentary-style footage (Veo 3)
-        instead of the slide-deck animations used by standard video overviews.
-        They do not accept VideoStyle options.
-
-        Requires a Google AI Ultra subscription. Uses the same CREATE_ARTIFACT
-        RPC as standard videos with VideoFormat.CINEMATIC (3). Parameter
-        structure verified against NotebookLM web UI network traffic
-        (March 2026).
-
-        Note: Generation takes significantly longer than standard videos
-        (~30-40 minutes) due to Veo 3 rendering.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Custom instructions for video generation.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        params = [
-            [2],
+        """Generate a Cinematic Video Overview."""
+        return await self._generation.generate_cinematic_video(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.VIDEO.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    None,
-                    [
-                        source_ids_double,
-                        language,
-                        instructions,
-                        None,
-                        VideoFormat.CINEMATIC.value,
-                    ],
-                ],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
+        )
 
     async def generate_report(
         self,
@@ -481,97 +330,15 @@ class ArtifactsAPI:
         custom_prompt: str | None = None,
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
-        """Generate a report artifact.
-
-        Args:
-            notebook_id: The notebook ID.
-            report_format: BRIEFING_DOC, STUDY_GUIDE, BLOG_POST, or CUSTOM.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            custom_prompt: Prompt for CUSTOM format. Falls back to a generic
-                default if None.
-            extra_instructions: Additional instructions appended to the built-in
-                template prompt. Ignored when report_format is CUSTOM; for custom
-                reports, embed all instructions in custom_prompt instead.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        format_configs = {
-            ReportFormat.BRIEFING_DOC: {
-                "title": "Briefing Doc",
-                "description": "Key insights and important quotes",
-                "prompt": (
-                    "Create a comprehensive briefing document that includes an "
-                    "Executive Summary, detailed analysis of key themes, important "
-                    "quotes with context, and actionable insights."
-                ),
-            },
-            ReportFormat.STUDY_GUIDE: {
-                "title": "Study Guide",
-                "description": "Short-answer quiz, essay questions, glossary",
-                "prompt": (
-                    "Create a comprehensive study guide that includes key concepts, "
-                    "short-answer practice questions, essay prompts for deeper "
-                    "exploration, and a glossary of important terms."
-                ),
-            },
-            ReportFormat.BLOG_POST: {
-                "title": "Blog Post",
-                "description": "Insightful takeaways in readable article format",
-                "prompt": (
-                    "Write an engaging blog post that presents the key insights "
-                    "in an accessible, reader-friendly format. Include an attention-"
-                    "grabbing introduction, well-organized sections, and a compelling "
-                    "conclusion with takeaways."
-                ),
-            },
-            ReportFormat.CUSTOM: {
-                "title": "Custom Report",
-                "description": "Custom format",
-                "prompt": custom_prompt or "Create a report based on the provided sources.",
-            },
-        }
-
-        config = format_configs[report_format]
-        if extra_instructions and report_format != ReportFormat.CUSTOM:
-            config = {**config, "prompt": f"{config['prompt']}\n\n{extra_instructions}"}
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        source_ids_double = nest_source_ids(source_ids, 1)
-
-        params = [
-            [2],
+        """Generate a report artifact."""
+        return await self._generation.generate_report(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.REPORT.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        config["title"],
-                        config["description"],
-                        None,
-                        source_ids_double,
-                        language,
-                        config["prompt"],
-                        None,
-                        True,
-                    ],
-                ],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            report_format=report_format,
+            source_ids=source_ids,
+            language=language,
+            custom_prompt=custom_prompt,
+            extra_instructions=extra_instructions,
+        )
 
     async def generate_study_guide(
         self,
@@ -580,25 +347,9 @@ class ArtifactsAPI:
         language: str | None = None,
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
-        """Generate a study guide report.
-
-        Convenience method wrapping generate_report with STUDY_GUIDE format.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            extra_instructions: Additional instructions appended to the default template.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        return await self.generate_report(
+        """Generate a study guide report."""
+        return await self._generation.generate_study_guide(
             notebook_id,
-            report_format=ReportFormat.STUDY_GUIDE,
             source_ids=source_ids,
             language=language,
             extra_instructions=extra_instructions,
@@ -612,54 +363,14 @@ class ArtifactsAPI:
         quantity: QuizQuantity | None = None,
         difficulty: QuizDifficulty | None = None,
     ) -> GenerationStatus:
-        """Generate a quiz.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            instructions: Custom instructions for quiz generation.
-            quantity: FEWER, STANDARD, or MORE questions.
-            difficulty: EASY, MEDIUM, or HARD.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        quantity_code = quantity.value if quantity else None
-        difficulty_code = difficulty.value if difficulty else None
-
-        params = [
-            [2],
+        """Generate a quiz."""
+        return await self._generation.generate_quiz(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.QUIZ_FLASHCARD.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        2,  # Variant: quiz
-                        None,
-                        instructions,
-                        None,
-                        None,
-                        None,
-                        None,
-                        [quantity_code, difficulty_code],
-                    ],
-                ],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            instructions=instructions,
+            quantity=quantity,
+            difficulty=difficulty,
+        )
 
     async def generate_flashcards(
         self,
@@ -669,53 +380,14 @@ class ArtifactsAPI:
         quantity: QuizQuantity | None = None,
         difficulty: QuizDifficulty | None = None,
     ) -> GenerationStatus:
-        """Generate flashcards.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            instructions: Custom instructions for flashcard generation.
-            quantity: FEWER, STANDARD, or MORE cards.
-            difficulty: EASY, MEDIUM, or HARD.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        quantity_code = quantity.value if quantity else None
-        difficulty_code = difficulty.value if difficulty else None
-
-        params = [
-            [2],
+        """Generate flashcards."""
+        return await self._generation.generate_flashcards(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.QUIZ_FLASHCARD.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [
-                    None,
-                    [
-                        1,  # Variant: flashcards
-                        None,
-                        instructions,
-                        None,
-                        None,
-                        None,
-                        [difficulty_code, quantity_code],
-                    ],
-                ],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            instructions=instructions,
+            quantity=quantity,
+            difficulty=difficulty,
+        )
 
     async def generate_infographic(
         self,
@@ -727,53 +399,16 @@ class ArtifactsAPI:
         detail_level: InfographicDetail | None = None,
         style: InfographicStyle | None = None,
     ) -> GenerationStatus:
-        """Generate an infographic.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Custom instructions for infographic generation.
-            orientation: LANDSCAPE, PORTRAIT, or SQUARE.
-            detail_level: CONCISE, STANDARD, or DETAILED.
-            style: Visual style preset for the infographic.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        orientation_code = orientation.value if orientation else None
-        detail_code = detail_level.value if detail_level else None
-        style_code = style.value if style else None
-
-        params = [
-            [2],
+        """Generate an infographic."""
+        return await self._generation.generate_infographic(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.INFOGRAPHIC.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [[instructions, language, None, orientation_code, detail_code, style_code]],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
+            orientation=orientation,
+            detail_level=detail_level,
+            style=style,
+        )
 
     async def generate_slide_deck(
         self,
@@ -784,53 +419,15 @@ class ArtifactsAPI:
         slide_format: SlideDeckFormat | None = None,
         slide_length: SlideDeckLength | None = None,
     ) -> GenerationStatus:
-        """Generate a slide deck.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Custom instructions for slide deck generation.
-            slide_format: DETAILED_DECK or PRESENTER_SLIDES.
-            slide_length: DEFAULT or SHORT.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-        format_code = slide_format.value if slide_format else None
-        length_code = slide_length.value if slide_length else None
-
-        params = [
-            [2],
+        """Generate a slide deck."""
+        return await self._generation.generate_slide_deck(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.SLIDE_DECK.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [[instructions, language, format_code, length_code]],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
+            slide_format=slide_format,
+            slide_length=slide_length,
+        )
 
     async def revise_slide(
         self,
@@ -839,52 +436,13 @@ class ArtifactsAPI:
         slide_index: int,
         prompt: str,
     ) -> GenerationStatus:
-        """Revise an individual slide in a completed slide deck using a prompt.
-
-        The slide deck must already be generated (status=COMPLETED) before
-        calling this method. Use poll_status() to wait for the revision to complete.
-
-        Args:
-            notebook_id: The notebook ID.
-            artifact_id: The slide deck artifact ID to revise.
-            slide_index: Zero-based index of the slide to revise.
-            prompt: Natural language instruction for the revision
-                    (e.g. "Move the title up", "Remove taxonomy section").
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if slide_index < 0:
-            raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
-
-        params = [
-            [2],
+        """Revise an individual slide in a completed slide deck using a prompt."""
+        return await self._generation.revise_slide(
+            notebook_id,
             artifact_id,
-            [[[slide_index, prompt]]],
-        ]
-        try:
-            result = await self._core.rpc_call(
-                RPCMethod.REVISE_SLIDE,
-                params,
-                source_path=f"/notebook/{notebook_id}",
-                allow_null=True,
-            )
-        except RPCError as e:
-            if e.rpc_code == "USER_DISPLAYABLE_ERROR":
-                return GenerationStatus(
-                    task_id="",
-                    status="failed",
-                    error=str(e),
-                    error_code=str(e.rpc_code) if e.rpc_code is not None else None,
-                )
-            raise
-        if result is None:
-            logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
-        # Parse outside the try/except so a strict-mode UnknownRPCMethodError
-        # (DecodingError -> RPCError) is not swallowed by the rpc_code guard
-        # above. Schema drift is a separate signal from quota/displayable
-        # errors and must surface to callers under strict decoding.
-        return self._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
+            slide_index,
+            prompt,
+        )
 
     async def generate_data_table(
         self,
@@ -893,51 +451,13 @@ class ArtifactsAPI:
         language: str | None = None,
         instructions: str | None = None,
     ) -> GenerationStatus:
-        """Generate a data table.
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Description of desired table structure.
-
-        Returns:
-            GenerationStatus with task_id for polling.
-        """
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_triple = nest_source_ids(source_ids, 2)
-
-        params = [
-            [2],
+        """Generate a data table."""
+        return await self._generation.generate_data_table(
             notebook_id,
-            [
-                None,
-                None,
-                ArtifactTypeCode.DATA_TABLE.value,
-                source_ids_triple,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                [None, [instructions, language]],
-            ],
-        ]
-        return await self._call_generate(notebook_id, params)
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
+        )
 
     async def generate_mind_map(
         self,
@@ -946,82 +466,13 @@ class ArtifactsAPI:
         language: str | None = None,
         instructions: str | None = None,
     ) -> dict[str, Any]:
-        """Generate an interactive mind map.
-
-        The mind map is generated and saved as a note in the notebook.
-        It will appear in artifact listings with type MIND_MAP (5).
-
-        Args:
-            notebook_id: The notebook ID.
-            source_ids: Source IDs to include. If None, uses all sources.
-            language: Language code. If None, uses the ``NOTEBOOKLM_HL``
-                environment variable, defaulting to ``"en"``.
-            instructions: Custom instructions for the mind map.
-
-        Returns:
-            Dictionary with 'mind_map' (JSON data) and 'note_id'.
-        """
-        import json as json_module
-
-        if language is None:
-            language = get_default_language()
-        if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
-
-        source_ids_nested = nest_source_ids(source_ids, 2)
-
-        params = [
-            source_ids_nested,
-            None,
-            None,
-            None,
-            None,
-            ["interactive_mindmap", [["[CONTEXT]", instructions or ""]], language],
-            None,
-            [2, None, [1]],
-        ]
-
-        result = await self._core.rpc_call(
-            RPCMethod.GENERATE_MIND_MAP,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
+        """Generate an interactive mind map."""
+        return await self._generation.generate_mind_map(
+            notebook_id,
+            source_ids=source_ids,
+            language=language,
+            instructions=instructions,
         )
-
-        if result and isinstance(result, list) and len(result) > 0:
-            inner = result[0]
-            if isinstance(inner, list) and len(inner) > 0:
-                mind_map_json = inner[0]
-
-                # Parse the mind map JSON
-                if isinstance(mind_map_json, str):
-                    try:
-                        mind_map_data = json_module.loads(mind_map_json)
-                    except json_module.JSONDecodeError:
-                        mind_map_data = mind_map_json
-                        mind_map_json = str(mind_map_json)
-                else:
-                    mind_map_data = mind_map_json
-                    mind_map_json = json_module.dumps(mind_map_json)
-
-                # Extract title from mind map data
-                title = "Mind Map"
-                if isinstance(mind_map_data, dict) and "name" in mind_map_data:
-                    title = mind_map_data["name"]
-
-                # The GENERATE_MIND_MAP RPC generates content but does NOT persist it.
-                # We must explicitly create a note to save the mind map.
-                note = await _mind_map.create_note(
-                    self._core, notebook_id, title=title, content=mind_map_json
-                )
-                note_id = note.id if note else None
-
-                return {
-                    "mind_map": mind_map_data,
-                    "note_id": note_id,
-                }
-
-        return {"mind_map": None, "note_id": None}
 
     # =========================================================================
     # Download Operations
@@ -1659,39 +1110,8 @@ class ArtifactsAPI:
         self,
         notebook_id: str,
     ) -> builtins.list[ReportSuggestion]:
-        """Get AI-suggested report formats for a notebook.
-
-        Args:
-            notebook_id: The notebook ID.
-
-        Returns:
-            List of ReportSuggestion objects.
-        """
-        params = [[2], notebook_id]
-
-        result = await self._core.rpc_call(
-            RPCMethod.GET_SUGGESTED_REPORTS,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-
-        suggestions = []
-        # Response format: [[[title, description, null, null, prompt, audience_level], ...]]
-        if result and isinstance(result, list) and len(result) > 0:
-            items = result[0] if isinstance(result[0], list) else result
-            for item in items:
-                if isinstance(item, list) and len(item) >= 5:
-                    suggestions.append(
-                        ReportSuggestion(
-                            title=item[0] if isinstance(item[0], str) else "",
-                            description=item[1] if isinstance(item[1], str) else "",
-                            prompt=item[4] if isinstance(item[4], str) else "",
-                            audience_level=item[5] if len(item) > 5 else 2,
-                        )
-                    )
-
-        return suggestions
+        """Get AI-suggested report formats for a notebook."""
+        return await self._generation.suggest_reports(notebook_id)
 
     # =========================================================================
     # Private Helpers
@@ -1700,42 +1120,8 @@ class ArtifactsAPI:
     async def _call_generate(
         self, notebook_id: str, params: builtins.list[Any]
     ) -> GenerationStatus:
-        """Make a generation RPC call with error handling.
-
-        Wraps the RPC call to handle UserDisplayableError (rate limiting/quota)
-        and convert to appropriate GenerationStatus.
-
-        Args:
-            notebook_id: The notebook ID.
-            params: RPC parameters for the generation call.
-
-        Returns:
-            GenerationStatus with task_id on success, or error info on failure.
-        """
-        # Extract artifact type from params for logging
-        artifact_type = params[2][2] if len(params) > 2 and len(params[2]) > 2 else "unknown"
-        logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
-        try:
-            result = await self._core.rpc_call(
-                RPCMethod.CREATE_ARTIFACT,
-                params,
-                source_path=f"/notebook/{notebook_id}",
-                allow_null=True,
-            )
-        except RPCError as e:
-            if e.rpc_code == "USER_DISPLAYABLE_ERROR":
-                return GenerationStatus(
-                    task_id="",
-                    status="failed",
-                    error=str(e),
-                    error_code=str(e.rpc_code) if e.rpc_code is not None else None,
-                )
-            raise
-        # Parse outside the try/except so a strict-mode UnknownRPCMethodError
-        # (DecodingError -> RPCError) is not swallowed by the rpc_code guard
-        # above. Schema drift is a separate signal from quota/displayable
-        # errors and must surface to callers under strict decoding.
-        return self._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
+        """Make a generation RPC call with error handling."""
+        return await self._generation._call_generate(notebook_id, params)
 
     async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw mind-map rows through the patchable module seam."""
@@ -1823,44 +1209,11 @@ class ArtifactsAPI:
         method_id: str,
         source: str = "_parse_generation_result",
     ) -> GenerationStatus:
-        """Parse generation API result into GenerationStatus.
-
-        The API returns a single ID that serves as both the task_id (for polling
-        during generation) and the artifact_id (once complete). This ID is at
-        position [0][0] in the response and becomes Artifact.id in the list.
-
-        Schema-drift handling is delegated to ``safe_index``: under the default
-        soft-strict mode (``NOTEBOOKLM_STRICT_DECODE=0``) drift returns ``None``
-        and falls through to the legacy "failed" path; under strict mode
-        (``=1``) ``safe_index`` raises ``UnknownRPCMethodError`` so callers can
-        surface schema changes early.
-
-        Args:
-            result: Decoded RPC payload.
-            method_id: Calling RPC method ID (``CREATE_ARTIFACT`` or
-                ``REVISE_SLIDE``) — threaded through to error diagnostics.
-            source: Caller label included in drift logs / exceptions.
-        """
-        artifact_id = safe_index(result, 0, 0, method_id=method_id, source=source)
-
-        if artifact_id:
-            # In every captured CREATE_ARTIFACT / REVISE_SLIDE response we have
-            # observed, ``status_code`` sits at ``result[0][4]``. We treat it
-            # as required: under strict mode, a missing leaf raises
-            # ``UnknownRPCMethodError`` so we learn early if Google starts
-            # omitting it. The ``is not None`` fallback to ``"pending"`` only
-            # exists for soft-mode drift, where ``safe_index`` returns
-            # ``None`` instead of raising.
-            #
-            # Fetching ``status_code`` here (after the ``artifact_id`` check)
-            # avoids emitting a duplicate drift warning when the outer
-            # descent already failed at ``result[0][0]``.
-            status_code = safe_index(result, 0, 4, method_id=method_id, source=source)
-            status = artifact_status_to_str(status_code) if status_code is not None else "pending"
-            return GenerationStatus(task_id=artifact_id, status=status)
-
-        return GenerationStatus(
-            task_id="", status="failed", error="Generation failed - no artifact_id returned"
+        """Parse generation API result into GenerationStatus."""
+        return self._generation._parse_generation_result(
+            result,
+            method_id=method_id,
+            source=source,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Extract artifact generation RPC builders, result parsing, report suggestions, and mind-map generation into `ArtifactGenerationService`.
- Keep `ArtifactsAPI.generate_*`, `revise_slide`, `_call_generate`, and `_parse_generation_result` as compatibility delegators.
- Preserve source-selection behavior, facade parse seams, `NOTEBOOKLM_HL` fallback, and `_mind_map.create_note` call-time patch seam.

## Task
`.sisyphus/phases/architecture-remediation/phase-7.md#t8e-artifact-generation`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_source_selection.py tests/unit/test_artifacts_integration.py::TestStudioContent tests/unit/test_artifacts_integration.py::TestGenerateQuiz tests/unit/test_artifacts_integration.py::TestMindMap tests/unit/test_artifacts_integration.py::TestReviseSlide tests/unit/test_artifacts_integration.py::TestGenerateMindMapParsing tests/unit/test_artifacts_integration.py::TestGenerateUsesNotebookLMHL tests/unit/test_artifacts_coverage.py::TestCallGenerateRateLimit tests/integration/test_artifacts_drift.py`
- [x] `rtk uv run pytest tests/unit/cli/test_generate.py`
- [x] `rtk uv run pytest tests/integration/cli_vcr/test_generate.py tests/integration/test_mind_map_chain_vcr.py`
- [x] `rtk uv run ruff check src/notebooklm/_artifacts.py src/notebooklm/_artifact_generation.py tests/unit/test_source_selection.py tests/unit/test_artifacts_integration.py tests/unit/cli/test_generate.py tests/integration/test_artifacts_drift.py`
- [x] `rtk uv run mypy src/notebooklm`
- [x] `rtk uv run pytest tests/unit/test_init_order.py`
- [x] `rtk uv run ruff format --check src/notebooklm/_artifacts.py src/notebooklm/_artifact_generation.py`

## Deferred polish findings
- Optional: restore longer public generate-method docstrings in a docs-focused follow-up if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and reorganized artifact generation into a dedicated service for improved reliability and maintainability.

* **User-facing improvements**
  * Artifact generation workflows (audio, video, cinematic video, reports, study guides, quizzes/flashcards, infographics, slide decks, data tables, mind maps) are more robust.
  * Slide revision and report-suggestion flows handle edge cases and errors more gracefully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->