### PR TITLE
fix(review): cover notebook service import guards

### DIFF
--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -548,6 +548,12 @@ def test_notebook_composition_services_do_not_runtime_import_facades_or_core() -
     assert forbidden_construction_by_module == {}
 
 
+def test_notebook_composition_services_import_cleanly() -> None:
+    """Notebook composition services must be import-safe."""
+    for module_name in _NOTEBOOK_COMPOSITION_SERVICE_MODULES:
+        importlib.import_module(f"notebooklm.{module_name.removesuffix('.py')}")
+
+
 def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> None:
     """Phase 9 notebook metadata work depends on the final Phase 8 lister name."""
     from notebooklm._source_listing import SourceLister
@@ -615,10 +621,6 @@ def test_client_constructs_sources_before_notebooks_and_injects_sources_api() ->
     assert notebooks_call.func.id == "NotebooksAPI"
 
     assert _self_attr_name(_call_keyword_value(notebooks_call, "sources_api")) == "sources"
-
-
-def test_notebook_metadata_service_imports_cleanly() -> None:
-    importlib.import_module("notebooklm._notebook_metadata")
 
 
 def test_core_private_access_guard_detects_simple_aliases() -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -548,10 +548,10 @@ def test_notebook_composition_services_do_not_runtime_import_facades_or_core() -
     assert forbidden_construction_by_module == {}
 
 
-def test_notebook_composition_services_import_cleanly() -> None:
+@pytest.mark.parametrize("module_name", _NOTEBOOK_COMPOSITION_SERVICE_MODULES)
+def test_notebook_composition_services_import_cleanly(module_name: str) -> None:
     """Notebook composition services must be import-safe."""
-    for module_name in _NOTEBOOK_COMPOSITION_SERVICE_MODULES:
-        importlib.import_module(f"notebooklm.{module_name.removesuffix('.py')}")
+    importlib.import_module(f"notebooklm.{module_name.removesuffix('.py')}")
 
 
 def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #692. PR #692 was squash-merged before the final Claude review follow-up landed on the source branch, so this PR carries that small review fix separately.

This extends the notebook composition service import-safety guard so it covers every current private notebook composition service:

- `_notebook_metadata.py`
- `_sharing_manager.py`
- `_mind_map.py`

The guard is parameterized so each service is reported as its own test case.

## Related PR

Follow-up to #692.

## Changes

- Replaces the single-module `_notebook_metadata` import-clean test with a parameterized test over `_NOTEBOOK_COMPOSITION_SERVICE_MODULES`.
- Keeps the guard in `tests/unit/test_init_order.py`, alongside the private-service boundary tests added by #692.

## Test Plan

- [x] `rtk uv run pytest -n auto tests/unit/test_init_order.py` — 31 passed
- [x] `rtk uv run ruff check tests/unit/test_init_order.py`
- [x] `rtk uv run ruff format --check tests/unit/test_init_order.py`
- [x] `rtk git diff --check`
- [x] `rtk uv run pytest -n auto` — 4681 passed, 12 skipped
- [x] `rtk uv run ruff check .`
- [x] `rtk uv run ruff format --check .`
- [x] `rtk uv run mypy src/notebooklm`
- [x] `rtk git diff --check origin/main..HEAD`

## Notes

No runtime code changes. This is a test-only guardrail follow-up for the Phase 9/T10d boundary audit.