### PR TITLE
test(cli): guard runtime and completion boundaries

### DIFF
--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -192,10 +192,11 @@ def test_options_completion_callbacks_stay_on_completion_provider_boundary() -> 
                 import_offenders.append(f"module import: {alias.name}")
 
     functions = {node.name: node for node in ast.walk(tree) if isinstance(node, FUNCTION_DEF_TYPES)}
+    top_level_functions = {node.name for node in tree.body if isinstance(node, FUNCTION_DEF_TYPES)}
 
-    assert set(functions) >= COMPLETION_CALLBACKS
+    assert top_level_functions >= COMPLETION_CALLBACKS
 
-    offenders = import_offenders
+    offenders = list(import_offenders)
     for function_name, function in sorted(functions.items()):
         for node in _iter_function_body_nodes(function):
             if isinstance(node, ast.Name) and node.id in forbidden_names:

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -35,6 +35,18 @@ import pathlib
 import pytest
 
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
+OPTIONS_PATH = CLI_ROOT / "options.py"
+COMPLETION_CALLBACKS = {
+    "_complete_artifacts",
+    "_complete_notebooks",
+    "_complete_sources",
+    "_resolve_notebook_for_completion",
+}
+COMPLETION_FORBIDDEN_SYMBOLS = {
+    "NotebookLMClient",
+    "get_auth_tokens",
+    "run_async",
+}
 
 
 def _is_private_segment(seg: str) -> bool:
@@ -135,6 +147,47 @@ def test_no_private_module_imports_in_cli():
         "or `_private` names out of public notebooklm modules. "
         "Promote needed symbols to a public module (config/urls/log/research/types) "
         f"and import from there.\nOffenders: {offenders}"
+    )
+
+
+def test_options_completion_callbacks_stay_on_completion_provider_boundary() -> None:
+    """Keep live completion auth/client/runtime work out of ``cli.options``."""
+    tree = ast.parse(OPTIONS_PATH.read_text(encoding="utf-8"))
+    forbidden_names = set(COMPLETION_FORBIDDEN_SYMBOLS)
+    import_offenders: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name not in COMPLETION_FORBIDDEN_SYMBOLS:
+                    continue
+                alias_name = alias.asname or alias.name
+                forbidden_names.add(alias_name)
+                import_offenders.append(f"module import: {alias.name}")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[-1] not in COMPLETION_FORBIDDEN_SYMBOLS:
+                    continue
+                alias_name = alias.asname or alias.name.split(".")[0]
+                forbidden_names.add(alias_name)
+                import_offenders.append(f"module import: {alias.name}")
+
+    functions = {node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+
+    assert set(functions) >= COMPLETION_CALLBACKS
+
+    offenders = import_offenders
+    for function_name, function in sorted(functions.items()):
+        for node in ast.walk(function):
+            if isinstance(node, ast.Name) and node.id in forbidden_names:
+                offenders.append(f"{function_name}: {node.id}")
+            elif isinstance(node, ast.Attribute) and node.attr in COMPLETION_FORBIDDEN_SYMBOLS:
+                offenders.append(f"{function_name}: .{node.attr}")
+
+    assert not offenders, (
+        "cli.options must delegate completion live auth/client/runtime work to "
+        "cli.completion instead of constructing clients, loading auth, or running "
+        f"async work directly: {offenders}"
     )
 
 

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
+from collections.abc import Iterator
 
 import pytest
 
@@ -47,6 +48,7 @@ COMPLETION_FORBIDDEN_SYMBOLS = {
     "get_auth_tokens",
     "run_async",
 }
+FUNCTION_DEF_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef)
 
 
 def _is_private_segment(seg: str) -> bool:
@@ -135,6 +137,22 @@ def _violations(tree: ast.AST) -> list[str]:  # noqa: C901 - flat dispatch on im
     return bad
 
 
+def _iter_function_body_nodes(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Iterator[ast.AST]:
+    """Yield nodes from a function body without descending into nested functions."""
+
+    def walk(node: ast.AST) -> Iterator[ast.AST]:
+        if isinstance(node, FUNCTION_DEF_TYPES):
+            return
+        yield node
+        for child in ast.iter_child_nodes(node):
+            yield from walk(child)
+
+    for statement in function.body:
+        yield from walk(statement)
+
+
 def test_no_private_module_imports_in_cli():
     offenders: list[tuple[str, list[str]]] = []
     for path in sorted(CLI_ROOT.rglob("*.py")):
@@ -168,17 +186,18 @@ def test_options_completion_callbacks_stay_on_completion_provider_boundary() -> 
             for alias in node.names:
                 if alias.name.split(".")[-1] not in COMPLETION_FORBIDDEN_SYMBOLS:
                     continue
+                # Python binds the root import name unless an explicit alias is used.
                 alias_name = alias.asname or alias.name.split(".")[0]
                 forbidden_names.add(alias_name)
                 import_offenders.append(f"module import: {alias.name}")
 
-    functions = {node.name: node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+    functions = {node.name: node for node in ast.walk(tree) if isinstance(node, FUNCTION_DEF_TYPES)}
 
     assert set(functions) >= COMPLETION_CALLBACKS
 
     offenders = import_offenders
     for function_name, function in sorted(functions.items()):
-        for node in ast.walk(function):
+        for node in _iter_function_body_nodes(function):
             if isinstance(node, ast.Name) and node.id in forbidden_names:
                 offenders.append(f"{function_name}: {node.id}")
             elif isinstance(node, ast.Attribute) and node.attr in COMPLETION_FORBIDDEN_SYMBOLS:


### PR DESCRIPTION
## Summary
- rebuild T11.4 guardrail on top of T11.2
- add AST guard that keeps cli.options completion callbacks on the cli.completion provider boundary
- include #698 follow-up: scan ast.Import and ast.ImportFrom shapes, scan all functions in options.py, and assert expected completion callbacks exist

## Verification
- uv run --extra dev pytest -n auto tests/unit/test_cli_boundary.py tests/unit/cli/test_completion.py
- uv run --extra dev ruff check .
- uv run --extra dev mypy src/notebooklm
- uv run --extra dev pre-commit run --all-files

## Note
- The broader runtime contract run `uv run --extra dev pytest -n auto tests/unit/test_cli_boundary.py tests/unit/cli/test_completion.py tests/unit/cli/test_phase10_cli_contract.py` currently has one T11.2 download-runtime failure unrelated to this PR diff: `test_json_stdout_routing_and_exit_codes_for_download_runtime[auth_required-missing_storage-1-AUTH_REQUIRED-False]` sees legacy stderr output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added enhanced CLI boundary testing to enforce additional import restrictions for options module completion callbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->