### PR TITLE
chore(scripts, ci): drop internal audit IDs (Phase 3 of 3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,19 +40,19 @@ jobs:
     - name: Run type checking
       run: uv run mypy src/notebooklm --ignore-missing-imports
 
-    - name: Assert workflow permissions are scoped (Phase 1 T4)
+    - name: Assert workflow permissions are scoped
       run: uv run python scripts/check_workflow_permissions.py
 
-    - name: Assert coverage thresholds match (Phase 1 T5)
+    - name: Assert coverage thresholds match
       run: uv run python scripts/check_coverage_thresholds.py
 
-    - name: Assert CI install matches CONTRIBUTING.md (Phase 6 P6.4)
+    - name: Assert CI install matches CONTRIBUTING.md
       run: uv run python scripts/check_ci_install_parity.py
 
-    - name: Assert CLAUDE.md paths are fresh (Phase 6 P6.6)
+    - name: Assert CLAUDE.md paths are fresh
       run: uv run python scripts/check_claude_md_freshness.py
 
-    - name: Assert per-method RPC coverage (Strategic 9, T8.E9)
+    - name: Assert per-method RPC coverage
       # Static check: each RPCMethod member must have at least one test
       # reference AND at least one cassette body containing its RPC id.
       # Pre-existing gaps are grandfathered via PREEXISTING_GAPS inside the
@@ -115,10 +115,10 @@ jobs:
           echo "::warning::Continuing so the non-browser test matrix can run."
         fi
 
-    - name: Assert cassettes are sanitized (T5.E, T8.A5a, T8.A5b)
+    - name: Assert cassettes are sanitized
       # Runs on all matrix entries (ubuntu, macos, windows × 5 Python versions).
-      # The legacy bash gate was lifted in T8.A5b after T8.A5a replaced the
-      # shell script with a portable Python invocation.
+      # The legacy bash gate was replaced by a portable Python invocation so the
+      # check runs uniformly across the cross-platform test matrix.
       run: uv run python tests/scripts/check_cassettes_clean.py
 
     - name: Run tests with coverage
@@ -127,7 +127,7 @@ jobs:
       # still show the missing-lines summary.
       run: uv run pytest --cov=src/notebooklm --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=90
 
-    - name: Assert per-file coverage floors (T6.C)
+    - name: Assert per-file coverage floors
       # Linux-only because ``coverage.json`` on Windows records backslash
       # paths (e.g. ``src\notebooklm\cli\doctor.py``) that won't match the
       # forward-slash keys in ``[tool.notebooklm.per_file_coverage_floors]``

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,8 @@ jobs:
 
     - name: Assert cassettes are sanitized
       # Runs on all matrix entries (ubuntu, macos, windows × 5 Python versions).
-      # The legacy bash gate was replaced by a portable Python invocation so the
-      # check runs uniformly across the cross-platform test matrix.
+      # An earlier bash-only gate was replaced by a portable Python invocation
+      # so the check runs uniformly across the cross-platform test matrix.
       run: uv run python tests/scripts/check_cassettes_clean.py
 
     - name: Run tests with coverage

--- a/scripts/check_ci_install_parity.py
+++ b/scripts/check_ci_install_parity.py
@@ -2,14 +2,14 @@
 
 Two checks:
 
-1. **Canonical install presence (Phase 6 / P6.4 — original):** the canonical
-   install command — ``uv sync --frozen --extra browser --extra dev
-   --extra markdown`` — must appear verbatim in both ``.github/workflows/test.yml``
-   and ``CONTRIBUTING.md``. The exact wording is deliberate (per
+1. **Canonical install presence:** the canonical install command —
+   ``uv sync --frozen --extra browser --extra dev --extra markdown`` — must
+   appear verbatim in both ``.github/workflows/test.yml`` and
+   ``CONTRIBUTING.md``. The exact wording is deliberate (per
    ``docs/installation.md``): the broader ``--all-extras`` form pulls in
    ``cookies`` (and ``ai``), which fails on Python 3.13/3.14.
 
-2. **Block-mirror policy (T6.D extension):** every fenced ``bash`` code block
+2. **Block-mirror policy:** every fenced ``bash`` code block
    in ``docs/installation.md`` (the canonical install guide) must EITHER
    appear verbatim in ``CONTRIBUTING.md``, OR be marked with
    ``<!-- not mirrored: <reason> -->`` on the line directly before the

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -1,12 +1,12 @@
 """Assert pyproject.toml `fail_under` matches `.github/workflows/test.yml` `--cov-fail-under`.
 
-Prevents the drift bug where CI claimed 70% and pyproject claimed 90% until
-they were aligned manually.
+Prevents the two values from drifting (e.g. CI passing at 70% while pyproject
+demands 90%, or vice versa) by failing CI whenever they disagree.
 
 When ``--coverage-json`` is provided, additionally enforces per-file floors
 declared in ``[tool.notebooklm.per_file_coverage_floors]``. Coverage.py's
 ``[tool.coverage.report]`` only supports a global ``fail_under``, so individual
-files that historically lag the project-wide 90% are guarded by this script.
+files that lag the project-wide 90% are guarded by this script.
 
 Usage:
     python scripts/check_coverage_thresholds.py

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -1,13 +1,12 @@
 """Assert pyproject.toml `fail_under` matches `.github/workflows/test.yml` `--cov-fail-under`.
 
-Phase 1 / T5: prevents the drift bug that was discovered during the multi-agent
-audit. CI claimed 70%, pyproject claimed 90% — until they were aligned manually.
+Prevents the drift bug where CI claimed 70% and pyproject claimed 90% until
+they were aligned manually.
 
-Phase 6 / T6.C extension: when ``--coverage-json`` is provided, additionally
-enforces per-file floors declared in ``[tool.notebooklm.per_file_coverage_floors]``.
-Coverage.py's ``[tool.coverage.report]`` only supports a global ``fail_under``,
-so individual files that historically lag the project-wide 90% are guarded by
-this script.
+When ``--coverage-json`` is provided, additionally enforces per-file floors
+declared in ``[tool.notebooklm.per_file_coverage_floors]``. Coverage.py's
+``[tool.coverage.report]`` only supports a global ``fail_under``, so individual
+files that historically lag the project-wide 90% are guarded by this script.
 
 Usage:
     python scripts/check_coverage_thresholds.py
@@ -41,7 +40,7 @@ else:
 
 
 def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
-    """Original Phase-1 check: pyproject ``fail_under`` vs CI ``--cov-fail-under``."""
+    """Compare pyproject ``fail_under`` against CI ``--cov-fail-under``."""
     try:
         with open(pyproject_path, "rb") as f:
             pp = tomllib.load(f)
@@ -96,7 +95,7 @@ def _check_global_drift(pyproject_path: str, workflow_path: str) -> int:
 
 
 def _check_per_file_floors(pyproject_path: str, coverage_json_path: str) -> int:
-    """T6.C: enforce per-file floors from ``[tool.notebooklm.per_file_coverage_floors]``.
+    """Enforce per-file floors from ``[tool.notebooklm.per_file_coverage_floors]``.
 
     Floors live in pyproject.toml so they're checked into the repo and bumped
     via PR (the commit message documents the new minimum). The script reads

--- a/scripts/rescrub-cassettes.py
+++ b/scripts/rescrub-cassettes.py
@@ -1,27 +1,26 @@
 #!/usr/bin/env python3
 """Bulk re-scrub VCR cassettes for ``lh3.googleusercontent.com/(a|ogw)/`` avatar URLs.
 
-T8.B6 — collapses every ``lh3.googleusercontent.com/(?:a|ogw)/<token>`` avatar
-URL to the canonical ``SCRUBBED_AVATAR_URL`` placeholder and re-derives the
-chunked ``<count>\\n<payload>\\n`` byte-count prefixes inside every recorded
-response body. Writes back only if anything changed; idempotent on a clean
-tree.
+Collapses every ``lh3.googleusercontent.com/(?:a|ogw)/<token>`` avatar URL to
+the canonical ``SCRUBBED_AVATAR_URL`` placeholder and re-derives the chunked
+``<count>\\n<payload>\\n`` byte-count prefixes inside every recorded response
+body. Writes back only if anything changed; idempotent on a clean tree.
 
 Why this script exists
 ----------------------
-The T8.A6a avatar-URL scrubber (PR #565) added
+The avatar-URL scrubber (PR #565) added
 ``lh3.googleusercontent.com/(?:a|ogw)/<token>`` → ``SCRUBBED_AVATAR_URL`` to
 the canonical pattern registry, but the ~67 cassettes recorded BEFORE that
-pattern landed still embed the raw avatar URLs. The phase-1 audit listed
-them in ``tests/scripts/cassette_repair_allowlist.txt`` under the "/ogw/
-avatar URL group" header; this script is the one-off tool that walks each
-of those cassettes, re-scrubs them in place, and reports a byte-level diff
-so reviewers can verify the change set.
+pattern landed still embed the raw avatar URLs. They were enumerated in
+``tests/scripts/cassette_repair_allowlist.txt`` under the "/ogw/ avatar URL
+group" header; this script is the one-off tool that walks each of those
+cassettes, re-scrubs them in place, and reports a byte-level diff so reviewers
+can verify the change set.
 
 Why we DON'T call ``scrub_string`` here
 ---------------------------------------
 ``cassette_patterns.scrub_string`` applies every pattern in
-:data:`SENSITIVE_PATTERNS` — including the T8.A6a escaped-display-name
+:data:`SENSITIVE_PATTERNS` — including the escaped-display-name
 scrubber that anchors on ``\\"First Last\\"`` inside double-encoded WRB
 payloads. That pattern carries a small false-positive allowlist
 (``DISPLAY_NAME_FALSE_POSITIVES``) covering font families, UI titles, and

--- a/scripts/rescrub-cassettes.py
+++ b/scripts/rescrub-cassettes.py
@@ -11,7 +11,7 @@ Why this script exists
 The avatar-URL scrubber (PR #565) added
 ``lh3.googleusercontent.com/(?:a|ogw)/<token>`` → ``SCRUBBED_AVATAR_URL`` to
 the canonical pattern registry, but the ~67 cassettes recorded BEFORE that
-pattern landed still embed the raw avatar URLs. They were enumerated in
+pattern landed still embed the raw avatar URLs. They are listed in
 ``tests/scripts/cassette_repair_allowlist.txt`` under the "/ogw/ avatar URL
 group" header; this script is the one-off tool that walks each of those
 cassettes, re-scrubs them in place, and reports a byte-level diff so reviewers


### PR DESCRIPTION
## Summary

Phase 3 (final) of a 3-PR cleanup that removes internal \`.sisyphus/\`-plan terminology from files shipped to GitHub. This phase is the smallest — scripts and a CI workflow file.

**No logic changes** — only comments, docstrings, and workflow step-name labels.

## Scope (in this PR)

- \`scripts/check_ci_install_parity.py\` — 2 refs (Phase 6 / P6.4, T6.D)
- \`scripts/check_coverage_thresholds.py\` — 3 refs (Phase 1 / T5, Phase 6 / T6.C, T6.C)
- \`scripts/rescrub-cassettes.py\` — 3 refs (T8.B6, T8.A6a x2)
- \`.github/workflows/test.yml\` — 8 step-name parentheticals and inline comments (Phase 1 T4, Phase 1 T5, Phase 6 P6.4, Phase 6 P6.6, Strategic 9 / T8.E9, T5.E / T8.A5a / T8.A5b, T8.A5b, T6.C)

## Diff stat

\`\`\`
.github/workflows/test.yml           | 18 +++++++++---------
 scripts/check_ci_install_parity.py   | 10 +++++-----
 scripts/check_coverage_thresholds.py | 17 ++++++++---------
 scripts/rescrub-cassettes.py         | 23 +++++++++++------------
 4 files changed, 33 insertions(+), 35 deletions(-)
\`\`\`

## Verification

- ruff format clean (325 files unchanged)
- ruff check clean (all checks passed)
- mypy clean (no issues found in 85 source files)
- pytest passes (4588 passed, 12 skipped)
- In-scope grep returns zero matches: \`T\d+\.[A-Z][0-9a-z]*|audit §\d+|audit row [A-Z]?\d|.sisyphus|PR-T\d+\.[A-Z]|cli-ux-remediation|tiered-remediation|synthesis §|load-bearing T\`
- Multi-model local review:
  - Codex (ACCURACY lens): 0 CRITICAL, 0 IMPORTANT, 1 NIT addressed elsewhere
  - Claude (CONSISTENCY lens): 0 CRITICAL, 0 IMPORTANT, 3 NITs all addressed in follow-up commit
  - Gemini (COMPLETENESS lens): quota-exhausted; not blocking

## Companion PRs

Phase 1 (\`src/\` + \`docs/\` + \`CHANGELOG\`) and Phase 2 (\`tests/\`) are filed separately from sibling branches and run in parallel against this one.

## Guarantees

- No source-code logic changes — every hunk is inside a docstring, \`#\` comment, or YAML \`- name:\` step label
- No \`run:\` / \`if:\` / regex / threshold / exit-code / function-body line modified
- No edits to \`tests/cassettes/**/*.yaml\` (out of scope)

---

**HOLD: Do not auto-merge. User retains merge authority.**

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured GitHub Actions CI workflow quality checks and test assertions for improved clarity and consistency.
  * Updated validation scripts and documentation for installation parity verification, coverage threshold enforcement, and test cassette handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->