### PR TITLE
refactor(notes): extract mind-map service

### DIFF
--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -1,14 +1,14 @@
-"""Mind-map RPC primitives shared by ``ArtifactsAPI`` and ``NotesAPI``.
+"""Note-backed mind-map service shared by ``ArtifactsAPI`` and ``NotesAPI``.
 
-Mind maps live in the "notes" backend (same ``GET_NOTES_AND_MIND_MAPS`` /
-``CREATE_NOTE`` / ``UPDATE_NOTE`` / ``DELETE_NOTE`` RPCs as user notes) but
-they are AI-generated artifacts from the caller's perspective. This module
-hosts the low-level RPC primitives so neither :class:`NotesAPI` nor
-:class:`ArtifactsAPI` needs to import the other.
+Mind maps live in the same backend collection as user notes and use the same
+``GET_NOTES_AND_MIND_MAPS`` / ``CREATE_NOTE`` / ``UPDATE_NOTE`` /
+``DELETE_NOTE`` RPC family. They are still AI-generated artifacts from the
+caller's perspective, so this private module owns the note-backed composition
+that both notes and artifacts need without either facade importing the other.
 
-Functions here take a :class:`ClientCore` as their first argument and return
-raw RPC-shaped data (lists). Higher-level dataclass parsing stays in
-:mod:`_notes` / :mod:`_artifacts`.
+``MindMapService`` is the explicit private service. The module-level functions
+remain as compatibility seams for existing private imports and artifact
+monkeypatch targets.
 """
 
 from __future__ import annotations
@@ -16,9 +16,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Protocol
 
-from ._core import ClientCore
 from .rpc import RPCMethod
 from .types import Note
 
@@ -36,61 +36,244 @@ logger = logging.getLogger(__name__)
 _cleanup_tasks: set[asyncio.Task[Any]] = set()
 
 
-async def _delete_note_best_effort(core: ClientCore, notebook_id: str, note_id: str) -> None:
-    """Best-effort DELETE_NOTE cleanup for a partially-finalized create.
+class MindMapRpc(Protocol):
+    """RPC surface needed by note-backed mind-map operations."""
 
-    Used as a fire-and-forget ``asyncio.create_task`` target when an
-    outer cancel arrives mid-UPDATE_NOTE: we never block the re-raise on
-    this call, and any failure (network, auth refresh, etc.) is logged
-    and swallowed — the only side-effect we want is the orphan-row
-    removal, not a secondary exception.
-    """
-    try:
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+    ) -> Any: ...
+
+
+_UpdateNoteCallback = Callable[[MindMapRpc, str, str, str, str], Coroutine[Any, Any, None]]
+_DeleteNoteBestEffortCallback = Callable[[MindMapRpc, str, str], Coroutine[Any, Any, None]]
+
+
+class MindMapService:
+    """Private service for note-backed mind-map rows."""
+
+    def __init__(
+        self,
+        rpc: MindMapRpc,
+        *,
+        update_note_callback: _UpdateNoteCallback | None = None,
+        delete_note_best_effort_callback: _DeleteNoteBestEffortCallback | None = None,
+    ) -> None:
+        self._rpc = rpc
+        self._update_note_callback = update_note_callback
+        self._delete_note_best_effort_callback = delete_note_best_effort_callback
+
+    async def _delete_note_best_effort(self, notebook_id: str, note_id: str) -> None:
+        """Best-effort DELETE_NOTE cleanup for a partially-finalized create.
+
+        Used as a fire-and-forget ``asyncio.create_task`` target when an
+        outer cancel arrives mid-UPDATE_NOTE: we never block the re-raise on
+        this call, and any failure (network, auth refresh, etc.) is logged
+        and swallowed. The only desired side effect is orphan-row removal.
+        """
+        try:
+            await self.delete_note(notebook_id, note_id)
+        except Exception:  # noqa: BLE001 — best-effort cleanup, must not surface
+            logger.warning(
+                "Best-effort DELETE_NOTE cleanup failed for note %s in notebook %s",
+                note_id,
+                notebook_id,
+                exc_info=True,
+            )
+
+    async def fetch_all_notes_and_mind_maps(self, notebook_id: str) -> list[Any]:
+        """Fetch all active raw note and mind-map rows for a notebook."""
+        params = [notebook_id]
+        result = await self._rpc.rpc_call(
+            RPCMethod.GET_NOTES_AND_MIND_MAPS,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        if not (
+            result and isinstance(result, list) and len(result) > 0 and isinstance(result[0], list)
+        ):
+            return []
+
+        return [
+            item
+            for item in result[0]
+            if isinstance(item, list) and len(item) > 0 and isinstance(item[0], str)
+        ]
+
+    @staticmethod
+    def is_deleted(item: list[Any]) -> bool:
+        """Return True if a note/mind-map item is soft-deleted."""
+        if not isinstance(item, list) or len(item) < 3:
+            return False
+        return item[1] is None and item[2] == 2
+
+    @staticmethod
+    def extract_content(item: list[Any]) -> str | None:
+        """Extract the content string from a note/mind-map item."""
+        if len(item) <= 1:
+            return None
+
+        if isinstance(item[1], str):
+            return item[1]
+        if isinstance(item[1], list) and len(item[1]) > 1 and isinstance(item[1][1], str):
+            return item[1][1]
+        return None
+
+    @staticmethod
+    def is_mind_map_content(content: str | None) -> bool:
+        """Return True if content looks like a persisted mind-map payload."""
+        return bool(content and ('"children":' in content or '"nodes":' in content))
+
+    async def list_mind_maps(self, notebook_id: str) -> list[Any]:
+        """List raw mind-map rows in a notebook, excluding soft-deleted rows."""
+        all_items = await self.fetch_all_notes_and_mind_maps(notebook_id)
+        mind_maps: list[Any] = []
+        for item in all_items:
+            if self.is_deleted(item):
+                continue
+            content = self.extract_content(item)
+            if self.is_mind_map_content(content):
+                mind_maps.append(item)
+        return mind_maps
+
+    async def update_note(
+        self,
+        notebook_id: str,
+        note_id: str,
+        content: str,
+        title: str,
+    ) -> None:
+        """Update a note/mind-map row's content and title in place."""
+        logger.debug("Updating note %s in notebook %s", note_id, notebook_id)
+        params = [
+            notebook_id,
+            note_id,
+            [[[content, title, [], 0]]],
+        ]
+        await self._rpc.rpc_call(
+            RPCMethod.UPDATE_NOTE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+
+    async def delete_note(self, notebook_id: str, note_id: str) -> bool:
+        """Delete a note-backed row using NotebookLM's soft-delete RPC."""
         params = [notebook_id, None, [note_id]]
-        await core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.DELETE_NOTE,
             params,
             source_path=f"/notebook/{notebook_id}",
             allow_null=True,
         )
-    except Exception:  # noqa: BLE001 — best-effort cleanup, must not surface
-        logger.warning(
-            "Best-effort DELETE_NOTE cleanup failed for note %s in notebook %s",
-            note_id,
-            notebook_id,
-            exc_info=True,
+        return True
+
+    async def create_note(
+        self,
+        notebook_id: str,
+        title: str = "New Note",
+        content: str = "",
+    ) -> Note:
+        """Create a note-backed row and finalize its content + title."""
+        logger.debug("Creating note in notebook %s: %s", notebook_id, title)
+        # The server currently ignores this slot (the follow-up UPDATE_NOTE is
+        # what actually persists the title) but pass the caller-supplied title
+        # rather than a hardcoded literal so the wire payload reflects the user
+        # intent if Google ever starts honoring it.
+        params = [notebook_id, "", [1], None, title]
+        result = await self._rpc.rpc_call(
+            RPCMethod.CREATE_NOTE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+        )
+
+        note_id: str | None = None
+        if result and isinstance(result, list) and len(result) > 0:
+            if isinstance(result[0], list) and len(result[0]) > 0:
+                note_id = result[0][0]
+            elif isinstance(result[0], str):
+                note_id = result[0]
+
+        if note_id:
+            # CREATE_NOTE ignores the title param server-side, so set it via
+            # UPDATE_NOTE alongside the actual content payload.
+            #
+            # Shield the UPDATE_NOTE finalize from outer cancellation.
+            # CREATE_NOTE has already persisted a row server-side; without the
+            # shield, a cancel arriving between CREATE_NOTE and UPDATE_NOTE
+            # completion leaves an orphan row with no title/content.
+            #
+            # When CancelledError lands here, the shielded UPDATE_NOTE Task is
+            # still running on the loop. Fire a best-effort DELETE_NOTE that
+            # covers both sub-cases:
+            #   (a) UPDATE_NOTE hasn't applied yet -> orphan-row cleanup.
+            #   (b) UPDATE_NOTE completes between the cancel and DELETE_NOTE ->
+            #       the now-applied note is deleted; caller's cancel intent
+            #       (note should not exist) is honored.
+            # Strong-ref the cleanup task in ``_cleanup_tasks`` so the loop's
+            # weak-ref Task storage cannot GC it mid-flight (RUF006); the
+            # done-callback discards on completion so the set stays bounded.
+            # The re-raise never awaits the cleanup task.
+            try:
+                update_note_callback = self._update_note_callback
+                if update_note_callback is None:
+                    update_note_task = self.update_note(notebook_id, note_id, content, title)
+                else:
+                    update_note_task = update_note_callback(
+                        self._rpc,
+                        notebook_id,
+                        note_id,
+                        content,
+                        title,
+                    )
+                await asyncio.shield(update_note_task)
+            except asyncio.CancelledError:
+                delete_note_best_effort_callback = self._delete_note_best_effort_callback
+                if delete_note_best_effort_callback is None:
+                    cleanup_coro = self._delete_note_best_effort(notebook_id, note_id)
+                else:
+                    cleanup_coro = delete_note_best_effort_callback(
+                        self._rpc,
+                        notebook_id,
+                        note_id,
+                    )
+                cleanup_task = asyncio.create_task(cleanup_coro)
+                _cleanup_tasks.add(cleanup_task)
+                cleanup_task.add_done_callback(_cleanup_tasks.discard)
+                raise
+
+        return Note(
+            id=note_id or "",
+            notebook_id=notebook_id,
+            title=title,
+            content=content,
         )
 
 
-async def fetch_all_notes_and_mind_maps(core: ClientCore, notebook_id: str) -> list[Any]:
+async def _delete_note_best_effort(core: MindMapRpc, notebook_id: str, note_id: str) -> None:
+    """Best-effort DELETE_NOTE cleanup for a partially-finalized create."""
+    await MindMapService(core)._delete_note_best_effort(notebook_id, note_id)
+
+
+async def fetch_all_notes_and_mind_maps(core: MindMapRpc, notebook_id: str) -> list[Any]:
     """Fetch all notes + mind maps in a notebook.
 
     Both notes and mind maps share the same backend collection; callers
     filter by content shape (``"children":`` / ``"nodes":`` for mind maps).
 
     Args:
-        core: The shared :class:`ClientCore`.
+        core: The shared :class:`MindMapRpc`.
         notebook_id: The notebook ID to query.
 
     Returns:
         Raw list of items; each item is a list whose first element is the
         item ID. Empty list on missing/unexpected payloads.
     """
-    params = [notebook_id]
-    result = await core.rpc_call(
-        RPCMethod.GET_NOTES_AND_MIND_MAPS,
-        params,
-        source_path=f"/notebook/{notebook_id}",
-        allow_null=True,
-    )
-    if result and isinstance(result, list) and len(result) > 0 and isinstance(result[0], list):
-        notes_list = result[0]
-        valid_notes = []
-        for item in notes_list:
-            if isinstance(item, list) and len(item) > 0 and isinstance(item[0], str):
-                valid_notes.append(item)
-        return valid_notes
-    return []
+    return await MindMapService(core).fetch_all_notes_and_mind_maps(notebook_id)
 
 
 def is_deleted(item: list[Any]) -> bool:
@@ -99,9 +282,7 @@ def is_deleted(item: list[Any]) -> bool:
     Deleted items have structure ``['id', None, 2]`` — content is None and
     the third position holds the status sentinel.
     """
-    if not isinstance(item, list) or len(item) < 3:
-        return False
-    return item[1] is None and item[2] == 2
+    return MindMapService.is_deleted(item)
 
 
 def extract_content(item: list[Any]) -> str | None:
@@ -110,17 +291,15 @@ def extract_content(item: list[Any]) -> str | None:
     Handles both the legacy ``[id, content]`` and the current
     ``[id, [id, content, metadata, None, title]]`` shapes.
     """
-    if len(item) <= 1:
-        return None
-
-    if isinstance(item[1], str):
-        return item[1]
-    if isinstance(item[1], list) and len(item[1]) > 1 and isinstance(item[1][1], str):
-        return item[1][1]
-    return None
+    return MindMapService.extract_content(item)
 
 
-async def list_mind_maps(core: ClientCore, notebook_id: str) -> list[Any]:
+def is_mind_map_content(content: str | None) -> bool:
+    """Return True if content looks like a persisted mind-map payload."""
+    return MindMapService.is_mind_map_content(content)
+
+
+async def list_mind_maps(core: MindMapRpc, notebook_id: str) -> list[Any]:
     """List raw mind-map items in a notebook (excluding soft-deleted ones).
 
     Mind maps are stored in the same collection as notes but contain JSON
@@ -128,47 +307,28 @@ async def list_mind_maps(core: ClientCore, notebook_id: str) -> list[Any]:
     collection down to mind-map-shaped entries.
 
     Args:
-        core: The shared :class:`ClientCore`.
+        core: The shared :class:`MindMapRpc`.
         notebook_id: The notebook ID to query.
 
     Returns:
         List of raw mind-map items (each a list, first element is the ID).
     """
-    all_items = await fetch_all_notes_and_mind_maps(core, notebook_id)
-    mind_maps: list[Any] = []
-    for item in all_items:
-        if is_deleted(item):
-            continue
-        content = extract_content(item)
-        if content and ('"children":' in content or '"nodes":' in content):
-            mind_maps.append(item)
-    return mind_maps
+    return await MindMapService(core).list_mind_maps(notebook_id)
 
 
 async def update_note(
-    core: ClientCore,
+    core: MindMapRpc,
     notebook_id: str,
     note_id: str,
     content: str,
     title: str,
 ) -> None:
     """Update a note/mind-map row's content and title in place."""
-    logger.debug("Updating note %s in notebook %s", note_id, notebook_id)
-    params = [
-        notebook_id,
-        note_id,
-        [[[content, title, [], 0]]],
-    ]
-    await core.rpc_call(
-        RPCMethod.UPDATE_NOTE,
-        params,
-        source_path=f"/notebook/{notebook_id}",
-        allow_null=True,
-    )
+    await MindMapService(core).update_note(notebook_id, note_id, content, title)
 
 
 async def create_note(
-    core: ClientCore,
+    core: MindMapRpc,
     notebook_id: str,
     title: str = "New Note",
     content: str = "",
@@ -181,7 +341,7 @@ async def create_note(
     higher-level :class:`NotesAPI`.
 
     Args:
-        core: The shared :class:`ClientCore`.
+        core: The shared :class:`MindMapRpc`.
         notebook_id: The notebook ID to create the note in.
         title: The desired title.
         content: The desired body content (mind-map JSON, plain text, ...).
@@ -189,59 +349,11 @@ async def create_note(
     Returns:
         The created :class:`Note` with the assigned ID.
     """
-    logger.debug("Creating note in notebook %s: %s", notebook_id, title)
-    # The server currently ignores this slot (the follow-up UPDATE_NOTE is
-    # what actually persists the title) but pass the caller-supplied title
-    # rather than a hardcoded literal so the wire payload reflects the user
-    # intent if Google ever starts honoring it.
-    params = [notebook_id, "", [1], None, title]
-    result = await core.rpc_call(
-        RPCMethod.CREATE_NOTE,
-        params,
-        source_path=f"/notebook/{notebook_id}",
-    )
-
-    note_id: str | None = None
-    if result and isinstance(result, list) and len(result) > 0:
-        if isinstance(result[0], list) and len(result[0]) > 0:
-            note_id = result[0][0]
-        elif isinstance(result[0], str):
-            note_id = result[0]
-
-    if note_id:
-        # CREATE_NOTE ignores the title param server-side, so set it via
-        # UPDATE_NOTE alongside the actual content payload.
-        #
-        # Shield the UPDATE_NOTE finalize from outer cancellation.
-        # CREATE_NOTE has already persisted a row server-side; without the
-        # shield, a cancel arriving between CREATE_NOTE and UPDATE_NOTE
-        # completion leaves an orphan row with no title/content.
-        #
-        # When CancelledError lands here, the shielded UPDATE_NOTE Task is
-        # still running on the loop. Fire a best-effort DELETE_NOTE that
-        # covers both sub-cases:
-        #   (a) UPDATE_NOTE hasn't applied yet → orphan-row cleanup.
-        #   (b) UPDATE_NOTE completes between the cancel and DELETE_NOTE →
-        #       the now-applied note is deleted; caller's cancel intent
-        #       (note should not exist) is honoured.
-        # Strong-ref the cleanup task in ``_cleanup_tasks`` so the loop's
-        # weak-ref Task storage cannot GC it mid-flight (RUF006); the
-        # done-callback discards on completion so the set stays bounded.
-        # The re-raise never awaits the cleanup task.
-        try:
-            await asyncio.shield(update_note(core, notebook_id, note_id, content, title))
-        except asyncio.CancelledError:
-            cleanup_task = asyncio.create_task(_delete_note_best_effort(core, notebook_id, note_id))
-            _cleanup_tasks.add(cleanup_task)
-            cleanup_task.add_done_callback(_cleanup_tasks.discard)
-            raise
-
-    return Note(
-        id=note_id or "",
-        notebook_id=notebook_id,
-        title=title,
-        content=content,
-    )
+    return await MindMapService(
+        core,
+        update_note_callback=update_note,
+        delete_note_best_effort_callback=_delete_note_best_effort,
+    ).create_note(notebook_id, title=title, content=content)
 
 
 # Rendering-flag trailer used inside every text-passage wrapper of the
@@ -466,7 +578,7 @@ def build_save_chat_as_note_params(
 
 
 async def save_chat_answer_as_note(
-    core: ClientCore,
+    core: MindMapRpc,
     notebook_id: str,
     answer_text: str,
     references: list[ChatReference],
@@ -482,7 +594,7 @@ async def save_chat_answer_as_note(
     NotebookLM UI renders ``[N]`` markers as hover-able passage links.
 
     Args:
-        core: The shared ``ClientCore``.
+        core: The shared RPC caller.
         notebook_id: Target notebook UUID.
         answer_text: AI answer text including ``[N]`` citation markers.
         references: Citation list from ``AskResult.references``.

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -4,8 +4,8 @@ Provides operations for creating, updating, listing, and deleting
 user-created notes in notebooks. Notes are distinct from artifacts -
 they are user-created content, not AI-generated.
 
-Mind-map-related RPC primitives live in :mod:`_mind_map` and are shared
-with :class:`ArtifactsAPI`. This module exposes them through the
+Mind-map-related service behavior lives in :mod:`_mind_map` and is shared
+with :class:`ArtifactsAPI`. This module exposes it through the
 historical ``NotesAPI`` method surface for backward compatibility.
 """
 
@@ -15,7 +15,6 @@ from typing import Any
 
 from . import _mind_map
 from ._core import ClientCore
-from .rpc import RPCMethod
 from .types import AskResult, Note
 
 logger = logging.getLogger(__name__)
@@ -38,13 +37,22 @@ class NotesAPI:
             await client.notes.delete(notebook_id, note.id)
     """
 
-    def __init__(self, core: ClientCore):
+    def __init__(
+        self,
+        core: ClientCore,
+        *,
+        mind_map_service: _mind_map.MindMapService | None = None,
+    ):
         """Initialize the notes API.
 
         Args:
             core: The core client infrastructure.
+            mind_map_service: Optional private service for note-backed
+                mind-map and note-row operations. Keyword-only so the public
+                positional constructor contract stays unchanged.
         """
         self._core = core
+        self._mind_map_service = mind_map_service or _mind_map.MindMapService(core)
 
     async def list(self, notebook_id: str) -> list[Note]:
         """List all text notes in the notebook.
@@ -69,8 +77,7 @@ class NotesAPI:
                 continue
 
             content = self._extract_content(item)
-            is_mind_map = content and ('"children":' in content or '"nodes":' in content)
-            if not is_mind_map:
+            if not self._mind_map_service.is_mind_map_content(content):
                 notes.append(self._parse_note(item, notebook_id))
 
         return notes
@@ -107,7 +114,11 @@ class NotesAPI:
         Returns:
             The created Note object.
         """
-        return await _mind_map.create_note(self._core, notebook_id, title=title, content=content)
+        return await self._mind_map_service.create_note(
+            notebook_id,
+            title=title,
+            content=content,
+        )
 
     async def create_from_chat(
         self,
@@ -181,7 +192,7 @@ class NotesAPI:
             content: The new content.
             title: The new title.
         """
-        await _mind_map.update_note(self._core, notebook_id, note_id, content, title)
+        await self._mind_map_service.update_note(notebook_id, note_id, content, title)
 
     async def delete(self, notebook_id: str, note_id: str) -> bool:
         """Delete a note from the notebook.
@@ -197,14 +208,7 @@ class NotesAPI:
             True if deletion succeeded.
         """
         logger.debug("Deleting note %s from notebook %s", note_id, notebook_id)
-        params = [notebook_id, None, [note_id]]
-        await self._core.rpc_call(
-            RPCMethod.DELETE_NOTE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        return True
+        return await self._mind_map_service.delete_note(notebook_id, note_id)
 
     async def list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """List all mind maps in the notebook.
@@ -223,7 +227,7 @@ class NotesAPI:
         Returns:
             List of raw mind map data.
         """
-        return await _mind_map.list_mind_maps(self._core, notebook_id)
+        return await self._mind_map_service.list_mind_maps(notebook_id)
 
     async def delete_mind_map(self, notebook_id: str, mind_map_id: str) -> bool:
         """Delete a mind map from the notebook.
@@ -235,14 +239,7 @@ class NotesAPI:
         Returns:
             True if deletion succeeded.
         """
-        params = [notebook_id, None, [mind_map_id]]
-        await self._core.rpc_call(
-            RPCMethod.DELETE_NOTE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
-        )
-        return True
+        return await self._mind_map_service.delete_note(notebook_id, mind_map_id)
 
     # =========================================================================
     # Private Helpers
@@ -250,7 +247,7 @@ class NotesAPI:
 
     async def _get_all_notes_and_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """Fetch all notes and mind maps from the API."""
-        return await _mind_map.fetch_all_notes_and_mind_maps(self._core, notebook_id)
+        return await self._mind_map_service.fetch_all_notes_and_mind_maps(notebook_id)
 
     def _is_deleted(self, item: builtins.list[Any]) -> bool:
         """Check if a note/mind map item is deleted (status=2).
@@ -264,11 +261,11 @@ class NotesAPI:
         Returns:
             True if the item is deleted (soft-deleted with status=2).
         """
-        return _mind_map.is_deleted(item)
+        return self._mind_map_service.is_deleted(item)
 
     def _extract_content(self, item: builtins.list[Any]) -> str | None:
         """Extract content string from note/mind map item."""
-        return _mind_map.extract_content(item)
+        return self._mind_map_service.extract_content(item)
 
     def _parse_note(self, item: builtins.list[Any], notebook_id: str) -> Note:
         """Parse a raw note item into a Note object."""

--- a/tests/unit/test_mind_map_service.py
+++ b/tests/unit/test_mind_map_service.py
@@ -1,0 +1,335 @@
+"""Unit tests for the private note-backed mind-map service."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from notebooklm import _mind_map
+from notebooklm._mind_map import MindMapService
+from notebooklm._notes import NotesAPI
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import Note
+
+
+@pytest.fixture
+def mock_core() -> MagicMock:
+    core = MagicMock()
+    core.rpc_call = AsyncMock()
+    return core
+
+
+@pytest.fixture
+def service(mock_core: MagicMock) -> MindMapService:
+    return MindMapService(mock_core)
+
+
+class TestMindMapServiceRows:
+    """Raw row fetch/filter behavior."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_notes_and_mind_maps_filters_invalid_rows(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+    ) -> None:
+        mock_core.rpc_call.return_value = [
+            [
+                ["note_1", "Content"],
+                [],
+                "not-a-row",
+                [123, "Non-string ID"],
+                ["note_2", "Content"],
+            ]
+        ]
+
+        result = await service.fetch_all_notes_and_mind_maps("nb_123")
+
+        assert result == [["note_1", "Content"], ["note_2", "Content"]]
+        mock_core.rpc_call.assert_awaited_once_with(
+            RPCMethod.GET_NOTES_AND_MIND_MAPS,
+            ["nb_123"],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [None, [], ["not-a-list"], [[]]])
+    async def test_fetch_all_notes_and_mind_maps_handles_empty_or_malformed_payload(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+        payload: object,
+    ) -> None:
+        mock_core.rpc_call.return_value = payload
+
+        assert await service.fetch_all_notes_and_mind_maps("nb_123") == []
+
+    def test_is_deleted_detects_only_soft_deleted_shape(self) -> None:
+        assert MindMapService.is_deleted(["row_1", None, 2]) is True
+        assert MindMapService.is_deleted(["row_1", "content", 2]) is False
+        assert MindMapService.is_deleted(["row_1", None, 1]) is False
+        assert MindMapService.is_deleted([]) is False
+        assert MindMapService.is_deleted("not-a-row") is False
+
+    def test_extract_content_supports_legacy_and_nested_shapes(self) -> None:
+        assert MindMapService.extract_content(["row_1", "legacy"]) == "legacy"
+        assert (
+            MindMapService.extract_content(["row_1", ["row_1", "nested", None, None, "Title"]])
+            == "nested"
+        )
+        assert MindMapService.extract_content(["row_1", ["row_1"]]) is None
+        assert MindMapService.extract_content(["row_1", 123]) is None
+        assert MindMapService.extract_content([]) is None
+
+    def test_is_mind_map_content_detects_supported_tree_keys(self) -> None:
+        assert MindMapService.is_mind_map_content('{"children": []}') is True
+        assert MindMapService.is_mind_map_content('{"nodes": []}') is True
+        assert MindMapService.is_mind_map_content("Regular note") is False
+        assert MindMapService.is_mind_map_content(None) is False
+
+    @pytest.mark.asyncio
+    async def test_list_mind_maps_filters_deleted_notes_and_detects_children_or_nodes(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+    ) -> None:
+        children_row = ["mm_children", '{"children": []}']
+        nodes_row = ["mm_nodes", ["mm_nodes", '{"nodes": []}', None, None, "Nodes"]]
+        mock_core.rpc_call.return_value = [
+            [
+                ["note_1", "Regular note"],
+                children_row,
+                nodes_row,
+                ["deleted", None, 2],
+            ]
+        ]
+
+        assert await service.list_mind_maps("nb_123") == [children_row, nodes_row]
+
+
+class TestMindMapServiceMutations:
+    """Create/update/delete service behavior."""
+
+    @pytest.mark.asyncio
+    async def test_update_note_sends_existing_payload(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+    ) -> None:
+        await service.update_note("nb_123", "note_123", "Body", "Title")
+
+        mock_core.rpc_call.assert_awaited_once_with(
+            RPCMethod.UPDATE_NOTE,
+            ["nb_123", "note_123", [[["Body", "Title", [], 0]]]],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_note_sends_soft_delete_payload(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+    ) -> None:
+        assert await service.delete_note("nb_123", "note_123") is True
+
+        mock_core.rpc_call.assert_awaited_once_with(
+            RPCMethod.DELETE_NOTE,
+            ["nb_123", None, ["note_123"]],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_note_uses_create_then_update_and_returns_note(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+    ) -> None:
+        mock_core.rpc_call.side_effect = [[["note_123"]], None]
+
+        note = await service.create_note(
+            "nb_123",
+            title="Mind Map",
+            content='{"children":[]}',
+        )
+
+        assert note == Note(
+            id="note_123",
+            notebook_id="nb_123",
+            title="Mind Map",
+            content='{"children":[]}',
+        )
+        assert mock_core.rpc_call.await_args_list == [
+            call(
+                RPCMethod.CREATE_NOTE,
+                ["nb_123", "", [1], None, "Mind Map"],
+                source_path="/notebook/nb_123",
+            ),
+            call(
+                RPCMethod.UPDATE_NOTE,
+                ["nb_123", "note_123", [[['{"children":[]}', "Mind Map", [], 0]]]],
+                source_path="/notebook/nb_123",
+                allow_null=True,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_note_cancellation_schedules_best_effort_cleanup(
+        self,
+        service: MindMapService,
+        mock_core: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_core.rpc_call.return_value = [["note_123"]]
+        update_started = asyncio.Event()
+        update_can_finish = asyncio.Event()
+        update_finished = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        cleanup_can_finish = asyncio.Event()
+        cleanup_finished = asyncio.Event()
+
+        async def fake_update_note(
+            notebook_id: str,
+            note_id: str,
+            content: str,
+            title: str,
+        ) -> None:
+            assert (notebook_id, note_id, content, title) == (
+                "nb_123",
+                "note_123",
+                "body",
+                "Title",
+            )
+            update_started.set()
+            try:
+                await update_can_finish.wait()
+            finally:
+                update_finished.set()
+
+        async def fake_delete_note_best_effort(notebook_id: str, note_id: str) -> None:
+            assert (notebook_id, note_id) == ("nb_123", "note_123")
+            cleanup_started.set()
+            try:
+                await cleanup_can_finish.wait()
+            finally:
+                cleanup_finished.set()
+
+        monkeypatch.setattr(service, "update_note", fake_update_note)
+        monkeypatch.setattr(service, "_delete_note_best_effort", fake_delete_note_best_effort)
+
+        task = asyncio.create_task(service.create_note("nb_123", title="Title", content="body"))
+        await asyncio.wait_for(update_started.wait(), timeout=1)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
+
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        assert not cleanup_finished.is_set()
+        assert not update_finished.is_set()
+
+        update_can_finish.set()
+        await asyncio.wait_for(update_finished.wait(), timeout=1)
+        cleanup_can_finish.set()
+        await asyncio.wait_for(cleanup_finished.wait(), timeout=1)
+
+
+class TestModuleCompatibility:
+    """Module-level functions remain patchable compatibility seams."""
+
+    @pytest.mark.asyncio
+    async def test_module_create_note_still_uses_module_update_patch(
+        self,
+        mock_core: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_core.rpc_call.return_value = [["note_123"]]
+        calls: list[tuple[str, str, str, str]] = []
+
+        async def fake_update_note(
+            core: object,
+            notebook_id: str,
+            note_id: str,
+            content: str,
+            title: str,
+        ) -> None:
+            assert core is mock_core
+            calls.append((notebook_id, note_id, content, title))
+
+        monkeypatch.setattr(_mind_map, "update_note", fake_update_note)
+
+        note = await _mind_map.create_note(
+            mock_core,
+            "nb_123",
+            title="Title",
+            content="body",
+        )
+
+        assert note.id == "note_123"
+        assert calls == [("nb_123", "note_123", "body", "Title")]
+
+
+class TestNotesAPIServiceInjection:
+    """NotesAPI delegates note-backed behavior through the injected service."""
+
+    @pytest.mark.asyncio
+    async def test_create_update_list_and_delete_mind_map_use_injected_service(
+        self,
+        mock_core: MagicMock,
+    ) -> None:
+        mind_map_service = MagicMock()
+        mind_map_service.create_note = AsyncMock(
+            return_value=Note("note_123", "nb_123", "Title", "Body")
+        )
+        mind_map_service.update_note = AsyncMock(return_value=None)
+        mind_map_service.list_mind_maps = AsyncMock(return_value=[["mm_1", '{"nodes": []}']])
+        mind_map_service.delete_note = AsyncMock(return_value=True)
+        api = NotesAPI(mock_core, mind_map_service=mind_map_service)
+
+        assert await api.create("nb_123", "Title", "Body") == Note(
+            "note_123",
+            "nb_123",
+            "Title",
+            "Body",
+        )
+        await api.update("nb_123", "note_123", "New Body", "New Title")
+        assert await api.list_mind_maps("nb_123") == [["mm_1", '{"nodes": []}']]
+        assert await api.delete("nb_123", "note_123") is True
+        assert await api.delete_mind_map("nb_123", "mm_1") is True
+
+        mind_map_service.create_note.assert_awaited_once_with(
+            "nb_123",
+            title="Title",
+            content="Body",
+        )
+        mind_map_service.update_note.assert_awaited_once_with(
+            "nb_123",
+            "note_123",
+            "New Body",
+            "New Title",
+        )
+        mind_map_service.list_mind_maps.assert_awaited_once_with("nb_123")
+        mind_map_service.delete_note.assert_has_awaits(
+            [
+                call("nb_123", "note_123"),
+                call("nb_123", "mm_1"),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_private_helpers_use_injected_service(self, mock_core: MagicMock) -> None:
+        mind_map_service = MagicMock()
+        mind_map_service.fetch_all_notes_and_mind_maps = AsyncMock(return_value=[["note_1"]])
+        mind_map_service.is_deleted = MagicMock(return_value=False)
+        mind_map_service.extract_content = MagicMock(return_value="Body")
+        api = NotesAPI(mock_core, mind_map_service=mind_map_service)
+
+        assert await api._get_all_notes_and_mind_maps("nb_123") == [["note_1"]]
+        assert api._is_deleted(["note_1"]) is False
+        assert api._extract_content(["note_1", "Body"]) == "Body"
+
+        mind_map_service.fetch_all_notes_and_mind_maps.assert_awaited_once_with("nb_123")
+        mind_map_service.is_deleted.assert_called_once_with(["note_1"])
+        mind_map_service.extract_content.assert_called_once_with(["note_1", "Body"])


### PR DESCRIPTION
## Summary
- Extract note-backed mind-map RPC behavior into a private `MindMapService`.
- Route `NotesAPI` note and mind-map operations through the service with keyword-only injection.
- Preserve private module-level `_mind_map` compatibility seams for existing imports and monkeypatch tests.
- Add focused unit coverage for service row filtering, create/update/delete, cancellation cleanup, and `NotesAPI` delegation.

Plan: `.sisyphus/phases/architecture-remediation/phase-9.md` T10c.

## Verification
- `rtk uv run pytest tests/unit/test_mind_map_service.py tests/unit/test_notes_unit.py tests/unit/test_notes_integration.py tests/integration/concurrency/test_note_create_cancel.py tests/unit/test_init_order.py` -> 117 passed
- `rtk uv run pytest tests/unit/test_artifact_downloads.py tests/unit/test_artifacts_integration.py tests/unit/test_source_selection.py tests/integration/concurrency/test_download_blocks_loop.py tests/integration/test_mind_map_chain_vcr.py tests/integration/cli_vcr/test_generate.py tests/integration/cli_vcr/test_artifacts.py tests/integration/cli_vcr/test_downloads.py tests/integration/cli_vcr/test_notes.py` -> 203 passed, 1 pre-existing warning
- `rtk uv run ruff check src/notebooklm/_mind_map.py src/notebooklm/_notes.py src/notebooklm/_artifacts.py src/notebooklm/_artifact_generation.py src/notebooklm/_artifact_downloads.py src/notebooklm/_artifact_listing.py src/notebooklm/_artifact_polling.py tests/unit/test_mind_map_service.py tests/unit/test_notes_unit.py tests/integration/concurrency/test_note_create_cancel.py`
- `rtk uv run ruff format --check src/notebooklm/_mind_map.py src/notebooklm/_notes.py src/notebooklm/_artifacts.py src/notebooklm/_artifact_generation.py src/notebooklm/_artifact_downloads.py src/notebooklm/_artifact_listing.py src/notebooklm/_artifact_polling.py tests/unit/test_mind_map_service.py tests/unit/test_notes_unit.py tests/integration/concurrency/test_note_create_cancel.py`
- `rtk uv run mypy src/notebooklm`
- `rtk git diff --check`

## Review Notes
- `builtins.list[...]` remains in `_notes.py` where `NotesAPI.list` shadows the builtin and mypy rejects bare `list[...]` in later class-scope annotations.
- `from __future__ import annotations` was intentionally not added to `_notes.py` to avoid changing runtime annotations on public `NotesAPI` methods.
- A graceful shutdown hook for background cleanup tasks remains optional future work; this PR preserves the existing cancellation semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal note and mind-map handling to improve code organization and maintainability through a centralized service architecture, enhancing system reliability.

* **Tests**
  * Added comprehensive unit tests for mind-map operations, content detection, and note mutations to ensure robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->