### PR TITLE
refactor(cli): add shared auth error runtime

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -18,7 +18,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 from urllib.parse import urlsplit, urlunsplit
 
 import click
@@ -1049,7 +1049,7 @@ def handle_error(e: Exception):
     raise SystemExit(1)
 
 
-def handle_auth_error(json_output: bool = False):
+def handle_auth_error(json_output: bool = False) -> NoReturn:
     """Handle authentication errors with helpful context."""
     from ..paths import get_path_info, get_storage_path
 
@@ -1073,6 +1073,7 @@ def handle_auth_error(json_output: bool = False):
                 "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
             },
         )
+        raise SystemExit(1)
     else:
         console.print("[red]Not logged in.[/red]\n")
         console.print("[dim]Checked locations:[/dim]")

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -14,10 +14,11 @@ import json
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlsplit, urlunsplit
 
 import click
@@ -41,6 +42,7 @@ console = Console()
 # active so that stdout stays parseable JSON for automation. See ``emit_status``.
 stderr_console = Console(stderr=True)
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
@@ -1091,6 +1093,74 @@ def handle_auth_error(json_output: bool = False):
 # =============================================================================
 
 
+def with_auth_and_errors(
+    ctx: click.Context,
+    *,
+    command_name: str,
+    json_output: bool,
+    body: Callable[[AuthTokens], Awaitable[T]],
+    auth_loader: Callable[[click.Context], AuthTokens] | None = None,
+) -> T:
+    """Run a CLI command body with shared auth bootstrap and error handling."""
+    from .error_handler import handle_errors
+
+    start = time.monotonic()
+    logger.debug("CLI command starting: %s", command_name)
+
+    # Verbose is captured on the root group via Click ``--verbose`` count.
+    # Use ``find_root`` so nested subcommand contexts still see it.
+    try:
+        verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
+    except Exception:
+        verbose_count = 0
+    verbose = verbose_count >= 1
+
+    def log_result(status: str, detail: str = "") -> float:
+        elapsed = time.monotonic() - start
+        if detail:
+            logger.debug(
+                "CLI command %s: %s (%.3fs) - %s",
+                status,
+                command_name,
+                elapsed,
+                detail,
+            )
+        else:
+            logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
+        return elapsed
+
+    with handle_errors(verbose=verbose, json_output=json_output):
+        # Auth bootstrap: FileNotFoundError here means the storage file is
+        # missing — it has a dedicated rich UX via ``handle_auth_error``.
+        # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
+        # raised *inside* the command body (e.g., a missing ``--source-file``
+        # argument; see issue #153) is NOT misclassified as an auth error —
+        # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
+        # Any OTHER exception from the auth bootstrap (malformed storage JSON,
+        # AuthError during token extraction, etc.) also reaches ``handle_errors``
+        # so users get typed hints rather than a raw traceback.
+        try:
+            loader = auth_loader or get_auth_tokens
+            auth = loader(ctx)
+        except FileNotFoundError:
+            log_result("failed", "not authenticated")
+            return handle_auth_error(json_output)
+        except Exception as e:
+            # Non-FileNotFoundError bootstrap failures (AuthError, malformed
+            # storage JSON, etc.) still need the structured debug-log entry;
+            # ``handle_errors`` will translate the exception to a typed hint.
+            log_result("failed", str(e))
+            raise
+
+        try:
+            result = run_async(body(auth))
+        except Exception as e:
+            log_result("failed", str(e))
+            raise
+        log_result("completed")
+        return result
+
+
 def with_client(f):
     """Decorator that handles auth, async execution, and errors for CLI commands.
 
@@ -1123,59 +1193,18 @@ def with_client(f):
     @wraps(f)
     @click.pass_context
     def wrapper(ctx, *args, **kwargs):
-        from .error_handler import handle_errors
-
         cmd_name = f.__name__
-        start = time.monotonic()
-        logger.debug("CLI command starting: %s", cmd_name)
-
         json_output = kwargs.get("json_output", False)
-        # Verbose is captured on the root group via Click ``--verbose`` count.
-        # Use ``find_root`` so nested subcommand contexts still see it.
-        try:
-            verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
-        except Exception:
-            verbose_count = 0
-        verbose = verbose_count >= 1
 
-        def log_result(status: str, detail: str = "") -> float:
-            elapsed = time.monotonic() - start
-            if detail:
-                logger.debug("CLI command %s: %s (%.3fs) - %s", status, cmd_name, elapsed, detail)
-            else:
-                logger.debug("CLI command %s: %s (%.3fs)", status, cmd_name, elapsed)
-            return elapsed
+        def body(auth: AuthTokens) -> Awaitable[Any]:
+            return f(ctx, *args, client_auth=auth, **kwargs)
 
-        with handle_errors(verbose=verbose, json_output=json_output):
-            # Auth bootstrap: FileNotFoundError here means the storage file is
-            # missing — it has a dedicated rich UX via ``handle_auth_error``.
-            # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
-            # raised *inside* the command body (e.g., a missing ``--source-file``
-            # argument; see issue #153) is NOT misclassified as an auth error —
-            # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
-            # Any OTHER exception from the auth bootstrap (malformed storage JSON,
-            # AuthError during token extraction, etc.) also reaches ``handle_errors``
-            # so users get typed hints rather than a raw traceback.
-            try:
-                auth = get_auth_tokens(ctx)
-            except FileNotFoundError:
-                log_result("failed", "not authenticated")
-                handle_auth_error(json_output)
-                return  # unreachable — handle_auth_error raises SystemExit
-            except Exception as e:
-                # Non-FileNotFoundError bootstrap failures (AuthError, malformed
-                # storage JSON, etc.) still need the structured debug-log entry;
-                # ``handle_errors`` will translate the exception to a typed hint.
-                log_result("failed", str(e))
-                raise
-            try:
-                coro = f(ctx, *args, client_auth=auth, **kwargs)
-                result = run_async(coro)
-            except Exception as e:
-                log_result("failed", str(e))
-                raise
-            log_result("completed")
-            return result
+        return with_auth_and_errors(
+            ctx,
+            command_name=cmd_name,
+            json_output=json_output,
+            body=body,
+        )
 
     return wrapper
 

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -158,6 +158,7 @@ def test_with_auth_and_errors_passes_verbose_json_to_current_handle_errors() -> 
         coro.close()
         return "patched run result"
 
+    # ``with_auth_and_errors`` imports this at call time, so patch the source module.
     with (
         patch("notebooklm.cli.error_handler.handle_errors", fake_handle_errors),
         patch("notebooklm.cli.helpers.run_async", side_effect=fake_run_async) as run_async,

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -21,13 +21,14 @@ from __future__ import annotations
 
 import json
 from collections.abc import Generator
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import click
 import pytest
 from click.testing import CliRunner
 
-from notebooklm.cli.helpers import with_client
+from notebooklm.cli.helpers import with_auth_and_errors, with_client
 from notebooklm.exceptions import AuthError, RateLimitError
 
 # ---------------------------------------------------------------------------
@@ -76,6 +77,182 @@ def _build_cli(body):
         return body(client_auth)
 
     return cli
+
+
+def _make_click_context(verbose: int = 0) -> click.Context:
+    @click.group()
+    def cli():
+        pass
+
+    @click.command()
+    def run():
+        pass
+
+    root_ctx = click.Context(cli)
+    root_ctx.params["verbose"] = verbose
+    return click.Context(run, parent=root_ctx)
+
+
+# ---------------------------------------------------------------------------
+# Shared primitive behavior
+# ---------------------------------------------------------------------------
+
+
+def test_with_auth_and_errors_uses_custom_auth_loader() -> None:
+    sentinel_auth = MagicMock(name="custom-auth")
+    seen: dict[str, object] = {}
+    ctx = _make_click_context()
+
+    def _loader(loader_ctx: click.Context):
+        seen["ctx"] = loader_ctx
+        return sentinel_auth
+
+    async def _body(auth):
+        seen["auth"] = auth
+        return "ok"
+
+    result = with_auth_and_errors(
+        ctx,
+        command_name="run",
+        json_output=False,
+        body=_body,
+        auth_loader=_loader,
+    )
+
+    assert result == "ok"
+    assert seen == {"ctx": ctx, "auth": sentinel_auth}
+
+
+def test_with_auth_and_errors_default_auth_loader_is_looked_up_at_call_time() -> None:
+    sentinel_auth = MagicMock(name="default-auth")
+    ctx = _make_click_context()
+
+    async def _body(auth):
+        return auth
+
+    with patch("notebooklm.cli.helpers.get_auth_tokens", return_value=sentinel_auth) as loader:
+        result = with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=False,
+            body=_body,
+        )
+
+    loader.assert_called_once_with(ctx)
+    assert result is sentinel_auth
+
+
+def test_with_auth_and_errors_passes_verbose_json_to_current_handle_errors() -> None:
+    calls: list[dict[str, bool]] = []
+    ctx = _make_click_context(verbose=1)
+
+    @contextmanager
+    def fake_handle_errors(*, verbose: bool, json_output: bool):
+        calls.append({"verbose": verbose, "json_output": json_output})
+        yield
+
+    async def _body(_auth):
+        return "real body result"
+
+    def fake_run_async(coro):
+        coro.close()
+        return "patched run result"
+
+    with (
+        patch("notebooklm.cli.error_handler.handle_errors", fake_handle_errors),
+        patch("notebooklm.cli.helpers.run_async", side_effect=fake_run_async) as run_async,
+    ):
+        result = with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_body,
+            auth_loader=lambda _ctx: MagicMock(name="auth"),
+        )
+
+    assert result == "patched run result"
+    assert calls == [{"verbose": True, "json_output": True}]
+    assert run_async.call_count == 1
+
+
+def test_with_auth_and_errors_auth_file_not_found_uses_auth_handler() -> None:
+    ctx = _make_click_context()
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    def _loader(_ctx):
+        raise FileNotFoundError("missing storage")
+
+    with (
+        patch("notebooklm.cli.helpers.handle_auth_error", side_effect=SystemExit(1)) as auth_error,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_never_called,
+            auth_loader=_loader,
+        )
+
+    assert exc_info.value.code == 1
+    auth_error.assert_called_once_with(True)
+
+
+def test_with_auth_and_errors_body_file_not_found_reaches_handle_errors(capsys) -> None:
+    ctx = _make_click_context()
+
+    async def _body(_auth):
+        raise FileNotFoundError("missing command input")
+
+    with (
+        patch("notebooklm.cli.helpers.handle_auth_error") as auth_error,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_body,
+            auth_loader=lambda _ctx: MagicMock(name="auth"),
+        )
+
+    assert exc_info.value.code == 2
+    auth_error.assert_not_called()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+    assert "missing command input" in payload["message"]
+
+
+def test_with_auth_and_errors_non_file_auth_failure_reaches_handle_errors(capsys) -> None:
+    ctx = _make_click_context()
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    def _loader(_ctx):
+        raise ValueError("malformed storage JSON")
+
+    with (
+        patch("notebooklm.cli.helpers.handle_auth_error") as auth_error,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_never_called,
+            auth_loader=_loader,
+        )
+
+    assert exc_info.value.code == 2
+    auth_error.assert_not_called()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+    assert "malformed storage JSON" in payload["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `with_auth_and_errors(...)` in `cli.helpers` as the shared auth/error/runtime primitive for T11.
- Refactor `with_client(...)` into a thin adapter without changing Click callback signatures or helper patch seams.
- Add focused primitive tests for auth bootstrap failures, command body `FileNotFoundError`, verbose/json propagation, call-time lookup, and custom `auth_loader`.

## Task
T11.1 from `.sisyphus/phases/architecture-remediation/phase-10.md`.

## Blocked / speculative status
- Draft/speculative until T11.0 is merged and audited.
- I did not find a merged or open T11.0 PR via `gh pr list` search, so this must not merge yet.
- Before merge: rebase onto current `main` after T11.0 lands and rerun the full gate.

## Test plan
- `uv run pytest tests/unit/test_with_client_handle_errors.py tests/unit/cli/test_helpers.py::TestWithClientDecorator tests/unit/cli/test_helpers.py::TestRunAsync`
- `uv run ruff check src/notebooklm/cli/helpers.py tests/unit/test_with_client_handle_errors.py tests/unit/cli/test_helpers.py`
- `uv run ruff format --check src/notebooklm/cli/helpers.py tests/unit/test_with_client_handle_errors.py tests/unit/cli/test_helpers.py`
- `uv run mypy src/notebooklm`
- `uv run pytest -n auto --dist=worksteal`
- `uv run pre-commit run --all-files`

## Polish evidence
- Step 4.1 code-simplifier fallback: applied 2 preservation/clarity edits; plugin config file was unavailable.
- Step 4.2 triple review: native Codex + Gemini + Claude, 0 critical, 0 important, 5 optional suggestions deferred.
- Step 4.3 ultrathink: no new correctness concerns.

## Deferred polish findings
- Optional: consider typing `handle_auth_error` as `NoReturn` in a later helper typing cleanup.
- Optional: inherited broad verbose fallback can be narrowed later.
- Optional: add a comment for the lazy `handle_errors` patch seam if future moves make that seam less obvious.
- Optional: simplify manual Click context fixture style in tests.
- Optional: remove the unused `log_result` return value in a later cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized CLI auth and error handling with verbose-aware logging and clearer start/failed/completed indicators.
  * Better handling of authentication failures (distinct exit behavior) and more consistent JSON error output.

* **Tests**
  * Expanded unit tests covering CLI auth loading, verbose/json forwarding, and error/failure modes to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->