### PR TITLE
polish(rpc,chat): document decoder review invariants

### DIFF
--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -326,6 +326,12 @@ def _extract_chunk_with_parseable(
 
                 refs = parse_citations(first)
                 return text, is_answer, refs, server_conv_id, parseable
+        # inner_json decoded but the record shape didn't match (empty/short
+        # list, dict, etc.) — keep ``parseable = True`` and fall through to
+        # the next item. Real-world ``wrb.fr`` heartbeats like ``"[]"`` hit
+        # this branch and are deliberately still counted as parseable so a
+        # heartbeats-only stream surfaces as "empty answer" rather than
+        # "API drift" / ``ChatResponseParseError``.
 
     return None, False, refs, None, parseable
 

--- a/src/notebooklm/_chat_protocol.py
+++ b/src/notebooklm/_chat_protocol.py
@@ -326,10 +326,13 @@ def _extract_chunk_with_parseable(
 
                 refs = parse_citations(first)
                 return text, is_answer, refs, server_conv_id, parseable
-        # inner_json decoded but the record shape didn't match (empty/short
-        # list, dict, etc.) — keep ``parseable = True`` and fall through to
-        # the next item. Real-world ``wrb.fr`` heartbeats like ``"[]"`` hit
-        # this branch and are deliberately still counted as parseable so a
+        # inner_json decoded but the record didn't yield usable answer data
+        # — either the outer ``isinstance(inner_data, list) and len > 0``
+        # guard failed (dict, empty list, non-list) OR the inner
+        # ``isinstance(first, list) and len > 0`` guard failed. In either
+        # case we keep ``parseable = True`` and fall through to the next
+        # item. Real-world ``wrb.fr`` heartbeats like ``"[]"`` hit this
+        # branch and are deliberately still counted as parseable so a
         # heartbeats-only stream surfaces as "empty answer" rather than
         # "API drift" / ``ChatResponseParseError``.
 

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -585,6 +585,12 @@ async def test_decode_shape_error_json_decode_wrapped() -> None:
         lambda: NameError("undefined name"),
         lambda: RuntimeError("invariant broken"),
         lambda: ZeroDivisionError("oops"),
+        # Bare ``ValueError`` (not a ``JSONDecodeError``) — e.g. ``int("bad")``
+        # or a ``uuid.UUID("...")`` failure inside a decoder. Only the
+        # ``JSONDecodeError`` subclass is in the narrow tuple, so a bare
+        # ``ValueError`` MUST propagate unmasked. Pinned per PR-D review
+        # (Claude bot) so the propagation behavior is documented in tests.
+        lambda: ValueError("non-json value error"),
     ],
 )
 @pytest.mark.asyncio
@@ -592,9 +598,10 @@ async def test_decode_code_bug_propagates(
     decoder_exc_factory: Callable[[], Exception],
 ) -> None:
     """Code-bug exceptions (``AttributeError``, ``NameError``, generic
-    ``RuntimeError``, etc.) propagate as their native type — they are NOT
-    wrapped as ``RPCError``. This is what surfaces decoder typos and
-    broken invariants instead of masking them as "API drift."
+    ``RuntimeError``, bare ``ValueError`` that isn't a ``JSONDecodeError``,
+    etc.) propagate as their native type — they are NOT wrapped as
+    ``RPCError``. This is what surfaces decoder typos and broken
+    invariants instead of masking them as "API drift."
     """
     decoder_exc = decoder_exc_factory()
     owner = _Owner()

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -588,8 +588,8 @@ async def test_decode_shape_error_json_decode_wrapped() -> None:
         # Bare ``ValueError`` (not a ``JSONDecodeError``) — e.g. ``int("bad")``
         # or a ``uuid.UUID("...")`` failure inside a decoder. Only the
         # ``JSONDecodeError`` subclass is in the narrow tuple, so a bare
-        # ``ValueError`` MUST propagate unmasked. Pinned per PR-D review
-        # (Claude bot) so the propagation behavior is documented in tests.
+        # ``ValueError`` MUST propagate unmasked. The new test guards
+        # against accidental future widening of the catch tuple.
         lambda: ValueError("non-json value error"),
     ],
 )


### PR DESCRIPTION
## Summary
- Follow-up to #744 because #744 was squash-merged before the post-review polish commit landed.
- Documents bare ValueError propagation in the code-bug test.
- Clarifies parseable-but-shape-mismatch fall-through in the streaming parser.

## Test plan
- uv run pytest -n auto tests/unit/test_core_rpc.py tests/unit/test_chat.py tests/unit/test_chat_characterization.py tests/unit/test_streaming_chat_protocol.py
- uv run ruff check src/notebooklm/_chat_protocol.py tests/unit/test_core_rpc.py
- uv run ruff format --check src/notebooklm/_chat_protocol.py tests/unit/test_core_rpc.py
- uv run mypy src/notebooklm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal code documentation clarifying payload handling behavior.

* **Tests**
  * Improved test coverage for error handling with additional validation cases.

---

*This release contains internal improvements with no user-facing changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->