### PR TITLE
refactor(notebooks): extract metadata service

### DIFF
--- a/src/notebooklm/_notebook_metadata.py
+++ b/src/notebooklm/_notebook_metadata.py
@@ -1,0 +1,76 @@
+"""Private notebook metadata composition service."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+from ._source_listing import RpcCall as SourceListingRpcCall
+from ._source_listing import SourceLister as SourceListingService
+from .types import Notebook, NotebookMetadata, Source, SourceSummary
+
+# Preserve the historical warning channel from NotebooksAPI.get_metadata().
+logger = logging.getLogger("notebooklm._notebooks")
+
+
+class NotebookSourceLister(Protocol):
+    """Structural source-listing dependency needed by notebook metadata."""
+
+    async def list(self, notebook_id: str, *, strict: bool = False) -> builtins.list[Source]:
+        """List sources for a notebook."""
+
+
+NotebookGetter = Callable[[str], Awaitable[Notebook]]
+
+
+def create_default_source_lister(rpc_call: SourceListingRpcCall) -> NotebookSourceLister:
+    """Build the direct-construction source lister without constructing SourcesAPI."""
+    return SourceListingService(rpc_call)
+
+
+class NotebookMetadataService:
+    """Compose notebook details and source summaries."""
+
+    def __init__(
+        self,
+        get_notebook: NotebookGetter,
+        source_lister: NotebookSourceLister,
+    ) -> None:
+        self._get_notebook = get_notebook
+        self._source_lister = source_lister
+
+    async def get_metadata(self, notebook_id: str) -> NotebookMetadata:
+        """Get notebook metadata and simplified sources concurrently."""
+        notebook, sources = await asyncio.gather(
+            self._get_notebook(notebook_id),
+            self._source_lister.list(notebook_id),
+        )
+
+        if notebook.sources_count > 0 and len(sources) == 0:
+            logger.warning(
+                "Notebook %s reports %d sources but listing returned empty",
+                notebook_id,
+                notebook.sources_count,
+            )
+
+        return NotebookMetadata(
+            notebook=notebook,
+            sources=[
+                SourceSummary(
+                    kind=source.kind,
+                    title=source.title,
+                    url=source.url,
+                )
+                for source in sources
+            ],
+        )
+
+
+__all__ = [
+    "NotebookMetadataService",
+    "NotebookSourceLister",
+    "create_default_source_lister",
+]

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -1,19 +1,20 @@
 """Notebook operations API."""
 
-import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ._core import ClientCore
 from ._env import get_base_url
 from ._idempotency import idempotent_create
+from ._notebook_metadata import (
+    NotebookMetadataService,
+    NotebookSourceLister,
+    create_default_source_lister,
+)
 from ._settings import build_get_user_settings_params, extract_account_limits
 from .exceptions import NotebookLimitError, NotebookNotFoundError, RPCError
 from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, SuggestedTopic
-
-if TYPE_CHECKING:
-    from ._sources import SourcesAPI
 
 logger = logging.getLogger(__name__)
 
@@ -130,19 +131,48 @@ class NotebooksAPI:
             await client.notebooks.rename(new_nb.id, "Better Title")
     """
 
-    def __init__(self, core: ClientCore, sources_api: "SourcesAPI | None" = None):
+    def __init__(
+        self,
+        core: ClientCore,
+        sources_api: NotebookSourceLister | None = None,
+        *,
+        metadata_service: NotebookMetadataService | None = None,
+    ) -> None:
         """Initialize the notebooks API.
 
         Args:
             core: The core client infrastructure.
-            sources_api: Optional sources API for cross-API calls. If None,
-                         creates a new instance (for backward compatibility).
+            sources_api: Optional source lister for cross-API metadata composition.
+            metadata_service: Optional explicit metadata service for tests or advanced wiring.
         """
         self._core = core
-        # Lazy import to avoid circular dependency
-        from ._sources import SourcesAPI
+        self._sources = sources_api or create_default_source_lister(self._rpc_call)
+        self._metadata_service = metadata_service or NotebookMetadataService(
+            # Keep notebook lookup late-bound so tests and advanced callers that
+            # replace ``api.get`` after construction still affect get_metadata().
+            get_notebook=lambda notebook_id: self.get(notebook_id),
+            source_lister=self._sources,
+        )
 
-        self._sources = sources_api or SourcesAPI(core)
+    async def _rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        """Delegate through the current core RPC method for late-bound overrides."""
+        return await self._core.rpc_call(
+            method,
+            params,
+            source_path=source_path,
+            allow_null=allow_null,
+            _is_retry=_is_retry,
+            disable_internal_retries=disable_internal_retries,
+        )
 
     async def list(self) -> list[Notebook]:
         """List all notebooks.
@@ -581,33 +611,4 @@ class NotebooksAPI:
             import json
             print(json.dumps(metadata.to_dict(), indent=2))
         """
-        # Get notebook details and sources list concurrently
-        notebook, sources = await asyncio.gather(
-            self.get(notebook_id),
-            self._sources.list(notebook_id),
-        )
-
-        # Warn on potential data loss
-        if notebook.sources_count > 0 and len(sources) == 0:
-            logger.warning(
-                "Notebook %s reports %d sources but listing returned empty",
-                notebook_id,
-                notebook.sources_count,
-            )
-
-        # Build simplified source info
-        from .types import NotebookMetadata, SourceSummary
-
-        simplified_sources = [
-            SourceSummary(
-                kind=source.kind,
-                title=source.title,
-                url=source.url,
-            )
-            for source in sources
-        ]
-
-        return NotebookMetadata(
-            notebook=notebook,
-            sources=simplified_sources,
-        )
+        return await self._metadata_service.get_metadata(notebook_id)

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -14,7 +14,7 @@ from ._notebook_metadata import (
 from ._settings import build_get_user_settings_params, extract_account_limits
 from .exceptions import NotebookLimitError, NotebookNotFoundError, RPCError
 from .rpc import RPCMethod, safe_index
-from .types import AccountLimits, Notebook, NotebookDescription, SuggestedTopic
+from .types import AccountLimits, Notebook, NotebookDescription, NotebookMetadata, SuggestedTopic
 
 logger = logging.getLogger(__name__)
 
@@ -588,7 +588,7 @@ class NotebooksAPI:
             return f"{base_url}?artifactId={artifact_id}"
         return base_url
 
-    async def get_metadata(self, notebook_id: str):
+    async def get_metadata(self, notebook_id: str) -> NotebookMetadata:
         """Get notebook metadata with sources list.
 
         This combines notebook details with a simplified sources list,

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -266,8 +266,8 @@ class NotebookLMClient:
         # ArtifactsAPI and NotesAPI both consume the shared ``_mind_map``
         # module for mind-map primitives, so their construction order is
         # not significant.
-        self.notebooks = NotebooksAPI(self._core)
         self.sources = SourcesAPI(self._core, upload_timeout=upload_timeout)
+        self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
         self.artifacts = ArtifactsAPI(self._core, storage_path=storage_path)
         self.notes = NotesAPI(self._core)
         self.chat = ChatAPI(self._core)

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -399,31 +399,42 @@ def test_phase7_artifact_mind_map_patch_seams_are_current() -> None:
     assert artifact_downloads._artifact_seams()._mind_map is mind_map
 
 
-@pytest.mark.xfail(
-    raises=AssertionError,
-    strict=True,
-    reason="T10a removes hidden SourcesAPI construction from NotebooksAPI.",
-)
 def test_notebooks_api_has_no_hidden_sources_api_runtime_dependency() -> None:
-    """TODO(T10a): remove xfail after direct metadata fallback no longer uses SourcesAPI."""
-    tree = ast.parse((SRC_ROOT / "_notebooks.py").read_text(encoding="utf-8"))
+    """Notebook metadata must use a narrow lister, not hidden SourcesAPI construction."""
+    notebooks_tree = ast.parse((SRC_ROOT / "_notebooks.py").read_text(encoding="utf-8"))
     visitor = _RuntimeImportVisitor(
         forbidden_names={"SourcesAPI"},
         forbidden_modules={"_sources", "notebooklm._sources"},
     )
-    visitor.visit(tree)
+    visitor.visit(notebooks_tree)
 
-    sources_api_constructions: list[int] = []
-    for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "SourcesAPI"
-        ):
-            sources_api_constructions.append(node.lineno)
+    def sources_api_construction_lines(tree: ast.AST) -> list[int]:
+        lines: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if isinstance(node.func, ast.Name) and node.func.id == "SourcesAPI":
+                lines.append(node.lineno)
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "SourcesAPI":
+                lines.append(node.lineno)
+        return lines
 
     assert visitor.forbidden == []
-    assert sources_api_constructions == []
+    assert sources_api_construction_lines(notebooks_tree) == []
+
+    metadata_tree = ast.parse((SRC_ROOT / "_notebook_metadata.py").read_text(encoding="utf-8"))
+    metadata_visitor = _RuntimeImportVisitor(
+        forbidden_names={"SourcesAPI"},
+        forbidden_modules={"_sources", "notebooklm._sources"},
+    )
+    metadata_visitor.visit(metadata_tree)
+
+    assert metadata_visitor.forbidden == []
+    assert sources_api_construction_lines(metadata_tree) == []
+
+
+def test_notebook_metadata_service_imports_cleanly() -> None:
+    importlib.import_module("notebooklm._notebook_metadata")
 
 
 def test_core_private_access_guard_detects_simple_aliases() -> None:

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -2,11 +2,15 @@
 
 import asyncio
 import logging
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from notebooklm._notebooks import NotebooksAPI, build_create_notebook_params
+from notebooklm._source_listing import SourceLister
+from notebooklm.auth import AuthTokens
+from notebooklm.client import NotebookLMClient
 from notebooklm.exceptions import (
     NetworkError,
     NotebookLimitError,
@@ -26,6 +30,20 @@ def _make_core() -> MagicMock:
 def _make_api() -> NotebooksAPI:
     core = _make_core()
     return NotebooksAPI(core, sources_api=MagicMock())
+
+
+def _source_entry(
+    source_id: str,
+    *,
+    title: str = "Source",
+    metadata: list[Any] | None = None,
+) -> list[Any]:
+    return [
+        [source_id],
+        title,
+        metadata or [None, 11, [1704067200, 0], None, 5],
+        [None, 2],
+    ]
 
 
 def _owned_notebooks(count: int) -> list[Notebook]:
@@ -55,6 +73,70 @@ def test_direct_notebooks_api_construction_remains_supported() -> None:
     api = NotebooksAPI(core)
 
     assert hasattr(api, "_sources")
+    assert isinstance(api._sources, SourceLister)
+
+
+@pytest.mark.asyncio
+async def test_direct_notebooks_api_get_metadata_uses_phase8_source_lister() -> None:
+    core = _make_core()
+    core.rpc_call.return_value = [
+        [
+            "Architecture",
+            [_source_entry("src_1", title="Design Paper", metadata=[None, 11, None, None, 3])],
+            "nb_123",
+        ]
+    ]
+    api = NotebooksAPI(core)
+
+    metadata = await api.get_metadata("nb_123")
+
+    assert metadata.notebook == Notebook(id="nb_123", title="Architecture", sources_count=1)
+    assert len(metadata.sources) == 1
+    assert metadata.sources[0].kind == SourceType.PDF
+    assert metadata.sources[0].title == "Design Paper"
+    assert core.rpc_call.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_direct_notebooks_api_metadata_lister_uses_late_bound_core_rpc_call() -> None:
+    core = _make_core()
+    api = NotebooksAPI(core)
+    replacement_rpc = AsyncMock(
+        return_value=[
+            [
+                "Late Bound",
+                [_source_entry("src_1", title="Design Paper", metadata=[None, 11, None, None, 3])],
+                "nb_123",
+            ]
+        ]
+    )
+    core.rpc_call = replacement_rpc
+
+    metadata = await api.get_metadata("nb_123")
+
+    assert metadata.title == "Late Bound"
+    assert metadata.sources[0].kind == SourceType.PDF
+    assert replacement_rpc.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_client_wires_sources_api_into_notebooks_as_structural_lister() -> None:
+    auth = AuthTokens(
+        cookies={"SID": "test_sid", "__Secure-1PSIDTS": "test_1psidts", "HSID": "test_hsid"},
+        csrf_token="test_csrf",
+        session_id="test_session",
+    )
+    client = NotebookLMClient(auth)
+    client.notebooks.get = AsyncMock(
+        return_value=Notebook(id="nb_123", title="Client", sources_count=1)
+    )
+    client.sources.list = AsyncMock(return_value=[Source(id="src_1", title="Paper", _type_code=3)])
+
+    metadata = await client.notebooks.get_metadata("nb_123")
+
+    assert metadata.notebook.title == "Client"
+    assert metadata.sources[0].kind == SourceType.PDF
+    client.sources.list.assert_awaited_once_with("nb_123")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_notebook_metadata.py
+++ b/tests/unit/test_notebook_metadata.py
@@ -1,0 +1,193 @@
+"""Unit tests for the private notebook metadata service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._notebook_metadata import (
+    NotebookMetadataService,
+    create_default_source_lister,
+)
+from notebooklm.exceptions import RPCError
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import Notebook, NotebookMetadata, Source, SourceType
+
+
+class RecordingRpc:
+    def __init__(self, response: Any) -> None:
+        self.response = response
+        self.calls: list[tuple[RPCMethod, list[Any], str | None]] = []
+
+    async def __call__(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        self.calls.append((method, params, source_path))
+        return self.response
+
+
+def source_entry(
+    source_id: str,
+    *,
+    title: str = "Source",
+    metadata: list[Any] | None = None,
+) -> list[Any]:
+    return [
+        [source_id],
+        title,
+        metadata or [None, 11, [1704067200, 0], None, 5],
+        [None, 2],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_metadata_service_uses_injected_lister_and_builds_source_summaries() -> None:
+    get_notebook = AsyncMock(
+        return_value=Notebook(id="nb_123", title="Architecture", sources_count=2)
+    )
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(
+        return_value=[
+            Source(
+                id="src_web",
+                title="Architecture Notes",
+                url="https://example.com/notes",
+                _type_code=5,  # SourceType.WEB_PAGE
+            ),
+            Source(id="src_pdf", title="Design Paper", _type_code=3),  # SourceType.PDF
+        ]
+    )
+    service = NotebookMetadataService(get_notebook, source_lister)
+
+    metadata = await service.get_metadata("nb_123")
+
+    assert isinstance(metadata, NotebookMetadata)
+    assert metadata.notebook == Notebook(id="nb_123", title="Architecture", sources_count=2)
+    assert [source.kind for source in metadata.sources] == [
+        SourceType.WEB_PAGE,
+        SourceType.PDF,
+    ]
+    assert metadata.sources[0].title == "Architecture Notes"
+    assert metadata.sources[0].url == "https://example.com/notes"
+    get_notebook.assert_awaited_once_with("nb_123")
+    source_lister.list.assert_awaited_once_with("nb_123")
+
+
+@pytest.mark.asyncio
+async def test_metadata_service_fetches_notebook_and_sources_concurrently() -> None:
+    get_started = asyncio.Event()
+    list_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def get_notebook(notebook_id: str) -> Notebook:
+        assert notebook_id == "nb_123"
+        get_started.set()
+        await list_started.wait()
+        await release.wait()
+        return Notebook(id="nb_123", title="Concurrent", sources_count=1)
+
+    async def list_sources(notebook_id: str) -> list[Source]:
+        assert notebook_id == "nb_123"
+        list_started.set()
+        await get_started.wait()
+        await release.wait()
+        return [Source(id="src_1", title="Paper", _type_code=3)]  # SourceType.PDF
+
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(side_effect=list_sources)
+    service = NotebookMetadataService(get_notebook, source_lister)
+
+    metadata_task = asyncio.create_task(service.get_metadata("nb_123"))
+    await asyncio.wait_for(get_started.wait(), timeout=1)
+    await asyncio.wait_for(list_started.wait(), timeout=1)
+    assert not metadata_task.done()
+
+    release.set()
+    metadata = await metadata_task
+
+    assert metadata.notebook.title == "Concurrent"
+    assert metadata.sources[0].kind == SourceType.PDF
+
+
+@pytest.mark.asyncio
+async def test_metadata_service_preserves_empty_source_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    get_notebook = AsyncMock(return_value=Notebook(id="nb_123", title="Sparse", sources_count=2))
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(return_value=[])
+    service = NotebookMetadataService(get_notebook, source_lister)
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._notebooks"):
+        metadata = await service.get_metadata("nb_123")
+
+    assert metadata.sources == []
+    assert "Notebook nb_123 reports 2 sources but listing returned empty" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_metadata_service_propagates_notebook_lookup_errors() -> None:
+    error = RuntimeError("notebook lookup failed")
+    get_notebook = AsyncMock(side_effect=error)
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(return_value=[Source(id="src_1")])
+    service = NotebookMetadataService(get_notebook, source_lister)
+
+    with pytest.raises(RuntimeError, match="notebook lookup failed"):
+        await service.get_metadata("nb_123")
+
+    get_notebook.assert_awaited_once_with("nb_123")
+    source_lister.list.assert_awaited_once_with("nb_123")
+
+
+@pytest.mark.asyncio
+async def test_metadata_service_propagates_source_listing_errors() -> None:
+    get_notebook = AsyncMock(return_value=Notebook(id="nb_123", title="Notebook"))
+    source_lister = MagicMock()
+    source_lister.list = AsyncMock(side_effect=RuntimeError("source listing failed"))
+    service = NotebookMetadataService(get_notebook, source_lister)
+
+    with pytest.raises(RuntimeError, match="source listing failed"):
+        await service.get_metadata("nb_123")
+
+    get_notebook.assert_awaited_once_with("nb_123")
+    source_lister.list.assert_awaited_once_with("nb_123")
+
+
+@pytest.mark.asyncio
+async def test_default_source_lister_uses_phase8_listing_service() -> None:
+    rpc = RecordingRpc([["Notebook", [source_entry("src_1", title="Web")]]])
+    source_lister = create_default_source_lister(rpc)
+
+    sources = await source_lister.list("nb_123")
+
+    assert len(sources) == 1
+    assert sources[0].id == "src_1"
+    assert sources[0].title == "Web"
+    assert sources[0].kind == SourceType.WEB_PAGE
+    assert rpc.calls == [
+        (
+            RPCMethod.GET_NOTEBOOK,
+            ["nb_123", None, [2], None, 0],
+            "/notebook/nb_123",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_default_source_lister_delegates_strict_malformed_handling() -> None:
+    source_lister = create_default_source_lister(RecordingRpc([["Notebook", None]]))
+
+    with pytest.raises(RPCError, match="sources data is NoneType, not list"):
+        await source_lister.list("nb_123", strict=True)


### PR DESCRIPTION
## Summary
- Add private `_notebook_metadata` service for notebook/source metadata composition.
- Remove hidden `SourcesAPI(core)` construction from `NotebooksAPI`; direct construction now uses the Phase 8 `SourceLister` fallback.
- Wire `NotebookLMClient` to construct `sources` before `notebooks` and pass `client.sources` structurally.

## Task
Phase 9 Wave 2 / T10a: `.sisyphus/phases/architecture-remediation/phase-9.md#t10a---notebook-metadata-service-and-sourcelister`

## Test plan
- [x] `rtk uv run pytest tests/unit/test_notebook_metadata.py tests/unit/test_notebook_api.py tests/unit/test_notebooks_integration.py tests/unit/cli/test_notebook.py tests/integration/cli_vcr/test_notebooks.py tests/unit/test_init_order.py`
- [x] `rtk uv run pytest tests/unit/test_source_listing_service.py tests/unit/test_sources_integration.py tests/unit/test_source_selection.py`
- [x] `rtk uv run ruff check src/notebooklm/_notebooks.py src/notebooklm/_notebook_metadata.py src/notebooklm/client.py tests/unit/test_notebook_metadata.py tests/unit/test_notebook_api.py tests/unit/test_notebooks_integration.py tests/unit/test_init_order.py`
- [x] `rtk uv run ruff format --check src/notebooklm/_notebooks.py src/notebooklm/_notebook_metadata.py src/notebooklm/client.py tests/unit/test_notebook_metadata.py tests/unit/test_notebook_api.py tests/unit/test_init_order.py`
- [x] `rtk uv run mypy src/notebooklm`
- [x] `rtk git diff --check`

## Polish / review
- Code-simplifier fallback: no changes needed.
- Triple review: Gemini approved with already-covered compatibility checks; Codex reported no actionable findings after mypy and full unit suite; Claude findings were fixed.
- Ultrathink: no blockers.

## Deferred polish findings
- Future performance work could collapse the two preserved `GET_NOTEBOOK` calls in metadata composition, but T10a intentionally preserves the current concurrency and RPC behavior.
- Duplicate test source-entry helpers can be centralized if a third copy appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved metadata composition and wiring so notebook metadata and source listings are built more modularly and reliably.
  * Adjusted initialization order to ensure source listing is available when notebooks request metadata.

* **Tests**
  * Added comprehensive unit and integration tests validating metadata construction, source-listing behavior, error handling, and import stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->