### PR TITLE
refactor(sources): extract upload pipeline

### DIFF
--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -497,6 +497,14 @@ class SourceUploadPipeline:
                     _retain_background_cancel_task(
                         asyncio.create_task(cancel_upload_session(upload_url, base_url, auth_route))
                     )
+                    raise
+                try:
+                    await asyncio.shield(finalize_task)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "Background finalize POST failed before cancellation propagated: %r",
+                        exc,
+                    )
                 raise
         except BaseException:
             if not close_wired and path_fallback is None:

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -142,6 +142,14 @@ class CancelUploadSession(Protocol):
     async def __call__(self, upload_url: str, base_url: str, auth_route: str) -> None: ...
 
 
+_BACKGROUND_CANCEL_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _retain_background_cancel_task(task: asyncio.Task[None]) -> None:
+    _BACKGROUND_CANCEL_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_CANCEL_TASKS.discard)
+
+
 def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
     """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
 
@@ -283,8 +291,9 @@ class SourceUploadPipeline:
                 _type_code=None,
             )
 
-        if title is not None and title != filename:
+        if needs_title_rename:
             try:
+                assert title is not None
                 renamed = await rename(notebook_id, source_id, title)
                 source = replace(source, title=renamed.title or title)
             except (RPCError, NetworkError):
@@ -333,8 +342,9 @@ class SourceUploadPipeline:
             return source_id
 
         if isinstance(result, str):
-            suffix = "..." if len(result) > 200 else ""
-            preview = repr(result[:200] + suffix)
+            preview = repr(result[:200])
+            if len(result) > 200:
+                preview += "..."
         else:
             preview = repr(result)
             if len(preview) > 200:
@@ -484,7 +494,9 @@ class SourceUploadPipeline:
             except asyncio.CancelledError:
                 if not finalize_started:
                     finalize_task.cancel()
-                    asyncio.create_task(cancel_upload_session(upload_url, base_url, auth_route))
+                    _retain_background_cancel_task(
+                        asyncio.create_task(cancel_upload_session(upload_url, base_url, auth_route))
+                    )
                 raise
         except BaseException:
             if not close_wired and path_fallback is None:

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -1,10 +1,525 @@
-"""Private source file upload pipeline skeleton."""
+"""Private source file upload pipeline."""
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
+import re
+import warnings
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from time import monotonic
+from typing import IO, Any, Protocol
+
+import httpx
+
+from ._callbacks import maybe_await_callback
+from ._capabilities import (
+    AuthRouteProvider,
+    CookieJarProvider,
+    TransportOperationProvider,
+    UploadConcurrencyProvider,
+)
+from ._env import get_base_url
+from .exceptions import (
+    AuthError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+)
+from .rpc import RPCError, RPCMethod, get_upload_url
+from .rpc.types import SourceStatus
+from .types import Source, SourceAddError
+
+_SOURCE_ID_UUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+class SourceUploadRuntime(
+    UploadConcurrencyProvider,
+    TransportOperationProvider,
+    Protocol,
+):
+    """Capabilities needed by public file-upload orchestration."""
+
+
+class SourceUploadHttpRuntime(
+    AuthRouteProvider,
+    CookieJarProvider,
+    Protocol,
+):
+    """Capabilities needed by Scotty upload HTTP calls."""
+
+
+class RpcCaller(Protocol):
+    """RPC callback shape used by upload registration."""
+
+    async def __call__(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any: ...
+
+
+class RegisterFileSource(Protocol):
+    """Late-bound facade hook for file-source registration."""
+
+    async def __call__(self, notebook_id: str, filename: str) -> str: ...
+
+
+class StartResumableUpload(Protocol):
+    """Late-bound facade hook for upload-session start."""
+
+    async def __call__(
+        self,
+        notebook_id: str,
+        filename: str,
+        file_size: int,
+        source_id: str,
+    ) -> str: ...
+
+
+class UploadFileStreaming(Protocol):
+    """Late-bound facade hook for streaming upload finalize."""
+
+    async def __call__(
+        self,
+        upload_url: str,
+        file_obj: IO[bytes] | Path,
+        *,
+        filename: str | None = None,
+        on_progress: Callable[[int, int], object] | None = None,
+        total_bytes: int | None = None,
+    ) -> None: ...
+
+
+class WaitForSource(Protocol):
+    """Wait helper used after upload registration."""
+
+    async def __call__(
+        self,
+        notebook_id: str,
+        source_id: str,
+        timeout: float = 120.0,
+    ) -> Source: ...
+
+
+class RenameSource(Protocol):
+    """Source rename callback shape."""
+
+    async def __call__(self, notebook_id: str, source_id: str, new_title: str) -> Source: ...
+
+
+class ResolveUploadTimeout(Protocol):
+    """Upload timeout resolution callback shape."""
+
+    def __call__(self, default: httpx.Timeout) -> httpx.Timeout: ...
+
+
+class AsyncClientFactory(Protocol):
+    """Factory for creating an ``httpx.AsyncClient``-compatible instance."""
+
+    def __call__(
+        self,
+        *,
+        timeout: httpx.Timeout,
+        cookies: httpx.Cookies,
+    ) -> httpx.AsyncClient: ...
+
+
+class CancelUploadSession(Protocol):
+    """Late-bound facade hook for best-effort upload cancellation."""
+
+    async def __call__(self, upload_url: str, base_url: str, auth_route: str) -> None: ...
+
+
+def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
+    """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
+
+    The historical shape was a strictly position-0 walk: ``[[[[id]]]]``. Issue
+    #474 surfaced cases where that walk lands on ``None`` or on the echoed
+    filename and silently fails. Walk the whole structure instead, prefer a
+    UUID-shaped leaf, and fall back to any other id-shaped string that is
+    plausibly not a status label.
+    """
+    uuid_match: str | None = None
+    fallback: str | None = None
+    # Depth guard for malformed/adversarial payloads. Google's real responses
+    # are shallow, so 50 is generous without risking RecursionError.
+    max_depth = 50
+
+    def walk(node: Any, depth: int) -> None:
+        nonlocal uuid_match, fallback
+        if uuid_match is not None or depth > max_depth:
+            return
+        if isinstance(node, str):
+            candidate = node.strip()
+            if not candidate or candidate == filename:
+                return
+            if _SOURCE_ID_UUID_PATTERN.match(candidate):
+                uuid_match = candidate
+                return
+            if fallback is None and _looks_like_id_string(candidate):
+                fallback = candidate
+        elif isinstance(node, list):
+            for child in node:
+                if uuid_match is not None:
+                    return
+                walk(child, depth + 1)
+
+    walk(result, 0)
+    return uuid_match or fallback
+
+
+def _looks_like_id_string(candidate: str) -> bool:
+    """Heuristic for the non-UUID fallback in file-source id extraction."""
+    if len(candidate) < 4:
+        return False
+    if any(c in candidate for c in " \t/"):
+        return False
+    return any(c.isdigit() or c in "-_" for c in candidate)
+
 
 class SourceUploadPipeline:
-    """Future owner of file registration and resumable upload orchestration."""
+    """Own file registration and resumable upload orchestration."""
+
+    async def add_file(
+        self,
+        notebook_id: str,
+        file_path: str | Path,
+        mime_type: str | None = None,
+        wait: bool = False,
+        wait_timeout: float = 120.0,
+        *,
+        title: str | None = None,
+        on_progress: Callable[[int, int], object] | None = None,
+        deprecation_warning_stacklevel: int = 2,
+        capabilities: SourceUploadRuntime,
+        register_file_source: RegisterFileSource,
+        start_resumable_upload: StartResumableUpload,
+        upload_file_streaming: UploadFileStreaming,
+        wait_until_ready: WaitForSource,
+        wait_until_registered: WaitForSource,
+        rename: RenameSource,
+        logger: Any,
+    ) -> Source:
+        """Add a file source to a notebook using resumable upload."""
+        logger.debug("Adding file source to notebook %s: %s", notebook_id, file_path)
+        if mime_type is not None:
+            warnings.warn(
+                "mime_type parameter is unused and will be removed in v0.X.0; "
+                "rely on filename extension instead",
+                DeprecationWarning,
+                stacklevel=deprecation_warning_stacklevel,
+            )
+        if title is not None:
+            title = title.strip()
+            if not title:
+                raise ValidationError("Title cannot be empty or whitespace-only")
+
+        file_path = Path(file_path).resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        if not file_path.is_file():
+            raise ValidationError(f"Not a regular file: {file_path}")
+
+        filename = file_path.name
+        upload_sem = capabilities.get_upload_semaphore()
+        upload_wait_start = monotonic()
+        async with upload_sem:
+            capabilities.record_upload_queue_wait(monotonic() - upload_wait_start)
+            file_obj = open(file_path, "rb")  # noqa: SIM115
+            handed_off = False
+            operation_token = None
+            try:
+                file_size = os.fstat(file_obj.fileno()).st_size
+                operation_token = await capabilities.begin_transport_post(
+                    f"source upload {filename}"
+                )
+                source_id = await register_file_source(notebook_id, filename)
+                upload_url = await start_resumable_upload(
+                    notebook_id,
+                    filename,
+                    file_size,
+                    source_id,
+                )
+                handed_off = True
+                await upload_file_streaming(
+                    upload_url,
+                    file_obj,
+                    filename=filename,
+                    on_progress=on_progress,
+                    total_bytes=file_size,
+                )
+            finally:
+                try:
+                    if operation_token is not None:
+                        await capabilities.finish_transport_post(operation_token)
+                finally:
+                    if not handed_off:
+                        file_obj.close()
+
+        needs_title_rename = title is not None and title != filename
+        if wait:
+            source = await wait_until_ready(notebook_id, source_id, timeout=wait_timeout)
+        elif needs_title_rename:
+            source = await wait_until_registered(notebook_id, source_id, timeout=wait_timeout)
+        else:
+            source = Source(
+                id=source_id,
+                title=filename,
+                status=SourceStatus.PROCESSING,
+                _type_code=None,
+            )
+
+        if title is not None and title != filename:
+            try:
+                renamed = await rename(notebook_id, source_id, title)
+                source = replace(source, title=renamed.title or title)
+            except (RPCError, NetworkError):
+                logger.warning(
+                    "Source %s uploaded but rename to %r failed",
+                    source_id,
+                    title,
+                    exc_info=True,
+                )
+
+        return source
+
+    async def register_file_source(
+        self,
+        notebook_id: str,
+        filename: str,
+        *,
+        rpc_call: RpcCaller,
+    ) -> str:
+        """Register a file source intent and get SOURCE_ID."""
+        params = [
+            [[filename]],
+            notebook_id,
+            [2],
+            [1, None, None, None, None, None, None, None, None, None, [1]],
+        ]
+
+        try:
+            result = await rpc_call(
+                RPCMethod.ADD_SOURCE_FILE,
+                params,
+                source_path=f"/notebook/{notebook_id}",
+                allow_null=False,
+            )
+        except (AuthError, RateLimitError, ServerError):
+            raise
+        except RPCError as exc:
+            raise SourceAddError(
+                filename,
+                cause=exc,
+                message=f"Failed to register file source for {filename}: {exc}",
+            ) from exc
+
+        source_id = _extract_register_file_source_id(result, filename)
+        if source_id:
+            return source_id
+
+        preview = repr(result)
+        if len(preview) > 200:
+            preview = preview[:200] + "..."
+        raise SourceAddError(
+            filename,
+            message=(
+                f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
+            ),
+        )
+
+    async def start_resumable_upload(
+        self,
+        notebook_id: str,
+        filename: str,
+        file_size: int,
+        source_id: str,
+        *,
+        capabilities: SourceUploadHttpRuntime,
+        resolve_upload_timeout: ResolveUploadTimeout,
+        async_client_factory: AsyncClientFactory,
+    ) -> str:
+        """Start a resumable upload session and get the upload URL."""
+        auth_route = capabilities.authuser_header()
+        base_url = get_base_url()
+        url = f"{get_upload_url()}?{capabilities.authuser_query()}"
+
+        headers = {
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
+            "x-goog-authuser": auth_route,
+            "x-goog-upload-command": "start",
+            "x-goog-upload-header-content-length": str(file_size),
+            "x-goog-upload-protocol": "resumable",
+        }
+
+        body = json.dumps(
+            {
+                "PROJECT_ID": notebook_id,
+                "SOURCE_NAME": filename,
+                "SOURCE_ID": source_id,
+            }
+        )
+
+        async with async_client_factory(
+            timeout=resolve_upload_timeout(httpx.Timeout(10.0, read=60.0)),
+            cookies=capabilities.live_cookies(),
+        ) as client:
+            response = await client.post(url, headers=headers, content=body)
+            response.raise_for_status()
+
+            upload_url = response.headers.get("x-goog-upload-url")
+            if not upload_url:
+                raise SourceAddError(
+                    filename, message="Failed to get upload URL from response headers"
+                )
+
+            return upload_url
+
+    async def upload_file_streaming(
+        self,
+        upload_url: str,
+        file_obj: IO[bytes] | Path,
+        *,
+        filename: str | None = None,
+        on_progress: Callable[[int, int], object] | None = None,
+        total_bytes: int | None = None,
+        capabilities: SourceUploadHttpRuntime,
+        resolve_upload_timeout: ResolveUploadTimeout,
+        async_client_factory: AsyncClientFactory,
+        cancel_upload_session: CancelUploadSession,
+        logger: Any,
+    ) -> None:
+        """Stream upload file content to the resumable upload URL."""
+        path_fallback: Path | None = file_obj if isinstance(file_obj, Path) else None
+        close_wired = False
+        try:
+            base_url = get_base_url()
+            auth_route = capabilities.authuser_header()
+            headers = {
+                "Accept": "*/*",
+                "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+                "x-goog-authuser": auth_route,
+                "Origin": base_url,
+                "Referer": f"{base_url}/",
+                "x-goog-upload-command": "upload, finalize",
+                "x-goog-upload-offset": "0",
+            }
+            diag_name = filename or (path_fallback.name if path_fallback is not None else "<file>")
+            logger.debug("Streaming upload to %s for %s", upload_url, diag_name)
+            if total_bytes is None and path_fallback is not None:
+                total_bytes = path_fallback.stat().st_size
+            progress_total = total_bytes if total_bytes is not None else 0
+            uploaded_bytes = 0
+
+            if on_progress is not None:
+                await maybe_await_callback(on_progress, uploaded_bytes, progress_total)
+
+            async def file_stream():
+                nonlocal uploaded_bytes
+                if path_fallback is not None:
+                    with open(path_fallback, "rb") as f:
+                        while chunk := await asyncio.to_thread(f.read, 65536):
+                            uploaded_bytes += len(chunk)
+                            if on_progress is not None:
+                                await maybe_await_callback(
+                                    on_progress, uploaded_bytes, progress_total
+                                )
+                            yield chunk
+                    return
+
+                assert not isinstance(file_obj, Path)
+                while chunk := await asyncio.to_thread(file_obj.read, 65536):
+                    uploaded_bytes += len(chunk)
+                    if on_progress is not None:
+                        await maybe_await_callback(on_progress, uploaded_bytes, progress_total)
+                    yield chunk
+
+            finalize_started = False
+
+            async def _do_finalize() -> None:
+                nonlocal finalize_started
+                async with async_client_factory(
+                    timeout=resolve_upload_timeout(httpx.Timeout(10.0, read=300.0)),
+                    cookies=capabilities.live_cookies(),
+                ) as client:
+                    finalize_started = True
+                    response = await client.post(upload_url, headers=headers, content=file_stream())
+                    response.raise_for_status()
+
+            def _on_finalize_done(t: asyncio.Task[None]) -> None:
+                if path_fallback is None:
+                    try:
+                        file_obj.close()  # type: ignore[union-attr]
+                    except Exception as close_exc:  # noqa: BLE001
+                        logger.debug("Caller FD close in finalize-done failed: %r", close_exc)
+                if not t.cancelled() and (exc := t.exception()) is not None:
+                    logger.debug("Background finalize POST failed: %r", exc)
+
+            finalize_task = asyncio.create_task(_do_finalize())
+            finalize_task.add_done_callback(_on_finalize_done)
+            close_wired = True
+            try:
+                await asyncio.shield(finalize_task)
+            except asyncio.CancelledError:
+                if not finalize_started:
+                    finalize_task.cancel()
+                    asyncio.create_task(cancel_upload_session(upload_url, base_url, auth_route))
+                raise
+        except BaseException:
+            if not close_wired and path_fallback is None:
+                try:
+                    file_obj.close()  # type: ignore[union-attr]
+                except Exception as close_exc:  # noqa: BLE001
+                    logger.debug("Caller FD close on pre-wire exception failed: %r", close_exc)
+            raise
+
+    async def cancel_upload_session(
+        self,
+        upload_url: str,
+        base_url: str,
+        auth_route: str,
+        *,
+        capabilities: SourceUploadHttpRuntime,
+        async_client_factory: AsyncClientFactory,
+        logger: Any,
+    ) -> None:
+        """Best-effort POST a Scotty resumable-upload cancel command."""
+        headers = {
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+            "x-goog-authuser": auth_route,
+            "Origin": base_url,
+            "Referer": f"{base_url}/",
+            "x-goog-upload-command": "cancel",
+        }
+        try:
+            async with async_client_factory(
+                timeout=httpx.Timeout(10.0, read=10.0),
+                cookies=capabilities.live_cookies(),
+            ) as client:
+                await client.post(upload_url, headers=headers)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Best-effort Scotty cancel for %s failed: %r", upload_url, exc)
 
 
-__all__ = ["SourceUploadPipeline"]
+__all__ = [
+    "SourceUploadPipeline",
+    "_SOURCE_ID_UUID_PATTERN",
+    "_extract_register_file_source_id",
+    "_looks_like_id_string",
+]

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -162,6 +162,8 @@ def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
         if uuid_match is not None or depth > max_depth:
             return
         if isinstance(node, str):
+            if len(node) > 1000:
+                return
             candidate = node.strip()
             if not candidate or candidate == filename:
                 return
@@ -330,9 +332,13 @@ class SourceUploadPipeline:
         if source_id:
             return source_id
 
-        preview = repr(result)
-        if len(preview) > 200:
-            preview = preview[:200] + "..."
+        if isinstance(result, str):
+            suffix = "..." if len(result) > 200 else ""
+            preview = repr(result[:200] + suffix)
+        else:
+            preview = repr(result)
+            if len(preview) > 200:
+                preview = preview[:200] + "..."
         raise SourceAddError(
             filename,
             message=(

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -3,11 +3,7 @@
 import asyncio
 import builtins
 import logging
-import os
-import re
-import warnings
 from collections.abc import Callable
-from dataclasses import replace
 from pathlib import Path
 from time import monotonic
 from typing import IO, Any, Literal
@@ -15,26 +11,17 @@ from urllib.parse import urlparse
 
 import httpx
 
-from ._callbacks import maybe_await_callback
+from . import _source_upload
 from ._capabilities import ClientCoreCapabilities
 from ._core import ClientCore
-from ._env import get_base_url
 from ._source_add import SourceAddService
 from ._source_listing import SourceLister
 from ._source_polling import SourcePoller
+from ._source_upload import SourceUploadPipeline
 from ._url_utils import is_youtube_url
-from .exceptions import (
-    AuthError,
-    NetworkError,
-    RateLimitError,
-    ServerError,
-    ValidationError,
-)
-from .rpc import RPCError, RPCMethod, get_upload_url
-from .rpc.types import SourceStatus
+from .rpc import RPCMethod
 from .types import (
     Source,
-    SourceAddError,
     SourceFulltext,
     SourceNotFoundError,
     _extract_source_url,
@@ -42,69 +29,9 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-
-_SOURCE_ID_UUID_PATTERN = re.compile(
-    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-)
-
-
-def _extract_register_file_source_id(result: Any, filename: str) -> str | None:
-    """Locate the SOURCE_ID string in an ADD_SOURCE_FILE response.
-
-    The historical shape was a strictly position-0 walk: ``[[[[id]]]]``. Issue
-    #474 surfaced cases where that walk lands on ``None`` or on the echoed
-    filename and silently fails. Walk the whole structure instead, prefer a
-    UUID-shaped leaf, and fall back to any other id-shaped string that is
-    plausibly not a status label.
-    """
-    uuid_match: str | None = None
-    fallback: str | None = None
-    # Depth guard for malformed/adversarial payloads — Google's real responses
-    # are shallow (≤5 levels), so 50 is generous without risking RecursionError.
-    max_depth = 50
-
-    def walk(node: Any, depth: int) -> None:
-        nonlocal uuid_match, fallback
-        if uuid_match is not None or depth > max_depth:
-            return
-        if isinstance(node, str):
-            candidate = node.strip()
-            if not candidate or candidate == filename:
-                return
-            if _SOURCE_ID_UUID_PATTERN.match(candidate):
-                uuid_match = candidate
-                return
-            # Fallback: reject obvious non-id strings — status labels ("OK",
-            # "DONE", "true"), mime types ("application/pdf"), free-form
-            # messages. An id-shaped string has no embedded whitespace, no
-            # slashes, is at least 4 chars, and contains at least one digit,
-            # hyphen, or underscore (excludes all-alpha status tokens).
-            if fallback is None and _looks_like_id_string(candidate):
-                fallback = candidate
-        elif isinstance(node, list):
-            for child in node:
-                if uuid_match is not None:
-                    return
-                walk(child, depth + 1)
-
-    walk(result, 0)
-    return uuid_match or fallback
-
-
-def _looks_like_id_string(candidate: str) -> bool:
-    """Heuristic for the non-UUID fallback in :func:`_extract_register_file_source_id`.
-
-    Accepts strings that look like an id (`src_pdf`, `source_id_123`) and
-    rejects short status tokens (`OK`, `DONE`, `true`) and structured fields
-    (`application/pdf`, anything with whitespace).
-    """
-    if len(candidate) < 4:
-        return False
-    if any(c in candidate for c in " \t/"):
-        return False
-    # Require at least one digit, hyphen, or underscore — blocks all-alpha
-    # status tokens while still admitting test-style ids like ``src_pdf``.
-    return any(c.isdigit() or c in "-_" for c in candidate)
+_SOURCE_ID_UUID_PATTERN = _source_upload._SOURCE_ID_UUID_PATTERN
+_extract_register_file_source_id = _source_upload._extract_register_file_source_id
+_looks_like_id_string = _source_upload._looks_like_id_string
 
 
 class SourcesAPI:
@@ -145,6 +72,7 @@ class SourcesAPI:
         self._adder = SourceAddService()
         self._lister = SourceLister(self._rpc_call)
         self._poller = SourcePoller()
+        self._uploader = SourceUploadPipeline()
         self._upload_timeout = upload_timeout
 
     async def _rpc_call(
@@ -519,182 +447,24 @@ class SourcesAPI:
             - EPUB: application/epub+zip
             - Word: application/vnd.openxmlformats-officedocument.wordprocessingml.document
         """
-        logger.debug("Adding file source to notebook %s: %s", notebook_id, file_path)
-        # DEPRECATION-REMOVAL: v0.X.0 — the ``mime_type`` argument is unused by
-        # the resumable-upload pipeline (the server derives the MIME type from
-        # the filename extension). Kept as a positional kwarg for backward
-        # compatibility; callers passing a non-None value get a warning. See
-        # CHANGELOG entry "Deprecated: ``SourcesAPI.add_file`` ``mime_type``
-        # parameter" under ``[Unreleased]`` for the planned removal release.
-        if mime_type is not None:
-            warnings.warn(
-                "mime_type parameter is unused and will be removed in v0.X.0; "
-                "rely on filename extension instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if title is not None:
-            title = title.strip()
-            if not title:
-                raise ValidationError("Title cannot be empty or whitespace-only")
-
-        file_path = Path(file_path).resolve()
-
-        # Cheap pre-check. The real existence + regular-file check is
-        # ``open()`` itself (errors with ``FileNotFoundError`` / ``IsADirectoryError``);
-        # these probes give a clearer up-front error AND short-circuit
-        # before we acquire the upload semaphore. They can't replace
-        # the FD-level check below because the file can be swapped between
-        # these probes and the ``open()``; that's the TOCTOU the FD-hold
-        # fix closes.
-        if not file_path.exists():
-            raise FileNotFoundError(f"File not found: {file_path}")
-        if not file_path.is_file():
-            raise ValidationError(f"Not a regular file: {file_path}")
-
-        filename = file_path.name
-
-        # Step 0–3 run under the upload semaphore so a fan-out caller can't
-        # hold more than ``max_concurrent_uploads`` open FDs at once. The
-        # semaphore is per-instance; see ClientCore.get_upload_semaphore.
-        upload_sem = self._capabilities.get_upload_semaphore()
-        upload_wait_start = monotonic()
-        async with upload_sem:
-            self._capabilities.record_upload_queue_wait(monotonic() - upload_wait_start)
-            # Open the file ONCE here. The FD lives across:
-            #   - the os.fstat() size check (so the size we send to
-            #     ``_start_resumable_upload`` matches the bytes we will
-            #     actually stream),
-            #   - the two RPC calls (registration + upload-session start),
-            #   - the streamed body POST inside ``_upload_file_streaming``.
-            # A racing rename/replace of the path between any of these
-            # points cannot swap the FD's underlying inode out from under
-            # us — closing the TOCTOU window the pre-T7.D3 implementation
-            # had between its ``stat()``-based size probe and the second
-            # ``open()`` inside the streaming helper (audit §23).
-            #
-            # FD ownership handoff:
-            # ``add_file`` opens the FD here and closes it on any
-            # exception raised by the size check OR the two RPCs (the
-            # ``except BaseException`` branch below). The moment
-            # ``_upload_file_streaming`` is invoked, ownership transfers
-            # to the streaming helper, which arranges close-on-done via
-            # ``add_done_callback`` on the shielded finalize task. The
-            # transfer is necessary because T7.C3 keeps the shielded
-            # POST running in the background after a post-finalize
-            # cancel — if ``add_file`` closed the FD here, the background
-            # POST would read from a closed FD and abort, breaking the
-            # T7.C3 dangling-session guarantee.
-            # noqa SIM115: a ``with open(...)`` would close the FD on
-            # exit of the block, but ``_upload_file_streaming`` takes
-            # ownership of the FD via its shielded done-callback (see
-            # the FD-handoff comment above). We close locally only when
-            # the handoff never happens (``handed_off=False`` branch in
-            # the ``finally`` below).
-            file_obj = open(file_path, "rb")  # noqa: SIM115
-            handed_off = False
-            operation_token = None
-            try:
-                # ``os.fstat(fd.fileno())`` reads inode metadata via the
-                # FD itself, not the path — even if the path has been
-                # relinked since ``open()``, this returns the inode we're
-                # about to upload.
-                file_size = os.fstat(file_obj.fileno()).st_size
-                operation_token = await self._core._begin_transport_post(
-                    f"source upload {filename}"
-                )
-
-                # Step 1: Register source intent with RPC → get SOURCE_ID
-                source_id = await self._register_file_source(notebook_id, filename)
-
-                # Step 2: Start resumable upload with the SOURCE_ID from step 1
-                upload_url = await self._start_resumable_upload(
-                    notebook_id, filename, file_size, source_id
-                )
-
-                # Step 3: Stream upload file content (memory-efficient).
-                # Ownership of ``file_obj`` transfers to
-                # ``_upload_file_streaming`` here — the helper closes it
-                # on shielded-task completion (success, error, or the
-                # post-finalize cancel branch). ``handed_off=True``
-                # prevents the local ``finally`` from double-closing.
-                handed_off = True
-                await self._upload_file_streaming(
-                    upload_url,
-                    file_obj,
-                    filename=filename,
-                    on_progress=on_progress,
-                    total_bytes=file_size,
-                )
-            finally:
-                # Close locally ONLY if ownership never transferred —
-                # i.e. ``_upload_file_streaming`` was never invoked
-                # (size-check or RPC raised). After hand-off the
-                # streaming helper owns the close.
-                try:
-                    if operation_token is not None:
-                        await self._core._finish_transport_post(operation_token)
-                finally:
-                    if not handed_off:
-                        file_obj.close()
-
-        # Step 4: Ensure the source is registered server-side BEFORE renaming.
-        # The UPDATE_SOURCE RPC silently no-ops against an unregistered source
-        # (returns success-shaped data, but the title change never propagates),
-        # so a custom-title request must force a brief registration wait even
-        # when the caller passed wait=False. See #388.
-        #
-        # When wait=True the caller asked for full processing; use
-        # wait_until_ready. When only a custom title was supplied, use the
-        # narrower wait_until_registered so wait=False callers don't pay the
-        # full processing latency just to get a rename through.
-        needs_title_rename = title is not None and title != filename
-        if wait:
-            source = await self.wait_until_ready(notebook_id, source_id, timeout=wait_timeout)
-        elif needs_title_rename:
-            # Honor the caller's wait_timeout directly — wait_until_registered
-            # polls and returns on the first PROCESSING/READY status, so the
-            # narrow wait still completes fast for typical sources even when
-            # the upper bound is generous (e.g. long-audio callers passing 300s).
-            source = await self.wait_until_registered(notebook_id, source_id, timeout=wait_timeout)
-        else:
-            # Fire-and-forget placeholder. _type_code is None because the
-            # actual type is determined by the API after processing (PDF,
-            # TEXT, IMAGE, etc.). status=PROCESSING reflects that the source
-            # has been registered but not yet processed — callers can use
-            # wait=True or get() to retrieve the resolved state.
-            source = Source(
-                id=source_id,
-                title=filename,
-                status=SourceStatus.PROCESSING,
-                _type_code=None,  # Placeholder until processed
-            )
-
-        # Step 5: Apply custom title now that the source is registered. The
-        # file-add RPC ignores any title hint, so a separate UPDATE_SOURCE
-        # call is the only way to honor the caller's intent.
-        if title is not None and title != filename:
-            try:
-                renamed = await self.rename(notebook_id, source_id, title)
-                # Only merge the new title onto the waited source. rename()'s
-                # response shape can be sparse (UPDATE_SOURCE sometimes returns
-                # just an id + title) and would otherwise null out _type_code,
-                # url, and created_at that wait_until_ready() populated. Fall
-                # back to the requested title if rename's response omits it.
-                source = replace(source, title=renamed.title or title)
-            except (RPCError, NetworkError):
-                # Don't fail the whole upload if the rename fails — the file is
-                # already uploaded and registered. Surface a warning so the
-                # caller can retry. The registered source (from the forced wait
-                # above) is returned with its server-side title.
-                logger.warning(
-                    "Source %s uploaded but rename to %r failed",
-                    source_id,
-                    title,
-                    exc_info=True,
-                )
-
-        return source
+        return await self._uploader.add_file(
+            notebook_id,
+            file_path,
+            mime_type=mime_type,
+            wait=wait,
+            wait_timeout=wait_timeout,
+            title=title,
+            on_progress=on_progress,
+            deprecation_warning_stacklevel=3,
+            capabilities=self._capabilities,
+            register_file_source=self._register_file_source,
+            start_resumable_upload=self._start_resumable_upload,
+            upload_file_streaming=self._upload_file_streaming,
+            wait_until_ready=self.wait_until_ready,
+            wait_until_registered=self.wait_until_registered,
+            rename=self.rename,
+            logger=logger,
+        )
 
     async def add_drive(
         self,
@@ -1119,59 +889,10 @@ class SourcesAPI:
 
     async def _register_file_source(self, notebook_id: str, filename: str) -> str:
         """Register a file source intent and get SOURCE_ID."""
-        # Note: filename is double-nested: [[filename]], not triple-nested
-        params = [
-            [[filename]],
+        return await self._uploader.register_file_source(
             notebook_id,
-            [2],
-            [1, None, None, None, None, None, None, None, None, None, [1]],
-        ]
-
-        # allow_null=False: ADD_SOURCE_FILE should always return the source id
-        # on success. When the server quietly returns null with a status code
-        # at wrb.fr[5] — the suspected #474 mode for account-routing mismatches
-        # (issues #114, #294) — the decoder enriches the error with that code
-        # and an account-routing hint. Surface that diagnostic to the caller
-        # via SourceAddError, instead of swallowing the null with allow_null=True
-        # and raising a generic "Failed to get SOURCE_ID" with no detail.
-        #
-        # AuthError, RateLimitError, and ServerError are allowed to propagate
-        # unchanged so callers can keep using their specific exception types
-        # for auth-refresh retry, rate-limit back-off, and server-error handling
-        # without having to unwrap SourceAddError.cause.
-        try:
-            result = await self._core.rpc_call(
-                RPCMethod.ADD_SOURCE_FILE,
-                params,
-                source_path=f"/notebook/{notebook_id}",
-                allow_null=False,
-            )
-        except (AuthError, RateLimitError, ServerError):
-            raise
-        except RPCError as exc:
-            raise SourceAddError(
-                filename,
-                cause=exc,
-                message=f"Failed to register file source for {filename}: {exc}",
-            ) from exc
-
-        source_id = _extract_register_file_source_id(result, filename)
-        if source_id:
-            return source_id
-
-        # The decoder returned a non-null payload that the walker couldn't
-        # parse — a genuine shape drift, not a null-result rejection. Include
-        # a faithful preview of the actual response (repr, not json — repr
-        # surfaces types the walker rejected) so future drift produces an
-        # actionable bug report (#474).
-        preview = repr(result)
-        if len(preview) > 200:
-            preview = preview[:200] + "..."
-        raise SourceAddError(
             filename,
-            message=(
-                f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
-            ),
+            rpc_call=self._rpc_call,
         )
 
     async def _start_resumable_upload(
@@ -1182,54 +903,15 @@ class SourcesAPI:
         source_id: str,
     ) -> str:
         """Start a resumable upload session and get the upload URL."""
-        import json
-
-        auth_route = self._capabilities.authuser_header()
-        base_url = get_base_url()
-        url = f"{get_upload_url()}?{self._capabilities.authuser_query()}"
-
-        headers = {
-            "Accept": "*/*",
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "Origin": base_url,
-            "Referer": f"{base_url}/",
-            "x-goog-authuser": auth_route,
-            "x-goog-upload-command": "start",
-            "x-goog-upload-header-content-length": str(file_size),
-            "x-goog-upload-protocol": "resumable",
-        }
-
-        body = json.dumps(
-            {
-                "PROJECT_ID": notebook_id,
-                "SOURCE_NAME": filename,
-                "SOURCE_ID": source_id,
-            }
+        return await self._uploader.start_resumable_upload(
+            notebook_id,
+            filename,
+            file_size,
+            source_id,
+            capabilities=self._capabilities,
+            resolve_upload_timeout=self._resolve_upload_timeout,
+            async_client_factory=httpx.AsyncClient,
         )
-
-        # Pass the live cookie jar (not a flat Cookie header) so httpx scopes
-        # cookies by Domain attribute, matching browser behavior. The /upload/_/
-        # endpoint is served by Scotty, which validates host-sensitive cookies
-        # (notably OSID) against the request host: an OSID issued for
-        # myaccount.google.com leaked to notebooklm.google.com is rejected with
-        # HTTP 500 and x-goog-upload-status: final. A real browser would never
-        # send the foreign-host OSID; Domain-scoping the jar enforces the same.
-        # Using get_http_client().cookies (instead of auth.cookie_jar) so we
-        # pick up SIDCC/SIDTS rotations applied during the live session. See #373.
-        async with httpx.AsyncClient(
-            timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=60.0)),
-            cookies=self._capabilities.live_cookies(),
-        ) as client:
-            response = await client.post(url, headers=headers, content=body)
-            response.raise_for_status()
-
-            upload_url = response.headers.get("x-goog-upload-url")
-            if not upload_url:
-                raise SourceAddError(
-                    filename, message="Failed to get upload URL from response headers"
-                )
-
-            return upload_url
 
     async def _upload_file_streaming(
         self,
@@ -1297,162 +979,18 @@ class SourcesAPI:
                 path; inferred from the path for legacy direct-call tests when
                 omitted.
         """
-        # Discriminate: caller passed an open FD (the T7.D3 add_file path),
-        # or a Path (legacy direct-call test path — opens locally). The
-        # ``add_file`` callsite always takes the FD branch; the Path branch
-        # exists only so the existing _upload_file_streaming unit tests
-        # don't need to set up their own ``open()`` machinery.
-        path_fallback: Path | None = file_obj if isinstance(file_obj, Path) else None
-        # The "donecallback wired" sentinel — flipped to True only AFTER
-        # ``add_done_callback`` registers the FD-close hook on
-        # ``finalize_task``. If the function raises BEFORE that flip,
-        # we synchronously close the FD ourselves so a caller that
-        # transferred ownership doesn't leak.
-        close_wired = False
-        try:
-            base_url = get_base_url()
-            auth_route = self._capabilities.authuser_header()
-            headers = {
-                "Accept": "*/*",
-                "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-                "x-goog-authuser": auth_route,
-                "Origin": base_url,
-                "Referer": f"{base_url}/",
-                "x-goog-upload-command": "upload, finalize",
-                "x-goog-upload-offset": "0",
-            }
-            diag_name = filename or (path_fallback.name if path_fallback is not None else "<file>")
-            logger.debug("Streaming upload to %s for %s", upload_url, diag_name)
-            if total_bytes is None and path_fallback is not None:
-                total_bytes = path_fallback.stat().st_size
-            progress_total = total_bytes if total_bytes is not None else 0
-            uploaded_bytes = 0
-
-            if on_progress is not None:
-                await maybe_await_callback(on_progress, uploaded_bytes, progress_total)
-
-            # Stream the file content instead of loading it all into memory.
-            # When the caller passed an FD, we read directly from it (single
-            # open() per add_file call). When the caller passed a Path
-            # (legacy direct-call), we open here as a one-off helper whose
-            # ``with`` closes the locally-opened FD when the generator ends.
-            async def file_stream():
-                nonlocal uploaded_bytes
-                # T7.D2 / audit §22: chunk reads are synchronous file I/O.
-                # On slow storage (network FS, encrypted home, large PDFs
-                # served from a cold cache) a bare ``f.read(65536)`` from
-                # an ``async`` context stalls the entire event loop for
-                # the duration of each chunk read. Wrap each read with
-                # ``asyncio.to_thread`` so the blocking syscall runs on
-                # the default thread executor and sibling tasks (auth
-                # refresh, heartbeats, the cancellation watchdog above)
-                # keep making progress while bytes stream in.
-                if path_fallback is not None:
-                    with open(path_fallback, "rb") as f:
-                        while chunk := await asyncio.to_thread(f.read, 65536):  # 64KB chunks
-                            uploaded_bytes += len(chunk)
-                            if on_progress is not None:
-                                await maybe_await_callback(
-                                    on_progress, uploaded_bytes, progress_total
-                                )
-                            yield chunk
-                    return
-                # FD path: caller transferred ownership to this helper; we
-                # do NOT use a ``with`` here — the FD is closed by the
-                # done-callback on ``finalize_task`` below so the shielded
-                # background task can still read from it under post-finalize
-                # cancel.
-                assert not isinstance(file_obj, Path)  # narrowed by branch above
-                while chunk := await asyncio.to_thread(file_obj.read, 65536):  # 64KB chunks
-                    uploaded_bytes += len(chunk)
-                    if on_progress is not None:
-                        await maybe_await_callback(on_progress, uploaded_bytes, progress_total)
-                    yield chunk
-
-            # `finalize_started` flips after the local ``httpx.AsyncClient``
-            # context enters and immediately before ``client.post(...)``. There
-            # is no ``await`` between the flip and the POST, so asyncio cannot
-            # deliver a cancel in that window — once the flag is True, the
-            # request is effectively in flight. On cancel we discriminate:
-            #   - True  → shield is keeping the in-flight POST alive; just re-raise.
-            #   - False → no POST went out, so fire a best-effort Scotty cancel.
-            finalize_started = False
-
-            async def _do_finalize() -> None:
-                nonlocal finalize_started
-                # See _start_resumable_upload: pass the live cookie jar so
-                # httpx scopes cookies per Domain attribute. Scotty validates
-                # OSID against host and rejects foreign-host cookies. (#373)
-                async with httpx.AsyncClient(
-                    timeout=self._resolve_upload_timeout(httpx.Timeout(10.0, read=300.0)),
-                    cookies=self._capabilities.live_cookies(),
-                ) as client:
-                    finalize_started = True
-                    response = await client.post(upload_url, headers=headers, content=file_stream())
-                    response.raise_for_status()
-
-            def _on_finalize_done(t: asyncio.Task[None]) -> None:
-                # Close the FD owned-by-this-helper (T7.D3 ownership transfer).
-                # Fires whether the task completed normally, raised, or was
-                # cancelled — including the post-finalize background-drain
-                # branch where the caller is long gone. The Path-branch
-                # closes its FD inside the generator's ``with`` block and
-                # does NOT need this hook.
-                if path_fallback is None:
-                    # path_fallback is None ⇔ file_obj is not a Path (see
-                    # line 1545 where path_fallback is derived).
-                    try:
-                        file_obj.close()  # type: ignore[union-attr]
-                    except Exception as close_exc:  # noqa: BLE001 — defensive
-                        # Already-closed / detached FD: harmless. Log at debug
-                        # so a real misconfiguration is still discoverable.
-                        logger.debug("Caller FD close in finalize-done failed: %r", close_exc)
-                # On post-finalize cancel, ``finalize_task`` keeps running in
-                # the background. Without this callback, an unawaited
-                # exception (e.g. server 5xx) would surface as a noisy
-                # "Task exception was never retrieved" asyncio warning.
-                if not t.cancelled() and (exc := t.exception()) is not None:
-                    logger.debug("Background finalize POST failed: %r", exc)
-
-            finalize_task = asyncio.create_task(_do_finalize())
-            finalize_task.add_done_callback(_on_finalize_done)
-            # FD-close is now wired to fire on task completion. Even if the
-            # ``await asyncio.shield(...)`` below raises, the done-callback
-            # will close the caller-owned FD when the (possibly cancelled,
-            # possibly shielded-into-the-background) task transitions to
-            # done. From this point we no longer need the synchronous
-            # ``finally`` fallback.
-            close_wired = True
-            try:
-                await asyncio.shield(finalize_task)
-            except asyncio.CancelledError:
-                if not finalize_started:
-                    # Pre-finalize cancel: the POST never went out. Cancel
-                    # the still-setting-up inner task and fire a best-effort
-                    # Scotty cancel so the resumable upload session doesn't
-                    # dangle until the server's GC sweeps it.
-                    finalize_task.cancel()
-                    asyncio.create_task(
-                        self._cancel_upload_session(upload_url, base_url, auth_route)
-                    )
-                # Post-finalize cancel: asyncio.shield is keeping the inner
-                # task alive; let it run to completion in the background,
-                # then propagate the cancel as the caller requested.
-                raise
-        except BaseException:
-            # Pre-task-creation raise (or pre-``add_done_callback`` raise):
-            # nothing else will close the caller-owned FD. Do it
-            # synchronously so a transferred FD doesn't leak. Once the
-            # done-callback is wired (``close_wired=True``), the task's
-            # done-callback handles close on every termination path,
-            # so we skip the local close to avoid double-close.
-            if not close_wired and path_fallback is None:
-                # path_fallback is None ⇔ file_obj is not a Path.
-                try:
-                    file_obj.close()  # type: ignore[union-attr]
-                except Exception as close_exc:  # noqa: BLE001 — defensive
-                    logger.debug("Caller FD close on pre-wire exception failed: %r", close_exc)
-            raise
+        return await self._uploader.upload_file_streaming(
+            upload_url,
+            file_obj,
+            filename=filename,
+            on_progress=on_progress,
+            total_bytes=total_bytes,
+            capabilities=self._capabilities,
+            resolve_upload_timeout=self._resolve_upload_timeout,
+            async_client_factory=httpx.AsyncClient,
+            cancel_upload_session=self._cancel_upload_session,
+            logger=logger,
+        )
 
     async def _cancel_upload_session(self, upload_url: str, base_url: str, auth_route: str) -> None:
         """Best-effort POST a Scotty resumable-upload cancel command.
@@ -1468,19 +1006,11 @@ class SourcesAPI:
         outer await chain that can deliver a cancellation here, so no
         extra shield is needed at this layer.
         """
-        headers = {
-            "Accept": "*/*",
-            "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-            "x-goog-authuser": auth_route,
-            "Origin": base_url,
-            "Referer": f"{base_url}/",
-            "x-goog-upload-command": "cancel",
-        }
-        try:
-            async with httpx.AsyncClient(
-                timeout=httpx.Timeout(10.0, read=10.0),
-                cookies=self._capabilities.live_cookies(),
-            ) as client:
-                await client.post(upload_url, headers=headers)
-        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
-            logger.debug("Best-effort Scotty cancel for %s failed: %r", upload_url, exc)
+        await self._uploader.cancel_upload_session(
+            upload_url,
+            base_url,
+            auth_route,
+            capabilities=self._capabilities,
+            async_client_factory=httpx.AsyncClient,
+            logger=logger,
+        )

--- a/tests/integration/concurrency/test_upload_cancel_dangling_session.py
+++ b/tests/integration/concurrency/test_upload_cancel_dangling_session.py
@@ -110,19 +110,22 @@ async def test_cancel_after_finalize_started_shield_completes_request(
         await asyncio.wait_for(finalize_arrived.wait(), timeout=2.0)
 
         # Cancel the outer task. With the shield in place, the inner POST
-        # keeps running; without the shield, the request is abandoned.
+        # keeps running and the outer helper stays suspended until that
+        # finalize task reaches a terminal state.
         upload_task.cancel()
+        await asyncio.sleep(0)
+        assert not upload_task.done(), (
+            "post-finalize cancel returned before finalize completed; "
+            "add_file would release upload concurrency and transport accounting too early"
+        )
 
         # Release the handler so the inner request can finish.
         # Give the cancel a beat to propagate first, mirroring the real
         # Ctrl-C interleave.
-        await asyncio.sleep(0)
         release.set()
 
-        # The outer task will see CancelledError (shield re-raises after
-        # the inner POST completes — or immediately, with the inner Task
-        # still scheduled). Either way, the captured POST must include
-        # the finalize command.
+        # The outer task sees CancelledError only after the inner POST
+        # completes. The captured POST must include the finalize command.
         with pytest.raises(asyncio.CancelledError):
             await upload_task
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -25,14 +25,8 @@ from notebooklm.client import NotebookLMClient
 
 SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 
-# TODO(architecture-remediation): later capability-migration tasks should move
-# these feature APIs off ClientCore private state and then shrink this baseline
-# to an empty set. Until then, this guard blocks new direct private-state access
-# without failing the legitimate pre-extraction call sites.
-_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS = {
-    ("_sources.py", "_begin_transport_post"): 1,
-    ("_sources.py", "_finish_transport_post"): 1,
-}
+# Feature APIs should not reach into ClientCore private state directly.
+_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS: dict[tuple[str, str], int] = {}
 
 _CORE_PRIVATE_GUARD_EXCLUDED_MODULES = {
     "__init__.py",

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from notebooklm._source_upload import SourceUploadPipeline
+from notebooklm._source_upload import SourceUploadPipeline, _extract_register_file_source_id
 from notebooklm.rpc import RPCError, RPCMethod
 from notebooklm.types import Source, SourceAddError
 
@@ -98,6 +98,12 @@ class RecordingRpc:
 @pytest.fixture
 def service() -> SourceUploadPipeline:
     return SourceUploadPipeline()
+
+
+def test_extract_register_file_source_id_skips_large_string_candidates() -> None:
+    long_payload = " " + ("x" * 2000) + " "
+
+    assert _extract_register_file_source_id([long_payload, "src_123"], "report.pdf") == "src_123"
 
 
 @pytest.mark.asyncio
@@ -202,6 +208,21 @@ async def test_register_file_source_uses_rpc_shape_and_wraps_rpc_error(
             "disable_internal_retries": False,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_register_file_source_truncates_large_string_response_preview(
+    service: SourceUploadPipeline,
+) -> None:
+    rpc = RecordingRpc("x" * 5000)
+
+    with pytest.raises(SourceAddError) as exc_info:
+        await service.register_file_source("nb_123", "report.pdf", rpc_call=rpc)
+
+    message = str(exc_info.value)
+    assert "..." in message
+    assert "x" * 300 not in message
+    assert len(message) < 320
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -1,0 +1,235 @@
+"""Unit tests for the private source upload pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from notebooklm._source_upload import SourceUploadPipeline
+from notebooklm.rpc import RPCError, RPCMethod
+from notebooklm.types import Source, SourceAddError
+
+
+class UploadRuntime:
+    def __init__(self) -> None:
+        self.semaphore = asyncio.Semaphore(1)
+        self.queue_waits: list[float] = []
+        self.labels: list[str] = []
+        self.finished: list[object] = []
+
+    def get_upload_semaphore(self) -> asyncio.Semaphore:
+        return self.semaphore
+
+    def record_upload_queue_wait(self, wait_seconds: float) -> None:
+        self.queue_waits.append(wait_seconds)
+
+    async def begin_transport_post(self, log_label: str) -> object:
+        token = object()
+        self.labels.append(log_label)
+        return token
+
+    async def begin_transport_task(
+        self,
+        task: asyncio.Task[Any],
+        log_label: str,
+    ) -> object:
+        self.labels.append(log_label)
+        return object()
+
+    async def finish_transport_post(self, token: object) -> None:
+        self.finished.append(token)
+
+
+class HttpRuntime:
+    def __init__(self) -> None:
+        self.cookies = httpx.Cookies()
+
+    @property
+    def authuser(self) -> int:
+        return 0
+
+    @property
+    def account_email(self) -> str | None:
+        return None
+
+    def authuser_query(self) -> str:
+        return "authuser=0"
+
+    def authuser_header(self) -> str:
+        return "0"
+
+    def live_cookies(self) -> httpx.Cookies:
+        return self.cookies
+
+
+class RecordingRpc:
+    def __init__(self, response: Any | BaseException) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        self.calls.append(
+            {
+                "method": method,
+                "params": params,
+                "source_path": source_path,
+                "allow_null": allow_null,
+                "disable_internal_retries": disable_internal_retries,
+            }
+        )
+        if isinstance(self.response, BaseException):
+            raise self.response
+        return self.response
+
+
+@pytest.fixture
+def service() -> SourceUploadPipeline:
+    return SourceUploadPipeline()
+
+
+@pytest.mark.asyncio
+async def test_add_file_uses_late_bound_hooks_and_finishes_transport(
+    service: SourceUploadPipeline,
+    tmp_path,
+) -> None:
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"hello")
+    runtime = UploadRuntime()
+
+    register_file_source = AsyncMock(return_value="src_123")
+    start_resumable_upload = AsyncMock(return_value="https://upload.example.com/session")
+
+    async def upload_file_streaming(upload_url, file_obj, **kwargs):
+        assert upload_url == "https://upload.example.com/session"
+        assert file_obj.read() == b"hello"
+        assert kwargs["filename"] == "report.pdf"
+        assert kwargs["total_bytes"] == 5
+        file_obj.close()
+
+    source = await service.add_file(
+        "nb_123",
+        file_path,
+        capabilities=runtime,
+        register_file_source=register_file_source,
+        start_resumable_upload=start_resumable_upload,
+        upload_file_streaming=upload_file_streaming,
+        wait_until_ready=AsyncMock(),
+        wait_until_registered=AsyncMock(),
+        rename=AsyncMock(),
+        logger=MagicMock(),
+    )
+
+    assert source.id == "src_123"
+    assert source.title == "report.pdf"
+    assert source.is_processing
+    assert runtime.labels == ["source upload report.pdf"]
+    assert len(runtime.finished) == 1
+    register_file_source.assert_awaited_once_with("nb_123", "report.pdf")
+    start_resumable_upload.assert_awaited_once_with("nb_123", "report.pdf", 5, "src_123")
+
+
+@pytest.mark.asyncio
+async def test_add_file_custom_title_waits_for_registration_before_rename(
+    service: SourceUploadPipeline,
+    tmp_path,
+) -> None:
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"hello")
+    runtime = UploadRuntime()
+    registered = Source(id="src_123", title="report.pdf", _type_code=7, url="https://source")
+    renamed = Source(id="src_123", title="Custom")
+    wait_until_registered = AsyncMock(return_value=registered)
+    rename = AsyncMock(return_value=renamed)
+
+    async def upload_file_streaming(_upload_url, file_obj, **_kwargs):
+        file_obj.close()
+
+    source = await service.add_file(
+        "nb_123",
+        file_path,
+        title="  Custom  ",
+        wait_timeout=45.0,
+        capabilities=runtime,
+        register_file_source=AsyncMock(return_value="src_123"),
+        start_resumable_upload=AsyncMock(return_value="https://upload.example.com/session"),
+        upload_file_streaming=upload_file_streaming,
+        wait_until_ready=AsyncMock(),
+        wait_until_registered=wait_until_registered,
+        rename=rename,
+        logger=MagicMock(),
+    )
+
+    assert source == Source(id="src_123", title="Custom", _type_code=7, url="https://source")
+    wait_until_registered.assert_awaited_once_with("nb_123", "src_123", timeout=45.0)
+    rename.assert_awaited_once_with("nb_123", "src_123", "Custom")
+
+
+@pytest.mark.asyncio
+async def test_register_file_source_uses_rpc_shape_and_wraps_rpc_error(
+    service: SourceUploadPipeline,
+) -> None:
+    rpc_error = RPCError("bad response")
+    rpc = RecordingRpc(rpc_error)
+
+    with pytest.raises(SourceAddError) as exc_info:
+        await service.register_file_source("nb_123", "report.pdf", rpc_call=rpc)
+
+    assert exc_info.value.cause is rpc_error
+    assert rpc.calls == [
+        {
+            "method": RPCMethod.ADD_SOURCE_FILE,
+            "params": [
+                [["report.pdf"]],
+                "nb_123",
+                [2],
+                [1, None, None, None, None, None, None, None, None, None, [1]],
+            ],
+            "source_path": "/notebook/nb_123",
+            "allow_null": False,
+            "disable_internal_retries": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_start_resumable_upload_uses_injected_http_client(
+    service: SourceUploadPipeline,
+) -> None:
+    response = MagicMock()
+    response.headers = {"x-goog-upload-url": "https://upload.example.com/session"}
+    response.raise_for_status = MagicMock()
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=response)
+    client_cm = AsyncMock()
+    client_cm.__aenter__.return_value = client
+    client_factory = MagicMock(return_value=client_cm)
+    runtime = HttpRuntime()
+
+    upload_url = await service.start_resumable_upload(
+        "nb_123",
+        "report.pdf",
+        12,
+        "src_123",
+        capabilities=runtime,
+        resolve_upload_timeout=lambda default: default,
+        async_client_factory=client_factory,
+    )
+
+    assert upload_url == "https://upload.example.com/session"
+    assert client_factory.call_args.kwargs["cookies"] is runtime.cookies
+    request = client.post.await_args
+    assert request.kwargs["headers"]["x-goog-upload-command"] == "start"
+    assert '"SOURCE_ID": "src_123"' in request.kwargs["content"]

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
 from notebooklm.exceptions import NetworkError, RPCError, ValidationError
 from notebooklm.rpc.types import SourceStatus
@@ -75,6 +76,9 @@ def _self_core_http_client_cookies_read(node: ast.AST) -> bool:
         SourcesAPI._start_resumable_upload,
         SourcesAPI._upload_file_streaming,
         SourcesAPI._cancel_upload_session,
+        SourceUploadPipeline.start_resumable_upload,
+        SourceUploadPipeline.upload_file_streaming,
+        SourceUploadPipeline.cancel_upload_session,
     ],
 )
 def test_upload_helpers_do_not_read_core_auth_or_live_cookies_directly(helper):
@@ -854,11 +858,12 @@ class TestAddFile:
             mock_client.post.side_effect = [mock_start_response, mock_upload_response]
             mock_client_cls.return_value = mock_client
 
-            with pytest.warns(DeprecationWarning, match="mime_type"):
+            with pytest.warns(DeprecationWarning, match="mime_type") as caught:
                 result = await sources_api.add_file("nb_123", str(test_file), mime_type="image/png")
 
         # Deprecation is non-fatal: the upload still completes normally.
         assert result.id == "src_png"
+        assert caught[0].filename.endswith("test_sources_upload.py")
 
     @pytest.mark.asyncio
     async def test_add_file_mime_type_none_does_not_warn(self, sources_api, mock_core, tmp_path):


### PR DESCRIPTION
## Summary
- Move file-source registration, resumable upload startup, streaming finalize, and cancel handling into SourceUploadPipeline.
- Keep SourcesAPI as the compatibility facade with existing private helper names and patch points preserved.
- Add direct pipeline tests plus guardrails proving upload helpers route through capabilities rather than ClientCore internals.

## Compatibility
- Public and private facade method signatures are preserved.
- Existing monkeypatch targets such as SourcesAPI._register_file_source, SourcesAPI._start_resumable_upload, SourcesAPI._upload_file_streaming, and notebooklm._sources.httpx.AsyncClient remain effective.
- DeprecationWarning stacklevel is preserved so add_file callers still receive the warning at their call site.

## Polish / Review Receipt
- Native simplification pass completed; no behavior-only cleanup needed.
- Triple review completed: Gemini OKAY, Claude OKAY, Codex OKAY after fixing warning stacklevel and AST guard coverage.
- Final architecture pass found no blocking edge-case, error-handling, performance, maintainability, security, or test gaps.

## Verification
- rtk uv run pytest tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py tests/integration/concurrency/test_add_file_toctou.py tests/unit/test_source_symlink.py tests/unit/test_env_base_url.py tests/unit/test_observability.py tests/unit/test_init_order.py tests/unit/test_capabilities.py
- rtk uv run pytest tests/unit/test_sources_integration.py -q
- rtk uv run ruff check src/notebooklm/_source_upload.py src/notebooklm/_sources.py tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py tests/unit/test_init_order.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py tests/integration/concurrency/test_add_file_toctou.py tests/unit/test_source_symlink.py tests/unit/test_env_base_url.py tests/unit/test_observability.py tests/unit/test_capabilities.py tests/unit/test_sources_integration.py
- rtk uv run ruff format --check src/notebooklm/_source_upload.py src/notebooklm/_sources.py tests/unit/test_source_upload_pipeline.py tests/unit/test_sources_upload.py tests/unit/test_init_order.py tests/integration/concurrency/test_upload_timeout_config.py tests/integration/concurrency/test_upload_blocks_loop.py tests/integration/concurrency/test_upload_cancel_dangling_session.py tests/integration/concurrency/test_add_file_toctou.py tests/unit/test_source_symlink.py tests/unit/test_env_base_url.py tests/unit/test_observability.py tests/unit/test_capabilities.py tests/unit/test_sources_integration.py
- rtk uv run mypy src/notebooklm
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved file uploads: resumable streaming, progress reporting, robust cancellation, and clearer error messages with safer rename attempts.

* **Refactor**
  * Centralized upload logic into a reusable pipeline for more reliable and maintainable uploads.

* **Bug Fixes**
  * Hardened cancellation/shielding behavior during finalize to avoid dangling sessions.

* **Tests**
  * Expanded unit and integration tests covering upload flows, ID heuristics, error truncation, rename/wait behavior, and HTTP interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/683?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->