### PR TITLE
refactor(sources): add service skeletons

### DIFF
--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -62,11 +62,24 @@ class TransportOperationProvider(Protocol):
     async def finish_transport_post(self, token: object) -> None: ...
 
 
+class UploadConcurrencyProvider(Protocol):
+    """Provider for shared source-upload concurrency and queue metrics."""
+
+    def get_upload_semaphore(self) -> asyncio.Semaphore:
+        """Return the existing per-core upload semaphore."""
+        ...
+
+    def record_upload_queue_wait(self, wait_seconds: float) -> None:
+        """Record how long an upload waited for the semaphore."""
+        ...
+
+
 class ClientCoreCapabilities(
     PollRegistryProvider,
     AuthRouteProvider,
     CookieJarProvider,
     TransportOperationProvider,
+    UploadConcurrencyProvider,
 ):
     """Narrow capability adapter around a ``ClientCore``-shaped object.
 
@@ -110,3 +123,9 @@ class ClientCoreCapabilities(
 
     async def finish_transport_post(self, token: object) -> None:
         await self._core._finish_transport_post(token)
+
+    def get_upload_semaphore(self) -> asyncio.Semaphore:
+        return self._core.get_upload_semaphore()
+
+    def record_upload_queue_wait(self, wait_seconds: float) -> None:
+        self._core.record_upload_queue_wait(wait_seconds)

--- a/src/notebooklm/_source_add.py
+++ b/src/notebooklm/_source_add.py
@@ -1,0 +1,10 @@
+"""Private non-file source creation service skeleton."""
+
+from __future__ import annotations
+
+
+class SourceAddService:
+    """Future owner of URL, YouTube, text, and Drive source creation."""
+
+
+__all__ = ["SourceAddService"]

--- a/src/notebooklm/_source_content.py
+++ b/src/notebooklm/_source_content.py
@@ -1,0 +1,10 @@
+"""Private source content rendering service skeleton."""
+
+from __future__ import annotations
+
+
+class SourceContentRenderer:
+    """Future owner of source fulltext and guide rendering behavior."""
+
+
+__all__ = ["SourceContentRenderer"]

--- a/src/notebooklm/_source_listing.py
+++ b/src/notebooklm/_source_listing.py
@@ -1,0 +1,10 @@
+"""Private source listing service skeleton."""
+
+from __future__ import annotations
+
+
+class SourceLister:
+    """Future owner of source listing and parsing behavior."""
+
+
+__all__ = ["SourceLister"]

--- a/src/notebooklm/_source_polling.py
+++ b/src/notebooklm/_source_polling.py
@@ -1,0 +1,10 @@
+"""Private source readiness polling service skeleton."""
+
+from __future__ import annotations
+
+
+class SourcePoller:
+    """Future owner of source readiness and registration polling behavior."""
+
+
+__all__ = ["SourcePoller"]

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -1,0 +1,10 @@
+"""Private source file upload pipeline skeleton."""
+
+from __future__ import annotations
+
+
+class SourceUploadPipeline:
+    """Future owner of file registration and resumable upload orchestration."""
+
+
+__all__ = ["SourceUploadPipeline"]

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -788,10 +788,10 @@ class SourcesAPI:
         # Step 0–3 run under the upload semaphore so a fan-out caller can't
         # hold more than ``max_concurrent_uploads`` open FDs at once. The
         # semaphore is per-instance; see ClientCore.get_upload_semaphore.
-        upload_sem = self._core.get_upload_semaphore()
+        upload_sem = self._capabilities.get_upload_semaphore()
         upload_wait_start = monotonic()
         async with upload_sem:
-            self._core.record_upload_queue_wait(monotonic() - upload_wait_start)
+            self._capabilities.record_upload_queue_wait(monotonic() - upload_wait_start)
             # Open the file ONCE here. The FD lives across:
             #   - the os.fstat() size check (so the size we send to
             #     ``_start_resumable_upload`` matches the bytes we will

--- a/tests/unit/test_capabilities.py
+++ b/tests/unit/test_capabilities.py
@@ -11,7 +11,11 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from notebooklm._capabilities import ClientCoreCapabilities, TransportOperationProvider
+from notebooklm._capabilities import (
+    ClientCoreCapabilities,
+    TransportOperationProvider,
+    UploadConcurrencyProvider,
+)
 from notebooklm._core_polling import PollRegistry
 from notebooklm.auth import authuser_query, format_authuser_value
 
@@ -120,6 +124,25 @@ async def test_client_core_capabilities_finish_transport_post_delegates_exact_to
     core._finish_transport_post.assert_awaited_once_with(token)
 
 
+def test_client_core_capabilities_get_upload_semaphore_delegates_to_core() -> None:
+    semaphore = asyncio.Semaphore(2)
+    core = MagicMock()
+    core.get_upload_semaphore.return_value = semaphore
+    adapter = ClientCoreCapabilities(core)
+
+    assert adapter.get_upload_semaphore() is semaphore
+    core.get_upload_semaphore.assert_called_once_with()
+
+
+def test_client_core_capabilities_record_upload_queue_wait_delegates_to_core() -> None:
+    core = MagicMock()
+    adapter = ClientCoreCapabilities(core)
+
+    adapter.record_upload_queue_wait(1.25)
+
+    core.record_upload_queue_wait.assert_called_once_with(1.25)
+
+
 @pytest.mark.asyncio
 async def test_transport_operation_provider_accepts_magicmock_shape() -> None:
     post_token = object()
@@ -140,6 +163,18 @@ async def test_transport_operation_provider_accepts_magicmock_shape() -> None:
     provider.begin_transport_post.assert_awaited_once_with("artifact generate")
     provider.begin_transport_task.assert_awaited_once_with(task, "artifact wait task_123")
     provider.finish_transport_post.assert_awaited_once_with(task_token)
+
+
+def test_upload_concurrency_provider_accepts_magicmock_shape() -> None:
+    semaphore = asyncio.Semaphore(1)
+    provider = MagicMock(spec=UploadConcurrencyProvider)
+    provider.get_upload_semaphore.return_value = semaphore
+
+    assert provider.get_upload_semaphore() is semaphore
+    provider.record_upload_queue_wait(0.5)
+
+    provider.get_upload_semaphore.assert_called_once_with()
+    provider.record_upload_queue_wait.assert_called_once_with(0.5)
 
 
 def test_capabilities_module_does_not_import_client_core_at_runtime() -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -276,22 +276,72 @@ class _RuntimeImportVisitor(ast.NodeVisitor):
             return
         self.generic_visit(node)
 
+    @staticmethod
+    def _is_dunder_name(name: str) -> bool:
+        return name.startswith("__") and name.endswith("__")
+
+    @classmethod
+    def _is_forbidden_module_reference(cls, name: str, forbidden_modules: set[str]) -> bool:
+        if not name:
+            return False
+
+        if any(cls._is_dunder_name(part) for part in name.split(".")):
+            return False
+
+        for forbidden_module in forbidden_modules:
+            if cls._is_dunder_name(forbidden_module):
+                continue
+            if name == forbidden_module or name.startswith(f"{forbidden_module}."):
+                return True
+
+        return False
+
     def visit_Import(self, node: ast.Import) -> None:
         self.forbidden.extend(
-            alias.name for alias in node.names if alias.name in self._forbidden_modules
+            alias.name
+            for alias in node.names
+            if self._is_forbidden_module_reference(alias.name, self._forbidden_modules)
         )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         module = node.module or ""
-        if module in self._forbidden_modules:
+        if self._is_forbidden_module_reference(module, self._forbidden_modules):
             self.forbidden.extend(f"{module}.{alias.name}" for alias in node.names)
             return
 
         self.forbidden.extend(
             alias.name
             for alias in node.names
-            if alias.name in self._forbidden_names or alias.name in self._forbidden_modules
+            if alias.name in self._forbidden_names
+            or self._is_forbidden_module_reference(alias.name, self._forbidden_modules)
         )
+
+
+def test_runtime_import_visitor_detects_nested_forbidden_modules() -> None:
+    """The import-boundary guard must catch nested forbidden module paths."""
+    tree = ast.parse(
+        """
+import notebooklm._sources.utils
+import http.client
+from notebooklm._sources.utils import SourceParser
+from notebooklm import _sources
+from . import _sources as relative_sources
+from __future__ import annotations
+"""
+    )
+    visitor = _RuntimeImportVisitor(
+        forbidden_names=set(),
+        forbidden_modules={"_sources", "notebooklm._sources", "__future__"},
+    )
+
+    visitor.visit(tree)
+
+    assert visitor.forbidden == [
+        "notebooklm._sources.utils",
+        "notebooklm._sources.utils.SourceParser",
+        "_sources",
+        "_sources",
+    ]
 
 
 def test_artifact_service_modules_do_not_runtime_import_facades_or_core() -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -9,6 +9,7 @@ invariant down so the load-bearing init order can't silently come back.
 from __future__ import annotations
 
 import ast
+import importlib
 import json
 from collections import Counter
 from pathlib import Path
@@ -56,6 +57,14 @@ _ARTIFACT_SERVICE_MODULES = [
     "_artifact_polling.py",
 ]
 
+_SOURCE_SERVICE_MODULES = [
+    "_source_listing.py",
+    "_source_polling.py",
+    "_source_add.py",
+    "_source_upload.py",
+    "_source_content.py",
+]
+
 _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_NAMES = {
     "NotebookLMClient",
     "ClientCore",
@@ -67,6 +76,21 @@ _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES = {
     "_core",
     "client",
     "notebooklm._artifacts",
+    "notebooklm._core",
+    "notebooklm.client",
+}
+
+_FORBIDDEN_SOURCE_SERVICE_RUNTIME_IMPORT_NAMES = {
+    "NotebookLMClient",
+    "ClientCore",
+    "SourcesAPI",
+}
+
+_FORBIDDEN_SOURCE_SERVICE_RUNTIME_IMPORT_MODULES = {
+    "_sources",
+    "_core",
+    "client",
+    "notebooklm._sources",
     "notebooklm._core",
     "notebooklm.client",
 }
@@ -235,7 +259,14 @@ def _is_type_checking_guard(node: ast.AST) -> bool:
 
 
 class _RuntimeImportVisitor(ast.NodeVisitor):
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        forbidden_names: set[str],
+        forbidden_modules: set[str],
+    ) -> None:
+        self._forbidden_names = forbidden_names
+        self._forbidden_modules = forbidden_modules
         self.forbidden: list[str] = []
 
     def visit_If(self, node: ast.If) -> None:
@@ -247,22 +278,19 @@ class _RuntimeImportVisitor(ast.NodeVisitor):
 
     def visit_Import(self, node: ast.Import) -> None:
         self.forbidden.extend(
-            alias.name
-            for alias in node.names
-            if alias.name in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES
+            alias.name for alias in node.names if alias.name in self._forbidden_modules
         )
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         module = node.module or ""
-        if module in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES:
+        if module in self._forbidden_modules:
             self.forbidden.extend(f"{module}.{alias.name}" for alias in node.names)
             return
 
         self.forbidden.extend(
             alias.name
             for alias in node.names
-            if alias.name in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_NAMES
-            or alias.name in _FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES
+            if alias.name in self._forbidden_names or alias.name in self._forbidden_modules
         )
 
 
@@ -271,7 +299,32 @@ def test_artifact_service_modules_do_not_runtime_import_facades_or_core() -> Non
     forbidden_by_module: dict[str, list[str]] = {}
     for module_name in _ARTIFACT_SERVICE_MODULES:
         tree = ast.parse((SRC_ROOT / module_name).read_text(encoding="utf-8"))
-        visitor = _RuntimeImportVisitor()
+        visitor = _RuntimeImportVisitor(
+            forbidden_names=_FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_NAMES,
+            forbidden_modules=_FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES,
+        )
+        visitor.visit(tree)
+        if visitor.forbidden:
+            forbidden_by_module[module_name] = visitor.forbidden
+
+    assert forbidden_by_module == {}
+
+
+def test_source_service_modules_import_cleanly() -> None:
+    """Source service skeletons must be import-safe before behavior moves."""
+    for module_name in _SOURCE_SERVICE_MODULES:
+        importlib.import_module(f"notebooklm.{module_name.removesuffix('.py')}")
+
+
+def test_source_service_modules_do_not_runtime_import_facades_or_core() -> None:
+    """Guard future source service extraction modules against facade/core imports."""
+    forbidden_by_module: dict[str, list[str]] = {}
+    for module_name in _SOURCE_SERVICE_MODULES:
+        tree = ast.parse((SRC_ROOT / module_name).read_text(encoding="utf-8"))
+        visitor = _RuntimeImportVisitor(
+            forbidden_names=_FORBIDDEN_SOURCE_SERVICE_RUNTIME_IMPORT_NAMES,
+            forbidden_modules=_FORBIDDEN_SOURCE_SERVICE_RUNTIME_IMPORT_MODULES,
+        )
         visitor.visit(tree)
         if visitor.forbidden:
             forbidden_by_module[module_name] = visitor.forbidden


### PR DESCRIPTION
## Summary
- add source service skeleton modules for Phase 8 extraction
- add upload concurrency capability methods to ClientCoreCapabilities
- route existing source upload semaphore/queue metric access through capabilities
- add source service import/core facade guard tests

## Verification
- rtk uv run pytest tests/unit/test_capabilities.py tests/unit/test_init_order.py tests/unit/test_sources_integration.py::TestSourcesAPI
- rtk uv run ruff check src/notebooklm/_sources.py src/notebooklm/_source_listing.py src/notebooklm/_source_polling.py src/notebooklm/_source_add.py src/notebooklm/_source_upload.py src/notebooklm/_source_content.py src/notebooklm/_capabilities.py tests/unit/test_capabilities.py tests/unit/test_init_order.py
- rtk uv run ruff format --check src/notebooklm/_sources.py src/notebooklm/_source_listing.py src/notebooklm/_source_polling.py src/notebooklm/_source_add.py src/notebooklm/_source_upload.py src/notebooklm/_source_content.py src/notebooklm/_capabilities.py tests/unit/test_capabilities.py tests/unit/test_init_order.py
- rtk uv run mypy src/notebooklm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Refactoring**
  * Centralized upload concurrency and queue-wait tracking for more reliable/uploads
  * Introduced a new, modular service structure for managing different source types and rendering

* **Tests**
  * Added tests for upload concurrency delegation and for import/safety of new service modules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->