### PR TITLE
refactor(artifacts): extract artifact polling boundary

### DIFF
--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -1,3 +1,412 @@
-"""Private artifact polling service skeletons."""
+"""Private artifact polling service."""
 
 from __future__ import annotations
+
+import asyncio
+import builtins
+import contextlib
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol
+
+from ._callbacks import maybe_await_callback
+from ._capabilities import PollRegistryProvider, TransportOperationProvider
+from .rpc import (
+    ArtifactStatus,
+    ArtifactTypeCode,
+    NetworkError,
+    RPCTimeoutError,
+    ServerError,
+    artifact_status_to_str,
+)
+from .types import GenerationStatus, _extract_artifact_url
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of retries for transient errors during artifact polling.
+POLL_MAX_RETRIES = 3
+
+# Media artifact types that require URL availability before reporting completion.
+_MEDIA_ARTIFACT_TYPES = frozenset(
+    {
+        ArtifactTypeCode.AUDIO.value,
+        ArtifactTypeCode.VIDEO.value,
+        ArtifactTypeCode.INFOGRAPHIC.value,
+        ArtifactTypeCode.SLIDE_DECK.value,
+    }
+)
+
+ListRawCallback = Callable[[str], Awaitable[builtins.list[Any]]]
+PollStatusCallback = Callable[[str, str], Awaitable[GenerationStatus]]
+MediaReadyCallback = Callable[[builtins.list[Any], int], bool]
+ArtifactTypeNameCallback = Callable[[int], str]
+ArtifactErrorCallback = Callable[[builtins.list[Any]], str | None]
+StatusChangeCallback = Callable[[GenerationStatus], object]
+
+
+class ArtifactPollingCapabilities(PollRegistryProvider, TransportOperationProvider, Protocol):
+    """Capabilities required by the artifact polling boundary."""
+
+
+class ArtifactPollingService:
+    """Leader/follower artifact polling boundary.
+
+    The service owns lifecycle and bookkeeping for shared artifact poll tasks.
+    Facade behavior that must remain patchable on ``ArtifactsAPI`` is supplied
+    as call-time callbacks instead of being captured during construction.
+    """
+
+    def __init__(self, capabilities: ArtifactPollingCapabilities) -> None:
+        self._capabilities = capabilities
+        self._completion_tasks: set[asyncio.Task[None]] = set()
+
+    async def poll_status(
+        self,
+        notebook_id: str,
+        task_id: str,
+        *,
+        list_raw: ListRawCallback,
+        is_media_ready: MediaReadyCallback,
+        get_artifact_type_name: ArtifactTypeNameCallback,
+        extract_artifact_error: ArtifactErrorCallback,
+    ) -> GenerationStatus:
+        """Poll the status of a generation task."""
+        # List all artifacts and find by ID (no poll-by-ID RPC exists).
+        artifacts_data = await list_raw(notebook_id)
+        for art in artifacts_data:
+            if len(art) > 0 and art[0] == task_id:
+                status_code = art[4] if len(art) > 4 else 0
+                artifact_type = art[2] if len(art) > 2 else 0
+
+                # For media artifacts, verify URL availability before reporting completion.
+                # The API may set status=COMPLETED before media URLs are populated.
+                if status_code == ArtifactStatus.COMPLETED:
+                    if not is_media_ready(art, artifact_type):
+                        type_name = get_artifact_type_name(artifact_type)
+                        logger.debug(
+                            "Artifact %s (type=%s) status=COMPLETED but media not ready, "
+                            "continuing poll",
+                            task_id,
+                            type_name,
+                        )
+                        # Downgrade to PROCESSING to continue polling.
+                        status_code = ArtifactStatus.PROCESSING
+
+                status = artifact_status_to_str(status_code)
+
+                # Extract error details from failed artifacts. The API may
+                # embed an error reason string at art[3] when the artifact
+                # fails (e.g. daily quota exceeded).
+                error_msg: str | None = None
+                if status == "failed":
+                    error_msg = extract_artifact_error(art)
+                url = _extract_artifact_url(art, artifact_type)
+
+                return GenerationStatus(
+                    task_id=task_id,
+                    status=status,
+                    url=url,
+                    error=error_msg,
+                )
+
+        # Artifact not found in the list. Use a distinct status so
+        # wait_for_completion can differentiate from genuine "pending".
+        return GenerationStatus(task_id=task_id, status="not_found")
+
+    async def wait_for_completion(
+        self,
+        notebook_id: str,
+        task_id: str,
+        *,
+        initial_interval: float = 2.0,
+        max_interval: float = 10.0,
+        timeout: float = 300.0,
+        poll_interval: float | None = None,
+        max_not_found: int = 5,
+        min_not_found_window: float = 10.0,
+        poll_status: PollStatusCallback,
+        on_status_change: StatusChangeCallback | None = None,
+        deprecation_warning_stacklevel: int = 2,
+    ) -> GenerationStatus:
+        """Wait for a generation task to complete using a shared poll loop."""
+        # Backward compatibility: poll_interval overrides initial_interval.
+        if poll_interval is not None:
+            import warnings
+
+            warnings.warn(
+                "poll_interval is deprecated, use initial_interval instead",
+                DeprecationWarning,
+                stacklevel=deprecation_warning_stacklevel,
+            )
+            initial_interval = poll_interval
+
+        pending = self._capabilities.poll_registry.pending
+        key = (notebook_id, task_id)
+
+        existing = pending.get(key)
+        if existing is not None:
+            # Follower path. ``asyncio.shield`` ensures that *this* caller's
+            # cancellation does not propagate into the shared future; the
+            # leader's poll task continues on behalf of every other follower.
+            result = await asyncio.shield(existing[0])
+            if on_status_change is not None:
+                await maybe_await_callback(on_status_change, result)
+            return result
+
+        # Leader path. Create the shared future, spawn the poll task, and
+        # register the pair so any follower can attach. The task reference
+        # anchors the running poll against GC until the completion callback
+        # resolves the shared future.
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[GenerationStatus] = loop.create_future()
+
+        # Consume any exception set on the future if no caller ever retrieves
+        # it (e.g. leader cancelled with no followers). Without this,
+        # ``set_exception`` on an unawaited future logs at GC time.
+        def _consume_orphan_exception(fut: asyncio.Future[GenerationStatus]) -> None:
+            if not fut.cancelled():
+                # ``exception()`` clears the _log_traceback flag inside the
+                # future. We intentionally drop the value.
+                fut.exception()
+
+        future.add_done_callback(_consume_orphan_exception)
+
+        poll_task = asyncio.create_task(
+            self._run_poll_loop(
+                notebook_id,
+                task_id,
+                initial_interval=initial_interval,
+                max_interval=max_interval,
+                timeout=timeout,
+                max_not_found=max_not_found,
+                min_not_found_window=min_not_found_window,
+                poll_status=poll_status,
+                on_status_change=on_status_change,
+            ),
+            name=f"artifact-poll-{notebook_id}-{task_id}",
+        )
+        try:
+            poll_operation_token = await self._capabilities.begin_transport_task(
+                poll_task,
+                f"artifact wait {task_id}",
+            )
+        except BaseException:
+            poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await poll_task
+            raise
+
+        pending[key] = (future, poll_task)
+
+        async def _finish_poll_operation() -> None:
+            try:
+                await self._capabilities.finish_transport_post(poll_operation_token)
+            except Exception as cleanup_exc:  # noqa: BLE001 - cleanup should not mask poll result
+                logger.warning("Artifact poll drain bookkeeping failed: %s", cleanup_exc)
+
+        def _resolve_poll(task: asyncio.Task[GenerationStatus]) -> None:
+            # Pop the registry entry before resolving the future so a waiter
+            # arriving concurrently with completion either attaches to this
+            # result or starts a fresh poll for a later generation.
+            pending.pop(key, None)
+            assert not future.done(), "future resolved before poll task done-callback"
+            if task.cancelled():
+                future.cancel()
+                return
+            poll_exc = task.exception()
+            if poll_exc is not None:
+                future.set_exception(poll_exc)
+                return
+            future.set_result(task.result())
+
+        def _on_poll_done(task: asyncio.Task[GenerationStatus]) -> None:
+            completion_task = asyncio.create_task(_finish_poll_operation())
+            self._completion_tasks.add(completion_task)
+            completion_task.add_done_callback(self._completion_tasks.discard)
+            _resolve_poll(task)
+
+        poll_task.add_done_callback(_on_poll_done)
+
+        # Leader awaits via ``asyncio.shield`` so that the leader's
+        # cancellation unwinds locally without taking down the shared poll.
+        # Remaining followers still receive the result.
+        return await asyncio.shield(future)
+
+    async def _run_poll_loop(
+        self,
+        notebook_id: str,
+        task_id: str,
+        *,
+        initial_interval: float,
+        max_interval: float,
+        timeout: float,
+        max_not_found: int,
+        min_not_found_window: float,
+        poll_status: PollStatusCallback,
+        on_status_change: StatusChangeCallback | None,
+    ) -> GenerationStatus:
+        """The actual polling loop. Driven by the leader's shielded task."""
+        start_time = asyncio.get_running_loop().time()
+        current_interval = initial_interval
+        consecutive_not_found = 0
+        total_not_found = 0
+        poll_retry_count = 0
+        first_not_found_time: float | None = None
+        last_status: str | None = None
+        last_emitted_status: str | None = None
+
+        while True:
+            try:
+                status = await poll_status(notebook_id, task_id)
+            except (NetworkError, RPCTimeoutError, ServerError) as e:
+                # Transient — retry up to POLL_MAX_RETRIES times with
+                # exponential backoff capped at 8s. Also clamp by remaining
+                # timeout budget so retries never extend past the caller's
+                # `timeout` parameter.
+                if poll_retry_count >= POLL_MAX_RETRIES:
+                    raise
+                remaining = timeout - (asyncio.get_running_loop().time() - start_time)
+                if remaining <= 0:
+                    raise
+                poll_retry_count += 1
+                backoff = min(2**poll_retry_count, 8.0, remaining)
+                logger.warning(
+                    "wait_for_completion: transient %s on poll #%d, retrying in %.1fs",
+                    e.__class__.__name__,
+                    poll_retry_count,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            poll_retry_count = 0  # reset on success
+            last_status = status.status
+            if status.status != last_emitted_status:
+                last_emitted_status = status.status
+                if on_status_change is not None:
+                    await maybe_await_callback(on_status_change, status)
+
+            if status.is_complete or status.is_failed:
+                return status
+
+            # Track consecutive and total "not found" responses. The API may
+            # remove quota-rejected artifacts from the list entirely instead
+            # of setting them to FAILED.
+            if status.status == "not_found":
+                consecutive_not_found += 1
+                total_not_found += 1
+                now = asyncio.get_running_loop().time()
+                if first_not_found_time is None:
+                    first_not_found_time = now
+                not_found_elapsed = now - first_not_found_time
+
+                consecutive_trigger = (
+                    consecutive_not_found >= max_not_found
+                    and not_found_elapsed >= min_not_found_window
+                )
+                total_trigger = total_not_found >= max_not_found * 2
+
+                if consecutive_trigger or total_trigger:
+                    trigger = (
+                        f"consecutive={consecutive_not_found}"
+                        if consecutive_trigger
+                        else f"total={total_not_found}"
+                    )
+                    logger.warning(
+                        "Artifact %s disappeared from list (%s not-found polls, "
+                        "%s) — treating as failed",
+                        task_id,
+                        trigger,
+                        f"elapsed={not_found_elapsed:.1f}s",
+                    )
+                    failed_status = GenerationStatus(
+                        task_id=task_id,
+                        status="failed",
+                        error=(
+                            "Generation failed: artifact was removed by the server. "
+                            "This may indicate a daily quota/rate limit was exceeded, "
+                            "an invalid notebook ID, or a transient API issue. "
+                            "Try again later."
+                        ),
+                    )
+                    if on_status_change is not None and last_emitted_status != "failed":
+                        await maybe_await_callback(on_status_change, failed_status)
+                    return failed_status
+            else:
+                consecutive_not_found = 0
+
+            elapsed = asyncio.get_running_loop().time() - start_time
+            if elapsed > timeout:
+                raise TimeoutError(
+                    f"Task {task_id} timed out after {timeout}s (last status: {last_status})"
+                )
+
+            remaining_time = timeout - elapsed
+            sleep_duration = min(current_interval, remaining_time)
+            if sleep_duration > 0:
+                await asyncio.sleep(sleep_duration)
+
+            current_interval = min(current_interval * 2, max_interval)
+
+
+def _extract_artifact_error(art: builtins.list[Any]) -> str | None:
+    """Try to extract a human-readable error from a failed artifact."""
+    try:
+        # art[3] — simple string error reason.
+        if len(art) > 3 and isinstance(art[3], str) and art[3].strip():
+            return art[3].strip()
+
+        # art[5] — nested structure that may contain error text. This
+        # position is protocol-dependent and may change without notice.
+        if len(art) > 5 and isinstance(art[5], list):
+            logger.debug(
+                "Falling back to art[5] for error extraction (art[3]=%r)",
+                art[3] if len(art) > 3 else "<missing>",
+            )
+            for item in art[5]:
+                if isinstance(item, str) and item.strip():
+                    return item.strip()
+                if isinstance(item, list):
+                    for sub in item:
+                        if isinstance(sub, str) and sub.strip():
+                            return sub.strip()
+
+        return None
+    except Exception:
+        logger.warning(
+            "Failed to extract error from artifact data: %r",
+            art[:6] if len(art) > 6 else art,
+            exc_info=True,
+        )
+        return None
+
+
+def _get_artifact_type_name(artifact_type: int) -> str:
+    """Get human-readable name for an artifact type."""
+    try:
+        return ArtifactTypeCode(artifact_type).name
+    except ValueError:
+        return str(artifact_type)
+
+
+def _is_media_ready(art: builtins.list[Any], artifact_type: int) -> bool:
+    """Check if media artifact has URLs populated."""
+    try:
+        if artifact_type in _MEDIA_ARTIFACT_TYPES:
+            return _extract_artifact_url(art, artifact_type) is not None
+
+        # Non-media artifacts (Report, Quiz, Flashcard, Data Table, Mind Map):
+        # Status code alone is sufficient for these types.
+        return True
+
+    except (IndexError, TypeError) as e:
+        # Defensive: if structure is unexpected, be conservative for media
+        # types. Media types need URLs, so return False to continue polling.
+        is_media = artifact_type in _MEDIA_ARTIFACT_TYPES
+        logger.debug(
+            "Unexpected artifact structure for type %s (media=%s): %s",
+            artifact_type,
+            is_media,
+            e,
+        )
+        return not is_media

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -185,18 +185,23 @@ class ArtifactPollingService:
             ),
             name=f"artifact-poll-{notebook_id}-{task_id}",
         )
+        pending[key] = (future, poll_task)
         try:
             poll_operation_token = await self._capabilities.begin_transport_task(
                 poll_task,
                 f"artifact wait {task_id}",
             )
-        except BaseException:
+        except BaseException as begin_exc:
+            pending.pop(key, None)
             poll_task.cancel()
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await poll_task
+            if not future.done():
+                if isinstance(begin_exc, asyncio.CancelledError):
+                    future.cancel()
+                else:
+                    future.set_exception(begin_exc)
             raise
-
-        pending[key] = (future, poll_task)
 
         async def _finish_poll_operation() -> None:
             try:
@@ -209,7 +214,8 @@ class ArtifactPollingService:
             # arriving concurrently with completion either attaches to this
             # result or starts a fresh poll for a later generation.
             pending.pop(key, None)
-            assert not future.done(), "future resolved before poll task done-callback"
+            if future.done():
+                raise RuntimeError("BUG: future resolved before poll task done-callback")
             if task.cancelled():
                 future.cancel()
                 return

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -5,25 +5,21 @@ AI-generated artifacts including Audio Overviews, Video Overviews, Reports,
 Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 """
 
-import asyncio
 import builtins
-import contextlib
 import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from . import _artifact_formatters, _mind_map
+from . import _artifact_formatters, _artifact_polling, _mind_map
 from ._artifact_downloads import ArtifactDownloadService, DownloadResult
 from ._artifact_generation import ArtifactGenerationService
 from ._artifact_listing import ArtifactListingService
-from ._callbacks import maybe_await_callback
 from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
 from .auth import load_httpx_cookies
 from .rpc import (
-    ArtifactStatus,
     ArtifactTypeCode,
     AudioFormat,
     AudioLength,
@@ -31,18 +27,14 @@ from .rpc import (
     InfographicDetail,
     InfographicOrientation,
     InfographicStyle,
-    NetworkError,
     QuizDifficulty,
     QuizQuantity,
     ReportFormat,
     RPCMethod,
-    RPCTimeoutError,
-    ServerError,
     SlideDeckFormat,
     SlideDeckLength,
     VideoFormat,
     VideoStyle,
-    artifact_status_to_str,
 )
 from .types import (
     Artifact,
@@ -53,23 +45,9 @@ from .types import (
     ArtifactType,
     GenerationStatus,
     ReportSuggestion,
-    _extract_artifact_url,
 )
 
 logger = logging.getLogger(__name__)
-
-# Maximum number of retries for transient errors during artifact polling
-POLL_MAX_RETRIES = 3
-
-# Media artifact types that require URL availability before reporting completion
-_MEDIA_ARTIFACT_TYPES = frozenset(
-    {
-        ArtifactTypeCode.AUDIO.value,
-        ArtifactTypeCode.VIDEO.value,
-        ArtifactTypeCode.INFOGRAPHIC.value,
-        ArtifactTypeCode.SLIDE_DECK.value,
-    }
-)
 
 if TYPE_CHECKING:
     from ._notes import NotesAPI  # retained for backward-compatible type hints
@@ -184,6 +162,7 @@ class ArtifactsAPI:
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
         self._downloads = ArtifactDownloadService(self)
+        self._polling = _artifact_polling.ArtifactPollingService(self._capabilities)
 
     # =========================================================================
     # List/Get Operations
@@ -668,47 +647,14 @@ class ArtifactsAPI:
             ``status="not_found"`` to allow callers to distinguish a
             genuinely pending artifact from one that was removed.
         """
-        # List all artifacts and find by ID (no poll-by-ID RPC exists)
-        artifacts_data = await self._list_raw(notebook_id)
-        for art in artifacts_data:
-            if len(art) > 0 and art[0] == task_id:
-                status_code = art[4] if len(art) > 4 else 0
-                artifact_type = art[2] if len(art) > 2 else 0
-
-                # For media artifacts, verify URL availability before reporting completion.
-                # The API may set status=COMPLETED before media URLs are populated.
-                if status_code == ArtifactStatus.COMPLETED:
-                    if not self._is_media_ready(art, artifact_type):
-                        type_name = self._get_artifact_type_name(artifact_type)
-                        logger.debug(
-                            "Artifact %s (type=%s) status=COMPLETED but media not ready, "
-                            "continuing poll",
-                            task_id,
-                            type_name,
-                        )
-                        # Downgrade to PROCESSING to continue polling
-                        status_code = ArtifactStatus.PROCESSING
-
-                status = artifact_status_to_str(status_code)
-
-                # Extract error details from failed artifacts.
-                # The API may embed an error reason string at art[3] when
-                # the artifact fails (e.g. daily quota exceeded).
-                error_msg: str | None = None
-                if status == "failed":
-                    error_msg = self._extract_artifact_error(art)
-                url = _extract_artifact_url(art, artifact_type)
-
-                return GenerationStatus(
-                    task_id=task_id,
-                    status=status,
-                    url=url,
-                    error=error_msg,
-                )
-
-        # Artifact not found in the list.  Use a distinct status so
-        # wait_for_completion can differentiate from genuine "pending".
-        return GenerationStatus(task_id=task_id, status="not_found")
+        return await self._polling.poll_status(
+            notebook_id,
+            task_id,
+            list_raw=self._list_raw,
+            is_media_ready=self._is_media_ready,
+            get_artifact_type_name=self._get_artifact_type_name,
+            extract_artifact_error=self._extract_artifact_error,
+        )
 
     async def wait_for_completion(
         self,
@@ -775,248 +721,19 @@ class ArtifactsAPI:
         Raises:
             TimeoutError: If task doesn't complete within timeout.
         """
-        # Backward compatibility: poll_interval overrides initial_interval
-        if poll_interval is not None:
-            import warnings
-
-            warnings.warn(
-                "poll_interval is deprecated, use initial_interval instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            initial_interval = poll_interval
-
-        pending = self._capabilities.poll_registry.pending
-        key = (notebook_id, task_id)
-
-        existing = pending.get(key)
-        if existing is not None:
-            # Follower path. ``asyncio.shield`` ensures that *this* caller's
-            # cancellation does not propagate into the shared future; the
-            # leader's poll task continues on behalf of every other follower.
-            result = await asyncio.shield(existing[0])
-            if on_status_change is not None:
-                await maybe_await_callback(on_status_change, result)
-            return result
-
-        # Leader path. Create the shared future, spawn the poll task,
-        # register the pair so any follower can attach. Both the future
-        # and the task live in the registry entry — the task reference
-        # alone is what anchors the running poll against GC (Python's
-        # task-GC contract is permissive; see asyncio C4 lesson /
-        # Python 3.11+ task GC fix). The done-callback pops the entry
-        # on every termination path (success / exception / cancel) so
-        # the registry cannot leak.
-        loop = asyncio.get_running_loop()
-        future: asyncio.Future[GenerationStatus] = loop.create_future()
-
-        # Consume any exception set on the future if no caller ever
-        # retrieves it (e.g. leader cancelled with no followers). Without
-        # this, ``set_exception`` on an unawaited future logs
-        # "Future exception was never retrieved" at GC time.
-        def _consume_orphan_exception(fut: asyncio.Future[GenerationStatus]) -> None:
-            if not fut.cancelled():
-                # ``exception()`` clears the _log_traceback flag inside the
-                # future. We intentionally drop the value.
-                fut.exception()
-
-        future.add_done_callback(_consume_orphan_exception)
-
-        poll_task = asyncio.create_task(
-            self._run_poll_loop(
-                notebook_id,
-                task_id,
-                initial_interval=initial_interval,
-                max_interval=max_interval,
-                timeout=timeout,
-                max_not_found=max_not_found,
-                min_not_found_window=min_not_found_window,
-                on_status_change=on_status_change,
-            ),
-            name=f"artifact-poll-{notebook_id}-{task_id}",
+        return await self._polling.wait_for_completion(
+            notebook_id,
+            task_id,
+            initial_interval=initial_interval,
+            max_interval=max_interval,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            max_not_found=max_not_found,
+            min_not_found_window=min_not_found_window,
+            poll_status=self.poll_status,
+            on_status_change=on_status_change,
+            deprecation_warning_stacklevel=3,
         )
-        try:
-            poll_operation_token = await self._capabilities.begin_transport_task(
-                poll_task,
-                f"artifact wait {task_id}",
-            )
-        except BaseException:
-            poll_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await poll_task
-            raise
-
-        pending[key] = (future, poll_task)
-
-        async def _finish_poll_operation() -> None:
-            try:
-                await self._capabilities.finish_transport_post(poll_operation_token)
-            except Exception as exc:  # noqa: BLE001 - cleanup should not mask poll result
-                logger.warning("Artifact poll drain bookkeeping failed: %s", exc)
-
-        def _on_poll_done(task: asyncio.Task[GenerationStatus]) -> None:
-            asyncio.create_task(_finish_poll_operation())
-            # Pop the registry entry first so a follower that arrives
-            # concurrently with completion either (a) attaches to the
-            # already-resolved future and gets the cached result, or
-            # (b) misses the entry entirely and starts a fresh poll for
-            # the *next* generation. Either is correct.
-            pending.pop(key, None)
-            # Inside this callback there are no ``await`` points, so
-            # the single-threaded asyncio model guarantees ``future`` is
-            # still pending — assert that invariant rather than guard
-            # silently. A regression in callback ordering would surface
-            # loudly instead of dropping a result on the floor.
-            assert not future.done(), "future resolved before poll task done-callback"
-            if task.cancelled():
-                # The poll task itself was cancelled. Followers shield
-                # the future and the leader's cancel doesn't propagate
-                # to the task, so this is exceedingly rare — but if it
-                # happens, surface ``CancelledError`` to attached waiters.
-                future.cancel()
-                return
-            exc = task.exception()
-            if exc is not None:
-                future.set_exception(exc)
-                return
-            future.set_result(task.result())
-
-        poll_task.add_done_callback(_on_poll_done)
-
-        # Leader awaits via ``asyncio.shield`` so that the leader's
-        # cancellation unwinds locally without taking down the shared
-        # poll. The shielded poll task continues until the done-callback
-        # fires; remaining followers still receive the result.
-        return await asyncio.shield(future)
-
-    async def _run_poll_loop(
-        self,
-        notebook_id: str,
-        task_id: str,
-        *,
-        initial_interval: float,
-        max_interval: float,
-        timeout: float,
-        max_not_found: int,
-        min_not_found_window: float,
-        on_status_change: Callable[[GenerationStatus], object] | None,
-    ) -> GenerationStatus:
-        """The actual polling loop. Driven by the leader's shielded task.
-
-        This is intentionally private and parameter-keyword-only — direct
-        callers should always go through ``wait_for_completion`` so the
-        leader/follower dedupe is honored.
-        """
-        start_time = asyncio.get_running_loop().time()
-        current_interval = initial_interval
-        consecutive_not_found = 0
-        total_not_found = 0
-        poll_retry_count = 0
-        first_not_found_time: float | None = None
-        last_status: str | None = None
-        last_emitted_status: str | None = None
-
-        while True:
-            try:
-                status = await self.poll_status(notebook_id, task_id)
-            except (NetworkError, RPCTimeoutError, ServerError) as e:
-                # Transient — retry up to POLL_MAX_RETRIES times with exponential
-                # backoff capped at 8s. Also clamp by remaining timeout budget so
-                # the retry path never extends wall-clock past the caller's
-                # `timeout` parameter; raise if there's no headroom left.
-                if poll_retry_count >= POLL_MAX_RETRIES:
-                    raise
-                remaining = timeout - (asyncio.get_running_loop().time() - start_time)
-                if remaining <= 0:
-                    raise
-                poll_retry_count += 1
-                backoff = min(2**poll_retry_count, 8.0, remaining)
-                logger.warning(
-                    "wait_for_completion: transient %s on poll #%d, retrying in %.1fs",
-                    e.__class__.__name__,
-                    poll_retry_count,
-                    backoff,
-                )
-                await asyncio.sleep(backoff)
-                continue
-
-            poll_retry_count = 0  # reset on success
-            last_status = status.status
-            if status.status != last_emitted_status:
-                last_emitted_status = status.status
-                if on_status_change is not None:
-                    await maybe_await_callback(on_status_change, status)
-
-            if status.is_complete or status.is_failed:
-                return status
-
-            # Track consecutive and total "not found" responses.  The API
-            # may remove quota-rejected artifacts from the list entirely
-            # instead of setting them to FAILED.  We track both a
-            # consecutive run *and* a total count to handle "flickering"
-            # artifacts that alternate between found/not-found due to API
-            # replication lag.
-            if status.status == "not_found":
-                consecutive_not_found += 1
-                total_not_found += 1
-                now = asyncio.get_running_loop().time()
-                if first_not_found_time is None:
-                    first_not_found_time = now
-                not_found_elapsed = now - first_not_found_time
-
-                # Trigger failure when consecutive threshold is met AND
-                # enough wall-clock time has passed (avoids false positives
-                # on fast networks), OR when total not-found count is high
-                # enough to indicate flickering artifacts.
-                consecutive_trigger = (
-                    consecutive_not_found >= max_not_found
-                    and not_found_elapsed >= min_not_found_window
-                )
-                total_trigger = total_not_found >= max_not_found * 2
-
-                if consecutive_trigger or total_trigger:
-                    trigger = (
-                        f"consecutive={consecutive_not_found}"
-                        if consecutive_trigger
-                        else f"total={total_not_found}"
-                    )
-                    logger.warning(
-                        "Artifact %s disappeared from list (%s not-found polls, "
-                        "%s) — treating as failed",
-                        task_id,
-                        trigger,
-                        f"elapsed={not_found_elapsed:.1f}s",
-                    )
-                    failed_status = GenerationStatus(
-                        task_id=task_id,
-                        status="failed",
-                        error=(
-                            "Generation failed: artifact was removed by the server. "
-                            "This may indicate a daily quota/rate limit was exceeded, "
-                            "an invalid notebook ID, or a transient API issue. "
-                            "Try again later."
-                        ),
-                    )
-                    if on_status_change is not None and last_emitted_status != "failed":
-                        await maybe_await_callback(on_status_change, failed_status)
-                    return failed_status
-            else:
-                consecutive_not_found = 0
-
-            elapsed = asyncio.get_running_loop().time() - start_time
-            if elapsed > timeout:
-                raise TimeoutError(
-                    f"Task {task_id} timed out after {timeout}s (last status: {last_status})"
-                )
-
-            # Clamp sleep duration to respect timeout
-            remaining_time = timeout - elapsed
-            sleep_duration = min(current_interval, remaining_time)
-            if sleep_duration > 0:
-                await asyncio.sleep(sleep_duration)
-
-            # Exponential backoff: double the interval up to max_interval
-            current_interval = min(current_interval * 2, max_interval)
 
     # =========================================================================
     # Export Operations
@@ -1236,36 +953,7 @@ class ArtifactsAPI:
             A human-readable error string, or ``None`` if no error detail
             could be extracted.
         """
-        try:
-            # art[3] — simple string error reason
-            if len(art) > 3 and isinstance(art[3], str) and art[3].strip():
-                return art[3].strip()
-
-            # art[5] — nested structure that may contain error text.
-            # NOTE: This position is protocol-dependent and was
-            # reverse-engineered; it may change without notice.
-            if len(art) > 5 and isinstance(art[5], list):
-                logger.debug(
-                    "Falling back to art[5] for error extraction (art[3]=%r)",
-                    art[3] if len(art) > 3 else "<missing>",
-                )
-                # Walk the list looking for the first non-empty string
-                for item in art[5]:
-                    if isinstance(item, str) and item.strip():
-                        return item.strip()
-                    if isinstance(item, list):
-                        for sub in item:
-                            if isinstance(sub, str) and sub.strip():
-                                return sub.strip()
-
-            return None
-        except Exception:
-            logger.warning(
-                "Failed to extract error from artifact data: %r",
-                art[:6] if len(art) > 6 else art,
-                exc_info=True,
-            )
-            return None
+        return _artifact_polling._extract_artifact_error(art)
 
     def _get_artifact_type_name(self, artifact_type: int) -> str:
         """Get human-readable name for an artifact type.
@@ -1276,10 +964,7 @@ class ArtifactsAPI:
         Returns:
             The enum name if valid, otherwise the raw integer as string.
         """
-        try:
-            return ArtifactTypeCode(artifact_type).name
-        except ValueError:
-            return str(artifact_type)
+        return _artifact_polling._get_artifact_type_name(artifact_type)
 
     def _is_media_ready(self, art: builtins.list[Any], artifact_type: int) -> bool:
         """Check if media artifact has URLs populated.
@@ -1304,23 +989,4 @@ class ArtifactsAPI:
             True if media URLs are available, or if artifact is non-media type.
             Returns True on unexpected structure (defensive fallback).
         """
-        try:
-            if artifact_type in _MEDIA_ARTIFACT_TYPES:
-                return _extract_artifact_url(art, artifact_type) is not None
-
-            # Non-media artifacts (Report, Quiz, Flashcard, Data Table, Mind Map):
-            # Status code alone is sufficient for these types
-            return True
-
-        except (IndexError, TypeError) as e:
-            # Defensive: if structure is unexpected, be conservative for media types
-            # Media types need URLs, so return False to continue polling
-            # Non-media types only need status code, so return True
-            is_media = artifact_type in _MEDIA_ARTIFACT_TYPES
-            logger.debug(
-                "Unexpected artifact structure for type %s (media=%s): %s",
-                artifact_type,
-                is_media,
-                e,
-            )
-            return not is_media  # False for media (continue polling), True for non-media
+        return _artifact_polling._is_media_ready(art, artifact_type)

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -45,6 +45,7 @@ from .types import (
     ArtifactType,
     GenerationStatus,
     ReportSuggestion,
+    _extract_artifact_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,7 @@ _DOWNLOAD_COMPAT_EXPORTS = (
     ArtifactNotFoundError,
     ArtifactNotReadyError,
     ArtifactParseError,
+    _extract_artifact_url,
     json,
     load_httpx_cookies,
 )

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -16,16 +16,19 @@ class _FakeTransportProvider:
         token: object | None = None,
         begin_error: BaseException | None = None,
         yield_before_begin_error: bool = False,
+        begin_release: asyncio.Event | None = None,
         finish_release: asyncio.Event | None = None,
     ) -> None:
         self.poll_registry = PollRegistry()
         self.token = object() if token is None else token
         self.begin_error = begin_error
         self.yield_before_begin_error = yield_before_begin_error
+        self.begin_release = begin_release
         self.finish_release = finish_release
         self.begin_tasks: list[asyncio.Task[object]] = []
         self.begin_labels: list[str] = []
         self.begin_task_done_states: list[bool] = []
+        self.begin_started = asyncio.Event()
         self.finish_tokens: list[object] = []
         self.finish_started = asyncio.Event()
         self.finish_finished = asyncio.Event()
@@ -41,6 +44,9 @@ class _FakeTransportProvider:
         self.begin_tasks.append(task)
         self.begin_labels.append(log_label)
         self.begin_task_done_states.append(task.done())
+        self.begin_started.set()
+        if self.begin_release is not None:
+            await self.begin_release.wait()
         if self.yield_before_begin_error:
             await asyncio.sleep(0)
         if self.begin_error is not None:
@@ -150,6 +156,63 @@ async def test_polling_service_begin_transport_task_receives_spawned_poll_task()
 
 
 @pytest.mark.asyncio
+async def test_polling_service_registers_pending_before_transport_begin_completes() -> None:
+    begin_release = asyncio.Event()
+    provider = _FakeTransportProvider(begin_release=begin_release)
+    service = ArtifactPollingService(provider)
+    poll_call_count = 0
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        nonlocal poll_call_count
+        poll_call_count += 1
+        return GenerationStatus(task_id=task_id, status="completed")
+
+    leader = asyncio.create_task(
+        service.wait_for_completion(
+            "nb1",
+            "task1",
+            initial_interval=0.0,
+            max_interval=0.0,
+            timeout=1.0,
+            poll_status=poll_status,
+        )
+    )
+    follower: asyncio.Task[GenerationStatus] | None = None
+    try:
+        await asyncio.wait_for(provider.begin_started.wait(), timeout=1.0)
+        assert ("nb1", "task1") in provider.poll_registry.pending
+
+        follower = asyncio.create_task(
+            service.wait_for_completion(
+                "nb1",
+                "task1",
+                initial_interval=0.0,
+                max_interval=0.0,
+                timeout=1.0,
+                poll_status=poll_status,
+            )
+        )
+        await asyncio.sleep(0)
+        begin_release.set()
+
+        leader_result = await asyncio.wait_for(leader, timeout=1.0)
+        follower_result = await asyncio.wait_for(follower, timeout=1.0)
+
+        assert leader_result.status == "completed"
+        assert follower_result.status == "completed"
+        assert poll_call_count == 1
+        await asyncio.wait_for(provider.finish_finished.wait(), timeout=1.0)
+        assert provider.poll_registry.pending == {}
+    finally:
+        begin_release.set()
+        cleanup_tasks = [task for task in (leader, follower) if task is not None and not task.done()]
+        for task in cleanup_tasks:
+            task.cancel()
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_polling_service_resolves_wait_before_slow_transport_finish() -> None:
     token = object()
     finish_release = asyncio.Event()
@@ -241,6 +304,7 @@ async def test_polling_service_cancels_and_drains_spawned_poll_task_if_begin_fai
     assert poll_finally.is_set()
     assert len(provider.begin_tasks) == 1
     assert provider.begin_tasks[0].cancelled()
+    assert provider.poll_registry.pending == {}
     assert not provider.finish_started.is_set()
     assert provider.finish_tokens == []
 

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -3,9 +3,56 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from notebooklm._artifact_polling import ArtifactPollingService
 from notebooklm._artifacts import ArtifactsAPI, GenerationStatus
 from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
+
+
+class _FakeTransportProvider:
+    def __init__(
+        self,
+        *,
+        token: object | None = None,
+        begin_error: BaseException | None = None,
+        yield_before_begin_error: bool = False,
+        finish_release: asyncio.Event | None = None,
+    ) -> None:
+        self.poll_registry = PollRegistry()
+        self.token = object() if token is None else token
+        self.begin_error = begin_error
+        self.yield_before_begin_error = yield_before_begin_error
+        self.finish_release = finish_release
+        self.begin_tasks: list[asyncio.Task[object]] = []
+        self.begin_labels: list[str] = []
+        self.begin_task_done_states: list[bool] = []
+        self.finish_tokens: list[object] = []
+        self.finish_started = asyncio.Event()
+        self.finish_finished = asyncio.Event()
+
+    async def begin_transport_post(self, log_label: str) -> object:
+        raise AssertionError(f"unexpected begin_transport_post({log_label!r})")
+
+    async def begin_transport_task(
+        self,
+        task: asyncio.Task[object],
+        log_label: str,
+    ) -> object:
+        self.begin_tasks.append(task)
+        self.begin_labels.append(log_label)
+        self.begin_task_done_states.append(task.done())
+        if self.yield_before_begin_error:
+            await asyncio.sleep(0)
+        if self.begin_error is not None:
+            raise self.begin_error
+        return self.token
+
+    async def finish_transport_post(self, token: object) -> None:
+        self.finish_tokens.append(token)
+        self.finish_started.set()
+        if self.finish_release is not None:
+            await self.finish_release.wait()
+        self.finish_finished.set()
 
 
 @pytest.fixture
@@ -69,6 +116,133 @@ async def test_wait_for_completion_no_retry_on_auth_error(api):
 
         assert api.poll_status.call_count == 1
         assert mock_sleep.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_polling_service_begin_transport_task_receives_spawned_poll_task() -> None:
+    token = object()
+    provider = _FakeTransportProvider(token=token)
+    service = ArtifactPollingService(provider)
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        assert (notebook_id, task_id) == ("nb1", "task1")
+        return GenerationStatus(task_id=task_id, status="completed")
+
+    result = await service.wait_for_completion(
+        "nb1",
+        "task1",
+        initial_interval=0.0,
+        max_interval=0.0,
+        timeout=1.0,
+        poll_status=poll_status,
+    )
+
+    assert result.status == "completed"
+    assert len(provider.begin_tasks) == 1
+    poll_task = provider.begin_tasks[0]
+    assert isinstance(poll_task, asyncio.Task)
+    assert poll_task.done()
+    assert poll_task.get_name() == "artifact-poll-nb1-task1"
+    assert provider.begin_task_done_states == [False]
+    assert provider.begin_labels == ["artifact wait task1"]
+    await asyncio.wait_for(provider.finish_finished.wait(), timeout=1.0)
+    assert provider.finish_tokens == [token]
+
+
+@pytest.mark.asyncio
+async def test_polling_service_resolves_wait_before_slow_transport_finish() -> None:
+    token = object()
+    finish_release = asyncio.Event()
+    provider = _FakeTransportProvider(token=token, finish_release=finish_release)
+    service = ArtifactPollingService(provider)
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        return GenerationStatus(task_id=task_id, status="completed")
+
+    result = await service.wait_for_completion(
+        "nb1",
+        "task1",
+        initial_interval=0.0,
+        max_interval=0.0,
+        timeout=1.0,
+        poll_status=poll_status,
+    )
+
+    assert result.status == "completed"
+    assert provider.finish_started.is_set()
+    assert not provider.finish_finished.is_set()
+    assert provider.finish_tokens == [token]
+
+    finish_release.set()
+    await asyncio.wait_for(provider.finish_finished.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_polling_service_finishes_transport_token_once_after_poll_failure() -> None:
+    token = object()
+    provider = _FakeTransportProvider(token=token)
+    service = ArtifactPollingService(provider)
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        raise ValueError(f"poll failed: {notebook_id}/{task_id}")
+
+    with pytest.raises(ValueError, match="poll failed: nb1/task1"):
+        await service.wait_for_completion(
+            "nb1",
+            "task1",
+            initial_interval=0.0,
+            max_interval=0.0,
+            timeout=1.0,
+            poll_status=poll_status,
+        )
+
+    assert len(provider.begin_tasks) == 1
+    assert provider.begin_tasks[0].done()
+    await asyncio.wait_for(provider.finish_finished.wait(), timeout=1.0)
+    assert provider.finish_tokens == [token]
+
+
+@pytest.mark.asyncio
+async def test_polling_service_cancels_and_drains_spawned_poll_task_if_begin_fails() -> None:
+    begin_error = RuntimeError("draining")
+    provider = _FakeTransportProvider(
+        begin_error=begin_error,
+        yield_before_begin_error=True,
+    )
+    service = ArtifactPollingService(provider)
+    poll_started = asyncio.Event()
+    poll_cancelled = asyncio.Event()
+    poll_finally = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        poll_started.set()
+        try:
+            await release_poll.wait()
+        except asyncio.CancelledError:
+            poll_cancelled.set()
+            raise
+        finally:
+            poll_finally.set()
+        return GenerationStatus(task_id=task_id, status="completed")
+
+    with pytest.raises(RuntimeError, match="draining"):
+        await service.wait_for_completion(
+            "nb1",
+            "task1",
+            initial_interval=0.0,
+            max_interval=0.0,
+            timeout=1.0,
+            poll_status=poll_status,
+        )
+
+    assert poll_started.is_set()
+    assert poll_cancelled.is_set()
+    assert poll_finally.is_set()
+    assert len(provider.begin_tasks) == 1
+    assert provider.begin_tasks[0].cancelled()
+    assert not provider.finish_started.is_set()
+    assert provider.finish_tokens == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -205,7 +205,9 @@ async def test_polling_service_registers_pending_before_transport_begin_complete
         assert provider.poll_registry.pending == {}
     finally:
         begin_release.set()
-        cleanup_tasks = [task for task in (leader, follower) if task is not None and not task.done()]
+        cleanup_tasks = [
+            task for task in (leader, follower) if task is not None and not task.done()
+        ]
         for task in cleanup_tasks:
             task.cancel()
         if cleanup_tasks:


### PR DESCRIPTION
## Summary
- Move artifact poll status, wait, loop, media readiness, and error helpers into a dedicated ArtifactPollingService.
- Keep ArtifactsAPI as a compatibility facade with call-time hooks for patchable behavior.
- Add fake transport tests for poll task registration, finish token cleanup, slow cleanup, failure cleanup, and begin-failure cancellation.

## Task
T8f - Artifact Polling Boundary Extraction

## Test plan
- [x] uv run pytest tests/unit/test_artifacts_polling_retries.py tests/unit/test_artifacts_coverage.py::TestWaitForCompletion tests/unit/test_artifacts_coverage.py::TestIsMediaReady tests/unit/test_artifacts_coverage.py::TestPollStatusMediaReadiness tests/unit/test_artifacts_integration.py::TestPollStatusVariousPaths tests/unit/test_artifacts_integration.py::TestGetArtifactTypeNameAndIsMediaReady tests/unit/test_artifacts_integration.py::TestWaitForCompletionDeprecated tests/unit/test_quota_failure_detection.py tests/unit/test_init_order.py tests/unit/test_capabilities.py
- [x] uv run pytest tests/unit/test_observability.py::test_drain_waits_for_artifact_poll_task tests/unit/test_observability.py::test_wait_for_completion_status_change_callback
- [x] uv run pytest tests/integration/concurrency/test_artifact_poll_dedupe.py tests/integration/test_polling_vcr.py
- [x] uv run ruff check src/notebooklm/_artifacts.py src/notebooklm/_artifact_polling.py src/notebooklm/_capabilities.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_observability.py tests/unit/test_init_order.py tests/unit/test_capabilities.py tests/integration/concurrency/test_artifact_poll_dedupe.py
- [x] uv run mypy src/notebooklm

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized artifact polling with shared polling for concurrent callers and optional status-change callbacks

* **Improvements**
  * Robust retry/backoff, stricter timeouts and cancellation isolation
  * Improved media-readiness handling and more accurate artifact status/error reporting
  * Cleaner transport lifecycle bookkeeping to avoid duplicate signals

* **Tests**
  * New unit tests covering polling lifecycle, transport begin/finish, leader/follower behavior, and failure scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->