### PR TITLE
test(cli): guard runtime and completion boundaries

### DIFF
--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -35,6 +35,18 @@ import pathlib
 import pytest
 
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
+OPTIONS_PATH = CLI_ROOT / "options.py"
+COMPLETION_CALLBACKS = {
+    "_complete_artifacts",
+    "_complete_notebooks",
+    "_complete_sources",
+    "_resolve_notebook_for_completion",
+}
+COMPLETION_FORBIDDEN_SYMBOLS = {
+    "NotebookLMClient",
+    "get_auth_tokens",
+    "run_async",
+}
 
 
 def _is_private_segment(seg: str) -> bool:
@@ -135,6 +147,43 @@ def test_no_private_module_imports_in_cli():
         "or `_private` names out of public notebooklm modules. "
         "Promote needed symbols to a public module (config/urls/log/research/types) "
         f"and import from there.\nOffenders: {offenders}"
+    )
+
+
+def test_options_completion_callbacks_stay_on_completion_provider_boundary() -> None:
+    """Keep live completion auth/client/runtime work out of ``cli.options``."""
+    tree = ast.parse(OPTIONS_PATH.read_text(encoding="utf-8"))
+    forbidden_names = set(COMPLETION_FORBIDDEN_SYMBOLS)
+    import_offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        for alias in node.names:
+            if alias.name not in COMPLETION_FORBIDDEN_SYMBOLS:
+                continue
+            alias_name = alias.asname or alias.name
+            forbidden_names.add(alias_name)
+            import_offenders.append(f"module import: {alias.name}")
+
+    callbacks = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name in COMPLETION_CALLBACKS
+    }
+
+    assert set(callbacks) == COMPLETION_CALLBACKS
+
+    offenders = import_offenders
+    for callback_name, callback in sorted(callbacks.items()):
+        for node in ast.walk(callback):
+            if isinstance(node, ast.Name) and node.id in forbidden_names:
+                offenders.append(f"{callback_name}: {node.id}")
+            elif isinstance(node, ast.Attribute) and node.attr in COMPLETION_FORBIDDEN_SYMBOLS:
+                offenders.append(f"{callback_name}: .{node.attr}")
+
+    assert not offenders, (
+        "cli.options completion callbacks must delegate to cli.completion instead of "
+        f"constructing clients, loading auth, or running async work directly: {offenders}"
     )
 
 


### PR DESCRIPTION
## Summary
- Add a static AST guardrail preventing `cli.options` completion callbacks from regaining direct `NotebookLMClient`, `get_auth_tokens`, or `run_async` logic.
- Confirm T11 runtime/completion seams can stand alone before T12 helper splitting begins.

## Task
T11.4 from `.sisyphus/phases/architecture-remediation/phase-10.md`.

## Speculative / stacked status
- Draft stacked on `architecture-remediation/t11-integrated-runtime-completion-base`, which combines T11.1, T11.2, and T11.3 for review isolation.
- Before merge: after #694, #696, and #697 land, rebase/retarget this PR to `main`, rerun the full gate, and resolve conflicts if needed.

## Test plan
- `rtk uv run --extra dev pytest -n auto tests/unit/test_with_client_handle_errors.py tests/unit/cli/test_download.py tests/unit/cli/test_completion.py tests/unit/cli/test_root_group.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py` -> 145 passed
- `rtk uv run --extra dev pytest -n auto tests/integration/cli_vcr/test_downloads.py` -> 7 passed
- `rtk uv run ruff check src/notebooklm/cli/download.py src/notebooklm/cli/options.py src/notebooklm/cli/helpers.py src/notebooklm/cli/completion.py tests/unit/cli/test_download.py tests/unit/cli/test_completion.py tests/unit/test_cli_boundary.py tests/unit/test_json_stdout_purity.py` -> passed
- `rtk uv run ruff format --check` on touched/related Python paths -> passed
- `rtk uv run mypy src/notebooklm` -> passed
- `rtk uv run pre-commit run --all-files` -> passed

## Stabilized seams for T12
- `cli.options` remains option/callback wiring only.
- Live completion auth/client/async work remains behind `cli.completion`.
- Runtime auth/error behavior remains behind `cli.helpers.with_auth_and_errors` / `with_client`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added stricter unit test coverage that verifies completion-related callbacks remain within their intended boundary, automatically detecting and failing on any disallowed direct references to restricted components or runtime symbols to preserve architectural separation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->