### PR TITLE
security: scrub payload_preview + final_url + quote share-URL IDs (I5, I2)

### DIFF
--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -31,6 +31,7 @@ __all__ = [
     "get_request_id",
     "install_redaction",
     "reset_request_id",
+    "scrub_secrets",
     "set_request_id",
 ]
 
@@ -122,7 +123,19 @@ _DEFAULT_FMT = "%(asctime)s %(levelname)s [%(name)s] %(message)s"
 _DEFAULT_DATEFMT = "%H:%M:%S"
 
 
-def _scrub(text: object) -> str:
+def scrub_secrets(text: object) -> str:
+    """Redact credential-shaped substrings (CSRF tokens, session cookies, etc).
+
+    Applies the package's shared redaction patterns to the input. Non-string
+    inputs (Exception instances, custom __str__ objects) are coerced via
+    ``str()`` before matching so callers can pass log-record fragments
+    directly without pre-stringifying.
+
+    Use this when including third-party text (HTML bodies, raw RPC payloads,
+    diagnostic previews) in exception messages or other surfaces that escape
+    the logging pipeline — the RedactingFilter only catches text that reaches
+    a configured handler.
+    """
     # Defensive: record.msg / stack_info can be non-string in unusual setups
     # (Exception instance, custom __str__ object). Coerce before regex.
     if not isinstance(text, str):
@@ -130,6 +143,11 @@ def _scrub(text: object) -> str:
     for pattern, replacement in _REDACT_PATTERNS:
         text = pattern.sub(replacement, text)
     return text
+
+
+# Backwards-compat alias for any in-package code that imported the historical
+# private name. New code should use ``scrub_secrets`` directly.
+_scrub = scrub_secrets
 
 
 def _has_redacting_filter(filters: Iterable[Any]) -> bool:
@@ -173,19 +191,19 @@ class RedactingFilter(logging.Filter):
             rendered = record.getMessage()
         except (TypeError, ValueError):
             rendered = str(record.msg)
-        record.msg = _scrub(rendered)
+        record.msg = scrub_secrets(rendered)
         record.args = ()
 
         if record.exc_info and not record.exc_text:
             exc_text = logging.Formatter().formatException(record.exc_info)
-            record.exc_text = _scrub(exc_text)
+            record.exc_text = scrub_secrets(exc_text)
         elif record.exc_text:
-            record.exc_text = _scrub(record.exc_text)
+            record.exc_text = scrub_secrets(record.exc_text)
 
         # stack_info from logger.<level>(..., stack_info=True) — rarely used
         # but technically a leak vector.
         if record.stack_info:
-            record.stack_info = _scrub(record.stack_info)
+            record.stack_info = scrub_secrets(record.stack_info)
 
         # Correlation prefix. AFTER scrub so an 8-hex id can never be
         # accidentally scrubbed by a future pattern. Marker attribute
@@ -220,7 +238,7 @@ class RedactingFormatter(logging.Formatter):
         )
 
     def format(self, record: logging.LogRecord) -> str:
-        rendered = _scrub(self._inner.format(record))
+        rendered = scrub_secrets(self._inner.format(record))
         # logging.Formatter.format() caches the rendered traceback on
         # record.exc_text as a side effect when exc_info is set and exc_text
         # was None. If we were called without the Filter pre-setting exc_text
@@ -228,17 +246,17 @@ class RedactingFormatter(logging.Formatter):
         # may have just stored an UNSCRUBBED traceback on the record. Re-scrub
         # so the record cannot leak via a subsequent handler.
         if record.exc_text:
-            record.exc_text = _scrub(record.exc_text)
+            record.exc_text = scrub_secrets(record.exc_text)
         return rendered
 
     def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
         return self._inner.formatTime(record, datefmt)
 
     def formatException(self, ei: logging._SysExcInfoType | tuple[None, None, None]) -> str:
-        return _scrub(self._inner.formatException(ei))
+        return scrub_secrets(self._inner.formatException(ei))
 
     def formatStack(self, stack_info: str) -> str:
-        return _scrub(self._inner.formatStack(stack_info))
+        return scrub_secrets(self._inner.formatStack(stack_info))
 
 
 def apply_redaction(handler: logging.Handler) -> logging.Handler:

--- a/src/notebooklm/_sharing_manager.py
+++ b/src/notebooklm/_sharing_manager.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from typing import Any, Protocol
+from urllib.parse import quote
 
 from ._env import get_base_url
 from .rpc import RPCMethod
@@ -23,10 +24,15 @@ class ShareRpc(Protocol):
 
 
 def build_share_url(base_url: str, notebook_id: str, artifact_id: str | None = None) -> str:
-    """Build the legacy NotebookLM notebook or artifact share URL."""
-    notebook_url = f"{base_url}/notebook/{notebook_id}"
+    """Build the legacy NotebookLM notebook or artifact share URL.
+
+    Both IDs are percent-encoded with ``safe=""`` so reserved characters
+    (``/``, ``?``, ``&``, ``#``) and whitespace cannot escape the path /
+    query position and rewrite the URL into another endpoint.
+    """
+    notebook_url = f"{base_url}/notebook/{quote(notebook_id, safe='')}"
     if artifact_id:
-        return f"{notebook_url}?artifactId={artifact_id}"
+        return f"{notebook_url}?artifactId={quote(artifact_id, safe='')}"
     return notebook_url
 
 

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from typing import Any, TypeAlias
+from urllib.parse import urlparse
 
 import httpx
 
@@ -456,6 +457,24 @@ def extract_wiz_field(html: str, key: str, *, strict: bool = True) -> str | None
     return None
 
 
+def _safe_url(url: str) -> str:
+    """Return ``url`` stripped of query string and fragment for error display.
+
+    Auth-handshake URLs often carry credential-shaped query params
+    (``f.sid=...``, ``continue=...``, ``access_token=...``) that must never
+    appear in exception messages or log lines. We surface only the
+    ``scheme://netloc/path`` triple — enough context for an operator to
+    recognize which endpoint failed without leaking session state.
+
+    Empty input passes through verbatim so error messages with the default
+    ``final_url=""`` still render cleanly instead of degenerating to ``"://"``.
+    """
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
 def extract_csrf_from_html(html: str, final_url: str = "") -> str:
     """
     Extract CSRF token (SNlM0e) from NotebookLM page HTML.
@@ -491,7 +510,7 @@ def extract_csrf_from_html(html: str, final_url: str = "") -> str:
             "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
         )
     raise ValueError(
-        f"CSRF token not found in HTML. Final URL: {final_url}\n"
+        f"CSRF token not found in HTML. Final URL: {_safe_url(final_url)}\n"
         "This may indicate the page structure has changed."
     )
 
@@ -524,7 +543,7 @@ def extract_session_id_from_html(html: str, final_url: str = "") -> str:
             "Authentication expired or invalid. Run 'notebooklm login' to re-authenticate."
         )
     raise ValueError(
-        f"Session ID not found in HTML. Final URL: {final_url}\n"
+        f"Session ID not found in HTML. Final URL: {_safe_url(final_url)}\n"
         "This may indicate the page structure has changed."
     )
 
@@ -1458,7 +1477,7 @@ async def _fetch_tokens_with_jar(
         if is_google_auth_redirect(final_url):
             raise ValueError(
                 "Authentication expired or invalid. "
-                "Redirected to: " + final_url + "\n"
+                "Redirected to: " + _safe_url(final_url) + "\n"
                 "Run 'notebooklm login' to re-authenticate."
             )
 

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -458,21 +458,31 @@ def extract_wiz_field(html: str, key: str, *, strict: bool = True) -> str | None
 
 
 def _safe_url(url: str) -> str:
-    """Return ``url`` stripped of query string and fragment for error display.
+    """Return ``url`` stripped of credential-shaped parts for error display.
 
-    Auth-handshake URLs often carry credential-shaped query params
-    (``f.sid=...``, ``continue=...``, ``access_token=...``) that must never
-    appear in exception messages or log lines. We surface only the
-    ``scheme://netloc/path`` triple — enough context for an operator to
-    recognize which endpoint failed without leaking session state.
+    Auth-handshake URLs can carry credentials in three positions, all of
+    which we strip:
 
-    Empty input passes through verbatim so error messages with the default
-    ``final_url=""`` still render cleanly instead of degenerating to ``"://"``.
+    * **Query string** — ``f.sid=...``, ``continue=...``, ``access_token=...``.
+    * **Fragment** — OAuth implicit-flow tokens (``#access_token=...``).
+    * **Userinfo** — ``https://TOKEN@host/...`` shapes; ``parsed.netloc``
+      preserves the userinfo, so we rebuild from ``hostname`` + optional
+      port instead of trusting ``netloc`` directly.
+
+    The surviving ``scheme://host[:port]/path`` is enough context for an
+    operator to recognize which endpoint failed without leaking session
+    state. Empty input passes through verbatim so error messages with the
+    default ``final_url=""`` still render cleanly instead of degenerating to
+    ``"://"``.
     """
     if not url:
         return ""
     parsed = urlparse(url)
-    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    # hostname strips userinfo; port survives separately. Both can be None
+    # on malformed input, in which case we degrade gracefully to "scheme:///path".
+    host = parsed.hostname or ""
+    netloc = f"{host}:{parsed.port}" if parsed.port is not None else host
+    return f"{parsed.scheme}://{netloc}{parsed.path}"
 
 
 def extract_csrf_from_html(html: str, final_url: str = "") -> str:

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -346,15 +346,21 @@ class AuthExtractionError(RPCError):
         message: str | None = None,
     ):
         self.key = key
-        # Scrub BEFORE slicing so credential-shaped substrings that straddle
-        # the 5x preview boundary (e.g., ``f.sid=`` near offset PREVIEW*5)
-        # are still fully matched and redacted. Slicing first could split a
-        # secret value across the boundary, leaving the prefix unredacted in
-        # the rendered preview.
-        scrubbed = scrub_secrets(payload_preview)
-        # Slice after scrubbing to a 5x-PREVIEW_LENGTH head — enough headroom
-        # that collapsing runs of whitespace still leaves PREVIEW_LENGTH chars
-        # of non-whitespace even on heavily indented HTML.
+        # Two-stage slice with the scrub in the middle, so we bound regex work
+        # without giving up boundary-straddle safety:
+        #
+        # 1. Pre-slice to a generous 10x cap. Bounds the scrub at O(2000 chars)
+        #    instead of O(len(payload)) — a multi-MB HTML body would otherwise
+        #    cost ~7 regex passes over the whole thing just to throw most away.
+        # 2. Scrub the slice. A secret straddling the 10x boundary is
+        #    theoretically possible but the 2000-char window gives ~19x more
+        #    slack than the 5x preview limit, so any realistic ``f.sid=``,
+        #    ``Bearer ...``, or ``Set-Cookie:`` value fits well inside.
+        # 3. Re-slice to 5x. The scrub already neutralized anything that would
+        #    have leaked from the 5x cut, including secrets that originally
+        #    straddled the 5x boundary inside the 10x window.
+        pre_sliced = payload_preview[: self.PREVIEW_LENGTH * 10]
+        scrubbed = scrub_secrets(pre_sliced)
         head = scrubbed[: self.PREVIEW_LENGTH * 5]
         # Collapse runs of whitespace so the preview stays compact and useful
         # even when the upstream HTML is heavily indented or contains newlines.

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -19,6 +19,7 @@ import re
 from typing import Any
 
 from ._env import DEFAULT_BASE_URL, get_base_url
+from ._logging import scrub_secrets
 
 
 def _truncate_response_preview(raw: str | None) -> str | None:
@@ -345,12 +346,16 @@ class AuthExtractionError(RPCError):
         message: str | None = None,
     ):
         self.key = key
-        # Slice before substituting so we don't run the regex over a multi-MB
-        # response body just to throw away most of it. A 5x headroom over
-        # PREVIEW_LENGTH guarantees we still have enough non-whitespace
-        # characters left after collapsing runs of whitespace, even on heavily
-        # indented HTML where ~80% of the prefix may be indentation.
-        head = payload_preview[: self.PREVIEW_LENGTH * 5]
+        # Scrub BEFORE slicing so credential-shaped substrings that straddle
+        # the 5x preview boundary (e.g., ``f.sid=`` near offset PREVIEW*5)
+        # are still fully matched and redacted. Slicing first could split a
+        # secret value across the boundary, leaving the prefix unredacted in
+        # the rendered preview.
+        scrubbed = scrub_secrets(payload_preview)
+        # Slice after scrubbing to a 5x-PREVIEW_LENGTH head — enough headroom
+        # that collapsing runs of whitespace still leaves PREVIEW_LENGTH chars
+        # of non-whitespace even on heavily indented HTML.
+        head = scrubbed[: self.PREVIEW_LENGTH * 5]
         # Collapse runs of whitespace so the preview stays compact and useful
         # even when the upstream HTML is heavily indented or contains newlines.
         collapsed = re.sub(r"\s+", " ", head).strip()

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Optional
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     import httpx
@@ -1525,8 +1526,12 @@ class ShareStatus:
         # view_level not in GET_SHARE_STATUS response - default to FULL_NOTEBOOK
         view_level = ShareViewLevel.FULL_NOTEBOOK
 
-        # Construct share URL if public
-        share_url = f"{get_base_url()}/notebook/{notebook_id}" if is_public else None
+        # Construct share URL if public. Percent-encode the id with ``safe=""``
+        # so reserved characters cannot escape the path position and rewrite
+        # the URL into another endpoint (mirrors ``_sharing_manager.build_share_url``).
+        share_url = (
+            f"{get_base_url()}/notebook/{quote(notebook_id, safe='')}" if is_public else None
+        )
 
         return cls(
             notebook_id=notebook_id,

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -848,7 +848,7 @@ class TestFinalUrlScrubbing:
         # redirect so we get the "shape changed" raise that interpolates
         # final_url into the message.
         html = "<html><body>not a notebooklm page</body></html>"
-        final_url = "https://x.example/y?continue=foo&f.sid=bar"
+        final_url = "https://x.example/y?continue=foo&f.sid=bar#access_token=frag"
 
         with pytest.raises(ValueError) as excinfo:
             extract_csrf_from_html(html, final_url)
@@ -856,6 +856,7 @@ class TestFinalUrlScrubbing:
         message = str(excinfo.value)
         assert "continue=foo" not in message
         assert "f.sid=bar" not in message
+        assert "access_token=frag" not in message
         # The scheme/netloc/path triple should still appear so operators can
         # identify the failing endpoint.
         assert "https://x.example/y" in message
@@ -863,7 +864,7 @@ class TestFinalUrlScrubbing:
     def test_final_url_stripped_session_id_path(self):
         """Session-ID drift error must NOT include query params from final_url."""
         html = "<html><body>not a notebooklm page</body></html>"
-        final_url = "https://x.example/y?continue=foo&f.sid=bar"
+        final_url = "https://x.example/y?continue=foo&f.sid=bar#access_token=frag"
 
         with pytest.raises(ValueError) as excinfo:
             extract_session_id_from_html(html, final_url)
@@ -871,6 +872,7 @@ class TestFinalUrlScrubbing:
         message = str(excinfo.value)
         assert "continue=foo" not in message
         assert "f.sid=bar" not in message
+        assert "access_token=frag" not in message
         assert "https://x.example/y" in message
 
 
@@ -967,6 +969,43 @@ class TestFetchTokens:
         cookies = {"SID": "expired_sid", "__Secure-1PSIDTS": "test_1psidts"}
         with pytest.raises(ValueError, match="Authentication expired"):
             await fetch_tokens(cookies)
+
+    @pytest.mark.asyncio
+    async def test_fetch_tokens_redirect_to_login_strips_query_and_fragment(self, monkeypatch):
+        """Redirect error must not expose query params or fragments from final_url."""
+
+        async def fake_poke_session(client, storage_path):
+            return None
+
+        class FakeAsyncClient:
+            def __init__(self, *args, **kwargs):
+                self.cookies = httpx.Cookies()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def get(self, *args, **kwargs):
+                request = httpx.Request(
+                    "GET",
+                    "https://accounts.google.com/signin?continue=foo&f.sid=bar"
+                    "#access_token=frag",
+                )
+                return httpx.Response(200, content=b"<html>Login</html>", request=request)
+
+        monkeypatch.setattr(auth_module, "_poke_session", fake_poke_session)
+        monkeypatch.setattr(auth_module.httpx, "AsyncClient", FakeAsyncClient)
+
+        with pytest.raises(ValueError) as excinfo:
+            await auth_module._fetch_tokens_with_jar(httpx.Cookies(), storage_path=None)
+
+        message = str(excinfo.value)
+        assert "continue=foo" not in message
+        assert "f.sid=bar" not in message
+        assert "access_token=frag" not in message
+        assert "https://accounts.google.com/signin" in message
 
     @pytest.mark.asyncio
     async def test_fetch_tokens_sends_cookies_on_account_redirect(self, httpx_mock: HTTPXMock):

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -833,6 +833,47 @@ class TestExtractSessionIdRedirect:
             extract_session_id_from_html(html)
 
 
+class TestFinalUrlScrubbing:
+    """Auth-error messages must strip query + fragment from final_url interpolations.
+
+    Auth-handshake URLs frequently carry credential-shaped query params
+    (``f.sid=...``, ``continue=...``, ``access_token=...``). Without
+    sanitization these would leak into every drift-error message and the
+    associated log line.
+    """
+
+    def test_final_url_stripped(self):
+        """CSRF drift error must NOT include query params from final_url."""
+        # No WIZ_global_data → drift path; URL is not an accounts.google.com
+        # redirect so we get the "shape changed" raise that interpolates
+        # final_url into the message.
+        html = "<html><body>not a notebooklm page</body></html>"
+        final_url = "https://x.example/y?continue=foo&f.sid=bar"
+
+        with pytest.raises(ValueError) as excinfo:
+            extract_csrf_from_html(html, final_url)
+
+        message = str(excinfo.value)
+        assert "continue=foo" not in message
+        assert "f.sid=bar" not in message
+        # The scheme/netloc/path triple should still appear so operators can
+        # identify the failing endpoint.
+        assert "https://x.example/y" in message
+
+    def test_final_url_stripped_session_id_path(self):
+        """Session-ID drift error must NOT include query params from final_url."""
+        html = "<html><body>not a notebooklm page</body></html>"
+        final_url = "https://x.example/y?continue=foo&f.sid=bar"
+
+        with pytest.raises(ValueError) as excinfo:
+            extract_session_id_from_html(html, final_url)
+
+        message = str(excinfo.value)
+        assert "continue=foo" not in message
+        assert "f.sid=bar" not in message
+        assert "https://x.example/y" in message
+
+
 class TestExtractCookiesEdgeCases:
     """Test cookie extraction edge cases."""
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -990,8 +990,7 @@ class TestFetchTokens:
             async def get(self, *args, **kwargs):
                 request = httpx.Request(
                     "GET",
-                    "https://accounts.google.com/signin?continue=foo&f.sid=bar"
-                    "#access_token=frag",
+                    "https://accounts.google.com/signin?continue=foo&f.sid=bar#access_token=frag",
                 )
                 return httpx.Response(200, content=b"<html>Login</html>", request=request)
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -875,6 +875,26 @@ class TestFinalUrlScrubbing:
         assert "access_token=frag" not in message
         assert "https://x.example/y" in message
 
+    def test_final_url_stripped_userinfo(self):
+        """URL userinfo (``https://TOKEN@host/...``) must NOT leak.
+
+        ``urlparse(...).netloc`` preserves the userinfo component, so a naive
+        reconstruction from ``scheme://netloc/path`` would surface tokens
+        carried in the ``user[:password]@`` position. ``_safe_url`` rebuilds
+        from ``hostname`` + port instead.
+        """
+        html = "<html><body>not a notebooklm page</body></html>"
+        # Token embedded as userinfo — the most adversarial leak vector.
+        final_url = "https://SECRET_TOKEN_USERINFO@x.example:8443/y?q=1"
+
+        with pytest.raises(ValueError) as excinfo:
+            extract_csrf_from_html(html, final_url)
+
+        message = str(excinfo.value)
+        assert "SECRET_TOKEN_USERINFO" not in message
+        # Port is preserved so operators can still identify the endpoint.
+        assert "https://x.example:8443/y" in message
+
 
 class TestExtractCookiesEdgeCases:
     """Test cookie extraction edge cases."""

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -11,6 +11,7 @@ from notebooklm.exceptions import (
     ArtifactNotReadyError,
     ArtifactParseError,
     AuthError,
+    AuthExtractionError,
     ChatError,
     ClientError,
     ConfigurationError,
@@ -346,6 +347,28 @@ class TestDomainExceptions:
         assert e.artifact_type == "audio"
         assert e.details == "404 Not Found"
         assert e.artifact_id == "art_789"
+
+
+class TestAuthExtractionErrorScrubbing:
+    """AuthExtractionError must redact credential-shaped substrings in its preview."""
+
+    def test_auth_extraction_error_scrubs_payload(self):
+        """payload_preview must not leak ``f.sid=`` values from raw HTML.
+
+        Drift previews can capture multi-KB HTML snippets that contain live
+        session-id query params; ``scrub_secrets`` is applied BEFORE the
+        slice + whitespace-collapse pipeline so the redaction cannot be
+        defeated by a value that straddles the slice boundary.
+        """
+        # Token value lives in the prefix that will survive truncation.
+        payload = "<html><body>boot script f.sid=ABC123XYZ remaining markup</body></html>"
+        exc = AuthExtractionError("SNlM0e", payload)
+
+        assert "ABC123XYZ" not in exc.payload_preview
+        assert "ABC123XYZ" not in str(exc)
+        # Sanity: the redaction marker should be present so operators can see
+        # WHY the value is missing.
+        assert "f.sid=***" in exc.payload_preview
 
 
 class TestCatchAllPattern:

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -356,9 +356,9 @@ class TestAuthExtractionErrorScrubbing:
         """payload_preview must not leak ``f.sid=`` values from raw HTML.
 
         Drift previews can capture multi-KB HTML snippets that contain live
-        session-id query params; ``scrub_secrets`` is applied BEFORE the
+        session-id query params; ``scrub_secrets`` is applied during the
         slice + whitespace-collapse pipeline so the redaction cannot be
-        defeated by a value that straddles the slice boundary.
+        defeated by a value that straddles the 5x preview boundary.
         """
         # Token value lives in the prefix that will survive truncation.
         payload = "<html><body>boot script f.sid=ABC123XYZ remaining markup</body></html>"
@@ -369,6 +369,22 @@ class TestAuthExtractionErrorScrubbing:
         # Sanity: the redaction marker should be present so operators can see
         # WHY the value is missing.
         assert "f.sid=***" in exc.payload_preview
+
+    def test_auth_extraction_error_scrubs_secret_near_5x_boundary(self):
+        """Secret straddling the 5x boundary is still scrubbed via the 10x slice.
+
+        The implementation pre-slices to 10x PREVIEW_LENGTH (2000 chars) before
+        scrubbing — large enough that a secret near the 5x cutoff (~1000 chars)
+        is fully contained in the pre-slice and gets redacted.
+        """
+        prefix = "A" * (AuthExtractionError.PREVIEW_LENGTH * 5 - 10)
+        # Secret begins inside the 5x cut and continues past it — without the
+        # 10x pre-slice we'd see the unredacted "f.sid=SECRET" prefix.
+        payload = prefix + "f.sid=SECRET_NEAR_BOUNDARY_VALUE"
+        exc = AuthExtractionError("SNlM0e", payload)
+
+        assert "SECRET_NEAR_BOUNDARY" not in exc.payload_preview
+        assert "SECRET_NEAR_BOUNDARY" not in str(exc)
 
 
 class TestCatchAllPattern:

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -31,6 +31,23 @@ def test_build_share_url_with_artifact() -> None:
     )
 
 
+def test_build_share_url_quotes_ids() -> None:
+    """Reserved characters and whitespace in IDs must be percent-encoded.
+
+    Without ``safe=""`` quoting, an ID like ``"foo bar/baz"`` would slip a
+    raw ``/`` into the path position and rewrite the URL into another
+    endpoint, and a raw space would produce an invalid URL.
+    """
+    url = build_share_url(BASE_URL, "foo bar/baz", artifact_id="qux?frag&y")
+    assert "foo%20bar%2Fbaz" in url
+    # Reserved characters in the artifact id are also encoded so they cannot
+    # smuggle additional query params or fragments.
+    assert "qux%3Ffrag%26y" in url
+    # Sanity: the raw, un-encoded forms must NOT appear anywhere in the URL.
+    assert "foo bar/baz" not in url
+    assert "qux?frag&y" not in url
+
+
 @pytest.mark.asyncio
 async def test_share_public_with_artifact_sends_legacy_payload_and_returns_deep_link() -> None:
     manager, rpc = _make_manager()

--- a/tests/unit/test_sharing_types.py
+++ b/tests/unit/test_sharing_types.py
@@ -275,6 +275,14 @@ class TestShareStatusDefaultValues:
         status = ShareStatus.from_api_response(data, "abc-123-xyz")
         assert status.share_url == "https://notebooklm.google.com/notebook/abc-123-xyz"
 
+    def test_share_url_quotes_notebook_id(self):
+        """Reserved characters in notebook IDs must be percent-encoded."""
+        data = [[], [True], 1000]
+        status = ShareStatus.from_api_response(data, "foo bar/baz?x")
+
+        assert status.share_url == "https://notebooklm.google.com/notebook/foo%20bar%2Fbaz%3Fx"
+        assert "foo bar/baz?x" not in status.share_url
+
     def test_share_url_none_when_private(self):
         """Test share URL is None when notebook is private."""
         data = [[], [False], 1000]


### PR DESCRIPTION
## Summary

Closes Tier-9 audit findings **I5** (sensitive tokens leak via \`AuthExtractionError.payload_preview\` + raw \`final_url\` in auth.py error messages) and **I2** (share-URL builders don't quote untrusted IDs).

### \`_logging.py\` — promote \`_scrub\` → \`scrub_secrets\`

Extract the public helper \`scrub_secrets(text) -> str\` from the existing private \`_scrub\` function. Internal callers updated to use the public name. Patterns themselves are unchanged.

### \`exceptions.py\` — \`AuthExtractionError\` scrubs \`payload_preview\`

\`AuthExtractionError.__init__\` now applies \`scrub_secrets\` to the raw HTML **before** truncating + collapsing whitespace. A payload like \`<form>f.sid=ABC123</form>\` will no longer surface \`ABC123\` in exception messages or logs.

### \`auth.py\` — \`_safe_url\` helper + interpolations

New module-level \`_safe_url(url) -> str\` parses via \`urllib.parse.urlparse()\` and returns only \`f"{scheme}://{netloc}{path}"\` (drops query + fragment). Replaces the three \`f"...{final_url}..."\` sites so a \`final_url\` like \`https://x/y?continue=foo&f.sid=bar\` no longer exposes query params in error text.

### \`_sharing_manager.py\` + \`types.py\` — quote share-URL IDs

\`build_share_url\` and \`ShareStatus.from_api_response\` now wrap both \`notebook_id\` and \`artifact_id\` with \`urllib.parse.quote(safe='')\`. An ID like \`"foo bar/baz"\` now renders as \`foo%20bar%2Fbaz\`.

## Tests

- \`test_exceptions.py::test_auth_extraction_error_scrubs_payload\`
- \`test_auth.py::test_final_url_stripped\`
- \`test_sharing_manager.py::test_build_share_url_quotes_ids\`

## Test plan

- [x] \`uv run ruff format .\` clean (348 files)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` clean (100 source files)
- [x] Targeted pytest on the 4 affected test files: 369 passed in 0.49s
- [ ] Full \`uv run pytest\` (CI will run this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Share links now percent-encode notebook and artifact IDs so special characters and whitespace can’t break or alter URLs.
  * Authentication error messages now show only the sanitized base URL (scheme/host/port/path), stripping queries, fragments, and userinfo.
  * Secret redaction centralized and strengthened so credentials are consistently removed from logs and error previews.

* **Tests**
  * Added unit tests covering share URL encoding, auth URL sanitization, and redaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->