### PR TITLE
refactor(cli): split resolve and input helpers

### DIFF
--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -18,14 +18,12 @@ from .helpers import (
     get_current_conversation,
     get_current_notebook,
     json_output_response,
-    require_notebook,
-    resolve_notebook_id,
-    resolve_prompt,
-    resolve_source_ids,
     set_current_conversation,
     with_client,
 )
+from .input import resolve_prompt
 from .options import _complete_sources, json_option, notebook_option, prompt_file_option
+from .resolve import require_notebook, resolve_notebook_id, resolve_source_ids
 
 logger = logging.getLogger(__name__)
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -53,7 +53,7 @@ def load_auth_from_storage(*args: Any, **kwargs: Any) -> Any:
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
     """Emit a status / diagnostic line."""
-    rendering_helpers._emit_status(
+    rendering_helpers.emit_status(
         msg,
         json_output=json_output,
         style=style,

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -12,7 +12,6 @@ patch targets; see ``cli.runtime``, ``cli.auth_runtime``, ``cli.context``, and
 """
 
 import logging
-import os
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
@@ -25,8 +24,10 @@ from ..paths import get_context_path
 from ..types import ArtifactType
 from . import auth_runtime as auth_runtime_helpers
 from . import context as context_helpers
+from . import input as input_helpers
 from . import rendering as rendering_helpers
 from . import research_import as research_import_helpers
+from . import resolve as resolve_helpers
 from . import runtime as runtime_helpers
 from ._encoding import safe_echo
 
@@ -223,68 +224,17 @@ def set_current_conversation(conversation_id: str | None):
 
 
 def validate_id(entity_id: str, entity_name: str = "ID") -> str:
-    """Validate and normalize an entity ID.
-
-    Args:
-        entity_id: The ID to validate
-        entity_name: Name for error messages (e.g., "notebook", "source")
-
-    Returns:
-        Stripped ID
-
-    Raises:
-        click.ClickException: If ID is empty or whitespace-only
-    """
-    if not entity_id or not entity_id.strip():
-        raise click.ClickException(f"{entity_name} ID cannot be empty")
-    return entity_id.strip()
+    """Validate and normalize an entity ID."""
+    return resolve_helpers.validate_id(entity_id, entity_name)
 
 
 def require_notebook(notebook_id: str | None) -> str:
-    """Get notebook ID from argument, env var, or active context.
-
-    Resolution order (env-var precedence):
-
-    1. ``notebook_id`` argument (the resolved value of the ``-n/--notebook``
-       Click flag — already env-var-aware via ``cli/options.py:notebook_option``,
-       which declares ``envvar="NOTEBOOKLM_NOTEBOOK"``).
-    2. ``NOTEBOOKLM_NOTEBOOK`` environment variable. Re-checked here so direct
-       callers that don't pass through the Click flag (programmatic usage,
-       legacy code paths, tests) honor the same precedence ladder.
-    3. The persisted active-notebook context written by ``notebooklm use``.
-    4. Hard error → ``SystemExit(1)`` with a discoverability hint listing all
-       three resolution paths.
-
-    Args:
-        notebook_id: Optional notebook ID from command argument. When the
-            Click flag was omitted AND the env var was unset, this is ``None``.
-
-    Returns:
-        Notebook ID (from argument, env var, or context), validated and stripped.
-
-    Raises:
-        SystemExit: If no notebook ID can be resolved from any source.
-        click.ClickException: If the resolved notebook ID is empty/whitespace
-            after stripping.
-    """
-    if notebook_id:
-        return validate_id(notebook_id, "Notebook")
-    # Env-var fallback runs BEFORE the active-context lookup so per-shell
-    # overrides (e.g. ``NOTEBOOKLM_NOTEBOOK=other notebooklm ask "..."``)
-    # compose without clobbering the persisted ``notebooklm use`` selection.
-    # Empty / whitespace-only values are treated as unset (consistent with
-    # ``NOTEBOOKLM_HL``'s same-shape handling) — the next fallback wins.
-    env_value = os.environ.get("NOTEBOOKLM_NOTEBOOK")
-    if env_value and env_value.strip():
-        return validate_id(env_value, "Notebook")
-    current = get_current_notebook()
-    if current:
-        return validate_id(current, "Notebook")
-    console.print(
-        "[red]No notebook specified. Use 'notebooklm use <id>' to set context, "
-        "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK.[/red]"
+    """Get notebook ID from argument, env var, or active context."""
+    return resolve_helpers.require_notebook(
+        notebook_id,
+        context_path_fn=get_context_path,
+        output_console=console,
     )
-    raise SystemExit(1)
 
 
 async def _resolve_partial_id(
@@ -295,122 +245,68 @@ async def _resolve_partial_id(
     *,
     json_output: bool = False,
 ) -> str:
-    """Generic partial ID resolver.
-
-    Allows users to type partial IDs like 'abc' instead of full UUIDs.
-    Matches are case-insensitive prefix matches.
-
-    Args:
-        partial_id: Full or partial ID to resolve
-        list_fn: Async function that returns list of items with id/title attributes
-        entity_name: Name for error messages (e.g., "notebook", "source")
-        list_command: CLI command to list items (e.g., "list", "source list")
-        json_output: When True, the "Matched..." diagnostic is routed to stderr
-            via ``emit_status`` so stdout stays parseable JSON.
-
-    Returns:
-        Full ID of the matched item
-
-    Raises:
-        click.ClickException: If ID is empty, no match, or ambiguous match
-    """
-    # Validate and normalize the ID
-    partial_id = validate_id(partial_id, entity_name)
-
-    # Skip resolution for IDs that look complete (20+ chars)
-    if len(partial_id) >= 20:
-        return partial_id
-
-    items = await list_fn()
-    matches = [item for item in items if item.id.lower().startswith(partial_id.lower())]
-
-    if len(matches) == 1:
-        if matches[0].id != partial_id:
-            title = matches[0].title or "(untitled)"
-            emit_status(
-                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
-                json_output=json_output,
-            )
-        return matches[0].id
-    elif len(matches) == 0:
-        raise click.ClickException(
-            f"No {entity_name} found starting with '{partial_id}'. "
-            f"Run 'notebooklm {list_command}' to see available {entity_name}s."
-        )
-    else:
-        lines = [f"Ambiguous ID '{partial_id}' matches {len(matches)} {entity_name}s:"]
-        for item in matches[:5]:
-            title = item.title or "(untitled)"
-            lines.append(f"  {item.id[:12]}... {title}")
-        if len(matches) > 5:
-            lines.append(f"  ... and {len(matches) - 5} more")
-        lines.append("\nSpecify more characters to narrow down.")
-        raise click.ClickException("\n".join(lines))
+    """Generic partial ID resolver."""
+    return await resolve_helpers._resolve_partial_id(
+        partial_id,
+        list_fn,
+        entity_name,
+        list_command,
+        json_output=json_output,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
+    )
 
 
 async def resolve_notebook_id(client, partial_id: str, *, json_output: bool = False) -> str:
-    """Resolve partial notebook ID to full ID.
-
-    When ``json_output`` is True, the "Matched..." diagnostic for a successful
-    partial match is routed to stderr so stdout stays parseable JSON.
-    """
-    return await _resolve_partial_id(
+    """Resolve partial notebook ID to full ID."""
+    return await resolve_helpers.resolve_notebook_id(
+        client,
         partial_id,
-        list_fn=lambda: client.notebooks.list(),
-        entity_name="notebook",
-        list_command="list",
         json_output=json_output,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
     )
 
 
 async def resolve_source_id(
     client, notebook_id: str, partial_id: str, *, json_output: bool = False
 ) -> str:
-    """Resolve partial source ID to full ID.
-
-    When ``json_output`` is True, the "Matched..." diagnostic for a successful
-    partial match is routed to stderr so stdout stays parseable JSON.
-    """
-    return await _resolve_partial_id(
+    """Resolve partial source ID to full ID."""
+    return await resolve_helpers.resolve_source_id(
+        client,
+        notebook_id,
         partial_id,
-        list_fn=lambda: client.sources.list(notebook_id),
-        entity_name="source",
-        list_command="source list",
         json_output=json_output,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
     )
 
 
 async def resolve_artifact_id(
     client, notebook_id: str, partial_id: str, *, json_output: bool = False
 ) -> str:
-    """Resolve partial artifact ID to full ID.
-
-    When ``json_output`` is True, the "Matched..." diagnostic for a successful
-    partial match is routed to stderr so stdout stays parseable JSON.
-    """
-    return await _resolve_partial_id(
+    """Resolve partial artifact ID to full ID."""
+    return await resolve_helpers.resolve_artifact_id(
+        client,
+        notebook_id,
         partial_id,
-        list_fn=lambda: client.artifacts.list(notebook_id),
-        entity_name="artifact",
-        list_command="artifact list",
         json_output=json_output,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
     )
 
 
 async def resolve_note_id(
     client, notebook_id: str, partial_id: str, *, json_output: bool = False
 ) -> str:
-    """Resolve partial note ID to full ID.
-
-    When ``json_output`` is True, the "Matched..." diagnostic for a successful
-    partial match is routed to stderr so stdout stays parseable JSON.
-    """
-    return await _resolve_partial_id(
+    """Resolve partial note ID to full ID."""
+    return await resolve_helpers.resolve_note_id(
+        client,
+        notebook_id,
         partial_id,
-        list_fn=lambda: client.notes.list(notebook_id),
-        entity_name="note",
-        list_command="note list",
         json_output=json_output,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
     )
 
 
@@ -421,46 +317,20 @@ async def resolve_source_ids(
     *,
     json_output: bool = False,
 ) -> list[str] | None:
-    """Resolve multiple partial source IDs to full IDs.
-
-    Args:
-        client: NotebookLM client
-        notebook_id: Resolved notebook ID
-        source_ids: Tuple of partial source IDs from CLI
-        json_output: When True, "Matched..." diagnostics for partial matches
-            are routed to stderr so stdout stays parseable JSON.
-
-    Returns:
-        List of resolved source IDs, or None if no source IDs provided
-    """
-    if not source_ids:
-        return None
-    resolved = []
-    for sid in source_ids:
-        resolved.append(await resolve_source_id(client, notebook_id, sid, json_output=json_output))
-    return resolved
+    """Resolve multiple partial source IDs to full IDs."""
+    return await resolve_helpers.resolve_source_ids(
+        client,
+        notebook_id,
+        source_ids,
+        json_output=json_output,
+        stdout_console=console,
+        stderr_output_console=stderr_console,
+    )
 
 
 def read_stdin_text(*, source_label: str = "stdin") -> str:
-    """Read all of stdin as UTF-8 text and strip surrounding whitespace.
-
-    Centralizes the Unix ``-`` (stdin) convention used by ``ask``, ``note
-    create``, ``source add``, and ``--prompt-file -``. Uses
-    ``click.get_text_stream("stdin").read()`` so ``CliRunner.invoke(input=...)``
-    in tests is honored without monkey-patching ``sys.stdin``.
-
-    Args:
-        source_label: Label used in error messages (e.g. ``"prompt file"``)
-            so the failure mode tells the user which input was empty.
-
-    Raises:
-        click.ClickException: stdin yields a non-UTF-8 byte sequence.
-    """
-    try:
-        text = click.get_text_stream("stdin").read()
-    except UnicodeDecodeError as e:
-        raise click.ClickException(f"{source_label} (stdin) is not valid UTF-8: {e}") from e
-    return text.strip()
+    """Read all of stdin as UTF-8 text and strip surrounding whitespace."""
+    return input_helpers.read_stdin_text(source_label=source_label)
 
 
 def resolve_prompt(
@@ -470,53 +340,13 @@ def resolve_prompt(
     *,
     required: bool = False,
 ) -> str:
-    """Resolve prompt text from a positional argument or ``--prompt-file``.
-
-    Exactly one source may be provided. The file is read as UTF-8 with surrounding
-    whitespace stripped. When ``required`` is True and neither source yields
-    text, a ``UsageError`` is raised; otherwise an empty string is returned.
-
-    The literal ``-`` is recognized as "read stdin" for either source,
-    matching the Unix convention.
-
-    Args:
-        argument_value: Value of the positional CLI argument (may be empty).
-        prompt_file: Path passed via ``--prompt-file`` (may be ``None``).
-        param_name: Name of the positional argument, used in error messages.
-        required: When True, raise ``UsageError`` if both sources are empty.
-
-    Raises:
-        click.UsageError: Both sources provided, or ``required`` and both empty.
-        click.ClickException: Prompt file unreadable or not valid UTF-8.
-    """
-    if argument_value and prompt_file:
-        raise click.UsageError(
-            f"Cannot use both the {param_name} argument and --prompt-file. Choose one."
-        )
-
-    if prompt_file == "-" or argument_value == "-":
-        # Unix ``-`` convention: read text from stdin. The label hints which
-        # input is the empty one if the required check fires below.
-        label = "prompt file" if prompt_file == "-" else param_name
-        text = read_stdin_text(source_label=label)
-    elif prompt_file:
-        path = Path(prompt_file)
-        if not path.is_file():
-            raise click.ClickException(f"Prompt file '{prompt_file}' is not a regular file.")
-        try:
-            text = path.read_text(encoding="utf-8").strip()
-        except OSError as e:
-            raise click.ClickException(f"Failed to read prompt file '{prompt_file}': {e}") from e
-        except UnicodeDecodeError as e:
-            raise click.ClickException(
-                f"Prompt file '{prompt_file}' is not valid UTF-8: {e}"
-            ) from e
-    else:
-        text = argument_value or ""
-
-    if required and not text:
-        raise click.UsageError(f"Provide a {param_name} argument or --prompt-file.")
-    return text
+    """Resolve prompt text from a positional argument or ``--prompt-file``."""
+    return input_helpers.resolve_prompt(
+        argument_value,
+        prompt_file,
+        param_name,
+        required=required,
+    )
 
 
 # =============================================================================

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import click
 
-_ARGUMENT_STRIP_MAX_CHARS = 10_000
-
 
 def read_stdin_text(*, source_label: str = "stdin") -> str:
     """Read all of stdin as UTF-8 text and strip surrounding whitespace.
@@ -44,11 +42,10 @@ def resolve_prompt(
     """Resolve prompt text from a positional argument or ``--prompt-file``.
 
     Exactly one source may be provided. The file/stdin path is read as UTF-8
-    with surrounding whitespace stripped. Normal-sized argument values are also
-    stripped for consistency; large argument payloads are preserved to avoid an
-    extra full-string allocation. When ``required`` is true and neither source
-    yields text, a ``UsageError`` is raised; otherwise an empty string is
-    returned.
+    with surrounding whitespace stripped. Positional argument values are
+    preserved verbatim for backward compatibility. When ``required`` is true and
+    neither source yields text, a ``UsageError`` is raised; otherwise an empty
+    string is returned.
 
     The literal ``-`` is recognized as "read stdin" for either source, matching
     the Unix convention.
@@ -89,11 +86,7 @@ def resolve_prompt(
                 f"Prompt file '{prompt_file}' is not valid UTF-8: {e}"
             ) from e
     else:
-        text = (
-            argument_value.strip()
-            if argument_value and len(argument_value) < _ARGUMENT_STRIP_MAX_CHARS
-            else argument_value or ""
-        )
+        text = argument_value or ""
 
     if required and not text:
         raise click.UsageError(f"Provide a {param_name} argument or --prompt-file.")

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import click
 
+_ARGUMENT_STRIP_MAX_CHARS = 10_000
+
 
 def read_stdin_text(*, source_label: str = "stdin") -> str:
     """Read all of stdin as UTF-8 text and strip surrounding whitespace.
@@ -41,9 +43,11 @@ def resolve_prompt(
 ) -> str:
     """Resolve prompt text from a positional argument or ``--prompt-file``.
 
-    Exactly one source may be provided. The file is read as UTF-8 with
-    surrounding whitespace stripped. When ``required`` is true and neither
-    source yields text, a ``UsageError`` is raised; otherwise an empty string is
+    Exactly one source may be provided. The file/stdin path is read as UTF-8
+    with surrounding whitespace stripped. Normal-sized argument values are also
+    stripped for consistency; large argument payloads are preserved to avoid an
+    extra full-string allocation. When ``required`` is true and neither source
+    yields text, a ``UsageError`` is raised; otherwise an empty string is
     returned.
 
     The literal ``-`` is recognized as "read stdin" for either source, matching
@@ -85,7 +89,11 @@ def resolve_prompt(
                 f"Prompt file '{prompt_file}' is not valid UTF-8: {e}"
             ) from e
     else:
-        text = argument_value or ""
+        text = (
+            argument_value.strip()
+            if argument_value and len(argument_value) < _ARGUMENT_STRIP_MAX_CHARS
+            else argument_value or ""
+        )
 
     if required and not text:
         raise click.UsageError(f"Provide a {param_name} argument or --prompt-file.")

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -19,6 +19,9 @@ def read_stdin_text(*, source_label: str = "stdin") -> str:
         source_label: Label used in error messages, e.g. ``"prompt file"``, so
             the failure mode identifies which input was empty or invalid.
 
+    Returns:
+        UTF-8 stdin text with surrounding whitespace removed.
+
     Raises:
         click.ClickException: If stdin yields a non-UTF-8 byte sequence.
     """

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -55,6 +55,10 @@ def resolve_prompt(
         param_name: Name of the positional argument, used in error messages.
         required: When true, raise ``UsageError`` if both sources are empty.
 
+    Returns:
+        Resolved and stripped prompt text, or an empty string when no source is
+        provided and ``required`` is false.
+
     Raises:
         click.UsageError: Both sources are provided, or ``required`` is true and
             both are empty.

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -1,0 +1,85 @@
+"""CLI prompt and stdin input helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+
+def read_stdin_text(*, source_label: str = "stdin") -> str:
+    """Read all of stdin as UTF-8 text and strip surrounding whitespace.
+
+    Centralizes the Unix ``-`` stdin convention used by ``ask``, ``note
+    create``, ``source add``, and ``--prompt-file -``. Uses
+    ``click.get_text_stream("stdin").read()`` so ``CliRunner.invoke(input=...)``
+    in tests is honored without monkey-patching ``sys.stdin``.
+
+    Args:
+        source_label: Label used in error messages, e.g. ``"prompt file"``, so
+            the failure mode identifies which input was empty or invalid.
+
+    Raises:
+        click.ClickException: If stdin yields a non-UTF-8 byte sequence.
+    """
+    try:
+        text = click.get_text_stream("stdin").read()
+    except UnicodeDecodeError as e:
+        raise click.ClickException(f"{source_label} (stdin) is not valid UTF-8: {e}") from e
+    return text.strip()
+
+
+def resolve_prompt(
+    argument_value: str | None,
+    prompt_file: str | None,
+    param_name: str = "prompt",
+    *,
+    required: bool = False,
+) -> str:
+    """Resolve prompt text from a positional argument or ``--prompt-file``.
+
+    Exactly one source may be provided. The file is read as UTF-8 with
+    surrounding whitespace stripped. When ``required`` is true and neither
+    source yields text, a ``UsageError`` is raised; otherwise an empty string is
+    returned.
+
+    The literal ``-`` is recognized as "read stdin" for either source, matching
+    the Unix convention.
+
+    Args:
+        argument_value: Value of the positional CLI argument, if any.
+        prompt_file: Path passed via ``--prompt-file``, or ``None``.
+        param_name: Name of the positional argument, used in error messages.
+        required: When true, raise ``UsageError`` if both sources are empty.
+
+    Raises:
+        click.UsageError: Both sources are provided, or ``required`` is true and
+            both are empty.
+        click.ClickException: Prompt file is unreadable or not valid UTF-8.
+    """
+    if argument_value and prompt_file:
+        raise click.UsageError(
+            f"Cannot use both the {param_name} argument and --prompt-file. Choose one."
+        )
+
+    if prompt_file == "-" or argument_value == "-":
+        label = "prompt file" if prompt_file == "-" else param_name
+        text = read_stdin_text(source_label=label)
+    elif prompt_file:
+        path = Path(prompt_file)
+        if not path.is_file():
+            raise click.ClickException(f"Prompt file '{prompt_file}' is not a regular file.")
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            raise click.ClickException(f"Failed to read prompt file '{prompt_file}': {e}") from e
+        except UnicodeDecodeError as e:
+            raise click.ClickException(
+                f"Prompt file '{prompt_file}' is not valid UTF-8: {e}"
+            ) from e
+    else:
+        text = argument_value or ""
+
+    if required and not text:
+        raise click.UsageError(f"Provide a {param_name} argument or --prompt-file.")
+    return text

--- a/src/notebooklm/cli/input.py
+++ b/src/notebooklm/cli/input.py
@@ -57,8 +57,9 @@ def resolve_prompt(
         required: When true, raise ``UsageError`` if both sources are empty.
 
     Returns:
-        Resolved and stripped prompt text, or an empty string when no source is
-        provided and ``required`` is false.
+        Resolved prompt text, or an empty string when no source is provided and
+        ``required`` is false. File/stdin sources are whitespace-stripped;
+        positional arguments are preserved verbatim.
 
     Raises:
         click.UsageError: Both sources are provided, or ``required`` is true and

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -21,13 +21,11 @@ from .error_handler import _output_error
 from .helpers import (
     console,
     json_output_response,
-    read_stdin_text,
-    require_notebook,
-    resolve_note_id,
-    resolve_notebook_id,
     with_client,
 )
+from .input import read_stdin_text
 from .options import json_option, notebook_option
+from .resolve import require_notebook, resolve_note_id, resolve_notebook_id
 
 
 @click.group()

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -22,12 +22,11 @@ from .helpers import (
     console,
     get_current_notebook,
     json_output_response,
-    require_notebook,
-    resolve_notebook_id,
     set_current_notebook,
     with_client,
 )
 from .options import list_options, notebook_option
+from .resolve import require_notebook, resolve_notebook_id
 
 
 def register_notebook_commands(cli):

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -42,14 +42,21 @@ def _emit_status(
         target.print(msg)
 
 
-def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
+def emit_status(
+    msg: str,
+    *,
+    json_output: bool,
+    style: str | None = None,
+    stdout_console: Console = console,
+    stderr_output_console: Console = stderr_console,
+) -> None:
     """Emit a status / diagnostic line."""
     _emit_status(
         msg,
         json_output=json_output,
         style=style,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
+        stdout_console=stdout_console,
+        stderr_output_console=stderr_output_console,
     )
 
 

--- a/src/notebooklm/cli/rendering.py
+++ b/src/notebooklm/cli/rendering.py
@@ -33,8 +33,8 @@ def _emit_status(
     stdout_console: Console = console,
     stderr_output_console: Console = stderr_console,
 ) -> None:
-    # ``cli.helpers`` calls this private variant to preserve helper-level
-    # Console patch seams while the public rendering helper uses local defaults.
+    # Shared implementation for callers that need explicit stdout/stderr
+    # console injection while preserving the public ``emit_status`` wrapper.
     target = stderr_output_console if json_output else stdout_console
     if style is not None:
         target.print(msg, style=style)

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -279,13 +279,23 @@ async def resolve_source_ids(
     """
     if not source_ids:
         return None
+
+    sources = None
+
+    async def list_sources():
+        nonlocal sources
+        if sources is None:
+            sources = await client.sources.list(notebook_id)
+        return sources
+
     resolved = []
     for source_id in source_ids:
         resolved.append(
-            await resolve_source_id(
-                client,
-                notebook_id,
+            await _resolve_partial_id(
                 source_id,
+                list_fn=list_sources,
+                entity_name="source",
+                list_command="source list",
                 json_output=json_output,
                 stdout_console=stdout_console,
                 stderr_output_console=stderr_output_console,

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -284,25 +285,25 @@ async def resolve_source_ids(
     if not source_ids:
         return None
 
-    sources = None
+    validated_source_ids = tuple(validate_id(source_id, "source") for source_id in source_ids)
+    sources = await client.sources.list(notebook_id)
 
     async def list_sources():
-        nonlocal sources
-        if sources is None:
-            sources = await client.sources.list(notebook_id)
         return sources
 
-    resolved = []
-    for source_id in source_ids:
-        resolved.append(
-            await _resolve_partial_id(
-                source_id,
-                list_fn=list_sources,
-                entity_name="source",
-                list_command="source list",
-                json_output=json_output,
-                stdout_console=stdout_console,
-                stderr_output_console=stderr_output_console,
+    return list(
+        await asyncio.gather(
+            *(
+                _resolve_partial_id(
+                    source_id,
+                    list_fn=list_sources,
+                    entity_name="source",
+                    list_command="source list",
+                    json_output=json_output,
+                    stdout_console=stdout_console,
+                    stderr_output_console=stderr_output_console,
+                )
+                for source_id in validated_source_ids
             )
         )
-    return resolved
+    )

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -308,7 +308,8 @@ async def resolve_source_ids(
     async def list_sources():
         return sources
 
-    return await asyncio.gather(
+    unique_source_ids = tuple(dict.fromkeys(validated_source_ids))
+    resolved_unique = await asyncio.gather(
         *(
             _resolve_partial_id(
                 source_id,
@@ -319,6 +320,8 @@ async def resolve_source_ids(
                 stdout_console=stdout_console,
                 stderr_output_console=stderr_output_console,
             )
-            for source_id in validated_source_ids
+            for source_id in unique_source_ids
         )
     )
+    resolved_by_input = dict(zip(unique_source_ids, resolved_unique, strict=True))
+    return [resolved_by_input[source_id] for source_id in validated_source_ids]

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -130,6 +130,8 @@ async def _resolve_partial_id(
     """
     partial_id = validate_id(partial_id, entity_name)
 
+    # Concrete IDs are passed through so direct get/delete commands can hit
+    # the backend by ID without forcing an extra list RPC first.
     if _is_full_id_candidate(partial_id):
         return partial_id
 
@@ -303,19 +305,17 @@ async def resolve_source_ids(
     async def list_sources():
         return sources
 
-    return list(
-        await asyncio.gather(
-            *(
-                _resolve_partial_id(
-                    source_id,
-                    list_fn=list_sources,
-                    entity_name="source",
-                    list_command="source list",
-                    json_output=json_output,
-                    stdout_console=stdout_console,
-                    stderr_output_console=stderr_output_console,
-                )
-                for source_id in validated_source_ids
+    return await asyncio.gather(
+        *(
+            _resolve_partial_id(
+                source_id,
+                list_fn=list_sources,
+                entity_name="source",
+                list_command="source list",
+                json_output=json_output,
+                stdout_console=stdout_console,
+                stderr_output_console=stderr_output_console,
             )
+            for source_id in validated_source_ids
         )
     )

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -1,0 +1,294 @@
+"""CLI notebook/entity ID resolution helpers."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+
+from ..paths import get_context_path
+from . import context as context_helpers
+from . import rendering as rendering_helpers
+
+ContextPathFn = Callable[..., Path]
+ListFn = Callable[[], Awaitable[list[Any]]]
+
+
+def validate_id(entity_id: str, entity_name: str = "ID") -> str:
+    """Validate and normalize an entity ID.
+
+    Args:
+        entity_id: The ID to validate.
+        entity_name: Name for error messages, e.g. ``"notebook"`` or
+            ``"source"``.
+
+    Returns:
+        Stripped ID.
+
+    Raises:
+        click.ClickException: If ID is empty or whitespace-only.
+    """
+    if not entity_id or not entity_id.strip():
+        raise click.ClickException(f"{entity_name} ID cannot be empty")
+    return entity_id.strip()
+
+
+def require_notebook(
+    notebook_id: str | None,
+    *,
+    context_path_fn: ContextPathFn = get_context_path,
+    output_console: Console = rendering_helpers.console,
+) -> str:
+    """Get notebook ID from argument, env var, or active context.
+
+    Resolution order (env-var precedence):
+
+    1. ``notebook_id`` argument (the resolved value of the ``-n/--notebook``
+       Click flag, which is already env-var-aware via ``cli/options.py``).
+    2. ``NOTEBOOKLM_NOTEBOOK`` environment variable.
+    3. The persisted active-notebook context written by ``notebooklm use``.
+    4. Hard error with a discoverability hint listing all resolution paths.
+
+    Args:
+        notebook_id: Optional notebook ID from command argument. When the
+            Click flag was omitted and the env var was unset, this is ``None``.
+        context_path_fn: Context-path resolver, injectable for compatibility
+            wrappers and tests.
+        output_console: Console used for the no-notebook diagnostic.
+
+    Returns:
+        Notebook ID from argument, env var, or context, validated and stripped.
+
+    Raises:
+        SystemExit: If no notebook ID can be resolved from any source.
+        click.ClickException: If the resolved notebook ID is empty/whitespace
+            after stripping.
+    """
+    if notebook_id:
+        return validate_id(notebook_id, "Notebook")
+
+    env_value = os.environ.get("NOTEBOOKLM_NOTEBOOK")
+    if env_value and env_value.strip():
+        return validate_id(env_value, "Notebook")
+
+    current = context_helpers.get_current_notebook(context_path_fn=context_path_fn)
+    if current:
+        return validate_id(current, "Notebook")
+
+    output_console.print(
+        "[red]No notebook specified. Use 'notebooklm use <id>' to set context, "
+        "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK.[/red]"
+    )
+    raise SystemExit(1)
+
+
+async def _resolve_partial_id(
+    partial_id: str,
+    list_fn: ListFn,
+    entity_name: str,
+    list_command: str,
+    *,
+    json_output: bool = False,
+    stdout_console: Console = rendering_helpers.console,
+    stderr_output_console: Console = rendering_helpers.stderr_console,
+) -> str:
+    """Resolve a case-insensitive partial ID prefix to a full entity ID.
+
+    Allows users to type partial IDs like ``abc`` instead of full UUIDs.
+    Matches are case-insensitive prefix matches. IDs that look complete
+    (20+ chars) are returned unchanged without a list call.
+
+    Args:
+        partial_id: Full or partial ID to resolve.
+        list_fn: Async function returning items with ``id`` and ``title``
+            attributes.
+        entity_name: Name for error messages, e.g. ``"notebook"``.
+        list_command: CLI command to list items, e.g. ``"source list"``.
+        json_output: When true, the successful "Matched..." diagnostic routes
+            to stderr so stdout stays parseable JSON.
+        stdout_console: Console for human-mode diagnostics.
+        stderr_output_console: Console for JSON-mode diagnostics.
+
+    Returns:
+        Full ID of the matched item.
+
+    Raises:
+        click.ClickException: If ID is empty, no match exists, or the prefix is
+            ambiguous.
+    """
+    partial_id = validate_id(partial_id, entity_name)
+
+    if len(partial_id) >= 20:
+        return partial_id
+
+    items = await list_fn()
+    matches = [item for item in items if item.id.lower().startswith(partial_id.lower())]
+
+    if len(matches) == 1:
+        if matches[0].id != partial_id:
+            title = matches[0].title or "(untitled)"
+            rendering_helpers._emit_status(
+                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
+                json_output=json_output,
+                stdout_console=stdout_console,
+                stderr_output_console=stderr_output_console,
+            )
+        return matches[0].id
+
+    if len(matches) == 0:
+        raise click.ClickException(
+            f"No {entity_name} found starting with '{partial_id}'. "
+            f"Run 'notebooklm {list_command}' to see available {entity_name}s."
+        )
+
+    lines = [f"Ambiguous ID '{partial_id}' matches {len(matches)} {entity_name}s:"]
+    for item in matches[:5]:
+        title = item.title or "(untitled)"
+        lines.append(f"  {item.id[:12]}... {title}")
+    if len(matches) > 5:
+        lines.append(f"  ... and {len(matches) - 5} more")
+    lines.append("\nSpecify more characters to narrow down.")
+    raise click.ClickException("\n".join(lines))
+
+
+async def resolve_notebook_id(
+    client,
+    partial_id: str,
+    *,
+    json_output: bool = False,
+    stdout_console: Console = rendering_helpers.console,
+    stderr_output_console: Console = rendering_helpers.stderr_console,
+) -> str:
+    """Resolve partial notebook ID to full ID.
+
+    When ``json_output`` is true, the successful "Matched..." diagnostic routes
+    to stderr so stdout stays parseable JSON.
+    """
+    return await _resolve_partial_id(
+        partial_id,
+        list_fn=lambda: client.notebooks.list(),
+        entity_name="notebook",
+        list_command="list",
+        json_output=json_output,
+        stdout_console=stdout_console,
+        stderr_output_console=stderr_output_console,
+    )
+
+
+async def resolve_source_id(
+    client,
+    notebook_id: str,
+    partial_id: str,
+    *,
+    json_output: bool = False,
+    stdout_console: Console = rendering_helpers.console,
+    stderr_output_console: Console = rendering_helpers.stderr_console,
+) -> str:
+    """Resolve partial source ID to full ID.
+
+    When ``json_output`` is true, the successful "Matched..." diagnostic routes
+    to stderr so stdout stays parseable JSON.
+    """
+    return await _resolve_partial_id(
+        partial_id,
+        list_fn=lambda: client.sources.list(notebook_id),
+        entity_name="source",
+        list_command="source list",
+        json_output=json_output,
+        stdout_console=stdout_console,
+        stderr_output_console=stderr_output_console,
+    )
+
+
+async def resolve_artifact_id(
+    client,
+    notebook_id: str,
+    partial_id: str,
+    *,
+    json_output: bool = False,
+    stdout_console: Console = rendering_helpers.console,
+    stderr_output_console: Console = rendering_helpers.stderr_console,
+) -> str:
+    """Resolve partial artifact ID to full ID.
+
+    When ``json_output`` is true, the successful "Matched..." diagnostic routes
+    to stderr so stdout stays parseable JSON.
+    """
+    return await _resolve_partial_id(
+        partial_id,
+        list_fn=lambda: client.artifacts.list(notebook_id),
+        entity_name="artifact",
+        list_command="artifact list",
+        json_output=json_output,
+        stdout_console=stdout_console,
+        stderr_output_console=stderr_output_console,
+    )
+
+
+async def resolve_note_id(
+    client,
+    notebook_id: str,
+    partial_id: str,
+    *,
+    json_output: bool = False,
+    stdout_console: Console = rendering_helpers.console,
+    stderr_output_console: Console = rendering_helpers.stderr_console,
+) -> str:
+    """Resolve partial note ID to full ID.
+
+    When ``json_output`` is true, the successful "Matched..." diagnostic routes
+    to stderr so stdout stays parseable JSON.
+    """
+    return await _resolve_partial_id(
+        partial_id,
+        list_fn=lambda: client.notes.list(notebook_id),
+        entity_name="note",
+        list_command="note list",
+        json_output=json_output,
+        stdout_console=stdout_console,
+        stderr_output_console=stderr_output_console,
+    )
+
+
+async def resolve_source_ids(
+    client,
+    notebook_id: str,
+    source_ids: tuple[str, ...],
+    *,
+    json_output: bool = False,
+    stdout_console: Console = rendering_helpers.console,
+    stderr_output_console: Console = rendering_helpers.stderr_console,
+) -> list[str] | None:
+    """Resolve multiple partial source IDs to full IDs.
+
+    Args:
+        client: NotebookLM client.
+        notebook_id: Resolved notebook ID.
+        source_ids: Tuple of partial source IDs from CLI.
+        json_output: When true, "Matched..." diagnostics for partial matches
+            route to stderr so stdout stays parseable JSON.
+        stdout_console: Console for human-mode diagnostics.
+        stderr_output_console: Console for JSON-mode diagnostics.
+
+    Returns:
+        List of resolved source IDs, or ``None`` if no source IDs were provided.
+    """
+    if not source_ids:
+        return None
+    resolved = []
+    for source_id in source_ids:
+        resolved.append(
+            await resolve_source_id(
+                client,
+                notebook_id,
+                source_id,
+                json_output=json_output,
+                stdout_console=stdout_console,
+                stderr_output_console=stderr_output_console,
+            )
+        )
+    return resolved

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -17,6 +17,7 @@ from . import rendering as rendering_helpers
 
 ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
+_FULL_ID_MIN_LEN = 20
 
 
 def validate_id(entity_id: str, entity_name: str = "ID") -> str:
@@ -36,6 +37,11 @@ def validate_id(entity_id: str, entity_name: str = "ID") -> str:
     if not entity_id or not entity_id.strip():
         raise click.ClickException(f"{entity_name} ID cannot be empty")
     return entity_id.strip()
+
+
+def _is_full_id_candidate(entity_id: str) -> bool:
+    """Return whether an ID is long enough to be treated as concrete."""
+    return len(entity_id) >= _FULL_ID_MIN_LEN
 
 
 def require_notebook(
@@ -123,6 +129,9 @@ async def _resolve_partial_id(
             ambiguous.
     """
     partial_id = validate_id(partial_id, entity_name)
+
+    if _is_full_id_candidate(partial_id):
+        return partial_id
 
     items = await list_fn()
     partial_id_lower = partial_id.lower()
@@ -286,6 +295,9 @@ async def resolve_source_ids(
         return None
 
     validated_source_ids = tuple(validate_id(source_id, "source") for source_id in source_ids)
+    if all(_is_full_id_candidate(source_id) for source_id in validated_source_ids):
+        return list(validated_source_ids)
+
     sources = await client.sources.list(notebook_id)
 
     async def list_sources():

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -16,7 +16,6 @@ from . import rendering as rendering_helpers
 
 ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
-_FULL_ID_MIN_LEN = 20
 
 
 def validate_id(entity_id: str, entity_name: str = "ID") -> str:
@@ -99,9 +98,10 @@ async def _resolve_partial_id(
 ) -> str:
     """Resolve a case-insensitive partial ID prefix to a full entity ID.
 
-    Allows users to type partial IDs like ``abc`` instead of full UUIDs.
-    Matches are case-insensitive prefix matches. IDs that look complete
-    (20+ chars) are returned unchanged without a list call.
+    Allows users to type partial IDs like ``abc`` instead of full IDs.
+    Exact matches are preferred before case-insensitive prefix matches so a
+    short-but-complete ID is not treated as ambiguous when another entity
+    shares that prefix.
 
     Args:
         partial_id: Full or partial ID to resolve.
@@ -123,11 +123,14 @@ async def _resolve_partial_id(
     """
     partial_id = validate_id(partial_id, entity_name)
 
-    if len(partial_id) >= _FULL_ID_MIN_LEN:
-        return partial_id
-
     items = await list_fn()
-    matches = [item for item in items if item.id.lower().startswith(partial_id.lower())]
+    partial_id_lower = partial_id.lower()
+
+    for item in items:
+        if item.id.lower() == partial_id_lower:
+            return item.id
+
+    matches = [item for item in items if item.id.lower().startswith(partial_id_lower)]
 
     if len(matches) == 1:
         if matches[0].id != partial_id:

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -141,6 +141,7 @@ async def _resolve_partial_id(
     matches = []
     for item in items:
         item_id_lower = item.id.lower()
+        # Exact short IDs win over prefix matches to avoid false ambiguity.
         if item_id_lower == partial_id_lower:
             return item.id
         if item_id_lower.startswith(partial_id_lower):

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -138,11 +138,13 @@ async def _resolve_partial_id(
     items = await list_fn()
     partial_id_lower = partial_id.lower()
 
+    matches = []
     for item in items:
-        if item.id.lower() == partial_id_lower:
+        item_id_lower = item.id.lower()
+        if item_id_lower == partial_id_lower:
             return item.id
-
-    matches = [item for item in items if item.id.lower().startswith(partial_id_lower)]
+        if item_id_lower.startswith(partial_id_lower):
+            matches.append(item)
 
     if len(matches) == 1:
         if matches[0].id != partial_id:

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -16,6 +16,7 @@ from . import rendering as rendering_helpers
 
 ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
+_FULL_ID_MIN_LEN = 20
 
 
 def validate_id(entity_id: str, entity_name: str = "ID") -> str:
@@ -122,7 +123,7 @@ async def _resolve_partial_id(
     """
     partial_id = validate_id(partial_id, entity_name)
 
-    if len(partial_id) >= 20:
+    if len(partial_id) >= _FULL_ID_MIN_LEN:
         return partial_id
 
     items = await list_fn()
@@ -131,7 +132,7 @@ async def _resolve_partial_id(
     if len(matches) == 1:
         if matches[0].id != partial_id:
             title = matches[0].title or "(untitled)"
-            rendering_helpers._emit_status(
+            rendering_helpers.emit_status(
                 f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
                 json_output=json_output,
                 stdout_console=stdout_console,

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -1020,7 +1020,10 @@ class TestNotebookMetadata:
             mock_client_cls.return_value = mock_client
 
             with (
-                patch("notebooklm.cli.helpers.get_current_notebook", return_value="nb_1"),
+                patch(
+                    "notebooklm.cli.resolve.context_helpers.get_current_notebook",
+                    return_value="nb_1",
+                ),
                 patch(
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
@@ -1058,7 +1061,10 @@ class TestNotebookMetadata:
             mock_client_cls.return_value = mock_client
 
             with (
-                patch("notebooklm.cli.helpers.get_current_notebook", return_value="nb_1"),
+                patch(
+                    "notebooklm.cli.resolve.context_helpers.get_current_notebook",
+                    return_value="nb_1",
+                ),
                 patch(
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
@@ -1089,7 +1095,10 @@ class TestNotebookMetadata:
             mock_client_cls.return_value = mock_client
 
             with (
-                patch("notebooklm.cli.helpers.get_current_notebook", return_value="nb_empty"),
+                patch(
+                    "notebooklm.cli.resolve.context_helpers.get_current_notebook",
+                    return_value="nb_empty",
+                ),
                 patch(
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
@@ -1125,7 +1134,10 @@ class TestNotebookMetadata:
             mock_client_cls.return_value = mock_client
 
             with (
-                patch("notebooklm.cli.helpers.get_current_notebook", return_value="nb_url"),
+                patch(
+                    "notebooklm.cli.resolve.context_helpers.get_current_notebook",
+                    return_value="nb_url",
+                ),
                 patch(
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,

--- a/tests/unit/cli/test_prompt_file.py
+++ b/tests/unit/cli/test_prompt_file.py
@@ -28,6 +28,14 @@ class TestResolvePrompt:
     def test_uses_argument_when_prompt_file_missing(self):
         assert resolve_prompt("hello", None, "question") == "hello"
 
+    def test_strips_normal_sized_argument_whitespace(self):
+        assert resolve_prompt("  hello from argument \n", None, "question") == "hello from argument"
+
+    def test_preserves_large_argument_without_stripping(self):
+        large_prompt = f" {'x' * 10000} "
+
+        assert resolve_prompt(large_prompt, None, "question") == large_prompt
+
     def test_reads_prompt_file_and_strips_whitespace(self, tmp_path):
         prompt_file = tmp_path / "prompt.txt"
         prompt_file.write_text("hello from file\n\n", encoding="utf-8")

--- a/tests/unit/cli/test_prompt_file.py
+++ b/tests/unit/cli/test_prompt_file.py
@@ -28,13 +28,10 @@ class TestResolvePrompt:
     def test_uses_argument_when_prompt_file_missing(self):
         assert resolve_prompt("hello", None, "question") == "hello"
 
-    def test_strips_normal_sized_argument_whitespace(self):
-        assert resolve_prompt("  hello from argument \n", None, "question") == "hello from argument"
+    def test_preserves_argument_whitespace(self):
+        prompt = "  hello from argument \n"
 
-    def test_preserves_large_argument_without_stripping(self):
-        large_prompt = f" {'x' * 10000} "
-
-        assert resolve_prompt(large_prompt, None, "question") == large_prompt
+        assert resolve_prompt(prompt, None, "question") == prompt
 
     def test_reads_prompt_file_and_strips_whitespace(self, tmp_path):
         prompt_file = tmp_path / "prompt.txt"

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -481,3 +481,14 @@ class TestResolveSourceIds:
 
         assert result == ["src123def456ghi789", "xyz789uvw456rst123"]
         mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
+
+    @pytest.mark.asyncio
+    async def test_empty_source_id_raises_before_listing(self, mock_client_with_sources):
+        """Invalid multi-source input does not trigger a source-list RPC."""
+        mock_client_with_sources.sources.list = AsyncMock()
+
+        with pytest.raises(click.ClickException) as exc_info:
+            await resolve_source_ids(mock_client_with_sources, "nb_123", ("xyz", ""))
+
+        assert "cannot be empty" in str(exc_info.value)
+        mock_client_with_sources.sources.list.assert_not_called()

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -467,6 +467,25 @@ class TestResolveSourceIds:
         mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
 
     @pytest.mark.asyncio
+    async def test_duplicate_partial_ids_resolve_once_preserving_duplicates(
+        self, mock_client_with_sources, sample_sources
+    ):
+        """Duplicate partial IDs produce one status message but preserve output shape."""
+        mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
+        mock_console = MagicMock()
+
+        result = await resolve_source_ids(
+            mock_client_with_sources,
+            "nb_123",
+            ("xyz", "xyz"),
+            stdout_console=mock_console,
+        )
+
+        assert result == ["xyz789uvw456rst123", "xyz789uvw456rst123"]
+        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
+        mock_console.print.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_empty_source_id_raises_before_listing(self, mock_client_with_sources):
         """Invalid multi-source input does not trigger a source-list RPC."""
         mock_client_with_sources.sources.list = AsyncMock()

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import click
 import pytest
 
-from notebooklm.cli.helpers import resolve_notebook_id, resolve_source_id
+from notebooklm.cli.helpers import resolve_notebook_id, resolve_source_id, resolve_source_ids
 from notebooklm.types import Notebook, Source
 
 
@@ -356,3 +356,34 @@ class TestResolveSourceIdAmbiguityDisplay:
         error_msg = str(exc_info.value)
         assert "First Source" in error_msg
         assert "Third Source" in error_msg
+
+
+class TestResolveSourceIds:
+    """Test multiple source ID resolution."""
+
+    @pytest.mark.asyncio
+    async def test_reuses_source_list_for_multiple_partial_ids(
+        self, mock_client_with_sources, sample_sources
+    ):
+        """Multiple partial IDs share one sources.list call."""
+        mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
+
+        with patch("notebooklm.cli.helpers.console"):
+            result = await resolve_source_ids(mock_client_with_sources, "nb_123", ("xyz", "src999"))
+
+        assert result == ["xyz789uvw456rst123", "src999zzz888yyy777"]
+        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
+
+    @pytest.mark.asyncio
+    async def test_full_ids_skip_source_list(self, mock_client_with_sources):
+        """Full source IDs keep the no-list behavior for direct IDs."""
+        mock_client_with_sources.sources.list = AsyncMock()
+
+        result = await resolve_source_ids(
+            mock_client_with_sources,
+            "nb_123",
+            ("src123def456ghi78900", "xyz789uvw456rst12300"),
+        )
+
+        assert result == ["src123def456ghi78900", "xyz789uvw456rst12300"]
+        mock_client_with_sources.sources.list.assert_not_called()

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -81,6 +81,32 @@ class TestResolveNotebookId:
         assert "abc999" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_exact_match_wins_over_prefix_ambiguity(self, mock_client):
+        """Exact short IDs win even when another item shares that prefix."""
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[
+                Notebook(
+                    id="abc",
+                    title="Exact Notebook",
+                    created_at=datetime(2024, 1, 1),
+                    is_owner=True,
+                ),
+                Notebook(
+                    id="abc123def456ghi789",
+                    title="Prefixed Notebook",
+                    created_at=datetime(2024, 1, 2),
+                    is_owner=True,
+                ),
+            ]
+        )
+
+        mock_console = MagicMock()
+        result = await resolve_notebook_id(mock_client, "abc", stdout_console=mock_console)
+
+        assert result == "abc"
+        mock_console.print.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_no_match_raises_exception(self, mock_client, sample_notebooks):
         """No matching prefix raises ClickException with helpful message."""
         mock_client.notebooks.list = AsyncMock(return_value=sample_notebooks)
@@ -92,16 +118,24 @@ class TestResolveNotebookId:
         assert "notebooklm list" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_long_id_skips_resolution(self, mock_client):
-        """IDs >= 20 chars skip resolution and return unchanged."""
-        mock_client.notebooks.list = AsyncMock()
-
+    async def test_long_id_resolves_against_list(self, mock_client):
+        """Long IDs are still resolved so ambiguous prefixes are not skipped."""
         long_id = "a" * 20
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[
+                Notebook(
+                    id=long_id,
+                    title="Long ID Notebook",
+                    created_at=datetime(2024, 1, 1),
+                    is_owner=True,
+                )
+            ]
+        )
+
         result = await resolve_notebook_id(mock_client, long_id)
 
         assert result == long_id
-        # Should NOT call notebooks.list
-        mock_client.notebooks.list.assert_not_called()
+        mock_client.notebooks.list.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_empty_id_raises_exception(self, mock_client):
@@ -265,6 +299,27 @@ class TestResolveSourceId:
         assert "src999" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_exact_match_wins_over_prefix_ambiguity(self, mock_client_with_sources):
+        """Exact short source IDs win even when another source shares that prefix."""
+        mock_client_with_sources.sources.list = AsyncMock(
+            return_value=[
+                Source(id="src", title="Exact Source"),
+                Source(id="src123def456ghi789", title="Prefixed Source"),
+            ]
+        )
+
+        mock_console = MagicMock()
+        result = await resolve_source_id(
+            mock_client_with_sources,
+            "nb_123",
+            "src",
+            stdout_console=mock_console,
+        )
+
+        assert result == "src"
+        mock_console.print.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_no_match_raises_exception(self, mock_client_with_sources, sample_sources):
         """No matching prefix raises ClickException with helpful message."""
         mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
@@ -276,16 +331,17 @@ class TestResolveSourceId:
         assert "notebooklm source list" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_long_id_skips_resolution(self, mock_client_with_sources):
-        """IDs >= 20 chars skip resolution and return unchanged."""
-        mock_client_with_sources.sources.list = AsyncMock()
-
+    async def test_long_id_resolves_against_list(self, mock_client_with_sources):
+        """Long IDs are still resolved so ambiguous prefixes are not skipped."""
         long_id = "a" * 20
+        mock_client_with_sources.sources.list = AsyncMock(
+            return_value=[Source(id=long_id, title="Long ID Source")]
+        )
+
         result = await resolve_source_id(mock_client_with_sources, "nb_123", long_id)
 
         assert result == long_id
-        # Should NOT call sources.list
-        mock_client_with_sources.sources.list.assert_not_called()
+        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
 
     @pytest.mark.asyncio
     async def test_empty_id_raises_exception(self, mock_client_with_sources):
@@ -391,9 +447,14 @@ class TestResolveSourceIds:
         mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
 
     @pytest.mark.asyncio
-    async def test_full_ids_skip_source_list(self, mock_client_with_sources):
-        """Full source IDs keep the no-list behavior for direct IDs."""
-        mock_client_with_sources.sources.list = AsyncMock()
+    async def test_full_ids_share_one_source_list(self, mock_client_with_sources):
+        """Full source IDs resolve exactly while sharing one source list."""
+        mock_client_with_sources.sources.list = AsyncMock(
+            return_value=[
+                Source(id="src123def456ghi78900", title="First Source"),
+                Source(id="xyz789uvw456rst12300", title="Second Source"),
+            ]
+        )
 
         result = await resolve_source_ids(
             mock_client_with_sources,
@@ -402,21 +463,21 @@ class TestResolveSourceIds:
         )
 
         assert result == ["src123def456ghi78900", "xyz789uvw456rst12300"]
-        mock_client_with_sources.sources.list.assert_not_called()
+        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
 
     @pytest.mark.asyncio
     async def test_mixed_full_and_partial_ids_list_once(
         self, mock_client_with_sources, sample_sources
     ):
-        """Full IDs skip listing while partial IDs reuse one shared list call."""
+        """Full and partial IDs share one source list call."""
         mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
 
         result = await resolve_source_ids(
             mock_client_with_sources,
             "nb_123",
-            ("src123def456ghi78900", "xyz"),
+            ("src123def456ghi789", "xyz"),
             stdout_console=MagicMock(),
         )
 
-        assert result == ["src123def456ghi78900", "xyz789uvw456rst123"]
+        assert result == ["src123def456ghi789", "xyz789uvw456rst123"]
         mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -118,24 +118,15 @@ class TestResolveNotebookId:
         assert "notebooklm list" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_long_id_resolves_against_list(self, mock_client):
-        """Long IDs are still resolved so ambiguous prefixes are not skipped."""
+    async def test_long_id_returns_without_listing(self, mock_client):
+        """Long IDs are treated as concrete IDs and do not list notebooks."""
         long_id = "a" * 20
-        mock_client.notebooks.list = AsyncMock(
-            return_value=[
-                Notebook(
-                    id=long_id,
-                    title="Long ID Notebook",
-                    created_at=datetime(2024, 1, 1),
-                    is_owner=True,
-                )
-            ]
-        )
+        mock_client.notebooks.list = AsyncMock()
 
         result = await resolve_notebook_id(mock_client, long_id)
 
         assert result == long_id
-        mock_client.notebooks.list.assert_awaited_once()
+        mock_client.notebooks.list.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_empty_id_raises_exception(self, mock_client):
@@ -331,17 +322,15 @@ class TestResolveSourceId:
         assert "notebooklm source list" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_long_id_resolves_against_list(self, mock_client_with_sources):
-        """Long IDs are still resolved so ambiguous prefixes are not skipped."""
+    async def test_long_id_returns_without_listing(self, mock_client_with_sources):
+        """Long IDs are treated as concrete IDs and do not list sources."""
         long_id = "a" * 20
-        mock_client_with_sources.sources.list = AsyncMock(
-            return_value=[Source(id=long_id, title="Long ID Source")]
-        )
+        mock_client_with_sources.sources.list = AsyncMock()
 
         result = await resolve_source_id(mock_client_with_sources, "nb_123", long_id)
 
         assert result == long_id
-        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
+        mock_client_with_sources.sources.list.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_empty_id_raises_exception(self, mock_client_with_sources):
@@ -447,14 +436,9 @@ class TestResolveSourceIds:
         mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
 
     @pytest.mark.asyncio
-    async def test_full_ids_share_one_source_list(self, mock_client_with_sources):
-        """Full source IDs resolve exactly while sharing one source list."""
-        mock_client_with_sources.sources.list = AsyncMock(
-            return_value=[
-                Source(id="src123def456ghi78900", title="First Source"),
-                Source(id="xyz789uvw456rst12300", title="Second Source"),
-            ]
-        )
+    async def test_full_ids_skip_source_list(self, mock_client_with_sources):
+        """Full source IDs pass through without a source list call."""
+        mock_client_with_sources.sources.list = AsyncMock()
 
         result = await resolve_source_ids(
             mock_client_with_sources,
@@ -463,7 +447,7 @@ class TestResolveSourceIds:
         )
 
         assert result == ["src123def456ghi78900", "xyz789uvw456rst12300"]
-        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
+        mock_client_with_sources.sources.list.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_mixed_full_and_partial_ids_list_once(

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -1,12 +1,12 @@
 """Tests for resolve_notebook_id and resolve_source_id partial ID matching."""
 
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import click
 import pytest
 
-from notebooklm.cli.helpers import resolve_notebook_id, resolve_source_id, resolve_source_ids
+from notebooklm.cli.resolve import resolve_notebook_id, resolve_source_id, resolve_source_ids
 from notebooklm.types import Notebook, Source
 
 
@@ -60,8 +60,8 @@ class TestResolveNotebookId:
         mock_client.notebooks.list = AsyncMock(return_value=sample_notebooks)
 
         # "xyz" uniquely matches "xyz789uvw456rst123"
-        with patch("notebooklm.cli.helpers.console") as mock_console:
-            result = await resolve_notebook_id(mock_client, "xyz")
+        mock_console = MagicMock()
+        result = await resolve_notebook_id(mock_client, "xyz", stdout_console=mock_console)
 
         assert result == "xyz789uvw456rst123"
         # Should print a match message
@@ -131,8 +131,7 @@ class TestResolveNotebookId:
         mock_client.notebooks.list = AsyncMock(return_value=sample_notebooks)
 
         # "XYZ" should match "xyz789..." (case-insensitive)
-        with patch("notebooklm.cli.helpers.console"):
-            result = await resolve_notebook_id(mock_client, "XYZ")
+        result = await resolve_notebook_id(mock_client, "XYZ", stdout_console=MagicMock())
 
         assert result == "xyz789uvw456rst123"
 
@@ -153,8 +152,8 @@ class TestResolveNotebookId:
             ]
         )
 
-        with patch("notebooklm.cli.helpers.console") as mock_console:
-            result = await resolve_notebook_id(mock_client, "shortid")
+        mock_console = MagicMock()
+        result = await resolve_notebook_id(mock_client, "shortid", stdout_console=mock_console)
 
         assert result == "shortid"
         # Should NOT print match message since it's an exact match
@@ -238,8 +237,13 @@ class TestResolveSourceId:
         mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
 
         # "xyz" uniquely matches "xyz789uvw456rst123"
-        with patch("notebooklm.cli.helpers.console") as mock_console:
-            result = await resolve_source_id(mock_client_with_sources, "nb_123", "xyz")
+        mock_console = MagicMock()
+        result = await resolve_source_id(
+            mock_client_with_sources,
+            "nb_123",
+            "xyz",
+            stdout_console=mock_console,
+        )
 
         assert result == "xyz789uvw456rst123"
         # Should print a match message
@@ -311,8 +315,12 @@ class TestResolveSourceId:
         mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
 
         # "XYZ" should match "xyz789..." (case-insensitive)
-        with patch("notebooklm.cli.helpers.console"):
-            result = await resolve_source_id(mock_client_with_sources, "nb_123", "XYZ")
+        result = await resolve_source_id(
+            mock_client_with_sources,
+            "nb_123",
+            "XYZ",
+            stdout_console=MagicMock(),
+        )
 
         assert result == "xyz789uvw456rst123"
 
@@ -321,8 +329,12 @@ class TestResolveSourceId:
         """Should pass the notebook ID to sources.list."""
         mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
 
-        with patch("notebooklm.cli.helpers.console"):
-            await resolve_source_id(mock_client_with_sources, "my_notebook_id", "xyz")
+        await resolve_source_id(
+            mock_client_with_sources,
+            "my_notebook_id",
+            "xyz",
+            stdout_console=MagicMock(),
+        )
 
         mock_client_with_sources.sources.list.assert_called_once_with("my_notebook_id")
 
@@ -368,8 +380,12 @@ class TestResolveSourceIds:
         """Multiple partial IDs share one sources.list call."""
         mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
 
-        with patch("notebooklm.cli.helpers.console"):
-            result = await resolve_source_ids(mock_client_with_sources, "nb_123", ("xyz", "src999"))
+        result = await resolve_source_ids(
+            mock_client_with_sources,
+            "nb_123",
+            ("xyz", "src999"),
+            stdout_console=MagicMock(),
+        )
 
         assert result == ["xyz789uvw456rst123", "src999zzz888yyy777"]
         mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
@@ -387,3 +403,20 @@ class TestResolveSourceIds:
 
         assert result == ["src123def456ghi78900", "xyz789uvw456rst12300"]
         mock_client_with_sources.sources.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mixed_full_and_partial_ids_list_once(
+        self, mock_client_with_sources, sample_sources
+    ):
+        """Full IDs skip listing while partial IDs reuse one shared list call."""
+        mock_client_with_sources.sources.list = AsyncMock(return_value=sample_sources)
+
+        result = await resolve_source_ids(
+            mock_client_with_sources,
+            "nb_123",
+            ("src123def456ghi78900", "xyz"),
+            stdout_console=MagicMock(),
+        )
+
+        assert result == ["src123def456ghi78900", "xyz789uvw456rst123"]
+        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -92,6 +92,7 @@ CONTEXT_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
 AUTH_RUNTIME_ALLOWED_MODULES = {"error_handler", "helpers"}
 RESOLVE_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
     "auth_runtime",
+    "completion",
     "helpers",
     "runtime",
 }

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -42,6 +42,7 @@ RENDERING_PATH = CLI_ROOT / "rendering.py"
 CONTEXT_PATH = CLI_ROOT / "context.py"
 RUNTIME_PATH = CLI_ROOT / "runtime.py"
 AUTH_RUNTIME_PATH = CLI_ROOT / "auth_runtime.py"
+RESOLVE_PATH = CLI_ROOT / "resolve.py"
 COMPLETION_CALLBACKS = {
     "_complete_artifacts",
     "_complete_notebooks",
@@ -89,6 +90,12 @@ CONTEXT_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
     "runtime",
 }
 AUTH_RUNTIME_ALLOWED_MODULES = {"error_handler", "helpers"}
+RESOLVE_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
+    "auth",
+    "auth_runtime",
+    "helpers",
+    "runtime",
+}
 
 
 def _is_private_segment(seg: str) -> bool:
@@ -147,6 +154,39 @@ def _cli_module_imports(path: pathlib.Path) -> set[str]:
                 if parts[:2] == ["notebooklm", "cli"] and len(parts) > 2:
                     imports.add(parts[2])
     return imports
+
+
+def _imports_notebooklm_auth(tree: ast.AST) -> list[str]:
+    """Return imports that bind CLI code directly to notebooklm.auth."""
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            mod_parts = mod.split(".") if mod else []
+            if node.level == 0:
+                if mod_parts[:2] == ["notebooklm", "auth"]:
+                    offenders.append(f"from {mod} import ...")
+                elif mod_parts == ["notebooklm"]:
+                    offenders.extend(
+                        f"from notebooklm import {alias.name}"
+                        for alias in node.names
+                        if alias.name == "auth"
+                    )
+            elif node.level >= 2:
+                if mod_parts[:1] == ["auth"]:
+                    offenders.append(f"from {'.' * node.level}{mod} import ...")
+                elif not mod:
+                    offenders.extend(
+                        f"from {'.' * node.level} import {alias.name}"
+                        for alias in node.names
+                        if alias.name == "auth"
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                parts = alias.name.split(".")
+                if parts[:2] == ["notebooklm", "auth"]:
+                    offenders.append(f"import {alias.name}")
+    return offenders
 
 
 @pytest.mark.parametrize(
@@ -372,6 +412,21 @@ def test_auth_runtime_imports_only_runtime_facade_collaborators() -> None:
         "cli.auth_runtime must not import command, rendering, context, resolve, "
         "input, or completion modules directly. "
         f"Offenders: {sorted(imports - AUTH_RUNTIME_ALLOWED_MODULES)}"
+    )
+
+
+def test_resolve_stays_off_helpers_runtime_auth_and_commands() -> None:
+    """Partial-ID resolution stays below helpers/runtime/auth and command modules."""
+    imports = _cli_module_imports(RESOLVE_PATH)
+    auth_imports = _imports_notebooklm_auth(ast.parse(RESOLVE_PATH.read_text(encoding="utf-8")))
+
+    assert not (imports & RESOLVE_FORBIDDEN_MODULES), (
+        "cli.resolve must not import cli.helpers, cli.runtime/auth_runtime, "
+        f"or command modules. Offenders: {sorted(imports & RESOLVE_FORBIDDEN_MODULES)}"
+    )
+    assert not auth_imports, (
+        "cli.resolve must not import notebooklm.auth; keep auth/runtime work outside "
+        f"the resolver layer. Offenders: {auth_imports}"
     )
 
 

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -91,7 +91,6 @@ CONTEXT_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
 }
 AUTH_RUNTIME_ALLOWED_MODULES = {"error_handler", "helpers"}
 RESOLVE_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
-    "auth",
     "auth_runtime",
     "helpers",
     "runtime",

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -56,6 +56,24 @@ def _storage_auth(tmp_path) -> tuple[AuthTokens, "object"]:
     return auth, storage_path
 
 
+async def _read_storage_text_when_available(storage_path):
+    """Read storage text, retrying transient Windows sharing violations."""
+    for _ in range(50):
+        try:
+            return storage_path.read_text()
+        except PermissionError:
+            await asyncio.sleep(0.05)
+    return storage_path.read_text()
+
+
+async def _wait_until_storage_contains(storage_path, needle: str, failure_message: str) -> None:
+    for _ in range(50):
+        if needle in await _read_storage_text_when_available(storage_path):
+            return
+        await asyncio.sleep(0.05)
+    pytest.fail(failure_message)
+
+
 class TestKeepaliveDisabledByDefault:
     @pytest.mark.asyncio
     async def test_keepalive_off_by_default(self, mock_auth, httpx_mock: HTTPXMock):
@@ -320,12 +338,11 @@ class TestKeepaliveExplicitStoragePath:
         )
 
         async with client:
-            for _ in range(50):
-                if "rotated_via_explicit" in storage_path.read_text():
-                    break
-                await asyncio.sleep(0.05)
-            else:
-                pytest.fail("Rotated cookie was not persisted to the explicit storage path")
+            await _wait_until_storage_contains(
+                storage_path,
+                "rotated_via_explicit",
+                "Rotated cookie was not persisted to the explicit storage path",
+            )
 
     def test_explicit_storage_path_normalizes_onto_auth_without_mutating_caller(self, tmp_path):
         """The constructor exposes ``storage_path`` on ``client.auth`` so
@@ -423,18 +440,15 @@ class TestKeepalivePersistence:
 
         async with client:
             # Wait long enough for at least one poke + persist
-            for _ in range(50):
-                if "rotated_value_xyz" in storage_path.read_text():
-                    break
-                await asyncio.sleep(0.05)
-            else:
-                pytest.fail(
-                    "Rotated cookie was not persisted to storage_state.json before __aexit__ ran"
-                )
+            await _wait_until_storage_contains(
+                storage_path,
+                "rotated_value_xyz",
+                "Rotated cookie was not persisted to storage_state.json before __aexit__ ran",
+            )
 
             # Sanity: the rotated cookie was written *while* the client was open,
             # not just at close time.
-            data = json.loads(storage_path.read_text())
+            data = json.loads(await _read_storage_text_when_available(storage_path))
             cookie_names = {c["name"] for c in data["cookies"]}
             assert "__Secure-1PSIDTS" in cookie_names
 


### PR DESCRIPTION
## Summary
- Add `cli.resolve` for notebook/source/artifact/note partial-ID resolution and `require_notebook`.
- Add `cli.input` for stdin and prompt-file resolution.
- Keep `helpers.py` compatibility wrappers while moving scoped command imports to the new modules.
- Add an import-boundary test proving `cli.resolve` stays off helpers/runtime/auth and command modules.

## Test plan
- [x] `rtk uv run --extra dev pytest -n auto tests/unit/cli/test_helpers.py::TestRequireNotebook tests/unit/cli/test_resolve.py tests/unit/cli/test_prompt_file.py tests/unit/cli/test_chat.py tests/unit/cli/test_note.py tests/unit/cli/test_notebook.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py`
- [x] `rtk uv run --extra dev ruff check src/notebooklm/cli/resolve.py src/notebooklm/cli/input.py src/notebooklm/cli/helpers.py src/notebooklm/cli/chat.py src/notebooklm/cli/note.py src/notebooklm/cli/notebook.py tests/unit/cli/test_helpers.py tests/unit/cli/test_resolve.py tests/unit/cli/test_prompt_file.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py`
- [x] `rtk uv run --extra dev ruff format --check src/notebooklm/cli/resolve.py src/notebooklm/cli/input.py src/notebooklm/cli/helpers.py src/notebooklm/cli/chat.py src/notebooklm/cli/note.py src/notebooklm/cli/notebook.py tests/unit/cli/test_helpers.py tests/unit/cli/test_resolve.py tests/unit/cli/test_prompt_file.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py`
- [x] `rtk uv run --extra dev mypy src/notebooklm`
- [x] `rtk git diff --check`

## Polish evidence
- Step 4.1 code-simplifier fallback: no simplification changes needed.
- Step 4.2 triple review: Gemini found one important docstring regression, fixed before PR; external Codex found no actionable issues.
- Step 4.3 ultrathink: no additional issues.

## Deferred polish findings
- Keep helper wrappers: required for compatibility by the task.
- Consider publicizing `rendering._emit_status` console-injection API in a future cleanup; out of scope for this split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI helpers into dedicated input, resolve, and facade layers; public CLI behavior unchanged.
  * Rendering status output now accepts injected consoles for testability.

* **New Features / UX**
  * Prompt/file/stdin handling: stricter UTF-8, file, and empty-input validation with clearer errors.
  * Partial-ID resolution: prefix matching with user-facing diagnostics for no or ambiguous matches.

* **Tests**
  * Added unit tests for resolver behavior and import-boundary guardrails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->