### PR TITLE
refactor(cli): finalize helper facade boundaries

### DIFF
--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md
@@ -67,8 +67,8 @@ High-risk helper patch seams found:
 | `build_cookie_jar` imported from `notebooklm.auth` | `notebooklm.cli.auth_runtime` wrapper | T12.2 | Existing tests patch `notebooklm.cli.helpers.build_cookie_jar`; keep or migrate in same slice. |
 | `handle_auth_error` | `notebooklm.cli.auth_runtime` | T12.2 | Preserve JSON/text UX, exit code 1, checked path fields, and `NoReturn` behavior. |
 | `run_async` | `notebooklm.cli.runtime` | T12.2 | Preserve nested-loop and coroutine cleanup semantics. Existing tests patch `helpers.run_async`. |
-| `with_auth_and_errors` | `notebooklm.cli.runtime` | T12.2 | Preserve T11 call-time lookup for `get_auth_tokens`, `handle_errors`, `handle_auth_error`, and `run_async`. |
-| `with_client` | `notebooklm.cli.runtime` | T12.2 | Keep decorator signature and command callback contract unchanged. |
+| `with_auth_and_errors` | `notebooklm.cli.auth_runtime` | T12.2 | Preserve T11 call-time lookup for `get_auth_tokens`, `handle_errors`, `handle_auth_error`, and `run_async`. |
+| `with_client` | `notebooklm.cli.auth_runtime` | T12.2 | Keep decorator signature and command callback contract unchanged. |
 | `handle_error` | `notebooklm.cli.runtime` or `notebooklm.cli.rendering` | T12.2 | Preserve exit code 1 and Unicode fallback. |
 | `validate_id` | `notebooklm.cli.resolve` | T12.3 | Preserve ClickException wording and trimming behavior. |
 | `require_notebook` | `notebooklm.cli.resolve` | T12.3 | Preserve flag/env/context precedence and failure message. |
@@ -137,3 +137,21 @@ The current plan order remains valid:
 
 The marker-only package file `src/notebooklm/cli/services/__init__.py` is
 created in T12.0 so later service slices do not race on package creation.
+
+## T12.8 Final Helper Facade Imports
+
+After T12.8, production command and service modules import moved helpers from
+their canonical owners instead of `notebooklm.cli.helpers`.
+
+Remaining production imports of `cli.helpers` are intentionally limited to:
+
+| File | Import shape | Reason |
+|---|---|---|
+| `src/notebooklm/cli/__init__.py` | `from .helpers import ...` | Compatibility re-export surface for callers that import helper names through the CLI package. |
+| `src/notebooklm/cli/auth_runtime.py` | lazy `from . import helpers` inside `_helpers_facade()` | Preserves call-time patch seams for `load_auth_from_storage`, `build_cookie_jar`, `get_client`, `get_auth_tokens`, `run_async`, `handle_auth_error`, JSON error rendering, and helper-level consoles. |
+| `src/notebooklm/cli/completion.py` | lazy `from . import helpers` inside provider methods | Preserves existing completion tests and shell-completion patch seams for `get_auth_tokens`, `get_current_notebook`, and `run_async` while keeping visible completion failures silent. |
+
+`tests/unit/test_cli_boundary.py::test_command_modules_do_not_import_helpers_facade_for_moved_symbols`
+guards that no other production CLI module imports moved helper symbols through
+the compatibility facade. `test_helpers_remains_compatibility_facade` guards
+against `cli.helpers` regaining new top-level command responsibilities.

--- a/src/notebooklm/cli/agent.py
+++ b/src/notebooklm/cli/agent.py
@@ -3,7 +3,7 @@
 import click
 
 from .agent_templates import get_agent_source_content
-from .helpers import console
+from .rendering import console
 
 
 @click.group()

--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -22,18 +22,20 @@ from rich.table import Table
 
 from ..client import NotebookLMClient
 from ..types import ExportType
+from .auth_runtime import with_client
 from .error_handler import _output_error, emit_cancelled_and_exit
-from .helpers import (
+from .options import json_option, list_options, notebook_option, wait_polling_options
+from .rendering import (
     cli_name_to_artifact_type,
     console,
     get_artifact_type_display,
     json_output_response,
+)
+from .resolve import (
     require_notebook,
     resolve_artifact_id,
     resolve_notebook_id,
-    with_client,
 )
-from .options import json_option, list_options, notebook_option, wait_polling_options
 
 
 @contextlib.asynccontextmanager

--- a/src/notebooklm/cli/chat.py
+++ b/src/notebooklm/cli/chat.py
@@ -13,16 +13,14 @@ from rich.table import Table
 
 from ..client import NotebookLMClient
 from ..types import ChatMode
-from .helpers import (
-    console,
-    get_current_conversation,
-    get_current_notebook,
-    json_output_response,
-    set_current_conversation,
-    with_client,
-)
+from .auth_runtime import with_client
+from .context import get_current_conversation, get_current_notebook, set_current_conversation
 from .input import resolve_prompt
 from .options import _complete_sources, json_option, notebook_option, prompt_file_option
+from .rendering import (
+    console,
+    json_output_response,
+)
 from .resolve import require_notebook, resolve_notebook_id, resolve_source_ids
 
 logger = logging.getLogger(__name__)

--- a/src/notebooklm/cli/doctor.py
+++ b/src/notebooklm/cli/doctor.py
@@ -17,7 +17,7 @@ from ..paths import (
     get_profile_dir,
     get_storage_path,
 )
-from .helpers import console, json_output_response
+from .rendering import console, json_output_response
 
 logger = logging.getLogger(__name__)
 

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -23,20 +23,16 @@ import click
 from ..auth import AuthTokens
 from ..client import NotebookLMClient
 from ..types import Artifact, ArtifactType
+from .auth_runtime import with_auth_and_errors
 from .download_helpers import (
     ArtifactDict,
     artifact_title_to_filename,
     resolve_partial_artifact_id,
     select_artifact,
 )
-from .helpers import (
-    console,
-    json_output_response,
-    require_notebook,
-    resolve_notebook_id,
-    with_auth_and_errors,
-)
 from .options import _complete_artifacts, notebook_option
+from .rendering import console, json_output_response
+from .resolve import require_notebook, resolve_notebook_id
 
 # Common signature shared by all artifact download functions.
 # Each function accepts (notebook_id, output_path, *, artifact_id=None, **kwargs).

--- a/src/notebooklm/cli/generate.py
+++ b/src/notebooklm/cli/generate.py
@@ -34,16 +34,8 @@ from ..types import (
     VideoFormat,
     VideoStyle,
 )
-from .helpers import (
-    console,
-    json_error_response,
-    json_output_response,
-    require_notebook,
-    resolve_notebook_id,
-    resolve_prompt,
-    resolve_source_ids,
-    with_client,
-)
+from .auth_runtime import with_client
+from .input import resolve_prompt
 from .language import SUPPORTED_LANGUAGES, get_language
 from .options import (
     _complete_artifacts,
@@ -53,6 +45,16 @@ from .options import (
     prompt_file_option,
     retry_option,
     wait_polling_options,
+)
+from .rendering import (
+    console,
+    json_error_response,
+    json_output_response,
+)
+from .resolve import (
+    require_notebook,
+    resolve_notebook_id,
+    resolve_source_ids,
 )
 from .services.artifact_generation import generate_with_retry, handle_generation_result
 

--- a/src/notebooklm/cli/language.py
+++ b/src/notebooklm/cli/language.py
@@ -15,8 +15,10 @@ from rich.table import Table
 from ..client import NotebookLMClient
 from ..io import atomic_update_json
 from ..paths import get_config_path, get_home_dir
-from .helpers import console, get_auth_tokens, json_output_response, run_async
+from .auth_runtime import get_auth_tokens
 from .options import json_option
+from .rendering import console, json_output_response
+from .runtime import run_async
 
 logger = logging.getLogger(__name__)
 

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -17,14 +17,11 @@ from rich.table import Table
 
 from ..client import NotebookLMClient
 from ..types import Note
+from .auth_runtime import with_client
 from .error_handler import _output_error
-from .helpers import (
-    console,
-    json_output_response,
-    with_client,
-)
 from .input import read_stdin_text
 from .options import json_option, notebook_option
+from .rendering import console, json_output_response
 from .resolve import require_notebook, resolve_note_id, resolve_notebook_id
 
 

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -17,15 +17,10 @@ import click
 from rich.table import Table
 
 from ..client import NotebookLMClient
-from .helpers import (
-    clear_context,
-    console,
-    get_current_notebook,
-    json_output_response,
-    set_current_notebook,
-    with_client,
-)
+from .auth_runtime import with_client
+from .context import clear_context, get_current_notebook, set_current_notebook
 from .options import list_options, notebook_option
+from .rendering import console, json_output_response
 from .resolve import require_notebook, resolve_notebook_id
 
 

--- a/src/notebooklm/cli/profile.py
+++ b/src/notebooklm/cli/profile.py
@@ -27,7 +27,7 @@ from ..paths import (
     read_default_profile,
     resolve_profile,
 )
-from .helpers import console, json_output_response
+from .rendering import console, json_output_response
 from .services import login as login_service
 
 _PROFILE_NAME_RE = login_service._PROFILE_NAME_RE

--- a/src/notebooklm/cli/research.py
+++ b/src/notebooklm/cli/research.py
@@ -10,17 +10,19 @@ import asyncio
 import click
 
 from ..client import NotebookLMClient
-from .helpers import (
+from .auth_runtime import with_client
+from .options import notebook_option
+from .rendering import (
     console,
     display_report,
     display_research_sources,
     json_output_response,
+)
+from .research_import import import_research_sources
+from .resolve import (
     require_notebook,
     resolve_notebook_id,
-    with_client,
 )
-from .options import notebook_option
-from .research_import import import_research_sources
 
 # UI-only cap for the research summary preview shown in `research status` /
 # `research wait`. Unlike RPC error previews (see

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -47,7 +47,7 @@ def _is_full_id_candidate(entity_id: str) -> bool:
 def require_notebook(
     notebook_id: str | None,
     *,
-    context_path_fn: ContextPathFn = get_context_path,
+    context_path_fn: ContextPathFn | None = None,
     output_console: Console = rendering_helpers.console,
 ) -> str:
     """Get notebook ID from argument, env var, or active context.
@@ -64,7 +64,8 @@ def require_notebook(
         notebook_id: Optional notebook ID from command argument. When the
             Click flag was omitted and the env var was unset, this is ``None``.
         context_path_fn: Context-path resolver, injectable for compatibility
-            wrappers and tests.
+            wrappers and tests. ``None`` keeps the module-level
+            ``get_context_path`` lookup call-time patchable.
         output_console: Console used for the no-notebook diagnostic.
 
     Returns:
@@ -82,7 +83,9 @@ def require_notebook(
     if env_value and env_value.strip():
         return validate_id(env_value, "Notebook")
 
-    current = context_helpers.get_current_notebook(context_path_fn=context_path_fn)
+    current = context_helpers.get_current_notebook(
+        context_path_fn=context_path_fn or get_context_path
+    )
     if current:
         return validate_id(current, "Notebook")
 

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -9,7 +9,7 @@ from typing import Any
 from ...client import NotebookLMClient
 from ...types import GenerationStatus
 from ..error_handler import emit_cancelled_and_exit
-from ..helpers import console, json_error_response, json_output_response
+from ..rendering import console, json_error_response, json_output_response
 
 # Retry constants
 RETRY_INITIAL_DELAY = 60.0  # seconds

--- a/src/notebooklm/cli/services/login.py
+++ b/src/notebooklm/cli/services/login.py
@@ -28,8 +28,9 @@ from ...auth import (
 from ...client import NotebookLMClient
 from ...io import atomic_write_json
 from ...paths import get_storage_path
-from ..helpers import console, run_async
 from ..language import set_language
+from ..rendering import console
+from ..runtime import run_async
 
 logger = logging.getLogger(__name__)
 

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -43,19 +43,17 @@ from ..paths import (
     get_path_info,
     get_storage_path,
 )
-from .error_handler import handle_errors
-from .helpers import (
+from .auth_runtime import get_auth_tokens, handle_auth_error
+from .context import (
     _current_storage_override,
     clear_context,
-    console,
-    get_auth_tokens,
     get_current_notebook,
-    handle_auth_error,
-    json_output_response,
-    resolve_notebook_id,
-    run_async,
     set_current_notebook,
 )
+from .error_handler import handle_errors
+from .rendering import console, json_output_response
+from .resolve import resolve_notebook_id
+from .runtime import run_async
 from .services import login as login_service
 
 logger = logging.getLogger(__name__)

--- a/src/notebooklm/cli/share.py
+++ b/src/notebooklm/cli/share.py
@@ -14,14 +14,10 @@ from rich.table import Table
 
 from ..client import NotebookLMClient
 from ..types import SharePermission, ShareViewLevel
-from .helpers import (
-    console,
-    json_output_response,
-    require_notebook,
-    resolve_notebook_id,
-    with_client,
-)
+from .auth_runtime import with_client
 from .options import notebook_option
+from .rendering import console, json_output_response
+from .resolve import require_notebook, resolve_notebook_id
 
 
 def _permission_name(perm: SharePermission) -> str:

--- a/src/notebooklm/cli/skill.py
+++ b/src/notebooklm/cli/skill.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import click
 
 from .agent_templates import get_agent_source_content
-from .helpers import console
+from .rendering import console
 
 
 @dataclass(frozen=True)

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -31,22 +31,9 @@ from rich.table import Table
 
 from ..client import NotebookLMClient
 from ..types import Source, source_status_to_str
+from .auth_runtime import with_client
 from .error_handler import _output_error, emit_cancelled_and_exit
-from .helpers import (
-    console,
-    display_report,
-    display_research_sources,
-    emit_status,
-    get_source_type_display,
-    json_output_response,
-    read_stdin_text,
-    require_notebook,
-    resolve_notebook_id,
-    resolve_prompt,
-    resolve_source_id,
-    validate_id,
-    with_client,
-)
+from .input import read_stdin_text, resolve_prompt
 from .options import (
     json_option,
     list_options,
@@ -54,7 +41,16 @@ from .options import (
     prompt_file_option,
     wait_polling_options,
 )
+from .rendering import (
+    console,
+    display_report,
+    display_research_sources,
+    emit_status,
+    get_source_type_display,
+    json_output_response,
+)
 from .research_import import import_research_sources
+from .resolve import require_notebook, resolve_notebook_id, resolve_source_id, validate_id
 from .services import source_add as source_add_service
 from .services import source_clean as source_clean_service
 

--- a/tests/integration/cli_vcr/conftest.py
+++ b/tests/integration/cli_vcr/conftest.py
@@ -53,7 +53,11 @@ def mock_context(tmp_path: Path):
     context_file = tmp_path / "context.json"
     context_file.write_text(json.dumps({"notebook_id": VCR_READONLY_NOTEBOOK_ID}))
 
-    with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+    with (
+        patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
+    ):
         yield context_file
 
 

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -319,5 +319,9 @@ def patch_main_cli_client():
 def mock_context_file(tmp_path):
     """Provide a temporary context file for testing context commands."""
     context_file = tmp_path / "context.json"
-    with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+    with (
+        patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
+    ):
         yield context_file

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -319,6 +319,9 @@ def patch_main_cli_client():
 def mock_context_file(tmp_path):
     """Provide a temporary context file for testing context commands."""
     context_file = tmp_path / "context.json"
+    # Patch every current context-path seam: the helpers facade passes the
+    # resolver explicitly, while context.py and resolve.py perform call-time
+    # lookups after the helper split.
     with (
         patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
         patch("notebooklm.cli.context.get_context_path", return_value=context_file),

--- a/tests/unit/cli/test_chat.py
+++ b/tests/unit/cli/test_chat.py
@@ -544,6 +544,7 @@ class TestAskServerResumed:
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.context.get_context_path", return_value=context_file),
             ):
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "question"])
@@ -576,6 +577,7 @@ class TestAskServerResumed:
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.context.get_context_path", return_value=context_file),
             ):
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "follow-up question"])
@@ -620,6 +622,7 @@ class TestAskNewFlag:
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.context.get_context_path", return_value=context_file),
             ):
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "--new", "question"])
@@ -693,6 +696,7 @@ class TestAskNewFlag:
                     "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
                 ) as mock_fetch,
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.context.get_context_path", return_value=context_file),
             ):
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["ask", "-n", "nb_123", "--new", "question"])

--- a/tests/unit/cli/test_notebook.py
+++ b/tests/unit/cli/test_notebook.py
@@ -521,6 +521,8 @@ class TestNotebookDelete:
 
             with (
                 patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+                patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
                 patch("notebooklm.cli.notebook.get_current_notebook", return_value="nb_to_delete"),
                 patch("notebooklm.cli.notebook.clear_context"),
                 patch(
@@ -774,6 +776,10 @@ class TestNotebookAsk:
             with (
                 patch(
                     "notebooklm.cli.helpers.get_context_path",
+                    return_value=Path("/nonexistent/context.json"),
+                ),
+                patch(
+                    "notebooklm.cli.context.get_context_path",
                     return_value=Path("/nonexistent/context.json"),
                 ),
                 patch(

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -43,6 +43,8 @@ def mock_context_file(tmp_path):
     context_file = tmp_path / "context.json"
     with (
         patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
         patch("notebooklm.cli.session.get_context_path", return_value=context_file),
     ):
         yield context_file

--- a/tests/unit/cli/test_use_fails_closed.py
+++ b/tests/unit/cli/test_use_fails_closed.py
@@ -58,6 +58,8 @@ def mock_context_file(tmp_path):
     context_file = tmp_path / "context.json"
     with (
         patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
         patch("notebooklm.cli.session.get_context_path", return_value=context_file),
     ):
         yield context_file

--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -36,6 +36,7 @@ from collections.abc import Iterator
 import pytest
 
 CLI_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "notebooklm" / "cli"
+HELPERS_PATH = CLI_ROOT / "helpers.py"
 OPTIONS_PATH = CLI_ROOT / "options.py"
 SERVICES_ROOT = CLI_ROOT / "services"
 RENDERING_PATH = CLI_ROOT / "rendering.py"
@@ -95,6 +96,51 @@ RESOLVE_FORBIDDEN_MODULES = CLI_COMMAND_MODULES | {
     "completion",
     "helpers",
     "runtime",
+}
+HELPERS_IMPORT_ALLOWED_FILES = {
+    "__init__.py",  # compatibility re-export surface
+    "auth_runtime.py",  # call-time patch seam for auth/runtime wrappers
+    "completion.py",  # call-time patch seam for completion callbacks
+}
+HELPERS_FACADE_ALLOWED_DEFS = {
+    "_current_storage_override",
+    "_display_cited_import_selection",
+    "_get_context_value",
+    "_resolve_partial_id",
+    "_set_context_value",
+    "build_cookie_jar",
+    "clear_context",
+    "cli_name_to_artifact_type",
+    "display_report",
+    "display_research_sources",
+    "emit_status",
+    "get_artifact_type_display",
+    "get_auth_tokens",
+    "get_client",
+    "get_current_conversation",
+    "get_current_notebook",
+    "get_source_type_display",
+    "handle_auth_error",
+    "handle_error",
+    "import_research_sources",
+    "import_with_retry",
+    "json_error_response",
+    "json_output_response",
+    "load_auth_from_storage",
+    "read_stdin_text",
+    "require_notebook",
+    "resolve_artifact_id",
+    "resolve_note_id",
+    "resolve_notebook_id",
+    "resolve_prompt",
+    "resolve_source_id",
+    "resolve_source_ids",
+    "run_async",
+    "set_current_conversation",
+    "set_current_notebook",
+    "validate_id",
+    "with_auth_and_errors",
+    "with_client",
 }
 
 
@@ -189,6 +235,48 @@ def _imports_notebooklm_auth(tree: ast.AST) -> list[str]:
     return offenders
 
 
+def _imports_helpers_facade(tree: ast.AST, relative_parts: tuple[str, ...]) -> list[str]:
+    """Return imports that bind a CLI module back to ``cli.helpers``."""
+    offenders: list[str] = []
+    cli_package_level = len(relative_parts)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            mod_parts = mod.split(".") if mod else []
+            if node.level > 0:
+                if node.level == cli_package_level and mod_parts[:1] == ["helpers"]:
+                    offenders.append(f"from {'.' * node.level}{mod} import ...")
+                elif node.level == cli_package_level and not mod:
+                    offenders.extend(
+                        f"from {'.' * node.level} import {alias.name}"
+                        for alias in node.names
+                        if alias.name == "helpers"
+                    )
+                elif node.level > cli_package_level and mod_parts[:1] == ["cli"]:
+                    if len(mod_parts) > 1 and mod_parts[1] == "helpers":
+                        offenders.append(f"from {'.' * node.level}{mod} import ...")
+                    elif len(mod_parts) == 1:
+                        offenders.extend(
+                            f"from {'.' * node.level}{mod} import {alias.name}"
+                            for alias in node.names
+                            if alias.name == "helpers"
+                        )
+            elif node.level == 0:
+                if mod_parts[:3] == ["notebooklm", "cli", "helpers"]:
+                    offenders.append(f"from {mod} import ...")
+                elif mod_parts[:2] == ["notebooklm", "cli"]:
+                    offenders.extend(
+                        f"from {mod} import {alias.name}"
+                        for alias in node.names
+                        if alias.name == "helpers"
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[:3] == ["notebooklm", "cli", "helpers"]:
+                    offenders.append(f"import {alias.name}")
+    return offenders
+
+
 @pytest.mark.parametrize(
     ("source", "expected"),
     [
@@ -205,6 +293,47 @@ def test_cli_module_imports_detects_cli_import_forms(
     path.write_text(source, encoding="utf-8")
 
     assert _cli_module_imports(path) == expected
+
+
+@pytest.mark.parametrize(
+    ("relative_parts", "source", "expected"),
+    [
+        (("source.py",), "from .helpers import console\n", ["from .helpers import ..."]),
+        (("source.py",), "from . import helpers\n", ["from . import helpers"]),
+        (
+            ("services", "source.py"),
+            "from ..helpers import console\n",
+            ["from ..helpers import ..."],
+        ),
+        (
+            ("services", "source.py"),
+            "from .. import helpers\n",
+            ["from .. import helpers"],
+        ),
+        (("services", "source.py"), "from . import helpers\n", []),
+        (
+            ("source.py",),
+            "from notebooklm.cli.helpers import console\n",
+            ["from notebooklm.cli.helpers import ..."],
+        ),
+        (
+            ("source.py",),
+            "from notebooklm.cli import helpers\n",
+            ["from notebooklm.cli import helpers"],
+        ),
+        (
+            ("source.py",),
+            "import notebooklm.cli.helpers as helpers\n",
+            ["import notebooklm.cli.helpers"],
+        ),
+    ],
+)
+def test_imports_helpers_facade_detects_cli_helpers_forms(
+    relative_parts: tuple[str, ...], source: str, expected: list[str]
+) -> None:
+    tree = ast.parse(source)
+
+    assert _imports_helpers_facade(tree, relative_parts) == expected
 
 
 def _violations(tree: ast.AST) -> list[str]:  # noqa: C901 - flat dispatch on import shape
@@ -427,6 +556,45 @@ def test_resolve_stays_off_helpers_runtime_auth_and_commands() -> None:
     assert not auth_imports, (
         "cli.resolve must not import notebooklm.auth; keep auth/runtime work outside "
         f"the resolver layer. Offenders: {auth_imports}"
+    )
+
+
+def test_command_modules_do_not_import_helpers_facade_for_moved_symbols() -> None:
+    """Production CLI modules import moved helpers from their owning modules."""
+    offenders: list[tuple[str, list[str]]] = []
+    for path in sorted(CLI_ROOT.rglob("*.py")):
+        if path.name == "helpers.py":
+            continue
+        relative = str(path.relative_to(CLI_ROOT))
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        helper_imports = _imports_helpers_facade(tree, tuple(path.relative_to(CLI_ROOT).parts))
+        if helper_imports and relative not in HELPERS_IMPORT_ALLOWED_FILES:
+            offenders.append((relative, helper_imports))
+
+    assert not offenders, (
+        "Production CLI modules must not import moved symbols from cli.helpers. "
+        "Import rendering/context/runtime/auth/resolve/input/research helpers from "
+        "their owning modules instead. Only the compatibility export surface and "
+        "documented call-time patch seams may bind to cli.helpers.\n"
+        f"Offenders: {offenders}"
+    )
+
+
+def test_helpers_remains_compatibility_facade() -> None:
+    """Keep ``cli.helpers`` from silently regaining broad command responsibilities."""
+    tree = ast.parse(HELPERS_PATH.read_text(encoding="utf-8"))
+    defs = {node.name for node in tree.body if isinstance(node, BLOCK_DEF_TYPES)}
+    imports = _cli_module_imports(HELPERS_PATH)
+
+    assert defs <= HELPERS_FACADE_ALLOWED_DEFS, (
+        "cli.helpers should stay a compatibility facade over moved helper modules. "
+        "Add compatibility re-exports to HELPERS_FACADE_ALLOWED_DEFS only after "
+        "the implementation lives in an owning module. "
+        f"Unexpected defs: {sorted(defs - HELPERS_FACADE_ALLOWED_DEFS)}"
+    )
+    assert not (imports & CLI_COMMAND_MODULES), (
+        "cli.helpers must not import command modules; keep it below commands. "
+        f"Offenders: {sorted(imports & CLI_COMMAND_MODULES)}"
     )
 
 

--- a/tests/unit/test_cli_source_delete.py
+++ b/tests/unit/test_cli_source_delete.py
@@ -59,7 +59,11 @@ def mock_context(tmp_path: Path):
         encoding="utf-8",
     )
 
-    with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+    with (
+        patch("notebooklm.cli.helpers.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.context.get_context_path", return_value=context_file),
+        patch("notebooklm.cli.resolve.get_context_path", return_value=context_file),
+    ):
         yield context_file
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI helper imports into smaller, focused modules; CLI commands behave the same but now rely on clearer internal boundaries.

* **Tests**
  * Strengthened fixtures and added boundary tests to enforce import constraints and ensure consistent context handling across CLI flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->