### PR TITLE
refactor(cli): split runtime and auth helpers

### DIFF
--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -13,7 +13,7 @@ import time
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from pathlib import Path
-from typing import Any, NoReturn, TypeVar
+from typing import Any, NoReturn, TypeVar, cast
 
 import click
 
@@ -21,6 +21,7 @@ from ..auth import AuthTokens
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+_RESOLVED_AUTH_STORAGE_PATH_CTX_KEY = "_notebooklm_resolved_auth_storage_path"
 
 
 def _helpers_facade():
@@ -30,14 +31,16 @@ def _helpers_facade():
     return helpers
 
 
-def _auth_context(ctx) -> tuple[str | None, str | None]:
+def _auth_context(ctx) -> tuple[Path | str | None, str | None]:
     """Return explicit storage and profile values from a Click context."""
     storage_path = ctx.obj.get("storage_path") if ctx.obj else None
     profile = ctx.obj.get("profile") if ctx.obj else None
     return storage_path, profile
 
 
-def _resolve_auth_storage_path(storage_path: str | None, profile: str | None) -> Any | None:
+def _resolve_auth_storage_path(
+    storage_path: Path | str | None, profile: str | None
+) -> Path | str | None:
     """Resolve storage unless auth is supplied directly by environment."""
     if storage_path is not None:
         return storage_path
@@ -47,6 +50,18 @@ def _resolve_auth_storage_path(storage_path: str | None, profile: str | None) ->
     from ..paths import get_storage_path
 
     return get_storage_path(profile=profile)
+
+
+def _resolved_auth_storage_path(ctx) -> Path | str | None:
+    """Return the per-command resolved auth storage path."""
+    if ctx.obj is not None and _RESOLVED_AUTH_STORAGE_PATH_CTX_KEY in ctx.obj:
+        return cast(Path | str | None, ctx.obj[_RESOLVED_AUTH_STORAGE_PATH_CTX_KEY])
+
+    storage_path, profile = _auth_context(ctx)
+    resolved_storage_path = _resolve_auth_storage_path(storage_path, profile)
+    if ctx.obj is not None:
+        ctx.obj[_RESOLVED_AUTH_STORAGE_PATH_CTX_KEY] = resolved_storage_path
+    return resolved_storage_path
 
 
 def get_client(ctx) -> tuple[dict, str, str]:
@@ -62,15 +77,16 @@ def get_client(ctx) -> tuple[dict, str, str]:
         FileNotFoundError: If auth storage not found
     """
     helpers = _helpers_facade()
-    storage_path, profile = _auth_context(ctx)
-    resolved_storage_path = _resolve_auth_storage_path(storage_path, profile)
+    _, profile = _auth_context(ctx)
+    resolved_storage_path = _resolved_auth_storage_path(ctx)
+    typed_storage_path = cast(Path | None, resolved_storage_path)
 
     # Load from storage (which respects NOTEBOOKLM_AUTH_JSON if resolved path is None).
     cookies = helpers.load_auth_from_storage(resolved_storage_path)
 
     from ..auth import fetch_tokens_with_domains
 
-    csrf, session_id = helpers.run_async(fetch_tokens_with_domains(resolved_storage_path, profile))
+    csrf, session_id = helpers.run_async(fetch_tokens_with_domains(typed_storage_path, profile))
     return cookies, csrf, session_id
 
 
@@ -85,8 +101,9 @@ def get_auth_tokens(ctx) -> AuthTokens:
     """
     helpers = _helpers_facade()
     cookies, csrf, session_id = helpers.get_client(ctx)
-    storage_path, profile = _auth_context(ctx)
-    resolved_storage_path = _resolve_auth_storage_path(storage_path, profile)
+    storage_path, _ = _auth_context(ctx)
+    resolved_storage_path = _resolved_auth_storage_path(ctx)
+    typed_storage_path = cast(Path | None, resolved_storage_path)
 
     if os.environ.get("NOTEBOOKLM_AUTH_JSON") and storage_path is None:
         from ..auth import build_httpx_cookies_from_storage
@@ -103,10 +120,10 @@ def get_auth_tokens(ctx) -> AuthTokens:
         cookies=cookies,
         csrf_token=csrf,
         session_id=session_id,
-        storage_path=resolved_storage_path,
+        storage_path=typed_storage_path,
         cookie_jar=jar,
-        authuser=get_authuser_for_storage(resolved_storage_path),
-        account_email=get_account_email_for_storage(resolved_storage_path),
+        authuser=get_authuser_for_storage(typed_storage_path),
+        account_email=get_account_email_for_storage(typed_storage_path),
     )
 
 

--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -12,6 +12,7 @@ import os
 import time
 from collections.abc import Awaitable, Callable
 from functools import wraps
+from pathlib import Path
 from typing import Any, NoReturn, TypeVar
 
 import click
@@ -29,6 +30,25 @@ def _helpers_facade():
     return helpers
 
 
+def _auth_context(ctx) -> tuple[str | None, str | None]:
+    """Return explicit storage and profile values from a Click context."""
+    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
+    profile = ctx.obj.get("profile") if ctx.obj else None
+    return storage_path, profile
+
+
+def _resolve_auth_storage_path(storage_path: str | None, profile: str | None) -> Any | None:
+    """Resolve storage unless auth is supplied directly by environment."""
+    if storage_path is not None:
+        return storage_path
+    if os.environ.get("NOTEBOOKLM_AUTH_JSON"):
+        return None
+
+    from ..paths import get_storage_path
+
+    return get_storage_path(profile=profile)
+
+
 def get_client(ctx) -> tuple[dict, str, str]:
     """Get auth components from context.
 
@@ -42,14 +62,8 @@ def get_client(ctx) -> tuple[dict, str, str]:
         FileNotFoundError: If auth storage not found
     """
     helpers = _helpers_facade()
-    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
-    profile = ctx.obj.get("profile") if ctx.obj else None
-
-    resolved_storage_path = storage_path
-    if resolved_storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
-        from ..paths import get_storage_path
-
-        resolved_storage_path = get_storage_path(profile=profile)
+    storage_path, profile = _auth_context(ctx)
+    resolved_storage_path = _resolve_auth_storage_path(storage_path, profile)
 
     # Load from storage (which respects NOTEBOOKLM_AUTH_JSON if resolved path is None).
     cookies = helpers.load_auth_from_storage(resolved_storage_path)
@@ -71,14 +85,8 @@ def get_auth_tokens(ctx) -> AuthTokens:
     """
     helpers = _helpers_facade()
     cookies, csrf, session_id = helpers.get_client(ctx)
-    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
-    profile = ctx.obj.get("profile") if ctx.obj else None
-
-    resolved_storage_path = storage_path
-    if resolved_storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
-        from ..paths import get_storage_path
-
-        resolved_storage_path = get_storage_path(profile=profile)
+    storage_path, profile = _auth_context(ctx)
+    resolved_storage_path = _resolve_auth_storage_path(storage_path, profile)
 
     if os.environ.get("NOTEBOOKLM_AUTH_JSON") and storage_path is None:
         from ..auth import build_httpx_cookies_from_storage
@@ -107,9 +115,14 @@ def handle_auth_error(json_output: bool = False) -> NoReturn:
     from ..paths import get_path_info, get_storage_path
 
     helpers = _helpers_facade()
+    ctx = click.get_current_context(silent=True)
+    profile = ctx.obj.get("profile") if ctx and ctx.obj else None
     storage_override = helpers._current_storage_override()
-    path_info = get_path_info(storage_path=storage_override)
-    storage_path = storage_override if storage_override is not None else get_storage_path()
+    path_info = get_path_info(profile=profile, storage_path=storage_override)
+    storage_path = (
+        storage_override if storage_override is not None else get_storage_path(profile=profile)
+    )
+    storage_path = Path(storage_path).expanduser().resolve()
     has_env_var = bool(os.environ.get("NOTEBOOKLM_AUTH_JSON"))
     has_home_env = bool(os.environ.get("NOTEBOOKLM_HOME"))
     storage_source = path_info["home_source"]

--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -1,0 +1,248 @@
+"""CLI authentication and command runtime helpers.
+
+``notebooklm.cli.helpers`` remains a compatibility facade for historical
+imports and tests. The functions here intentionally look up selected
+collaborators through that facade at call time so established patch seams such
+as ``notebooklm.cli.helpers.get_auth_tokens`` and
+``notebooklm.cli.helpers.run_async`` continue to affect runtime behavior.
+"""
+
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import Any, NoReturn, TypeVar
+
+import click
+
+from ..auth import AuthTokens
+
+logger = logging.getLogger(__name__)
+T = TypeVar("T")
+
+
+def _helpers_facade():
+    """Return the backward-compatible helpers facade without a top-level cycle."""
+    from . import helpers
+
+    return helpers
+
+
+def get_client(ctx) -> tuple[dict, str, str]:
+    """Get auth components from context.
+
+    Args:
+        ctx: Click context with optional storage_path in obj
+
+    Returns:
+        Tuple of (cookies, csrf_token, session_id)
+
+    Raises:
+        FileNotFoundError: If auth storage not found
+    """
+    helpers = _helpers_facade()
+    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
+    profile = ctx.obj.get("profile") if ctx.obj else None
+
+    resolved_storage_path = storage_path
+    if resolved_storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
+        from ..paths import get_storage_path
+
+        resolved_storage_path = get_storage_path(profile=profile)
+
+    # Load from storage (which respects NOTEBOOKLM_AUTH_JSON if resolved path is None).
+    cookies = helpers.load_auth_from_storage(resolved_storage_path)
+
+    from ..auth import fetch_tokens_with_domains
+
+    csrf, session_id = helpers.run_async(fetch_tokens_with_domains(resolved_storage_path, profile))
+    return cookies, csrf, session_id
+
+
+def get_auth_tokens(ctx) -> AuthTokens:
+    """Get AuthTokens object from context.
+
+    Args:
+        ctx: Click context
+
+    Returns:
+        AuthTokens ready for client construction
+    """
+    helpers = _helpers_facade()
+    cookies, csrf, session_id = helpers.get_client(ctx)
+    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
+    profile = ctx.obj.get("profile") if ctx.obj else None
+
+    resolved_storage_path = storage_path
+    if resolved_storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
+        from ..paths import get_storage_path
+
+        resolved_storage_path = get_storage_path(profile=profile)
+
+    if os.environ.get("NOTEBOOKLM_AUTH_JSON") and storage_path is None:
+        from ..auth import build_httpx_cookies_from_storage
+
+        jar = build_httpx_cookies_from_storage(None)
+    else:
+        jar = helpers.build_cookie_jar(cookies=cookies, storage_path=resolved_storage_path)
+
+    # Read persisted account routing so RPC URLs target the same Google
+    # account the tokens were minted for.
+    from ..auth import get_account_email_for_storage, get_authuser_for_storage
+
+    return AuthTokens(
+        cookies=cookies,
+        csrf_token=csrf,
+        session_id=session_id,
+        storage_path=resolved_storage_path,
+        cookie_jar=jar,
+        authuser=get_authuser_for_storage(resolved_storage_path),
+        account_email=get_account_email_for_storage(resolved_storage_path),
+    )
+
+
+def handle_auth_error(json_output: bool = False) -> NoReturn:
+    """Handle authentication errors with helpful context."""
+    from ..paths import get_path_info, get_storage_path
+
+    helpers = _helpers_facade()
+    storage_override = helpers._current_storage_override()
+    path_info = get_path_info(storage_path=storage_override)
+    storage_path = storage_override if storage_override is not None else get_storage_path()
+    has_env_var = bool(os.environ.get("NOTEBOOKLM_AUTH_JSON"))
+    has_home_env = bool(os.environ.get("NOTEBOOKLM_HOME"))
+    storage_source = path_info["home_source"]
+
+    if json_output:
+        helpers.json_error_response(
+            "AUTH_REQUIRED",
+            "Auth not found. Run 'notebooklm login' first.",
+            extra={
+                "checked_paths": {
+                    "storage_file": str(storage_path),
+                    "storage_source": storage_source,
+                    "env_var": "NOTEBOOKLM_AUTH_JSON" if has_env_var else None,
+                },
+                "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
+            },
+        )
+        raise SystemExit(1)
+    else:
+        helpers.console.print("[red]Not logged in.[/red]\n")
+        helpers.console.print("[dim]Checked locations:[/dim]")
+        helpers.console.print(f"  • Storage file: [cyan]{storage_path}[/cyan]")
+        if has_home_env:
+            helpers.console.print("    [dim](via $NOTEBOOKLM_HOME)[/dim]")
+        env_status = "[yellow]set but invalid[/yellow]" if has_env_var else "[dim]not set[/dim]"
+        helpers.console.print(f"  • NOTEBOOKLM_AUTH_JSON: {env_status}")
+        helpers.console.print("\n[bold]Options to authenticate:[/bold]")
+        helpers.console.print("  1. Run: [green]notebooklm login[/green]")
+        helpers.console.print("  2. Set [cyan]NOTEBOOKLM_AUTH_JSON[/cyan] env var (for CI/CD)")
+        helpers.console.print("  3. Use [cyan]--storage /path/to/file.json[/cyan] flag")
+        raise SystemExit(1)
+
+
+def with_auth_and_errors(
+    ctx: click.Context,
+    *,
+    command_name: str,
+    json_output: bool,
+    body: Callable[[AuthTokens], Awaitable[T]],
+    auth_loader: Callable[[click.Context], AuthTokens] | None = None,
+) -> T:
+    """Run a CLI command body with shared auth bootstrap and error handling."""
+    from .error_handler import handle_errors
+
+    helpers = _helpers_facade()
+    start = time.monotonic()
+    logger.debug("CLI command starting: %s", command_name)
+
+    # Verbose is captured on the root group via Click ``--verbose`` count.
+    # Use ``find_root`` so nested subcommand contexts still see it.
+    try:
+        verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
+    except (AttributeError, TypeError, ValueError):
+        verbose_count = 0
+    verbose = verbose_count >= 1
+
+    def log_result(status: str, detail: str = "") -> None:
+        elapsed = time.monotonic() - start
+        if detail:
+            logger.debug(
+                "CLI command %s: %s (%.3fs) - %s",
+                status,
+                command_name,
+                elapsed,
+                detail,
+            )
+        else:
+            logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
+
+    with handle_errors(verbose=verbose, json_output=json_output):
+        # Auth bootstrap: FileNotFoundError here means the storage file is
+        # missing -- it has a dedicated rich UX via ``handle_auth_error``.
+        # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
+        # raised *inside* the command body (e.g., a missing ``--source-file``
+        # argument; see issue #153) is NOT misclassified as an auth error --
+        # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
+        # Any OTHER exception from the auth bootstrap (malformed storage JSON,
+        # AuthError during token extraction, etc.) also reaches ``handle_errors``
+        # so users get typed hints rather than a raw traceback.
+        try:
+            loader = auth_loader or helpers.get_auth_tokens
+            auth = loader(ctx)
+        except FileNotFoundError:
+            log_result("failed", "not authenticated")
+            return helpers.handle_auth_error(json_output)
+        except Exception as e:
+            # Non-FileNotFoundError bootstrap failures (AuthError, malformed
+            # storage JSON, etc.) still need the structured debug-log entry;
+            # ``handle_errors`` will translate the exception to a typed hint.
+            log_result("failed", str(e))
+            raise
+
+        try:
+            result = helpers.run_async(body(auth))
+        except Exception as e:
+            log_result("failed", str(e))
+            raise
+        log_result("completed")
+        return result
+
+
+def with_client(f):
+    """Decorator that handles auth, async execution, and errors for CLI commands.
+
+    This decorator eliminates boilerplate from commands that need:
+    - Authentication (get AuthTokens from context)
+    - Async execution (run coroutine with asyncio.run)
+    - Error handling (auth errors, general exceptions)
+
+    The decorated function stays SYNC (Click doesn't support async) but returns
+    a coroutine. The decorator runs the coroutine and handles errors.
+
+    Args:
+        f: Function that accepts client_auth (AuthTokens) and returns a coroutine
+
+    Returns:
+        Decorated function with Click pass_context
+    """
+
+    @wraps(f)
+    @click.pass_context
+    def wrapper(ctx, *args, **kwargs):
+        cmd_name = f.__name__
+        json_output = kwargs.get("json_output", False)
+
+        def body(auth: AuthTokens) -> Awaitable[Any]:
+            return f(ctx, *args, client_auth=auth, **kwargs)
+
+        return with_auth_and_errors(
+            ctx,
+            command_name=cmd_name,
+            json_output=json_output,
+            body=body,
+        )
+
+    return wrapper

--- a/src/notebooklm/cli/auth_runtime.py
+++ b/src/notebooklm/cli/auth_runtime.py
@@ -252,6 +252,18 @@ def with_client(f):
     The decorated function stays SYNC (Click doesn't support async) but returns
     a coroutine. The decorator runs the coroutine and handles errors.
 
+    Usage:
+        @cli.command("list")
+        @click.option("--json", "json_output", is_flag=True)
+        @with_client
+        def list_notebooks(ctx, json_output, client_auth):
+            async def _run():
+                async with NotebookLMClient(client_auth) as client:
+                    notebooks = await client.notebooks.list()
+                    output_notebooks(notebooks, json_output)
+
+            return _run()
+
     Args:
         f: Function that accepts client_auth (AuthTokens) and returns a coroutine
 

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -23,7 +23,6 @@ import click
 from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
-from .auth_runtime import with_auth_and_errors
 from .download_helpers import (
     ArtifactDict,
     artifact_title_to_filename,
@@ -35,6 +34,7 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
+    with_auth_and_errors,
 )
 from .options import _complete_artifacts, notebook_option
 

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -23,6 +23,7 @@ import click
 from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
+from .auth_runtime import with_auth_and_errors
 from .download_helpers import (
     ArtifactDict,
     artifact_title_to_filename,
@@ -34,7 +35,6 @@ from .helpers import (
     json_output_response,
     require_notebook,
     resolve_notebook_id,
-    with_auth_and_errors,
 )
 from .options import _complete_artifacts, notebook_option
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -15,7 +15,7 @@ import logging
 import os
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn, TypeVar
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
 
 import click
 

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -39,9 +39,15 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 ResearchImportResult = research_import_helpers.ResearchImportResult
 
-# Compatibility patch targets used by older tests and command paths.
-build_cookie_jar = auth_helpers.build_cookie_jar
-load_auth_from_storage = auth_helpers.load_auth_from_storage
+
+def build_cookie_jar(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility patch target for auth cookie-jar construction."""
+    return auth_helpers.build_cookie_jar(*args, **kwargs)
+
+
+def load_auth_from_storage(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility patch target for auth storage loading."""
+    return auth_helpers.load_auth_from_storage(*args, **kwargs)
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -1,34 +1,33 @@
 """CLI helper utilities.
 
 Provides common functionality for all CLI commands:
-- Authentication handling (get_client)
-- Async execution (run_async)
+- Compatibility re-exports for runtime/auth helpers
 - Error handling
 - JSON/Rich output formatting
 - Context management (current notebook/conversation)
-- @with_client decorator for command boilerplate reduction
 
 This module is also the backward-compatible facade for older imports and test
-patch targets; see ``cli.context`` and ``cli.rendering`` for canonical helpers.
+patch targets; see ``cli.runtime``, ``cli.auth_runtime``, ``cli.context``, and
+``cli.rendering`` for canonical helpers.
 """
 
-import asyncio
 import logging
 import os
-import time
 from collections.abc import Awaitable, Callable
-from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
+from typing import TYPE_CHECKING, NoReturn, TypeVar
 
 import click
 
-from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
+from .. import auth as auth_helpers
+from ..auth import AuthTokens
 from ..paths import get_context_path
 from ..types import ArtifactType
+from . import auth_runtime as auth_runtime_helpers
 from . import context as context_helpers
 from . import rendering as rendering_helpers
 from . import research_import as research_import_helpers
+from . import runtime as runtime_helpers
 from ._encoding import safe_echo
 
 if TYPE_CHECKING:
@@ -39,6 +38,10 @@ stderr_console = rendering_helpers.stderr_console
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
 ResearchImportResult = research_import_helpers.ResearchImportResult
+
+# Compatibility patch targets used by older tests and command paths.
+build_cookie_jar = auth_helpers.build_cookie_jar
+load_auth_from_storage = auth_helpers.load_auth_from_storage
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
@@ -63,35 +66,8 @@ def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
 
 
 def run_async(coro):
-    """Run async coroutine in sync context.
-
-    Guards against being called from inside an already-running event loop.
-    ``asyncio.run`` raises ``RuntimeError`` in that case ("asyncio.run() cannot
-    be called from a running event loop"); we re-raise with a CLI-shaped
-    message and explicitly close the coroutine first so the caller does not
-    see a ``RuntimeWarning: coroutine '...' was never awaited``.
-
-    Nested event loops are intentionally not supported (no ``nest_asyncio``,
-    no ``loop.run_until_complete`` fallback): the CLI assumes a single
-    top-level ``asyncio.run`` invariant.
-    """
-    try:
-        return asyncio.run(coro)
-    except RuntimeError as exc:
-        # Distinguish "loop already running" from other RuntimeErrors (e.g.,
-        # programmer errors inside the coroutine that surface as RuntimeError).
-        # Only the running-loop case requires us to close the coroutine — in
-        # every other case ``asyncio.run`` has already driven it to completion
-        # or cancellation, and calling ``close()`` would be a no-op at best
-        # (and could mask a still-pending state at worst).
-        if "running event loop" not in str(exc):
-            raise
-        coro.close()
-        raise RuntimeError(
-            "Cannot run sync CLI command from within an existing event loop. "
-            "Use the async API (``async with NotebookLMClient(...)``) directly "
-            "instead of invoking the sync CLI helper from async code."
-        ) from exc
+    """Run async coroutine in sync context."""
+    return runtime_helpers.run_async(coro)
 
 
 async def import_with_retry(
@@ -165,74 +141,13 @@ async def import_research_sources(
 
 
 def get_client(ctx) -> tuple[dict, str, str]:
-    """Get auth components from context.
-
-    Args:
-        ctx: Click context with optional storage_path in obj
-
-    Returns:
-        Tuple of (cookies, csrf_token, session_id)
-
-    Raises:
-        FileNotFoundError: If auth storage not found
-    """
-    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
-    profile = ctx.obj.get("profile") if ctx.obj else None
-
-    resolved_storage_path = storage_path
-    if resolved_storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
-        from ..paths import get_storage_path
-
-        resolved_storage_path = get_storage_path(profile=profile)
-
-    # Load from storage (which respects NOTEBOOKLM_AUTH_JSON if resolved path is None)
-    cookies = load_auth_from_storage(resolved_storage_path)
-
-    from ..auth import fetch_tokens_with_domains
-
-    csrf, session_id = run_async(fetch_tokens_with_domains(resolved_storage_path, profile))
-    return cookies, csrf, session_id
+    """Get auth components from context."""
+    return auth_runtime_helpers.get_client(ctx)
 
 
 def get_auth_tokens(ctx) -> AuthTokens:
-    """Get AuthTokens object from context.
-
-    Args:
-        ctx: Click context
-
-    Returns:
-        AuthTokens ready for client construction
-    """
-    cookies, csrf, session_id = get_client(ctx)
-    storage_path = ctx.obj.get("storage_path") if ctx.obj else None
-    profile = ctx.obj.get("profile") if ctx.obj else None
-
-    resolved_storage_path = storage_path
-    if resolved_storage_path is None and not os.environ.get("NOTEBOOKLM_AUTH_JSON"):
-        from ..paths import get_storage_path
-
-        resolved_storage_path = get_storage_path(profile=profile)
-
-    if os.environ.get("NOTEBOOKLM_AUTH_JSON") and storage_path is None:
-        from ..auth import build_httpx_cookies_from_storage
-
-        jar = build_httpx_cookies_from_storage(None)
-    else:
-        jar = build_cookie_jar(cookies=cookies, storage_path=resolved_storage_path)
-
-    # Read persisted account routing so RPC URLs target the same Google
-    # account the tokens were minted for.
-    from ..auth import get_account_email_for_storage, get_authuser_for_storage
-
-    return AuthTokens(
-        cookies=cookies,
-        csrf_token=csrf,
-        session_id=session_id,
-        storage_path=resolved_storage_path,
-        cookie_jar=jar,
-        authuser=get_authuser_for_storage(resolved_storage_path),
-        account_email=get_account_email_for_storage(resolved_storage_path),
-    )
+    """Get AuthTokens object from context."""
+    return auth_runtime_helpers.get_auth_tokens(ctx)
 
 
 # =============================================================================
@@ -615,41 +530,7 @@ def handle_error(e: Exception):
 
 def handle_auth_error(json_output: bool = False) -> NoReturn:
     """Handle authentication errors with helpful context."""
-    from ..paths import get_path_info, get_storage_path
-
-    storage_override = _current_storage_override()
-    path_info = get_path_info(storage_path=storage_override)
-    storage_path = storage_override if storage_override is not None else get_storage_path()
-    has_env_var = bool(os.environ.get("NOTEBOOKLM_AUTH_JSON"))
-    has_home_env = bool(os.environ.get("NOTEBOOKLM_HOME"))
-    storage_source = path_info["home_source"]
-
-    if json_output:
-        json_error_response(
-            "AUTH_REQUIRED",
-            "Auth not found. Run 'notebooklm login' first.",
-            extra={
-                "checked_paths": {
-                    "storage_file": str(storage_path),
-                    "storage_source": storage_source,
-                    "env_var": "NOTEBOOKLM_AUTH_JSON" if has_env_var else None,
-                },
-                "help": "Run 'notebooklm login' or set NOTEBOOKLM_AUTH_JSON",
-            },
-        )
-    else:
-        console.print("[red]Not logged in.[/red]\n")
-        console.print("[dim]Checked locations:[/dim]")
-        console.print(f"  • Storage file: [cyan]{storage_path}[/cyan]")
-        if has_home_env:
-            console.print("    [dim](via $NOTEBOOKLM_HOME)[/dim]")
-        env_status = "[yellow]set but invalid[/yellow]" if has_env_var else "[dim]not set[/dim]"
-        console.print(f"  • NOTEBOOKLM_AUTH_JSON: {env_status}")
-        console.print("\n[bold]Options to authenticate:[/bold]")
-        console.print("  1. Run: [green]notebooklm login[/green]")
-        console.print("  2. Set [cyan]NOTEBOOKLM_AUTH_JSON[/cyan] env var (for CI/CD)")
-        console.print("  3. Use [cyan]--storage /path/to/file.json[/cyan] flag")
-        raise SystemExit(1)
+    auth_runtime_helpers.handle_auth_error(json_output)
 
 
 # =============================================================================
@@ -666,110 +547,18 @@ def with_auth_and_errors(
     auth_loader: Callable[[click.Context], AuthTokens] | None = None,
 ) -> T:
     """Run a CLI command body with shared auth bootstrap and error handling."""
-    from .error_handler import handle_errors
-
-    start = time.monotonic()
-    logger.debug("CLI command starting: %s", command_name)
-
-    # Verbose is captured on the root group via Click ``--verbose`` count.
-    # Use ``find_root`` so nested subcommand contexts still see it.
-    try:
-        verbose_count = int(ctx.find_root().params.get("verbose", 0) or 0)
-    except (AttributeError, TypeError, ValueError):
-        verbose_count = 0
-    verbose = verbose_count >= 1
-
-    def log_result(status: str, detail: str = "") -> None:
-        elapsed = time.monotonic() - start
-        if detail:
-            logger.debug(
-                "CLI command %s: %s (%.3fs) - %s",
-                status,
-                command_name,
-                elapsed,
-                detail,
-            )
-        else:
-            logger.debug("CLI command %s: %s (%.3fs)", status, command_name, elapsed)
-
-    with handle_errors(verbose=verbose, json_output=json_output):
-        # Auth bootstrap: FileNotFoundError here means the storage file is
-        # missing — it has a dedicated rich UX via ``handle_auth_error``.
-        # The narrow ``except FileNotFoundError`` ensures a FileNotFoundError
-        # raised *inside* the command body (e.g., a missing ``--source-file``
-        # argument; see issue #153) is NOT misclassified as an auth error —
-        # it propagates to ``handle_errors``' UNEXPECTED_ERROR branch instead.
-        # Any OTHER exception from the auth bootstrap (malformed storage JSON,
-        # AuthError during token extraction, etc.) also reaches ``handle_errors``
-        # so users get typed hints rather than a raw traceback.
-        try:
-            loader = auth_loader or get_auth_tokens
-            auth = loader(ctx)
-        except FileNotFoundError:
-            log_result("failed", "not authenticated")
-            return handle_auth_error(json_output)
-        except Exception as e:
-            # Non-FileNotFoundError bootstrap failures (AuthError, malformed
-            # storage JSON, etc.) still need the structured debug-log entry;
-            # ``handle_errors`` will translate the exception to a typed hint.
-            log_result("failed", str(e))
-            raise
-
-        try:
-            result = run_async(body(auth))
-        except Exception as e:
-            log_result("failed", str(e))
-            raise
-        log_result("completed")
-        return result
+    return auth_runtime_helpers.with_auth_and_errors(
+        ctx,
+        command_name=command_name,
+        json_output=json_output,
+        body=body,
+        auth_loader=auth_loader,
+    )
 
 
 def with_client(f):
-    """Decorator that handles auth, async execution, and errors for CLI commands.
-
-    This decorator eliminates boilerplate from commands that need:
-    - Authentication (get AuthTokens from context)
-    - Async execution (run coroutine with asyncio.run)
-    - Error handling (auth errors, general exceptions)
-
-    The decorated function stays SYNC (Click doesn't support async) but returns
-    a coroutine. The decorator runs the coroutine and handles errors.
-
-    Usage:
-        @cli.command("list")
-        @click.option("--json", "json_output", is_flag=True)
-        @with_client
-        def list_notebooks(ctx, json_output, client_auth):
-            async def _run():
-                async with NotebookLMClient(client_auth) as client:
-                    notebooks = await client.notebooks.list()
-                    output_notebooks(notebooks, json_output)
-            return _run()
-
-    Args:
-        f: Function that accepts client_auth (AuthTokens) and returns a coroutine
-
-    Returns:
-        Decorated function with Click pass_context
-    """
-
-    @wraps(f)
-    @click.pass_context
-    def wrapper(ctx, *args, **kwargs):
-        cmd_name = f.__name__
-        json_output = kwargs.get("json_output", False)
-
-        def body(auth: AuthTokens) -> Awaitable[Any]:
-            return f(ctx, *args, client_auth=auth, **kwargs)
-
-        return with_auth_and_errors(
-            ctx,
-            command_name=cmd_name,
-            json_output=json_output,
-            body=body,
-        )
-
-    return wrapper
+    """Decorator that handles auth, async execution, and errors for CLI commands."""
+    return auth_runtime_helpers.with_client(f)
 
 
 # =============================================================================

--- a/src/notebooklm/cli/runtime.py
+++ b/src/notebooklm/cli/runtime.py
@@ -1,0 +1,35 @@
+"""CLI runtime primitives."""
+
+import asyncio
+
+
+def run_async(coro):
+    """Run async coroutine in sync context.
+
+    Guards against being called from inside an already-running event loop.
+    ``asyncio.run`` raises ``RuntimeError`` in that case ("asyncio.run() cannot
+    be called from a running event loop"); we re-raise with a CLI-shaped
+    message and explicitly close the coroutine first so the caller does not
+    see a ``RuntimeWarning: coroutine '...' was never awaited``.
+
+    Nested event loops are intentionally not supported (no ``nest_asyncio``,
+    no ``loop.run_until_complete`` fallback): the CLI assumes a single
+    top-level ``asyncio.run`` invariant.
+    """
+    try:
+        return asyncio.run(coro)
+    except RuntimeError as exc:
+        # Distinguish "loop already running" from other RuntimeErrors (e.g.,
+        # programmer errors inside the coroutine that surface as RuntimeError).
+        # Only the running-loop case requires us to close the coroutine -- in
+        # every other case ``asyncio.run`` has already driven it to completion
+        # or cancellation, and calling ``close()`` would be a no-op at best
+        # (and could mask a still-pending state at worst).
+        if "running event loop" not in str(exc):
+            raise
+        coro.close()
+        raise RuntimeError(
+            "Cannot run sync CLI command from within an existing event loop. "
+            "Use the async API (``async with NotebookLMClient(...)``) directly "
+            "instead of invoking the sync CLI helper from async code."
+        ) from exc

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -11,10 +11,12 @@ import pytest
 from filelock import Timeout
 
 import notebooklm.cli._encoding as encoding_module
+import notebooklm.cli.auth_runtime as auth_runtime_module
 import notebooklm.cli.context as context_module
 import notebooklm.cli.helpers as helpers_module
 import notebooklm.cli.rendering as rendering_module
 import notebooklm.cli.research_import as research_import_module
+import notebooklm.cli.runtime as runtime_module
 from notebooklm import Artifact
 from notebooklm.cli.helpers import (
     clear_context,
@@ -1034,6 +1036,28 @@ class TestGetClient:
 
         mock_load.assert_called_once_with("/custom/path")
 
+    def test_auth_runtime_observes_helper_patch_seams(self):
+        ctx = MagicMock()
+        ctx.obj = {"storage_path": "/custom/path", "profile": "agent"}
+
+        with (
+            patch("notebooklm.cli.helpers.load_auth_from_storage") as mock_load,
+            patch("notebooklm.cli.helpers.run_async", return_value=("csrf", "session")) as runner,
+        ):
+            mock_load.return_value = {"SID": "test", "__Secure-1PSIDTS": "test_1psidts"}
+            token_fetch = object()
+            mock_fetch = MagicMock(return_value=token_fetch)
+
+            with patch("notebooklm.auth.fetch_tokens_with_domains", new=mock_fetch):
+                cookies, csrf, session = auth_runtime_module.get_client(ctx)
+
+        mock_load.assert_called_once_with("/custom/path")
+        mock_fetch.assert_called_once_with("/custom/path", "agent")
+        runner.assert_called_once_with(token_fetch)
+        assert cookies == {"SID": "test", "__Secure-1PSIDTS": "test_1psidts"}
+        assert csrf == "csrf"
+        assert session == "session"
+
 
 class TestGetAuthTokens:
     def test_returns_auth_tokens_object(self):
@@ -1105,6 +1129,27 @@ class TestRunAsync:
 
         result = run_async(sample_coro())
         assert result == "result"
+
+    def test_runtime_module_runs_coroutine_and_returns_result(self):
+        async def sample_coro():
+            return "result"
+
+        result = runtime_module.run_async(sample_coro())
+        assert result == "result"
+
+    def test_helpers_run_async_is_compatibility_wrapper(self):
+        async def sample_coro():
+            return "result"
+
+        coro = sample_coro()
+        try:
+            with patch("notebooklm.cli.runtime.run_async", return_value="patched") as runner:
+                result = run_async(coro)
+        finally:
+            coro.close()
+
+        runner.assert_called_once_with(coro)
+        assert result == "patched"
 
     def test_nested_event_loop_raises_helpful_error(self):
         """Calling run_async from inside a running loop raises a CLI-shaped

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -40,6 +40,8 @@ OPTIONS_PATH = CLI_ROOT / "options.py"
 SERVICES_ROOT = CLI_ROOT / "services"
 RENDERING_PATH = CLI_ROOT / "rendering.py"
 CONTEXT_PATH = CLI_ROOT / "context.py"
+RUNTIME_PATH = CLI_ROOT / "runtime.py"
+AUTH_RUNTIME_PATH = CLI_ROOT / "auth_runtime.py"
 COMPLETION_CALLBACKS = {
     "_complete_artifacts",
     "_complete_notebooks",
@@ -86,6 +88,7 @@ CONTEXT_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
     "resolve",
     "runtime",
 }
+AUTH_RUNTIME_ALLOWED_MODULES = {"error_handler", "helpers"}
 
 
 def _is_private_segment(seg: str) -> bool:
@@ -353,6 +356,22 @@ def test_context_stays_on_low_level_cli_import_boundary() -> None:
         "cli.context must not import runtime/auth/rendering/resolve/input/completion "
         "or command modules. "
         f"Offenders: {sorted(imports & CONTEXT_FORBIDDEN_MODULES)}"
+    )
+
+
+def test_runtime_stays_leaf_module() -> None:
+    imports = _cli_module_imports(RUNTIME_PATH)
+
+    assert imports == set(), f"cli.runtime must not import other cli modules. Offenders: {imports}"
+
+
+def test_auth_runtime_imports_only_runtime_facade_collaborators() -> None:
+    imports = _cli_module_imports(AUTH_RUNTIME_PATH)
+
+    assert imports <= AUTH_RUNTIME_ALLOWED_MODULES, (
+        "cli.auth_runtime must not import command, rendering, context, resolve, "
+        "input, or completion modules directly. "
+        f"Offenders: {sorted(imports - AUTH_RUNTIME_ALLOWED_MODULES)}"
     )
 
 

--- a/tests/unit/test_with_client_handle_errors.py
+++ b/tests/unit/test_with_client_handle_errors.py
@@ -28,6 +28,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+import notebooklm.cli.auth_runtime as auth_runtime
 from notebooklm.cli.helpers import with_auth_and_errors, with_client
 from notebooklm.exceptions import AuthError, RateLimitError
 
@@ -132,6 +133,25 @@ def test_with_auth_and_errors_default_auth_loader_is_looked_up_at_call_time() ->
 
     with patch("notebooklm.cli.helpers.get_auth_tokens", return_value=sentinel_auth) as loader:
         result = with_auth_and_errors(
+            ctx,
+            command_name="run",
+            json_output=False,
+            body=_body,
+        )
+
+    loader.assert_called_once_with(ctx)
+    assert result is sentinel_auth
+
+
+def test_auth_runtime_default_auth_loader_preserves_helpers_patch_seam() -> None:
+    sentinel_auth = MagicMock(name="default-auth")
+    ctx = _make_click_context()
+
+    async def _body(auth):
+        return auth
+
+    with patch("notebooklm.cli.helpers.get_auth_tokens", return_value=sentinel_auth) as loader:
+        result = auth_runtime.with_auth_and_errors(
             ctx,
             command_name="run",
             json_output=False,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized CLI authentication/runtime wiring and exposed a lightweight helpers facade for compatibility.

* **New Features**
  * Commands can receive injected authenticated client tokens via a synchronous decorator.
  * Added robust async execution helper with clear guidance for nested event loops.

* **Bug Fixes**
  * Improved auth-error handling with optional structured JSON output.

* **Tests**
  * Added tests for CLI import boundaries and auth/runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->