### PR TITLE
refactor(cli): split research import helpers

### DIFF
--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -39,13 +39,6 @@ stderr_console = rendering_helpers.stderr_console
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
 ResearchImportResult = research_import_helpers.ResearchImportResult
-_normalize_url = research_import_helpers._normalize_url
-_source_url_norm = research_import_helpers._source_url_norm
-_requested_urls_norm = research_import_helpers._requested_urls_norm
-_has_no_url_entry = research_import_helpers._has_no_url_entry
-_imported_source_entry = research_import_helpers._imported_source_entry
-_merge_imported_sources = research_import_helpers._merge_imported_sources
-_select_research_sources_for_import = research_import_helpers._select_research_sources_for_import
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -17,30 +17,35 @@ import logging
 import os
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, TypeVar
-from urllib.parse import urlsplit, urlunsplit
 
 import click
 
 from ..auth import AuthTokens, build_cookie_jar, load_auth_from_storage
-from ..exceptions import NetworkError, RPCError, RPCTimeoutError
 from ..paths import get_context_path
-from ..research import select_cited_sources
-from ..types import ArtifactType, CitedSourceSelection
+from ..types import ArtifactType
 from . import context as context_helpers
 from . import rendering as rendering_helpers
+from . import research_import as research_import_helpers
 from ._encoding import safe_echo
 
 if TYPE_CHECKING:
-    from ..types import Artifact, Source
+    from ..types import Artifact
 
 console = rendering_helpers.console
 stderr_console = rendering_helpers.stderr_console
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+ResearchImportResult = research_import_helpers.ResearchImportResult
+_normalize_url = research_import_helpers._normalize_url
+_source_url_norm = research_import_helpers._source_url_norm
+_requested_urls_norm = research_import_helpers._requested_urls_norm
+_has_no_url_entry = research_import_helpers._has_no_url_entry
+_imported_source_entry = research_import_helpers._imported_source_entry
+_merge_imported_sources = research_import_helpers._merge_imported_sources
+_select_research_sources_for_import = research_import_helpers._select_research_sources_for_import
 
 
 def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> None:
@@ -52,15 +57,6 @@ def emit_status(msg: str, *, json_output: bool, style: str | None = None) -> Non
         stdout_console=console,
         stderr_output_console=stderr_console,
     )
-
-
-@dataclass(frozen=True)
-class ResearchImportResult:
-    """Result of importing research sources from CLI commands."""
-
-    imported: list[dict[str, str]]
-    sources: list[dict]
-    cited_selection: CitedSourceSelection | None = None
 
 
 def cli_name_to_artifact_type(name: str) -> ArtifactType | None:
@@ -105,57 +101,6 @@ def run_async(coro):
         ) from exc
 
 
-def _normalize_url(url: str) -> str:
-    """Lowercase scheme + host and strip a trailing slash for comparison.
-
-    Server-side URL storage normalizes case and trailing slashes; client-side
-    requests may not. Compare via this helper to avoid false-negative misses
-    when verifying that a requested URL appears post-import.
-    """
-    parsed = urlsplit(url)
-    return urlunsplit(
-        (
-            parsed.scheme.lower(),
-            parsed.netloc.lower(),
-            parsed.path.rstrip("/"),
-            parsed.query,
-            parsed.fragment,
-        )
-    )
-
-
-def _source_url_norm(source: dict) -> str | None:
-    url = source.get("url")
-    if not isinstance(url, str) or not url:
-        return None
-    return _normalize_url(url)
-
-
-def _requested_urls_norm(sources: list[dict]) -> set[str]:
-    return {url for source in sources if (url := _source_url_norm(source))}
-
-
-def _has_no_url_entry(sources: list[dict]) -> bool:
-    return any(_source_url_norm(source) is None for source in sources)
-
-
-def _imported_source_entry(source: "Source") -> dict[str, str]:
-    return {"id": source.id, "title": source.title or source.url or ""}
-
-
-def _merge_imported_sources(
-    imported: list[dict[str, str]],
-    verified_imported: list[dict[str, str]],
-    verified_imported_ids: set[str],
-) -> list[dict[str, str]]:
-    if not verified_imported:
-        return imported
-    return [
-        *verified_imported,
-        *(entry for entry in imported if entry.get("id") not in verified_imported_ids),
-    ]
-
-
 async def import_with_retry(
     client,
     notebook_id: str,
@@ -168,232 +113,26 @@ async def import_with_retry(
     max_delay: float = 60,
     json_output: bool = False,
 ) -> list[dict[str, str]]:
-    """Retry research import on RPC timeouts with exponential backoff.
-
-    On RPC timeout, probes the notebook's source list to detect server-side
-    imports that succeeded despite the client deadline firing. This avoids the
-    duplicate-on-retry inflation that otherwise occurs when each retry re-adds
-    a copy of the same sources (a single timeout cascade can otherwise inflate
-    a 60-source import to 300+ sources across 5-6 retries).
-
-    If the pre-import source snapshot is unavailable, retries still filter out
-    URLs that are already visible after each timeout, but the returned list may
-    undercount server-side imports because the function cannot prove those
-    sources were absent before this call.
-
-    This is intentionally CLI-only policy. Library consumers calling
-    `client.research.import_sources()` directly still get one-shot behavior.
-    """
-    started_at = time.monotonic()
-    delay = initial_delay
-    attempt = 1
-    verified_imported: list[dict[str, str]] = []
-    verified_imported_ids: set[str] = set()
-
-    requested_urls_norm = _requested_urls_norm(sources)
-    # Track whether the request itself includes any non-URL entries (research
-    # reports, pasted text). If it doesn't, we must NOT include concurrent
-    # no-URL additions in the synthesized return — those would be unrelated
-    # sources reported as "imported" by this call.
-    requested_has_no_url_entry = _has_no_url_entry(sources)
-
-    # Snapshot baseline source IDs so the post-timeout probe can identify
-    # truly-new sources. We anchor the verified-success condition on URLs of
-    # *new* sources — not on a baseline→current URL delta — so concurrent
-    # additions from another session and pre-existing URLs cannot satisfy it.
-    baseline_ids: set[str] | None
-    try:
-        baseline = await client.sources.list(notebook_id, strict=True)
-        baseline_ids = {src.id for src in baseline}
-    except (NetworkError, RPCError) as snapshot_exc:
-        logger.warning(
-            "Pre-import sources.list snapshot failed for %s: %s; "
-            "verified-success path disabled for this call",
-            notebook_id,
-            snapshot_exc,
-        )
-        baseline_ids = None
-
-    while True:
-        try:
-            imported = await client.research.import_sources(notebook_id, task_id, sources)
-            return _merge_imported_sources(imported, verified_imported, verified_imported_ids)
-        except RPCTimeoutError:
-            elapsed = time.monotonic() - started_at
-            remaining = max_elapsed - elapsed
-
-            # Verify server-side state before retrying. The IMPORT_RESEARCH RPC
-            # frequently times out at the client (30s) after a successful
-            # server-side write; retrying then duplicates every source.
-            if requested_urls_norm:
-                try:
-                    current = await client.sources.list(notebook_id, strict=True)
-                    new_sources = (
-                        [src for src in current if src.id not in baseline_ids]
-                        if baseline_ids is not None
-                        else []
-                    )
-                    new_urls_norm = {_normalize_url(src.url) for src in new_sources if src.url}
-                    current_urls_norm = {_normalize_url(src.url) for src in current if src.url}
-                    # Success requires every requested URL to appear among the
-                    # *new* sources. Trivial-true cases (pre-existing URLs) and
-                    # concurrent unrelated additions both fail this check.
-                    if baseline_ids is not None and requested_urls_norm.issubset(new_urls_norm):
-                        logger.warning(
-                            "IMPORT_RESEARCH timed out for notebook %s but "
-                            "sources.list shows all %d requested URLs among "
-                            "new sources; treating as success and skipping "
-                            "retry to avoid duplicate inflation",
-                            notebook_id,
-                            len(requested_urls_norm),
-                        )
-                        if not json_output:
-                            console.print(
-                                f"[yellow]Import RPC timed out, but server-side "
-                                f"verified {len(requested_urls_norm)} requested "
-                                f"sources — skipping retry.[/yellow]"
-                            )
-                        else:
-                            logger.debug(
-                                "Import RPC timed out, but server-side verified "
-                                "%d requested sources — skipping retry (json mode).",
-                                len(requested_urls_norm),
-                            )
-                        # Return only new sources that match a requested URL.
-                        # No-URL new sources (research reports, pasted text)
-                        # are included only if the request itself had no-URL
-                        # entries — otherwise they're concurrent unrelated
-                        # additions and don't belong in the return.
-                        imported = [
-                            _imported_source_entry(src)
-                            for src in new_sources
-                            if (src.url and _normalize_url(src.url) in requested_urls_norm)
-                            or (not src.url and requested_has_no_url_entry)
-                        ]
-                        return _merge_imported_sources(
-                            imported, verified_imported, verified_imported_ids
-                        )
-                    source_norms = [(source, _source_url_norm(source)) for source in sources]
-                    removed_urls_norm = {
-                        url
-                        for _, url in source_norms
-                        if url is not None and url in current_urls_norm
-                    }
-                    filtered_sources = [
-                        source for source, url in source_norms if url not in current_urls_norm
-                    ]
-                    if len(filtered_sources) != len(sources):
-                        removed_count = len(sources) - len(filtered_sources)
-                        for src in new_sources:
-                            if (
-                                src.url
-                                and _normalize_url(src.url) in removed_urls_norm
-                                and src.id not in verified_imported_ids
-                            ):
-                                verified_imported.append(_imported_source_entry(src))
-                                verified_imported_ids.add(src.id)
-                        sources = filtered_sources
-                        requested_urls_norm = _requested_urls_norm(sources)
-                        requested_has_no_url_entry = _has_no_url_entry(sources)
-                        if not sources:
-                            logger.warning(
-                                "IMPORT_RESEARCH timed out for notebook %s but "
-                                "sources.list shows all requested URLs already "
-                                "present; treating as success and skipping retry "
-                                "to avoid duplicate inflation",
-                                notebook_id,
-                            )
-                            if not json_output:
-                                console.print(
-                                    "[yellow]Import RPC timed out, but all "
-                                    "requested sources are already present — "
-                                    "skipping retry.[/yellow]"
-                                )
-                            else:
-                                logger.debug(
-                                    "Import RPC timed out, but all requested "
-                                    "sources are already present — skipping retry "
-                                    "(json mode)."
-                                )
-                            return _merge_imported_sources(
-                                [], verified_imported, verified_imported_ids
-                            )
-                        logger.warning(
-                            "IMPORT_RESEARCH timed out for notebook %s after "
-                            "%d requested source(s) were already present; retrying "
-                            "with %d remaining source(s)",
-                            notebook_id,
-                            removed_count,
-                            len(sources),
-                        )
-                except (NetworkError, RPCError) as probe_exc:
-                    # CancelledError is a BaseException, not Exception, and is
-                    # not in this tuple — it propagates naturally for callers
-                    # that need to cancel the operation cleanly.
-                    logger.warning(
-                        "Failed to probe server state after timeout: %s; falling back to retry",
-                        probe_exc,
-                    )
-
-            if remaining <= 0:
-                raise
-
-            # Report-only imports (no URLs to verify) can't use the success
-            # check above. Cap retries at one to bound worst-case duplicate
-            # inflation for report entries when timeouts persist.
-            if not requested_urls_norm and attempt >= 2:
-                logger.warning(
-                    "IMPORT_RESEARCH timed out for notebook %s with no URLs to "
-                    "verify; giving up after %d attempts to bound duplicate inflation",
-                    notebook_id,
-                    attempt,
-                )
-                raise
-
-            sleep_for = min(delay, max_delay, remaining)
-            logger.warning(
-                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs (attempt %d, %.1fs elapsed)",
-                notebook_id,
-                sleep_for,
-                attempt + 1,
-                elapsed,
-            )
-            if not json_output:
-                console.print(
-                    f"[yellow]Import timed out; retrying in {sleep_for:.0f}s "
-                    f"(attempt {attempt + 1})[/yellow]"
-                )
-            else:
-                logger.debug(
-                    "Import timed out; retrying in %.0fs (attempt %d) (json mode).",
-                    sleep_for,
-                    attempt + 1,
-                )
-            await asyncio.sleep(sleep_for)
-            delay = min(delay * backoff_factor, max_delay)
-            attempt += 1
+    """Compatibility wrapper for :func:`cli.research_import.import_with_retry`."""
+    return await research_import_helpers.import_with_retry(
+        client,
+        notebook_id,
+        task_id,
+        sources,
+        max_elapsed=max_elapsed,
+        initial_delay=initial_delay,
+        backoff_factor=backoff_factor,
+        max_delay=max_delay,
+        json_output=json_output,
+        output_console=console,
+    )
 
 
-def _select_research_sources_for_import(
-    sources: list[dict], report: str, cited_only: bool
-) -> tuple[list[dict], CitedSourceSelection | None]:
-    if not cited_only or not sources:
-        return sources, None
-
-    cited_selection = select_cited_sources(sources, report)
-    return cited_selection.sources, cited_selection
-
-
-def _display_cited_import_selection(cited_selection: CitedSourceSelection | None) -> None:
-    if cited_selection is None:
-        return
-
-    if cited_selection.used_fallback:
-        console.print("[yellow]Could not resolve cited sources; importing all sources.[/yellow]")
-        return
-
-    console.print(
-        f"[dim]Importing {cited_selection.matched_url_source_count} cited source(s)[/dim]"
+def _display_cited_import_selection(cited_selection) -> None:
+    """Compatibility wrapper for the research import cited-source display."""
+    research_import_helpers._display_cited_import_selection(
+        cited_selection,
+        output_console=console,
     )
 
 
@@ -408,37 +147,21 @@ async def import_research_sources(
     max_elapsed: float = 1800,
     json_output: bool = False,
     status_message: str | None = None,
-) -> ResearchImportResult:
-    """Select and import research sources using shared CLI policy."""
-    sources_to_import, cited_selection = _select_research_sources_for_import(
-        sources, report, cited_only
+) -> research_import_helpers.ResearchImportResult:
+    """Compatibility wrapper for :func:`cli.research_import.import_research_sources`."""
+    return await research_import_helpers.import_research_sources(
+        client,
+        notebook_id,
+        task_id,
+        sources,
+        report=report,
+        cited_only=cited_only,
+        max_elapsed=max_elapsed,
+        json_output=json_output,
+        status_message=status_message,
+        import_func=import_with_retry,
+        output_console=console,
     )
-    if not sources_to_import:
-        return ResearchImportResult([], sources_to_import, cited_selection)
-
-    if not json_output:
-        _display_cited_import_selection(cited_selection)
-
-    retry_kwargs: dict[str, Any] = {"max_elapsed": max_elapsed}
-    if json_output:
-        retry_kwargs["json_output"] = True
-
-    async def _import_selected() -> list[dict[str, str]]:
-        return await import_with_retry(
-            client,
-            notebook_id,
-            task_id,
-            sources_to_import,
-            **retry_kwargs,
-        )
-
-    if status_message and not json_output:
-        with console.status(status_message):
-            imported = await _import_selected()
-    else:
-        imported = await _import_selected()
-
-    return ResearchImportResult(imported, sources_to_import, cited_selection)
 
 
 # =============================================================================

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -128,7 +128,9 @@ async def import_with_retry(
     )
 
 
-def _display_cited_import_selection(cited_selection) -> None:
+def _display_cited_import_selection(
+    cited_selection: research_import_helpers.CitedSourceSelection | None,
+) -> None:
     """Compatibility wrapper for the research import cited-source display."""
     research_import_helpers._display_cited_import_selection(
         cited_selection,

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -14,13 +14,13 @@ from .helpers import (
     console,
     display_report,
     display_research_sources,
-    import_research_sources,
     json_output_response,
     require_notebook,
     resolve_notebook_id,
     with_client,
 )
 from .options import notebook_option
+from .research_import import import_research_sources
 
 # UI-only cap for the research summary preview shown in `research status` /
 # `research wait`. Unlike RPC error previews (see

--- a/src/notebooklm/cli/research_import.py
+++ b/src/notebooklm/cli/research_import.py
@@ -45,7 +45,7 @@ def _normalize_url(url: str) -> str:
             parsed.netloc.lower(),
             parsed.path.rstrip("/"),
             parsed.query,
-            parsed.fragment,
+            "",
         )
     )
 
@@ -63,6 +63,10 @@ def _requested_urls_norm(sources: list[dict]) -> set[str]:
 
 def _has_no_url_entry(sources: list[dict]) -> bool:
     return any(_source_url_norm(source) is None for source in sources)
+
+
+def _no_url_entry_count(sources: list[dict]) -> int:
+    return sum(1 for source in sources if _source_url_norm(source) is None)
 
 
 def _imported_source_entry(source: "Source") -> dict[str, str]:
@@ -119,11 +123,10 @@ async def import_with_retry(
     verified_imported_ids: set[str] = set()
 
     requested_urls_norm = _requested_urls_norm(sources)
-    # Track whether the request itself includes any non-URL entries (research
-    # reports, pasted text). If it doesn't, we must NOT include concurrent
-    # no-URL additions in the synthesized return — those would be unrelated
-    # sources reported as "imported" by this call.
-    requested_has_no_url_entry = _has_no_url_entry(sources)
+    # Track how many non-URL entries (research reports, pasted text) the
+    # request includes so concurrent no-URL additions cannot inflate the
+    # synthesized return.
+    requested_no_url_count = _no_url_entry_count(sources)
 
     # Snapshot baseline source IDs so the post-timeout probe can identify
     # truly-new sources. We anchor the verified-success condition on URLs of
@@ -188,18 +191,16 @@ async def import_with_retry(
                                 len(requested_urls_norm),
                             )
                         # Return only new sources that match a requested URL.
-                        # No-URL new sources (research reports, pasted text)
-                        # are included only if the request itself had no-URL
-                        # entries — otherwise they're concurrent unrelated
-                        # additions and don't belong in the return.
-                        imported = [
-                            _imported_source_entry(src)
-                            for src in new_sources
-                            if (src.url and _normalize_url(src.url) in requested_urls_norm)
-                            or (not src.url and requested_has_no_url_entry)
-                        ]
+                        timeout_verified: list[dict[str, str]] = []
+                        remaining_no_url = requested_no_url_count
+                        for src in new_sources:
+                            if src.url and _normalize_url(src.url) in requested_urls_norm:
+                                timeout_verified.append(_imported_source_entry(src))
+                            elif not src.url and remaining_no_url > 0:
+                                timeout_verified.append(_imported_source_entry(src))
+                                remaining_no_url -= 1
                         return _merge_imported_sources(
-                            imported, verified_imported, verified_imported_ids
+                            timeout_verified, verified_imported, verified_imported_ids
                         )
                     source_norms = [(source, _source_url_norm(source)) for source in sources]
                     removed_urls_norm = {
@@ -222,7 +223,7 @@ async def import_with_retry(
                                 verified_imported_ids.add(src.id)
                         sources = filtered_sources
                         requested_urls_norm = _requested_urls_norm(sources)
-                        requested_has_no_url_entry = _has_no_url_entry(sources)
+                        requested_no_url_count = _no_url_entry_count(sources)
                         if not sources:
                             logger.warning(
                                 "IMPORT_RESEARCH timed out for notebook %s but "

--- a/src/notebooklm/cli/research_import.py
+++ b/src/notebooklm/cli/research_import.py
@@ -1,0 +1,390 @@
+"""Research import helpers shared by CLI commands."""
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+
+from ..exceptions import NetworkError, RPCError, RPCTimeoutError
+from ..research import select_cited_sources
+from ..types import CitedSourceSelection
+from . import rendering as rendering_helpers
+
+if TYPE_CHECKING:
+    from ..types import Source
+
+console = rendering_helpers.console
+logger = logging.getLogger(__name__)
+
+ImportWithRetry = Callable[..., Awaitable[list[dict[str, str]]]]
+
+
+@dataclass(frozen=True)
+class ResearchImportResult:
+    """Result of importing research sources from CLI commands."""
+
+    imported: list[dict[str, str]]
+    sources: list[dict]
+    cited_selection: CitedSourceSelection | None = None
+
+
+def _normalize_url(url: str) -> str:
+    """Lowercase scheme + host and strip a trailing slash for comparison.
+
+    Server-side URL storage normalizes case and trailing slashes; client-side
+    requests may not. Compare via this helper to avoid false-negative misses
+    when verifying that a requested URL appears post-import.
+    """
+    parsed = urlsplit(url)
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            parsed.path.rstrip("/"),
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _source_url_norm(source: dict) -> str | None:
+    url = source.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    return _normalize_url(url)
+
+
+def _requested_urls_norm(sources: list[dict]) -> set[str]:
+    return {url for source in sources if (url := _source_url_norm(source))}
+
+
+def _has_no_url_entry(sources: list[dict]) -> bool:
+    return any(_source_url_norm(source) is None for source in sources)
+
+
+def _imported_source_entry(source: "Source") -> dict[str, str]:
+    return {"id": source.id, "title": source.title or source.url or ""}
+
+
+def _merge_imported_sources(
+    imported: list[dict[str, str]],
+    verified_imported: list[dict[str, str]],
+    verified_imported_ids: set[str],
+) -> list[dict[str, str]]:
+    if not verified_imported:
+        return imported
+    return [
+        *verified_imported,
+        *(entry for entry in imported if entry.get("id") not in verified_imported_ids),
+    ]
+
+
+async def import_with_retry(
+    client,
+    notebook_id: str,
+    task_id: str,
+    sources: list[dict],
+    *,
+    max_elapsed: float = 1800,
+    initial_delay: float = 5,
+    backoff_factor: float = 2,
+    max_delay: float = 60,
+    json_output: bool = False,
+    output_console: Any | None = None,
+) -> list[dict[str, str]]:
+    """Retry research import on RPC timeouts with exponential backoff.
+
+    On RPC timeout, probes the notebook's source list to detect server-side
+    imports that succeeded despite the client deadline firing. This avoids the
+    duplicate-on-retry inflation that otherwise occurs when each retry re-adds
+    a copy of the same sources (a single timeout cascade can otherwise inflate
+    a 60-source import to 300+ sources across 5-6 retries).
+
+    If the pre-import source snapshot is unavailable, retries still filter out
+    URLs that are already visible after each timeout, but the returned list may
+    undercount server-side imports because the function cannot prove those
+    sources were absent before this call.
+
+    This is intentionally CLI-only policy. Library consumers calling
+    `client.research.import_sources()` directly still get one-shot behavior.
+    """
+    started_at = time.monotonic()
+    status_console = console if output_console is None else output_console
+    delay = initial_delay
+    attempt = 1
+    verified_imported: list[dict[str, str]] = []
+    verified_imported_ids: set[str] = set()
+
+    requested_urls_norm = _requested_urls_norm(sources)
+    # Track whether the request itself includes any non-URL entries (research
+    # reports, pasted text). If it doesn't, we must NOT include concurrent
+    # no-URL additions in the synthesized return — those would be unrelated
+    # sources reported as "imported" by this call.
+    requested_has_no_url_entry = _has_no_url_entry(sources)
+
+    # Snapshot baseline source IDs so the post-timeout probe can identify
+    # truly-new sources. We anchor the verified-success condition on URLs of
+    # *new* sources — not on a baseline→current URL delta — so concurrent
+    # additions from another session and pre-existing URLs cannot satisfy it.
+    baseline_ids: set[str] | None
+    try:
+        baseline = await client.sources.list(notebook_id, strict=True)
+        baseline_ids = {src.id for src in baseline}
+    except (NetworkError, RPCError) as snapshot_exc:
+        logger.warning(
+            "Pre-import sources.list snapshot failed for %s: %s; "
+            "verified-success path disabled for this call",
+            notebook_id,
+            snapshot_exc,
+        )
+        baseline_ids = None
+
+    while True:
+        try:
+            imported = await client.research.import_sources(notebook_id, task_id, sources)
+            return _merge_imported_sources(imported, verified_imported, verified_imported_ids)
+        except RPCTimeoutError:
+            elapsed = time.monotonic() - started_at
+            remaining = max_elapsed - elapsed
+
+            # Verify server-side state before retrying. The IMPORT_RESEARCH RPC
+            # frequently times out at the client (30s) after a successful
+            # server-side write; retrying then duplicates every source.
+            if requested_urls_norm:
+                try:
+                    current = await client.sources.list(notebook_id, strict=True)
+                    new_sources = (
+                        [src for src in current if src.id not in baseline_ids]
+                        if baseline_ids is not None
+                        else []
+                    )
+                    new_urls_norm = {_normalize_url(src.url) for src in new_sources if src.url}
+                    current_urls_norm = {_normalize_url(src.url) for src in current if src.url}
+                    # Success requires every requested URL to appear among the
+                    # *new* sources. Trivial-true cases (pre-existing URLs) and
+                    # concurrent unrelated additions both fail this check.
+                    if baseline_ids is not None and requested_urls_norm.issubset(new_urls_norm):
+                        logger.warning(
+                            "IMPORT_RESEARCH timed out for notebook %s but "
+                            "sources.list shows all %d requested URLs among "
+                            "new sources; treating as success and skipping "
+                            "retry to avoid duplicate inflation",
+                            notebook_id,
+                            len(requested_urls_norm),
+                        )
+                        if not json_output:
+                            status_console.print(
+                                f"[yellow]Import RPC timed out, but server-side "
+                                f"verified {len(requested_urls_norm)} requested "
+                                f"sources — skipping retry.[/yellow]"
+                            )
+                        else:
+                            logger.debug(
+                                "Import RPC timed out, but server-side verified "
+                                "%d requested sources — skipping retry (json mode).",
+                                len(requested_urls_norm),
+                            )
+                        # Return only new sources that match a requested URL.
+                        # No-URL new sources (research reports, pasted text)
+                        # are included only if the request itself had no-URL
+                        # entries — otherwise they're concurrent unrelated
+                        # additions and don't belong in the return.
+                        imported = [
+                            _imported_source_entry(src)
+                            for src in new_sources
+                            if (src.url and _normalize_url(src.url) in requested_urls_norm)
+                            or (not src.url and requested_has_no_url_entry)
+                        ]
+                        return _merge_imported_sources(
+                            imported, verified_imported, verified_imported_ids
+                        )
+                    source_norms = [(source, _source_url_norm(source)) for source in sources]
+                    removed_urls_norm = {
+                        url
+                        for _, url in source_norms
+                        if url is not None and url in current_urls_norm
+                    }
+                    filtered_sources = [
+                        source for source, url in source_norms if url not in current_urls_norm
+                    ]
+                    if len(filtered_sources) != len(sources):
+                        removed_count = len(sources) - len(filtered_sources)
+                        for src in new_sources:
+                            if (
+                                src.url
+                                and _normalize_url(src.url) in removed_urls_norm
+                                and src.id not in verified_imported_ids
+                            ):
+                                verified_imported.append(_imported_source_entry(src))
+                                verified_imported_ids.add(src.id)
+                        sources = filtered_sources
+                        requested_urls_norm = _requested_urls_norm(sources)
+                        requested_has_no_url_entry = _has_no_url_entry(sources)
+                        if not sources:
+                            logger.warning(
+                                "IMPORT_RESEARCH timed out for notebook %s but "
+                                "sources.list shows all requested URLs already "
+                                "present; treating as success and skipping retry "
+                                "to avoid duplicate inflation",
+                                notebook_id,
+                            )
+                            if not json_output:
+                                status_console.print(
+                                    "[yellow]Import RPC timed out, but all "
+                                    "requested sources are already present — "
+                                    "skipping retry.[/yellow]"
+                                )
+                            else:
+                                logger.debug(
+                                    "Import RPC timed out, but all requested "
+                                    "sources are already present — skipping retry "
+                                    "(json mode)."
+                                )
+                            return _merge_imported_sources(
+                                [], verified_imported, verified_imported_ids
+                            )
+                        logger.warning(
+                            "IMPORT_RESEARCH timed out for notebook %s after "
+                            "%d requested source(s) were already present; retrying "
+                            "with %d remaining source(s)",
+                            notebook_id,
+                            removed_count,
+                            len(sources),
+                        )
+                except (NetworkError, RPCError) as probe_exc:
+                    # CancelledError is a BaseException, not Exception, and is
+                    # not in this tuple — it propagates naturally for callers
+                    # that need to cancel the operation cleanly.
+                    logger.warning(
+                        "Failed to probe server state after timeout: %s; falling back to retry",
+                        probe_exc,
+                    )
+
+            if remaining <= 0:
+                raise
+
+            # Report-only imports (no URLs to verify) can't use the success
+            # check above. Cap retries at one to bound worst-case duplicate
+            # inflation for report entries when timeouts persist.
+            if not requested_urls_norm and attempt >= 2:
+                logger.warning(
+                    "IMPORT_RESEARCH timed out for notebook %s with no URLs to "
+                    "verify; giving up after %d attempts to bound duplicate inflation",
+                    notebook_id,
+                    attempt,
+                )
+                raise
+
+            sleep_for = min(delay, max_delay, remaining)
+            logger.warning(
+                "IMPORT_RESEARCH timed out for notebook %s; retrying in %.1fs "
+                "(attempt %d, %.1fs elapsed)",
+                notebook_id,
+                sleep_for,
+                attempt + 1,
+                elapsed,
+            )
+            if not json_output:
+                status_console.print(
+                    f"[yellow]Import timed out; retrying in {sleep_for:.0f}s "
+                    f"(attempt {attempt + 1})[/yellow]"
+                )
+            else:
+                logger.debug(
+                    "Import timed out; retrying in %.0fs (attempt %d) (json mode).",
+                    sleep_for,
+                    attempt + 1,
+                )
+            await asyncio.sleep(sleep_for)
+            delay = min(delay * backoff_factor, max_delay)
+            attempt += 1
+
+
+def _select_research_sources_for_import(
+    sources: list[dict], report: str, cited_only: bool
+) -> tuple[list[dict], CitedSourceSelection | None]:
+    if not cited_only or not sources:
+        return sources, None
+
+    cited_selection = select_cited_sources(sources, report)
+    return cited_selection.sources, cited_selection
+
+
+def _display_cited_import_selection(
+    cited_selection: CitedSourceSelection | None,
+    *,
+    output_console: Any | None = None,
+) -> None:
+    if cited_selection is None:
+        return
+
+    status_console = console if output_console is None else output_console
+    if cited_selection.used_fallback:
+        status_console.print(
+            "[yellow]Could not resolve cited sources; importing all sources.[/yellow]"
+        )
+        return
+
+    status_console.print(
+        f"[dim]Importing {cited_selection.matched_url_source_count} cited source(s)[/dim]"
+    )
+
+
+async def import_research_sources(
+    client,
+    notebook_id: str,
+    task_id: str,
+    sources: list[dict],
+    *,
+    report: str = "",
+    cited_only: bool = False,
+    max_elapsed: float = 1800,
+    json_output: bool = False,
+    status_message: str | None = None,
+    import_func: ImportWithRetry | None = None,
+    output_console: Any | None = None,
+) -> ResearchImportResult:
+    """Select and import research sources using shared CLI policy."""
+    status_console = console if output_console is None else output_console
+    sources_to_import, cited_selection = _select_research_sources_for_import(
+        sources, report, cited_only
+    )
+    if not sources_to_import:
+        return ResearchImportResult([], sources_to_import, cited_selection)
+
+    if not json_output:
+        _display_cited_import_selection(cited_selection, output_console=status_console)
+
+    retry_kwargs: dict[str, Any] = {"max_elapsed": max_elapsed}
+    if json_output:
+        retry_kwargs["json_output"] = True
+
+    async def _import_selected() -> list[dict[str, str]]:
+        if import_func is not None:
+            return await import_func(
+                client,
+                notebook_id,
+                task_id,
+                sources_to_import,
+                **retry_kwargs,
+            )
+        if output_console is not None:
+            retry_kwargs["output_console"] = status_console
+        return await import_with_retry(
+            client,
+            notebook_id,
+            task_id,
+            sources_to_import,
+            **retry_kwargs,
+        )
+
+    if status_message and not json_output:
+        with status_console.status(status_message):
+            imported = await _import_selected()
+    else:
+        imported = await _import_selected()
+
+    return ResearchImportResult(imported, sources_to_import, cited_selection)

--- a/src/notebooklm/cli/research_import.py
+++ b/src/notebooklm/cli/research_import.py
@@ -61,10 +61,6 @@ def _requested_urls_norm(sources: list[dict]) -> set[str]:
     return {url for source in sources if (url := _source_url_norm(source))}
 
 
-def _has_no_url_entry(sources: list[dict]) -> bool:
-    return any(_source_url_norm(source) is None for source in sources)
-
-
 def _no_url_entry_count(sources: list[dict]) -> int:
     return sum(1 for source in sources if _source_url_norm(source) is None)
 

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -54,9 +54,9 @@ from .options import (
     prompt_file_option,
     wait_polling_options,
 )
+from .research_import import import_research_sources
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
-from .research_import import import_research_sources
 
 
 @contextlib.asynccontextmanager

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -38,7 +38,6 @@ from .helpers import (
     display_research_sources,
     emit_status,
     get_source_type_display,
-    import_research_sources,
     json_output_response,
     read_stdin_text,
     require_notebook,
@@ -57,6 +56,7 @@ from .options import (
 )
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
+from .research_import import import_research_sources
 
 
 @contextlib.asynccontextmanager

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -12,7 +12,9 @@ from filelock import Timeout
 
 import notebooklm.cli._encoding as encoding_module
 import notebooklm.cli.context as context_module
+import notebooklm.cli.helpers as helpers_module
 import notebooklm.cli.rendering as rendering_module
+import notebooklm.cli.research_import as research_import_module
 from notebooklm import Artifact
 from notebooklm.cli.helpers import (
     clear_context,
@@ -27,7 +29,6 @@ from notebooklm.cli.helpers import (
     get_source_type_display,
     handle_auth_error,
     handle_error,
-    import_with_retry,
     json_error_response,
     json_output_response,
     require_notebook,
@@ -36,6 +37,7 @@ from notebooklm.cli.helpers import (
     set_current_notebook,
     with_client,
 )
+from notebooklm.cli.research_import import import_with_retry
 from notebooklm.exceptions import NetworkError, RPCError, RPCTimeoutError
 from notebooklm.types import ArtifactType
 
@@ -1151,6 +1153,71 @@ class TestRunAsync:
 
 class TestImportWithRetry:
     @pytest.mark.asyncio
+    async def test_helpers_import_with_retry_passes_console_without_global_mutation(self):
+        client = MagicMock()
+        original_console = research_import_module.console
+
+        with (
+            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch.object(
+                research_import_module,
+                "import_with_retry",
+                new_callable=AsyncMock,
+            ) as mock_import,
+        ):
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+
+            imported = await helpers_module.import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+            )
+
+        assert imported == [{"id": "src_1", "title": "Source 1"}]
+        assert research_import_module.console is original_console
+        mock_import.assert_awaited_once_with(
+            client,
+            "nb_123",
+            "task_123",
+            [{"url": "https://example.com", "title": "Source 1"}],
+            max_elapsed=1800,
+            initial_delay=5,
+            backoff_factor=2,
+            max_delay=60,
+            json_output=False,
+            output_console=mock_console,
+        )
+
+    @pytest.mark.asyncio
+    async def test_helpers_import_research_sources_uses_patchable_retry_wrapper(self):
+        client = MagicMock()
+
+        with patch.object(
+            helpers_module,
+            "import_with_retry",
+            new_callable=AsyncMock,
+        ) as mock_import:
+            mock_import.return_value = [{"id": "src_1", "title": "Source 1"}]
+
+            result = await helpers_module.import_research_sources(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com", "title": "Source 1"}],
+                max_elapsed=123,
+            )
+
+        assert result.imported == [{"id": "src_1", "title": "Source 1"}]
+        mock_import.assert_awaited_once_with(
+            client,
+            "nb_123",
+            "task_123",
+            [{"url": "https://example.com", "title": "Source 1"}],
+            max_elapsed=123,
+        )
+
+    @pytest.mark.asyncio
     async def test_retries_rpc_timeout_then_succeeds(self):
         # Empty baseline + empty post-timeout probe → verification fails →
         # falls through to legacy retry. This exercises the retry path
@@ -1165,8 +1232,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console") as mock_console,
         ):
             imported = await import_with_retry(
                 client,
@@ -1194,8 +1263,8 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
-            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console") as mock_console,
         ):
             await import_with_retry(
                 client,
@@ -1219,10 +1288,12 @@ class TestImportWithRetry:
         # path (elapsed check). Past-budget on second read forces the raise.
         with (
             patch(
-                "notebooklm.cli.helpers.time.monotonic",
+                "notebooklm.cli.research_import.time.monotonic",
                 side_effect=[0.0, 1801.0],
             ),
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
             pytest.raises(RPCTimeoutError),
         ):
             await import_with_retry(
@@ -1242,7 +1313,9 @@ class TestImportWithRetry:
         client.research.import_sources = AsyncMock(side_effect=ValueError("boom"))
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
             pytest.raises(ValueError, match="boom"),
         ):
             await import_with_retry(
@@ -1278,8 +1351,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console") as mock_console,
         ):
             imported = await import_with_retry(
                 client,
@@ -1319,8 +1394,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1349,8 +1426,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1390,8 +1469,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1447,8 +1528,8 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
-            patch("notebooklm.cli.helpers.console"),
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1496,8 +1577,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1547,8 +1630,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1590,8 +1675,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console") as mock_console,
         ):
             imported = await import_with_retry(
                 client,
@@ -1640,8 +1727,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1678,8 +1767,8 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
-            patch("notebooklm.cli.helpers.console"),
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1726,8 +1815,8 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
-            patch("notebooklm.cli.helpers.console"),
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1774,8 +1863,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1815,8 +1906,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1852,11 +1945,13 @@ class TestImportWithRetry:
         with (
             # Time budget never expires — only the retry cap can stop the loop.
             patch(
-                "notebooklm.cli.helpers.time.monotonic",
+                "notebooklm.cli.research_import.time.monotonic",
                 return_value=0.0,
             ),
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
             pytest.raises(RPCTimeoutError),
         ):
             await import_with_retry(
@@ -1903,8 +1998,10 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
-            patch("notebooklm.cli.helpers.console"),
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
         ):
             imported = await import_with_retry(
                 client,
@@ -1935,8 +2032,8 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
-            patch("notebooklm.cli.helpers.console") as mock_console,
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console") as mock_console,
         ):
             imported = await import_with_retry(
                 client,
@@ -1987,8 +2084,8 @@ class TestImportWithRetry:
         )
 
         with (
-            patch("notebooklm.cli.helpers.asyncio.sleep", new_callable=AsyncMock),
-            patch("notebooklm.cli.helpers.console"),
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console"),
             pytest.raises(asyncio.CancelledError),
         ):
             await import_with_retry(

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -1412,6 +1412,32 @@ class TestImportWithRetry:
         mock_sleep.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_skips_retry_when_only_url_fragment_differs(self):
+        new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com/a")
+        client = MagicMock()
+        client.sources.list = AsyncMock(side_effect=[[], [new_src]])
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            patch(
+                "notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+            patch("notebooklm.cli.research_import.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [{"url": "https://example.com/a#top", "title": "Source 1"}],
+            )
+
+        assert imported == [{"id": "src_new", "title": "Source 1"}]
+        assert client.research.import_sources.await_count == 1
+        mock_sleep.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_retries_when_server_state_shows_no_progress(self):
         """If sources.list shows the requested URLs were NOT imported, fall
         back to the original retry behavior.
@@ -1786,6 +1812,41 @@ class TestImportWithRetry:
             )
 
         # Both sources are returned — the report (no URL) and the URL source.
+        ids_returned = {entry["id"] for entry in imported}
+        assert ids_returned == {"src_report", "src_new"}
+
+    @pytest.mark.asyncio
+    async def test_no_url_verified_success_is_capped_to_requested_no_url_count(self):
+        """Concurrent no-URL rows must not inflate the synthesized import count."""
+        requested_report = MagicMock(id="src_report", title="Research Report", url=None)
+        concurrent_report = MagicMock(id="src_concurrent", title="Concurrent Report", url=None)
+        new_src = MagicMock(id="src_new", title="Source 1", url="https://example.com")
+        client = MagicMock()
+        client.sources.list = AsyncMock(
+            side_effect=[[], [requested_report, concurrent_report, new_src]]
+        )
+        client.research.import_sources = AsyncMock(
+            side_effect=RPCTimeoutError("Timed out", timeout_seconds=30.0)
+        )
+
+        with (
+            patch("notebooklm.cli.research_import.asyncio.sleep", new_callable=AsyncMock),
+            patch("notebooklm.cli.research_import.console"),
+        ):
+            imported = await import_with_retry(
+                client,
+                "nb_123",
+                "task_123",
+                [
+                    {"url": "https://example.com", "title": "Source 1"},
+                    {
+                        "title": "Research Report",
+                        "report_markdown": "# Findings\n...",
+                        "result_type": 5,
+                    },
+                ],
+            )
+
         ids_returned = {entry["id"] for entry in imported}
         assert ids_returned == {"src_report", "src_new"}
 

--- a/tests/unit/cli/test_research.py
+++ b/tests/unit/cli/test_research.py
@@ -9,7 +9,7 @@ from notebooklm.notebooklm_cli import cli
 from .conftest import create_mock_client, patch_client_for_module
 
 research_module = importlib.import_module("notebooklm.cli.research")
-helpers_module = importlib.import_module("notebooklm.cli.helpers")
+research_import_module = importlib.import_module("notebooklm.cli.research_import")
 
 # =============================================================================
 # RESEARCH STATUS TESTS
@@ -179,7 +179,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -210,7 +210,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -277,7 +277,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -314,7 +314,7 @@ class TestResearchWait:
         with (
             patch_client_for_module("research") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -22,7 +22,7 @@ from notebooklm.types import (
 from .conftest import create_mock_client, patch_client_for_module
 
 source_module = importlib.import_module("notebooklm.cli.source")
-helpers_module = importlib.import_module("notebooklm.cli.helpers")
+research_import_module = importlib.import_module("notebooklm.cli.research_import")
 
 
 @pytest.fixture
@@ -1061,7 +1061,7 @@ class TestSourceAddResearch:
         with (
             patch_client_for_module("source") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -1109,7 +1109,7 @@ class TestSourceAddResearch:
         with (
             patch_client_for_module("source") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()
@@ -1171,7 +1171,7 @@ class TestSourceAddResearch:
         with (
             patch_client_for_module("source") as mock_client_cls,
             patch.object(
-                helpers_module, "import_with_retry", new_callable=AsyncMock
+                research_import_module, "import_with_retry", new_callable=AsyncMock
             ) as mock_import,
         ):
             mock_client = create_mock_client()


### PR DESCRIPTION
## Summary
- Move research import retry, cited-source selection/display, URL normalization, and orchestration helpers into cli.research_import
- Keep cli.helpers compatibility wrappers and re-exports, including legacy patch seams
- Update research/source command import call sites and focused tests

## Test plan
- [x] rtk uv run --extra dev pytest -n auto tests/unit/cli/test_helpers.py::TestImportWithRetry tests/unit/cli/test_research.py tests/unit/cli/test_source.py tests/integration/concurrency/test_research_task_crosswire.py tests/integration/cli_vcr/test_sources.py tests/unit/test_cli_boundary.py
- [x] rtk uv run --extra dev ruff check src/notebooklm/cli/research_import.py src/notebooklm/cli/research.py src/notebooklm/cli/source.py src/notebooklm/cli/helpers.py tests/unit/cli/test_helpers.py tests/unit/cli/test_research.py tests/unit/cli/test_source.py tests/unit/test_cli_boundary.py
- [x] rtk uv run --extra dev ruff format --check src/notebooklm/cli/research_import.py src/notebooklm/cli/research.py src/notebooklm/cli/source.py src/notebooklm/cli/helpers.py tests/unit/cli/test_helpers.py tests/unit/cli/test_research.py tests/unit/cli/test_source.py tests/unit/test_cli_boundary.py
- [x] rtk uv run --extra dev mypy src/notebooklm

## Deferred polish findings
- Kept private helper re-exports in cli.helpers intentionally because this slice requires backward-compatible wrappers/re-exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust research-source import with retry-and-verification to handle timeouts and reduce duplicate entries.
  * Improved handling of cited-only imports and “no-URL” report entries to produce more accurate import results.

* **Refactor**
  * Consolidated CLI research-import helpers into a single shared implementation for consistent behavior (no change to commands).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->