### PR TITLE
refactor(cli): route downloads through shared runtime

### DIFF
--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -28,14 +28,12 @@ from .download_helpers import (
     resolve_partial_artifact_id,
     select_artifact,
 )
-from .error_handler import handle_errors
 from .helpers import (
     console,
-    handle_auth_error,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
-    run_async,
+    with_auth_and_errors,
 )
 from .options import _complete_artifacts, notebook_option
 
@@ -131,6 +129,7 @@ async def _get_completed_artifacts_as_dicts(
 
 async def _download_artifacts_generic(
     ctx,
+    client_auth,
     artifact_type_name: str,
     artifact_kind: ArtifactType,
     file_extension: str,
@@ -184,13 +183,8 @@ async def _download_artifacts_generic(
     if download_all and artifact_id:
         raise click.UsageError("Cannot specify both --all and --artifact")
 
-    # Get notebook and auth
+    # Get notebook
     nb_id = require_notebook(notebook_id)
-    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
-    profile = ctx.obj.get("profile") if ctx.obj else None
-    from ..auth import AuthTokens
-
-    auth = await AuthTokens.from_storage(storage_path, profile=profile)
 
     # Adjust extension for PPTX format (must be outside _download() to avoid UnboundLocalError)
     if artifact_type_name == "slide-deck" and slide_format == "pptx":
@@ -214,7 +208,7 @@ async def _download_artifacts_generic(
             )
 
     async def _download() -> dict[str, Any]:
-        async with NotebookLMClient(auth) as client:
+        async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
             # Setup download method dispatch
@@ -711,12 +705,10 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
 
     Handles the common pattern across all artifact download commands.
 
-    Exception path is routed through ``cli.error_handler.handle_errors`` so
-    ``--json`` is honored on errors (typed JSON envelope on stdout),
-    ``RateLimitError.retry_after`` surfaces in the JSON body, ``AuthError``
-    shows the re-authentication hint in text mode, and exit codes follow the
-    typed policy (1 = library/user error, 2 = unexpected/system error).
-    See ``error_handler.py`` for the canonical exit-code table.
+    Exception and auth-bootstrap paths are routed through the shared
+    ``with_auth_and_errors`` runtime so download commands match decorator-based
+    commands for ``--json`` error envelopes, auth-required UX, verbose logging,
+    and exit-code policy.
 
     The "returned dict with an ``error`` field" path
     (``_download_artifacts_generic`` → ``{"error": ...}`` for empty artifact
@@ -724,58 +716,45 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     typed handler — it preserves the legacy `{"error": "<msg>"}` JSON shape
     that scripts already depend on, and exits 1 directly.
 
-    Missing storage file is routed through ``handle_auth_error`` (exit 1)
-    rather than being misclassified as ``UNEXPECTED_ERROR`` (exit 2). This
-    mirrors the canonical ``with_client`` decorator pattern in
-    ``helpers.py:1079-1084`` — a missing ``storage_state.json`` is a typed
-    auth condition, not a system bug, and deserves the rich "Run
-    'notebooklm login'" UX. The narrow ``FileNotFoundError`` catch ensures
-    a ``FileNotFoundError`` raised *inside* the download body (e.g. a
-    user-supplied path that doesn't exist — see issue #153) is NOT
-    misclassified as auth failure; it propagates through ``handle_errors``'
-    UNEXPECTED_ERROR branch instead.
+    Missing storage files are handled inside ``with_auth_and_errors`` before
+    the command body runs. ``FileNotFoundError`` raised by the download body
+    still reaches the typed error handler as an unexpected command failure.
     """
     config = ARTIFACT_CONFIGS[artifact_type]
     json_output = kwargs.get("json_output", False)
-    # ``--verbose`` is captured on the root group as a count; opt-in to the
-    # extra error context (RPC method_id, etc.) only when the user asks.
-    try:
-        verbose = int(ctx.find_root().params.get("verbose", 0) or 0) >= 1
-    except Exception:
-        verbose = False
 
-    with handle_errors(verbose=verbose, json_output=json_output):
-        try:
-            result = run_async(
-                _download_artifacts_generic(
-                    ctx=ctx,
-                    artifact_type_name=artifact_type,
-                    artifact_kind=config["kind"],
-                    file_extension=config["extension"],
-                    default_output_dir=config["default_dir"],
-                    **kwargs,
-                )
-            )
-        except FileNotFoundError:
-            # Auth bootstrap missing storage_state.json — surface the rich
-            # "Not logged in" UX instead of a generic UNEXPECTED_ERROR.
-            handle_auth_error(json_output)
-            return  # unreachable — handle_auth_error raises SystemExit
+    async def body(client_auth):
+        return await _download_artifacts_generic(
+            ctx=ctx,
+            client_auth=client_auth,
+            artifact_type_name=artifact_type,
+            artifact_kind=config["kind"],
+            file_extension=config["extension"],
+            default_output_dir=config["default_dir"],
+            **kwargs,
+        )
 
-        if json_output:
-            json_output_response(result)
-            # Mirror the non-JSON exit-code behavior: any top-level "error"
-            # field means the operation failed even though we returned a
-            # parseable JSON document. Automation must see a nonzero exit.
-            # NOTE: this preserves the legacy returned-dict envelope shape
-            # (free-form ``error`` string, no typed ``code``) — see docstring.
-            if "error" in result:
-                raise SystemExit(1)
-            return
+    result = with_auth_and_errors(
+        ctx,
+        command_name=f"download_{artifact_type.replace('-', '_')}",
+        json_output=json_output,
+        body=body,
+    )
 
-        _display_download_result(result, artifact_type)
+    if json_output:
+        json_output_response(result)
+        # Mirror the non-JSON exit-code behavior: any top-level "error"
+        # field means the operation failed even though we returned a
+        # parseable JSON document. Automation must see a nonzero exit.
+        # NOTE: this preserves the legacy returned-dict envelope shape
+        # (free-form ``error`` string, no typed ``code``) — see docstring.
         if "error" in result:
             raise SystemExit(1)
+        return
+
+    _display_download_result(result, artifact_type)
+    if "error" in result:
+        raise SystemExit(1)
 
 
 @download.command("report")

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -20,6 +20,7 @@ from typing import Any, TypedDict
 
 import click
 
+from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
 from .download_helpers import (
@@ -128,8 +129,7 @@ async def _get_completed_artifacts_as_dicts(
 
 
 async def _download_artifacts_generic(
-    ctx,
-    client_auth,
+    client_auth: AuthTokens,
     artifact_type_name: str,
     artifact_kind: ArtifactType,
     file_extension: str,
@@ -155,7 +155,7 @@ async def _download_artifacts_generic(
     with the same logic, only varying by extension and type filters.
 
     Args:
-        ctx: Click context
+        client_auth: Auth tokens for constructing the NotebookLM client
         artifact_type_name: Human-readable type name ("audio", "video", etc.)
         artifact_kind: ArtifactType enum value to filter by
         file_extension: File extension (".mp3", ".mp4", ".png", ".pdf")
@@ -723,9 +723,8 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     config = ARTIFACT_CONFIGS[artifact_type]
     json_output = kwargs.get("json_output", False)
 
-    async def body(client_auth):
+    async def body(client_auth: AuthTokens) -> dict[str, Any]:
         return await _download_artifacts_generic(
-            ctx=ctx,
             client_auth=client_auth,
             artifact_type_name=artifact_type,
             artifact_kind=config["kind"],
@@ -743,16 +742,12 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
 
     if json_output:
         json_output_response(result)
-        # Mirror the non-JSON exit-code behavior: any top-level "error"
-        # field means the operation failed even though we returned a
-        # parseable JSON document. Automation must see a nonzero exit.
-        # NOTE: this preserves the legacy returned-dict envelope shape
-        # (free-form ``error`` string, no typed ``code``) — see docstring.
-        if "error" in result:
-            raise SystemExit(1)
-        return
+    else:
+        _display_download_result(result, artifact_type)
 
-    _display_download_result(result, artifact_type)
+    # Mirror the non-JSON exit-code behavior: any top-level "error" field means
+    # the operation failed even though JSON mode returned a parseable legacy
+    # error document (free-form ``error`` string, no typed ``code``).
     if "error" in result:
         raise SystemExit(1)
 

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -53,10 +53,10 @@ def mock_auth():
 
     with (
         patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
-        patch("notebooklm.auth.AuthTokens.from_storage", new_callable=AsyncMock) as mock_from,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
     ):
         mock_load.return_value = auth.flat_cookies
-        mock_from.return_value = auth
+        mock_fetch.return_value = ("csrf", "session")
         yield mock_load
 
 
@@ -1789,18 +1789,16 @@ class TestDownloadTypedErrorPath:
         """A missing ``storage_state.json`` exits 1 via ``handle_auth_error``.
 
         Regression guard for the integration-test failure that surfaced after
-        the typed-handler swap: ``AuthTokens.from_storage`` raises
+        the typed-handler swap: the shared auth loader raises
         ``FileNotFoundError`` when no auth file exists, and the typed handler
         would otherwise classify it as ``UNEXPECTED_ERROR`` (exit 2). The
-        canonical ``with_client`` decorator catches this exact case and routes
-        it through ``handle_auth_error`` — ``download`` must do the same so
+        shared runtime catches this exact case and routes it through
+        ``handle_auth_error`` — ``download`` must do the same so
         ``tests/integration/cli_vcr/test_downloads.py`` (which asserts
         ``exit_code in (0, 1)`` for unauth invocations) keeps passing.
         """
-        from notebooklm.auth import AuthTokens
-
-        with patch.object(AuthTokens, "from_storage", new_callable=AsyncMock) as mock_from_storage:
-            mock_from_storage.side_effect = FileNotFoundError(
+        with patch("notebooklm.cli.helpers.get_auth_tokens") as mock_get_auth_tokens:
+            mock_get_auth_tokens.side_effect = FileNotFoundError(
                 "Storage file not found: /tmp/missing/storage_state.json"
             )
             result = runner.invoke(cli, ["download", "audio", "-n", "nb_123"])
@@ -1813,10 +1811,8 @@ class TestDownloadTypedErrorPath:
 
     def test_missing_storage_json_emits_auth_required_envelope(self, runner):
         """Missing storage in --json mode emits AUTH_REQUIRED envelope, exit 1."""
-        from notebooklm.auth import AuthTokens
-
-        with patch.object(AuthTokens, "from_storage", new_callable=AsyncMock) as mock_from_storage:
-            mock_from_storage.side_effect = FileNotFoundError("Storage file not found")
+        with patch("notebooklm.cli.helpers.get_auth_tokens") as mock_get_auth_tokens:
+            mock_get_auth_tokens.side_effect = FileNotFoundError("Storage file not found")
             result = runner.invoke(cli, ["download", "audio", "--json", "-n", "nb_123"])
 
         assert result.exit_code == 1, result.output


### PR DESCRIPTION
## Summary
- Route download command execution through the shared T11 auth/error runtime primitive.
- Pass `client_auth` into `_download_artifacts_generic(...)` instead of bootstrapping auth inside download code.
- Update download auth-bootstrap tests to patch the shared helper auth seam.

## Task
T11.2 from `.sisyphus/phases/architecture-remediation/phase-10.md`.

## Speculative / stacked status
- Draft stacked on #694 (`architecture-remediation/t11-1-shared-auth-error-runtime`).
- This PR intentionally shows only the download normalization diff relative to T11.1.
- Before merge: after #694 lands, rebase onto `main`, retarget this PR to `main`, rerun the full gate, and resolve conflicts if needed.

## Test plan
- `rtk uv run --extra dev pytest -n auto tests/unit/cli/test_download.py tests/unit/test_with_client_handle_errors.py tests/unit/test_json_stdout_purity.py tests/integration/cli_vcr/test_downloads.py`
- `rtk uv run ruff check src/notebooklm/cli/download.py src/notebooklm/cli/helpers.py tests/unit/cli/test_download.py tests/unit/test_with_client_handle_errors.py tests/unit/test_json_stdout_purity.py`
- `rtk uv run ruff format --check src/notebooklm/cli/download.py src/notebooklm/cli/helpers.py tests/unit/cli/test_download.py tests/unit/test_with_client_handle_errors.py tests/unit/test_json_stdout_purity.py`
- `rtk uv run mypy src/notebooklm`
- `rtk uv run pre-commit run --all-files`
- `rtk git diff --check origin/architecture-remediation/t11-1-shared-auth-error-runtime...HEAD`

## Review evidence
Local takeover review found no blocking issues after rebasing onto the real T11.1 branch. Bot review is requested on this stacked draft so feedback can run before dependency merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized authentication and error handling for the download command; existing JSON/text error output and exit-code behavior are preserved.

* **Tests**
  * Updated authentication-related test fixtures and adjusted coverage for missing-auth scenarios and typed error routing.

**Note:** Internal improvements only; no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->