### PR TITLE
refactor(cli): split helper context rendering seams

### DIFF
--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md
@@ -7,7 +7,7 @@ Generated during T12.0 against the speculative T11 stack:
 - T11.3 completion provider extraction in `notebooklm.cli.completion`
 - T11.4 options completion guardrail in `tests/unit/test_cli_boundary.py`
 
-This artifact is a migration contract for T12.1-T12.8. It is intentionally
+This artifact is a migration contract for T12.1-T12.9. It is intentionally
 refactor-only: preserve public CLI behavior, Click option wiring, JSON/text
 output, stdout/stderr routing, shell completion values, and existing test patch
 seams unless a later task explicitly migrates every affected test in the same

--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md
@@ -1,0 +1,139 @@
+# Phase 10 T12 Helper Seam Map
+
+Generated during T12.0 against the speculative T11 stack:
+
+- T11.1 shared runtime primitive in `notebooklm.cli.helpers`
+- T11.2 download commands routed through that runtime
+- T11.3 completion provider extraction in `notebooklm.cli.completion`
+- T11.4 options completion guardrail in `tests/unit/test_cli_boundary.py`
+
+This artifact is a migration contract for T12.1-T12.8. It is intentionally
+refactor-only: preserve public CLI behavior, Click option wiring, JSON/text
+output, stdout/stderr routing, shell completion values, and existing test patch
+seams unless a later task explicitly migrates every affected test in the same
+slice.
+
+## Search Snapshot
+
+Commands rerun for this map:
+
+```bash
+rtk rg -n "from notebooklm\\.cli\\.helpers import|import notebooklm\\.cli\\.helpers|notebooklm\\.cli\\.helpers\\.|patch\\(\"notebooklm\\.cli\\.helpers" src tests
+rtk rg -n "^(class|def|async def) " src/notebooklm/cli/helpers.py
+rtk rg -n "console|stderr_console|asyncio\\.sleep|time\\.monotonic|get_auth_tokens|load_auth_from_storage|build_cookie_jar|get_context_path|_complete_notebooks|_complete_sources|_complete_artifacts|_resolve_notebook_for_completion|resolve_.*id|require_notebook|resolve_prompt|read_stdin_text" src/notebooklm/cli tests/unit/cli tests/unit tests/integration/cli_vcr
+```
+
+High-risk helper patch seams found:
+
+- `notebooklm.cli.helpers.get_context_path`
+- `notebooklm.cli.helpers.load_auth_from_storage`
+- `notebooklm.cli.helpers.build_cookie_jar`
+- `notebooklm.cli.helpers.get_auth_tokens`
+- `notebooklm.cli.helpers.handle_auth_error`
+- `notebooklm.cli.helpers.run_async`
+- `notebooklm.cli.helpers.console`
+- `notebooklm.cli.helpers.asyncio.sleep`
+- `notebooklm.cli.helpers.time.monotonic`
+- `notebooklm.cli.options._complete_notebooks`
+- `notebooklm.cli.options._resolve_notebook_for_completion`
+- `notebooklm.cli.options._complete_sources`
+- `notebooklm.cli.options._complete_artifacts`
+
+## Symbol Migration Map
+
+| Current helper symbol | Planned home | T12 slice | Compatibility requirement |
+|---|---|---:|---|
+| `console` | `notebooklm.cli.rendering` | T12.1 | Keep `helpers.console` patchable or migrate every test patch in the same slice. Many command modules import this symbol directly. |
+| `stderr_console` | `notebooklm.cli.rendering` | T12.1 | Keep `helpers.stderr_console` patchable; JSON stdout purity depends on stderr routing. |
+| `emit_status` | `notebooklm.cli.rendering` | T12.1 | Keep `helpers.emit_status` wrapper/re-export until all imports move. |
+| `json_output_response` | `notebooklm.cli.rendering` | T12.1 | Preserve exact JSON serialization and newline behavior. |
+| `json_error_response` | `notebooklm.cli.rendering` | T12.1 | Preserve stdout/stderr routing and typed error envelope fields. |
+| `display_research_sources` | `notebooklm.cli.rendering` | T12.1 | Preserve table labels, truncation, and max-display behavior. |
+| `display_report` | `notebooklm.cli.rendering` | T12.1 | Preserve text truncation and JSON hint behavior. |
+| `get_artifact_type_display` | `notebooklm.cli.rendering` | T12.1 | Keep helper import stable for artifact/source command modules. |
+| `get_source_type_display` | `notebooklm.cli.rendering` | T12.1 | Keep helper import stable for source command output. |
+| `_current_storage_override` | `notebooklm.cli.context` | T12.1/T12.2 | Preserve the value observed by auth and context helpers. Keep it out of `auth_runtime` because `context.py` cannot import `auth_runtime.py`, while `auth_runtime.py` may import `context.py`. |
+| `_get_context_value` | `notebooklm.cli.context` | T12.1 | Preserve corrupt-context recovery and context file lock behavior. |
+| `_set_context_value` | `notebooklm.cli.context` | T12.1 | Preserve account metadata and remove-key behavior. |
+| `get_current_notebook` | `notebooklm.cli.context` | T12.1 | Keep `helpers.get_current_notebook` patch target effective for completion/notebook tests until migrated. |
+| `set_current_notebook` | `notebooklm.cli.context` | T12.1 | Preserve account-email/authuser persistence semantics. |
+| `clear_context` | `notebooklm.cli.context` | T12.1 | Preserve `clear_account` behavior. |
+| `get_current_conversation` | `notebooklm.cli.context` | T12.1 | Preserve conversation context file shape. |
+| `set_current_conversation` | `notebooklm.cli.context` | T12.1 | Preserve delete-on-None behavior. |
+| `get_context_path` imported from `notebooklm.paths` | `notebooklm.cli.context` wrapper | T12.1 | Existing tests patch `notebooklm.cli.helpers.get_context_path`; resolve through that helper facade at call time or migrate all affected tests, because direct early binding to `notebooklm.paths.get_context_path` bypasses the patch. |
+| `get_client` | `notebooklm.cli.auth_runtime` | T12.2 | Preserve storage/profile/authuser/account-email lookup and return tuple shape. |
+| `get_auth_tokens` | `notebooklm.cli.auth_runtime` | T12.2 | Preserve call-time patching through `notebooklm.cli.helpers.get_auth_tokens`, including download and completion paths. |
+| `load_auth_from_storage` imported from `notebooklm.auth` | `notebooklm.cli.auth_runtime` wrapper | T12.2 | Existing tests patch `notebooklm.cli.helpers.load_auth_from_storage`; keep or migrate in same slice. |
+| `build_cookie_jar` imported from `notebooklm.auth` | `notebooklm.cli.auth_runtime` wrapper | T12.2 | Existing tests patch `notebooklm.cli.helpers.build_cookie_jar`; keep or migrate in same slice. |
+| `handle_auth_error` | `notebooklm.cli.auth_runtime` | T12.2 | Preserve JSON/text UX, exit code 1, checked path fields, and `NoReturn` behavior. |
+| `run_async` | `notebooklm.cli.runtime` | T12.2 | Preserve nested-loop and coroutine cleanup semantics. Existing tests patch `helpers.run_async`. |
+| `with_auth_and_errors` | `notebooklm.cli.runtime` | T12.2 | Preserve T11 call-time lookup for `get_auth_tokens`, `handle_errors`, `handle_auth_error`, and `run_async`. |
+| `with_client` | `notebooklm.cli.runtime` | T12.2 | Keep decorator signature and command callback contract unchanged. |
+| `handle_error` | `notebooklm.cli.runtime` or `notebooklm.cli.rendering` | T12.2 | Preserve exit code 1 and Unicode fallback. |
+| `validate_id` | `notebooklm.cli.resolve` | T12.3 | Preserve ClickException wording and trimming behavior. |
+| `require_notebook` | `notebooklm.cli.resolve` | T12.3 | Preserve flag/env/context precedence and failure message. |
+| `_resolve_partial_id` | `notebooklm.cli.resolve` | T12.3 | Preserve exact/partial/ambiguous/no-match behavior and JSON output suppression. |
+| `resolve_notebook_id` | `notebooklm.cli.resolve` | T12.3 | Keep `helpers.resolve_notebook_id` importable until command modules migrate. |
+| `resolve_source_id` | `notebooklm.cli.resolve` | T12.3 | Preserve source list lookup and ambiguity messages. |
+| `resolve_artifact_id` | `notebooklm.cli.resolve` | T12.3 | Preserve artifact id/title partial matching. |
+| `resolve_note_id` | `notebooklm.cli.resolve` | T12.3 | Preserve note id/title partial matching. |
+| `resolve_source_ids` | `notebooklm.cli.resolve` | T12.3 | Preserve multi-id error aggregation. |
+| `read_stdin_text` | `notebooklm.cli.input` | T12.3 | Preserve stdin empty/error handling and source label messages. |
+| `resolve_prompt` | `notebooklm.cli.input` | T12.3 | Preserve prompt/file/stdin precedence and required behavior. |
+| `ResearchImportResult` | `notebooklm.cli.research_import` | T12.4 | Preserve dataclass fields and result semantics. |
+| `cli_name_to_artifact_type` | `notebooklm.cli.research_import` or `notebooklm.cli.rendering` | T12.4 | Preserve CLI artifact aliases, especially singular `flashcard`. |
+| `_normalize_url` | `notebooklm.cli.research_import` | T12.4 | Preserve URL normalization for research import dedupe. |
+| `_source_url_norm` | `notebooklm.cli.research_import` | T12.4 | Preserve no-URL handling. |
+| `_requested_urls_norm` | `notebooklm.cli.research_import` | T12.4 | Preserve requested URL set behavior. |
+| `_has_no_url_entry` | `notebooklm.cli.research_import` | T12.4 | Preserve cited-source import decisions. |
+| `_imported_source_entry` | `notebooklm.cli.research_import` | T12.4 | Preserve result dictionary keys. |
+| `_merge_imported_sources` | `notebooklm.cli.research_import` | T12.4 | Preserve duplicate merge semantics. |
+| `import_with_retry` | `notebooklm.cli.research_import` | T12.4 | Preserve retry/backoff semantics and patch seams for `asyncio.sleep` and `console`. |
+| `_select_research_sources_for_import` | `notebooklm.cli.research_import` | T12.4 | Preserve cited/all selection behavior. |
+| `_display_cited_import_selection` | `notebooklm.cli.research_import` | T12.4 | Preserve Rich text output. |
+| `import_research_sources` | `notebooklm.cli.research_import` | T12.4 | Preserve import orchestration and result counters. |
+
+## Patch Seam Decisions
+
+| Existing patch target | Current owner | Later slice decision |
+|---|---|---|
+| `notebooklm.cli.helpers.console` | `helpers.py` global | T12.1 must keep this patch target effective until every test and command import is migrated. Pure re-export is not enough if moved code reads a different module global. |
+| `notebooklm.cli.helpers.stderr_console` | `helpers.py` global | T12.1 should preserve helper-level patchability for JSON stdout tests. |
+| `notebooklm.cli.helpers.get_context_path` | imported path helper | T12.1 must keep helper patch target effective via call-time helper facade lookup for context tests, CLI VCR fixtures, chat/notebook/session/use tests. Moved code must not bind directly to `notebooklm.paths.get_context_path` if those tests still patch the helper symbol. |
+| `notebooklm.cli.helpers.load_auth_from_storage` | imported auth helper | T12.2 must keep helper patch target effective for broad CLI fixtures and auth tests. |
+| `notebooklm.cli.helpers.build_cookie_jar` | imported auth helper | T12.2 must keep helper patch target effective for `get_auth_tokens` and source-delete tests. |
+| `notebooklm.cli.helpers.get_auth_tokens` | helper function | T12.2 must keep call-time lookup through the helper facade for `with_auth_and_errors`, download, and completion until tests migrate. |
+| `notebooklm.cli.helpers.handle_auth_error` | helper function | T12.2 must keep call-time lookup or migrate primitive tests in the same slice. |
+| `notebooklm.cli.helpers.run_async` | helper function | T12.2 must keep call-time lookup for completion tests and runtime primitive tests. |
+| `notebooklm.cli.helpers.asyncio.sleep` | imported module global | T12.4 must either preserve helper-level retry patch target or migrate all research import retry tests to `notebooklm.cli.research_import.asyncio.sleep`. |
+| `notebooklm.cli.helpers.time.monotonic` | imported module global | T12.4 must either preserve helper-level elapsed-time patch target or migrate all research import retry tests. |
+| `notebooklm.cli.options._complete_notebooks` | options wrapper | T11.3/T11.4 keep this wrapper. Later completion changes must not remove it without migrating shell-complete binding tests. |
+| `notebooklm.cli.options._resolve_notebook_for_completion` | options wrapper | Keep wrapper in options while tests patch it for source/artifact completion. |
+| `notebooklm.cli.options._complete_sources` | options wrapper | Keep wrapper in options while `source_option` binds it directly. |
+| `notebooklm.cli.options._complete_artifacts` | options wrapper | Keep wrapper in options while `artifact_option` binds it directly. |
+
+## Import DAG For Later Slices
+
+- `rendering.py` must not import runtime, auth, context, resolve, or command modules.
+- `context.py` must not import runtime, auth, resolve, or command modules.
+- `auth_runtime.py` may import `context.py` and `rendering.py`; it must not import command modules.
+- `runtime.py` may import `auth_runtime.py` and `error_handler.py`; it must not import command modules.
+- `resolve.py` may import `rendering.py`; it must not import runtime/auth or command modules.
+- `input.py` should avoid runtime/auth imports.
+- `completion.py` must not import `options.py`.
+- `cli/services/*` must not import private library modules or `notebooklm.rpc.*`.
+
+## Final T12 Task Order
+
+The current plan order remains valid:
+
+1. T12.1 moves rendering and context first. These are low-level dependencies.
+2. T12.2 moves runtime and auth after rendering/context exist.
+3. T12.3 moves resolve and input helpers after runtime/auth are stable.
+4. T12.4, T12.6, and T12.7 can run together after T12.2/T12.3 because their target command surfaces are separate.
+5. T12.5 must run after T12.4 because both touch `source.py`.
+6. T12.8 performs final import cleanup and guardrails.
+7. T12.9 runs final verification and Phase 11 handoff.
+
+The marker-only package file `src/notebooklm/cli/services/__init__.py` is
+created in T12.0 so later service slices do not race on package creation.

--- a/src/notebooklm/cli/context.py
+++ b/src/notebooklm/cli/context.py
@@ -60,6 +60,8 @@ def _set_context_value(
     """Set or clear a single value in context.json."""
     context_file = _resolve_context_path(context_path_fn)
     if not context_file.exists():
+        # Conversation updates are context-only: callers must select a notebook
+        # first, which creates the file and account metadata to preserve.
         return
 
     def _mutate(data: dict[str, Any]) -> dict[str, Any]:
@@ -138,6 +140,8 @@ def clear_context(
             return True
         original = dict(data)
         account = original.get("account")
+        # ``clear`` intentionally removes every non-account field so future
+        # notebook/conversation context keys do not need explicit pop entries.
         data.clear()
         if "account" in original:
             data["account"] = account

--- a/src/notebooklm/cli/context.py
+++ b/src/notebooklm/cli/context.py
@@ -6,16 +6,22 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import click
-from filelock import FileLock
+from filelock import FileLock, Timeout
 
 from ..io import atomic_update_json, atomic_write_json
 from ..paths import get_context_path
 
 logger = logging.getLogger(__name__)
 ContextPathFn = Callable[..., Path]
+ContextClearStatus = Literal["cleared", "unchanged", "contended", "unavailable"]
+
+
+def _describe_json_shape(value: Any) -> str:
+    """Return a compact diagnostic description for unexpected JSON payloads."""
+    return f"{type(value).__name__} {value!r}"
 
 
 def _current_storage_override() -> Path | None:
@@ -43,8 +49,9 @@ def _get_context_value(key: str, *, context_path_fn: ContextPathFn | None = None
         data = json.loads(context_file.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             logger.warning(
-                "Context file %s has invalid shape; expected JSON object.",
+                "Context file %s has invalid shape; expected JSON object, got %s.",
                 context_file,
+                _describe_json_shape(data),
             )
             return None
         return data.get(key)
@@ -128,24 +135,43 @@ def clear_context(
 ) -> bool:
     """Clear the current context."""
     context_file = _resolve_context_path(context_path_fn)
+    return _clear_context_file(context_file, clear_account=clear_account) == "cleared"
+
+
+def _clear_context_file(context_file: Path, *, clear_account: bool) -> ContextClearStatus:
+    """Clear context file data and report the precise lock/storage outcome."""
     if not context_file.exists():
-        return False
+        return "unchanged"
     lock_path = context_file.with_suffix(context_file.suffix + ".lock")
     context_file.parent.mkdir(parents=True, exist_ok=True)
-    with FileLock(str(lock_path), timeout=10.0):
+    try:
+        lock = FileLock(str(lock_path), timeout=10.0)
+        with lock:
+            return _clear_context_file_locked(context_file, clear_account=clear_account)
+    except Timeout as e:
+        logger.warning("Context file %s lock is contended; clear skipped: %s", context_file, e)
+        return "contended"
+    except OSError as e:
+        logger.warning("Context file %s is unavailable; clear skipped: %s", context_file, e)
+        return "unavailable"
+
+
+def _clear_context_file_locked(context_file: Path, *, clear_account: bool) -> ContextClearStatus:
+    """Clear context file data while the file lock is held."""
+    try:
         if not context_file.exists():
-            return False
+            return "unchanged"
         if clear_account:
             context_file.unlink(missing_ok=True)
-            return True
+            return "cleared"
         try:
             data = json.loads(context_file.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             context_file.unlink(missing_ok=True)
-            return True
+            return "cleared"
         if not isinstance(data, dict):
             context_file.unlink(missing_ok=True)
-            return True
+            return "cleared"
         original = dict(data)
         account = original.get("account")
         # ``clear`` intentionally removes every non-account field so future
@@ -155,11 +181,14 @@ def clear_context(
             data["account"] = account
         if not data:
             context_file.unlink(missing_ok=True)
-            return True
+            return "cleared"
         if data != original:
             atomic_write_json(context_file, data)
-            return True
-        return False
+            return "cleared"
+        return "unchanged"
+    except OSError as e:
+        logger.warning("Context file %s is unavailable; clear skipped: %s", context_file, e)
+        return "unavailable"
 
 
 def get_current_conversation(*, context_path_fn: ContextPathFn | None = None) -> str | None:

--- a/src/notebooklm/cli/context.py
+++ b/src/notebooklm/cli/context.py
@@ -41,6 +41,12 @@ def _get_context_value(key: str, *, context_path_fn: ContextPathFn | None = None
         return None
     try:
         data = json.loads(context_file.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            logger.warning(
+                "Context file %s has invalid shape; expected JSON object.",
+                context_file,
+            )
+            return None
         return data.get(key)
     except json.JSONDecodeError:
         logger.warning(
@@ -64,7 +70,8 @@ def _set_context_value(
         # first, which creates the file and account metadata to preserve.
         return
 
-    def _mutate(data: dict[str, Any]) -> dict[str, Any]:
+    def _mutate(existing: Any) -> dict[str, Any]:
+        data = dict(existing) if isinstance(existing, dict) else {}
         if value is not None:
             data[key] = value
         elif key in data:
@@ -99,10 +106,11 @@ def set_current_notebook(
     """Set the current notebook context."""
     context_file = _resolve_context_path(context_path_fn)
 
-    def _mutate(existing: dict[str, Any]) -> dict[str, Any]:
+    def _mutate(existing: Any) -> dict[str, Any]:
+        existing_dict = existing if isinstance(existing, dict) else {}
         data: dict[str, Any] = {}
-        if isinstance(existing.get("account"), dict):
-            data["account"] = existing["account"]
+        if isinstance(existing_dict.get("account"), dict):
+            data["account"] = existing_dict["account"]
         data["notebook_id"] = notebook_id
         if title:
             data["title"] = title

--- a/src/notebooklm/cli/context.py
+++ b/src/notebooklm/cli/context.py
@@ -1,0 +1,162 @@
+"""CLI context persistence helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import click
+from filelock import FileLock
+
+from ..io import atomic_update_json, atomic_write_json
+from ..paths import get_context_path
+
+logger = logging.getLogger(__name__)
+ContextPathFn = Callable[..., Path]
+
+
+def _current_storage_override() -> Path | None:
+    """Resolve the active ``--storage`` override from the current Click context."""
+    ctx = click.get_current_context(silent=True)
+    if ctx is None or not ctx.obj:
+        return None
+    storage = ctx.obj.get("storage_path")
+    if storage is None:
+        return None
+    return Path(storage).expanduser().resolve()
+
+
+def _resolve_context_path(context_path_fn: ContextPathFn | None = None) -> Path:
+    context_path_fn = context_path_fn or get_context_path
+    return context_path_fn(storage_path=_current_storage_override())
+
+
+def _get_context_value(key: str, *, context_path_fn: ContextPathFn | None = None) -> str | None:
+    """Read a single value from context.json."""
+    context_file = _resolve_context_path(context_path_fn)
+    if not context_file.exists():
+        return None
+    try:
+        data = json.loads(context_file.read_text(encoding="utf-8"))
+        return data.get(key)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Context file %s is corrupted; cannot read '%s'. Run 'notebooklm clear' to reset.",
+            context_file,
+            key,
+        )
+        return None
+    except OSError as e:
+        logger.warning("Cannot read context file %s: %s", context_file, e)
+        return None
+
+
+def _set_context_value(
+    key: str, value: str | None, *, context_path_fn: ContextPathFn | None = None
+) -> None:
+    """Set or clear a single value in context.json."""
+    context_file = _resolve_context_path(context_path_fn)
+    if not context_file.exists():
+        return
+
+    def _mutate(data: dict[str, Any]) -> dict[str, Any]:
+        if value is not None:
+            data[key] = value
+        elif key in data:
+            del data[key]
+        return data
+
+    try:
+        atomic_update_json(context_file, _mutate)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Context file %s is corrupted; cannot update '%s'. Run 'notebooklm clear' to reset.",
+            context_file,
+            key,
+        )
+    except OSError as e:
+        logger.warning("Failed to write context file %s for key '%s': %s", context_file, key, e)
+
+
+def get_current_notebook(*, context_path_fn: ContextPathFn | None = None) -> str | None:
+    """Get the current notebook ID from context."""
+    return _get_context_value("notebook_id", context_path_fn=context_path_fn)
+
+
+def set_current_notebook(
+    notebook_id: str,
+    title: str | None = None,
+    is_owner: bool | None = None,
+    created_at: str | None = None,
+    *,
+    context_path_fn: ContextPathFn | None = None,
+) -> None:
+    """Set the current notebook context."""
+    context_file = _resolve_context_path(context_path_fn)
+
+    def _mutate(existing: dict[str, Any]) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        if isinstance(existing.get("account"), dict):
+            data["account"] = existing["account"]
+        data["notebook_id"] = notebook_id
+        if title:
+            data["title"] = title
+        if is_owner is not None:
+            data["is_owner"] = is_owner
+        if created_at:
+            data["created_at"] = created_at
+        return data
+
+    atomic_update_json(context_file, _mutate, recover_from_corrupt=True)
+
+
+def clear_context(
+    *, clear_account: bool = False, context_path_fn: ContextPathFn | None = None
+) -> bool:
+    """Clear the current context."""
+    context_file = _resolve_context_path(context_path_fn)
+    if not context_file.exists():
+        return False
+    lock_path = context_file.with_suffix(context_file.suffix + ".lock")
+    context_file.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(str(lock_path), timeout=10.0):
+        if not context_file.exists():
+            return False
+        if clear_account:
+            context_file.unlink(missing_ok=True)
+            return True
+        try:
+            data = json.loads(context_file.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            context_file.unlink(missing_ok=True)
+            return True
+        if not isinstance(data, dict):
+            context_file.unlink(missing_ok=True)
+            return True
+        original = dict(data)
+        account = original.get("account")
+        data.clear()
+        if "account" in original:
+            data["account"] = account
+        if not data:
+            context_file.unlink(missing_ok=True)
+            return True
+        if data != original:
+            atomic_write_json(context_file, data)
+            return True
+        return False
+
+
+def get_current_conversation(*, context_path_fn: ContextPathFn | None = None) -> str | None:
+    """Get the current conversation ID from context."""
+    return _get_context_value("conversation_id", context_path_fn=context_path_fn)
+
+
+def set_current_conversation(
+    conversation_id: str | None, *, context_path_fn: ContextPathFn | None = None
+) -> None:
+    """Set or clear the current conversation ID in context."""
+    _set_context_value("conversation_id", conversation_id, context_path_fn=context_path_fn)

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -7,6 +7,9 @@ Provides common functionality for all CLI commands:
 - JSON/Rich output formatting
 - Context management (current notebook/conversation)
 - @with_client decorator for command boilerplate reduction
+
+This module is also the backward-compatible facade for older imports and test
+patch targets; see ``cli.context`` and ``cli.rendering`` for canonical helpers.
 """
 
 import asyncio
@@ -916,7 +919,6 @@ def handle_auth_error(json_output: bool = False) -> NoReturn:
                 "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
             },
         )
-        raise SystemExit(1)
     else:
         console.print("[red]Not logged in.[/red]\n")
         console.print("[dim]Checked locations:[/dim]")
@@ -955,11 +957,11 @@ def with_auth_and_errors(
     # Use ``find_root`` so nested subcommand contexts still see it.
     try:
         verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         verbose_count = 0
     verbose = verbose_count >= 1
 
-    def log_result(status: str, detail: str = "") -> float:
+    def log_result(status: str, detail: str = "") -> None:
         elapsed = time.monotonic() - start
         if detail:
             logger.debug(
@@ -971,7 +973,6 @@ def with_auth_and_errors(
             )
         else:
             logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
-        return elapsed
 
     with handle_errors(verbose=verbose, json_output=json_output):
         # Auth bootstrap: FileNotFoundError here means the storage file is
@@ -1063,7 +1064,7 @@ def json_output_response(data: dict | list) -> None:
     rendering_helpers.json_output_response(data)
 
 
-def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
+def json_error_response(code: str, message: str, extra: dict | None = None) -> NoReturn:
     """Print JSON error and exit (no colors for machine parsing)."""
     rendering_helpers.json_error_response(code, message, extra)
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -10,7 +10,6 @@ Provides common functionality for all CLI commands:
 """
 
 import asyncio
-import json
 import logging
 import os
 import time
@@ -22,52 +21,34 @@ from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 from urllib.parse import urlsplit, urlunsplit
 
 import click
-from filelock import FileLock
-from rich.console import Console
-from rich.table import Table
 
 from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
 from ..exceptions import NetworkError, RPCError, RPCTimeoutError
-from ..io import atomic_update_json, atomic_write_json
 from ..paths import get_context_path
 from ..research import select_cited_sources
 from ..types import ArtifactType, CitedSourceSelection
+from . import context as context_helpers
+from . import rendering as rendering_helpers
 from ._encoding import safe_echo
 
 if TYPE_CHECKING:
     from ..types import Artifact, Source
 
-console = Console()
-# stderr_console is used for diagnostic / status output when --json mode is
-# active so that stdout stays parseable JSON for automation. See ``emit_status``.
-stderr_console = Console(stderr=True)
+console = rendering_helpers.console
+stderr_console = rendering_helpers.stderr_console
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
-    """Emit a status / diagnostic line.
-
-    When ``json_output`` is True, the message is written to stderr via a
-    dedicated Rich console so that stdout remains pure JSON for downstream
-    automation. Otherwise the message goes through the regular stdout console.
-
-    Args:
-        msg: The message text. Rich markup is honored by both consoles.
-        json_output: True when the current command is producing JSON on stdout.
-        style: Optional Rich style to apply (e.g., ``"yellow"``, ``"dim"``).
-    """
-    target = stderr_console if json_output else console
-    if style is not None:
-        target.print(msg, style=style)
-    else:
-        target.print(msg)
-
-
-# CLI artifact type name aliases
-_CLI_ARTIFACT_ALIASES = {
-    "flashcard": "flashcards",  # CLI uses singular, enum uses plural
-}
+    """Emit a status / diagnostic line."""
+    rendering_helpers._emit_status(
+        msg,
+        json_output=json_output,
+        style=style,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
+    )
 
 
 @dataclass(frozen=True)
@@ -80,27 +61,8 @@ class ResearchImportResult:
 
 
 def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
-    """Convert CLI artifact type name to ArtifactType enum.
-
-    Args:
-        name: CLI artifact type name (e.g., "video", "slide-deck", "flashcard").
-            Use "all" to get None (no filter).
-
-    Returns:
-        ArtifactType enum member, or None if name is "all".
-
-    Raises:
-        KeyError: If name is not a valid artifact type.
-    """
-    if name == "all":
-        return None
-
-    # Handle aliases
-    name = _CLI_ARTIFACT_ALIASES.get(name, name)
-
-    # Convert kebab-case to snake_case and uppercase for enum lookup
-    enum_name = name.upper().replace("-", "_")
-    return ArtifactType[enum_name]
+    """Convert CLI artifact type name to ArtifactType enum."""
+    return rendering_helpers.cli_name_to_artifact_type(name)
 
 
 # =============================================================================
@@ -558,89 +520,23 @@ def get_auth_tokens(ctx) -> AuthTokens:
 
 
 def _current_storage_override() -> Path | None:
-    """Resolve the active ``--storage`` override from the current Click context.
-
-    Returns the explicit storage path stored in ``ctx.obj["storage_path"]`` by
-    the root CLI group (see ``notebooklm_cli.cli``), canonicalized via
-    ``expanduser().resolve()`` so two representations of the same file (e.g.,
-    ``~/foo.json`` and ``/home/user/foo.json``) share one sibling-context
-    namespace. When no Click context is active (library usage) or no override
-    was passed, returns ``None``.
-
-    ``click.get_current_context(silent=True)`` already returns ``None`` outside
-    of a Click invocation, so no try/except is needed.
-    """
-    ctx = click.get_current_context(silent=True)
-    if ctx is None or not ctx.obj:
-        return None
-    storage = ctx.obj.get("storage_path")
-    if storage is None:
-        return None
-    # Defensive normalization: ``notebooklm_cli`` already wraps strings via
-    # ``Path(storage)``, but accept either form so future callers (tests,
-    # library wrappers populating ``ctx.obj`` directly) don't get a
-    # string-vs-``Path`` mismatch crash inside ``get_context_path``.
-    return Path(storage).expanduser().resolve()
+    """Resolve the active ``--storage`` override from the current Click context."""
+    return context_helpers._current_storage_override()
 
 
 def _get_context_value(key: str) -> str | None:
     """Read a single value from context.json."""
-    context_file = get_context_path(storage_path=_current_storage_override())
-    if not context_file.exists():
-        return None
-    try:
-        data = json.loads(context_file.read_text(encoding="utf-8"))
-        return data.get(key)
-    except json.JSONDecodeError:
-        logger.warning(
-            "Context file %s is corrupted; cannot read '%s'. Run 'notebooklm clear' to reset.",
-            context_file,
-            key,
-        )
-        return None
-    except OSError as e:
-        logger.warning("Cannot read context file %s: %s", context_file, e)
-        return None
+    return context_helpers._get_context_value(key, context_path_fn=get_context_path)
 
 
 def _set_context_value(key: str, value: str | None) -> None:
-    """Set or clear a single value in context.json.
-
-    Uses ``atomic_update_json`` so concurrent CLI invocations cannot lose
-    updates by interleaving read-modify-write cycles.
-
-    Note: the ``context_file.exists()`` pre-check below is a TOCTOU window —
-    a concurrent ``clear`` could delete the file between this check and the
-    lock acquire, but the worst case is one unnecessary lock + create cycle,
-    not data loss. We accept the minor inefficiency to keep the early-return
-    fast path: most invocations have no context file at all.
-    """
-    context_file = get_context_path(storage_path=_current_storage_override())
-    if not context_file.exists():
-        return
-
-    def _mutate(data: dict[str, Any]) -> dict[str, Any]:
-        if value is not None:
-            data[key] = value
-        elif key in data:
-            del data[key]
-        return data
-
-    try:
-        atomic_update_json(context_file, _mutate)
-    except json.JSONDecodeError:
-        logger.warning(
-            "Context file %s is corrupted; cannot update '%s'. Run 'notebooklm clear' to reset.",
-            context_file,
-            key,
-        )
-    except OSError as e:
-        logger.warning("Failed to write context file %s for key '%s': %s", context_file, key, e)
+    """Set or clear a single value in context.json."""
+    context_helpers._set_context_value(key, value, context_path_fn=get_context_path)
 
 
 def get_current_notebook() -> str | None:
     """Get the current notebook ID from context."""
-    return _get_context_value("notebook_id")
+    return context_helpers.get_current_notebook(context_path_fn=get_context_path)
 
 
 def set_current_notebook(
@@ -649,35 +545,14 @@ def set_current_notebook(
     is_owner: bool | None = None,
     created_at: str | None = None,
 ):
-    """Set the current notebook context.
-
-    conversation_id is never preserved — the server owns the canonical ID per
-    notebook, and a stale local value would silently use the wrong UUID.
-
-    Uses ``atomic_update_json`` so the account-metadata preservation and the
-    notebook-context overwrite happen as one lock-protected critical section.
-    """
-    context_file = get_context_path(storage_path=_current_storage_override())
-
-    def _mutate(existing: dict[str, Any]) -> dict[str, Any]:
-        data: dict[str, Any] = {}
-        # Preserve account metadata used for multi-account auth routing.
-        if isinstance(existing.get("account"), dict):
-            data["account"] = existing["account"]
-        data["notebook_id"] = notebook_id
-        if title:
-            data["title"] = title
-        if is_owner is not None:
-            data["is_owner"] = is_owner
-        if created_at:
-            data["created_at"] = created_at
-        return data
-
-    # ``recover_from_corrupt=True`` keeps the empty-dict fallback **inside**
-    # the file lock. An outside-the-lock unlink-and-retry would race a
-    # concurrent process that wrote a valid payload between our raise and
-    # our retry, causing us to delete their good write (see PR #465 review).
-    atomic_update_json(context_file, _mutate, recover_from_corrupt=True)
+    """Set the current notebook context."""
+    context_helpers.set_current_notebook(
+        notebook_id,
+        title=title,
+        is_owner=is_owner,
+        created_at=created_at,
+        context_path_fn=get_context_path,
+    )
 
 
 def clear_context(*, clear_account: bool = False) -> bool:
@@ -687,54 +562,22 @@ def clear_context(*, clear_account: bool = False) -> bool:
     metadata used for multi-account auth routing is preserved. ``auth logout``
     passes ``clear_account=True`` to remove the whole file.
 
-    Holds the same sibling ``.lock`` file used by :func:`atomic_update_json`
-    so concurrent writers don't lose updates against our clear-and-delete.
-
-    Returns True if a context file was changed or removed, False if none existed.
+    Returns True if a context file was changed or removed, False if none
+    existed or no clearable fields were present.
     """
-    context_file = get_context_path(storage_path=_current_storage_override())
-    if not context_file.exists():
-        return False
-    lock_path = context_file.with_suffix(context_file.suffix + ".lock")
-    context_file.parent.mkdir(parents=True, exist_ok=True)
-    with FileLock(str(lock_path), timeout=10.0):
-        # Re-check existence under the lock — another writer may have
-        # removed it between the early-return check and the lock acquire.
-        if not context_file.exists():
-            return False
-        if clear_account:
-            context_file.unlink()
-            return True
-        try:
-            data = json.loads(context_file.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            context_file.unlink()
-            return True
-        if not isinstance(data, dict):
-            context_file.unlink()
-            return True
-        original = dict(data)
-        for key in ("notebook_id", "title", "is_owner", "created_at", "conversation_id"):
-            data.pop(key, None)
-        if not data:
-            context_file.unlink()
-            return True
-        if data != original:
-            # atomic_update_json would re-acquire the lock; instead use the
-            # atomic write directly since we already hold the lock here.
-            atomic_write_json(context_file, data)
-            return True
-        return False
+    return context_helpers.clear_context(
+        clear_account=clear_account, context_path_fn=get_context_path
+    )
 
 
 def get_current_conversation() -> str | None:
     """Get the current conversation ID from context."""
-    return _get_context_value("conversation_id")
+    return context_helpers.get_current_conversation(context_path_fn=get_context_path)
 
 
 def set_current_conversation(conversation_id: str | None):
     """Set or clear the current conversation ID in context."""
-    _set_context_value("conversation_id", conversation_id)
+    context_helpers.set_current_conversation(conversation_id, context_path_fn=get_context_path)
 
 
 def validate_id(entity_id: str, entity_name: str = "ID") -> str:
@@ -1073,6 +916,7 @@ def handle_auth_error(json_output: bool = False) -> NoReturn:
                 "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
             },
         )
+        raise SystemExit(1)
     else:
         console.print("[red]Not logged in.[/red]\n")
         console.print("[dim]Checked locations:[/dim]")
@@ -1111,11 +955,11 @@ def with_auth_and_errors(
     # Use ``find_root`` so nested subcommand contexts still see it.
     try:
         verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
-    except (AttributeError, TypeError, ValueError):
+    except Exception:
         verbose_count = 0
     verbose = verbose_count >= 1
 
-    def log_result(status: str, detail: str = "") -> None:
+    def log_result(status: str, detail: str = "") -> float:
         elapsed = time.monotonic() - start
         if detail:
             logger.debug(
@@ -1127,6 +971,7 @@ def with_auth_and_errors(
             )
         else:
             logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
+        return elapsed
 
     with handle_errors(verbose=verbose, json_output=json_output):
         # Auth bootstrap: FileNotFoundError here means the storage file is
@@ -1215,90 +1060,26 @@ def with_client(f):
 
 def json_output_response(data: dict | list) -> None:
     """Print JSON response (no colors for machine parsing)."""
-    click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
+    rendering_helpers.json_output_response(data)
 
 
-def json_error_response(code: str, message: str, extra: dict | None = None) -> NoReturn:
-    """Print JSON error and exit (no colors for machine parsing).
-
-    Args:
-        code: Error code (e.g., "AUTH_REQUIRED", "ERROR")
-        message: Human-readable error message
-        extra: Optional additional data to include in response
-    """
-    response = {"error": True, "code": code, "message": message}
-    if extra:
-        response.update(extra)
-    click.echo(json.dumps(response, indent=2, default=str, ensure_ascii=False))
-    raise SystemExit(1)
-
-
-_RESULT_TYPE_LABELS = {
-    1: "Web",
-    2: "Drive",
-    5: "Report",
-    "web": "Web",
-    "drive": "Drive",
-    "report": "Report",
-}
+def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
+    """Print JSON error and exit (no colors for machine parsing)."""
+    rendering_helpers.json_error_response(code, message, extra)
 
 
 def display_research_sources(sources: list[dict], max_display: int = 10) -> None:
-    """Display research sources in a formatted table.
-
-    Args:
-        sources: List of source dicts with 'title', 'url', and optional 'result_type' keys
-        max_display: Maximum sources to show before truncating (default 10)
-    """
-    console.print(f"[bold]Found {len(sources)} sources[/bold]")
-
-    if sources:
-        # Only show Type column if any source has result_type
-        has_types = any("result_type" in s for s in sources)
-
-        table = Table(show_header=True, header_style="bold")
-        table.add_column("Title", style="cyan")
-        if has_types:
-            table.add_column("Type", style="yellow")
-        table.add_column("URL", style="dim")
-        for src in sources[:max_display]:
-            row = [src.get("title", "Untitled")[:50]]
-            if has_types:
-                rt: int | None = src.get("result_type")
-                label = (
-                    _RESULT_TYPE_LABELS.get(rt, str(rt) if rt is not None else "")
-                    if rt is not None
-                    else ""
-                )
-                row.append(label)
-            row.append(src.get("url", "")[:60])
-            table.add_row(*row)
-        if len(sources) > max_display:
-            extra_row = [f"... and {len(sources) - max_display} more"]
-            if has_types:
-                extra_row.append("")
-            extra_row.append("")
-            table.add_row(*extra_row)
-        console.print(table)
+    """Display research sources in a formatted table."""
+    rendering_helpers._display_research_sources(
+        sources, max_display=max_display, output_console=console
+    )
 
 
 def display_report(report: str, max_chars: int = 1000, json_hint: bool = True) -> None:
-    """Display a research report, truncated for terminal output.
-
-    Args:
-        report: The report markdown text.
-        max_chars: Maximum characters to display (default 1000).
-        json_hint: Whether to suggest --json for full output in truncation message.
-    """
-    if not report:
-        return
-    console.print("\n[bold]Report:[/bold]")
-    console.print(report[:max_chars], markup=False)
-    if len(report) > max_chars:
-        hint = " use --json for full report" if json_hint else ""
-        console.print(
-            f"[dim]... (truncated,{hint})[/dim]" if hint else "[dim]... (truncated)[/dim]"
-        )
+    """Display a research report, truncated for terminal output."""
+    rendering_helpers._display_report(
+        report, max_chars=max_chars, json_hint=json_hint, output_console=console
+    )
 
 
 # =============================================================================
@@ -1307,71 +1088,10 @@ def display_report(report: str, max_chars: int = 1000, json_hint: bool = True) -
 
 
 def get_artifact_type_display(artifact: "Artifact") -> str:
-    """Get display string for artifact type.
-
-    Args:
-        artifact: Artifact object
-
-    Returns:
-        Display string with emoji
-    """
-    from notebooklm import ArtifactType
-
-    kind = artifact.kind
-
-    # Map ArtifactType enum to display strings
-    display_map = {
-        ArtifactType.AUDIO: "🎧 Audio",
-        ArtifactType.VIDEO: "🎬 Video",
-        ArtifactType.QUIZ: "📝 Quiz",
-        ArtifactType.FLASHCARDS: "🃏 Flashcards",
-        ArtifactType.MIND_MAP: "🧠 Mind Map",
-        ArtifactType.INFOGRAPHIC: "🖼️ Infographic",
-        ArtifactType.SLIDE_DECK: "📊 Slide Deck",
-        ArtifactType.DATA_TABLE: "📈 Data Table",
-    }
-
-    # Handle report subtypes specially
-    if kind == ArtifactType.REPORT:
-        report_displays = {
-            "briefing_doc": "📋 Briefing Doc",
-            "study_guide": "📚 Study Guide",
-            "blog_post": "✍️ Blog Post",
-            "report": "📄 Report",
-        }
-        return report_displays.get(artifact.report_subtype or "report", "📄 Report")
-
-    return display_map.get(kind, f"Unknown ({kind})")
+    """Get display string for artifact type."""
+    return rendering_helpers.get_artifact_type_display(artifact)
 
 
 def get_source_type_display(source_type: str) -> str:
-    """Get display string for source type.
-
-    Args:
-        source_type: Type string from Source.kind (SourceType str enum)
-
-    Returns:
-        Display string with emoji
-    """
-    # Extract value if it's a SourceType enum, otherwise use as-is
-    type_str = source_type.value if hasattr(source_type, "value") else str(source_type)
-    type_map = {
-        # From SourceType str enum values (types.py)
-        "google_docs": "📄 Google Docs",
-        "google_slides": "📊 Google Slides",
-        "google_spreadsheet": "📊 Google Sheets",
-        "pdf": "📄 PDF",
-        "pasted_text": "📝 Pasted Text",
-        "docx": "📝 DOCX",
-        "web_page": "🌐 Web Page",
-        "markdown": "📝 Markdown",
-        "youtube": "🎬 YouTube",
-        "media": "🎵 Media",
-        "google_drive_audio": "🎧 Drive Audio",
-        "google_drive_video": "🎬 Drive Video",
-        "image": "🖼️ Image",
-        "csv": "📊 CSV",
-        "epub": "📕 EPUB",
-        "unknown": "❓ Unknown",
-    }
-    return type_map.get(type_str, f"❓ {type_str}")
+    """Get display string for source type."""
+    return rendering_helpers.get_source_type_display(source_type)

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -65,7 +65,7 @@ def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
 
     name = _CLI_ARTIFACT_ALIASES.get(name, name)
     enum_name = name.upper().replace("-", "_")
-    return ArtifactType[enum_name]
+    return ArtifactType.__members__.get(enum_name)
 
 
 def json_output_response(data: dict | list) -> None:

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -8,7 +8,7 @@ for older imports and patch targets.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import click
 from rich.console import Console
@@ -33,6 +33,8 @@ def _emit_status(
     stdout_console: Console = console,
     stderr_output_console: Console = stderr_console,
 ) -> None:
+    # ``cli.helpers`` calls this private variant to preserve helper-level
+    # Console patch seams while the public rendering helper uses local defaults.
     target = stderr_output_console if json_output else stdout_console
     if style is not None:
         target.print(msg, style=style)
@@ -71,7 +73,7 @@ def json_output_response(data: dict | list) -> None:
     click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
 
 
-def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
+def json_error_response(code: str, message: str, extra: dict | None = None) -> NoReturn:
     """Print JSON error and exit (no colors for machine parsing)."""
     response: dict[str, Any] = {"error": True, "code": code, "message": message}
     if extra:
@@ -93,6 +95,8 @@ _RESULT_TYPE_LABELS = {
 def _display_research_sources(
     sources: list[dict], max_display: int = 10, *, output_console: Console = console
 ) -> None:
+    # ``cli.helpers`` calls this private variant to inject its compatibility
+    # ``console`` patch target instead of binding to this module's Console.
     output_console.print(f"[bold]Found {len(sources)} sources[/bold]")
 
     if sources:
@@ -136,6 +140,8 @@ def _display_report(
     *,
     output_console: Console = console,
 ) -> None:
+    # ``cli.helpers`` calls this private variant to inject its compatibility
+    # ``console`` patch target instead of binding to this module's Console.
     if not report:
         return
     output_console.print("\n[bold]Report:[/bold]")

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -1,0 +1,204 @@
+"""CLI rendering helpers.
+
+This module owns stdout/stderr formatting, Rich display helpers, and CLI-facing
+source/artifact display labels. ``cli.helpers`` remains a compatibility facade
+for older imports and patch targets.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from ..types import ArtifactType
+
+if TYPE_CHECKING:
+    from ..types import Artifact
+
+console = Console()
+# Diagnostic / status output in --json mode must go to stderr so stdout stays
+# parseable JSON for automation.
+stderr_console = Console(stderr=True)
+
+
+def _emit_status(
+    msg: str,
+    *,
+    json_output: bool,
+    style: str | None = None,
+    stdout_console: Console = console,
+    stderr_output_console: Console = stderr_console,
+) -> None:
+    target = stderr_output_console if json_output else stdout_console
+    if style is not None:
+        target.print(msg, style=style)
+    else:
+        target.print(msg)
+
+
+def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
+    """Emit a status / diagnostic line."""
+    _emit_status(
+        msg,
+        json_output=json_output,
+        style=style,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
+    )
+
+
+_CLI_ARTIFACT_ALIASES = {
+    "flashcard": "flashcards",  # CLI uses singular, enum uses plural
+}
+
+
+def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
+    """Convert CLI artifact type name to ArtifactType enum."""
+    if name == "all":
+        return None
+
+    name = _CLI_ARTIFACT_ALIASES.get(name, name)
+    enum_name = name.upper().replace("-", "_")
+    return ArtifactType[enum_name]
+
+
+def json_output_response(data: dict | list) -> None:
+    """Print JSON response (no colors for machine parsing)."""
+    click.echo(json.dumps(data, indent=2, default=str, ensure_ascii=False))
+
+
+def json_error_response(code: str, message: str, extra: dict | None = None) -> None:
+    """Print JSON error and exit (no colors for machine parsing)."""
+    response: dict[str, Any] = {"error": True, "code": code, "message": message}
+    if extra:
+        response.update(extra)
+    click.echo(json.dumps(response, indent=2, default=str, ensure_ascii=False))
+    raise SystemExit(1)
+
+
+_RESULT_TYPE_LABELS = {
+    1: "Web",
+    2: "Drive",
+    5: "Report",
+    "web": "Web",
+    "drive": "Drive",
+    "report": "Report",
+}
+
+
+def _display_research_sources(
+    sources: list[dict], max_display: int = 10, *, output_console: Console = console
+) -> None:
+    output_console.print(f"[bold]Found {len(sources)} sources[/bold]")
+
+    if sources:
+        has_types = any("result_type" in s for s in sources)
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Title", style="cyan")
+        if has_types:
+            table.add_column("Type", style="yellow")
+        table.add_column("URL", style="dim")
+        for src in sources[:max_display]:
+            row = [src.get("title", "Untitled")[:50]]
+            if has_types:
+                rt: int | None = src.get("result_type")
+                label = (
+                    _RESULT_TYPE_LABELS.get(rt, str(rt) if rt is not None else "")
+                    if rt is not None
+                    else ""
+                )
+                row.append(label)
+            row.append(src.get("url", "")[:60])
+            table.add_row(*row)
+        if len(sources) > max_display:
+            extra_row = [f"... and {len(sources) - max_display} more"]
+            if has_types:
+                extra_row.append("")
+            extra_row.append("")
+            table.add_row(*extra_row)
+        output_console.print(table)
+
+
+def display_research_sources(sources: list[dict], max_display: int = 10) -> None:
+    """Display research sources in a formatted table."""
+    _display_research_sources(sources, max_display, output_console=console)
+
+
+def _display_report(
+    report: str,
+    max_chars: int = 1000,
+    json_hint: bool = True,
+    *,
+    output_console: Console = console,
+) -> None:
+    if not report:
+        return
+    output_console.print("\n[bold]Report:[/bold]")
+    output_console.print(report[:max_chars], markup=False)
+    if len(report) > max_chars:
+        hint = " use --json for full report" if json_hint else ""
+        output_console.print(
+            f"[dim]... (truncated,{hint})[/dim]" if hint else "[dim]... (truncated)[/dim]"
+        )
+
+
+def display_report(report: str, max_chars: int = 1000, json_hint: bool = True) -> None:
+    """Display a research report, truncated for terminal output."""
+    _display_report(report, max_chars, json_hint, output_console=console)
+
+
+def get_artifact_type_display(artifact: Artifact) -> str:
+    """Get display string for artifact type."""
+    kind = artifact.kind
+
+    display_map = {
+        ArtifactType.AUDIO: "🎧 Audio",
+        ArtifactType.VIDEO: "🎬 Video",
+        ArtifactType.QUIZ: "📝 Quiz",
+        ArtifactType.FLASHCARDS: "🃏 Flashcards",
+        ArtifactType.MIND_MAP: "🧠 Mind Map",
+        ArtifactType.INFOGRAPHIC: "🖼️ Infographic",
+        ArtifactType.SLIDE_DECK: "📊 Slide Deck",
+        ArtifactType.DATA_TABLE: "📈 Data Table",
+    }
+
+    if kind == ArtifactType.REPORT:
+        report_displays = {
+            "briefing_doc": "📋 Briefing Doc",
+            "study_guide": "📚 Study Guide",
+            "blog_post": "✍️ Blog Post",
+            "report": "📄 Report",
+        }
+        return report_displays.get(artifact.report_subtype or "report", "📄 Report")
+
+    fallback_label = kind.name if hasattr(kind, "name") else kind
+    return display_map.get(kind, f"Unknown ({fallback_label})")
+
+
+def get_source_type_display(source_type: str) -> str:
+    """Get display string for source type."""
+    type_str = source_type.value if hasattr(source_type, "value") else str(source_type)
+    type_map = {
+        "google_docs": "📄 Google Docs",
+        "google_slides": "📊 Google Slides",
+        "google_spreadsheet": "📊 Google Sheets",
+        "pdf": "📄 PDF",
+        "pasted_text": "📝 Pasted Text",
+        "docx": "📝 DOCX",
+        "web_page": "🌐 Web Page",
+        "markdown": "📝 Markdown",
+        "youtube": "🎬 YouTube",
+        "media": "🎵 Media",
+        "google_drive_audio": "🎧 Drive Audio",
+        "google_drive_video": "🎬 Drive Video",
+        "image": "🖼️ Image",
+        "csv": "📊 CSV",
+        "epub": "📕 EPUB",
+        "unknown": "❓ Unknown",
+    }
+    return type_map.get(type_str, f"❓ {type_str}")

--- a/src/notebooklm/cli/services/__init__.py
+++ b/src/notebooklm/cli/services/__init__.py
@@ -1,0 +1,1 @@
+"""CLI-internal workflow service modules."""

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -411,6 +411,31 @@ class TestContextManagement:
             result = get_current_notebook()
             assert result is None
 
+    def test_get_notebook_non_object_json(self, tmp_path):
+        context_file = tmp_path / "context.json"
+        context_file.write_text("[]")
+        with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+            result = get_current_notebook()
+            assert result is None
+
+    def test_set_current_notebook_recovers_non_object_json(self, tmp_path):
+        context_file = tmp_path / "context.json"
+        context_file.write_text("[]")
+        with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+            set_current_notebook("nb_new", title="New Notebook")
+
+        data = json.loads(context_file.read_text())
+        assert data["notebook_id"] == "nb_new"
+        assert data["title"] == "New Notebook"
+
+    def test_set_current_conversation_recovers_non_object_json(self, tmp_path):
+        context_file = tmp_path / "context.json"
+        context_file.write_text("[]")
+        with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+            set_current_conversation("conv_456")
+
+        assert json.loads(context_file.read_text()) == {"conversation_id": "conv_456"}
+
     def test_set_current_notebook_clears_conversation_on_switch(self, tmp_path):
         context_file = tmp_path / "context.json"
         context_file.write_text('{"notebook_id": "nb_old", "conversation_id": "conv_1"}')

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from filelock import Timeout
 
 import notebooklm.cli._encoding as encoding_module
 import notebooklm.cli.context as context_module
@@ -410,12 +411,32 @@ class TestContextManagement:
             result = get_current_notebook()
             assert result is None
 
-    def test_get_notebook_non_object_json(self, tmp_path):
+    def test_get_notebook_non_object_json(self, tmp_path, caplog):
         context_file = tmp_path / "context.json"
         context_file.write_text("[]")
-        with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+        with (
+            patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+            caplog.at_level("WARNING", logger="notebooklm.cli.context"),
+        ):
             result = get_current_notebook()
             assert result is None
+        assert "expected JSON object, got list []" in caplog.text
+
+    def test_clear_context_lock_timeout_returns_false(self, tmp_path, caplog):
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "test"}')
+        with (
+            patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+            patch(
+                "notebooklm.cli.context.FileLock",
+                side_effect=Timeout(str(context_file.with_suffix(".json.lock"))),
+            ),
+            caplog.at_level("WARNING", logger="notebooklm.cli.context"),
+        ):
+            assert clear_context() is False
+
+        assert context_file.exists()
+        assert "lock is contended" in caplog.text
 
     def test_set_current_notebook_recovers_non_object_json(self, tmp_path):
         context_file = tmp_path / "context.json"

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -210,9 +210,8 @@ class TestCliNameToArtifactType:
     def test_all_returns_none(self):
         assert cli_name_to_artifact_type("all") is None
 
-    def test_invalid_type_raises_keyerror(self):
-        with pytest.raises(KeyError):
-            cli_name_to_artifact_type("invalid-type")
+    def test_invalid_type_returns_none(self):
+        assert cli_name_to_artifact_type("invalid-type") is None
 
 
 # =============================================================================

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -10,6 +10,8 @@ import httpx
 import pytest
 
 import notebooklm.cli._encoding as encoding_module
+import notebooklm.cli.context as context_module
+import notebooklm.cli.rendering as rendering_module
 from notebooklm import Artifact
 from notebooklm.cli.helpers import (
     clear_context,
@@ -109,6 +111,7 @@ class TestGetArtifactTypeDisplay:
         # Unknown types return "Unknown (<kind>)" format
         display = get_artifact_type_display(art)
         assert "Unknown" in display
+        assert repr(art.kind) not in display
 
     def test_report_subtype_briefing_doc(self):
         # report_subtype is computed from title
@@ -248,6 +251,13 @@ class TestJsonOutputResponse:
         assert "🚀" in captured.out
         assert "\\u" not in captured.out
 
+    def test_rendering_module_outputs_valid_json(self, capsys):
+        rendering_module.json_output_response({"test": "value"})
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["test"] == "value"
+
 
 class TestJsonErrorResponse:
     def test_outputs_error_json_and_exits(self, capsys):
@@ -309,6 +319,13 @@ class TestContextManagement:
             result = get_current_notebook()
             assert result == "nb_test123"
 
+    def test_context_module_uses_own_get_context_path(self, tmp_path):
+        context_file = tmp_path / "context.json"
+        with patch("notebooklm.cli.context.get_context_path", return_value=context_file):
+            context_module.set_current_notebook("nb_test123", title="Test Notebook")
+            result = context_module.get_current_notebook()
+            assert result == "nb_test123"
+
     def test_set_notebook_with_all_fields(self, tmp_path):
         context_file = tmp_path / "context.json"
         with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
@@ -335,6 +352,7 @@ class TestContextManagement:
                 {
                     "notebook_id": "test",
                     "conversation_id": "conv",
+                    "future_context_field": "clear me too",
                     "account": {"authuser": 1, "email": "bob@example.com"},
                 }
             )
@@ -729,6 +747,17 @@ class TestDisplayReport:
 
         with patch("notebooklm.cli.helpers.console") as mock_console:
             display_report(report, max_chars=1000)
+
+        assert mock_console.print.call_count == 2
+        assert mock_console.print.call_args_list[0].args[0] == "\n[bold]Report:[/bold]"
+        assert mock_console.print.call_args_list[1].args[0] == report
+        assert mock_console.print.call_args_list[1].kwargs["markup"] is False
+
+    def test_rendering_module_prints_markdown_as_literal_text(self):
+        report = "See [NotebookLM](https://example.com) and [1]"
+
+        with patch("notebooklm.cli.rendering.console") as mock_console:
+            rendering_module.display_report(report, max_chars=1000)
 
         assert mock_console.print.call_count == 2
         assert mock_console.print.call_args_list[0].args[0] == "\n[bold]Report:[/bold]"

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -37,6 +37,9 @@ import pytest
 
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
 OPTIONS_PATH = CLI_ROOT / "options.py"
+SERVICES_ROOT = CLI_ROOT / "services"
+RENDERING_PATH = CLI_ROOT / "rendering.py"
+CONTEXT_PATH = CLI_ROOT / "context.py"
 COMPLETION_CALLBACKS = {
     "_complete_artifacts",
     "_complete_notebooks",
@@ -50,6 +53,39 @@ COMPLETION_FORBIDDEN_SYMBOLS = {
 }
 FUNCTION_DEF_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef)
 BLOCK_DEF_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+CLI_COMMAND_MODULES = {
+    "agent",
+    "artifact",
+    "chat",
+    "doctor",
+    "download",
+    "generate",
+    "language",
+    "note",
+    "notebook",
+    "profile",
+    "research",
+    "session",
+    "share",
+    "skill",
+    "source",
+}
+RENDERING_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
+    "auth_runtime",
+    "completion",
+    "context",
+    "input",
+    "resolve",
+    "runtime",
+}
+CONTEXT_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
+    "auth_runtime",
+    "completion",
+    "input",
+    "rendering",
+    "resolve",
+    "runtime",
+}
 
 
 def _is_private_segment(seg: str) -> bool:
@@ -77,6 +113,29 @@ def _is_rpc_path(parts: list[str]) -> bool:
     ``["rpc"]`` or ``["rpc", "types"]``.
     """
     return bool(parts) and parts[0] == "rpc"
+
+
+def _cli_module_imports(path: pathlib.Path) -> set[str]:
+    """Return direct ``notebooklm.cli`` module imports used by a CLI file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            mod_parts = mod.split(".") if mod else []
+            if node.level == 1:
+                if mod:
+                    imports.add(mod_parts[0])
+                else:
+                    imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif node.level == 0 and mod_parts[:2] == ["notebooklm", "cli"] and len(mod_parts) > 2:
+                imports.add(mod_parts[2])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                parts = alias.name.split(".")
+                if parts[:2] == ["notebooklm", "cli"] and len(parts) > 2:
+                    imports.add(parts[2])
+    return imports
 
 
 def _violations(tree: ast.AST) -> list[str]:  # noqa: C901 - flat dispatch on import shape
@@ -232,6 +291,42 @@ def test_no_private_module_imports_in_cli():
         "or `_private` names out of public notebooklm modules. "
         "Promote needed symbols to a public module (config/urls/log/research/types) "
         f"and import from there.\nOffenders: {offenders}"
+    )
+
+
+def test_cli_services_stay_on_public_library_boundary() -> None:
+    """Keep service-layer modules from binding directly to private library/RPC APIs."""
+    offenders: list[tuple[str, list[str]]] = []
+    for path in sorted(SERVICES_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        bad = _violations(tree)
+        if bad:
+            offenders.append((str(path.relative_to(CLI_ROOT.parent)), bad))
+
+    assert not offenders, (
+        "notebooklm.cli.services.* must not import notebooklm._* private modules, "
+        "notebooklm.rpc.*, or `_private` names from public notebooklm modules. "
+        "Route service collaborators through public library APIs or CLI facades.\n"
+        f"Offenders: {offenders}"
+    )
+
+
+def test_rendering_stays_on_low_level_cli_import_boundary() -> None:
+    imports = _cli_module_imports(RENDERING_PATH)
+
+    assert not (imports & RENDERING_FORBIDDEN_MODULES), (
+        "cli.rendering must not import runtime/auth/context/resolve/input/completion "
+        f"or command modules. Offenders: {sorted(imports & RENDERING_FORBIDDEN_MODULES)}"
+    )
+
+
+def test_context_stays_on_low_level_cli_import_boundary() -> None:
+    imports = _cli_module_imports(CONTEXT_PATH)
+
+    assert not (imports & CONTEXT_FORBIDDEN_MODULES), (
+        "cli.context must not import runtime/auth/rendering/resolve/input/completion "
+        "or command modules. "
+        f"Offenders: {sorted(imports & CONTEXT_FORBIDDEN_MODULES)}"
     )
 
 

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -128,6 +128,11 @@ def _cli_module_imports(path: pathlib.Path) -> set[str]:
                     imports.add(mod_parts[0])
                 else:
                     imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif node.level >= 2 and mod_parts[:1] == ["cli"]:
+                if len(mod_parts) > 1:
+                    imports.add(mod_parts[1])
+                else:
+                    imports.update(alias.name.split(".")[0] for alias in node.names)
             elif node.level == 0 and mod_parts[:2] == ["notebooklm", "cli"] and len(mod_parts) > 2:
                 imports.add(mod_parts[2])
         elif isinstance(node, ast.Import):

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -133,14 +133,35 @@ def _cli_module_imports(path: pathlib.Path) -> set[str]:
                     imports.add(mod_parts[1])
                 else:
                     imports.update(alias.name.split(".")[0] for alias in node.names)
-            elif node.level == 0 and mod_parts[:2] == ["notebooklm", "cli"] and len(mod_parts) > 2:
-                imports.add(mod_parts[2])
+            elif node.level == 0 and mod_parts[:2] == ["notebooklm", "cli"]:
+                if len(mod_parts) > 2:
+                    imports.add(mod_parts[2])
+                elif len(mod_parts) == 2:
+                    imports.update(alias.name.split(".")[0] for alias in node.names)
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 parts = alias.name.split(".")
                 if parts[:2] == ["notebooklm", "cli"] and len(parts) > 2:
                     imports.add(parts[2])
     return imports
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("from notebooklm.cli import completion\n", {"completion"}),
+        ("from notebooklm.cli.runtime import with_client\n", {"runtime"}),
+        ("from ..cli import rendering\n", {"rendering"}),
+        ("from ..cli.context import get_current_notebook\n", {"context"}),
+    ],
+)
+def test_cli_module_imports_detects_cli_import_forms(
+    tmp_path: pathlib.Path, source: str, expected: set[str]
+) -> None:
+    path = tmp_path / "sample.py"
+    path.write_text(source, encoding="utf-8")
+
+    assert _cli_module_imports(path) == expected
 
 
 def _violations(tree: ast.AST) -> list[str]:  # noqa: C901 - flat dispatch on import shape


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist CLI context for current notebook and conversation across sessions
  * Centralized CLI rendering with structured JSON output, clearer status messaging, and improved report/source display

* **Refactor**
  * CLI helpers now delegate rendering and context responsibilities to dedicated modules for cleaner separation

* **Documentation**
  * Added Phase 10 architecture remediation seam map outlining migration targets and task plan

* **Tests**
  * Expanded tests for context persistence, rendering behavior, and CLI import/boundary rules

* **Chores**
  * Added minimal CLI services module placeholder

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->