### PR TITLE
refactor(cli): extract artifact generation service

### DIFF
--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -13,11 +13,7 @@ Commands:
     report       Generate report
 """
 
-import asyncio
-import contextlib
 import os
-import time
-from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 import click
@@ -27,7 +23,6 @@ from ..client import NotebookLMClient
 from ..types import (
     AudioFormat,
     AudioLength,
-    GenerationStatus,
     InfographicDetail,
     InfographicOrientation,
     InfographicStyle,
@@ -39,7 +34,6 @@ from ..types import (
     VideoFormat,
     VideoStyle,
 )
-from .error_handler import emit_cancelled_and_exit
 from .helpers import (
     console,
     json_error_response,
@@ -60,13 +54,20 @@ from .options import (
     retry_option,
     wait_polling_options,
 )
+from .services import artifact_generation as _artifact_generation
 
 DEFAULT_LANGUAGE = "en"
 
-# Retry constants
-RETRY_INITIAL_DELAY = 60.0  # seconds
-RETRY_MAX_DELAY = 300.0  # 5 minutes
-RETRY_BACKOFF_MULTIPLIER = 2.0
+RETRY_INITIAL_DELAY = _artifact_generation.RETRY_INITIAL_DELAY
+RETRY_MAX_DELAY = _artifact_generation.RETRY_MAX_DELAY
+RETRY_BACKOFF_MULTIPLIER = _artifact_generation.RETRY_BACKOFF_MULTIPLIER
+_format_status_message = _artifact_generation._format_status_message
+_status_with_elapsed = _artifact_generation._status_with_elapsed
+calculate_backoff_delay = _artifact_generation.calculate_backoff_delay
+generate_with_retry = _artifact_generation.generate_with_retry
+handle_generation_result = _artifact_generation.handle_generation_result
+_extract_task_id = _artifact_generation._extract_task_id
+_output_generation_status = _artifact_generation._output_generation_status
 
 _INFOGRAPHIC_STYLE_MAP = {
     "auto": InfographicStyle.AUTO_SELECT,
@@ -81,164 +82,6 @@ _INFOGRAPHIC_STYLE_MAP = {
     "kawaii": InfographicStyle.KAWAII,
     "scientific": InfographicStyle.SCIENTIFIC,
 }
-
-
-# Typical-duration hints for the spinner status line.
-# Empirical observation; the API exposes no progress channel so these are
-# user-facing wall-clock heuristics, not authoritative ETAs. Missing keys fall
-# back to no hint — the spinner still renders kind + elapsed seconds.
-_TYPICAL_DURATIONS: dict[str, str] = {
-    "audio": "typically 2-5 min",
-    "video": "typically 5-15 min",
-    "cinematic-video": "typically 30-40 min",
-    "slide-deck": "typically 1-3 min",
-    "quiz": "typically 30-60 sec",
-    "flashcards": "typically 30-60 sec",
-    "infographic": "typically 1-3 min",
-    "data-table": "typically 30-90 sec",
-    "mind-map": "typically 30-90 sec",
-    "report": "typically 1-3 min",
-}
-
-
-def _format_status_message(artifact_type: str, elapsed: float | None = None) -> str:
-    """Build the spinner status line for a long-running generation.
-
-    Mirrors the format suggested in the audit — kind + typical-duration
-    hint + optional elapsed timer. ``elapsed`` is ``None`` on first paint and
-    an integer seconds value once the periodic ticker starts updating.
-    """
-    hint = _TYPICAL_DURATIONS.get(artifact_type)
-    suffix = f" ({hint})" if hint else ""
-    base = f"Waiting for {artifact_type} generation{suffix}..."
-    if elapsed is None:
-        return base
-    return f"{base} [{int(elapsed)}s elapsed]"
-
-
-@contextlib.asynccontextmanager
-async def _status_with_elapsed(
-    artifact_type: str,
-    *,
-    json_output: bool = False,
-    resume_hint: str | None = None,
-) -> AsyncIterator[None]:
-    """Show a Rich spinner with a periodically updated elapsed timer.
-
-    No-op (for the spinner) when ``json_output`` is True so stdout stays pure
-    JSON for automation. The spinner is transient — it disappears on exit, so
-    the final ``[green]... ready[/green]`` line is the only persistent output.
-
-    The ticker task updates the status text once per second while the wrapped
-    coroutine awaits the long-running call. Cancellation is best-effort: if
-    the wrapped block raises, the ticker is cancelled in ``finally`` and the
-    exception propagates unchanged.
-
-    SIGINT handling: when ``resume_hint`` is provided, a
-    ``KeyboardInterrupt`` raised inside the wrapped block is caught and
-    converted into a friendly cancellation message via
-    :func:`emit_cancelled_and_exit`, which prints
-    ``Cancelled. Resume with: <resume_hint>`` to stderr (or a structured
-    ``CANCELLED`` envelope under ``--json``) and exits 130. When
-    ``resume_hint`` is ``None`` the interrupt propagates so the generic
-    handler in ``error_handler.handle_errors`` keeps owning non-wait paths.
-    """
-
-    @contextlib.contextmanager
-    def _sigint_guard() -> Any:
-        try:
-            yield
-        except KeyboardInterrupt:
-            if resume_hint is None:
-                raise
-            emit_cancelled_and_exit(resume_hint, json_output=json_output)
-
-    if json_output:
-        with _sigint_guard():
-            yield
-        return
-    start = time.monotonic()
-    initial = _format_status_message(artifact_type)
-    with console.status(initial) as status:
-
-        async def _ticker() -> None:
-            while True:
-                await asyncio.sleep(1.0)
-                status.update(_format_status_message(artifact_type, time.monotonic() - start))
-
-        ticker_task = asyncio.create_task(_ticker())
-        try:
-            with _sigint_guard():
-                yield
-        finally:
-            ticker_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await ticker_task
-
-
-def calculate_backoff_delay(
-    attempt: int,
-    initial_delay: float = RETRY_INITIAL_DELAY,
-    max_delay: float = RETRY_MAX_DELAY,
-    multiplier: float = RETRY_BACKOFF_MULTIPLIER,
-) -> float:
-    """Calculate exponential backoff delay for a retry attempt.
-
-    Args:
-        attempt: The current attempt number (0-indexed).
-        initial_delay: Initial delay in seconds.
-        max_delay: Maximum delay cap in seconds.
-        multiplier: Backoff multiplier.
-
-    Returns:
-        Delay in seconds for this attempt.
-    """
-    delay = initial_delay * (multiplier**attempt)
-    return min(delay, max_delay)
-
-
-async def generate_with_retry(
-    generate_fn: Callable[[], Awaitable[GenerationStatus | None]],
-    max_retries: int,
-    artifact_type: str,
-    json_output: bool = False,
-) -> GenerationStatus | None:
-    """Generate artifact with retry on rate limit.
-
-    Retries the generation call with exponential backoff when rate limited.
-    Always makes at least one attempt, even when max_retries=0.
-
-    Args:
-        generate_fn: Async function that performs the generation.
-        max_retries: Maximum number of retries (0 = no retry, just one attempt).
-        artifact_type: Display name for progress messages.
-        json_output: Whether to suppress console output.
-
-    Returns:
-        GenerationStatus or None if generation failed.
-    """
-    for attempt in range(max_retries + 1):
-        result = await generate_fn()
-
-        # Return immediately if not rate limited (success or other failure)
-        if not isinstance(result, GenerationStatus) or not result.is_rate_limited:
-            return result
-
-        # Rate limited with no retries left
-        if attempt >= max_retries:
-            return result
-
-        # Wait before retry
-        delay = calculate_backoff_delay(attempt)
-        if not json_output:
-            console.print(
-                f"[yellow]{artifact_type.title()} rate limited. "
-                f"Retrying in {int(delay)}s (attempt {attempt + 2}/{max_retries + 1})...[/yellow]"
-            )
-        await asyncio.sleep(delay)
-
-    # Unreachable, but satisfies type checker
-    return None
 
 
 def resolve_language(language: str | None) -> str:
@@ -275,160 +118,6 @@ def resolve_language(language: str | None) -> str:
             )
         return config_lang
     return DEFAULT_LANGUAGE
-
-
-async def handle_generation_result(
-    client: NotebookLMClient,
-    notebook_id: str,
-    result: Any,
-    artifact_type: str,
-    wait: bool = False,
-    json_output: bool = False,
-    timeout: float = 300.0,
-    interval: float | None = None,
-) -> GenerationStatus | None:
-    """Handle generation result with optional waiting and output formatting.
-
-    Consolidates common pattern across all generate commands:
-    - Check for None/failed result
-    - Optionally wait for completion
-    - Output status in JSON or console format
-
-    Args:
-        client: The NotebookLM client.
-        notebook_id: The notebook ID.
-        result: The generation result from artifacts API.
-        artifact_type: Display name for the artifact type (e.g., "audio", "video").
-        wait: Whether to wait for completion.
-        json_output: Whether to output as JSON.
-        timeout: Timeout for waiting (default: 300s).
-        interval: Polling interval in seconds. ``None`` (default) lets
-            ``wait_for_completion`` use its built-in default
-            (``initial_interval=2.0``); when supplied, the value is forwarded
-            as ``initial_interval`` so callers can tighten or loosen the
-            cadence.
-
-    Returns:
-        Final GenerationStatus, or None if generation failed.
-    """
-    # Handle failed generation or rate limiting
-    if not result:
-        if json_output:
-            json_error_response(
-                "GENERATION_FAILED",
-                f"{artifact_type.title()} generation failed",
-            )
-        else:
-            console.print(f"[red]{artifact_type.title()} generation failed.[/red]")
-        return None
-
-    # Check for rate limiting (result exists but failed due to rate limit)
-    if isinstance(result, GenerationStatus) and result.is_rate_limited:
-        if json_output:
-            json_error_response(
-                "RATE_LIMITED",
-                f"{artifact_type.title()} generation rate limited by Google",
-            )
-        else:
-            console.print(
-                f"[red]{artifact_type.title()} generation rate limited by Google.[/red]\n"
-                "[yellow]Daily quota may be exceeded. Try again in 1-24 hours, "
-                "or use --retry N to retry automatically.[/yellow]"
-            )
-        return result
-
-    # Extract task_id from various result formats
-    task_id: str | None = None
-    status: Any = result
-    if isinstance(result, GenerationStatus):
-        task_id = result.task_id
-        status = result
-    elif isinstance(result, dict):
-        task_id = result.get("artifact_id") or result.get("task_id")
-        status = result
-    elif isinstance(result, list) and len(result) > 0:
-        task_id = result[0] if isinstance(result[0], str) else None
-        status = result
-
-    # Wait for completion if requested
-    if wait and task_id:
-        if not json_output:
-            console.print(f"[yellow]Generating {artifact_type}...[/yellow] Task: {task_id}")
-        wait_kwargs: dict[str, Any] = {"timeout": timeout}
-        if interval is not None:
-            wait_kwargs["initial_interval"] = interval
-        # Wrap the blocking poll in a transient spinner so interactive users see
-        # progress feedback during long generations. The status
-        # line includes the artifact kind, a typical-duration hint, and a
-        # live elapsed-seconds counter. No-op under --json.
-        #
-        # The ``resume_hint`` plumbs the canonical M2 cancellation message
-        # (``Cancelled. Resume with: notebooklm artifact poll <task_id>``)
-        # so Ctrl-C during the wait surfaces the resume command instead of
-        # a Python KeyboardInterrupt traceback. See ``cli/error_handler.py``
-        # ``emit_cancelled_and_exit``.
-        async with _status_with_elapsed(
-            artifact_type,
-            json_output=json_output,
-            resume_hint=f"notebooklm artifact poll {task_id}",
-        ):
-            status = await client.artifacts.wait_for_completion(notebook_id, task_id, **wait_kwargs)
-
-    # Output status
-    _output_generation_status(status, artifact_type, json_output)
-
-    return status if isinstance(status, GenerationStatus) else None
-
-
-def _extract_task_id(status: Any) -> str | None:
-    """Extract task ID from various status formats.
-
-    Handles GenerationStatus objects, dicts with task_id/artifact_id keys,
-    and lists where the first element is an ID string.
-    """
-    if hasattr(status, "task_id"):
-        return status.task_id
-    if isinstance(status, dict):
-        return status.get("task_id") or status.get("artifact_id")
-    if isinstance(status, list) and len(status) > 0 and isinstance(status[0], str):
-        return status[0]
-    return None
-
-
-def _output_generation_status(status: Any, artifact_type: str, json_output: bool) -> None:
-    """Output generation status in appropriate format."""
-    is_complete = hasattr(status, "is_complete") and status.is_complete
-    is_failed = hasattr(status, "is_failed") and status.is_failed
-
-    if json_output:
-        if is_complete:
-            json_output_response(
-                {
-                    "task_id": getattr(status, "task_id", None),
-                    "status": "completed",
-                    "url": getattr(status, "url", None),
-                }
-            )
-        elif is_failed:
-            json_error_response(
-                "GENERATION_FAILED",
-                getattr(status, "error", None) or f"{artifact_type.title()} generation failed",
-            )
-        else:
-            task_id = _extract_task_id(status)
-            json_output_response({"task_id": task_id, "status": "pending"})
-    else:
-        if is_complete:
-            url = getattr(status, "url", None)
-            if url:
-                console.print(f"[green]{artifact_type.title()} ready:[/green] {url}")
-            else:
-                console.print(f"[green]{artifact_type.title()} ready[/green]")
-        elif is_failed:
-            console.print(f"[red]Failed:[/red] {getattr(status, 'error', 'Unknown error')}")
-        else:
-            task_id = _extract_task_id(status)
-            console.print(f"[yellow]Started:[/yellow] {task_id or status}")
 
 
 @click.group()

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -54,20 +54,9 @@ from .options import (
     retry_option,
     wait_polling_options,
 )
-from .services import artifact_generation as _artifact_generation
+from .services.artifact_generation import generate_with_retry, handle_generation_result
 
 DEFAULT_LANGUAGE = "en"
-
-RETRY_INITIAL_DELAY = _artifact_generation.RETRY_INITIAL_DELAY
-RETRY_MAX_DELAY = _artifact_generation.RETRY_MAX_DELAY
-RETRY_BACKOFF_MULTIPLIER = _artifact_generation.RETRY_BACKOFF_MULTIPLIER
-_format_status_message = _artifact_generation._format_status_message
-_status_with_elapsed = _artifact_generation._status_with_elapsed
-calculate_backoff_delay = _artifact_generation.calculate_backoff_delay
-generate_with_retry = _artifact_generation.generate_with_retry
-handle_generation_result = _artifact_generation.handle_generation_result
-_extract_task_id = _artifact_generation._extract_task_id
-_output_generation_status = _artifact_generation._output_generation_status
 
 _INFOGRAPHIC_STYLE_MAP = {
     "auto": InfographicStyle.AUTO_SELECT,

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -235,18 +235,8 @@ async def handle_generation_result(
             )
         return result
 
-    # Extract task_id from various result formats
-    task_id: str | None = None
     status: Any = result
-    if isinstance(result, GenerationStatus):
-        task_id = result.task_id
-        status = result
-    elif isinstance(result, dict):
-        task_id = result.get("artifact_id") or result.get("task_id")
-        status = result
-    elif isinstance(result, list) and len(result) > 0:
-        task_id = result[0] if isinstance(result[0], str) else None
-        status = result
+    task_id = _extract_generation_task_id(result)
 
     # Wait for completion if requested
     if wait and task_id:
@@ -276,6 +266,22 @@ async def handle_generation_result(
     _output_generation_status(status, artifact_type, json_output)
 
     return status if isinstance(status, GenerationStatus) else None
+
+
+def _extract_generation_task_id(result: Any) -> str | None:
+    """Extract the task ID used to wait after a generation-start response.
+
+    Generation-start dicts historically prefer ``artifact_id`` over
+    ``task_id``. Keep that precedence separate from final status rendering,
+    where ``_extract_task_id`` preserves the existing ``task_id``-first order.
+    """
+    if isinstance(result, GenerationStatus):
+        return result.task_id
+    if isinstance(result, dict):
+        return result.get("artifact_id") or result.get("task_id")
+    if isinstance(result, list) and len(result) > 0 and isinstance(result[0], str):
+        return result[0]
+    return None
 
 
 def _extract_task_id(status: Any) -> str | None:

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -329,7 +329,7 @@ def _output_generation_status(status: Any, artifact_type: str, json_output: bool
             else:
                 console.print(f"[green]{artifact_type.title()} ready[/green]")
         elif is_failed:
-            console.print(f"[red]Failed:[/red] {getattr(status, 'error', 'Unknown error')}")
+            console.print(f"[red]Failed:[/red] {getattr(status, 'error', None) or 'Unknown error'}")
         else:
             task_id = _extract_task_id(status)
             console.print(f"[yellow]Started:[/yellow] {task_id or status}")

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -1,0 +1,329 @@
+"""CLI-internal services for artifact generation commands."""
+
+import asyncio
+import contextlib
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+from ...client import NotebookLMClient
+from ...types import GenerationStatus
+from ..error_handler import emit_cancelled_and_exit
+from ..helpers import console, json_error_response, json_output_response
+
+# Retry constants
+RETRY_INITIAL_DELAY = 60.0  # seconds
+RETRY_MAX_DELAY = 300.0  # 5 minutes
+RETRY_BACKOFF_MULTIPLIER = 2.0
+
+
+# Typical-duration hints for the spinner status line.
+# Empirical observation; the API exposes no progress channel so these are
+# user-facing wall-clock heuristics, not authoritative ETAs. Missing keys fall
+# back to no hint — the spinner still renders kind + elapsed seconds.
+_TYPICAL_DURATIONS: dict[str, str] = {
+    "audio": "typically 2-5 min",
+    "video": "typically 5-15 min",
+    "cinematic-video": "typically 30-40 min",
+    "slide-deck": "typically 1-3 min",
+    "quiz": "typically 30-60 sec",
+    "flashcards": "typically 30-60 sec",
+    "infographic": "typically 1-3 min",
+    "data-table": "typically 30-90 sec",
+    "mind-map": "typically 30-90 sec",
+    "report": "typically 1-3 min",
+}
+
+
+def _format_status_message(artifact_type: str, elapsed: float | None = None) -> str:
+    """Build the spinner status line for a long-running generation.
+
+    Mirrors the format suggested in the audit — kind + typical-duration
+    hint + optional elapsed timer. ``elapsed`` is ``None`` on first paint and
+    an integer seconds value once the periodic ticker starts updating.
+    """
+    hint = _TYPICAL_DURATIONS.get(artifact_type)
+    suffix = f" ({hint})" if hint else ""
+    base = f"Waiting for {artifact_type} generation{suffix}..."
+    if elapsed is None:
+        return base
+    return f"{base} [{int(elapsed)}s elapsed]"
+
+
+@contextlib.asynccontextmanager
+async def _status_with_elapsed(
+    artifact_type: str,
+    *,
+    json_output: bool = False,
+    resume_hint: str | None = None,
+) -> AsyncIterator[None]:
+    """Show a Rich spinner with a periodically updated elapsed timer.
+
+    No-op (for the spinner) when ``json_output`` is True so stdout stays pure
+    JSON for automation. The spinner is transient — it disappears on exit, so
+    the final ``[green]... ready[/green]`` line is the only persistent output.
+
+    The ticker task updates the status text once per second while the wrapped
+    coroutine awaits the long-running call. Cancellation is best-effort: if
+    the wrapped block raises, the ticker is cancelled in ``finally`` and the
+    exception propagates unchanged.
+
+    SIGINT handling: when ``resume_hint`` is provided, a
+    ``KeyboardInterrupt`` raised inside the wrapped block is caught and
+    converted into a friendly cancellation message via
+    :func:`emit_cancelled_and_exit`, which prints
+    ``Cancelled. Resume with: <resume_hint>`` to stderr (or a structured
+    ``CANCELLED`` envelope under ``--json``) and exits 130. When
+    ``resume_hint`` is ``None`` the interrupt propagates so the generic
+    handler in ``error_handler.handle_errors`` keeps owning non-wait paths.
+    """
+
+    @contextlib.contextmanager
+    def _sigint_guard() -> Any:
+        try:
+            yield
+        except KeyboardInterrupt:
+            if resume_hint is None:
+                raise
+            emit_cancelled_and_exit(resume_hint, json_output=json_output)
+
+    if json_output:
+        with _sigint_guard():
+            yield
+        return
+    start = time.monotonic()
+    initial = _format_status_message(artifact_type)
+    with console.status(initial) as status:
+
+        async def _ticker() -> None:
+            while True:
+                await asyncio.sleep(1.0)
+                status.update(_format_status_message(artifact_type, time.monotonic() - start))
+
+        ticker_task = asyncio.create_task(_ticker())
+        try:
+            with _sigint_guard():
+                yield
+        finally:
+            ticker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await ticker_task
+
+
+def calculate_backoff_delay(
+    attempt: int,
+    initial_delay: float = RETRY_INITIAL_DELAY,
+    max_delay: float = RETRY_MAX_DELAY,
+    multiplier: float = RETRY_BACKOFF_MULTIPLIER,
+) -> float:
+    """Calculate exponential backoff delay for a retry attempt.
+
+    Args:
+        attempt: The current attempt number (0-indexed).
+        initial_delay: Initial delay in seconds.
+        max_delay: Maximum delay cap in seconds.
+        multiplier: Backoff multiplier.
+
+    Returns:
+        Delay in seconds for this attempt.
+    """
+    delay = initial_delay * (multiplier**attempt)
+    return min(delay, max_delay)
+
+
+async def generate_with_retry(
+    generate_fn: Callable[[], Awaitable[GenerationStatus | None]],
+    max_retries: int,
+    artifact_type: str,
+    json_output: bool = False,
+) -> GenerationStatus | None:
+    """Generate artifact with retry on rate limit.
+
+    Retries the generation call with exponential backoff when rate limited.
+    Always makes at least one attempt, even when max_retries=0.
+
+    Args:
+        generate_fn: Async function that performs the generation.
+        max_retries: Maximum number of retries (0 = no retry, just one attempt).
+        artifact_type: Display name for progress messages.
+        json_output: Whether to suppress console output.
+
+    Returns:
+        GenerationStatus or None if generation failed.
+    """
+    for attempt in range(max_retries + 1):
+        result = await generate_fn()
+
+        # Return immediately if not rate limited (success or other failure)
+        if not isinstance(result, GenerationStatus) or not result.is_rate_limited:
+            return result
+
+        # Rate limited with no retries left
+        if attempt >= max_retries:
+            return result
+
+        # Wait before retry
+        delay = calculate_backoff_delay(attempt)
+        if not json_output:
+            console.print(
+                f"[yellow]{artifact_type.title()} rate limited. "
+                f"Retrying in {int(delay)}s (attempt {attempt + 2}/{max_retries + 1})...[/yellow]"
+            )
+        await asyncio.sleep(delay)
+
+    # Unreachable, but satisfies type checker
+    return None
+
+
+async def handle_generation_result(
+    client: NotebookLMClient,
+    notebook_id: str,
+    result: Any,
+    artifact_type: str,
+    wait: bool = False,
+    json_output: bool = False,
+    timeout: float = 300.0,
+    interval: float | None = None,
+) -> GenerationStatus | None:
+    """Handle generation result with optional waiting and output formatting.
+
+    Consolidates common pattern across all generate commands:
+    - Check for None/failed result
+    - Optionally wait for completion
+    - Output status in JSON or console format
+
+    Args:
+        client: The NotebookLM client.
+        notebook_id: The notebook ID.
+        result: The generation result from artifacts API.
+        artifact_type: Display name for the artifact type (e.g., "audio", "video").
+        wait: Whether to wait for completion.
+        json_output: Whether to output as JSON.
+        timeout: Timeout for waiting (default: 300s).
+        interval: Polling interval in seconds. ``None`` (default) lets
+            ``wait_for_completion`` use its built-in default
+            (``initial_interval=2.0``); when supplied, the value is forwarded
+            as ``initial_interval`` so callers can tighten or loosen the
+            cadence.
+
+    Returns:
+        Final GenerationStatus, or None if generation failed.
+    """
+    # Handle failed generation or rate limiting
+    if not result:
+        if json_output:
+            json_error_response(
+                "GENERATION_FAILED",
+                f"{artifact_type.title()} generation failed",
+            )
+        else:
+            console.print(f"[red]{artifact_type.title()} generation failed.[/red]")
+        return None
+
+    # Check for rate limiting (result exists but failed due to rate limit)
+    if isinstance(result, GenerationStatus) and result.is_rate_limited:
+        if json_output:
+            json_error_response(
+                "RATE_LIMITED",
+                f"{artifact_type.title()} generation rate limited by Google",
+            )
+        else:
+            console.print(
+                f"[red]{artifact_type.title()} generation rate limited by Google.[/red]\n"
+                "[yellow]Daily quota may be exceeded. Try again in 1-24 hours, "
+                "or use --retry N to retry automatically.[/yellow]"
+            )
+        return result
+
+    # Extract task_id from various result formats
+    task_id: str | None = None
+    status: Any = result
+    if isinstance(result, GenerationStatus):
+        task_id = result.task_id
+        status = result
+    elif isinstance(result, dict):
+        task_id = result.get("artifact_id") or result.get("task_id")
+        status = result
+    elif isinstance(result, list) and len(result) > 0:
+        task_id = result[0] if isinstance(result[0], str) else None
+        status = result
+
+    # Wait for completion if requested
+    if wait and task_id:
+        if not json_output:
+            console.print(f"[yellow]Generating {artifact_type}...[/yellow] Task: {task_id}")
+        wait_kwargs: dict[str, Any] = {"timeout": timeout}
+        if interval is not None:
+            wait_kwargs["initial_interval"] = interval
+        # Wrap the blocking poll in a transient spinner so interactive users see
+        # progress feedback during long generations. The status
+        # line includes the artifact kind, a typical-duration hint, and a
+        # live elapsed-seconds counter. No-op under --json.
+        #
+        # The ``resume_hint`` plumbs the canonical M2 cancellation message
+        # (``Cancelled. Resume with: notebooklm artifact poll <task_id>``)
+        # so Ctrl-C during the wait surfaces the resume command instead of
+        # a Python KeyboardInterrupt traceback. See ``cli/error_handler.py``
+        # ``emit_cancelled_and_exit``.
+        async with _status_with_elapsed(
+            artifact_type,
+            json_output=json_output,
+            resume_hint=f"notebooklm artifact poll {task_id}",
+        ):
+            status = await client.artifacts.wait_for_completion(notebook_id, task_id, **wait_kwargs)
+
+    # Output status
+    _output_generation_status(status, artifact_type, json_output)
+
+    return status if isinstance(status, GenerationStatus) else None
+
+
+def _extract_task_id(status: Any) -> str | None:
+    """Extract task ID from various status formats.
+
+    Handles GenerationStatus objects, dicts with task_id/artifact_id keys,
+    and lists where the first element is an ID string.
+    """
+    if hasattr(status, "task_id"):
+        return status.task_id
+    if isinstance(status, dict):
+        return status.get("task_id") or status.get("artifact_id")
+    if isinstance(status, list) and len(status) > 0 and isinstance(status[0], str):
+        return status[0]
+    return None
+
+
+def _output_generation_status(status: Any, artifact_type: str, json_output: bool) -> None:
+    """Output generation status in appropriate format."""
+    is_complete = hasattr(status, "is_complete") and status.is_complete
+    is_failed = hasattr(status, "is_failed") and status.is_failed
+
+    if json_output:
+        if is_complete:
+            json_output_response(
+                {
+                    "task_id": getattr(status, "task_id", None),
+                    "status": "completed",
+                    "url": getattr(status, "url", None),
+                }
+            )
+        elif is_failed:
+            json_error_response(
+                "GENERATION_FAILED",
+                getattr(status, "error", None) or f"{artifact_type.title()} generation failed",
+            )
+        else:
+            task_id = _extract_task_id(status)
+            json_output_response({"task_id": task_id, "status": "pending"})
+    else:
+        if is_complete:
+            url = getattr(status, "url", None)
+            if url:
+                console.print(f"[green]{artifact_type.title()} ready:[/green] {url}")
+            else:
+                console.print(f"[green]{artifact_type.title()} ready[/green]")
+        elif is_failed:
+            console.print(f"[red]Failed:[/red] {getattr(status, 'error', 'Unknown error')}")
+        else:
+            task_id = _extract_task_id(status)
+            console.print(f"[yellow]Started:[/yellow] {task_id or status}")

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -8,7 +8,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from notebooklm.cli.services.artifact_generation import _format_status_message, _status_with_elapsed
+from notebooklm.cli.services.artifact_generation import (
+    RETRY_MAX_DELAY,
+    _format_status_message,
+    _status_with_elapsed,
+    calculate_backoff_delay,
+    generate_with_retry,
+)
 from notebooklm.notebooklm_cli import cli
 from notebooklm.rpc.types import ReportFormat
 
@@ -1132,30 +1138,22 @@ class TestCalculateBackoffDelay:
 
     def test_initial_delay(self):
         """Test that first attempt uses initial delay."""
-        from notebooklm.cli.generate import calculate_backoff_delay
-
         delay = calculate_backoff_delay(0, initial_delay=60.0)
         assert delay == 60.0
 
     def test_exponential_backoff(self):
         """Test that delay increases exponentially."""
-        from notebooklm.cli.generate import calculate_backoff_delay
-
         assert calculate_backoff_delay(0, initial_delay=60.0) == 60.0
         assert calculate_backoff_delay(1, initial_delay=60.0) == 120.0
         assert calculate_backoff_delay(2, initial_delay=60.0) == 240.0
 
     def test_max_delay_cap(self):
         """Test that delay is capped at max_delay."""
-        from notebooklm.cli.generate import calculate_backoff_delay
-
         delay = calculate_backoff_delay(10, initial_delay=60.0, max_delay=300.0)
         assert delay == 300.0
 
     def test_custom_multiplier(self):
         """Test custom backoff multiplier."""
-        from notebooklm.cli.generate import calculate_backoff_delay
-
         delay = calculate_backoff_delay(1, initial_delay=10.0, multiplier=3.0)
         assert delay == 30.0
 
@@ -1166,7 +1164,6 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_no_retry_on_success(self):
         """Test that successful generation doesn't trigger retry."""
-        from notebooklm.cli.generate import generate_with_retry
         from notebooklm.types import GenerationStatus
 
         success_result = GenerationStatus(
@@ -1182,7 +1179,6 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_retry_on_rate_limit(self):
         """Test that rate limit triggers retry."""
-        from notebooklm.cli.generate import generate_with_retry
         from notebooklm.types import GenerationStatus
 
         rate_limited = GenerationStatus(
@@ -1205,7 +1201,6 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_retry_exhausted(self):
         """Test that all retries being exhausted returns last result."""
-        from notebooklm.cli.generate import generate_with_retry
         from notebooklm.types import GenerationStatus
 
         rate_limited = GenerationStatus(
@@ -1224,7 +1219,6 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_no_retry_when_max_retries_zero(self):
         """Test that max_retries=0 means no retry attempts."""
-        from notebooklm.cli.generate import generate_with_retry
         from notebooklm.types import GenerationStatus
 
         rate_limited = GenerationStatus(
@@ -1242,7 +1236,6 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_retry_delays_increase_exponentially(self):
         """Verify delays follow exponential backoff pattern (60s, 120s, 240s)."""
-        from notebooklm.cli.generate import generate_with_retry
         from notebooklm.types import GenerationStatus
 
         rate_limited = GenerationStatus(
@@ -1262,7 +1255,6 @@ class TestGenerateWithRetry:
     @pytest.mark.asyncio
     async def test_retry_delay_caps_at_max(self):
         """Verify delay caps at 300s even with many retries."""
-        from notebooklm.cli.generate import RETRY_MAX_DELAY, generate_with_retry
         from notebooklm.types import GenerationStatus
 
         rate_limited = GenerationStatus(
@@ -2152,6 +2144,41 @@ class TestHandleGenerationResultListPathAndWait:
 
         assert result.exit_code == 0
         mock_client.artifacts.wait_for_completion.assert_called_once()
+
+    def test_dict_result_prefers_artifact_id_for_wait(self, runner, mock_auth):
+        """Dict generation-start results preserve artifact_id-first wait semantics."""
+        from notebooklm.types import GenerationStatus
+
+        completed_status = GenerationStatus(
+            task_id="artifact_wait_id",
+            status="completed",
+            error=None,
+            error_code=None,
+            url="https://example.com/audio.mp3",
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(
+                return_value={
+                    "artifact_id": "artifact_wait_id",
+                    "task_id": "task_wait_id",
+                    "status": "processing",
+                }
+            )
+            mock_client.artifacts.wait_for_completion = AsyncMock(return_value=completed_status)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
+
+        assert result.exit_code == 0, result.output
+        mock_client.artifacts.wait_for_completion.assert_awaited_once()
+        args = mock_client.artifacts.wait_for_completion.await_args.args
+        assert args[:2] == ("nb_123", "artifact_wait_id")
 
 
 class TestOutputMindMapNonDictMindMap:

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-from notebooklm.cli.generate import _format_status_message, _status_with_elapsed
+from notebooklm.cli.services.artifact_generation import _format_status_message, _status_with_elapsed
 from notebooklm.notebooklm_cli import cli
 from notebooklm.rpc.types import ReportFormat
 
@@ -19,6 +19,7 @@ from .conftest import create_mock_client, patch_client_for_module
 # tests target the module's attribute set (``console``, helpers) rather than
 # the Click Group sitting at the same dotted path.
 generate_module = importlib.import_module("notebooklm.cli.generate")
+artifact_generation_module = importlib.import_module("notebooklm.cli.services.artifact_generation")
 
 
 @pytest.fixture
@@ -1513,9 +1514,7 @@ class TestOutputGenerationStatusDirect:
     """Direct tests for _output_generation_status() covering uncovered branches."""
 
     def setup_method(self):
-        import importlib
-
-        self.generate_module = importlib.import_module("notebooklm.cli.generate")
+        self.generate_module = artifact_generation_module
 
     def _make_status(
         self, *, is_complete=False, is_failed=False, task_id=None, url=None, error=None
@@ -1618,9 +1617,7 @@ class TestExtractTaskIdDirect:
     """Direct tests for _extract_task_id() covering list path."""
 
     def setup_method(self):
-        import importlib
-
-        self.generate_module = importlib.import_module("notebooklm.cli.generate")
+        self.generate_module = artifact_generation_module
 
     def test_extract_from_list_first_string(self):
         """Lines 231-232: list where first element is a string."""
@@ -2066,11 +2063,8 @@ class TestGenerateWithRetryConsoleOutput:
     @pytest.mark.asyncio
     async def test_retry_shows_console_message_when_not_json(self):
         """Line 111: console.print shown during retry when json_output=False."""
-        import importlib
 
         from notebooklm.types import GenerationStatus
-
-        generate_module = importlib.import_module("notebooklm.cli.generate")
 
         rate_limited = GenerationStatus(
             task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
@@ -2081,10 +2075,10 @@ class TestGenerateWithRetryConsoleOutput:
         generate_fn = AsyncMock(side_effect=[rate_limited, success_result])
 
         with (
-            patch.object(generate_module, "console") as mock_console,
+            patch.object(artifact_generation_module, "console") as mock_console,
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            result = await generate_module.generate_with_retry(
+            result = await artifact_generation_module.generate_with_retry(
                 generate_fn, max_retries=1, artifact_type="audio", json_output=False
             )
 
@@ -2211,7 +2205,7 @@ class TestStatusWithElapsed:
         """Under --json the helper must NOT call console.status (stdout stays JSON)."""
 
         async def _exercise() -> None:
-            with patch.object(generate_module.console, "status") as mock_status:
+            with patch.object(artifact_generation_module.console, "status") as mock_status:
                 async with _status_with_elapsed("audio", json_output=True):
                     pass
                 assert not mock_status.called, "console.status must not be invoked under --json"
@@ -2325,7 +2319,7 @@ class TestGenerateWaitSigintResumeHint:
         """
 
         async def _exercise() -> None:
-            with patch.object(generate_module.console, "status") as mock_status:
+            with patch.object(artifact_generation_module.console, "status") as mock_status:
                 mock_status.return_value.__enter__ = MagicMock(return_value=MagicMock())
                 mock_status.return_value.__exit__ = MagicMock(return_value=False)
                 with pytest.raises(KeyboardInterrupt):

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1581,6 +1581,13 @@ class TestOutputGenerationStatusDirect:
             self.generate_module._output_generation_status(status, "audio", json_output=False)
         mock_console.print.assert_called_once_with("[red]Failed:[/red] Transcription error")
 
+    def test_text_failed_no_error_message(self):
+        """Text failed output falls back to Unknown error when error is None."""
+        status = self._make_status(is_failed=True, error=None)
+        with patch.object(self.generate_module, "console") as mock_console:
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_console.print.assert_called_once_with("[red]Failed:[/red] Unknown error")
+
     def test_text_pending_with_task_id(self):
         """Line 268: Text output for pending status shows task_id."""
         status = self._make_status(task_id="task_789")


### PR DESCRIPTION
## Summary
- Extract shared generation retry/wait/result/status handling from `cli/generate.py` into `cli/services/artifact_generation.py`
- Keep Click command declarations and `NotebookLMClient(client_auth, ...)` construction in `generate.py`
- Retarget direct helper tests to the new CLI-internal service while preserving command behavior

## Test plan
- [x] `rtk uv run --extra dev pytest -n auto tests/unit/cli/test_generate.py tests/unit/cli/test_artifact.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py tests/integration/cli_vcr/test_generate.py tests/integration/cli_vcr/test_artifacts.py`
- [x] `rtk uv run --extra dev ruff check src/notebooklm/cli/generate.py src/notebooklm/cli/artifact.py src/notebooklm/cli/services/artifact_generation.py src/notebooklm/cli/services/__init__.py tests/unit/cli/test_generate.py tests/unit/cli/test_artifact.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py`
- [x] `rtk uv run --extra dev ruff format --check src/notebooklm/cli/generate.py src/notebooklm/cli/artifact.py src/notebooklm/cli/services/artifact_generation.py tests/unit/cli/test_generate.py tests/unit/cli/test_artifact.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_json_stdout_purity.py tests/unit/test_cli_boundary.py`
- [x] `rtk uv run --extra dev mypy src/notebooklm`

## Deferred polish findings
- Cosmetic test variable naming/docstring cleanup only; no critical or important findings from polish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated artifact generation utilities (retry/backoff, rate-limit handling, interactive progress, cancellation, and unified output) into a shared service used by CLI commands for consistent behavior.
* **Tests**
  * Updated test coverage to exercise the new shared generation service and its interactive/cancellation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->