### PR TITLE
refactor(notebooks): extract legacy share manager

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -155,7 +155,7 @@ class NotebooksAPI:
             get_notebook=lambda notebook_id: self.get(notebook_id),
             source_lister=self._sources,
         )
-        self._share_manager = share_manager or ShareManager(core)
+        self._share_manager = share_manager or ShareManager(self._rpc_call)
 
     async def _rpc_call(
         self,

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 from ._core import ClientCore
-from ._env import get_base_url
 from ._idempotency import idempotent_create
 from ._notebook_metadata import (
     NotebookMetadataService,
@@ -12,6 +11,7 @@ from ._notebook_metadata import (
     create_default_source_lister,
 )
 from ._settings import build_get_user_settings_params, extract_account_limits
+from ._sharing_manager import ShareManager
 from .exceptions import NotebookLimitError, NotebookNotFoundError, RPCError
 from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, NotebookMetadata, SuggestedTopic
@@ -137,6 +137,7 @@ class NotebooksAPI:
         sources_api: NotebookSourceLister | None = None,
         *,
         metadata_service: NotebookMetadataService | None = None,
+        share_manager: ShareManager | None = None,
     ) -> None:
         """Initialize the notebooks API.
 
@@ -144,6 +145,7 @@ class NotebooksAPI:
             core: The core client infrastructure.
             sources_api: Optional source lister for cross-API metadata composition.
             metadata_service: Optional explicit metadata service for tests or advanced wiring.
+            share_manager: Optional explicit legacy share manager for tests or advanced wiring.
         """
         self._core = core
         self._sources = sources_api or create_default_source_lister(self._rpc_call)
@@ -153,6 +155,7 @@ class NotebooksAPI:
             get_notebook=lambda notebook_id: self.get(notebook_id),
             source_lister=self._sources,
         )
+        self._share_manager = share_manager or ShareManager(core)
 
     async def _rpc_call(
         self,
@@ -542,33 +545,7 @@ class NotebooksAPI:
         Returns:
             Dict with 'public' status, 'url', and 'artifact_id'.
         """
-        share_options = [1] if public else [0]
-        if artifact_id:
-            params = [share_options, notebook_id, artifact_id]
-        else:
-            params = [share_options, notebook_id]
-
-        await self._core.rpc_call(
-            RPCMethod.SHARE_ARTIFACT,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-
-        # Build share URL
-        base_url = f"{get_base_url()}/notebook/{notebook_id}"
-        if public and artifact_id:
-            url = f"{base_url}?artifactId={artifact_id}"
-        elif public:
-            url = base_url
-        else:
-            url = None
-
-        return {
-            "public": public,
-            "url": url,
-            "artifact_id": artifact_id,
-        }
+        return await self._share_manager.share(notebook_id, public, artifact_id)
 
     def get_share_url(self, notebook_id: str, artifact_id: str | None = None) -> str:
         """Get share URL for a notebook or artifact.
@@ -583,10 +560,7 @@ class NotebooksAPI:
         Returns:
             The share URL string.
         """
-        base_url = f"{get_base_url()}/notebook/{notebook_id}"
-        if artifact_id:
-            return f"{base_url}?artifactId={artifact_id}"
-        return base_url
+        return self._share_manager.get_share_url(notebook_id, artifact_id)
 
     async def get_metadata(self, notebook_id: str) -> NotebookMetadata:
         """Get notebook metadata with sources list.

--- a/src/notebooklm/_sharing_manager.py
+++ b/src/notebooklm/_sharing_manager.py
@@ -1,0 +1,71 @@
+"""Legacy notebook share-link composition."""
+
+from collections.abc import Callable
+from typing import Any, Protocol
+
+from ._env import get_base_url
+from .rpc import RPCMethod
+
+
+class ShareRpc(Protocol):
+    """RPC surface needed by the legacy notebook share manager."""
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any: ...
+
+
+def build_share_url(base_url: str, notebook_id: str, artifact_id: str | None = None) -> str:
+    """Build the legacy NotebookLM notebook or artifact share URL."""
+    notebook_url = f"{base_url}/notebook/{notebook_id}"
+    if artifact_id:
+        return f"{notebook_url}?artifactId={artifact_id}"
+    return notebook_url
+
+
+class ShareManager:
+    """Legacy ``SHARE_ARTIFACT`` manager used by ``NotebooksAPI.share``."""
+
+    def __init__(
+        self,
+        rpc: ShareRpc,
+        base_url_provider: Callable[[], str] = get_base_url,
+    ) -> None:
+        self._rpc = rpc
+        self._base_url_provider = base_url_provider
+
+    async def share(
+        self, notebook_id: str, public: bool = True, artifact_id: str | None = None
+    ) -> dict[str, Any]:
+        """Toggle legacy notebook sharing through ``SHARE_ARTIFACT``."""
+        share_options = [1] if public else [0]
+        params: list[Any] = [share_options, notebook_id]
+        if artifact_id:
+            params.append(artifact_id)
+
+        await self._rpc.rpc_call(
+            RPCMethod.SHARE_ARTIFACT,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+
+        return {
+            "public": public,
+            "url": self.get_share_url(notebook_id, artifact_id) if public else None,
+            "artifact_id": artifact_id,
+        }
+
+    def get_share_url(self, notebook_id: str, artifact_id: str | None = None) -> str:
+        """Return the legacy share URL without toggling server-side sharing."""
+        return build_share_url(self._base_url_provider(), notebook_id, artifact_id)
+
+
+__all__ = ["ShareManager", "ShareRpc", "build_share_url"]

--- a/src/notebooklm/_sharing_manager.py
+++ b/src/notebooklm/_sharing_manager.py
@@ -10,7 +10,7 @@ from .rpc import RPCMethod
 class ShareRpc(Protocol):
     """RPC surface needed by the legacy notebook share manager."""
 
-    async def rpc_call(
+    async def __call__(
         self,
         method: RPCMethod,
         params: list[Any],
@@ -50,7 +50,7 @@ class ShareManager:
         if artifact_id:
             params.append(artifact_id)
 
-        await self._rpc.rpc_call(
+        await self._rpc(
             RPCMethod.SHARE_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -259,6 +259,8 @@ async def test_share_sends_exact_share_artifact_payload_and_returns_deep_link(
         [[1], "nb_123", "art_456"],
         source_path="/notebook/nb_123",
         allow_null=True,
+        _is_retry=False,
+        disable_internal_retries=False,
     )
 
 
@@ -277,6 +279,8 @@ async def test_share_private_sends_disable_payload_and_returns_no_url(
         [[0], "nb_123"],
         source_path="/notebook/nb_123",
         allow_null=True,
+        _is_retry=False,
+        disable_internal_retries=False,
     )
 
 

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -11,13 +11,11 @@ from notebooklm.rpc import RPCMethod
 BASE_URL = "https://notebooklm.google.com"
 
 
-def _make_rpc() -> MagicMock:
-    rpc = MagicMock()
-    rpc.rpc_call = AsyncMock(return_value=None)
-    return rpc
+def _make_rpc() -> AsyncMock:
+    return AsyncMock(return_value=None)
 
 
-def _make_manager() -> tuple[ShareManager, MagicMock]:
+def _make_manager() -> tuple[ShareManager, AsyncMock]:
     rpc = _make_rpc()
     return ShareManager(rpc, base_url_provider=lambda: BASE_URL), rpc
 
@@ -44,7 +42,7 @@ async def test_share_public_with_artifact_sends_legacy_payload_and_returns_deep_
         "url": "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456",
         "artifact_id": "art_456",
     }
-    rpc.rpc_call.assert_awaited_once_with(
+    rpc.assert_awaited_once_with(
         RPCMethod.SHARE_ARTIFACT,
         [[1], "nb_123", "art_456"],
         source_path="/notebook/nb_123",
@@ -63,7 +61,7 @@ async def test_share_public_without_artifact_returns_notebook_url() -> None:
         "url": "https://notebooklm.google.com/notebook/nb_123",
         "artifact_id": None,
     }
-    rpc.rpc_call.assert_awaited_once_with(
+    rpc.assert_awaited_once_with(
         RPCMethod.SHARE_ARTIFACT,
         [[1], "nb_123"],
         source_path="/notebook/nb_123",
@@ -78,7 +76,7 @@ async def test_share_private_sends_disable_payload_and_returns_no_url() -> None:
     result = await manager.share("nb_123", public=False)
 
     assert result == {"public": False, "url": None, "artifact_id": None}
-    rpc.rpc_call.assert_awaited_once_with(
+    rpc.assert_awaited_once_with(
         RPCMethod.SHARE_ARTIFACT,
         [[0], "nb_123"],
         source_path="/notebook/nb_123",
@@ -93,7 +91,7 @@ async def test_share_private_with_artifact_preserves_artifact_id_but_returns_no_
     result = await manager.share("nb_123", public=False, artifact_id="art_456")
 
     assert result == {"public": False, "url": None, "artifact_id": "art_456"}
-    rpc.rpc_call.assert_awaited_once_with(
+    rpc.assert_awaited_once_with(
         RPCMethod.SHARE_ARTIFACT,
         [[0], "nb_123", "art_456"],
         source_path="/notebook/nb_123",
@@ -107,7 +105,28 @@ def test_get_share_url_is_sync_and_does_not_call_rpc() -> None:
     url = manager.get_share_url("nb_123", artifact_id="art_456")
 
     assert url == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
-    rpc.rpc_call.assert_not_called()
+    rpc.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notebooks_api_default_share_manager_uses_late_bound_core_rpc_call() -> None:
+    core = MagicMock()
+    core.rpc_call = AsyncMock(return_value=None)
+    api = NotebooksAPI(core, sources_api=MagicMock())
+    replacement_rpc = AsyncMock(return_value=None)
+    core.rpc_call = replacement_rpc
+
+    result = await api.share("nb_123", public=True, artifact_id="art_456")
+
+    assert result["url"] == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
+    replacement_rpc.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[1], "nb_123", "art_456"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+        _is_retry=False,
+        disable_internal_retries=False,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -1,0 +1,135 @@
+"""Unit tests for the legacy notebook share manager."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._notebooks import NotebooksAPI
+from notebooklm._sharing_manager import ShareManager, build_share_url
+from notebooklm.rpc import RPCMethod
+
+BASE_URL = "https://notebooklm.google.com"
+
+
+def _make_rpc() -> MagicMock:
+    rpc = MagicMock()
+    rpc.rpc_call = AsyncMock(return_value=None)
+    return rpc
+
+
+def _make_manager() -> tuple[ShareManager, MagicMock]:
+    rpc = _make_rpc()
+    return ShareManager(rpc, base_url_provider=lambda: BASE_URL), rpc
+
+
+def test_build_share_url_without_artifact() -> None:
+    assert build_share_url(BASE_URL, "nb_123") == "https://notebooklm.google.com/notebook/nb_123"
+
+
+def test_build_share_url_with_artifact() -> None:
+    assert (
+        build_share_url(BASE_URL, "nb_123", "art_456")
+        == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_public_with_artifact_sends_legacy_payload_and_returns_deep_link() -> None:
+    manager, rpc = _make_manager()
+
+    result = await manager.share("nb_123", public=True, artifact_id="art_456")
+
+    assert result == {
+        "public": True,
+        "url": "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456",
+        "artifact_id": "art_456",
+    }
+    rpc.rpc_call.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[1], "nb_123", "art_456"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_public_without_artifact_returns_notebook_url() -> None:
+    manager, rpc = _make_manager()
+
+    result = await manager.share("nb_123")
+
+    assert result == {
+        "public": True,
+        "url": "https://notebooklm.google.com/notebook/nb_123",
+        "artifact_id": None,
+    }
+    rpc.rpc_call.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[1], "nb_123"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_private_sends_disable_payload_and_returns_no_url() -> None:
+    manager, rpc = _make_manager()
+
+    result = await manager.share("nb_123", public=False)
+
+    assert result == {"public": False, "url": None, "artifact_id": None}
+    rpc.rpc_call.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[0], "nb_123"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_share_private_with_artifact_preserves_artifact_id_but_returns_no_url() -> None:
+    manager, rpc = _make_manager()
+
+    result = await manager.share("nb_123", public=False, artifact_id="art_456")
+
+    assert result == {"public": False, "url": None, "artifact_id": "art_456"}
+    rpc.rpc_call.assert_awaited_once_with(
+        RPCMethod.SHARE_ARTIFACT,
+        [[0], "nb_123", "art_456"],
+        source_path="/notebook/nb_123",
+        allow_null=True,
+    )
+
+
+def test_get_share_url_is_sync_and_does_not_call_rpc() -> None:
+    manager, rpc = _make_manager()
+
+    url = manager.get_share_url("nb_123", artifact_id="art_456")
+
+    assert url == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
+    rpc.rpc_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notebooks_api_share_delegates_to_injected_share_manager() -> None:
+    core = MagicMock()
+    share_manager = MagicMock()
+    share_manager.share = AsyncMock(return_value={"public": True, "url": "u", "artifact_id": None})
+    api = NotebooksAPI(core, sources_api=MagicMock(), share_manager=share_manager)
+
+    result = await api.share("nb_123", public=True)
+
+    assert result == {"public": True, "url": "u", "artifact_id": None}
+    share_manager.share.assert_awaited_once_with("nb_123", True, None)
+
+
+def test_notebooks_api_get_share_url_delegates_to_injected_share_manager() -> None:
+    core = MagicMock()
+    share_manager = MagicMock()
+    share_manager.get_share_url.return_value = "https://example.test/notebook/nb_123"
+    api = NotebooksAPI(core, sources_api=MagicMock(), share_manager=share_manager)
+
+    url = api.get_share_url("nb_123")
+
+    assert url == "https://example.test/notebook/nb_123"
+    share_manager.get_share_url.assert_called_once_with("nb_123", None)


### PR DESCRIPTION
## Summary
- Extract legacy NotebooksAPI SHARE_ARTIFACT link handling into ShareManager.
- Keep public NotebooksAPI.share/get_share_url signatures as thin delegators.
- Add focused tests for exact RPC payloads, allow_null=True, deep links, URL-only behavior, and facade delegation.

## Task
Phase 9 Wave 3 T10b from .sisyphus/phases/architecture-remediation/phase-9.md.

## Test plan
- [x] uv run pytest tests/unit/test_sharing_manager.py tests/unit/test_notebook_api.py tests/unit/test_notebooks_integration.py::TestShareEdgeCases tests/unit/test_sharing_integration.py tests/unit/test_sharing_types.py tests/unit/cli/test_share.py tests/integration/test_sharing_vcr.py tests/integration/cli_vcr/test_notebooks.py
- [x] uv run ruff check src/notebooklm/_notebooks.py src/notebooklm/_sharing.py src/notebooklm/_sharing_manager.py tests/unit/test_sharing_manager.py tests/unit/test_notebooks_integration.py tests/unit/test_sharing_integration.py tests/unit/test_sharing_types.py tests/unit/cli/test_share.py tests/unit/test_notebook_api.py
- [x] uv run ruff format --check src/notebooklm/_notebooks.py src/notebooklm/_sharing.py src/notebooklm/_sharing_manager.py tests/unit/test_sharing_manager.py tests/unit/test_notebooks_integration.py tests/unit/test_sharing_integration.py tests/unit/test_sharing_types.py tests/unit/cli/test_share.py tests/unit/test_notebook_api.py
- [x] uv run mypy src/notebooklm

## Deferred polish findings
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extracted legacy notebook sharing into a dedicated sharing manager and updated the notebook API to delegate sharing and URL retrieval to it.

* **Tests**
  * Added comprehensive unit tests covering share URL construction, public/private sharing behaviors, delegation, and updated API share-call expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->