### PR TITLE
test(cli): characterize runtime and completion contracts

### DIFF
--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json
@@ -107,7 +107,6 @@
   },
   "commands": {
     "agent": {
-      "callback": "agent",
       "class": "Group",
       "commands": [
         "show"
@@ -116,7 +115,6 @@
       "short_help": "Show bundled instructions for supported..."
     },
     "agent show": {
-      "callback": "show_agent",
       "class": "Command",
       "params": [
         {
@@ -137,7 +135,6 @@
       "short_help": "Display instructions for Codex or Claude..."
     },
     "artifact": {
-      "callback": "artifact",
       "class": "Group",
       "commands": [
         "delete",
@@ -153,7 +150,6 @@
       "short_help": "Artifact management commands."
     },
     "artifact delete": {
-      "callback": "artifact_delete",
       "class": "Command",
       "params": [
         {
@@ -168,6 +164,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -179,7 +176,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -187,6 +183,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -198,7 +195,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -206,6 +202,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -216,7 +213,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -225,7 +221,6 @@
       "short_help": "Delete an artifact."
     },
     "artifact export": {
-      "callback": "artifact_export",
       "class": "Command",
       "params": [
         {
@@ -240,6 +235,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -251,7 +247,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -259,6 +254,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Title for exported document",
           "is_flag": false,
           "kind": "option",
@@ -269,7 +265,6 @@
           ],
           "required": true,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -277,6 +272,7 @@
         {
           "default": "docs",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -287,7 +283,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -300,6 +295,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -310,7 +306,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -319,7 +314,6 @@
       "short_help": "Export artifact to Google Docs/Sheets."
     },
     "artifact get": {
-      "callback": "artifact_get",
       "class": "Command",
       "params": [
         {
@@ -334,6 +328,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -345,7 +340,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -353,6 +347,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -363,7 +358,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -372,12 +366,12 @@
       "short_help": "Get artifact details."
     },
     "artifact list": {
-      "callback": "artifact_list",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -389,7 +383,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -397,6 +390,7 @@
         {
           "default": "all",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by type",
           "is_flag": false,
           "kind": "option",
@@ -407,7 +401,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -428,6 +421,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -438,7 +432,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -446,6 +439,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show at most N rows (default: unlimited). Applies to both text and --json output.",
           "is_flag": false,
           "kind": "option",
@@ -456,7 +450,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -464,6 +457,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Disable column truncation in the rendered table (default: truncate).",
           "is_flag": true,
           "kind": "option",
@@ -474,7 +468,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -483,7 +476,6 @@
       "short_help": "List artifacts in a notebook."
     },
     "artifact poll": {
-      "callback": "artifact_poll",
       "class": "Command",
       "params": [
         {
@@ -498,6 +490,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -509,7 +502,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -517,6 +509,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -527,7 +520,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -536,7 +528,6 @@
       "short_help": "Single non-blocking generation status check."
     },
     "artifact rename": {
-      "callback": "artifact_rename",
       "class": "Command",
       "params": [
         {
@@ -560,6 +551,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -571,7 +563,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -579,6 +570,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -589,7 +581,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -598,12 +589,12 @@
       "short_help": "Rename an artifact."
     },
     "artifact suggestions": {
-      "callback": "artifact_suggestions",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -615,7 +606,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -623,6 +613,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON format",
           "is_flag": true,
           "kind": "option",
@@ -633,7 +624,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -642,7 +632,6 @@
       "short_help": "Get AI-suggested report topics based on..."
     },
     "artifact wait": {
-      "callback": "artifact_wait",
       "class": "Command",
       "params": [
         {
@@ -657,6 +646,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -668,7 +658,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -676,6 +665,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -686,7 +676,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -694,6 +683,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -704,7 +694,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -712,6 +701,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -722,7 +712,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -731,7 +720,6 @@
       "short_help": "Block until artifact generation finishes..."
     },
     "ask": {
-      "callback": "ask_cmd",
       "class": "Command",
       "params": [
         {
@@ -746,6 +734,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -756,7 +745,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -764,6 +752,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -775,7 +764,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -783,6 +771,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Continue a specific conversation",
           "is_flag": false,
           "kind": "option",
@@ -794,7 +783,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -802,6 +790,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Start a fresh conversation, skipping the auto-resume of the last one.",
           "is_flag": true,
           "kind": "option",
@@ -812,7 +801,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -820,6 +808,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs (can be repeated)",
           "is_flag": false,
           "kind": "option",
@@ -831,7 +820,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -839,6 +827,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON (includes references)",
           "is_flag": true,
           "kind": "option",
@@ -849,7 +838,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -857,6 +845,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Save response as a note. When the answer has citations, the saved note preserves interactive [N] hover-anchor links (matching the NotebookLM web UI's 'Save to note' behavior); otherwise falls back to a plain-text note.",
           "is_flag": true,
           "kind": "option",
@@ -867,7 +856,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -875,6 +863,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Note title (use with --save-as-note)",
           "is_flag": false,
           "kind": "option",
@@ -885,7 +874,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -893,6 +881,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "HTTP request timeout in seconds (default: 30, from the library). Increase for long or complex prompts.",
           "is_flag": false,
           "kind": "option",
@@ -903,7 +892,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "clamp": false,
             "max": null,
@@ -915,7 +903,6 @@
       "short_help": "Ask a notebook a question."
     },
     "auth": {
-      "callback": "auth_group",
       "class": "Group",
       "commands": [
         "check",
@@ -927,12 +914,12 @@
       "short_help": "Authentication management commands."
     },
     "auth check": {
-      "callback": "auth_check",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Test token fetch (makes network request)",
           "is_flag": true,
           "kind": "option",
@@ -943,7 +930,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -951,6 +937,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -961,7 +948,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -970,12 +956,12 @@
       "short_help": "Check authentication status and diagnose..."
     },
     "auth inspect": {
-      "callback": "auth_inspect",
       "class": "Command",
       "params": [
         {
           "default": "auto",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Browser to read cookies from (chrome, firefox, brave, edge, safari, arc, ...). 'auto' picks the first one rookiepy can read. Use 'chrome::<profile>' for one Chromium profile or 'firefox::<container>' for one Firefox container. Requires: pip install 'notebooklm-py[cookies]'",
           "is_flag": false,
           "kind": "option",
@@ -986,7 +972,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -994,6 +979,7 @@
         {
           "default": [],
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Opt in to enumerating accounts via sibling-product cookies. Same syntax as 'notebooklm login --include-domains'. By default this command only consults required Google auth cookies, which is sufficient for account discovery on every tested path.",
           "is_flag": false,
           "kind": "option",
@@ -1004,7 +990,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1012,6 +997,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -1022,7 +1008,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1030,6 +1015,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Also show which browser user-profile each account's cookies came from. Useful for Chromium-family browsers with multiple user-profiles.",
           "is_flag": true,
           "kind": "option",
@@ -1041,7 +1027,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1050,18 +1035,17 @@
       "short_help": "List Google accounts visible to a..."
     },
     "auth logout": {
-      "callback": "auth_logout",
       "class": "Command",
       "params": [],
       "short_help": "Log out by clearing saved authentication."
     },
     "auth refresh": {
-      "callback": "auth_refresh",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Re-extract cookies from an installed browser and match the profile account from context.json. Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... Use 'chrome::<profile>' for one Chromium profile or 'firefox::<container>' for one Firefox container.",
           "is_flag": false,
           "kind": "option",
@@ -1073,7 +1057,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1081,6 +1064,7 @@
         {
           "default": [],
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Forward to the browser-cookie reader (only meaningful with --browser-cookies). Same syntax as 'notebooklm login --include-domains'.",
           "is_flag": false,
           "kind": "option",
@@ -1091,7 +1075,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1099,6 +1082,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Suppress success output (only print on error)",
           "is_flag": true,
           "kind": "option",
@@ -1110,7 +1094,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1119,13 +1102,11 @@
       "short_help": "Refresh stored cookies by exercising the..."
     },
     "clear": {
-      "callback": "clear_cmd",
       "class": "Command",
       "params": [],
       "short_help": "Clear current notebook context."
     },
     "completion": {
-      "callback": "completion_cmd",
       "class": "Command",
       "params": [
         {
@@ -1147,12 +1128,12 @@
       "short_help": "Print the shell completion script for SHELL."
     },
     "configure": {
-      "callback": "configure_cmd",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -1164,7 +1145,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -1172,6 +1152,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Predefined chat mode",
           "is_flag": false,
           "kind": "option",
@@ -1182,7 +1163,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -1197,6 +1177,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Custom persona prompt (up to 10,000 chars)",
           "is_flag": false,
           "kind": "option",
@@ -1207,7 +1188,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1215,6 +1195,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Response verbosity",
           "is_flag": false,
           "kind": "option",
@@ -1225,7 +1206,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -1239,6 +1219,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -1249,7 +1230,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1258,7 +1238,6 @@
       "short_help": "Configure chat persona and response settings."
     },
     "create": {
-      "callback": "create_cmd",
       "class": "Command",
       "params": [
         {
@@ -1273,6 +1252,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Set the new notebook as the current context (like 'notebooklm use <id>').",
           "is_flag": true,
           "kind": "option",
@@ -1284,7 +1264,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1292,6 +1271,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -1302,7 +1282,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1311,12 +1290,12 @@
       "short_help": "Create a new notebook."
     },
     "delete": {
-      "callback": "delete_cmd",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -1328,7 +1307,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -1336,6 +1314,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -1347,7 +1326,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1356,12 +1334,12 @@
       "short_help": "Delete a notebook."
     },
     "doctor": {
-      "callback": "doctor",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Attempt to fix detected issues",
           "is_flag": true,
           "kind": "option",
@@ -1372,7 +1350,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1380,6 +1357,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -1390,7 +1368,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1399,7 +1376,6 @@
       "short_help": "Check profile setup, auth status, and..."
     },
     "download": {
-      "callback": "download",
       "class": "Group",
       "commands": [
         "audio",
@@ -1417,7 +1393,6 @@
       "short_help": "Download generated content."
     },
     "download audio": {
-      "callback": "download_audio",
       "class": "Command",
       "params": [
         {
@@ -1440,6 +1415,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -1451,7 +1427,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -1459,6 +1434,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -1469,7 +1445,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1477,6 +1452,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -1487,7 +1463,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1495,6 +1470,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -1505,7 +1481,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1513,6 +1488,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -1523,7 +1499,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1531,6 +1506,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -1542,7 +1518,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -1550,6 +1525,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -1560,7 +1536,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1568,6 +1543,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -1578,7 +1554,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1586,6 +1561,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -1596,7 +1572,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1604,6 +1579,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -1614,7 +1590,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1623,7 +1598,6 @@
       "short_help": "Download audio overview(s) to file."
     },
     "download cinematic-video": {
-      "callback": "download_video",
       "class": "Command",
       "params": [
         {
@@ -1646,6 +1620,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -1657,7 +1632,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -1665,6 +1639,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -1675,7 +1650,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1683,6 +1657,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -1693,7 +1668,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1701,6 +1675,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -1711,7 +1686,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1719,6 +1693,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -1729,7 +1704,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1737,6 +1711,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -1748,7 +1723,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -1756,6 +1730,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -1766,7 +1741,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1774,6 +1748,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -1784,7 +1759,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1792,6 +1766,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -1802,7 +1777,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1810,6 +1784,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -1820,7 +1795,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1829,7 +1803,6 @@
       "short_help": "Download cinematic video overview(s) to file."
     },
     "download data-table": {
-      "callback": "download_data_table",
       "class": "Command",
       "params": [
         {
@@ -1852,6 +1825,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -1863,7 +1837,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -1871,6 +1844,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -1881,7 +1855,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1889,6 +1862,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -1899,7 +1873,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1907,6 +1880,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -1917,7 +1891,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1925,6 +1898,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -1935,7 +1909,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -1943,6 +1916,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -1954,7 +1928,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -1962,6 +1935,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -1972,7 +1946,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1980,6 +1953,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -1990,7 +1964,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -1998,6 +1971,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -2008,7 +1982,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2016,6 +1989,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -2026,7 +2000,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2035,7 +2008,6 @@
       "short_help": "Download data table(s) as CSV files."
     },
     "download flashcards": {
-      "callback": "download_flashcards_cmd",
       "class": "Command",
       "params": [
         {
@@ -2058,6 +2030,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -2069,7 +2042,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -2077,6 +2049,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -2087,7 +2060,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2095,6 +2067,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -2105,7 +2078,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2113,6 +2085,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -2123,7 +2096,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2131,6 +2103,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -2141,7 +2114,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -2149,6 +2121,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -2160,7 +2133,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -2168,6 +2140,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -2178,7 +2151,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2186,6 +2158,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -2196,7 +2169,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2204,6 +2176,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -2214,7 +2187,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2222,6 +2194,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -2232,7 +2205,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2240,6 +2212,7 @@
         {
           "default": "json",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output format: json (default), markdown, or html",
           "is_flag": false,
           "kind": "option",
@@ -2250,7 +2223,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -2265,7 +2237,6 @@
       "short_help": "Download flashcard deck."
     },
     "download infographic": {
-      "callback": "download_infographic",
       "class": "Command",
       "params": [
         {
@@ -2288,6 +2259,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -2299,7 +2271,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -2307,6 +2278,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -2317,7 +2289,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2325,6 +2296,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -2335,7 +2307,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2343,6 +2314,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -2353,7 +2325,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2361,6 +2332,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -2371,7 +2343,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -2379,6 +2350,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -2390,7 +2362,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -2398,6 +2369,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -2408,7 +2380,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2416,6 +2387,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -2426,7 +2398,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2434,6 +2405,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -2444,7 +2416,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2452,6 +2423,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -2462,7 +2434,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2471,7 +2442,6 @@
       "short_help": "Download infographic(s) to file."
     },
     "download mind-map": {
-      "callback": "download_mind_map",
       "class": "Command",
       "params": [
         {
@@ -2494,6 +2464,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -2505,7 +2476,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -2513,6 +2483,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -2523,7 +2494,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2531,6 +2501,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -2541,7 +2512,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2549,6 +2519,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -2559,7 +2530,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2567,6 +2537,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -2577,7 +2548,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -2585,6 +2555,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -2596,7 +2567,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -2604,6 +2574,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -2614,7 +2585,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2622,6 +2592,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -2632,7 +2603,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2640,6 +2610,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -2650,7 +2621,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2658,6 +2628,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -2668,7 +2639,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2677,7 +2647,6 @@
       "short_help": "Download mind map(s) as JSON files."
     },
     "download quiz": {
-      "callback": "download_quiz_cmd",
       "class": "Command",
       "params": [
         {
@@ -2700,6 +2669,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -2711,7 +2681,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -2719,6 +2688,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -2729,7 +2699,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2737,6 +2706,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -2747,7 +2717,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2755,6 +2724,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -2765,7 +2735,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2773,6 +2742,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -2783,7 +2753,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -2791,6 +2760,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -2802,7 +2772,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -2810,6 +2779,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -2820,7 +2790,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2828,6 +2797,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -2838,7 +2808,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2846,6 +2815,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -2856,7 +2826,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2864,6 +2833,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -2874,7 +2844,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2882,6 +2851,7 @@
         {
           "default": "json",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output format: json (default), markdown, or html",
           "is_flag": false,
           "kind": "option",
@@ -2892,7 +2862,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -2907,7 +2876,6 @@
       "short_help": "Download quiz questions."
     },
     "download report": {
-      "callback": "download_report",
       "class": "Command",
       "params": [
         {
@@ -2930,6 +2898,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -2941,7 +2910,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -2949,6 +2917,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -2959,7 +2928,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2967,6 +2935,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -2977,7 +2946,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -2985,6 +2953,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -2995,7 +2964,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3003,6 +2971,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -3013,7 +2982,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -3021,6 +2989,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -3032,7 +3001,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -3040,6 +3008,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -3050,7 +3019,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3058,6 +3026,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -3068,7 +3037,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3076,6 +3044,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -3086,7 +3055,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3094,6 +3062,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -3104,7 +3073,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3113,7 +3081,6 @@
       "short_help": "Download report(s) as markdown files."
     },
     "download slide-deck": {
-      "callback": "download_slide_deck",
       "class": "Command",
       "params": [
         {
@@ -3136,6 +3103,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -3147,7 +3115,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -3155,6 +3122,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -3165,7 +3133,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3173,6 +3140,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -3183,7 +3151,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3191,6 +3158,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -3201,7 +3169,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3209,6 +3176,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -3219,7 +3187,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -3227,6 +3194,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -3238,7 +3206,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -3246,6 +3213,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -3256,7 +3224,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3264,6 +3231,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -3274,7 +3242,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3282,6 +3249,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -3292,7 +3260,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3300,6 +3267,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -3310,7 +3278,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3318,6 +3285,7 @@
         {
           "default": "pdf",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download format: pdf (default) or pptx",
           "is_flag": false,
           "kind": "option",
@@ -3328,7 +3296,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -3342,7 +3309,6 @@
       "short_help": "Download slide deck(s) as PDF or PPTX."
     },
     "download video": {
-      "callback": "download_video",
       "class": "Command",
       "params": [
         {
@@ -3365,6 +3331,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -3376,7 +3343,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -3384,6 +3350,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download latest (default behavior)",
           "is_flag": true,
           "kind": "option",
@@ -3394,7 +3361,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3402,6 +3368,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download earliest",
           "is_flag": true,
           "kind": "option",
@@ -3412,7 +3379,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3420,6 +3386,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Download all artifacts",
           "is_flag": true,
           "kind": "option",
@@ -3430,7 +3397,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3438,6 +3404,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Filter by artifact title (fuzzy match)",
           "is_flag": false,
           "kind": "option",
@@ -3448,7 +3415,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -3456,6 +3422,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Select by artifact ID",
           "is_flag": false,
           "kind": "option",
@@ -3467,7 +3434,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -3475,6 +3441,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output JSON instead of text",
           "is_flag": true,
           "kind": "option",
@@ -3485,7 +3452,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3493,6 +3459,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Preview without downloading",
           "is_flag": true,
           "kind": "option",
@@ -3503,7 +3470,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3511,6 +3477,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Overwrite existing files",
           "is_flag": true,
           "kind": "option",
@@ -3521,7 +3488,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3529,6 +3495,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip if file exists",
           "is_flag": true,
           "kind": "option",
@@ -3539,7 +3506,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3548,7 +3514,6 @@
       "short_help": "Download video overview(s) to file."
     },
     "generate": {
-      "callback": "generate",
       "class": "Group",
       "commands": [
         "audio",
@@ -3567,7 +3532,6 @@
       "short_help": "Generate content from notebook."
     },
     "generate audio": {
-      "callback": "generate_audio",
       "class": "Command",
       "params": [
         {
@@ -3582,6 +3546,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -3592,7 +3557,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -3600,6 +3564,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -3611,7 +3576,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -3619,6 +3583,7 @@
         {
           "default": "deep-dive",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -3629,7 +3594,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -3644,6 +3608,7 @@
         {
           "default": "default",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -3654,7 +3619,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -3668,6 +3632,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -3678,7 +3643,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -3686,6 +3650,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -3697,7 +3662,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -3705,6 +3669,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -3717,7 +3682,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3725,6 +3689,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -3735,7 +3700,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -3743,6 +3707,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -3753,7 +3718,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -3761,6 +3725,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -3771,7 +3736,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -3779,6 +3743,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -3789,7 +3754,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3798,7 +3762,6 @@
       "short_help": "Generate audio overview (podcast)."
     },
     "generate cinematic-video": {
-      "callback": "generate_video",
       "class": "Command",
       "params": [
         {
@@ -3813,6 +3776,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -3823,7 +3787,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -3831,6 +3794,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -3842,7 +3806,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -3850,6 +3813,7 @@
         {
           "default": "explainer",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -3860,7 +3824,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -3874,6 +3837,7 @@
         {
           "default": "auto",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -3884,7 +3848,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -3905,6 +3868,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Custom visual style prompt",
           "is_flag": false,
           "kind": "option",
@@ -3915,7 +3879,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -3923,6 +3886,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -3933,7 +3897,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -3941,6 +3904,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -3952,7 +3916,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -3960,6 +3923,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -3972,7 +3936,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -3980,6 +3943,7 @@
         {
           "default": 600,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 600)",
           "is_flag": false,
           "kind": "option",
@@ -3990,7 +3954,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -3998,6 +3961,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -4008,7 +3972,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4016,6 +3979,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -4026,7 +3990,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4034,6 +3997,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -4044,7 +4008,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4053,7 +4016,6 @@
       "short_help": "Generate cinematic video overview..."
     },
     "generate data-table": {
-      "callback": "generate_data_table",
       "class": "Command",
       "params": [
         {
@@ -4068,6 +4030,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -4078,7 +4041,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -4086,6 +4048,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -4097,7 +4060,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -4105,6 +4067,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -4115,7 +4078,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -4123,6 +4085,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -4134,7 +4097,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -4142,6 +4104,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -4154,7 +4117,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4162,6 +4124,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -4172,7 +4135,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4180,6 +4142,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -4190,7 +4153,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4198,6 +4160,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -4208,7 +4171,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4216,6 +4178,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -4226,7 +4189,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4235,7 +4197,6 @@
       "short_help": "Generate data table."
     },
     "generate flashcards": {
-      "callback": "generate_flashcards",
       "class": "Command",
       "params": [
         {
@@ -4250,6 +4211,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -4260,7 +4222,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -4268,6 +4229,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -4279,7 +4241,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -4287,6 +4248,7 @@
         {
           "default": "standard",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4297,7 +4259,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4311,6 +4272,7 @@
         {
           "default": "medium",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4321,7 +4283,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4335,6 +4296,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -4346,7 +4308,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -4354,6 +4315,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -4366,7 +4328,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4374,6 +4335,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -4384,7 +4346,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4392,6 +4353,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -4402,7 +4364,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4410,6 +4371,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -4420,7 +4382,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4428,6 +4389,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -4438,7 +4400,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4447,7 +4408,6 @@
       "short_help": "Generate flashcards."
     },
     "generate infographic": {
-      "callback": "generate_infographic",
       "class": "Command",
       "params": [
         {
@@ -4462,6 +4422,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -4472,7 +4433,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -4480,6 +4440,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -4491,7 +4452,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -4499,6 +4459,7 @@
         {
           "default": "landscape",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4509,7 +4470,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4523,6 +4483,7 @@
         {
           "default": "standard",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4533,7 +4494,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4547,6 +4507,7 @@
         {
           "default": "auto",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4557,7 +4518,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4579,6 +4539,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -4589,7 +4550,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -4597,6 +4557,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -4608,7 +4569,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -4616,6 +4576,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -4628,7 +4589,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4636,6 +4596,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -4646,7 +4607,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4654,6 +4614,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -4664,7 +4625,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4672,6 +4632,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -4682,7 +4643,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4690,6 +4650,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -4700,7 +4661,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4709,12 +4669,12 @@
       "short_help": "Generate infographic."
     },
     "generate mind-map": {
-      "callback": "generate_mind_map",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -4726,7 +4686,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -4734,6 +4693,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -4745,7 +4705,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -4753,6 +4712,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -4763,7 +4723,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -4771,6 +4730,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Custom instructions for the mind map",
           "is_flag": false,
           "kind": "option",
@@ -4781,7 +4741,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -4789,6 +4748,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -4799,7 +4759,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4808,7 +4767,6 @@
       "short_help": "Generate mind map."
     },
     "generate quiz": {
-      "callback": "generate_quiz",
       "class": "Command",
       "params": [
         {
@@ -4823,6 +4781,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -4833,7 +4792,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -4841,6 +4799,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -4852,7 +4811,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -4860,6 +4818,7 @@
         {
           "default": "standard",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4870,7 +4829,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4884,6 +4842,7 @@
         {
           "default": "medium",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -4894,7 +4853,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -4908,6 +4866,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -4919,7 +4878,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -4927,6 +4885,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -4939,7 +4898,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -4947,6 +4905,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -4957,7 +4916,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4965,6 +4923,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -4975,7 +4934,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -4983,6 +4941,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -4993,7 +4952,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5001,6 +4959,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -5011,7 +4970,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5020,7 +4978,6 @@
       "short_help": "Generate quiz."
     },
     "generate report": {
-      "callback": "generate_report_cmd",
       "class": "Command",
       "params": [
         {
@@ -5035,6 +4992,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -5045,7 +5003,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -5053,6 +5010,7 @@
         {
           "default": "briefing-doc",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Report format (default: briefing-doc)",
           "is_flag": false,
           "kind": "option",
@@ -5063,7 +5021,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -5078,6 +5035,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -5089,7 +5047,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -5097,6 +5054,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -5108,7 +5066,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -5116,6 +5073,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -5126,7 +5084,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -5134,6 +5091,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Append extra instructions to the built-in prompt for non-custom formats. Has no effect with --format custom.",
           "is_flag": false,
           "kind": "option",
@@ -5144,7 +5102,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -5152,6 +5109,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -5164,7 +5122,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5172,6 +5129,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -5182,7 +5140,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5190,6 +5147,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -5200,7 +5158,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5208,6 +5165,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -5218,7 +5176,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5226,6 +5183,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -5236,7 +5194,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5245,7 +5202,6 @@
       "short_help": "Generate a report (briefing doc, study..."
     },
     "generate revise-slide": {
-      "callback": "generate_revise_slide",
       "class": "Command",
       "params": [
         {
@@ -5260,6 +5216,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -5270,7 +5227,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -5278,6 +5234,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -5289,7 +5246,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -5297,6 +5253,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Slide deck artifact ID to revise",
           "is_flag": false,
           "kind": "option",
@@ -5308,7 +5265,6 @@
           ],
           "required": true,
           "secondary_opts": [],
-          "shell_complete": "_complete_artifacts",
           "type": {
             "name": "text"
           }
@@ -5316,6 +5272,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Zero-based index of the slide to revise (0 = first slide)",
           "is_flag": false,
           "kind": "option",
@@ -5326,7 +5283,6 @@
           ],
           "required": true,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5334,6 +5290,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -5346,7 +5303,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5354,6 +5310,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -5364,7 +5321,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5372,6 +5328,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -5382,7 +5339,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5390,6 +5346,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -5400,7 +5357,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5408,6 +5364,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -5418,7 +5375,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5427,7 +5383,6 @@
       "short_help": "Revise an individual slide in an existing..."
     },
     "generate slide-deck": {
-      "callback": "generate_slide_deck",
       "class": "Command",
       "params": [
         {
@@ -5442,6 +5397,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -5452,7 +5408,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -5460,6 +5415,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -5471,7 +5427,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -5479,6 +5434,7 @@
         {
           "default": "detailed",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -5489,7 +5445,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -5502,6 +5457,7 @@
         {
           "default": "default",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -5512,7 +5468,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -5525,6 +5480,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -5535,7 +5491,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -5543,6 +5498,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -5554,7 +5510,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -5562,6 +5517,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -5574,7 +5530,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5582,6 +5537,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -5592,7 +5548,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5600,6 +5555,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -5610,7 +5566,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5618,6 +5573,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -5628,7 +5584,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5636,6 +5591,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -5646,7 +5602,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5655,7 +5610,6 @@
       "short_help": "Generate slide deck."
     },
     "generate video": {
-      "callback": "generate_video",
       "class": "Command",
       "params": [
         {
@@ -5670,6 +5624,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -5680,7 +5635,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -5688,6 +5642,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -5699,7 +5654,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -5707,6 +5661,7 @@
         {
           "default": "explainer",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -5717,7 +5672,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -5731,6 +5685,7 @@
         {
           "default": "auto",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": null,
           "is_flag": false,
           "kind": "option",
@@ -5741,7 +5696,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -5762,6 +5716,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Custom visual style prompt",
           "is_flag": false,
           "kind": "option",
@@ -5772,7 +5727,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -5780,6 +5734,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
           "is_flag": false,
           "kind": "option",
@@ -5790,7 +5745,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -5798,6 +5752,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": true,
           "help": "Limit to specific source IDs",
           "is_flag": false,
           "kind": "option",
@@ -5809,7 +5764,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_sources",
           "type": {
             "name": "text"
           }
@@ -5817,6 +5771,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Wait for completion (default: no-wait)",
           "is_flag": true,
           "kind": "option",
@@ -5829,7 +5784,6 @@
           "secondary_opts": [
             "--no-wait"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5837,6 +5791,7 @@
         {
           "default": 600,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 600)",
           "is_flag": false,
           "kind": "option",
@@ -5847,7 +5802,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5855,6 +5809,7 @@
         {
           "default": 2,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 2)",
           "is_flag": false,
           "kind": "option",
@@ -5865,7 +5820,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5873,6 +5827,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry N times with exponential backoff on rate limit",
           "is_flag": false,
           "kind": "option",
@@ -5883,7 +5838,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5891,6 +5845,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -5901,7 +5856,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5910,12 +5864,12 @@
       "short_help": "Generate video overview."
     },
     "history": {
-      "callback": "history_cmd",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -5927,7 +5881,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -5935,6 +5888,7 @@
         {
           "default": 100,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum number of Q&A turns to show",
           "is_flag": false,
           "kind": "option",
@@ -5946,7 +5900,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -5954,6 +5907,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Clear local conversation cache",
           "is_flag": true,
           "kind": "option",
@@ -5964,7 +5918,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5972,6 +5925,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Save history as a note",
           "is_flag": true,
           "kind": "option",
@@ -5982,7 +5936,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -5990,6 +5943,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Note title (with --save)",
           "is_flag": false,
           "kind": "option",
@@ -6001,7 +5955,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6009,6 +5962,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6019,7 +5973,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6027,6 +5980,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show full Q&A content instead of preview",
           "is_flag": true,
           "kind": "option",
@@ -6037,7 +5991,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6045,6 +5998,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Disable the 50-char preview cap on Question/Answer columns in the table view.",
           "is_flag": true,
           "kind": "option",
@@ -6055,7 +6009,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6064,7 +6017,6 @@
       "short_help": "Get conversation history or save it as a..."
     },
     "language": {
-      "callback": "language",
       "class": "Group",
       "commands": [
         "get",
@@ -6075,12 +6027,12 @@
       "short_help": "Manage output language for artifact..."
     },
     "language get": {
-      "callback": "language_get",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show local config only (skip server sync)",
           "is_flag": true,
           "kind": "option",
@@ -6091,7 +6043,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6099,6 +6050,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6109,7 +6061,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6118,12 +6069,12 @@
       "short_help": "Get current language setting."
     },
     "language list": {
-      "callback": "language_list",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6134,7 +6085,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6143,7 +6093,6 @@
       "short_help": "List all supported language codes."
     },
     "language set": {
-      "callback": "language_set",
       "class": "Command",
       "params": [
         {
@@ -6158,6 +6107,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Set local config only (skip server sync)",
           "is_flag": true,
           "kind": "option",
@@ -6168,7 +6118,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6176,6 +6125,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6186,7 +6136,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6195,12 +6144,12 @@
       "short_help": "Set default language for artifact generation."
     },
     "list": {
-      "callback": "list_cmd",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6211,7 +6160,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6219,6 +6167,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show at most N rows (default: unlimited). Applies to both text and --json output.",
           "is_flag": false,
           "kind": "option",
@@ -6229,7 +6178,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -6237,6 +6185,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Disable column truncation in the rendered table (default: truncate).",
           "is_flag": true,
           "kind": "option",
@@ -6247,7 +6196,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6256,12 +6204,12 @@
       "short_help": "List all notebooks."
     },
     "login": {
-      "callback": "login",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Where to save storage_state.json (default: profile-specific location)",
           "is_flag": false,
           "kind": "option",
@@ -6272,7 +6220,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "allow_dash": false,
             "dir_okay": true,
@@ -6288,6 +6235,7 @@
         {
           "default": "chromium",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Browser to use for login (default: chromium). Use 'chrome' for system Google Chrome (workaround when bundled Chromium crashes, e.g. macOS 15+), 'msedge' for Microsoft Edge.",
           "is_flag": false,
           "kind": "option",
@@ -6298,7 +6246,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": false,
             "choices": [
@@ -6312,6 +6259,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read cookies from an installed browser instead of launching Playwright. Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... For Chromium-family profiles, target one with 'chrome::<profile>' (e.g. 'chrome::Profile 1' or 'brave::Work'). For Firefox Multi-Account Containers, target a specific container with 'firefox::<container-name>' (or 'firefox::none' for the default). Requires: pip install 'notebooklm-py[cookies]'",
           "is_flag": false,
           "kind": "option",
@@ -6322,7 +6270,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6330,6 +6277,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Pick a signed-in Google account by email when several are present in the browser. Only valid with --browser-cookies.",
           "is_flag": false,
           "kind": "option",
@@ -6340,7 +6288,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6348,6 +6295,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Extract every Google account signed in to the browser into its own profile (auto-named from each account's email). Only valid with --browser-cookies.",
           "is_flag": true,
           "kind": "option",
@@ -6358,7 +6306,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6366,6 +6313,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "With --all-accounts: when an account's natural profile name (e.g. 'alice' for alice@gmail.com) already exists but has no account metadata, update that profile in place instead of creating a suffixed 'alice-2'. Profiles that already bind a different email are still given a suffix to avoid clobbering. Only valid with --all-accounts.",
           "is_flag": true,
           "kind": "option",
@@ -6376,7 +6324,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6384,6 +6331,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Name to give the new profile when extracting a non-default account. Defaults to the account email's local-part. Only valid with --browser-cookies.",
           "is_flag": false,
           "kind": "option",
@@ -6394,7 +6342,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6402,6 +6349,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Start with a clean browser session (deletes cached browser profile). Use to switch Google accounts.",
           "is_flag": true,
           "kind": "option",
@@ -6412,7 +6360,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6420,6 +6367,7 @@
         {
           "default": [],
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Opt in to extracting sibling-product cookies (default: required Google auth/Drive cookies only). Pass labels comma-separated or repeat the flag: --include-domains=youtube,docs OR --include-domains=youtube --include-domains=docs. Supported labels: youtube, docs, myaccount, mail, all.",
           "is_flag": false,
           "kind": "option",
@@ -6430,7 +6378,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6439,12 +6386,12 @@
       "short_help": "Log in to NotebookLM via browser."
     },
     "metadata": {
-      "callback": "metadata_cmd",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6456,7 +6403,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6464,6 +6410,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON (default: human-readable)",
           "is_flag": true,
           "kind": "option",
@@ -6474,7 +6421,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6483,7 +6429,6 @@
       "short_help": "Export notebook metadata with sources list."
     },
     "note": {
-      "callback": "note",
       "class": "Group",
       "commands": [
         "create",
@@ -6497,7 +6442,6 @@
       "short_help": "Note management commands."
     },
     "note create": {
-      "callback": "note_create",
       "class": "Command",
       "params": [
         {
@@ -6512,6 +6456,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Note content (or '-' to read from stdin). Mutually exclusive with the positional CONTENT argument.",
           "is_flag": false,
           "kind": "option",
@@ -6522,7 +6467,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6530,6 +6474,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6541,7 +6486,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6549,6 +6493,7 @@
         {
           "default": "New Note",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Note title",
           "is_flag": false,
           "kind": "option",
@@ -6560,7 +6505,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6568,6 +6512,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6578,7 +6523,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6587,7 +6531,6 @@
       "short_help": "Create a new note."
     },
     "note delete": {
-      "callback": "note_delete",
       "class": "Command",
       "params": [
         {
@@ -6602,6 +6545,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6613,7 +6557,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6621,6 +6564,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -6632,7 +6576,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6640,6 +6583,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6650,7 +6594,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6659,7 +6602,6 @@
       "short_help": "Delete a note."
     },
     "note get": {
-      "callback": "note_get",
       "class": "Command",
       "params": [
         {
@@ -6674,6 +6616,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6685,7 +6628,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6693,6 +6635,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6703,7 +6646,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6712,12 +6654,12 @@
       "short_help": "Get note content."
     },
     "note list": {
-      "callback": "note_list",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6729,7 +6671,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6737,6 +6678,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6747,7 +6689,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6756,7 +6697,6 @@
       "short_help": "List all notes in a notebook."
     },
     "note rename": {
-      "callback": "note_rename",
       "class": "Command",
       "params": [
         {
@@ -6780,6 +6720,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6791,7 +6732,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6799,6 +6739,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6809,7 +6750,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6818,7 +6758,6 @@
       "short_help": "Rename a note."
     },
     "note save": {
-      "callback": "note_save",
       "class": "Command",
       "params": [
         {
@@ -6833,6 +6772,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -6844,7 +6784,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -6852,6 +6791,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "New title",
           "is_flag": false,
           "kind": "option",
@@ -6862,7 +6802,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6870,6 +6809,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "New content",
           "is_flag": false,
           "kind": "option",
@@ -6880,7 +6820,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -6888,6 +6827,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -6898,7 +6838,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6907,7 +6846,6 @@
       "short_help": "Update note content."
     },
     "notebooklm": {
-      "callback": "cli",
       "class": "SectionedGroup",
       "commands": [
         "agent",
@@ -6942,6 +6880,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show the version and exit.",
           "is_flag": true,
           "kind": "option",
@@ -6952,7 +6891,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -6960,6 +6898,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Path to storage_state.json (default: ~/.notebooklm/profiles/<profile>/storage_state.json)",
           "is_flag": false,
           "kind": "option",
@@ -6970,7 +6909,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "allow_dash": false,
             "dir_okay": true,
@@ -6986,6 +6924,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Profile name (default: from config or 'default'). Use 'notebooklm profile list' to see profiles.",
           "is_flag": false,
           "kind": "option",
@@ -6997,7 +6936,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -7005,6 +6943,7 @@
         {
           "default": 0,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Increase verbosity (-v for INFO, -vv for DEBUG)",
           "is_flag": false,
           "kind": "option",
@@ -7016,7 +6955,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "clamp": false,
             "max": null,
@@ -7027,6 +6965,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Suppress INFO/WARN log records on stderr (only ERROR survives). Mutually exclusive with -v/-vv.",
           "is_flag": true,
           "kind": "option",
@@ -7037,7 +6976,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7046,7 +6984,6 @@
       "short_help": "NotebookLM CLI."
     },
     "profile": {
-      "callback": "profile",
       "class": "Group",
       "commands": [
         "create",
@@ -7059,7 +6996,6 @@
       "short_help": "Manage authentication profiles for..."
     },
     "profile create": {
-      "callback": "create_cmd",
       "class": "Command",
       "params": [
         {
@@ -7075,7 +7011,6 @@
       "short_help": "Create a new profile."
     },
     "profile delete": {
-      "callback": "delete_cmd",
       "class": "Command",
       "params": [
         {
@@ -7090,6 +7025,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation prompt",
           "is_flag": true,
           "kind": "option",
@@ -7100,7 +7036,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7109,12 +7044,12 @@
       "short_help": "Delete a profile and its data."
     },
     "profile list": {
-      "callback": "list_cmd",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7125,7 +7060,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7134,7 +7068,6 @@
       "short_help": "List all profiles and their status."
     },
     "profile rename": {
-      "callback": "rename_cmd",
       "class": "Command",
       "params": [
         {
@@ -7159,7 +7092,6 @@
       "short_help": "Rename a profile."
     },
     "profile switch": {
-      "callback": "switch_cmd",
       "class": "Command",
       "params": [
         {
@@ -7175,7 +7107,6 @@
       "short_help": "Set the default profile."
     },
     "rename": {
-      "callback": "rename_cmd",
       "class": "Command",
       "params": [
         {
@@ -7190,6 +7121,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7201,7 +7133,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7210,7 +7141,6 @@
       "short_help": "Rename a notebook."
     },
     "research": {
-      "callback": "research",
       "class": "Group",
       "commands": [
         "status",
@@ -7220,12 +7150,12 @@
       "short_help": "Research management commands."
     },
     "research status": {
-      "callback": "research_status",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7237,7 +7167,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7245,6 +7174,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7255,7 +7185,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7264,12 +7193,12 @@
       "short_help": "Check research status for the current..."
     },
     "research wait": {
-      "callback": "research_wait",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7281,7 +7210,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7289,6 +7217,7 @@
         {
           "default": 300,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 300)",
           "is_flag": false,
           "kind": "option",
@@ -7299,7 +7228,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -7307,6 +7235,7 @@
         {
           "default": 5,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 5)",
           "is_flag": false,
           "kind": "option",
@@ -7317,7 +7246,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -7325,6 +7253,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Import all found sources when done",
           "is_flag": true,
           "kind": "option",
@@ -7335,7 +7264,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7343,6 +7271,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "With --import-all, import only cited sources",
           "is_flag": true,
           "kind": "option",
@@ -7353,7 +7282,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7361,6 +7289,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7371,7 +7300,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7380,7 +7308,6 @@
       "short_help": "Wait for research to complete."
     },
     "share": {
-      "callback": "share",
       "class": "Group",
       "commands": [
         "add",
@@ -7394,7 +7321,6 @@
       "short_help": "Notebook sharing commands."
     },
     "share add": {
-      "callback": "share_add",
       "class": "Command",
       "params": [
         {
@@ -7409,6 +7335,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7420,7 +7347,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7428,6 +7354,7 @@
         {
           "default": "viewer",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Permission level (default: viewer)",
           "is_flag": false,
           "kind": "option",
@@ -7439,7 +7366,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": false,
             "choices": [
@@ -7452,6 +7378,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Don't send email notification",
           "is_flag": true,
           "kind": "option",
@@ -7462,7 +7389,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7470,6 +7396,7 @@
         {
           "default": "",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Welcome message for the user",
           "is_flag": false,
           "kind": "option",
@@ -7481,7 +7408,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -7489,6 +7415,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7499,7 +7426,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7508,12 +7434,12 @@
       "short_help": "Share notebook with a user."
     },
     "share public": {
-      "callback": "share_public",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7525,7 +7451,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7533,6 +7458,7 @@
         {
           "default": true,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Enable or disable public sharing",
           "is_flag": true,
           "kind": "option",
@@ -7545,7 +7471,6 @@
           "secondary_opts": [
             "--disable"
           ],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7553,6 +7478,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7563,7 +7489,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7572,7 +7497,6 @@
       "short_help": "Enable or disable public link sharing."
     },
     "share remove": {
-      "callback": "share_remove",
       "class": "Command",
       "params": [
         {
@@ -7587,6 +7511,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7598,7 +7523,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7606,6 +7530,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -7617,7 +7542,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7625,6 +7549,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7635,7 +7560,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7644,12 +7568,12 @@
       "short_help": "Remove a user's access to the notebook."
     },
     "share status": {
-      "callback": "share_status",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7661,7 +7585,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7669,6 +7592,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7679,7 +7603,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7688,7 +7611,6 @@
       "short_help": "Show sharing status and shared users."
     },
     "share update": {
-      "callback": "share_update",
       "class": "Command",
       "params": [
         {
@@ -7703,6 +7625,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7714,7 +7637,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7722,6 +7644,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "New permission level",
           "is_flag": false,
           "kind": "option",
@@ -7733,7 +7656,6 @@
           ],
           "required": true,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": false,
             "choices": [
@@ -7746,6 +7668,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7756,7 +7679,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7765,7 +7687,6 @@
       "short_help": "Update a user's permission level."
     },
     "share view-level": {
-      "callback": "share_view_level",
       "class": "Command",
       "params": [
         {
@@ -7785,6 +7706,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -7796,7 +7718,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -7804,6 +7725,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -7814,7 +7736,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -7823,7 +7744,6 @@
       "short_help": "Set what viewers can access."
     },
     "skill": {
-      "callback": "skill",
       "class": "Group",
       "commands": [
         "install",
@@ -7835,12 +7755,12 @@
       "short_help": "Manage NotebookLM agent skill integration."
     },
     "skill install": {
-      "callback": "install",
       "class": "Command",
       "params": [
         {
           "default": "user",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Install for the current user or into the current project.",
           "is_flag": false,
           "kind": "option",
@@ -7851,7 +7771,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -7864,6 +7783,7 @@
         {
           "default": "all",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Install for Claude Code, universal agent skill directories, or both.",
           "is_flag": false,
           "kind": "option",
@@ -7874,7 +7794,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -7889,12 +7808,12 @@
       "short_help": "Install or update the NotebookLM skill for..."
     },
     "skill show": {
-      "callback": "show",
       "class": "Command",
       "params": [
         {
           "default": "user",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read an installed skill from user or project scope.",
           "is_flag": false,
           "kind": "option",
@@ -7905,7 +7824,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -7918,6 +7836,7 @@
         {
           "default": "source",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show the packaged skill source or an installed target.",
           "is_flag": false,
           "kind": "option",
@@ -7928,7 +7847,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -7943,12 +7861,12 @@
       "short_help": "Display the packaged skill content or an..."
     },
     "skill status": {
-      "callback": "status",
       "class": "Command",
       "params": [
         {
           "default": "user",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Inspect user-level or project-level skill installs.",
           "is_flag": false,
           "kind": "option",
@@ -7959,7 +7877,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -7972,6 +7889,7 @@
         {
           "default": "all",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Inspect Claude Code, universal agent skill directories, or both.",
           "is_flag": false,
           "kind": "option",
@@ -7982,7 +7900,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -7997,12 +7914,12 @@
       "short_help": "Check installed skill targets and version..."
     },
     "skill uninstall": {
-      "callback": "uninstall",
       "class": "Command",
       "params": [
         {
           "default": "user",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Remove user-level or project-level skill installs.",
           "is_flag": false,
           "kind": "option",
@@ -8013,7 +7930,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8026,6 +7942,7 @@
         {
           "default": "all",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Remove Claude Code, universal agent skill directories, or both.",
           "is_flag": false,
           "kind": "option",
@@ -8036,7 +7953,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8051,7 +7967,6 @@
       "short_help": "Remove the NotebookLM skill from supported..."
     },
     "source": {
-      "callback": "source",
       "class": "Group",
       "commands": [
         "add",
@@ -8073,7 +7988,6 @@
       "short_help": "Source management commands."
     },
     "source add": {
-      "callback": "source_add",
       "class": "Command",
       "params": [
         {
@@ -8088,6 +8002,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8099,7 +8014,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8107,6 +8021,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Source type (auto-detected if not specified)",
           "is_flag": false,
           "kind": "option",
@@ -8117,7 +8032,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8132,6 +8046,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Custom title for text and uploaded-file sources",
           "is_flag": false,
           "kind": "option",
@@ -8142,7 +8057,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -8150,6 +8064,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "[Deprecated] MIME type for file sources \u2014 unused; the server derives MIME from the filename extension. Drive sources retain this option (see ``source add-drive``).",
           "is_flag": false,
           "kind": "option",
@@ -8160,7 +8075,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "text"
           }
@@ -8168,6 +8082,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "HTTP request timeout in seconds (default: 30, from the library). Increase when adding slow URLs or large files that exceed the default.",
           "is_flag": false,
           "kind": "option",
@@ -8178,7 +8093,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "float"
           }
@@ -8186,6 +8100,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Follow symbolic links when uploading a file. By default, symlinks are rejected so a workspace symlink cannot silently exfiltrate the file it points at (e.g. ~/Downloads/foo.pdf -> /etc/passwd).",
           "is_flag": true,
           "kind": "option",
@@ -8196,7 +8111,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8204,6 +8118,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8214,7 +8129,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8223,7 +8137,6 @@
       "short_help": "Add a source to a notebook."
     },
     "source add-drive": {
-      "callback": "source_add_drive",
       "class": "Command",
       "params": [
         {
@@ -8247,6 +8160,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8258,7 +8172,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8266,6 +8179,7 @@
         {
           "default": "google-doc",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Document type (default: google-doc)",
           "is_flag": false,
           "kind": "option",
@@ -8276,7 +8190,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8291,6 +8204,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8301,7 +8215,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8310,7 +8223,6 @@
       "short_help": "Add a Google Drive document as a source."
     },
     "source add-research": {
-      "callback": "source_add_research",
       "class": "Command",
       "params": [
         {
@@ -8325,6 +8237,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
           "is_flag": false,
           "kind": "option",
@@ -8335,7 +8248,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "prompt_file"
           }
@@ -8343,6 +8255,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8354,7 +8267,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8362,6 +8274,7 @@
         {
           "default": "web",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Search source (default: web)",
           "is_flag": false,
           "kind": "option",
@@ -8372,7 +8285,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8385,6 +8297,7 @@
         {
           "default": "fast",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Search mode (default: fast)",
           "is_flag": false,
           "kind": "option",
@@ -8395,7 +8308,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8408,6 +8320,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Import all found sources",
           "is_flag": true,
           "kind": "option",
@@ -8418,7 +8331,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8426,6 +8338,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "With --import-all, import only cited sources",
           "is_flag": true,
           "kind": "option",
@@ -8436,7 +8349,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8444,6 +8356,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Start research and return immediately (use 'research status/wait' to monitor)",
           "is_flag": true,
           "kind": "option",
@@ -8454,7 +8367,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8462,6 +8374,7 @@
         {
           "default": 1800,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Retry budget in seconds for --import-all when the IMPORT_RESEARCH RPC times out (default: 1800). Mirrors 'research wait --timeout'. Has no effect without --import-all.",
           "is_flag": false,
           "kind": "option",
@@ -8472,7 +8385,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -8481,12 +8393,12 @@
       "short_help": "Search web or drive and add sources from..."
     },
     "source clean": {
-      "callback": "source_clean",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8498,7 +8410,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8506,6 +8417,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show what would be deleted without actually deleting",
           "is_flag": true,
           "kind": "option",
@@ -8516,7 +8428,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8524,6 +8435,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -8535,7 +8447,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8543,6 +8454,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8553,7 +8465,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8562,7 +8473,6 @@
       "short_help": "Automatically remove duplicate, error, and..."
     },
     "source delete": {
-      "callback": "source_delete",
       "class": "Command",
       "params": [
         {
@@ -8577,6 +8487,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8588,7 +8499,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8596,6 +8506,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -8607,7 +8518,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8615,6 +8525,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8625,7 +8536,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8634,7 +8544,6 @@
       "short_help": "Delete a source."
     },
     "source delete-by-title": {
-      "callback": "source_delete_by_title",
       "class": "Command",
       "params": [
         {
@@ -8649,6 +8558,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8660,7 +8570,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8668,6 +8577,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip confirmation",
           "is_flag": true,
           "kind": "option",
@@ -8679,7 +8589,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8687,6 +8596,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8697,7 +8607,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8706,7 +8615,6 @@
       "short_help": "Delete a source by exact title."
     },
     "source fulltext": {
-      "callback": "source_fulltext",
       "class": "Command",
       "params": [
         {
@@ -8721,6 +8629,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8732,7 +8641,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8740,6 +8648,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8750,7 +8659,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8758,6 +8666,7 @@
         {
           "default": "Sentinel.UNSET",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Write content to file",
           "is_flag": false,
           "kind": "option",
@@ -8769,7 +8678,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "allow_dash": false,
             "dir_okay": true,
@@ -8785,6 +8693,7 @@
         {
           "default": "text",
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Content format: text (default) or markdown",
           "is_flag": false,
           "kind": "option",
@@ -8796,7 +8705,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "case_sensitive": true,
             "choices": [
@@ -8810,7 +8718,6 @@
       "short_help": "Get full content of a source."
     },
     "source get": {
-      "callback": "source_get",
       "class": "Command",
       "params": [
         {
@@ -8825,6 +8732,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8836,7 +8744,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8844,6 +8751,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8854,7 +8762,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8863,7 +8770,6 @@
       "short_help": "Get source details."
     },
     "source guide": {
-      "callback": "source_guide",
       "class": "Command",
       "params": [
         {
@@ -8878,6 +8784,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8889,7 +8796,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8897,6 +8803,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8907,7 +8814,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8916,12 +8822,12 @@
       "short_help": "Get AI-generated source summary and keywords."
     },
     "source list": {
-      "callback": "source_list",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -8933,7 +8839,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -8941,6 +8846,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -8951,7 +8857,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8959,6 +8864,7 @@
         {
           "default": null,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show at most N rows (default: unlimited). Applies to both text and --json output.",
           "is_flag": false,
           "kind": "option",
@@ -8969,7 +8875,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -8977,6 +8882,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Disable column truncation in the rendered table (default: truncate).",
           "is_flag": true,
           "kind": "option",
@@ -8987,7 +8893,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -8996,7 +8901,6 @@
       "short_help": "List all sources in a notebook."
     },
     "source refresh": {
-      "callback": "source_refresh",
       "class": "Command",
       "params": [
         {
@@ -9011,6 +8915,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -9022,7 +8927,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -9030,6 +8934,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -9040,7 +8945,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9049,7 +8953,6 @@
       "short_help": "Refresh a URL/Drive source."
     },
     "source rename": {
-      "callback": "source_rename",
       "class": "Command",
       "params": [
         {
@@ -9073,6 +8976,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -9084,7 +8988,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -9092,6 +8995,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -9102,7 +9006,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9111,7 +9014,6 @@
       "short_help": "Rename a source."
     },
     "source stale": {
-      "callback": "source_stale",
       "class": "Command",
       "params": [
         {
@@ -9126,6 +9028,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -9137,7 +9040,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -9145,6 +9047,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -9155,7 +9058,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9164,7 +9066,6 @@
       "short_help": "Check if a URL/Drive source needs refresh."
     },
     "source wait": {
-      "callback": "source_wait",
       "class": "Command",
       "params": [
         {
@@ -9179,6 +9080,7 @@
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -9190,7 +9092,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -9198,6 +9099,7 @@
         {
           "default": 120,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Maximum seconds to wait (default: 120)",
           "is_flag": false,
           "kind": "option",
@@ -9208,7 +9110,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -9216,6 +9117,7 @@
         {
           "default": 1,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Seconds between status checks (default: 1)",
           "is_flag": false,
           "kind": "option",
@@ -9226,7 +9128,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "integer"
           }
@@ -9234,6 +9135,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -9244,7 +9146,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9253,12 +9154,12 @@
       "short_help": "Wait for a source to finish processing."
     },
     "status": {
-      "callback": "status",
       "class": "Command",
       "params": [
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -9269,7 +9170,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9277,6 +9177,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Show resolved file paths",
           "is_flag": true,
           "kind": "option",
@@ -9287,7 +9188,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9296,12 +9196,12 @@
       "short_help": "Show current context (active notebook and..."
     },
     "summary": {
-      "callback": "summary_cmd",
       "class": "Command",
       "params": [
         {
           "default": null,
           "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "has_custom_shell_complete": true,
           "help": "Notebook ID (uses current if not set). Supports partial IDs.",
           "is_flag": false,
           "kind": "option",
@@ -9313,7 +9213,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "_complete_notebooks",
           "type": {
             "name": "text"
           }
@@ -9321,6 +9220,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Include suggested topics",
           "is_flag": true,
           "kind": "option",
@@ -9331,7 +9231,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9340,7 +9239,6 @@
       "short_help": "Get notebook summary with AI-generated..."
     },
     "use": {
-      "callback": "use_notebook",
       "class": "Command",
       "params": [
         {
@@ -9355,6 +9253,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Skip the existence check and persist the notebook ID even if verification fails. Use for offline work or debugging.",
           "is_flag": true,
           "kind": "option",
@@ -9365,7 +9264,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9373,6 +9271,7 @@
         {
           "default": false,
           "envvar": null,
+          "has_custom_shell_complete": false,
           "help": "Output as JSON",
           "is_flag": true,
           "kind": "option",
@@ -9383,7 +9282,6 @@
           ],
           "required": false,
           "secondary_opts": [],
-          "shell_complete": "shell_complete",
           "type": {
             "name": "boolean"
           }
@@ -9393,8 +9291,8 @@
     }
   },
   "completion_callbacks": {
-    "download_artifact": "_complete_artifacts",
-    "notebook": "_complete_notebooks"
+    "download_artifact": true,
+    "notebook": true
   },
   "root_commands": [
     "agent",

--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json
@@ -1,0 +1,9464 @@
+{
+  "aliases": {
+    "download cinematic-video": {
+      "canonical": "download video",
+      "same_callback": true,
+      "same_params": true
+    },
+    "generate cinematic-video": {
+      "canonical": "generate video --format cinematic",
+      "same_callback": true,
+      "same_params": true
+    }
+  },
+  "click_groups": {
+    "agent": [
+      "show"
+    ],
+    "artifact": [
+      "delete",
+      "export",
+      "get",
+      "list",
+      "poll",
+      "rename",
+      "suggestions",
+      "wait"
+    ],
+    "download": [
+      "audio",
+      "cinematic-video",
+      "data-table",
+      "flashcards",
+      "infographic",
+      "mind-map",
+      "quiz",
+      "report",
+      "slide-deck",
+      "video"
+    ],
+    "generate": [
+      "audio",
+      "cinematic-video",
+      "data-table",
+      "flashcards",
+      "infographic",
+      "mind-map",
+      "quiz",
+      "report",
+      "revise-slide",
+      "slide-deck",
+      "video"
+    ],
+    "language": [
+      "get",
+      "list",
+      "set"
+    ],
+    "note": [
+      "create",
+      "delete",
+      "get",
+      "list",
+      "rename",
+      "save"
+    ],
+    "profile": [
+      "create",
+      "delete",
+      "list",
+      "rename",
+      "switch"
+    ],
+    "research": [
+      "status",
+      "wait"
+    ],
+    "share": [
+      "add",
+      "public",
+      "remove",
+      "status",
+      "update",
+      "view-level"
+    ],
+    "skill": [
+      "install",
+      "show",
+      "status",
+      "uninstall"
+    ],
+    "source": [
+      "add",
+      "add-drive",
+      "add-research",
+      "clean",
+      "delete",
+      "delete-by-title",
+      "fulltext",
+      "get",
+      "guide",
+      "list",
+      "refresh",
+      "rename",
+      "stale",
+      "wait"
+    ]
+  },
+  "commands": {
+    "agent": {
+      "callback": "agent",
+      "class": "Group",
+      "commands": [
+        "show"
+      ],
+      "params": [],
+      "short_help": "Show bundled instructions for supported..."
+    },
+    "agent show": {
+      "callback": "show_agent",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "target",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "codex",
+              "claude"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Display instructions for Codex or Claude..."
+    },
+    "artifact": {
+      "callback": "artifact",
+      "class": "Group",
+      "commands": [
+        "delete",
+        "export",
+        "get",
+        "list",
+        "poll",
+        "rename",
+        "suggestions",
+        "wait"
+      ],
+      "params": [],
+      "short_help": "Artifact management commands."
+    },
+    "artifact delete": {
+      "callback": "artifact_delete",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete an artifact."
+    },
+    "artifact export": {
+      "callback": "artifact_export",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Title for exported document",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "docs",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "export_type",
+          "opts": [
+            "--type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "docs",
+              "sheets"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Export artifact to Google Docs/Sheets."
+    },
+    "artifact get": {
+      "callback": "artifact_get",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get artifact details."
+    },
+    "artifact list": {
+      "callback": "artifact_list",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "help": "Filter by type",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_type",
+          "opts": [
+            "--type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "audio",
+              "video",
+              "slide-deck",
+              "quiz",
+              "flashcard",
+              "infographic",
+              "data-table",
+              "mind-map",
+              "report"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Show at most N rows (default: unlimited). Applies to both text and --json output.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Disable column truncation in the rendered table (default: truncate).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List artifacts in a notebook."
+    },
+    "artifact poll": {
+      "callback": "artifact_poll",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "task_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Single non-blocking generation status check."
+    },
+    "artifact rename": {
+      "callback": "artifact_rename",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Rename an artifact."
+    },
+    "artifact suggestions": {
+      "callback": "artifact_suggestions",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON format",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get AI-suggested report topics based on..."
+    },
+    "artifact wait": {
+      "callback": "artifact_wait",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "artifact_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Block until artifact generation finishes..."
+    },
+    "ask": {
+      "callback": "ask_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "question",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Continue a specific conversation",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "conversation_id",
+          "opts": [
+            "--conversation-id",
+            "-c"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Start a fresh conversation, skipping the auto-resume of the last one.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "new_conversation",
+          "opts": [
+            "--new"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs (can be repeated)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON (includes references)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Save response as a note. When the answer has citations, the saved note preserves interactive [N] hover-anchor links (matching the NotebookLM web UI's 'Save to note' behavior); otherwise falls back to a plain-text note.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "save_as_note",
+          "opts": [
+            "--save-as-note"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Note title (use with --save-as-note)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "note_title",
+          "opts": [
+            "--note-title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "HTTP request timeout in seconds (default: 30, from the library). Increase for long or complex prompts.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 1,
+            "name": "integer range"
+          }
+        }
+      ],
+      "short_help": "Ask a notebook a question."
+    },
+    "auth": {
+      "callback": "auth_group",
+      "class": "Group",
+      "commands": [
+        "check",
+        "inspect",
+        "logout",
+        "refresh"
+      ],
+      "params": [],
+      "short_help": "Authentication management commands."
+    },
+    "auth check": {
+      "callback": "auth_check",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Test token fetch (makes network request)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "test_fetch",
+          "opts": [
+            "--test"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check authentication status and diagnose..."
+    },
+    "auth inspect": {
+      "callback": "auth_inspect",
+      "class": "Command",
+      "params": [
+        {
+          "default": "auto",
+          "envvar": null,
+          "help": "Browser to read cookies from (chrome, firefox, brave, edge, safari, arc, ...). 'auto' picks the first one rookiepy can read. Use 'chrome::<profile>' for one Chromium profile or 'firefox::<container>' for one Firefox container. Requires: pip install 'notebooklm-py[cookies]'",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser_name",
+          "opts": [
+            "--browser"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "help": "Opt in to enumerating accounts via sibling-product cookies. Same syntax as 'notebooklm login --include-domains'. By default this command only consults required Google auth cookies, which is sufficient for account discovery on every tested path.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Also show which browser user-profile each account's cookies came from. Useful for Chromium-family browsers with multiple user-profiles.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "verbose",
+          "opts": [
+            "-v",
+            "--verbose"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List Google accounts visible to a..."
+    },
+    "auth logout": {
+      "callback": "auth_logout",
+      "class": "Command",
+      "params": [],
+      "short_help": "Log out by clearing saved authentication."
+    },
+    "auth refresh": {
+      "callback": "auth_refresh",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Re-extract cookies from an installed browser and match the profile account from context.json. Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... Use 'chrome::<profile>' for one Chromium profile or 'firefox::<container>' for one Firefox container.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser_cookies",
+          "opts": [
+            "--browser-cookies",
+            "--browser-cookie"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "help": "Forward to the browser-cookie reader (only meaningful with --browser-cookies). Same syntax as 'notebooklm login --include-domains'.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Suppress success output (only print on error)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "quiet",
+          "opts": [
+            "--quiet",
+            "-q"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Refresh stored cookies by exercising the..."
+    },
+    "clear": {
+      "callback": "clear_cmd",
+      "class": "Command",
+      "params": [],
+      "short_help": "Clear current notebook context."
+    },
+    "completion": {
+      "callback": "completion_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "shell",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "bash",
+              "zsh",
+              "fish"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Print the shell completion script for SHELL."
+    },
+    "configure": {
+      "callback": "configure_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Predefined chat mode",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "chat_mode",
+          "opts": [
+            "--mode"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "default",
+              "learning-guide",
+              "concise",
+              "detailed"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Custom persona prompt (up to 10,000 chars)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "persona",
+          "opts": [
+            "--persona"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Response verbosity",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "response_length",
+          "opts": [
+            "--response-length"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "default",
+              "longer",
+              "shorter"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Configure chat persona and response settings."
+    },
+    "create": {
+      "callback": "create_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Set the new notebook as the current context (like 'notebooklm use <id>').",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "switch_context",
+          "opts": [
+            "--use",
+            "-u"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Create a new notebook."
+    },
+    "delete": {
+      "callback": "delete_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a notebook."
+    },
+    "doctor": {
+      "callback": "doctor",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Attempt to fix detected issues",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "fix_issues",
+          "opts": [
+            "--fix"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check profile setup, auth status, and..."
+    },
+    "download": {
+      "callback": "download",
+      "class": "Group",
+      "commands": [
+        "audio",
+        "cinematic-video",
+        "data-table",
+        "flashcards",
+        "infographic",
+        "mind-map",
+        "quiz",
+        "report",
+        "slide-deck",
+        "video"
+      ],
+      "params": [],
+      "short_help": "Download generated content."
+    },
+    "download audio": {
+      "callback": "download_audio",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download audio overview(s) to file."
+    },
+    "download cinematic-video": {
+      "callback": "download_video",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download cinematic video overview(s) to file."
+    },
+    "download data-table": {
+      "callback": "download_data_table",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download data table(s) as CSV files."
+    },
+    "download flashcards": {
+      "callback": "download_flashcards_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "json",
+          "envvar": null,
+          "help": "Output format: json (default), markdown, or html",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "json",
+              "markdown",
+              "html"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Download flashcard deck."
+    },
+    "download infographic": {
+      "callback": "download_infographic",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download infographic(s) to file."
+    },
+    "download mind-map": {
+      "callback": "download_mind_map",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download mind map(s) as JSON files."
+    },
+    "download quiz": {
+      "callback": "download_quiz_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "json",
+          "envvar": null,
+          "help": "Output format: json (default), markdown, or html",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "json",
+              "markdown",
+              "html"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Download quiz questions."
+    },
+    "download report": {
+      "callback": "download_report",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download report(s) as markdown files."
+    },
+    "download slide-deck": {
+      "callback": "download_slide_deck",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "pdf",
+          "envvar": null,
+          "help": "Download format: pdf (default) or pptx",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "slide_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "pdf",
+              "pptx"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Download slide deck(s) as PDF or PPTX."
+    },
+    "download video": {
+      "callback": "download_video",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "output_path",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download latest (default behavior)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "latest",
+          "opts": [
+            "--latest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download earliest",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "earliest",
+          "opts": [
+            "--earliest"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Download all artifacts",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "download_all",
+          "opts": [
+            "--all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Filter by artifact title (fuzzy match)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "name",
+          "opts": [
+            "--name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Select by artifact ID",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output JSON instead of text",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Preview without downloading",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Overwrite existing files",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip if file exists",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_clobber",
+          "opts": [
+            "--no-clobber"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Download video overview(s) to file."
+    },
+    "generate": {
+      "callback": "generate",
+      "class": "Group",
+      "commands": [
+        "audio",
+        "cinematic-video",
+        "data-table",
+        "flashcards",
+        "infographic",
+        "mind-map",
+        "quiz",
+        "report",
+        "revise-slide",
+        "slide-deck",
+        "video"
+      ],
+      "params": [],
+      "short_help": "Generate content from notebook."
+    },
+    "generate audio": {
+      "callback": "generate_audio",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "deep-dive",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "audio_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "deep-dive",
+              "brief",
+              "critique",
+              "debate"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "default",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "audio_length",
+          "opts": [
+            "--length"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "short",
+              "default",
+              "long"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate audio overview (podcast)."
+    },
+    "generate cinematic-video": {
+      "callback": "generate_video",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "explainer",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "video_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "explainer",
+              "brief",
+              "cinematic"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "auto",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style",
+          "opts": [
+            "--style"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "auto",
+              "custom",
+              "classic",
+              "whiteboard",
+              "kawaii",
+              "anime",
+              "watercolor",
+              "retro-print",
+              "heritage",
+              "paper-craft"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Custom visual style prompt",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style_prompt",
+          "opts": [
+            "--style-prompt"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 600,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 600)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate cinematic video overview..."
+    },
+    "generate data-table": {
+      "callback": "generate_data_table",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate data table."
+    },
+    "generate flashcards": {
+      "callback": "generate_flashcards",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "standard",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "quantity",
+          "opts": [
+            "--quantity"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "fewer",
+              "standard",
+              "more"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "medium",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "difficulty",
+          "opts": [
+            "--difficulty"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate flashcards."
+    },
+    "generate infographic": {
+      "callback": "generate_infographic",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "landscape",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "orientation",
+          "opts": [
+            "--orientation"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "landscape",
+              "portrait",
+              "square"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "standard",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "detail",
+          "opts": [
+            "--detail"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "concise",
+              "standard",
+              "detailed"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "auto",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style",
+          "opts": [
+            "--style"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "auto",
+              "sketch-note",
+              "professional",
+              "bento-grid",
+              "editorial",
+              "instructional",
+              "bricks",
+              "clay",
+              "anime",
+              "kawaii",
+              "scientific"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate infographic."
+    },
+    "generate mind-map": {
+      "callback": "generate_mind_map",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Custom instructions for the mind map",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "instructions",
+          "opts": [
+            "--instructions"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate mind map."
+    },
+    "generate quiz": {
+      "callback": "generate_quiz",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "standard",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "quantity",
+          "opts": [
+            "--quantity"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "fewer",
+              "standard",
+              "more"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "medium",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "difficulty",
+          "opts": [
+            "--difficulty"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "easy",
+              "medium",
+              "hard"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate quiz."
+    },
+    "generate report": {
+      "callback": "generate_report_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": "briefing-doc",
+          "envvar": null,
+          "help": "Report format (default: briefing-doc)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "report_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "briefing-doc",
+              "study-guide",
+              "blog-post",
+              "custom"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Append extra instructions to the built-in prompt for non-custom formats. Has no effect with --format custom.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "append_instructions",
+          "opts": [
+            "--append"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate a report (briefing doc, study..."
+    },
+    "generate revise-slide": {
+      "callback": "generate_revise_slide",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Slide deck artifact ID to revise",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "artifact_id",
+          "opts": [
+            "-a",
+            "--artifact"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "shell_complete": "_complete_artifacts",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Zero-based index of the slide to revise (0 = first slide)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "slide_index",
+          "opts": [
+            "--slide"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Revise an individual slide in an existing..."
+    },
+    "generate slide-deck": {
+      "callback": "generate_slide_deck",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "detailed",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "deck_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "detailed",
+              "presenter"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "default",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "deck_length",
+          "opts": [
+            "--length"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "default",
+              "short"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate slide deck."
+    },
+    "generate video": {
+      "callback": "generate_video",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "description",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "explainer",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "video_format",
+          "opts": [
+            "--format"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "explainer",
+              "brief",
+              "cinematic"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "auto",
+          "envvar": null,
+          "help": null,
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style",
+          "opts": [
+            "--style"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "auto",
+              "custom",
+              "classic",
+              "whiteboard",
+              "kawaii",
+              "anime",
+              "watercolor",
+              "retro-print",
+              "heritage",
+              "paper-craft"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Custom visual style prompt",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "style_prompt",
+          "opts": [
+            "--style-prompt"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Output language (default: --language > NOTEBOOKLM_HL env > config > 'en')",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "language",
+          "opts": [
+            "--language"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Limit to specific source IDs",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "source_ids",
+          "opts": [
+            "--source",
+            "-s"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_sources",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Wait for completion (default: no-wait)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "wait",
+          "opts": [
+            "--wait"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--no-wait"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 600,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 600)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 2,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 2)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Retry N times with exponential backoff on rate limit",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "max_retries",
+          "opts": [
+            "--retry"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Generate video overview."
+    },
+    "history": {
+      "callback": "history_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 100,
+          "envvar": null,
+          "help": "Maximum number of Q&A turns to show",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit",
+            "-l"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Clear local conversation cache",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "clear_cache",
+          "opts": [
+            "--clear"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Save history as a note",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "save_as_note",
+          "opts": [
+            "--save"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Note title (with --save)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "note_title",
+          "opts": [
+            "-t",
+            "--note-title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Show full Q&A content instead of preview",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "show_all",
+          "opts": [
+            "--show-all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Disable the 50-char preview cap on Question/Answer columns in the table view.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get conversation history or save it as a..."
+    },
+    "language": {
+      "callback": "language",
+      "class": "Group",
+      "commands": [
+        "get",
+        "list",
+        "set"
+      ],
+      "params": [],
+      "short_help": "Manage output language for artifact..."
+    },
+    "language get": {
+      "callback": "language_get",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Show local config only (skip server sync)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "local",
+          "opts": [
+            "--local"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get current language setting."
+    },
+    "language list": {
+      "callback": "language_list",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all supported language codes."
+    },
+    "language set": {
+      "callback": "language_set",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "code",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Set local config only (skip server sync)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "local",
+          "opts": [
+            "--local"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Set default language for artifact generation."
+    },
+    "list": {
+      "callback": "list_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Show at most N rows (default: unlimited). Applies to both text and --json output.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Disable column truncation in the rendered table (default: truncate).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all notebooks."
+    },
+    "login": {
+      "callback": "login",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Where to save storage_state.json (default: profile-specific location)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "storage",
+          "opts": [
+            "--storage"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": "chromium",
+          "envvar": null,
+          "help": "Browser to use for login (default: chromium). Use 'chrome' for system Google Chrome (workaround when bundled Chromium crashes, e.g. macOS 15+), 'msedge' for Microsoft Edge.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser",
+          "opts": [
+            "--browser"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "chromium",
+              "msedge",
+              "chrome"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read cookies from an installed browser instead of launching Playwright. Optionally specify browser: chrome, firefox, brave, edge, safari, arc, ... For Chromium-family profiles, target one with 'chrome::<profile>' (e.g. 'chrome::Profile 1' or 'brave::Work'). For Firefox Multi-Account Containers, target a specific container with 'firefox::<container-name>' (or 'firefox::none' for the default). Requires: pip install 'notebooklm-py[cookies]'",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "browser_cookies",
+          "opts": [
+            "--browser-cookies"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Pick a signed-in Google account by email when several are present in the browser. Only valid with --browser-cookies.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "account_email",
+          "opts": [
+            "--account"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Extract every Google account signed in to the browser into its own profile (auto-named from each account's email). Only valid with --browser-cookies.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "all_accounts",
+          "opts": [
+            "--all-accounts"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "With --all-accounts: when an account's natural profile name (e.g. 'alice' for alice@gmail.com) already exists but has no account metadata, update that profile in place instead of creating a suffixed 'alice-2'. Profiles that already bind a different email are still given a suffix to avoid clobbering. Only valid with --all-accounts.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "update",
+          "opts": [
+            "--update"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Name to give the new profile when extracting a non-default account. Defaults to the account email's local-part. Only valid with --browser-cookies.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "profile_name",
+          "opts": [
+            "--profile-name"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Start with a clean browser session (deletes cached browser profile). Use to switch Google accounts.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "fresh",
+          "opts": [
+            "--fresh"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": [],
+          "envvar": null,
+          "help": "Opt in to extracting sibling-product cookies (default: required Google auth/Drive cookies only). Pass labels comma-separated or repeat the flag: --include-domains=youtube,docs OR --include-domains=youtube --include-domains=docs. Supported labels: youtube, docs, myaccount, mail, all.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": true,
+          "name": "include_domains_raw",
+          "opts": [
+            "--include-domains"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Log in to NotebookLM via browser."
+    },
+    "metadata": {
+      "callback": "metadata_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON (default: human-readable)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Export notebook metadata with sources list."
+    },
+    "note": {
+      "callback": "note",
+      "class": "Group",
+      "commands": [
+        "create",
+        "delete",
+        "get",
+        "list",
+        "rename",
+        "save"
+      ],
+      "params": [],
+      "short_help": "Note management commands."
+    },
+    "note create": {
+      "callback": "note_create",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "content",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Note content (or '-' to read from stdin). Mutually exclusive with the positional CONTENT argument.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "content_flag",
+          "opts": [
+            "--content"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "New Note",
+          "envvar": null,
+          "help": "Note title",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "-t",
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Create a new note."
+    },
+    "note delete": {
+      "callback": "note_delete",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a note."
+    },
+    "note get": {
+      "callback": "note_get",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get note content."
+    },
+    "note list": {
+      "callback": "note_list",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all notes in a notebook."
+    },
+    "note rename": {
+      "callback": "note_rename",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Rename a note."
+    },
+    "note save": {
+      "callback": "note_save",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "note_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "New title",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "New content",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "content",
+          "opts": [
+            "--content"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Update note content."
+    },
+    "notebooklm": {
+      "callback": "cli",
+      "class": "SectionedGroup",
+      "commands": [
+        "agent",
+        "artifact",
+        "ask",
+        "auth",
+        "clear",
+        "completion",
+        "configure",
+        "create",
+        "delete",
+        "doctor",
+        "download",
+        "generate",
+        "history",
+        "language",
+        "list",
+        "login",
+        "metadata",
+        "note",
+        "profile",
+        "rename",
+        "research",
+        "share",
+        "skill",
+        "source",
+        "status",
+        "summary",
+        "use"
+      ],
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Show the version and exit.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "version",
+          "opts": [
+            "--version"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Path to storage_state.json (default: ~/.notebooklm/profiles/<profile>/storage_state.json)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "storage",
+          "opts": [
+            "--storage"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Profile name (default: from config or 'default'). Use 'notebooklm profile list' to see profiles.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "profile",
+          "opts": [
+            "-p",
+            "--profile"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 0,
+          "envvar": null,
+          "help": "Increase verbosity (-v for INFO, -vv for DEBUG)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "verbose",
+          "opts": [
+            "-v",
+            "--verbose"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "clamp": false,
+            "max": null,
+            "min": 0,
+            "name": "integer range"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Suppress INFO/WARN log records on stderr (only ERROR survives). Mutually exclusive with -v/-vv.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "quiet",
+          "opts": [
+            "--quiet"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "NotebookLM CLI."
+    },
+    "profile": {
+      "callback": "profile",
+      "class": "Group",
+      "commands": [
+        "create",
+        "delete",
+        "list",
+        "rename",
+        "switch"
+      ],
+      "params": [],
+      "short_help": "Manage authentication profiles for..."
+    },
+    "profile create": {
+      "callback": "create_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Create a new profile."
+    },
+    "profile delete": {
+      "callback": "delete_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation prompt",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "confirm",
+          "opts": [
+            "--confirm"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a profile and its data."
+    },
+    "profile list": {
+      "callback": "list_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all profiles and their status."
+    },
+    "profile rename": {
+      "callback": "rename_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "old_name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Rename a profile."
+    },
+    "profile switch": {
+      "callback": "switch_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "name",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Set the default profile."
+    },
+    "rename": {
+      "callback": "rename_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        }
+      ],
+      "short_help": "Rename a notebook."
+    },
+    "research": {
+      "callback": "research",
+      "class": "Group",
+      "commands": [
+        "status",
+        "wait"
+      ],
+      "params": [],
+      "short_help": "Research management commands."
+    },
+    "research status": {
+      "callback": "research_status",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check research status for the current..."
+    },
+    "research wait": {
+      "callback": "research_wait",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 300,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 300)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 5,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 5)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Import all found sources when done",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "import_all",
+          "opts": [
+            "--import-all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "With --import-all, import only cited sources",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "cited_only",
+          "opts": [
+            "--cited-only"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Wait for research to complete."
+    },
+    "share": {
+      "callback": "share",
+      "class": "Group",
+      "commands": [
+        "add",
+        "public",
+        "remove",
+        "status",
+        "update",
+        "view-level"
+      ],
+      "params": [],
+      "short_help": "Notebook sharing commands."
+    },
+    "share add": {
+      "callback": "share_add",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "email",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "viewer",
+          "envvar": null,
+          "help": "Permission level (default: viewer)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "permission",
+          "opts": [
+            "--permission",
+            "-p"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "editor",
+              "viewer"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Don't send email notification",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_notify",
+          "opts": [
+            "--no-notify"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "",
+          "envvar": null,
+          "help": "Welcome message for the user",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "message",
+          "opts": [
+            "--message",
+            "-m"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Share notebook with a user."
+    },
+    "share public": {
+      "callback": "share_public",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": true,
+          "envvar": null,
+          "help": "Enable or disable public sharing",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "enable",
+          "opts": [
+            "--enable"
+          ],
+          "required": false,
+          "secondary_opts": [
+            "--disable"
+          ],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Enable or disable public link sharing."
+    },
+    "share remove": {
+      "callback": "share_remove",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "email",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Remove a user's access to the notebook."
+    },
+    "share status": {
+      "callback": "share_status",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Show sharing status and shared users."
+    },
+    "share update": {
+      "callback": "share_update",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "email",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "New permission level",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "permission",
+          "opts": [
+            "--permission",
+            "-p"
+          ],
+          "required": true,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "editor",
+              "viewer"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Update a user's permission level."
+    },
+    "share view-level": {
+      "callback": "share_view_level",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "level",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "case_sensitive": false,
+            "choices": [
+              "full",
+              "chat"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Set what viewers can access."
+    },
+    "skill": {
+      "callback": "skill",
+      "class": "Group",
+      "commands": [
+        "install",
+        "show",
+        "status",
+        "uninstall"
+      ],
+      "params": [],
+      "short_help": "Manage NotebookLM agent skill integration."
+    },
+    "skill install": {
+      "callback": "install",
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "help": "Install for the current user or into the current project.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "help": "Install for Claude Code, universal agent skill directories, or both.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Install or update the NotebookLM skill for..."
+    },
+    "skill show": {
+      "callback": "show",
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "help": "Read an installed skill from user or project scope.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "source",
+          "envvar": null,
+          "help": "Show the packaged skill source or an installed target.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "source",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Display the packaged skill content or an..."
+    },
+    "skill status": {
+      "callback": "status",
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "help": "Inspect user-level or project-level skill installs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "help": "Inspect Claude Code, universal agent skill directories, or both.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Check installed skill targets and version..."
+    },
+    "skill uninstall": {
+      "callback": "uninstall",
+      "class": "Command",
+      "params": [
+        {
+          "default": "user",
+          "envvar": null,
+          "help": "Remove user-level or project-level skill installs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "scope",
+          "opts": [
+            "--scope"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "user",
+              "project"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "all",
+          "envvar": null,
+          "help": "Remove Claude Code, universal agent skill directories, or both.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "target_name",
+          "opts": [
+            "--target"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "all",
+              "claude",
+              "agents"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Remove the NotebookLM skill from supported..."
+    },
+    "source": {
+      "callback": "source",
+      "class": "Group",
+      "commands": [
+        "add",
+        "add-drive",
+        "add-research",
+        "clean",
+        "delete",
+        "delete-by-title",
+        "fulltext",
+        "get",
+        "guide",
+        "list",
+        "refresh",
+        "rename",
+        "stale",
+        "wait"
+      ],
+      "params": [],
+      "short_help": "Source management commands."
+    },
+    "source add": {
+      "callback": "source_add",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "content",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Source type (auto-detected if not specified)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "source_type",
+          "opts": [
+            "--type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "url",
+              "text",
+              "file",
+              "youtube"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Custom title for text and uploaded-file sources",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "title",
+          "opts": [
+            "--title"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "[Deprecated] MIME type for file sources \u2014 unused; the server derives MIME from the filename extension. Drive sources retain this option (see ``source add-drive``).",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mime_type",
+          "opts": [
+            "--mime-type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "HTTP request timeout in seconds (default: 30, from the library). Increase when adding slow URLs or large files that exceed the default.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "float"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Follow symbolic links when uploading a file. By default, symlinks are rejected so a workspace symlink cannot silently exfiltrate the file it points at (e.g. ~/Downloads/foo.pdf -> /etc/passwd).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "follow_symlinks",
+          "opts": [
+            "--follow-symlinks"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Add a source to a notebook."
+    },
+    "source add-drive": {
+      "callback": "source_add_drive",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "file_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "google-doc",
+          "envvar": null,
+          "help": "Document type (default: google-doc)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mime_type",
+          "opts": [
+            "--mime-type"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "google-doc",
+              "google-slides",
+              "google-sheets",
+              "pdf"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Add a Google Drive document as a source."
+    },
+    "source add-research": {
+      "callback": "source_add_research",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "query",
+          "nargs": 1,
+          "required": false,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Read prompt/query text from a file (or '-' for stdin) instead of the positional argument",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "prompt_file",
+          "opts": [
+            "--prompt-file"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "prompt_file"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": "web",
+          "envvar": null,
+          "help": "Search source (default: web)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "search_source",
+          "opts": [
+            "--from"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "web",
+              "drive"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": "fast",
+          "envvar": null,
+          "help": "Search mode (default: fast)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "mode",
+          "opts": [
+            "--mode"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "fast",
+              "deep"
+            ],
+            "name": "choice"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Import all found sources",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "import_all",
+          "opts": [
+            "--import-all"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "With --import-all, import only cited sources",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "cited_only",
+          "opts": [
+            "--cited-only"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Start research and return immediately (use 'research status/wait' to monitor)",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_wait",
+          "opts": [
+            "--no-wait"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": 1800,
+          "envvar": null,
+          "help": "Retry budget in seconds for --import-all when the IMPORT_RESEARCH RPC times out (default: 1800). Mirrors 'research wait --timeout'. Has no effect without --import-all.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        }
+      ],
+      "short_help": "Search web or drive and add sources from..."
+    },
+    "source clean": {
+      "callback": "source_clean",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Show what would be deleted without actually deleting",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "dry_run",
+          "opts": [
+            "--dry-run"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Automatically remove duplicate, error, and..."
+    },
+    "source delete": {
+      "callback": "source_delete",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a source."
+    },
+    "source delete-by-title": {
+      "callback": "source_delete_by_title",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip confirmation",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "yes",
+          "opts": [
+            "--yes",
+            "-y"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Delete a source by exact title."
+    },
+    "source fulltext": {
+      "callback": "source_fulltext",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": "Sentinel.UNSET",
+          "envvar": null,
+          "help": "Write content to file",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output",
+          "opts": [
+            "--output",
+            "-o"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "allow_dash": false,
+            "dir_okay": true,
+            "executable": false,
+            "exists": false,
+            "file_okay": true,
+            "name": "path",
+            "readable": true,
+            "resolve_path": false,
+            "writable": false
+          }
+        },
+        {
+          "default": "text",
+          "envvar": null,
+          "help": "Content format: text (default) or markdown",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "output_format",
+          "opts": [
+            "--format",
+            "-f"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "case_sensitive": true,
+            "choices": [
+              "text",
+              "markdown"
+            ],
+            "name": "choice"
+          }
+        }
+      ],
+      "short_help": "Get full content of a source."
+    },
+    "source get": {
+      "callback": "source_get",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get source details."
+    },
+    "source guide": {
+      "callback": "source_guide",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get AI-generated source summary and keywords."
+    },
+    "source list": {
+      "callback": "source_list",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": null,
+          "envvar": null,
+          "help": "Show at most N rows (default: unlimited). Applies to both text and --json output.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "limit",
+          "opts": [
+            "--limit"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Disable column truncation in the rendered table (default: truncate).",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "no_truncate",
+          "opts": [
+            "--no-truncate"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "List all sources in a notebook."
+    },
+    "source refresh": {
+      "callback": "source_refresh",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Refresh a URL/Drive source."
+    },
+    "source rename": {
+      "callback": "source_rename",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "kind": "argument",
+          "name": "new_title",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Rename a source."
+    },
+    "source stale": {
+      "callback": "source_stale",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Check if a URL/Drive source needs refresh."
+    },
+    "source wait": {
+      "callback": "source_wait",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "source_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": 120,
+          "envvar": null,
+          "help": "Maximum seconds to wait (default: 120)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "timeout",
+          "opts": [
+            "--timeout"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": 1,
+          "envvar": null,
+          "help": "Seconds between status checks (default: 1)",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "interval",
+          "opts": [
+            "--interval"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "integer"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Wait for a source to finish processing."
+    },
+    "status": {
+      "callback": "status",
+      "class": "Command",
+      "params": [
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Show resolved file paths",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "show_paths",
+          "opts": [
+            "--paths"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Show current context (active notebook and..."
+    },
+    "summary": {
+      "callback": "summary_cmd",
+      "class": "Command",
+      "params": [
+        {
+          "default": null,
+          "envvar": "NOTEBOOKLM_NOTEBOOK",
+          "help": "Notebook ID (uses current if not set). Supports partial IDs.",
+          "is_flag": false,
+          "kind": "option",
+          "multiple": false,
+          "name": "notebook_id",
+          "opts": [
+            "-n",
+            "--notebook"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "_complete_notebooks",
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Include suggested topics",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "topics",
+          "opts": [
+            "--topics"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Get notebook summary with AI-generated..."
+    },
+    "use": {
+      "callback": "use_notebook",
+      "class": "Command",
+      "params": [
+        {
+          "kind": "argument",
+          "name": "notebook_id",
+          "nargs": 1,
+          "required": true,
+          "type": {
+            "name": "text"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Skip the existence check and persist the notebook ID even if verification fails. Use for offline work or debugging.",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "force",
+          "opts": [
+            "--force"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        },
+        {
+          "default": false,
+          "envvar": null,
+          "help": "Output as JSON",
+          "is_flag": true,
+          "kind": "option",
+          "multiple": false,
+          "name": "json_output",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "secondary_opts": [],
+          "shell_complete": "shell_complete",
+          "type": {
+            "name": "boolean"
+          }
+        }
+      ],
+      "short_help": "Set the current notebook context."
+    }
+  },
+  "completion_callbacks": {
+    "download_artifact": "_complete_artifacts",
+    "notebook": "_complete_notebooks"
+  },
+  "root_commands": [
+    "agent",
+    "artifact",
+    "ask",
+    "auth",
+    "clear",
+    "completion",
+    "configure",
+    "create",
+    "delete",
+    "doctor",
+    "download",
+    "generate",
+    "history",
+    "language",
+    "list",
+    "login",
+    "metadata",
+    "note",
+    "profile",
+    "rename",
+    "research",
+    "share",
+    "skill",
+    "source",
+    "status",
+    "summary",
+    "use"
+  ],
+  "schema_version": 1,
+  "top_level_surfaces": {
+    "chat": [
+      "ask",
+      "configure",
+      "history"
+    ],
+    "notebook": [
+      "list",
+      "create",
+      "delete",
+      "rename",
+      "metadata",
+      "summary"
+    ],
+    "session": [
+      "login",
+      "auth",
+      "use",
+      "status",
+      "clear"
+    ]
+  },
+  "tracked_surfaces": [
+    "download",
+    "source",
+    "generate",
+    "artifact",
+    "session",
+    "profile",
+    "notebook",
+    "chat",
+    "note",
+    "share",
+    "research"
+  ]
+}

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -1,0 +1,381 @@
+"""Phase 10 CLI contract baseline before runtime refactors.
+
+This file intentionally characterizes public behavior without moving code. Later
+T11/T12 slices can refactor runtime/auth/completion internals while comparing
+against the JSON baseline generated from ``build_phase10_cli_contract``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.notebooklm_cli import cli
+
+ROOT_COMMAND = "notebooklm"
+
+BASELINE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / ".sisyphus/phases/architecture-remediation/runs/"
+    / "phase-10-cli-contract-baseline.json"
+)
+
+TRACKED_GROUPS = (
+    "download",
+    "source",
+    "generate",
+    "artifact",
+    "session",
+    "profile",
+    "notebook",
+    "chat",
+    "note",
+    "share",
+    "research",
+)
+
+CLICK_GROUPS = (
+    "agent",
+    "download",
+    "source",
+    "generate",
+    "artifact",
+    "language",
+    "profile",
+    "note",
+    "share",
+    "research",
+    "skill",
+)
+
+TOP_LEVEL_SURFACES = {
+    "session": ("login", "auth", "use", "status", "clear"),
+    "notebook": ("list", "create", "delete", "rename", "metadata", "summary"),
+    "chat": ("ask", "configure", "history"),
+}
+
+EXTRA_TOP_LEVEL_COMMANDS = ("completion", "doctor")
+
+HELP_SNIPPETS = {
+    "": ("NotebookLM CLI", "notebooklm login", "completion"),
+    "completion": ("Print the shell completion script", "bash", "zsh", "fish"),
+    "download": ("Download generated content", "cinematic-video", "flashcards"),
+    "download audio": ("Download audio", "--latest", "--no-clobber"),
+    "source add": ("--follow-symlinks", "--mime-type", "--json"),
+    "share public": ("--enable", "--disable", "--json"),
+    "research wait": ("--import-all", "--cited-only", "--timeout"),
+}
+
+
+class _Stub:
+    def __init__(self, stub_id: str, title: str = "") -> None:
+        self.id = stub_id
+        self.title = title
+
+
+def _ctx_with_notebook(notebook_id: str = "nb_contract"):
+    return type("Ctx", (), {"params": {"notebook_id": notebook_id}, "parent": None})()
+
+
+def _command_for(path: str) -> click.Command:
+    cmd: click.Command = cli
+    if not path or path == ROOT_COMMAND:
+        return cmd
+    for part in path.split():
+        if not isinstance(cmd, click.Group):
+            raise AssertionError(f"{path!r} traversed through non-group {cmd!r}")
+        next_cmd = cmd.get_command(click.Context(cmd), part)
+        if next_cmd is None:
+            raise AssertionError(f"missing command path: {path!r}")
+        cmd = next_cmd
+    return cmd
+
+
+def _json_default(value):
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, tuple):
+        return [_json_default(v) for v in value]
+    if isinstance(value, list):
+        return [_json_default(v) for v in value]
+    return str(value)
+
+
+def _type_contract(param_type: click.ParamType) -> dict[str, object]:
+    data: dict[str, object] = {"name": param_type.name}
+    if isinstance(param_type, click.Choice):
+        data["choices"] = list(param_type.choices)
+        data["case_sensitive"] = param_type.case_sensitive
+    if isinstance(param_type, click.IntRange):
+        data["min"] = param_type.min
+        data["max"] = param_type.max
+        data["clamp"] = param_type.clamp
+    if isinstance(param_type, click.Path):
+        data["exists"] = param_type.exists
+        data["file_okay"] = param_type.file_okay
+        data["dir_okay"] = param_type.dir_okay
+        data["writable"] = param_type.writable
+        data["readable"] = param_type.readable
+        data["executable"] = param_type.executable
+        data["resolve_path"] = param_type.resolve_path
+        data["allow_dash"] = param_type.allow_dash
+    return data
+
+
+def _shell_complete_name(param: click.Option) -> str | None:
+    callback = getattr(param, "_custom_shell_complete", None)
+    if callback is None:
+        callback = param.shell_complete
+    return getattr(callback, "__name__", None)
+
+
+def _param_contract(param: click.Parameter) -> dict[str, object]:
+    base: dict[str, object] = {
+        "name": param.name,
+        "required": param.required,
+        "type": _type_contract(param.type),
+    }
+    if isinstance(param, click.Option):
+        base.update(
+            {
+                "kind": "option",
+                "opts": list(param.opts),
+                "secondary_opts": list(param.secondary_opts),
+                "default": _json_default(param.default),
+                "envvar": _json_default(param.envvar),
+                "is_flag": param.is_flag,
+                "multiple": param.multiple,
+                "help": param.help,
+                "shell_complete": _shell_complete_name(param),
+            }
+        )
+    else:
+        base.update({"kind": "argument", "nargs": param.nargs})
+    return base
+
+
+def _command_contract(path: str) -> dict[str, object]:
+    cmd = _command_for(path)
+    data: dict[str, object] = {
+        "class": type(cmd).__name__,
+        "callback": getattr(cmd.callback, "__name__", None),
+        "params": [_param_contract(param) for param in cmd.params],
+        "short_help": cmd.get_short_help_str(),
+    }
+    if isinstance(cmd, click.Group):
+        data["commands"] = sorted(cmd.commands)
+    return data
+
+
+def _option_by_name(path: str, name: str) -> click.Option:
+    for param in _command_for(path).params:
+        if isinstance(param, click.Option) and param.name == name:
+            return param
+    raise AssertionError(f"{path!r} has no option named {name!r}")
+
+
+def _iter_command_paths(path: str) -> list[str]:
+    cmd = _command_for(path)
+    paths = [path]
+    if isinstance(cmd, click.Group):
+        for child in sorted(cmd.commands):
+            child_path = f"{path} {child}" if path else child
+            paths.extend(_iter_command_paths(child_path))
+    return paths
+
+
+def _tracked_command_paths() -> list[str]:
+    paths: list[str] = [ROOT_COMMAND]
+    for group in CLICK_GROUPS:
+        paths.extend(_iter_command_paths(group))
+    for commands in TOP_LEVEL_SURFACES.values():
+        for name in commands:
+            paths.extend(_iter_command_paths(name))
+    for name in EXTRA_TOP_LEVEL_COMMANDS:
+        paths.extend(_iter_command_paths(name))
+    return sorted(set(paths))
+
+
+def _same_params(left: click.Command, right: click.Command) -> bool:
+    return [_param_contract(p) for p in left.params] == [_param_contract(p) for p in right.params]
+
+
+def build_phase10_cli_contract() -> dict[str, object]:
+    """Return the deterministic public CLI inventory used by the baseline."""
+    download_cinematic_video = _command_for("download cinematic-video")
+    download_video = _command_for("download video")
+    generate_cinematic_video = _command_for("generate cinematic-video")
+    generate_video = _command_for("generate video")
+    return {
+        "schema_version": 1,
+        "tracked_surfaces": list(TRACKED_GROUPS),
+        "root_commands": sorted(cli.commands),
+        "top_level_surfaces": {key: list(value) for key, value in TOP_LEVEL_SURFACES.items()},
+        "click_groups": {group: sorted(_command_for(group).commands) for group in CLICK_GROUPS},
+        "aliases": {
+            "download cinematic-video": {
+                "canonical": "download video",
+                "same_callback": download_cinematic_video.callback is download_video.callback,
+                "same_params": _same_params(download_cinematic_video, download_video),
+            },
+            "generate cinematic-video": {
+                "canonical": "generate video --format cinematic",
+                "same_callback": generate_cinematic_video.callback is generate_video.callback,
+                "same_params": _same_params(generate_cinematic_video, generate_video),
+            },
+        },
+        "completion_callbacks": {
+            "notebook": _shell_complete_name(_option_by_name("source list", "notebook_id")),
+            "download_artifact": _shell_complete_name(
+                _option_by_name("download audio", "artifact_id")
+            ),
+        },
+        "commands": {path: _command_contract(path) for path in _tracked_command_paths()},
+    }
+
+
+def test_phase10_cli_contract_matches_baseline() -> None:
+    """Public command tree, options, defaults, help, and aliases match T11.0."""
+    expected = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    assert build_phase10_cli_contract() == expected
+
+
+@pytest.mark.parametrize("path,snippets", HELP_SNIPPETS.items(), ids=lambda value: value or "root")
+def test_representative_help_snippets_remain_visible(path: str, snippets: tuple[str, ...]) -> None:
+    argv = [*path.split(), "--help"] if path else ["--help"]
+    result = CliRunner().invoke(cli, argv)
+
+    assert result.exit_code == 0, result.output
+    for snippet in snippets:
+        assert snippet in result.output
+
+
+def test_completion_callbacks_return_value_help_shape_and_50_row_caps() -> None:
+    from notebooklm.cli import options
+
+    fake_client = AsyncMock()
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = None
+    fake_client.sources.list = AsyncMock(
+        return_value=[_Stub(f"src_{index:03d}", f"Source {index}") for index in range(60)]
+    )
+    fake_client.artifacts.list = AsyncMock(
+        return_value=[_Stub(f"art_{index:03d}", f"Artifact {index}") for index in range(60)]
+    )
+
+    with (
+        patch.object(options, "_resolve_notebook_for_completion", return_value="nb_contract"),
+        patch("notebooklm.cli.helpers.get_auth_tokens", return_value=object()),
+        patch("notebooklm.client.NotebookLMClient", return_value=fake_client),
+    ):
+        source_items = options._complete_sources(_ctx_with_notebook(), None, "src_")
+        artifact_items = options._complete_artifacts(_ctx_with_notebook(), None, "art_")
+
+    assert len(source_items) == 50
+    assert (source_items[0].value, source_items[0].help) == ("src_000", "Source 0")
+    assert source_items[-1].value == "src_049"
+    assert len(artifact_items) == 50
+    assert (artifact_items[0].value, artifact_items[0].help) == ("art_000", "Artifact 0")
+    assert artifact_items[-1].value == "art_049"
+
+
+def test_completion_callbacks_are_silent_on_failures(capsys: pytest.CaptureFixture[str]) -> None:
+    from notebooklm.cli import options
+
+    with patch("notebooklm.cli.helpers.get_auth_tokens", side_effect=RuntimeError("no auth")):
+        assert options._complete_notebooks(_ctx_with_notebook(), None, "nb_") == []
+
+    fake_client = AsyncMock()
+    fake_client.__aenter__.return_value = fake_client
+    fake_client.__aexit__.return_value = None
+    fake_client.sources.list = AsyncMock(side_effect=RuntimeError("offline"))
+    fake_client.artifacts.list = AsyncMock(side_effect=RuntimeError("offline"))
+
+    with (
+        patch.object(options, "_resolve_notebook_for_completion", return_value="nb_contract"),
+        patch("notebooklm.cli.helpers.get_auth_tokens", return_value=object()),
+        patch("notebooklm.client.NotebookLMClient", return_value=fake_client),
+    ):
+        assert options._complete_sources(_ctx_with_notebook(), None, "src_") == []
+        assert options._complete_artifacts(_ctx_with_notebook(), None, "art_") == []
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    ("case_id", "setup", "expected_exit", "expected_code", "legacy_error"),
+    [
+        ("auth_required", "missing_storage", 1, "AUTH_REQUIRED", False),
+        ("returned_download_error", "empty_artifacts", 1, None, True),
+        ("typed_user_error", "rate_limited", 1, "RATE_LIMITED", False),
+        ("unexpected_error", "runtime_error", 2, "UNEXPECTED_ERROR", False),
+    ],
+)
+def test_json_stdout_routing_and_exit_codes_for_download_runtime(
+    case_id: str,
+    setup: str,
+    expected_exit: int,
+    expected_code: str | None,
+    legacy_error: bool,
+) -> None:
+    from notebooklm.auth import AuthTokens
+    from notebooklm.exceptions import RateLimitError
+
+    from .conftest import create_mock_client, patch_client_for_module
+
+    auth = AuthTokens(
+        cookies={
+            "SID": "test",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        },
+        csrf_token="csrf",
+        session_id="session",
+    )
+    mock_client = create_mock_client()
+    if setup == "empty_artifacts":
+        mock_client.artifacts.list = AsyncMock(return_value=[])
+    elif setup == "rate_limited":
+        mock_client.artifacts.list = AsyncMock(side_effect=RateLimitError("quota", retry_after=7))
+    elif setup == "runtime_error":
+        mock_client.artifacts.list = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with (
+        patch.object(AuthTokens, "from_storage", new_callable=AsyncMock) as mock_from_storage,
+        patch_client_for_module("download") as mock_client_cls,
+    ):
+        if setup == "missing_storage":
+            mock_from_storage.side_effect = FileNotFoundError("Storage file not found")
+        else:
+            mock_from_storage.return_value = auth
+            mock_client_cls.return_value = mock_client
+
+        result = CliRunner().invoke(
+            cli,
+            ["download", "audio", "--json", "-n", "nb_123"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == expected_exit, case_id
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    if legacy_error:
+        assert isinstance(payload["error"], str)
+        assert "No completed audio artifacts" in payload["error"]
+        assert "code" not in payload
+    else:
+        assert payload["error"] is True
+        assert payload["code"] == expected_code
+
+
+if __name__ == "__main__":
+    print(json.dumps(build_phase10_cli_contract(), indent=2, sort_keys=True))

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -142,11 +142,14 @@ def _type_contract(param_type: click.ParamType) -> dict[str, object]:
     return data
 
 
-def _shell_complete_name(param: click.Option) -> str | None:
-    callback = getattr(param, "_custom_shell_complete", None)
-    if callback is None:
-        callback = param.shell_complete
-    return getattr(callback, "__name__", None)
+def _has_custom_shell_complete(param: click.Option) -> bool:
+    return getattr(param, "_custom_shell_complete", None) is not None
+
+
+def _visible_command_names(group: click.Group) -> list[str]:
+    ctx = click.Context(group)
+    names = group.list_commands(ctx)
+    return [name for name in names if not getattr(group.get_command(ctx, name), "hidden", False)]
 
 
 def _param_contract(param: click.Parameter) -> dict[str, object]:
@@ -166,7 +169,7 @@ def _param_contract(param: click.Parameter) -> dict[str, object]:
                 "is_flag": param.is_flag,
                 "multiple": param.multiple,
                 "help": param.help,
-                "shell_complete": _shell_complete_name(param),
+                "has_custom_shell_complete": _has_custom_shell_complete(param),
             }
         )
     else:
@@ -178,12 +181,11 @@ def _command_contract(path: str) -> dict[str, object]:
     cmd = _command_for(path)
     data: dict[str, object] = {
         "class": type(cmd).__name__,
-        "callback": getattr(cmd.callback, "__name__", None),
         "params": [_param_contract(param) for param in cmd.params],
         "short_help": cmd.get_short_help_str(),
     }
     if isinstance(cmd, click.Group):
-        data["commands"] = sorted(cmd.commands)
+        data["commands"] = _visible_command_names(cmd)
     return data
 
 
@@ -198,7 +200,7 @@ def _iter_command_paths(path: str) -> list[str]:
     cmd = _command_for(path)
     paths = [path]
     if isinstance(cmd, click.Group):
-        for child in sorted(cmd.commands):
+        for child in _visible_command_names(cmd):
             child_path = f"{path} {child}" if path else child
             paths.extend(_iter_command_paths(child_path))
     return paths
@@ -229,9 +231,11 @@ def build_phase10_cli_contract() -> dict[str, object]:
     return {
         "schema_version": 1,
         "tracked_surfaces": list(TRACKED_GROUPS),
-        "root_commands": sorted(cli.commands),
+        "root_commands": _visible_command_names(cli),
         "top_level_surfaces": {key: list(value) for key, value in TOP_LEVEL_SURFACES.items()},
-        "click_groups": {group: sorted(_command_for(group).commands) for group in CLICK_GROUPS},
+        "click_groups": {
+            group: _visible_command_names(_command_for(group)) for group in CLICK_GROUPS
+        },
         "aliases": {
             "download cinematic-video": {
                 "canonical": "download video",
@@ -245,8 +249,8 @@ def build_phase10_cli_contract() -> dict[str, object]:
             },
         },
         "completion_callbacks": {
-            "notebook": _shell_complete_name(_option_by_name("source list", "notebook_id")),
-            "download_artifact": _shell_complete_name(
+            "notebook": _has_custom_shell_complete(_option_by_name("source list", "notebook_id")),
+            "download_artifact": _has_custom_shell_complete(
                 _option_by_name("download audio", "artifact_id")
             ),
         },

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -19,8 +19,17 @@ from notebooklm.notebooklm_cli import cli
 
 ROOT_COMMAND = "notebooklm"
 
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in (current, *current.parents):
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("Could not locate repository root")
+
+
 BASELINE_PATH = (
-    Path(__file__).resolve().parents[3]
+    _find_repo_root()
     / ".sisyphus/phases/architecture-remediation/runs/"
     / "phase-10-cli-contract-baseline.json"
 )
@@ -78,8 +87,14 @@ class _Stub:
         self.title = title
 
 
-def _ctx_with_notebook(notebook_id: str = "nb_contract"):
-    return type("Ctx", (), {"params": {"notebook_id": notebook_id}, "parent": None})()
+class _CompletionCtx:
+    def __init__(self, notebook_id: str) -> None:
+        self.params = {"notebook_id": notebook_id}
+        self.parent = None
+
+
+def _ctx_with_notebook(notebook_id: str = "nb_contract") -> _CompletionCtx:
+    return _CompletionCtx(notebook_id)
 
 
 def _command_for(path: str) -> click.Command:

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -293,7 +293,6 @@ def test_command_body_file_not_found_is_not_auth_required(runner: CliRunner, stu
     payload = json.loads(result.stdout)
     assert payload["error"] is True
     assert payload["code"] == "UNEXPECTED_ERROR"
-    assert payload["code"] != "AUTH_REQUIRED"
 
 
 def test_unexpected_error_json_payload_exits_2(runner: CliRunner, stubbed_auth) -> None:

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -280,6 +280,22 @@ def test_file_not_found_json_payload(runner: CliRunner, monkeypatch) -> None:
     assert payload["code"] == "AUTH_REQUIRED"
 
 
+def test_command_body_file_not_found_is_not_auth_required(runner: CliRunner, stubbed_auth) -> None:
+    """Command-body ``FileNotFoundError`` stays on the unexpected-error path."""
+
+    async def _raise(_auth):
+        raise FileNotFoundError("missing source-file payload")
+
+    cli = _build_cli(_raise)
+    result = runner.invoke(cli, ["run", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 2, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+    assert payload["code"] != "AUTH_REQUIRED"
+
+
 def test_unexpected_error_json_payload_exits_2(runner: CliRunner, stubbed_auth) -> None:
     """JSON mode: unknown ``RuntimeError`` → UNEXPECTED_ERROR + exit 2 (system error)."""
 


### PR DESCRIPTION
## Summary

T11.0 only. This adds a Phase 10 CLI characterization suite and baseline artifact before any runtime/helper movement:

- adds `tests/unit/cli/test_phase10_cli_contract.py` to pin the public CLI command tree, root options, all public command groups, top-level session/notebook/chat commands, aliases, option names/defaults/help/completion callbacks, representative help snippets, completion row shape/caps/silent failure, and download JSON stdout/exit-code routing
- generates `.sisyphus/phases/architecture-remediation/runs/phase-10-cli-contract-baseline.json` from the same inventory
- adds a named `with_client(...)` test proving command-body `FileNotFoundError` remains `UNEXPECTED_ERROR`, not `AUTH_REQUIRED`

No production CLI code was moved in this slice.

## Phase / Gate Evidence

- Parent state read-only check now reports P1-P9 `status=merged audit=clean`; I did not edit `.sisyphus/phases/architecture-remediation/state.json`.
- GitHub merge evidence checked for Phase 9 follow-ups: #687, #688, #689, #690, #692, and #693 are merged. #693 only touched `tests/unit/test_init_order.py`; this branch does not touch that file.
- Branch is rebased onto `origin/main` at `3fd8f9a` (`fix(review): cover notebook service import guards (#693)`).
- Current diff is limited to the T11.0 test/baseline files: baseline JSON, `tests/unit/cli/test_phase10_cli_contract.py`, and `tests/unit/test_with_client_handle_errors.py`.
- I noticed later-wave PR #694 opened after this branch was built; it is T11.1 and should consume/rebase after this T11.0 baseline.

## Pre-Implementation Refresh Findings

- Line counts: `helpers.py` 1349, `download.py` 1016, `options.py` 430, `source.py` 1630, `generate.py` 1515, `session.py` 2758 (8698 total).
- Runtime/completion anchors remain in the legacy locations: `helpers.py` has `run_async`, `get_auth_tokens`, `handle_auth_error`, and `with_client`; `download.py` still has `AuthTokens.from_storage`, `_download_artifacts_generic`, and `_run_artifact_download`; `options.py` still owns `_complete_notebooks`, `_complete_sources`, and `_complete_artifacts`.
- Patch seams found for `notebooklm.cli.helpers` auth/context/console/sleep seams, `notebooklm.cli.options` completion seams, and `download_module._download_artifacts_generic`; the new contract test adds explicit coverage for the completion and download-runtime surfaces that later slices will move.
- Existing characterization already covered download JSON/error/completion/stdout surfaces; this PR adds the generated inventory baseline plus missing named `with_client` FileNotFoundError proof.

## Review / Polish Evidence

- `/polish` ran code-simplifier fallback plus Gemini, external Codex, and native Codex review.
- Initial reviewers flagged missing root/global command coverage, incomplete public group inventory, non-recursive command discovery, and incomplete Click path metadata. Fixed before PR by adding root command coverage, all public groups/top-level commands, recursive discovery, and path metadata including `exists/file_okay/dir_okay/readable/writable/executable/resolve_path/allow_dash`.
- Gemini final review: no blocking findings.
- External Codex final review: no blocking findings; its focused read-only checks passed (`27 passed` for new characterization/error tests and `89 passed` for completion/download suites, with `pytest-rerunfailures` disabled only in that reviewer sandbox due local socket restrictions).
- Native final sanity pass added the extra `click.Path` `executable` and `resolve_path` fields, regenerated the baseline, and reran all local gates below.

## Verification

Re-run after rebasing onto `origin/main`:

- `rtk uv run pytest tests/unit/test_with_client_handle_errors.py tests/unit/cli/test_download.py tests/unit/cli/test_completion.py tests/unit/cli/test_phase10_cli_contract.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py` — 139 passed
- `rtk uv run ruff check src/notebooklm/cli/download.py src/notebooklm/cli/options.py src/notebooklm/cli/helpers.py tests/unit/cli/test_download.py tests/unit/cli/test_completion.py tests/unit/cli/test_phase10_cli_contract.py tests/unit/test_with_client_handle_errors.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py` — passed
- `rtk uv run ruff format --check src/notebooklm/cli/download.py src/notebooklm/cli/options.py src/notebooklm/cli/helpers.py tests/unit/cli/test_download.py tests/unit/cli/test_completion.py tests/unit/cli/test_phase10_cli_contract.py tests/unit/test_with_client_handle_errors.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py` — 9 files already formatted
- `rtk uv run mypy src/notebooklm` — passed
- `rtk uv run pytest -n auto --dist=worksteal` — 4698 passed, 12 skipped, 7 warnings
- `rtk uv run pre-commit run --all-files` — passed

## Deferred / Not Changed

- No VCR cassettes were re-recorded.
- Did not edit Phase 11 files, `tests/unit/test_init_order.py`, or orchestration state.
- A reviewer noted the existing `download.py` `FileNotFoundError` catch covers the full async body despite the docstring saying body errors should propagate. I did not change production behavior in T11.0; T11.2 owns download runtime normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CLI contract validation to lock down command surfaces, help snippets, and persisted contract JSON.
  * Added tests for shell completion behavior (value/help shape, 50-item cap, and silent failures on errors).
  * Added integration tests for JSON stdout routing and exit codes across download scenarios (missing storage, legacy empty-artifacts, rate-limit, unexpected errors).
  * Added regression test ensuring FileNotFoundError yields exit code 2 with JSON error/code fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->