### PR TITLE
refactor(cli): extract completion providers

### DIFF
--- a/src/notebooklm/cli/completion.py
+++ b/src/notebooklm/cli/completion.py
@@ -17,6 +17,21 @@ _NotebookResolver = Callable[[Any], str | None]
 _CurrentNotebookLoader = Callable[[], str | None]
 
 
+def _notebook_id_from_context(ctx: Any) -> str | None:
+    """Return a parsed notebook id from a Click context chain, if present."""
+    cur = ctx
+    while cur is not None:
+        try:
+            params = getattr(cur, "params", None)
+            notebook_id = params.get("notebook_id") if params else None
+            if isinstance(notebook_id, str) and notebook_id:
+                return notebook_id
+            cur = getattr(cur, "parent", None)
+        except Exception:
+            return None
+    return None
+
+
 def _close_awaitable(awaitable: Awaitable[Any]) -> None:
     """Close an unconsumed coroutine when an injected runner fails immediately."""
     close = getattr(awaitable, "close", None)
@@ -133,16 +148,9 @@ class CompletionProvider:
             return None
 
     def _resolve_notebook_from_context(self, ctx: Any) -> str | None:
-        cur = ctx
-        while cur is not None:
-            try:
-                params = getattr(cur, "params", None)
-                notebook_id = params.get("notebook_id") if params else None
-                if notebook_id:
-                    return notebook_id
-                cur = getattr(cur, "parent", None)
-            except Exception:
-                return None
+        notebook_id = _notebook_id_from_context(ctx)
+        if notebook_id:
+            return notebook_id
 
         env_val = os.environ.get("NOTEBOOKLM_NOTEBOOK", "").strip()
         if env_val:

--- a/src/notebooklm/cli/completion.py
+++ b/src/notebooklm/cli/completion.py
@@ -80,8 +80,10 @@ class CompletionProvider:
             notebooks = self._run(_list())
             items: list[CompletionItem] = []
             for notebook in notebooks:
-                if notebook.id.startswith(incomplete):
-                    items.append(CompletionItem(notebook.id, help=notebook.title or ""))
+                notebook_id = getattr(notebook, "id", "")
+                if isinstance(notebook_id, str) and notebook_id.startswith(incomplete):
+                    title = getattr(notebook, "title", "") or ""
+                    items.append(CompletionItem(notebook_id, help=title))
                     if len(items) >= self._row_limit:
                         break
             return items

--- a/src/notebooklm/cli/completion.py
+++ b/src/notebooklm/cli/completion.py
@@ -1,0 +1,219 @@
+"""Best-effort shell-completion providers for live NotebookLM IDs."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from click.shell_completion import CompletionItem
+
+MAX_COMPLETION_ITEMS = 50
+
+_AuthLoader = Callable[[Any], Any]
+_AsyncRunner = Callable[[Awaitable[Any]], Any]
+_ClientFactory = Callable[[Any], Any]
+_NotebookResolver = Callable[[Any], str | None]
+_CurrentNotebookLoader = Callable[[], str | None]
+
+
+def _close_awaitable(awaitable: Awaitable[Any]) -> None:
+    """Close an unconsumed coroutine when an injected runner fails immediately."""
+    close = getattr(awaitable, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            pass
+
+
+class CompletionProvider:
+    """Load completion rows while preserving shell-safe failure behavior.
+
+    All external seams are resolved lazily so existing tests and callers can
+    patch ``notebooklm.cli.helpers`` and ``notebooklm.client`` symbols at call
+    time. Every completion method catches broad exceptions and returns ``[]``;
+    shell completion must never print diagnostics into the user's terminal.
+    """
+
+    def __init__(
+        self,
+        *,
+        auth_loader: _AuthLoader | None = None,
+        async_runner: _AsyncRunner | None = None,
+        client_factory: _ClientFactory | None = None,
+        notebook_resolver: _NotebookResolver | None = None,
+        current_notebook_loader: _CurrentNotebookLoader | None = None,
+        row_limit: int = MAX_COMPLETION_ITEMS,
+    ) -> None:
+        self._auth_loader = auth_loader
+        self._async_runner = async_runner
+        self._client_factory = client_factory
+        self._notebook_resolver = notebook_resolver
+        self._current_notebook_loader = current_notebook_loader
+        self._row_limit = row_limit
+
+    def complete_notebooks(self, ctx: Any, incomplete: str) -> list[CompletionItem]:
+        """Complete notebook ids, filtered by prefix and capped for shells."""
+        try:
+            auth = self._load_auth(ctx)
+
+            async def _list() -> Any:
+                async with self._make_client(auth) as client:
+                    return await client.notebooks.list()
+
+            notebooks = self._run(_list())
+            items: list[CompletionItem] = []
+            for notebook in notebooks:
+                if notebook.id.startswith(incomplete):
+                    items.append(CompletionItem(notebook.id, help=notebook.title or ""))
+                    if len(items) >= self._row_limit:
+                        break
+            return items
+        except Exception:
+            return []
+
+    def complete_sources(self, ctx: Any, incomplete: str) -> list[CompletionItem]:
+        """Complete source ids for the resolved notebook."""
+        try:
+            notebook_id = self.resolve_notebook(ctx)
+            if not notebook_id:
+                return []
+            auth = self._load_auth(ctx)
+
+            async def _list() -> Any:
+                async with self._make_client(auth) as client:
+                    return await client.sources.list(notebook_id)
+
+            sources = self._run(_list())
+            items: list[CompletionItem] = []
+            for source in sources:
+                source_id = getattr(source, "id", None) or getattr(source, "source_id", "")
+                if source_id and source_id.startswith(incomplete):
+                    title = getattr(source, "title", "") or ""
+                    items.append(CompletionItem(source_id, help=title))
+                    if len(items) >= self._row_limit:
+                        break
+            return items
+        except Exception:
+            return []
+
+    def complete_artifacts(self, ctx: Any, incomplete: str) -> list[CompletionItem]:
+        """Complete artifact ids for the resolved notebook."""
+        try:
+            notebook_id = self.resolve_notebook(ctx)
+            if not notebook_id:
+                return []
+            auth = self._load_auth(ctx)
+
+            async def _list() -> Any:
+                async with self._make_client(auth) as client:
+                    return await client.artifacts.list(notebook_id)
+
+            artifacts = self._run(_list())
+            items: list[CompletionItem] = []
+            for artifact in artifacts:
+                artifact_id = getattr(artifact, "id", None) or getattr(artifact, "artifact_id", "")
+                if artifact_id and artifact_id.startswith(incomplete):
+                    title = getattr(artifact, "title", "") or getattr(artifact, "name", "") or ""
+                    items.append(CompletionItem(artifact_id, help=title))
+                    if len(items) >= self._row_limit:
+                        break
+            return items
+        except Exception:
+            return []
+
+    def resolve_notebook(self, ctx: Any) -> str | None:
+        """Resolve the notebook id usable for sub-resource completion."""
+        try:
+            if self._notebook_resolver is not None:
+                return self._notebook_resolver(ctx)
+            return self._resolve_notebook_from_context(ctx)
+        except Exception:
+            return None
+
+    def _resolve_notebook_from_context(self, ctx: Any) -> str | None:
+        cur = ctx
+        while cur is not None:
+            try:
+                params = getattr(cur, "params", None)
+                notebook_id = params.get("notebook_id") if params else None
+                if notebook_id:
+                    return notebook_id
+                cur = getattr(cur, "parent", None)
+            except Exception:
+                return None
+
+        env_val = os.environ.get("NOTEBOOKLM_NOTEBOOK", "").strip()
+        if env_val:
+            return env_val
+
+        return self._load_current_notebook()
+
+    def _load_auth(self, ctx: Any) -> Any:
+        if self._auth_loader is not None:
+            return self._auth_loader(ctx)
+        from . import helpers
+
+        return helpers.get_auth_tokens(ctx)
+
+    def _load_current_notebook(self) -> str | None:
+        try:
+            if self._current_notebook_loader is not None:
+                return self._current_notebook_loader()
+            from . import helpers
+
+            return helpers.get_current_notebook()
+        except Exception:
+            return None
+
+    def _make_client(self, auth: Any) -> Any:
+        if self._client_factory is not None:
+            return self._client_factory(auth)
+        from ..client import NotebookLMClient
+
+        return NotebookLMClient(auth)
+
+    def _run(self, awaitable: Awaitable[Any]) -> Any:
+        try:
+            if self._async_runner is not None:
+                return self._async_runner(awaitable)
+            from . import helpers
+
+            return helpers.run_async(awaitable)
+        except Exception:
+            _close_awaitable(awaitable)
+            raise
+
+
+def complete_notebooks(ctx: Any, incomplete: str) -> list[CompletionItem]:
+    """Complete notebook ids using the default provider."""
+    return CompletionProvider().complete_notebooks(ctx, incomplete)
+
+
+def resolve_notebook(ctx: Any) -> str | None:
+    """Resolve the notebook id using the default provider."""
+    return CompletionProvider().resolve_notebook(ctx)
+
+
+def complete_sources(
+    ctx: Any,
+    incomplete: str,
+    *,
+    notebook_resolver: _NotebookResolver | None = None,
+) -> list[CompletionItem]:
+    """Complete source ids using the default provider."""
+    return CompletionProvider(notebook_resolver=notebook_resolver).complete_sources(ctx, incomplete)
+
+
+def complete_artifacts(
+    ctx: Any,
+    incomplete: str,
+    *,
+    notebook_resolver: _NotebookResolver | None = None,
+) -> list[CompletionItem]:
+    """Complete artifact ids using the default provider."""
+    return CompletionProvider(notebook_resolver=notebook_resolver).complete_artifacts(
+        ctx,
+        incomplete,
+    )

--- a/src/notebooklm/cli/options.py
+++ b/src/notebooklm/cli/options.py
@@ -16,12 +16,12 @@ just gets no suggestions instead of an error printed by their shell. This
 keeps tab-completion safe to use even in fresh shells without credentials.
 """
 
-import os
 from collections.abc import Callable
 
 import click
 from click.decorators import FC
-from click.shell_completion import CompletionItem
+
+from . import completion as _completion
 
 
 def _complete_notebooks(ctx, param, incomplete):
@@ -38,26 +38,7 @@ def _complete_notebooks(ctx, param, incomplete):
     suggestions" — exactly what the user expects when ``notebooklm list``
     would also fail.
     """
-    try:
-        from ..client import NotebookLMClient
-        from .helpers import get_auth_tokens, run_async
-
-        auth = get_auth_tokens(ctx)
-
-        async def _list():
-            async with NotebookLMClient(auth) as client:
-                return await client.notebooks.list()
-
-        notebooks = run_async(_list())
-        items: list[CompletionItem] = []
-        for nb in notebooks:
-            if nb.id.startswith(incomplete):
-                items.append(CompletionItem(nb.id, help=nb.title or ""))
-                if len(items) >= 50:
-                    break
-        return items
-    except Exception:
-        return []
+    return _completion.complete_notebooks(ctx, incomplete)
 
 
 def _resolve_notebook_for_completion(ctx) -> str | None:
@@ -75,26 +56,7 @@ def _resolve_notebook_for_completion(ctx) -> str | None:
     Returns ``None`` when no notebook can be resolved, in which case the
     caller should return an empty completion list rather than guess.
     """
-    # 1) walk up Click contexts looking for an already-parsed --notebook value.
-    cur = ctx
-    while cur is not None:
-        nid = cur.params.get("notebook_id") if cur.params else None
-        if nid:
-            return nid
-        cur = cur.parent
-
-    # 2) env var fallback (helpers.require_notebook treats whitespace-only as unset).
-    env_val = os.environ.get("NOTEBOOKLM_NOTEBOOK", "").strip()
-    if env_val:
-        return env_val
-
-    # 3) active context written by ``notebooklm use``.
-    try:
-        from .helpers import get_current_notebook
-
-        return get_current_notebook()
-    except Exception:
-        return None
+    return _completion.resolve_notebook(ctx)
 
 
 def _complete_sources(ctx, param, incomplete):
@@ -104,31 +66,11 @@ def _complete_sources(ctx, param, incomplete):
     sources and filters by ``incomplete`` prefix. Returns ``[]`` on any
     failure — see ``_complete_notebooks`` for the rationale.
     """
-    try:
-        from ..client import NotebookLMClient
-        from .helpers import get_auth_tokens, run_async
-
-        nb_id = _resolve_notebook_for_completion(ctx)
-        if not nb_id:
-            return []
-        auth = get_auth_tokens(ctx)
-
-        async def _list():
-            async with NotebookLMClient(auth) as client:
-                return await client.sources.list(nb_id)
-
-        sources = run_async(_list())
-        items: list[CompletionItem] = []
-        for src in sources:
-            sid = getattr(src, "id", None) or getattr(src, "source_id", "")
-            if sid and sid.startswith(incomplete):
-                title = getattr(src, "title", "") or ""
-                items.append(CompletionItem(sid, help=title))
-                if len(items) >= 50:
-                    break
-        return items
-    except Exception:
-        return []
+    return _completion.complete_sources(
+        ctx,
+        incomplete,
+        notebook_resolver=_resolve_notebook_for_completion,
+    )
 
 
 def _complete_artifacts(ctx, param, incomplete):
@@ -137,31 +79,11 @@ def _complete_artifacts(ctx, param, incomplete):
     Same shape as ``_complete_sources`` but lists artifacts in the resolved
     notebook. Returns ``[]`` on any failure.
     """
-    try:
-        from ..client import NotebookLMClient
-        from .helpers import get_auth_tokens, run_async
-
-        nb_id = _resolve_notebook_for_completion(ctx)
-        if not nb_id:
-            return []
-        auth = get_auth_tokens(ctx)
-
-        async def _list():
-            async with NotebookLMClient(auth) as client:
-                return await client.artifacts.list(nb_id)
-
-        artifacts = run_async(_list())
-        items: list[CompletionItem] = []
-        for art in artifacts:
-            aid = getattr(art, "id", None) or getattr(art, "artifact_id", "")
-            if aid and aid.startswith(incomplete):
-                title = getattr(art, "title", "") or getattr(art, "name", "") or ""
-                items.append(CompletionItem(aid, help=title))
-                if len(items) >= 50:
-                    break
-        return items
-    except Exception:
-        return []
+    return _completion.complete_artifacts(
+        ctx,
+        incomplete,
+        notebook_resolver=_resolve_notebook_for_completion,
+    )
 
 
 def notebook_option(f: FC) -> FC:

--- a/tests/unit/cli/test_completion.py
+++ b/tests/unit/cli/test_completion.py
@@ -206,6 +206,34 @@ class TestCompleteNotebooks:
 
         assert items == []
 
+    def test_skips_malformed_rows_without_dropping_valid_notebooks(self):
+        """A bad notebook row should not discard the rest of the completions."""
+        from notebooklm.cli import options
+
+        async def fake_list():
+            return [
+                object(),
+                _Stub("nb_good_1", "Good One"),
+                _Stub("other", "Other Notebook"),
+                type("BadTitle", (), {"id": "nb_good_2", "title": None})(),
+            ]
+
+        fake_client = AsyncMock()
+        fake_client.__aenter__.return_value = fake_client
+        fake_client.__aexit__.return_value = None
+        fake_client.notebooks.list = AsyncMock(side_effect=fake_list)
+
+        with (
+            patch("notebooklm.cli.helpers.get_auth_tokens", return_value=object()),
+            patch("notebooklm.client.NotebookLMClient", return_value=fake_client),
+        ):
+            items = options._complete_notebooks(ctx=None, param=None, incomplete="nb_good")
+
+        assert [(item.value, item.help) for item in items] == [
+            ("nb_good_1", "Good One"),
+            ("nb_good_2", ""),
+        ]
+
     def test_caps_results_at_50(self):
         """The completer must cap the result list at 50 to keep the shell
         snappy on profiles with hundreds of notebooks.

--- a/tests/unit/cli/test_completion.py
+++ b/tests/unit/cli/test_completion.py
@@ -247,7 +247,7 @@ class TestCompletionProviderSilentFailures:
         assert captured.out == ""
         assert captured.err == ""
 
-    def test_corrupt_context_returns_empty_without_output(self, capsys):
+    def test_corrupt_context_falls_back_to_env_without_output(self, capsys):
         from notebooklm.cli.completion import CompletionProvider
 
         class BrokenCtx:
@@ -258,14 +258,33 @@ class TestCompletionProviderSilentFailures:
                 raise RuntimeError("bad context")
 
         provider = CompletionProvider(
-            auth_loader=lambda _ctx: pytest.fail("auth should not load"),
             current_notebook_loader=lambda: pytest.fail("context should not load"),
         )
         with patch.dict(os.environ, {"NOTEBOOKLM_NOTEBOOK": "nb_from_env"}):
-            items = provider.complete_sources(ctx=BrokenCtx(), incomplete="src_")
+            notebook_id = provider.resolve_notebook(ctx=BrokenCtx())
 
         captured = capsys.readouterr()
-        assert items == []
+        assert notebook_id == "nb_from_env"
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_corrupt_context_falls_back_to_current_notebook_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        class BrokenCtx:
+            parent = None
+
+            @property
+            def params(self):
+                raise RuntimeError("bad context")
+
+        provider = CompletionProvider(current_notebook_loader=lambda: "nb_from_context")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NOTEBOOKLM_NOTEBOOK", None)
+            notebook_id = provider.resolve_notebook(ctx=BrokenCtx())
+
+        captured = capsys.readouterr()
+        assert notebook_id == "nb_from_context"
         assert captured.out == ""
         assert captured.err == ""
 

--- a/tests/unit/cli/test_completion.py
+++ b/tests/unit/cli/test_completion.py
@@ -229,6 +229,120 @@ class TestCompleteNotebooks:
         assert len(items) == 50
 
 
+class TestCompletionProviderSilentFailures:
+    """Provider-level failure paths stay invisible to shell completion."""
+
+    def test_missing_auth_returns_empty_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        provider = CompletionProvider()
+        with patch(
+            "notebooklm.cli.helpers.get_auth_tokens",
+            side_effect=FileNotFoundError("no auth"),
+        ):
+            items = provider.complete_notebooks(ctx=None, incomplete="nb_")
+
+        captured = capsys.readouterr()
+        assert items == []
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_corrupt_context_returns_empty_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        class BrokenCtx:
+            parent = None
+
+            @property
+            def params(self):
+                raise RuntimeError("bad context")
+
+        provider = CompletionProvider(
+            auth_loader=lambda _ctx: pytest.fail("auth should not load"),
+            current_notebook_loader=lambda: pytest.fail("context should not load"),
+        )
+        with patch.dict(os.environ, {"NOTEBOOKLM_NOTEBOOK": "nb_from_env"}):
+            items = provider.complete_sources(ctx=BrokenCtx(), incomplete="src_")
+
+        captured = capsys.readouterr()
+        assert items == []
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_no_active_notebook_returns_empty_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        provider = CompletionProvider(current_notebook_loader=lambda: None)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("NOTEBOOKLM_NOTEBOOK", None)
+            items = provider.complete_artifacts(ctx=None, incomplete="art_")
+
+        captured = capsys.readouterr()
+        assert items == []
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_client_factory_error_returns_empty_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        def broken_client(_auth):
+            raise RuntimeError("client unavailable")
+
+        provider = CompletionProvider(
+            auth_loader=lambda _ctx: object(), client_factory=broken_client
+        )
+
+        items = provider.complete_notebooks(ctx=None, incomplete="nb_")
+
+        captured = capsys.readouterr()
+        assert items == []
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_listing_error_returns_empty_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        async def fake_list(_nb_id):
+            raise RuntimeError("offline")
+
+        fake_client = AsyncMock()
+        fake_client.__aenter__.return_value = fake_client
+        fake_client.__aexit__.return_value = None
+        fake_client.sources.list = AsyncMock(side_effect=fake_list)
+
+        provider = CompletionProvider(
+            auth_loader=lambda _ctx: object(),
+            client_factory=lambda _auth: fake_client,
+            notebook_resolver=lambda _ctx: "nb_x",
+        )
+
+        items = provider.complete_sources(ctx=None, incomplete="src_")
+
+        captured = capsys.readouterr()
+        assert items == []
+        assert captured.out == ""
+        assert captured.err == ""
+
+    def test_async_runner_error_returns_empty_without_output(self, capsys):
+        from notebooklm.cli.completion import CompletionProvider
+
+        def broken_runner(_awaitable):
+            raise RuntimeError("event loop unavailable")
+
+        provider = CompletionProvider(
+            auth_loader=lambda _ctx: object(),
+            async_runner=broken_runner,
+            notebook_resolver=lambda _ctx: "nb_x",
+        )
+
+        items = provider.complete_artifacts(ctx=None, incomplete="art_")
+
+        captured = capsys.readouterr()
+        assert items == []
+        assert captured.out == ""
+        assert captured.err == ""
+
+
 # ---------------------------------------------------------------------------
 # `_resolve_notebook_for_completion` precedence
 # ---------------------------------------------------------------------------
@@ -382,6 +496,8 @@ class TestCompleteSourcesAndArtifacts:
 
         ids = [it.value for it in items]
         assert ids == ["src_001", "src_002"]
+        helps = [it.help for it in items]
+        assert helps == ["First", "Second"]
 
     def test_complete_artifacts_filters_by_prefix(self):
         """Same shape as ``test_complete_sources_filters_by_prefix`` but for
@@ -410,6 +526,50 @@ class TestCompleteSourcesAndArtifacts:
 
         ids = [it.value for it in items]
         assert ids == ["art_aaa", "art_aac"]
+        helps = [it.help for it in items]
+        assert helps == ["Audio", "Audio 2"]
+
+    def test_complete_sources_caps_results_at_50(self):
+        """Source completion keeps the same 50-row shell safety cap."""
+        from notebooklm.cli import options
+
+        async def fake_list(_nb_id):
+            return [_Stub(f"src_{i:03d}", f"Source {i}") for i in range(100)]
+
+        fake_client = AsyncMock()
+        fake_client.__aenter__.return_value = fake_client
+        fake_client.__aexit__.return_value = None
+        fake_client.sources.list = AsyncMock(side_effect=fake_list)
+
+        with (
+            patch.object(options, "_resolve_notebook_for_completion", return_value="nb_x"),
+            patch("notebooklm.cli.helpers.get_auth_tokens", return_value=object()),
+            patch("notebooklm.client.NotebookLMClient", return_value=fake_client),
+        ):
+            items = options._complete_sources(ctx=None, param=None, incomplete="src_")
+
+        assert len(items) == 50
+
+    def test_complete_artifacts_caps_results_at_50(self):
+        """Artifact completion keeps the same 50-row shell safety cap."""
+        from notebooklm.cli import options
+
+        async def fake_list(_nb_id):
+            return [_Stub(f"art_{i:03d}", f"Artifact {i}") for i in range(100)]
+
+        fake_client = AsyncMock()
+        fake_client.__aenter__.return_value = fake_client
+        fake_client.__aexit__.return_value = None
+        fake_client.artifacts.list = AsyncMock(side_effect=fake_list)
+
+        with (
+            patch.object(options, "_resolve_notebook_for_completion", return_value="nb_x"),
+            patch("notebooklm.cli.helpers.get_auth_tokens", return_value=object()),
+            patch("notebooklm.client.NotebookLMClient", return_value=fake_client),
+        ):
+            items = options._complete_artifacts(ctx=None, param=None, incomplete="art_")
+
+        assert len(items) == 50
 
     def test_complete_sources_swallows_listing_error(self):
         """An exception raised during ``sources.list(...)`` must NOT escape


### PR DESCRIPTION
## Summary
- Add `notebooklm.cli.completion` with shell-safe completion provider logic.
- Keep `cli.options` as the option declaration/wrapper layer for existing callback names.
- Add silent-failure tests for missing auth, broken context, no active notebook, client/listing errors, and async runner errors.

## Task
T11.3 from `.sisyphus/phases/architecture-remediation/phase-10.md`.

## Speculative status
- Draft until T11.0 and T11.1 settle.
- This branch intentionally does not edit `src/notebooklm/cli/helpers.py`, so it can be reviewed in parallel with T11.2.
- Before merge: rebase onto current `main` after prerequisite PRs land and rerun the gate.

## Test plan
- `rtk uv run --extra dev pytest -n auto tests/unit/cli/test_completion.py tests/unit/cli/test_root_group.py`
- `rtk uv run ruff check src/notebooklm/cli/options.py src/notebooklm/cli/completion.py src/notebooklm/cli/helpers.py tests/unit/cli/test_completion.py tests/unit/cli/test_root_group.py`
- `rtk uv run ruff format --check src/notebooklm/cli/options.py src/notebooklm/cli/completion.py src/notebooklm/cli/helpers.py tests/unit/cli/test_completion.py tests/unit/cli/test_root_group.py`
- `rtk uv run mypy src/notebooklm`
- `rtk uv run pre-commit run --all-files`

## Review evidence
Initial local takeover review found no blocking issues. Bot review is requested on this draft so feedback can run before dependency merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell completion for notebooks, sources, and artifacts with prefix filtering, helpful labels, and a cap on results for consistent CLI performance.
* **Bug Fixes**
  * Completion now fails silently and reliably on errors, avoiding noisy output in the shell.
* **Refactor**
  * Completion behavior centralized to improve consistency across commands.
* **Tests**
  * Added coverage verifying silent failures, help text, and result-capping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->