### PR TITLE
test(notebooks): characterize composition seams

### DIFF
--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -376,6 +376,56 @@ def test_source_service_modules_do_not_runtime_import_facades_or_core() -> None:
     assert forbidden_by_module == {}
 
 
+def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> None:
+    """Phase 9 notebook metadata work depends on the final Phase 8 lister name."""
+    from notebooklm._source_listing import SourceLister
+    from notebooklm._sources import SourcesAPI
+
+    core = MagicMock()
+    api = SourcesAPI(core)
+
+    assert isinstance(api._lister, SourceLister)
+
+
+def test_phase7_artifact_mind_map_patch_seams_are_current() -> None:
+    """Final artifact services must still resolve mind-map seams via ``_artifacts``."""
+    import notebooklm._artifact_downloads as artifact_downloads
+    import notebooklm._artifact_generation as artifact_generation
+    import notebooklm._artifacts as artifacts
+    import notebooklm._mind_map as mind_map
+
+    assert artifacts._mind_map is mind_map
+    assert artifact_generation._artifact_seams()._mind_map is mind_map
+    assert artifact_downloads._artifact_seams()._mind_map is mind_map
+
+
+@pytest.mark.xfail(
+    raises=AssertionError,
+    strict=True,
+    reason="T10a removes hidden SourcesAPI construction from NotebooksAPI.",
+)
+def test_notebooks_api_has_no_hidden_sources_api_runtime_dependency() -> None:
+    """TODO(T10a): remove xfail after direct metadata fallback no longer uses SourcesAPI."""
+    tree = ast.parse((SRC_ROOT / "_notebooks.py").read_text(encoding="utf-8"))
+    visitor = _RuntimeImportVisitor(
+        forbidden_names={"SourcesAPI"},
+        forbidden_modules={"_sources", "notebooklm._sources"},
+    )
+    visitor.visit(tree)
+
+    sources_api_constructions: list[int] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "SourcesAPI"
+        ):
+            sources_api_constructions.append(node.lineno)
+
+    assert visitor.forbidden == []
+    assert sources_api_constructions == []
+
+
 def test_core_private_access_guard_detects_simple_aliases() -> None:
     tree = ast.parse(
         """

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -142,6 +142,23 @@ async def test_get_metadata_warns_when_notebook_reports_sources_but_listing_is_e
 
 
 @pytest.mark.asyncio
+async def test_get_metadata_does_not_warn_when_empty_notebook_listing_is_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    core = _make_core()
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(return_value=[])
+    api = NotebooksAPI(core, sources_api=source_lister)
+    api.get = AsyncMock(return_value=Notebook(id="nb_123", title="Empty", sources_count=0))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._notebooks"):
+        metadata = await api.get_metadata("nb_123")
+
+    assert metadata.sources == []
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
 async def test_share_sends_exact_share_artifact_payload_and_returns_deep_link(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -1,5 +1,7 @@
 """Unit tests for notebook operations."""
 
+import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -12,12 +14,17 @@ from notebooklm.exceptions import (
     RPCError,
 )
 from notebooklm.rpc import RPCMethod
-from notebooklm.types import AccountLimits, Notebook
+from notebooklm.types import AccountLimits, Notebook, NotebookMetadata, Source, SourceType
+
+
+def _make_core() -> MagicMock:
+    core = MagicMock()
+    core.rpc_call = AsyncMock()
+    return core
 
 
 def _make_api() -> NotebooksAPI:
-    core = MagicMock()
-    core.rpc_call = AsyncMock()
+    core = _make_core()
     return NotebooksAPI(core, sources_api=MagicMock())
 
 
@@ -41,6 +48,147 @@ def _create_invalid_argument_error(
 
 def test_build_create_notebook_params_matches_live_payload() -> None:
     assert build_create_notebook_params("Daily News") == ["Daily News", None, None, [2], [1]]
+
+
+def test_direct_notebooks_api_construction_remains_supported() -> None:
+    core = _make_core()
+    api = NotebooksAPI(core)
+
+    assert hasattr(api, "_sources")
+
+
+@pytest.mark.asyncio
+async def test_get_metadata_uses_injected_source_lister_and_builds_summaries() -> None:
+    core = _make_core()
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(
+        return_value=[
+            Source(
+                id="src_1",
+                title="Architecture Notes",
+                url="https://example.com/notes",
+                _type_code=5,  # SourceType.WEB_PAGE
+            )
+        ]
+    )
+    api = NotebooksAPI(core, sources_api=source_lister)
+    api.get = AsyncMock(return_value=Notebook(id="nb_123", title="Architecture", sources_count=1))
+
+    metadata = await api.get_metadata("nb_123")
+
+    assert isinstance(metadata, NotebookMetadata)
+    assert metadata.notebook == Notebook(id="nb_123", title="Architecture", sources_count=1)
+    assert len(metadata.sources) == 1
+    assert metadata.sources[0].kind == SourceType.WEB_PAGE
+    assert metadata.sources[0].title == "Architecture Notes"
+    assert metadata.sources[0].url == "https://example.com/notes"
+    api.get.assert_awaited_once_with("nb_123")
+    source_lister.list.assert_awaited_once_with("nb_123")
+
+
+@pytest.mark.asyncio
+async def test_get_metadata_fetches_notebook_and_sources_concurrently() -> None:
+    core = _make_core()
+    source_lister = MagicMock()
+    get_started = asyncio.Event()
+    list_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def get_notebook(notebook_id: str) -> Notebook:
+        assert notebook_id == "nb_123"
+        get_started.set()
+        await list_started.wait()
+        await release.wait()
+        return Notebook(id="nb_123", title="Concurrent", sources_count=1)
+
+    async def list_sources(notebook_id: str) -> list[Source]:
+        assert notebook_id == "nb_123"
+        list_started.set()
+        await get_started.wait()
+        await release.wait()
+        return [Source(id="src_1", title="Paper", _type_code=3)]  # SourceType.PDF
+
+    source_lister.list = AsyncMock(side_effect=list_sources)
+    api = NotebooksAPI(core, sources_api=source_lister)
+    api.get = AsyncMock(side_effect=get_notebook)
+
+    metadata_task = asyncio.create_task(api.get_metadata("nb_123"))
+    await asyncio.wait_for(get_started.wait(), timeout=1)
+    await asyncio.wait_for(list_started.wait(), timeout=1)
+    assert not metadata_task.done()
+
+    release.set()
+    metadata = await metadata_task
+
+    assert metadata.notebook.title == "Concurrent"
+    assert metadata.sources[0].kind == SourceType.PDF
+
+
+@pytest.mark.asyncio
+async def test_get_metadata_warns_when_notebook_reports_sources_but_listing_is_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    core = _make_core()
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(return_value=[])
+    api = NotebooksAPI(core, sources_api=source_lister)
+    api.get = AsyncMock(return_value=Notebook(id="nb_123", title="Sparse", sources_count=2))
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._notebooks"):
+        metadata = await api.get_metadata("nb_123")
+
+    assert metadata.sources == []
+    assert "Notebook nb_123 reports 2 sources but listing returned empty" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_share_sends_exact_share_artifact_payload_and_returns_deep_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+    api = _make_api()
+
+    result = await api.share("nb_123", public=True, artifact_id="art_456")
+
+    assert result == {
+        "public": True,
+        "url": "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456",
+        "artifact_id": "art_456",
+    }
+    api._core.rpc_call.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[1], "nb_123", "art_456"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_private_sends_disable_payload_and_returns_no_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+    api = _make_api()
+
+    result = await api.share("nb_123", public=False)
+
+    assert result == {"public": False, "url": None, "artifact_id": None}
+    api._core.rpc_call.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[0], "nb_123"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+    )
+
+
+def test_get_share_url_remains_sync_url_formatter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
+    api = _make_api()
+
+    url = api.get_share_url("nb_123", artifact_id="art_456")
+
+    assert isinstance(url, str)
+    assert url == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
 
 
 def _set_account_limit(api: NotebooksAPI, limit: int | None) -> AsyncMock:

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -1,10 +1,14 @@
 """Unit tests for NotesAPI private helpers and edge cases."""
 
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
+from notebooklm import _mind_map
 from notebooklm._notes import NotesAPI
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import Note
 
 
 @pytest.fixture
@@ -19,6 +23,106 @@ def mock_core():
 def notes_api(mock_core):
     """Create NotesAPI with mocked core."""
     return NotesAPI(mock_core)
+
+
+class TestMindMapCreateNotePrimitive:
+    """Characterize the shared mind-map note primitive before Phase 9 movement."""
+
+    @pytest.mark.asyncio
+    async def test_create_note_uses_create_then_update_and_returns_note(self, mock_core):
+        mock_core.rpc_call.side_effect = [[["note_123"]], None]
+
+        note = await _mind_map.create_note(
+            mock_core,
+            "nb_123",
+            title="Mind Map",
+            content='{"children":[]}',
+        )
+
+        assert note == Note(
+            id="note_123",
+            notebook_id="nb_123",
+            title="Mind Map",
+            content='{"children":[]}',
+        )
+        assert mock_core.rpc_call.await_args_list == [
+            call(
+                RPCMethod.CREATE_NOTE,
+                ["nb_123", "", [1], None, "Mind Map"],
+                source_path="/notebook/nb_123",
+            ),
+            call(
+                RPCMethod.UPDATE_NOTE,
+                ["nb_123", "note_123", [[['{"children":[]}', "Mind Map", [], 0]]]],
+                source_path="/notebook/nb_123",
+                allow_null=True,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_note_cancellation_schedules_best_effort_cleanup(
+        self,
+        mock_core,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        mock_core.rpc_call.return_value = [["note_123"]]
+        update_started = asyncio.Event()
+        update_can_finish = asyncio.Event()
+        update_finished = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        cleanup_can_finish = asyncio.Event()
+        cleanup_finished = asyncio.Event()
+
+        async def fake_update_note(
+            core,
+            notebook_id: str,
+            note_id: str,
+            content: str,
+            title: str,
+        ) -> None:
+            assert core is mock_core
+            assert (notebook_id, note_id, content, title) == (
+                "nb_123",
+                "note_123",
+                "body",
+                "Title",
+            )
+            update_started.set()
+            try:
+                await update_can_finish.wait()
+            finally:
+                update_finished.set()
+
+        async def fake_delete_note_best_effort(core, notebook_id: str, note_id: str) -> None:
+            assert core is mock_core
+            assert (notebook_id, note_id) == ("nb_123", "note_123")
+            cleanup_started.set()
+            try:
+                await cleanup_can_finish.wait()
+            finally:
+                cleanup_finished.set()
+
+        monkeypatch.setattr(_mind_map, "update_note", fake_update_note)
+        monkeypatch.setattr(_mind_map, "_delete_note_best_effort", fake_delete_note_best_effort)
+
+        task = asyncio.create_task(
+            _mind_map.create_note(mock_core, "nb_123", title="Title", content="body")
+        )
+        await asyncio.wait_for(update_started.wait(), timeout=1)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
+
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        assert not cleanup_finished.is_set()
+        # ``asyncio.shield`` keeps UPDATE_NOTE running after the outer task is cancelled.
+        assert not update_finished.is_set()
+
+        update_can_finish.set()
+        await asyncio.wait_for(update_finished.wait(), timeout=1)
+        cleanup_can_finish.set()
+        await asyncio.wait_for(cleanup_finished.wait(), timeout=1)
 
 
 # =============================================================================

--- a/tests/unit/test_notes_unit.py
+++ b/tests/unit/test_notes_unit.py
@@ -115,6 +115,7 @@ class TestMindMapCreateNotePrimitive:
             await asyncio.wait_for(task, timeout=1)
 
         await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        # Cleanup is scheduled but not awaited before the outer cancellation propagates.
         assert not cleanup_finished.is_set()
         # ``asyncio.shield`` keeps UPDATE_NOTE running after the outer task is cancelled.
         assert not update_finished.is_set()


### PR DESCRIPTION
## Summary
- Add T10.0 characterization tests for notebook metadata source-listing injection, concurrent fetch behavior, share payload/URL formatting, and direct NotebooksAPI construction.
- Pin final Phase 7/8 seam names for artifact mind-map patching and SourceLister facade wiring.
- Add strict xfail guard for the hidden SourcesAPI runtime dependency that T10a must activate, plus direct _mind_map.create_note create/update/cancellation coverage.

## Task
- Phase 9 T10.0: `.sisyphus/phases/architecture-remediation/phase-9.md#t100---promotion-audit-and-characterization`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_notebook_api.py tests/unit/test_notebooks_integration.py tests/unit/test_sharing_integration.py tests/unit/test_sharing_types.py tests/unit/test_notes_unit.py tests/unit/test_artifacts_integration.py tests/unit/test_artifact_downloads.py tests/unit/test_init_order.py`
- [x] `rtk uv run ruff check src/notebooklm/_notebooks.py src/notebooklm/client.py src/notebooklm/_sharing.py src/notebooklm/_mind_map.py src/notebooklm/_notes.py tests/unit/test_notebook_api.py tests/unit/test_notebooks_integration.py tests/unit/test_notes_unit.py tests/unit/test_init_order.py`
- [x] `rtk uv run mypy src/notebooklm`

## Deferred polish findings
- Existing unrelated test-name nit in `tests/unit/test_notes_unit.py` (`test_list_returns_empty_for_null_content`) deferred outside T10.0 scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests to lock module-wiring and mind‑map decoupling invariants (including an xfail for a known T10a case).
  * Expanded notebook API tests for metadata composition, concurrent source fetching, warning vs no-warning behaviors, share payloads and public/private URL results, and synchronous URL formatting.
  * Added mind‑map note-creation tests covering RPC sequence and cancellation semantics with best‑effort cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->