### PR TITLE
ci(release): gate publish on manual approval + wheel smoke test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
   build-and-publish:
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: read
@@ -39,6 +40,20 @@ jobs:
     - name: Build package
       run: |
         python -m build
+
+    - name: Install built wheel in a clean venv
+      run: |
+        python -m venv smoke-venv
+        smoke-venv/bin/pip install dist/notebooklm_py-*.whl
+        smoke-venv/bin/python -c "import notebooklm; print(notebooklm.__version__)"
+
+    - name: Install dev deps for unit-test smoke
+      run: pip install -e .[dev]
+
+    - name: Run unit tests against wheel
+      env:
+        PYTHONPATH: ""  # force loading from installed site-packages, not src/
+      run: pytest tests/unit -q --no-cov -x
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,19 +41,15 @@ jobs:
       run: |
         python -m build
 
-    - name: Install built wheel in a clean venv
+    - name: Install built wheel + dev extras in a clean venv
       run: |
         python -m venv smoke-venv
-        smoke-venv/bin/pip install dist/notebooklm_py-*.whl
+        WHEEL=$(ls dist/notebooklm_py-*.whl)
+        smoke-venv/bin/pip install "${WHEEL}[dev]"
         smoke-venv/bin/python -c "import notebooklm; print(notebooklm.__version__)"
 
-    - name: Install dev deps for unit-test smoke
-      run: pip install -e .[dev]
-
     - name: Run unit tests against wheel
-      env:
-        PYTHONPATH: ""  # force loading from installed site-packages, not src/
-      run: pytest tests/unit -q --no-cov -x
+      run: smoke-venv/bin/pytest tests/unit -q --no-cov -x
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -7,7 +7,6 @@ jobs:
   publish:
     name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
-    environment: testpypi
     permissions:
       id-token: write
       contents: read
@@ -35,19 +34,15 @@ jobs:
     - name: Build package
       run: python -m build
 
-    - name: Install built wheel in a clean venv
+    - name: Install built wheel + dev extras in a clean venv
       run: |
         python -m venv smoke-venv
-        smoke-venv/bin/pip install dist/notebooklm_py-*.whl
+        WHEEL=$(ls dist/notebooklm_py-*.whl)
+        smoke-venv/bin/pip install "${WHEEL}[dev]"
         smoke-venv/bin/python -c "import notebooklm; print(notebooklm.__version__)"
 
-    - name: Install dev deps for unit-test smoke
-      run: pip install -e .[dev]
-
     - name: Run unit tests against wheel
-      env:
-        PYTHONPATH: ""  # force loading from installed site-packages, not src/
-      run: pytest tests/unit -q --no-cov -x
+      run: smoke-venv/bin/pytest tests/unit -q --no-cov -x
 
     - name: Upload to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -7,6 +7,7 @@ jobs:
   publish:
     name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
+    environment: testpypi
     permissions:
       id-token: write
       contents: read
@@ -33,6 +34,20 @@ jobs:
 
     - name: Build package
       run: python -m build
+
+    - name: Install built wheel in a clean venv
+      run: |
+        python -m venv smoke-venv
+        smoke-venv/bin/pip install dist/notebooklm_py-*.whl
+        smoke-venv/bin/python -c "import notebooklm; print(notebooklm.__version__)"
+
+    - name: Install dev deps for unit-test smoke
+      run: pip install -e .[dev]
+
+    - name: Run unit tests against wheel
+      env:
+        PYTHONPATH: ""  # force loading from installed site-packages, not src/
+      run: pytest tests/unit -q --no-cov -x
 
     - name: Upload to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Closes Tier-9 audit findings **C1** (PyPI publish runs unattended on any tag-push) and **C4** (no published-wheel smoke gate before release).

- `publish.yml` now declares `environment: release` so PyPI publication requires manual approval via the repo's Environments protection rules. OIDC trusted-publisher (`id-token: write`) and `pypa/gh-action-pypi-publish` are unchanged — only the gate added.
- Both `publish.yml` and `testpypi-publish.yml` gain a 3-step smoke gate that runs **after** `python -m build` and **before** the publish action:
  1. Install the freshly-built wheel into a clean venv, `import notebooklm`, print `__version__`.
  2. Install dev extras (`pip install -e .[dev]`).
  3. Run `pytest tests/unit -q --no-cov -x` with `PYTHONPATH=""` so packages resolve from site-packages, not `src/`.
- `testpypi-publish.yml` deliberately does **not** add the `environment` gate — TestPyPI is the rehearsal channel and gating it would defeat its purpose.

## Known limitation (deferred)

Step 2 installs `-e .[dev]` against the runner's Python, so the unit tests exercise the editable `src/` install — **not** the wheel itself. Step 1's wheel-import sanity check IS a true wheel test. A future PR can extract the smoke-gate to a reusable composite action and have `smoke-venv` install test deps + run pytest from `smoke-venv` directly. Documented inline in commit body.

## Test plan

- [x] `uv run ruff format .` clean (336 files already formatted)
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (88 source files)
- [x] `uv run pytest` baseline preserved
- [ ] Manual: tag-push triggers the workflow but pauses at the `release` environment for approval; approver sees the smoke-gate logs before clicking through.
- [ ] Manual: TestPyPI tag-push runs the smoke gate AND publishes (no environment gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)