### PR TITLE
polish(rpc,chat): document decoder review invariants

### DIFF
--- a/src/notebooklm/__init__.py
+++ b/src/notebooklm/__init__.py
@@ -65,6 +65,7 @@ from .exceptions import (
     AuthExtractionError,
     # Domain: Chat
     ChatError,
+    ChatResponseParseError,
     ClientError,
     # Validation/Config
     ConfigurationError,
@@ -205,6 +206,7 @@ __all__ = [
     "NotebookLimitError",
     # Domain Exceptions: Chat
     "ChatError",
+    "ChatResponseParseError",
     # Domain Exceptions: Sources
     "SourceError",
     "SourceAddError",

--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -17,7 +17,7 @@ from urllib.parse import quote, urlencode
 
 from ._env import get_default_bl, get_default_language
 from .auth import format_authuser_value
-from .exceptions import ChatError
+from .exceptions import ChatError, ChatResponseParseError
 from .rpc.encoder import nest_source_ids
 from .rpc.types import get_query_url
 from .types import ChatReference
@@ -130,7 +130,21 @@ def build_streaming_chat_request(
 
 
 def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResult:
-    """Parse a streamed-chat response into answer, references, and conversation ID."""
+    """Parse a streamed-chat response into answer, references, and conversation ID.
+
+    Failure contract (see :class:`notebooklm.exceptions.ChatResponseParseError`):
+
+    * **Zero parseable chunks** — no chunk in the response yielded a
+      successfully decoded ``wrb.fr`` envelope. This means either the
+      response body was empty/garbage, or the API's wire format drifted
+      and the parser no longer recognizes the envelope shape. Raises
+      :class:`ChatResponseParseError`.
+    * **Chunks parsed but empty answer** — at least one ``wrb.fr`` chunk
+      decoded, but no chunk yielded answer text (the model legitimately
+      returned an empty response). Returns
+      ``StreamingChatParseResult("", refs, conv_id)`` — empty answer is
+      a valid outcome, not a parse failure.
+    """
     if response_text.startswith(")]}'"):
         response_text = response_text[4:]
 
@@ -140,13 +154,16 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
     best_unmarked_answer = ""
     best_unmarked_refs: list[ChatReference] = []
     server_conv_id: str | None = None
+    parseable_chunk_count = 0
 
     def process_chunk(json_str: str) -> None:
         """Process a JSON chunk, updating best answer candidates and their refs."""
         nonlocal best_marked_answer, best_marked_refs
         nonlocal best_unmarked_answer, best_unmarked_refs
-        nonlocal server_conv_id
-        text, is_answer, refs, conv_id = extract_answer_and_refs_from_chunk(json_str)
+        nonlocal server_conv_id, parseable_chunk_count
+        text, is_answer, refs, conv_id, parseable = _extract_chunk_with_parseable(json_str)
+        if parseable:
+            parseable_chunk_count += 1
         if text:
             if is_answer and len(text) > len(best_marked_answer):
                 best_marked_answer = text
@@ -174,6 +191,16 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
             process_chunk(line)
             i += 1
 
+    if parseable_chunk_count == 0:
+        # No ``wrb.fr`` envelopes recognized — distinguishable from a
+        # legitimate empty answer (which still produces at least one
+        # parseable chunk). Raise so callers can distinguish wire-drift
+        # / empty-body from "the model returned nothing."
+        raise ChatResponseParseError(
+            f"No parseable chunks in streaming chat response ({len(lines)} lines scanned). "
+            "The response was empty or the API wire format may have changed."
+        )
+
     if best_marked_answer:
         longest_answer = best_marked_answer
         final_refs = best_marked_refs
@@ -191,8 +218,9 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
 
     if not longest_answer:
         logger.warning(
-            "No answer extracted from response (%d lines parsed)",
+            "No answer extracted from response (%d lines parsed, %d parseable chunks)",
             len(lines),
+            parseable_chunk_count,
         )
 
     for idx, ref in enumerate(final_refs, start=1):
@@ -205,17 +233,41 @@ def parse_streaming_chat_response(response_text: str) -> StreamingChatParseResul
 def extract_answer_and_refs_from_chunk(
     json_str: str,
 ) -> tuple[str | None, bool, list[ChatReference], str | None]:
-    """Extract answer text, references, and conversation ID from one response chunk."""
+    """Extract answer text, references, and conversation ID from one response chunk.
+
+    Public 4-tuple wrapper around :func:`_extract_chunk_with_parseable`.
+    The parseable-flag bit is internal-only — it exists for the streaming
+    parser's "zero parseable chunks" detection and is not part of this
+    module's outward-facing contract.
+    """
+    text, is_answer, refs, conv_id, _parseable = _extract_chunk_with_parseable(json_str)
+    return text, is_answer, refs, conv_id
+
+
+def _extract_chunk_with_parseable(
+    json_str: str,
+) -> tuple[str | None, bool, list[ChatReference], str | None, bool]:
+    """Extract answer/refs/conv-id from one chunk and report wire-format parseability.
+
+    The 5th element is True iff at least one ``wrb.fr`` envelope was
+    found AND its inner JSON decoded successfully — regardless of whether
+    any answer text was extracted. This lets the streaming parser
+    distinguish two failure modes:
+
+    * Zero parseable chunks → API drift or empty body (raise).
+    * At least one parseable chunk but no text → real empty answer (return).
+    """
     refs: list[ChatReference] = []
 
     try:
         data = json.loads(json_str)
     except json.JSONDecodeError:
-        return None, False, refs, None
+        return None, False, refs, None, False
 
     if not isinstance(data, list):
-        return None, False, refs, None
+        return None, False, refs, None, False
 
+    parseable = False
     for item in data:
         if not isinstance(item, list) or len(item) < 3:
             continue
@@ -224,38 +276,17 @@ def extract_answer_and_refs_from_chunk(
 
         inner_json = item[2]
         if not isinstance(inner_json, str):
-            # item[2] is null — check item[5] for a server-side error payload
+            # item[2] is null — check item[5] for a server-side error payload.
+            # Don't flip ``parseable`` here: a null inner_json without a
+            # recognized error payload is not a successfully decoded
+            # envelope. The error-payload path raises, so flow only
+            # reaches the next iteration when item[5] was absent/unusable.
             if len(item) > 5 and isinstance(item[5], list):
                 raise_if_rate_limited(item[5])
             continue
 
         try:
             inner_data = json.loads(inner_json)
-            if isinstance(inner_data, list) and len(inner_data) > 0:
-                first = inner_data[0]
-                if isinstance(first, list) and len(first) > 0:
-                    text = first[0]
-                    if not isinstance(text, str) or not text:
-                        continue
-
-                    is_answer = (
-                        len(first) > 4
-                        and isinstance(first[4], list)
-                        and len(first[4]) > 0
-                        and first[4][-1] == 1
-                    )
-
-                    server_conv_id: str | None = None
-                    if (
-                        len(first) > 2
-                        and isinstance(first[2], list)
-                        and first[2]
-                        and isinstance(first[2][0], str)
-                    ):
-                        server_conv_id = first[2][0]
-
-                    refs = parse_citations(first)
-                    return text, is_answer, refs, server_conv_id
         except json.JSONDecodeError:
             # Hot-path stream parser: skip non-JSON chunks. Guard the
             # debug log with isEnabledFor so the redaction regex doesn't
@@ -264,7 +295,39 @@ def extract_answer_and_refs_from_chunk(
                 logger.debug("Stream parser: non-JSON chunk skipped")
             continue
 
-    return None, False, refs, None
+        # The wire envelope decoded. Mark parseable BEFORE the answer-text
+        # extraction so a real empty-answer chunk (text == "") still counts
+        # — that's exactly the case the new failure contract preserves
+        # against ``ChatResponseParseError``.
+        parseable = True
+
+        if isinstance(inner_data, list) and len(inner_data) > 0:
+            first = inner_data[0]
+            if isinstance(first, list) and len(first) > 0:
+                text = first[0]
+                if not isinstance(text, str) or not text:
+                    continue
+
+                is_answer = (
+                    len(first) > 4
+                    and isinstance(first[4], list)
+                    and len(first[4]) > 0
+                    and first[4][-1] == 1
+                )
+
+                server_conv_id: str | None = None
+                if (
+                    len(first) > 2
+                    and isinstance(first[2], list)
+                    and first[2]
+                    and isinstance(first[2][0], str)
+                ):
+                    server_conv_id = first[2][0]
+
+                refs = parse_citations(first)
+                return text, is_answer, refs, server_conv_id, parseable
+
+    return None, False, refs, None, parseable
 
 
 def raise_if_rate_limited(error_payload: list) -> None:

--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -326,6 +326,12 @@ def _extract_chunk_with_parseable(
 
                 refs = parse_citations(first)
                 return text, is_answer, refs, server_conv_id, parseable
+        # inner_json decoded but the record shape didn't match (empty/short
+        # list, dict, etc.) — keep ``parseable = True`` and fall through to
+        # the next item. Real-world ``wrb.fr`` heartbeats like ``"[]"`` hit
+        # this branch and are deliberately still counted as parseable so a
+        # heartbeats-only stream surfaces as "empty answer" rather than
+        # "API drift" / ``ChatResponseParseError``.
 
     return None, False, refs, None, parseable
 

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from collections.abc import Awaitable, Callable
@@ -184,7 +185,15 @@ class RpcExecutor:
 
             logger.error("RPC %s failed after %.3fs", method.name, elapsed)
             raise
-        except Exception as exc:
+        except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+            # Narrow on purpose: only genuine shape-drift exceptions (bad
+            # JSON, missing keys/indices, type-mismatched access) get wrapped
+            # as ``RPCError``. ``AttributeError`` / ``NameError`` / other
+            # ``RuntimeError`` subclasses indicate code bugs (typos, broken
+            # invariants) and MUST propagate as their native type so they
+            # surface unmasked in stack traces and tests. Adding any of those
+            # back to this tuple re-introduces the shape-vs-bug conflation
+            # this guard exists to remove.
             elapsed = time.perf_counter() - start
             logger.error("RPC %s failed after %.3fs: %s", method.name, elapsed, exc)
             raise RPCError(

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -63,6 +63,7 @@ __all__ = [
     "NotebookLimitError",
     # Domain: Chat
     "ChatError",
+    "ChatResponseParseError",
     # Domain: Sources
     "SourceError",
     "SourceAddError",
@@ -597,6 +598,24 @@ class NotebookLimitError(NotebookError):
 
 class ChatError(NotebookLMError):
     """Base for chat operations."""
+
+
+class ChatResponseParseError(ChatError):
+    """The streaming chat response yielded no parseable chunks.
+
+    Raised when :func:`notebooklm._chat_protocol.parse_streaming_chat_response`
+    iterates the streamed response and finds zero ``wrb.fr`` envelopes it
+    could decode — that is, the wire protocol drifted or the response body
+    was empty/malformed.
+
+    This is distinct from "the model returned an empty answer": a real
+    empty answer still produces at least one parseable ``wrb.fr`` chunk
+    (with empty answer text), in which case the parser returns a
+    ``StreamingChatParseResult("", [], conv_id)`` rather than raising.
+
+    Inherits from :class:`ChatError` so existing chat-domain ``except
+    ChatError`` clauses continue to catch it without modification.
+    """
 
 
 # =============================================================================

--- a/tests/unit/test_chat.py
+++ b/tests/unit/test_chat.py
@@ -1,0 +1,114 @@
+"""Unit tests for chat-domain exception contracts.
+
+Pins the PR-D (audit I4) failure-mode contract for
+:func:`notebooklm._chat_protocol.parse_streaming_chat_response`:
+
+* Zero parseable chunks (empty body, garbage, or API wire drift) →
+  raise :class:`notebooklm.exceptions.ChatResponseParseError`.
+* At least one parseable chunk but no extracted answer (the model
+  legitimately returned an empty answer) → return
+  :class:`StreamingChatParseResult` with ``answer == ""``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from notebooklm._chat_protocol import (
+    StreamingChatParseResult,
+    parse_streaming_chat_response,
+)
+from notebooklm.exceptions import ChatError, ChatResponseParseError, NotebookLMError
+
+
+def _wire_chunk(text: str, *, marked: bool = True) -> str:
+    """Build a length-prefixed streaming response with a single ``wrb.fr`` chunk.
+
+    Mirrors the shape that ``_chunk`` / ``_length_prefixed`` in
+    ``test_streaming_chat_protocol.py`` produce — kept inline here so this
+    file stays self-contained.
+    """
+    marker = 1 if marked else 0
+    type_info = [[], None, None, [], marker]
+    inner_json = json.dumps([[text, None, None, None, type_info]])
+    envelope = json.dumps([["wrb.fr", None, inner_json]])
+    return f")]}}'\n{len(envelope)}\n{envelope}\n"
+
+
+# ---------------------------------------------------------------------------
+# Zero-parseable-chunks → raise
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_empty_raises() -> None:
+    """Empty response body → no ``wrb.fr`` envelope parsed → raise."""
+    with pytest.raises(ChatResponseParseError) as raised:
+        parse_streaming_chat_response("")
+
+    assert "No parseable chunks" in str(raised.value)
+
+
+def test_streaming_xssi_only_raises() -> None:
+    """Body containing only the XSSI prefix has zero parseable chunks."""
+    with pytest.raises(ChatResponseParseError):
+        parse_streaming_chat_response(")]}'\n")
+
+
+def test_streaming_garbage_text_raises() -> None:
+    """Non-JSON garbage in the body yields zero parseable chunks → raise."""
+    with pytest.raises(ChatResponseParseError):
+        parse_streaming_chat_response("not json at all\nmore garbage\n")
+
+
+def test_streaming_non_wrb_fr_envelope_raises() -> None:
+    """A well-formed JSON envelope that is NOT ``wrb.fr`` is unparseable."""
+    other = json.dumps([["other.envelope", None, "{}"]])
+    body = f")]}}'\n{len(other)}\n{other}\n"
+    with pytest.raises(ChatResponseParseError):
+        parse_streaming_chat_response(body)
+
+
+def test_chat_response_parse_error_is_chat_error_subclass() -> None:
+    """Existing ``except ChatError`` clauses must still catch it.
+
+    This pins the inheritance contract — :class:`ChatResponseParseError`
+    MUST inherit (transitively) from :class:`ChatError`, not directly
+    from :class:`NotebookLMError`. Existing chat-domain catches keep
+    working without code changes.
+    """
+    assert issubclass(ChatResponseParseError, ChatError)
+    assert issubclass(ChatResponseParseError, NotebookLMError)
+    try:
+        parse_streaming_chat_response("")
+    except ChatError as exc:
+        assert isinstance(exc, ChatResponseParseError)
+    else:  # pragma: no cover
+        pytest.fail("ChatResponseParseError did not propagate as ChatError")
+
+
+# ---------------------------------------------------------------------------
+# Chunks-parsed-but-empty-answer → return empty (the other half of the contract)
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_parseable_chunk_with_empty_answer_returns_empty() -> None:
+    """A parseable ``wrb.fr`` envelope with empty answer text is NOT a parse
+    failure — it's a legitimate empty answer from the model. The parser
+    must return an empty result, not raise.
+    """
+    body = _wire_chunk("")  # parseable envelope, empty answer text
+    result = parse_streaming_chat_response(body)
+    assert result == StreamingChatParseResult("", [], None)
+
+
+def test_streaming_parseable_chunk_with_non_string_answer_returns_empty() -> None:
+    """Envelope decodes but ``first[0]`` is not a string — still parseable,
+    still an empty-answer return path (not a raise).
+    """
+    inner = json.dumps([[None, None, None, None, [[], None, None, [], 1]]])
+    env = json.dumps([["wrb.fr", None, inner]])
+    body = f")]}}'\n{len(env)}\n{env}\n"
+    result = parse_streaming_chat_response(body)
+    assert result.answer == ""

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -818,15 +818,32 @@ class TestChatAskErrorHandling:
     ):
         """Empty answer on a follow-up must not append a turn to the cache.
 
-        After issue #659, empty responses on new conversations raise
-        ``ChatError`` (no server conv_id to attach to). The cache-poison
-        guard now only matters on follow-ups, where the caller-supplied
-        conversation_id stays stable across an empty response.
+        Two paths reach this assertion under the post-PR-D contract:
+
+        * **Unparseable response body** (e.g. just the XSSI prefix, garbage,
+          or wire-drift): now raises ``ChatResponseParseError`` instead of
+          silently returning an empty answer. The "no cache poisoning"
+          guarantee falls out of the raise — no turn is appended because
+          no ``AskResult`` is constructed.
+        * **Parseable ``wrb.fr`` envelope with empty answer text** (a
+          legitimate empty answer from the model): still returns
+          ``answer == ""``, preserves the caller-supplied conversation_id,
+          and skips the cache append.
+
+        This test covers the second path — the first is covered in
+        ``tests/unit/test_chat.py::test_streaming_empty_raises``.
         """
+        import json
         import re
 
-        # Return totally empty/unparseable response
-        response_body = ")]}'\n"
+        # Parseable wrb.fr envelope with an empty answer text. The chunk
+        # decodes (so parseable_chunk_count > 0 and the parser returns)
+        # but extracts no answer — exactly the "real empty answer" case
+        # the PR-D contract preserves against ``ChatResponseParseError``.
+        inner_data = [["", None, None, None, [[], None, None, [], 1]]]
+        inner_json = json.dumps(inner_data)
+        chunk_json = json.dumps([["wrb.fr", None, inner_json]])
+        response_body = f")]}}'\n{len(chunk_json)}\n{chunk_json}\n"
 
         httpx_mock.add_response(
             url=re.compile(r".*GenerateFreeFormStreamed.*"),
@@ -1336,13 +1353,21 @@ class TestParseAskResponseEdgeCases:
         assert answer == "Answer without prefix."
         assert conv_id is None
 
-    def test_parse_empty_response_returns_empty_string(self, auth_tokens):
-        """Test that completely empty response returns empty string (line 489)."""
+    def test_parse_empty_response_raises_chat_response_parse_error(self, auth_tokens):
+        """A response with no parseable ``wrb.fr`` chunk raises (post-PR-D).
+
+        The XSSI-prefix-only body used to return an empty
+        ``StreamingChatParseResult``. After PR-D, zero parseable chunks
+        means wire-protocol drift / empty body, which is no longer the
+        same thing as a legitimate empty answer. The parser now raises
+        ``ChatResponseParseError`` so callers can surface the failure
+        instead of silently producing an empty ``AskResult``.
+        """
+        from notebooklm.exceptions import ChatResponseParseError
+
         client = NotebookLMClient(auth_tokens)
-        answer, refs, conv_id = client.chat._parse_ask_response_with_references(")]}'\n")
-        assert answer == ""
-        assert refs == []
-        assert conv_id is None
+        with pytest.raises(ChatResponseParseError):
+            client.chat._parse_ask_response_with_references(")]}'\n")
 
     def test_parse_response_no_marked_answer_falls_back_to_unmarked(self, auth_tokens):
         """Test fallback to unmarked text when no marked answer exists (line 486)."""

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -503,3 +503,112 @@ def test_request_error_mapper_parity(
 
     with pytest.raises(expected_type):
         executor.raise_rpc_error_from_request_error(exc, RPCMethod.LIST_NOTEBOOKS)
+
+
+# =============================================================================
+# PR-D (I3): decode-time exception surface contract
+#
+# The ``except`` at ``_core_rpc.py::RpcExecutor.execute`` only wraps genuine
+# shape-drift exceptions (``json.JSONDecodeError``, ``KeyError``, ``IndexError``,
+# ``TypeError``) as ``RPCError``. Code bugs (``AttributeError`` and friends)
+# must propagate unmasked. These tests pin that contract.
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("decoder_exc_factory", "_label"),
+    [
+        (lambda: KeyError("missing"), "KeyError"),
+        (lambda: IndexError("oob"), "IndexError"),
+        (lambda: TypeError("bad type"), "TypeError"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_decode_shape_error_wrapped(
+    decoder_exc_factory: Callable[[], Exception], _label: str
+) -> None:
+    """Genuine shape-drift exceptions get wrapped as ``RPCError`` with the
+    ``Failed to decode response`` message and the original cause chained
+    via ``__cause__``.
+    """
+    decoder_exc = decoder_exc_factory()
+    owner = _Owner()
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise decoder_exc
+
+    with pytest.raises(RPCError) as raised:
+        await _executor(owner, decode_response_late_bound=decode).execute(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+        )
+
+    assert "Failed to decode response for LIST_NOTEBOOKS" in str(raised.value)
+    assert raised.value.method_id == RPCMethod.LIST_NOTEBOOKS.value
+    assert raised.value.__cause__ is decoder_exc
+
+
+@pytest.mark.asyncio
+async def test_decode_shape_error_json_decode_wrapped() -> None:
+    """``json.JSONDecodeError`` (a ``ValueError`` subclass) is wrapped too —
+    it's explicitly named in the narrow tuple at the catch site so callers
+    don't have to depend on the ``ValueError`` base-class relationship.
+    """
+    import json as _json
+
+    owner = _Owner()
+    decoder_exc = _json.JSONDecodeError("expecting value", "doc", 0)
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise decoder_exc
+
+    with pytest.raises(RPCError) as raised:
+        await _executor(owner, decode_response_late_bound=decode).execute(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+        )
+
+    assert "Failed to decode response for LIST_NOTEBOOKS" in str(raised.value)
+    assert raised.value.__cause__ is decoder_exc
+
+
+@pytest.mark.parametrize(
+    "decoder_exc_factory",
+    [
+        lambda: AttributeError("typo: response.gotcha"),
+        lambda: NameError("undefined name"),
+        lambda: RuntimeError("invariant broken"),
+        lambda: ZeroDivisionError("oops"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_decode_code_bug_propagates(
+    decoder_exc_factory: Callable[[], Exception],
+) -> None:
+    """Code-bug exceptions (``AttributeError``, ``NameError``, generic
+    ``RuntimeError``, etc.) propagate as their native type — they are NOT
+    wrapped as ``RPCError``. This is what surfaces decoder typos and
+    broken invariants instead of masking them as "API drift."
+    """
+    decoder_exc = decoder_exc_factory()
+    owner = _Owner()
+
+    def decode(_: str, __: str, *, allow_null: bool = False) -> Any:
+        raise decoder_exc
+
+    with pytest.raises(type(decoder_exc)) as raised:
+        await _executor(owner, decode_response_late_bound=decode).execute(
+            RPCMethod.LIST_NOTEBOOKS,
+            [],
+            "/",
+            False,
+            False,
+        )
+
+    assert raised.value is decoder_exc

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -585,6 +585,12 @@ async def test_decode_shape_error_json_decode_wrapped() -> None:
         lambda: NameError("undefined name"),
         lambda: RuntimeError("invariant broken"),
         lambda: ZeroDivisionError("oops"),
+        # Bare ``ValueError`` (not a ``JSONDecodeError``) — e.g. ``int("bad")``
+        # or a ``uuid.UUID("...")`` failure inside a decoder. Only the
+        # ``JSONDecodeError`` subclass is in the narrow tuple, so a bare
+        # ``ValueError`` MUST propagate unmasked. Pinned per PR-D review
+        # (Claude bot) so the propagation behavior is documented in tests.
+        lambda: ValueError("non-json value error"),
     ],
 )
 @pytest.mark.asyncio
@@ -592,9 +598,10 @@ async def test_decode_code_bug_propagates(
     decoder_exc_factory: Callable[[], Exception],
 ) -> None:
     """Code-bug exceptions (``AttributeError``, ``NameError``, generic
-    ``RuntimeError``, etc.) propagate as their native type — they are NOT
-    wrapped as ``RPCError``. This is what surfaces decoder typos and
-    broken invariants instead of masking them as "API drift."
+    ``RuntimeError``, bare ``ValueError`` that isn't a ``JSONDecodeError``,
+    etc.) propagate as their native type — they are NOT wrapped as
+    ``RPCError``. This is what surfaces decoder typos and broken
+    invariants instead of masking them as "API drift."
     """
     decoder_exc = decoder_exc_factory()
     owner = _Owner()

--- a/tests/unit/test_streaming_chat_protocol.py
+++ b/tests/unit/test_streaming_chat_protocol.py
@@ -288,15 +288,20 @@ def test_unmarked_fallback_logs_under_chat_logger(caplog) -> None:
     )
 
 
-def test_empty_response_returns_empty_result_and_logs_under_chat_logger(caplog) -> None:
-    with caplog.at_level(logging.WARNING, logger="notebooklm._chat"):
-        result = parse_streaming_chat_response("")
+def test_empty_response_raises_chat_response_parse_error() -> None:
+    """Empty response body → zero parseable ``wrb.fr`` envelopes → raise.
 
-    assert result == StreamingChatParseResult("", [], None)
-    assert any(
-        record.name == "notebooklm._chat" and "No answer extracted" in record.message
-        for record in caplog.records
-    )
+    This pins the PR-D (audit I4) contract: an empty body is wire-protocol
+    drift / a failed RPC, NOT a legitimate empty answer. The legitimate
+    empty-answer path (parseable chunk with empty text) is covered in
+    ``tests/unit/test_chat.py``.
+    """
+    from notebooklm.exceptions import ChatResponseParseError
+
+    with pytest.raises(ChatResponseParseError) as raised:
+        parse_streaming_chat_response("")
+
+    assert "No parseable chunks" in str(raised.value)
 
 
 def test_parse_citations_extracts_multiple_references_and_assigns_numbers() -> None:


### PR DESCRIPTION
## Summary
- Follow-up to #744: keep Claude's review-polish commit after #744 was squash-merged from the prior head.
- Documents bare ValueError propagation in the code-bug test and clarifies parseable-but-shape-mismatch fall-through in the streaming parser.

## Test plan
- uv run pytest -n auto tests/unit/test_core_rpc.py tests/unit/test_chat.py tests/unit/test_chat_characterization.py tests/unit/test_streaming_chat_protocol.py
- uv run ruff check src/notebooklm/__init__.py src/notebooklm/_chat_protocol.py src/notebooklm/_core_rpc.py src/notebooklm/exceptions.py tests/unit/test_chat.py tests/unit/test_chat_characterization.py tests/unit/test_core_rpc.py tests/unit/test_streaming_chat_protocol.py
- uv run ruff format --check src/notebooklm/__init__.py src/notebooklm/_chat_protocol.py src/notebooklm/_core_rpc.py src/notebooklm/exceptions.py tests/unit/test_chat.py tests/unit/test_chat_characterization.py tests/unit/test_core_rpc.py tests/unit/test_streaming_chat_protocol.py
- uv run mypy src/notebooklm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publicly exposed `ChatResponseParseError` exception for handling chat response parsing failures.

* **Bug Fixes**
  * Streaming chat response parser now raises an error when no parseable protocol chunks are detected, distinguishing from valid empty responses.
  * RPC executor error handling refined to propagate code-level exceptions separately from decoding errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->