### PR TITLE
refactor(cli): route downloads through shared runtime

### DIFF
--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -28,14 +28,12 @@ from .download_helpers import (
     resolve_partial_artifact_id,
     select_artifact,
 )
-from .error_handler import handle_errors
 from .helpers import (
     console,
-    handle_auth_error,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
-    run_async,
+    with_auth_and_errors,
 )
 from .options import _complete_artifacts, notebook_option
 
@@ -131,6 +129,7 @@ async def _get_completed_artifacts_as_dicts(
 
 async def _download_artifacts_generic(
     ctx,
+    client_auth,
     artifact_type_name: str,
     artifact_kind: ArtifactType,
     file_extension: str,
@@ -184,13 +183,8 @@ async def _download_artifacts_generic(
     if download_all and artifact_id:
         raise click.UsageError("Cannot specify both --all and --artifact")
 
-    # Get notebook and auth
+    # Get notebook
     nb_id = require_notebook(notebook_id)
-    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
-    profile = ctx.obj.get("profile") if ctx.obj else None
-    from ..auth import AuthTokens
-
-    auth = await AuthTokens.from_storage(storage_path, profile=profile)
 
     # Adjust extension for PPTX format (must be outside _download() to avoid UnboundLocalError)
     if artifact_type_name == "slide-deck" and slide_format == "pptx":
@@ -214,7 +208,7 @@ async def _download_artifacts_generic(
             )
 
     async def _download() -> dict[str, Any]:
-        async with NotebookLMClient(auth) as client:
+        async with NotebookLMClient(client_auth) as client:
             nb_id_resolved = await resolve_notebook_id(client, nb_id, json_output=json_output)
 
             # Setup download method dispatch
@@ -711,12 +705,10 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
 
     Handles the common pattern across all artifact download commands.
 
-    Exception path is routed through ``cli.error_handler.handle_errors`` so
-    ``--json`` is honored on errors (typed JSON envelope on stdout),
-    ``RateLimitError.retry_after`` surfaces in the JSON body, ``AuthError``
-    shows the re-authentication hint in text mode, and exit codes follow the
-    typed policy (1 = library/user error, 2 = unexpected/system error).
-    See ``error_handler.py`` for the canonical exit-code table.
+    Exception and auth-bootstrap paths are routed through the shared
+    ``with_auth_and_errors`` runtime so download commands match decorator-based
+    commands for ``--json`` error envelopes, auth-required UX, verbose logging,
+    and exit-code policy.
 
     The "returned dict with an ``error`` field" path
     (``_download_artifacts_generic`` → ``{"error": ...}`` for empty artifact
@@ -724,58 +716,45 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     typed handler — it preserves the legacy `{"error": "<msg>"}` JSON shape
     that scripts already depend on, and exits 1 directly.
 
-    Missing storage file is routed through ``handle_auth_error`` (exit 1)
-    rather than being misclassified as ``UNEXPECTED_ERROR`` (exit 2). This
-    mirrors the canonical ``with_client`` decorator pattern in
-    ``helpers.py:1079-1084`` — a missing ``storage_state.json`` is a typed
-    auth condition, not a system bug, and deserves the rich "Run
-    'notebooklm login'" UX. The narrow ``FileNotFoundError`` catch ensures
-    a ``FileNotFoundError`` raised *inside* the download body (e.g. a
-    user-supplied path that doesn't exist — see issue #153) is NOT
-    misclassified as auth failure; it propagates through ``handle_errors``'
-    UNEXPECTED_ERROR branch instead.
+    Missing storage files are handled inside ``with_auth_and_errors`` before
+    the command body runs. ``FileNotFoundError`` raised by the download body
+    still reaches the typed error handler as an unexpected command failure.
     """
     config = ARTIFACT_CONFIGS[artifact_type]
     json_output = kwargs.get("json_output", False)
-    # ``--verbose`` is captured on the root group as a count; opt-in to the
-    # extra error context (RPC method_id, etc.) only when the user asks.
-    try:
-        verbose = int(ctx.find_root().params.get("verbose", 0) or 0) >= 1
-    except Exception:
-        verbose = False
 
-    with handle_errors(verbose=verbose, json_output=json_output):
-        try:
-            result = run_async(
-                _download_artifacts_generic(
-                    ctx=ctx,
-                    artifact_type_name=artifact_type,
-                    artifact_kind=config["kind"],
-                    file_extension=config["extension"],
-                    default_output_dir=config["default_dir"],
-                    **kwargs,
-                )
-            )
-        except FileNotFoundError:
-            # Auth bootstrap missing storage_state.json — surface the rich
-            # "Not logged in" UX instead of a generic UNEXPECTED_ERROR.
-            handle_auth_error(json_output)
-            return  # unreachable — handle_auth_error raises SystemExit
+    async def body(client_auth):
+        return await _download_artifacts_generic(
+            ctx=ctx,
+            client_auth=client_auth,
+            artifact_type_name=artifact_type,
+            artifact_kind=config["kind"],
+            file_extension=config["extension"],
+            default_output_dir=config["default_dir"],
+            **kwargs,
+        )
 
-        if json_output:
-            json_output_response(result)
-            # Mirror the non-JSON exit-code behavior: any top-level "error"
-            # field means the operation failed even though we returned a
-            # parseable JSON document. Automation must see a nonzero exit.
-            # NOTE: this preserves the legacy returned-dict envelope shape
-            # (free-form ``error`` string, no typed ``code``) — see docstring.
-            if "error" in result:
-                raise SystemExit(1)
-            return
+    result = with_auth_and_errors(
+        ctx,
+        command_name=f"download_{artifact_type.replace('-', '_')}",
+        json_output=json_output,
+        body=body,
+    )
 
-        _display_download_result(result, artifact_type)
+    if json_output:
+        json_output_response(result)
+        # Mirror the non-JSON exit-code behavior: any top-level "error"
+        # field means the operation failed even though we returned a
+        # parseable JSON document. Automation must see a nonzero exit.
+        # NOTE: this preserves the legacy returned-dict envelope shape
+        # (free-form ``error`` string, no typed ``code``) — see docstring.
         if "error" in result:
             raise SystemExit(1)
+        return
+
+    _display_download_result(result, artifact_type)
+    if "error" in result:
+        raise SystemExit(1)
 
 
 @download.command("report")

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -20,6 +20,7 @@ from typing import Any, TypedDict
 
 import click
 
+from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
 from .download_helpers import (
@@ -128,8 +129,7 @@ async def _get_completed_artifacts_as_dicts(
 
 
 async def _download_artifacts_generic(
-    ctx,
-    client_auth,
+    client_auth: AuthTokens,
     artifact_type_name: str,
     artifact_kind: ArtifactType,
     file_extension: str,
@@ -155,7 +155,7 @@ async def _download_artifacts_generic(
     with the same logic, only varying by extension and type filters.
 
     Args:
-        ctx: Click context
+        client_auth: Auth tokens for constructing the NotebookLM client
         artifact_type_name: Human-readable type name ("audio", "video", etc.)
         artifact_kind: ArtifactType enum value to filter by
         file_extension: File extension (".mp3", ".mp4", ".png", ".pdf")
@@ -723,9 +723,8 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
     config = ARTIFACT_CONFIGS[artifact_type]
     json_output = kwargs.get("json_output", False)
 
-    async def body(client_auth):
+    async def body(client_auth: AuthTokens) -> dict[str, Any]:
         return await _download_artifacts_generic(
-            ctx=ctx,
             client_auth=client_auth,
             artifact_type_name=artifact_type,
             artifact_kind=config["kind"],
@@ -743,16 +742,12 @@ def _run_artifact_download(ctx, artifact_type: str, **kwargs) -> None:
 
     if json_output:
         json_output_response(result)
-        # Mirror the non-JSON exit-code behavior: any top-level "error"
-        # field means the operation failed even though we returned a
-        # parseable JSON document. Automation must see a nonzero exit.
-        # NOTE: this preserves the legacy returned-dict envelope shape
-        # (free-form ``error`` string, no typed ``code``) — see docstring.
-        if "error" in result:
-            raise SystemExit(1)
-        return
+    else:
+        _display_download_result(result, artifact_type)
 
-    _display_download_result(result, artifact_type)
+    # Mirror the non-JSON exit-code behavior: any top-level "error" field means
+    # the operation failed even though JSON mode returned a parseable legacy
+    # error document (free-form ``error`` string, no typed ``code``).
     if "error" in result:
         raise SystemExit(1)
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -18,7 +18,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 from urllib.parse import urlsplit, urlunsplit
 
 import click
@@ -1049,7 +1049,7 @@ def handle_error(e: Exception):
     raise SystemExit(1)
 
 
-def handle_auth_error(json_output: bool = False):
+def handle_auth_error(json_output: bool = False) -> NoReturn:
     """Handle authentication errors with helpful context."""
     from ..paths import get_path_info, get_storage_path
 
@@ -1073,6 +1073,7 @@ def handle_auth_error(json_output: bool = False):
                 "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
             },
         )
+        raise SystemExit(1)
     else:
         console.print("[red]Not logged in.[/red]\n")
         console.print("[dim]Checked locations:[/dim]")

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -14,10 +14,11 @@ import json
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlsplit, urlunsplit
 
 import click
@@ -41,6 +42,7 @@ console = Console()
 # active so that stdout stays parseable JSON for automation. See ``emit_status``.
 stderr_console = Console(stderr=True)
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
@@ -1091,6 +1093,74 @@ def handle_auth_error(json_output: bool = False):
 # =============================================================================
 
 
+def with_auth_and_errors(
+    ctx: click.Context,
+    *,
+    command_name: str,
+    json_output: bool,
+    body: Callable[[AuthTokens], Awaitable[T]],
+    auth_loader: Callable[[click.Context], AuthTokens] | None = None,
+) -> T:
+    """Run a CLI command body with shared auth bootstrap and error handling."""
+    from .error_handler import handle_errors
+
+    start = time.monotonic()
+    logger.debug("CLI command starting: %s", command_name)
+
+    # Verbose is captured on the root group via Click ``--verbose`` count.
+    # Use ``find_root`` so nested subcommand contexts still see it.
+    try:
+        verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
+    except Exception:
+        verbose_count = 0
+    verbose = verbose_count >= 1
+
+    def log_result(status: str, detail: str = "") -> float:
+        elapsed = time.monotonic() - start
+        if detail:
+            logger.debug(
+                "CLI command %s: %s (%.3fs) - %s",
+                status,
+                command_name,
+                elapsed,
+                detail,
+            )
+        else:
+            logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
+        return elapsed
+
+    with handle_errors(verbose=verbose, json_output=json_output):
+        # Auth bootstrap: FileNotFoundError here means the storage file is
+        # missing — it has a dedicated rich UX via ``handle_auth_error``.
+        # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
+        # raised *inside* the command body (e.g., a missing ``--source-file``
+        # argument; see issue #153) is NOT misclassified as an auth error —
+        # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
+        # Any OTHER exception from the auth bootstrap (malformed storage JSON,
+        # AuthError during token extraction, etc.) also reaches ``handle_errors``
+        # so users get typed hints rather than a raw traceback.
+        try:
+            loader = auth_loader or get_auth_tokens
+            auth = loader(ctx)
+        except FileNotFoundError:
+            log_result("failed", "not authenticated")
+            return handle_auth_error(json_output)
+        except Exception as e:
+            # Non-FileNotFoundError bootstrap failures (AuthError, malformed
+            # storage JSON, etc.) still need the structured debug-log entry;
+            # ``handle_errors`` will translate the exception to a typed hint.
+            log_result("failed", str(e))
+            raise
+
+        try:
+            result = run_async(body(auth))
+        except Exception as e:
+            log_result("failed", str(e))
+            raise
+        log_result("completed")
+        return result
+
+
 def with_client(f):
     """Decorator that handles auth, async execution, and errors for CLI commands.
 
@@ -1123,59 +1193,18 @@ def with_client(f):
     @wraps(f)
     @click.pass_context
     def wrapper(ctx, *args, **kwargs):
-        from .error_handler import handle_errors
-
         cmd_name = f.__name__
-        start = time.monotonic()
-        logger.debug("CLI command starting: %s", cmd_name)
-
         json_output = kwargs.get("json_output", False)
-        # Verbose is captured on the root group via Click ``--verbose`` count.
-        # Use ``find_root`` so nested subcommand contexts still see it.
-        try:
-            verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
-        except Exception:
-            verbose_count = 0
-        verbose = verbose_count >= 1
 
-        def log_result(status: str, detail: str = "") -> float:
-            elapsed = time.monotonic() - start
-            if detail:
-                logger.debug("CLI command %s: %s (%.3fs) - %s", status, cmd_name, elapsed, detail)
-            else:
-                logger.debug("CLI command %s: %s (%.3fs)", status, cmd_name, elapsed)
-            return elapsed
+        def body(auth: AuthTokens) -> Awaitable[Any]:
+            return f(ctx, *args, client_auth=auth, **kwargs)
 
-        with handle_errors(verbose=verbose, json_output=json_output):
-            # Auth bootstrap: FileNotFoundError here means the storage file is
-            # missing — it has a dedicated rich UX via ``handle_auth_error``.
-            # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
-            # raised *inside* the command body (e.g., a missing ``--source-file``
-            # argument; see issue #153) is NOT misclassified as an auth error —
-            # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
-            # Any OTHER exception from the auth bootstrap (malformed storage JSON,
-            # AuthError during token extraction, etc.) also reaches ``handle_errors``
-            # so users get typed hints rather than a raw traceback.
-            try:
-                auth = get_auth_tokens(ctx)
-            except FileNotFoundError:
-                log_result("failed", "not authenticated")
-                handle_auth_error(json_output)
-                return  # unreachable — handle_auth_error raises SystemExit
-            except Exception as e:
-                # Non-FileNotFoundError bootstrap failures (AuthError, malformed
-                # storage JSON, etc.) still need the structured debug-log entry;
-                # ``handle_errors`` will translate the exception to a typed hint.
-                log_result("failed", str(e))
-                raise
-            try:
-                coro = f(ctx, *args, client_auth=auth, **kwargs)
-                result = run_async(coro)
-            except Exception as e:
-                log_result("failed", str(e))
-                raise
-            log_result("completed")
-            return result
+        return with_auth_and_errors(
+            ctx,
+            command_name=cmd_name,
+            json_output=json_output,
+            body=body,
+        )
 
     return wrapper
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -1112,7 +1112,7 @@ def with_auth_and_errors(
     # Use ``find_root`` so nested subcommand contexts still see it.
     try:
         verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         verbose_count = 0
     verbose = verbose_count >= 1
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -1073,7 +1073,6 @@ def handle_auth_error(json_output: bool = False) -> NoReturn:
                 "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
             },
         )
-        raise SystemExit(1)
     else:
         console.print("[red]Not logged in.[/red]\n")
         console.print("[dim]Checked locations:[/dim]")
@@ -1116,7 +1115,7 @@ def with_auth_and_errors(
         verbose_count = 0
     verbose = verbose_count >= 1
 
-    def log_result(status: str, detail: str = "") -> float:
+    def log_result(status: str, detail: str = "") -> None:
         elapsed = time.monotonic() - start
         if detail:
             logger.debug(
@@ -1128,7 +1127,6 @@ def with_auth_and_errors(
             )
         else:
             logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
-        return elapsed
 
     with handle_errors(verbose=verbose, json_output=json_output):
         # Auth bootstrap: FileNotFoundError here means the storage file is
@@ -1220,7 +1218,7 @@ def json_output_response(data: dict | list) -> None:
     click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
 
 
-def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
+def json_error_response(code: str, message: str, extra: dict | None = None) -> NoReturn:
     """Print JSON error and exit (no colors for machine parsing).
 
     Args:

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -53,10 +53,10 @@ def mock_auth():
 
     with (
         patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
-        patch("notebooklm.auth.AuthTokens.from_storage", new_callable=AsyncMock) as mock_from,
+        patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as mock_fetch,
     ):
         mock_load.return_value = auth.flat_cookies
-        mock_from.return_value = auth
+        mock_fetch.return_value = ("csrf", "session")
         yield mock_load
 
 
@@ -1789,18 +1789,16 @@ class TestDownloadTypedErrorPath:
         """A missing ``storage_state.json`` exits 1 via ``handle_auth_error``.
 
         Regression guard for the integration-test failure that surfaced after
-        the typed-handler swap: ``AuthTokens.from_storage`` raises
+        the typed-handler swap: the shared auth loader raises
         ``FileNotFoundError`` when no auth file exists, and the typed handler
         would otherwise classify it as ``UNEXPECTED_ERROR`` (exit 2). The
-        canonical ``with_client`` decorator catches this exact case and routes
-        it through ``handle_auth_error`` — ``download`` must do the same so
+        shared runtime catches this exact case and routes it through
+        ``handle_auth_error`` — ``download`` must do the same so
         ``tests/integration/cli_vcr/test_downloads.py`` (which asserts
         ``exit_code in (0, 1)`` for unauth invocations) keeps passing.
         """
-        from notebooklm.auth import AuthTokens
-
-        with patch.object(AuthTokens, "from_storage", new_callable=AsyncMock) as mock_from_storage:
-            mock_from_storage.side_effect = FileNotFoundError(
+        with patch("notebooklm.cli.helpers.get_auth_tokens") as mock_get_auth_tokens:
+            mock_get_auth_tokens.side_effect = FileNotFoundError(
                 "Storage file not found: /tmp/missing/storage_state.json"
             )
             result = runner.invoke(cli, ["download", "audio", "-n", "nb_123"])
@@ -1813,10 +1811,8 @@ class TestDownloadTypedErrorPath:
 
     def test_missing_storage_json_emits_auth_required_envelope(self, runner):
         """Missing storage in --json mode emits AUTH_REQUIRED envelope, exit 1."""
-        from notebooklm.auth import AuthTokens
-
-        with patch.object(AuthTokens, "from_storage", new_callable=AsyncMock) as mock_from_storage:
-            mock_from_storage.side_effect = FileNotFoundError("Storage file not found")
+        with patch("notebooklm.cli.helpers.get_auth_tokens") as mock_get_auth_tokens:
+            mock_get_auth_tokens.side_effect = FileNotFoundError("Storage file not found")
             result = runner.invoke(cli, ["download", "audio", "--json", "-n", "nb_123"])
 
         assert result.exit_code == 1, result.output

--- a/tests/unit/cli/test_phase10_cli_contract.py
+++ b/tests/unit/cli/test_phase10_cli_contract.py
@@ -369,13 +369,13 @@ def test_json_stdout_routing_and_exit_codes_for_download_runtime(
         mock_client.artifacts.list = AsyncMock(side_effect=RuntimeError("boom"))
 
     with (
-        patch.object(AuthTokens, "from_storage", new_callable=AsyncMock) as mock_from_storage,
+        patch("notebooklm.cli.helpers.get_auth_tokens") as mock_get_auth_tokens,
         patch_client_for_module("download") as mock_client_cls,
     ):
         if setup == "missing_storage":
-            mock_from_storage.side_effect = FileNotFoundError("Storage file not found")
+            mock_get_auth_tokens.side_effect = FileNotFoundError("Storage file not found")
         else:
-            mock_from_storage.return_value = auth
+            mock_get_auth_tokens.return_value = auth
             mock_client_cls.return_value = mock_client
 
         result = CliRunner().invoke(

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -158,6 +158,7 @@ def test_with_auth_and_errors_passes_verbose_json_to_current_handle_errors() -> 
         coro.close()
         return "patched run result"
 
+    # ``with_auth_and_errors`` imports this at call time, so patch the source module.
     with (
         patch("notebooklm.cli.error_handler.handle_errors", fake_handle_errors),
         patch("notebooklm.cli.helpers.run_async", side_effect=fake_run_async) as run_async,

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -21,13 +21,14 @@ from __future__ import annotations
 
 import json
 from collections.abc import Generator
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import click
 import pytest
 from click.testing import CliRunner
 
-from notebooklm.cli.helpers import with_client
+from notebooklm.cli.helpers import with_auth_and_errors, with_client
 from notebooklm.exceptions import AuthError, RateLimitError
 
 # ---------------------------------------------------------------------------
@@ -76,6 +77,182 @@ def _build_cli(body):
         return body(client_auth)
 
     return cli
+
+
+def _make_click_context(verbose: int = 0) -> click.Context:
+    @click.group()
+    def cli():
+        pass
+
+    @click.command()
+    def run():
+        pass
+
+    root_ctx = click.Context(cli)
+    root_ctx.params["verbose"] = verbose
+    return click.Context(run, parent=root_ctx)
+
+
+# ---------------------------------------------------------------------------
+# Shared primitive behavior
+# ---------------------------------------------------------------------------
+
+
+def test_with_auth_and_errors_uses_custom_auth_loader() -> None:
+    sentinel_auth = MagicMock(name="custom-auth")
+    seen: dict[str, object] = {}
+    ctx = _make_click_context()
+
+    def _loader(loader_ctx: click.Context):
+        seen["ctx"] = loader_ctx
+        return sentinel_auth
+
+    async def _body(auth):
+        seen["auth"] = auth
+        return "ok"
+
+    result = with_auth_and_errors(
+        ctx,
+        command_name="run",
+        json_output=False,
+        body=_body,
+        auth_loader=_loader,
+    )
+
+    assert result == "ok"
+    assert seen == {"ctx": ctx, "auth": sentinel_auth}
+
+
+def test_with_auth_and_errors_default_auth_loader_is_looked_up_at_call_time() -> None:
+    sentinel_auth = MagicMock(name="default-auth")
+    ctx = _make_click_context()
+
+    async def _body(auth):
+        return auth
+
+    with patch("notebooklm.cli.helpers.get_auth_tokens", return_value=sentinel_auth) as loader:
+        result = with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=False,
+            body=_body,
+        )
+
+    loader.assert_called_once_with(ctx)
+    assert result is sentinel_auth
+
+
+def test_with_auth_and_errors_passes_verbose_json_to_current_handle_errors() -> None:
+    calls: list[dict[str, bool]] = []
+    ctx = _make_click_context(verbose=1)
+
+    @contextmanager
+    def fake_handle_errors(*, verbose: bool, json_output: bool):
+        calls.append({"verbose": verbose, "json_output": json_output})
+        yield
+
+    async def _body(_auth):
+        return "real body result"
+
+    def fake_run_async(coro):
+        coro.close()
+        return "patched run result"
+
+    with (
+        patch("notebooklm.cli.error_handler.handle_errors", fake_handle_errors),
+        patch("notebooklm.cli.helpers.run_async", side_effect=fake_run_async) as run_async,
+    ):
+        result = with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_body,
+            auth_loader=lambda _ctx: MagicMock(name="auth"),
+        )
+
+    assert result == "patched run result"
+    assert calls == [{"verbose": True, "json_output": True}]
+    assert run_async.call_count == 1
+
+
+def test_with_auth_and_errors_auth_file_not_found_uses_auth_handler() -> None:
+    ctx = _make_click_context()
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    def _loader(_ctx):
+        raise FileNotFoundError("missing storage")
+
+    with (
+        patch("notebooklm.cli.helpers.handle_auth_error", side_effect=SystemExit(1)) as auth_error,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_never_called,
+            auth_loader=_loader,
+        )
+
+    assert exc_info.value.code == 1
+    auth_error.assert_called_once_with(True)
+
+
+def test_with_auth_and_errors_body_file_not_found_reaches_handle_errors(capsys) -> None:
+    ctx = _make_click_context()
+
+    async def _body(_auth):
+        raise FileNotFoundError("missing command input")
+
+    with (
+        patch("notebooklm.cli.helpers.handle_auth_error") as auth_error,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_body,
+            auth_loader=lambda _ctx: MagicMock(name="auth"),
+        )
+
+    assert exc_info.value.code == 2
+    auth_error.assert_not_called()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+    assert "missing command input" in payload["message"]
+
+
+def test_with_auth_and_errors_non_file_auth_failure_reaches_handle_errors(capsys) -> None:
+    ctx = _make_click_context()
+
+    async def _never_called(_auth):
+        raise AssertionError("body should not run when auth bootstrap fails")
+
+    def _loader(_ctx):
+        raise ValueError("malformed storage JSON")
+
+    with (
+        patch("notebooklm.cli.helpers.handle_auth_error") as auth_error,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=True,
+            body=_never_called,
+            auth_loader=_loader,
+        )
+
+    assert exc_info.value.code == 2
+    auth_error.assert_not_called()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"] is True
+    assert payload["code"] == "UNEXPECTED_ERROR"
+    assert "malformed storage JSON" in payload["message"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Recreates the remaining T11.1 shared auth runtime and T11.2 download runtime changes directly on current origin/main.
- Supersedes stacked PRs #694/#697 because those were merged into stacked bases rather than main.
- Keeps the prior review fixes from the branch, including the content from a616469.

## Verification
- rtk uv run --extra dev pytest -n auto tests/unit/cli/test_download.py tests/unit/test_with_client_handle_errors.py tests/unit/test_json_stdout_purity.py tests/integration/cli_vcr/test_downloads.py
- rtk uv run --extra dev ruff check .
- rtk uv run --extra dev ruff format --check .
- rtk uv run --extra dev mypy src/notebooklm
- rtk uv run --extra dev pre-commit run --all-files
- rtk git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized CLI authentication bootstrap and error handling for more consistent behavior across commands.
  * Simplified command wrappers so downloads and other CLI actions uniformly handle verbose/json output and auth failures.

* **Tests**
  * Updated unit tests and fixtures to validate the new auth/error flow and preserve existing JSON envelope and exit-code behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->