### PR TITLE
fix(rpc-health): silence false-positive ERRORs + dedup issues

### DIFF
--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -73,10 +73,13 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+        if ! count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open --label automated --label rpc-breakage \
           --search 'in:title "RPC ID Mismatch Detected"' \
-          --json number --jq 'length')
+          --json number --jq 'length'); then
+          echo "::warning::RPC mismatch dedup probe failed; allowing issue creation"
+          count=0
+        fi
         echo "open=${count}" >> "$GITHUB_OUTPUT"
 
     - name: Create Issue on RPC Mismatch
@@ -96,10 +99,13 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+        if ! count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open --label automated \
           --search 'in:title "RPC Health Check: Authentication Failure"' \
-          --json number --jq 'length')
+          --json number --jq 'length'); then
+          echo "::warning::Auth failure dedup probe failed; allowing issue creation"
+          count=0
+        fi
         echo "open=${count}" >> "$GITHUB_OUTPUT"
 
     - name: Create Issue on Auth Failure
@@ -119,10 +125,13 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+        if ! count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
           --state open --label automated --label rpc-error \
           --search 'in:title "RPC Health Check: Non-transient ERROR detected"' \
-          --json number --jq 'length')
+          --json number --jq 'length'); then
+          echo "::warning::Non-transient ERROR dedup probe failed; allowing issue creation"
+          count=0
+        fi
         echo "open=${count}" >> "$GITHUB_OUTPUT"
 
     - name: Extract failing methods for ERROR issue

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -61,24 +61,75 @@ jobs:
         echo "## RPC Health Check Results" >> "$GITHUB_STEP_SUMMARY"
         grep -A 10 "^SUMMARY$" health-report.txt >> "$GITHUB_STEP_SUMMARY" || echo "No summary found" >> "$GITHUB_STEP_SUMMARY"
 
-    - name: Create Issue on RPC Mismatch
+    # Each issue-creating step is paired with a dedup probe that counts
+    # open issues sharing the same title + automated label. Without this,
+    # back-to-back failing runs (manual reruns, cron + workflow_dispatch,
+    # in-flight PR branches without the gate fix from #736) farm one
+    # fresh issue per run instead of letting the open one accumulate
+    # context.
+    - name: Check for existing RPC Mismatch issue
       if: github.event_name != 'pull_request' && steps.health.outputs.exit_code == '1'
+      id: dup_mismatch
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+          --state open --label automated --label rpc-breakage \
+          --search 'in:title "RPC ID Mismatch Detected"' \
+          --json number --jq 'length')
+        echo "open=${count}" >> "$GITHUB_OUTPUT"
+
+    - name: Create Issue on RPC Mismatch
+      if: |
+        github.event_name != 'pull_request'
+        && steps.health.outputs.exit_code == '1'
+        && steps.dup_mismatch.outputs.open == '0'
       uses: peter-evans/create-issue-from-file@v6
       with:
         title: "RPC ID Mismatch Detected"
         content-filepath: health-report.txt
         labels: bug, rpc-breakage, automated
 
-    - name: Create Issue on Auth Failure
+    - name: Check for existing Auth Failure issue
       if: github.event_name != 'pull_request' && steps.health.outputs.exit_code == '2'
+      id: dup_auth
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+          --state open --label automated \
+          --search 'in:title "RPC Health Check: Authentication Failure"' \
+          --json number --jq 'length')
+        echo "open=${count}" >> "$GITHUB_OUTPUT"
+
+    - name: Create Issue on Auth Failure
+      if: |
+        github.event_name != 'pull_request'
+        && steps.health.outputs.exit_code == '2'
+        && steps.dup_auth.outputs.open == '0'
       uses: peter-evans/create-issue-from-file@v6
       with:
         title: "RPC Health Check: Authentication Failure"
         content-filepath: health-report.txt
         labels: bug, automated
 
-    - name: Extract failing methods for ERROR issue
+    - name: Check for existing non-transient ERROR issue
       if: github.event_name != 'pull_request' && steps.health.outputs.exit_code == '3'
+      id: dup_error
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        count=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+          --state open --label automated --label rpc-error \
+          --search 'in:title "RPC Health Check: Non-transient ERROR detected"' \
+          --json number --jq 'length')
+        echo "open=${count}" >> "$GITHUB_OUTPUT"
+
+    - name: Extract failing methods for ERROR issue
+      if: |
+        github.event_name != 'pull_request'
+        && steps.health.outputs.exit_code == '3'
+        && steps.dup_error.outputs.open == '0'
       id: error_details
       shell: bash
       run: |
@@ -105,7 +156,10 @@ jobs:
         } > error-issue-body.md
 
     - name: Create Issue on Non-transient ERROR
-      if: github.event_name != 'pull_request' && steps.health.outputs.exit_code == '3'
+      if: |
+        github.event_name != 'pull_request'
+        && steps.health.outputs.exit_code == '3'
+        && steps.dup_error.outputs.open == '0'
       uses: peter-evans/create-issue-from-file@v6
       with:
         title: "RPC Health Check: Non-transient ERROR detected"

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -480,7 +480,11 @@ def get_test_params(method: RPCMethod, notebook_id: str | None) -> list[Any] | N
     # notebook is available, route this method there instead so the
     # canary keeps drift-checking the RPC ID.
     if method == RPCMethod.GET_SUGGESTED_REPORTS:
-        stable_id = os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID") or notebook_id
+        stable_id = (
+            os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID")
+            or os.environ.get("NOTEBOOKLM_GENERATION_NOTEBOOK_ID")
+            or notebook_id
+        )
         return [[2], stable_id]
 
     # Methods that take [[notebook_id]] as the only param.

--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -15,8 +15,10 @@ Priority order when multiple statuses are present:
     MISMATCH (1) > AUTH (2) > non-transient ERROR (3) > OK (0)
 
 Transient errors that still exit 0 are limited to rate-limit signals
-(HTTP 429 and gRPC ``RESOURCE_EXHAUSTED``). Everything else is treated
-as a real failure so the nightly canary can flag silent breakage.
+(HTTP 429, gRPC ``RESOURCE_EXHAUSTED``, and the decoder's user-displayable
+``API rate limit`` / quota messages raised as ``RateLimitError``).
+Everything else is treated as a real failure so the nightly canary can
+flag silent breakage.
 
 Environment variables:
     NOTEBOOKLM_AUTH_JSON - Playwright storage state JSON (required)
@@ -471,9 +473,15 @@ def get_test_params(method: RPCMethod, notebook_id: str | None) -> list[Any] | N
     ):
         return [notebook_id]
 
-    # GET_SUGGESTED_REPORTS has special params: [[2], notebook_id]
+    # GET_SUGGESTED_REPORTS has special params: [[2], notebook_id].
+    # Suggestions only exist once a notebook has indexed sources, so the
+    # freshly-created temp notebook used in --full mode returns an empty
+    # body and trips the empty-response guard. When a stable read-only
+    # notebook is available, route this method there instead so the
+    # canary keeps drift-checking the RPC ID.
     if method == RPCMethod.GET_SUGGESTED_REPORTS:
-        return [[2], notebook_id]
+        stable_id = os.environ.get("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID") or notebook_id
+        return [[2], stable_id]
 
     # Methods that take [[notebook_id]] as the only param.
     if method == RPCMethod.GET_NOTES_AND_MIND_MAPS:
@@ -1002,9 +1010,16 @@ async def run_health_check(full_mode: bool = False) -> list[CheckResult]:
 # (timeouts, parse failures, unexpected HTTP errors) is treated as a real
 # failure so the nightly canary can flag silent breakage. Keep this list
 # narrow on purpose: broadening it would mask real RPC drift.
+#
+# ``API rate limit`` catches the decoder's user-displayable messages
+# raised as ``RateLimitError`` ("API rate limit exceeded..." and
+# "API rate limit or quota exceeded..."). These reach the canary via the
+# ``except RPCError`` parse-error branch in ``test_rpc_method_with_data``
+# and were previously misclassified as non-transient.
 TRANSIENT_ERROR_MARKERS: tuple[str, ...] = (
     "HTTP 429",
     "RESOURCE_EXHAUSTED",
+    "API rate limit",
 )
 
 

--- a/tests/integration/concurrency/conftest.py
+++ b/tests/integration/concurrency/conftest.py
@@ -46,6 +46,7 @@ import logging
 import traceback
 from collections import deque
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any, TypeVar
 
@@ -73,6 +74,45 @@ def _default_rpc_response_text(rpc_id: str = _DEFAULT_RPC_ID) -> str:
     inner = json.dumps([])
     chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
     return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def install_post_as_stream(
+    monkeypatch: pytest.MonkeyPatch | None,
+    http_client: Any,
+    fake_post: Callable[..., Awaitable[Any]],
+) -> None:
+    """Adapt legacy fake ``post`` callbacks to the streaming RPC POST API."""
+
+    @asynccontextmanager
+    async def fake_stream(method: str, url: str, **kwargs: Any) -> Any:
+        response = await fake_post(url, **kwargs)
+        if type(response) is httpx.Response:
+            yield response
+            return
+
+        text = getattr(response, "text", "")
+        payload = text.encode("utf-8") if isinstance(text, str) else bytes(text or b"")
+        raw_status = getattr(response, "status_code", 200)
+        status = raw_status if isinstance(raw_status, int) else 200
+        try:
+            raw_headers = getattr(response, "headers", None)
+        except AttributeError:
+            raw_headers = None
+        try:
+            headers = dict(raw_headers) if raw_headers else None
+        except (TypeError, AttributeError):
+            headers = None
+        yield httpx.Response(
+            status_code=status,
+            headers=headers,
+            content=payload,
+            request=httpx.Request("POST", url),
+        )
+
+    if monkeypatch is not None:
+        monkeypatch.setattr(http_client, "stream", fake_stream)
+    else:
+        http_client.stream = fake_stream
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -33,6 +33,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 
+from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient, RateLimitError
 from notebooklm.rpc import RPCMethod
 
@@ -89,6 +90,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
@@ -118,6 +120,7 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
@@ -157,6 +160,7 @@ async def test_default_retries_use_exponential_backoff_when_header_missing(
     client = NotebookLMClient(auth_tokens)
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     sleep_calls: list[float] = []
@@ -205,6 +209,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     def _build_request(_snap):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,12 @@
 """Shared fixtures for integration tests."""
 
 import importlib.util
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
+import httpx
 import pytest
 
 from notebooklm.auth import AuthTokens
@@ -55,6 +59,45 @@ skip_no_cassettes = pytest.mark.skipif(
     not _cassettes_available,
     reason="VCR cassettes not available. Set NOTEBOOKLM_VCR_RECORD=1 to record.",
 )
+
+
+def install_post_as_stream(
+    monkeypatch: pytest.MonkeyPatch | None,
+    http_client: Any,
+    fake_post: Callable[..., Awaitable[Any]],
+) -> None:
+    """Adapt legacy fake ``post`` callbacks to the streaming RPC POST API."""
+
+    @asynccontextmanager
+    async def fake_stream(method: str, url: str, **kwargs: Any) -> Any:
+        response = await fake_post(url, **kwargs)
+        if type(response) is httpx.Response:
+            yield response
+            return
+
+        text = getattr(response, "text", "")
+        payload = text.encode("utf-8") if isinstance(text, str) else bytes(text or b"")
+        raw_status = getattr(response, "status_code", 200)
+        status = raw_status if isinstance(raw_status, int) else 200
+        try:
+            raw_headers = getattr(response, "headers", None)
+        except AttributeError:
+            raw_headers = None
+        try:
+            headers = dict(raw_headers) if raw_headers else None
+        except (TypeError, AttributeError):
+            headers = None
+        yield httpx.Response(
+            status_code=status,
+            headers=headers,
+            content=payload,
+            request=httpx.Request("POST", url),
+        )
+
+    if monkeypatch is not None:
+        monkeypatch.setattr(http_client, "stream", fake_stream)
+    else:
+        http_client.stream = fake_stream
 
 
 async def get_vcr_auth() -> AuthTokens:

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCError
@@ -77,7 +78,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             with patch("notebooklm._core.decode_response") as mock_decode:
                 mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
@@ -124,7 +125,7 @@ class TestAutoRefreshIntegration:
             return [[["nb1"], ["Notebook 1"]]]
 
         async with client:
-            client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             with patch("notebooklm._core.decode_response", side_effect=mock_decode):
                 await client.notebooks.list()
@@ -163,7 +164,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             start_time = asyncio.get_event_loop().time()
 
@@ -199,7 +200,7 @@ class TestAutoRefreshIntegration:
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
         async with client:
-            client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             # Should raise the original HTTP error with refresh failure as cause
             with pytest.raises(httpx.HTTPStatusError) as exc_info:

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from conftest import install_post_as_stream
 from notebooklm import AuthTokens, NotebookLMClient
 from notebooklm._core import MAX_CONVERSATION_CACHE_SIZE, ClientCore, is_auth_error
 from notebooklm.rpc import (
@@ -21,6 +22,12 @@ from notebooklm.rpc import (
 # httpx-mock + MagicMock based core-layer tests; no real HTTP, no
 # cassette. Opt out of the tier-enforcement hook in tests/integration/conftest.py.
 pytestmark = pytest.mark.allow_no_vcr
+
+
+def _install_error_post(core: ClientCore, error: Exception) -> AsyncMock:
+    mock_post = AsyncMock(side_effect=error)
+    install_post_as_stream(None, core._http_client, mock_post)
+    return mock_post
 
 
 class TestClientInitialization:
@@ -145,10 +152,8 @@ class TestRPCCallHTTPErrors:
             mock_response.reason_phrase = "Too Many Requests"
             error = httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response)
 
-            with (
-                patch.object(core._http_client, "post", side_effect=error),
-                pytest.raises(RateLimitError) as exc_info,
-            ):
+            _install_error_post(core, error)
+            with pytest.raises(RateLimitError) as exc_info:
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
             assert exc_info.value.retry_after == 60
 
@@ -165,10 +170,8 @@ class TestRPCCallHTTPErrors:
             mock_response.reason_phrase = "Too Many Requests"
             error = httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response)
 
-            with (
-                patch.object(core._http_client, "post", side_effect=error),
-                pytest.raises(RateLimitError) as exc_info,
-            ):
+            _install_error_post(core, error)
+            with pytest.raises(RateLimitError) as exc_info:
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
             assert exc_info.value.retry_after is None
 
@@ -185,10 +188,8 @@ class TestRPCCallHTTPErrors:
             mock_response.reason_phrase = "Too Many Requests"
             error = httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response)
 
-            with (
-                patch.object(core._http_client, "post", side_effect=error),
-                pytest.raises(RateLimitError) as exc_info,
-            ):
+            _install_error_post(core, error)
+            with pytest.raises(RateLimitError) as exc_info:
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
             assert exc_info.value.retry_after is None
 
@@ -208,10 +209,8 @@ class TestRPCCallHTTPErrors:
             mock_response.reason_phrase = "Bad Request"
             error = httpx.HTTPStatusError("400", request=MagicMock(), response=mock_response)
 
-            with (
-                patch.object(core._http_client, "post", side_effect=error),
-                pytest.raises(ClientError),
-            ):
+            _install_error_post(core, error)
+            with pytest.raises(ClientError):
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -226,10 +225,8 @@ class TestRPCCallHTTPErrors:
             mock_response.reason_phrase = "Internal Server Error"
             error = httpx.HTTPStatusError("500", request=MagicMock(), response=mock_response)
 
-            with (
-                patch.object(core._http_client, "post", side_effect=error),
-                pytest.raises(ServerError),
-            ):
+            _install_error_post(core, error)
+            with pytest.raises(ServerError):
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -239,14 +236,8 @@ class TestRPCCallHTTPErrors:
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
-            with (
-                patch.object(
-                    core._http_client,
-                    "post",
-                    side_effect=httpx.ConnectTimeout("connect timeout"),
-                ),
-                pytest.raises(NetworkError),
-            ):
+            _install_error_post(core, httpx.ConnectTimeout("connect timeout"))
+            with pytest.raises(NetworkError):
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -254,14 +245,8 @@ class TestRPCCallHTTPErrors:
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
-            with (
-                patch.object(
-                    core._http_client,
-                    "post",
-                    side_effect=httpx.ReadTimeout("read timeout"),
-                ),
-                pytest.raises(RPCTimeoutError),
-            ):
+            _install_error_post(core, httpx.ReadTimeout("read timeout"))
+            with pytest.raises(RPCTimeoutError):
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -269,14 +254,8 @@ class TestRPCCallHTTPErrors:
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
-            with (
-                patch.object(
-                    core._http_client,
-                    "post",
-                    side_effect=httpx.ConnectError("connection refused"),
-                ),
-                pytest.raises(NetworkError),
-            ):
+            _install_error_post(core, httpx.ConnectError("connection refused"))
+            with pytest.raises(NetworkError):
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -284,14 +263,8 @@ class TestRPCCallHTTPErrors:
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
             core = client._core
 
-            with (
-                patch.object(
-                    core._http_client,
-                    "post",
-                    side_effect=httpx.RequestError("something went wrong"),
-                ),
-                pytest.raises(NetworkError),
-            ):
+            _install_error_post(core, httpx.RequestError("something went wrong"))
+            with pytest.raises(NetworkError):
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
 
@@ -313,15 +286,14 @@ class TestRPCCallAuthRetry:
             success_response.status_code = 200
             success_response.text = "some_valid_response"
 
-            with (
-                patch.object(core._http_client, "post", return_value=success_response),
-                patch(
-                    "notebooklm._core.decode_response",
-                    side_effect=[
-                        RPCError("authentication expired"),
-                        ["result_data"],
-                    ],
-                ),
+            mock_post = AsyncMock(return_value=success_response)
+            install_post_as_stream(None, core._http_client, mock_post)
+            with patch(
+                "notebooklm._core.decode_response",
+                side_effect=[
+                    RPCError("authentication expired"),
+                    ["result_data"],
+                ],
             ):
                 result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -291,6 +291,21 @@ def test_get_suggested_reports_prefers_stable_read_only_notebook(
     assert params == [[2], "stable_nb"]
 
 
+def test_get_suggested_reports_prefers_generation_notebook_when_read_only_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In --full mode, use the generation notebook as the stable fallback
+    when a dedicated read-only notebook is not configured.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID", raising=False)
+    monkeypatch.setenv("NOTEBOOKLM_GENERATION_NOTEBOOK_ID", "generation_nb")
+    params = check_rpc_health.get_test_params(
+        check_rpc_health.RPCMethod.GET_SUGGESTED_REPORTS,
+        "temp_nb",
+    )
+    assert params == [[2], "generation_nb"]
+
+
 def test_get_suggested_reports_falls_back_to_caller_notebook(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -298,6 +313,7 @@ def test_get_suggested_reports_falls_back_to_caller_notebook(
     passed (preserves quick-mode behaviour where there's no temp notebook).
     """
     monkeypatch.delenv("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID", raising=False)
+    monkeypatch.delenv("NOTEBOOKLM_GENERATION_NOTEBOOK_ID", raising=False)
     params = check_rpc_health.get_test_params(
         check_rpc_health.RPCMethod.GET_SUGGESTED_REPORTS,
         "caller_nb",

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -90,6 +90,12 @@ def _result(
         "HTTP 429: Too Many Requests",
         "rpc error: code = RESOURCE_EXHAUSTED desc = quota exceeded",
         "RESOURCE_EXHAUSTED",
+        # The decoder raises RateLimitError with these user-displayable
+        # messages; before the marker was added they leaked through the
+        # "Parse error: ..." branch as non-transient and farmed dup
+        # issues. Pin both phrasings (decoder.py:117 and :470).
+        "Parse error: API rate limit exceeded. Please wait before retrying.",
+        "Parse error: API rate limit or quota exceeded. Please wait before retrying.",
     ],
 )
 def test_transient_markers_match(message: str) -> None:
@@ -124,11 +130,18 @@ def test_partition_errors_separates_transient_from_real() -> None:
         _result("timeout", CheckStatus.ERROR, error="Connection timeout"),
         _result("parse", CheckStatus.ERROR, error="Parse error: bad JSON"),
         _result("quota", CheckStatus.ERROR, error="RESOURCE_EXHAUSTED on RPC"),
+        # RateLimitError raised by the decoder reaches the canary wrapped in
+        # the "Parse error: ..." prefix — it must still partition as transient.
+        _result(
+            "ratelimit_leak",
+            CheckStatus.ERROR,
+            error="Parse error: API rate limit or quota exceeded. Please wait before retrying.",
+        ),
         _result("mismatch", CheckStatus.MISMATCH),
     ]
     non_transient, transient = partition_errors(results)
     assert [r.method.name for r in non_transient] == ["timeout", "parse"]
-    assert [r.method.name for r in transient] == ["rate", "quota"]
+    assert [r.method.name for r in transient] == ["rate", "quota", "ratelimit_leak"]
 
 
 @pytest.mark.asyncio
@@ -255,6 +268,41 @@ async def test_setup_temp_resources_uses_canonical_create_notebook_payload(
     assert captured["params"][1:] == [None, None, [2], [1]]
     assert results[0].status == CheckStatus.ERROR
     assert temp.notebook_id is None
+
+
+# ---------------------------------------------------------------------------
+# get_test_params: GET_SUGGESTED_REPORTS routing
+# ---------------------------------------------------------------------------
+
+
+def test_get_suggested_reports_prefers_stable_read_only_notebook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In --full mode the temp notebook has no indexed sources, so
+    GET_SUGGESTED_REPORTS returns an empty body and trips the empty-response
+    guard. When NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID is set, the canary should
+    route this method there even if the caller passes the temp ID.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID", "stable_nb")
+    params = check_rpc_health.get_test_params(
+        check_rpc_health.RPCMethod.GET_SUGGESTED_REPORTS,
+        "temp_nb",
+    )
+    assert params == [[2], "stable_nb"]
+
+
+def test_get_suggested_reports_falls_back_to_caller_notebook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the stable secret, fall back to the notebook_id the caller
+    passed (preserves quick-mode behaviour where there's no temp notebook).
+    """
+    monkeypatch.delenv("NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID", raising=False)
+    params = check_rpc_health.get_test_params(
+        check_rpc_health.RPCMethod.GET_SUGGESTED_REPORTS,
+        "caller_nb",
+    )
+    assert params == [[2], "caller_nb"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three related fixes to stop the RPC health canary from farming duplicate GitHub issues for known-noisy failure modes.

- **#714** — Classify the decoder's `RateLimitError` messages (`"API rate limit exceeded..."` / `"API rate limit or quota exceeded..."`) as transient. They reach the canary via the `except RPCError` parse-error branch in `test_rpc_method_with_data` and were leaking past the narrow `HTTP 429 / RESOURCE_EXHAUSTED` filter.
- **#709** — Route `GET_SUGGESTED_REPORTS` to `NOTEBOOKLM_READ_ONLY_NOTEBOOK_ID` when set. The `--full` mode temp notebook has no indexed sources, so the API returns an empty body and trips the defensive empty-response guard. Using the stable notebook preserves drift detection.
- **Workflow dedup gate** — each of the three `create-issue-from-file` steps now has a paired `gh issue list` probe; the create step skips when an open issue with the same title + `automated` label already exists. This is what would have stopped the 24-issue burst from in-flight PR branches that hadn't picked up #736 yet.

Filing this so the auth-failure (#742) followup the maintainer is doing is the only manual step needed.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues
- [x] `uv run pytest tests/unit/test_check_rpc_health.py tests/unit/test_rpc_health_coverage.py` — 35 passed
- [x] `uv run pytest` — 4760 passed, 6 pre-existing VCR cassette failures unrelated to this change (same failures on `main`)
- [ ] Next scheduled canary run (or a manual `workflow_dispatch`) confirms: rate-limit ERRORs now classify as transient → exit 0; if exit 3 fires while an open `RPC Health Check: Non-transient ERROR detected` issue exists, no new issue is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow now deduplicates health-check issue creation and prevents duplicate failure reports; concurrency grouping simplified.

* **Bug Fixes**
  * API rate limit messages treated as transient errors to avoid false non-transient failures.
  * Notebook selection now prefers a stable read-only notebook ID when available.

* **Tests**
  * Expanded tests for rate-limit handling and notebook ID routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->