### PR TITLE
docs(architecture): add phase 10 verification handoff

### DIFF
--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-9-final-verification-handoff.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-9-final-verification-handoff.md
@@ -73,10 +73,10 @@ T12.8 leaves the CLI boundary in this shape:
 
 - `cli.helpers` is a compatibility facade over `rendering`, `context`,
   `runtime`, `auth_runtime`, `resolve`, `input`, and `research_import`.
-- `cli.rendering` stays below runtime/auth/context/resolve/input/completion
-  and command modules.
-- `cli.context` stays below runtime/auth/rendering/resolve/input/completion and
-  command modules.
+- `cli.rendering` stays below runtime/auth/resolve/input/completion and command
+  modules, without importing peer low-level context helpers.
+- `cli.context` stays below runtime/auth/resolve/input/completion and command
+  modules, without importing peer low-level rendering helpers.
 - `cli.runtime` remains a leaf CLI module.
 - `cli.auth_runtime` imports only the CLI collaborators `error_handler` and the
   `helpers` facade for call-time patching.
@@ -132,8 +132,8 @@ head `34c3c04`.
 
 | Command | Result |
 |---|---|
-| `rtk uv run pytest tests/unit/test_cli_boundary.py -q` | Passed: 36 passed in 0.15s |
-| `rtk uv run pytest -n auto` | Passed: 4772 passed, 12 skipped, 8 warnings in 13.41s |
+| `rtk uv run pytest tests/unit/test_cli_boundary.py -q` | Passed: 36 passed in 0.13s |
+| `rtk uv run pytest -n auto` | Passed: 4772 passed, 12 skipped, 8 warnings in 12.92s |
 | `rtk uv run ruff check .` | Passed: all checks passed |
 | `rtk uv run mypy src/notebooklm` | Passed: no issues found in 100 source files |
 | `rtk uv run pre-commit run --all-files` | Passed: ruff and ruff format |

--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-9-final-verification-handoff.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-9-final-verification-handoff.md
@@ -1,0 +1,143 @@
+# Phase 10 T12.9 Final Verification And Phase 11 Handoff
+
+Generated: 2026-05-17
+Branch: `architecture-remediation/t12-9-final-verification-handoff`
+Base: `architecture-remediation/t12-8-final-cli-guardrails` at `34c3c04`
+
+## Inputs
+
+- Required T12.8 seam map read:
+  `.sisyphus/phases/architecture-remediation/runs/phase-10-t12-helper-seam-map.md`
+- Requested phase plan path:
+  `.sisyphus/phases/architecture-remediation/phase-10.md`
+
+## Input Gap
+
+The requested phase plan file,
+`.sisyphus/phases/architecture-remediation/phase-10.md`, is missing from the
+T12.8 branch, `origin/main`, and local worktrees at verification time. This
+handoff uses the T12.9 task instructions from the caller plus the T12.8 seam map
+as the source of truth.
+
+## Landing Evidence
+
+The Phase 10 CLI/runtime helper stack is present in the stacked branch. All
+T11.0-T12.7 slices below are merged to `origin/main`; T12.8 is present on the
+base branch for this handoff and remains blocked on PR review/CI before being
+rebased onto main.
+
+| Slice | Evidence | Status |
+|---|---|---|
+| T11.0 runtime/completion characterization | PR #695, `aa2e8f0` | Merged |
+| T11.1 shared auth error runtime | PR #694 | Merged |
+| T11.2 download runtime normalization | PR #697 | Merged |
+| T11.3 completion provider extraction | PR #696, `d7792bd` | Merged |
+| T11.4 runtime/completion guardrails | PR #703 and PR #705 | Merged as a guardrail stack |
+| T12.0 helper seam map | PR #699 | Merged |
+| T12.1 rendering/context foundation | PR #702 and PR #704, `ea756ed` | Merged as a foundation/integration stack |
+| T12.2 runtime/auth split | PR #713, `8521b30` | Merged |
+| T12.3 resolve/input split | PR #711, `2be3c83` | Merged |
+| T12.4 research import split | PR #716, `8de39e5` | Merged |
+| T12.5 source command services | PR #720 | Merged |
+| T12.6 generation/artifact services | PR #712, `d10c5ab` | Merged |
+| T12.7 session/login services | PR #724, `ff6252c` | Merged |
+| T12.8 final helper facade guardrails | PR #745, `34c3c04` | Open, base for T12.9 |
+
+## Final Helper Import Inventory
+
+Command used:
+
+```bash
+rtk rg -n "from \\.helpers import|from \\. import helpers|from \\.\\.helpers import|from \\.\\. import helpers|from notebooklm\\.cli\\.helpers import|from notebooklm\\.cli import helpers|import notebooklm\\.cli\\.helpers" src/notebooklm/cli
+```
+
+Production `cli.helpers` imports are limited to the compatibility surface and
+the documented call-time patch seams:
+
+| File | Import shape | Boundary reason |
+|---|---|---|
+| `src/notebooklm/cli/__init__.py:26` | `from .helpers import ...` | Public compatibility re-export surface |
+| `src/notebooklm/cli/auth_runtime.py:29` | lazy `from . import helpers` | Preserves existing auth/runtime test patch seams |
+| `src/notebooklm/cli/completion.py:166` | lazy `from . import helpers` | Preserves completion auth patch seam |
+| `src/notebooklm/cli/completion.py:174` | lazy `from . import helpers` | Preserves completion context patch seam |
+| `src/notebooklm/cli/completion.py:191` | lazy `from . import helpers` | Preserves completion runtime patch seam |
+
+No command module or service module imports moved helper symbols through the
+facade. Test fixtures still patch `notebooklm.cli.helpers.*` by design; those
+patch seams remain part of the compatibility contract until a later migration
+explicitly moves every affected test in the same slice.
+
+## CLI Boundary Status
+
+T12.8 leaves the CLI boundary in this shape:
+
+- `cli.helpers` is a compatibility facade over `rendering`, `context`,
+  `runtime`, `auth_runtime`, `resolve`, `input`, and `research_import`.
+- `cli.rendering` stays below runtime/auth/context/resolve/input/completion
+  and command modules.
+- `cli.context` stays below runtime/auth/rendering/resolve/input/completion and
+  command modules.
+- `cli.runtime` remains a leaf CLI module.
+- `cli.auth_runtime` imports only the CLI collaborators `error_handler` and the
+  `helpers` facade for call-time patching.
+- `cli.resolve` stays off `helpers`, runtime/auth, `notebooklm.auth`, and
+  command modules.
+- `cli.options` keeps live completion auth/client/runtime work delegated to
+  `cli.completion`.
+- `cli.services.*` stays on public library APIs and does not import private
+  library modules or `notebooklm.rpc.*`.
+
+Guardrail coverage is concentrated in `tests/unit/test_cli_boundary.py`,
+including:
+
+- `test_no_private_module_imports_in_cli`
+- `test_cli_services_stay_on_public_library_boundary`
+- `test_rendering_stays_on_low_level_cli_import_boundary`
+- `test_context_stays_on_low_level_cli_import_boundary`
+- `test_runtime_stays_leaf_module`
+- `test_auth_runtime_imports_only_runtime_facade_collaborators`
+- `test_resolve_stays_off_helpers_runtime_auth_and_commands`
+- `test_command_modules_do_not_import_helpers_facade_for_moved_symbols`
+- `test_helpers_remains_compatibility_facade`
+- `test_options_completion_callbacks_stay_on_completion_provider_boundary`
+
+## Phase 11 Handoff
+
+Phase 11 can proceed only after PR #745 is merged and this T12.9 branch is
+rebased onto `origin/main`.
+
+Blocked until then:
+
+- Treating `origin/main` as containing the final T12 helper facade import
+  cleanup.
+- Starting any T13 or Phase 11 implementation work that depends on the final
+  CLI helper boundary.
+- Removing remaining compatibility patch seams in `cli.helpers`; those are
+  intentionally preserved until a future slice migrates all tests and call
+  sites together.
+
+Recommended Phase 11 starting checks after #745 merges:
+
+```bash
+rtk git fetch origin
+rtk git rebase origin/main
+rtk uv run pytest tests/unit/test_cli_boundary.py -q
+rtk uv run pytest -n auto
+```
+
+## Verification Results
+
+Verification was run from the T12.9 worktree after rebasing the stack onto #745
+head `34c3c04`.
+
+| Command | Result |
+|---|---|
+| `rtk uv run pytest tests/unit/test_cli_boundary.py -q` | Passed: 36 passed in 0.15s |
+| `rtk uv run pytest -n auto` | Passed: 4772 passed, 12 skipped, 8 warnings in 13.41s |
+| `rtk uv run ruff check .` | Passed: all checks passed |
+| `rtk uv run mypy src/notebooklm` | Passed: no issues found in 100 source files |
+| `rtk uv run pre-commit run --all-files` | Passed: ruff and ruff format |
+
+Warnings in the full test run were pre-existing suite warnings: unknown artifact
+type fixture data, ambiguous research poll deprecation, one async mock resource
+warning, and pytest-asyncio fixture-loop deprecations.

--- a/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-9-final-verification-handoff.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-10-t12-9-final-verification-handoff.md
@@ -48,7 +48,7 @@ rebased onto main.
 Command used:
 
 ```bash
-rtk rg -n "from \\.helpers import|from \\. import helpers|from \\.\\.helpers import|from \\.\\. import helpers|from notebooklm\\.cli\\.helpers import|from notebooklm\\.cli import helpers|import notebooklm\\.cli\\.helpers" src/notebooklm/cli
+rtk rg -n 'from\s+(\.\.?|notebooklm\.cli)(\.helpers\s+import\b|\s+import\s+helpers\b)|import\s+notebooklm\.cli\.helpers\b' src/notebooklm/cli
 ```
 
 Production `cli.helpers` imports are limited to the compatibility surface and
@@ -78,8 +78,8 @@ T12.8 leaves the CLI boundary in this shape:
 - `cli.context` stays below runtime/auth/resolve/input/completion and command
   modules, without importing peer low-level rendering helpers.
 - `cli.runtime` remains a leaf CLI module.
-- `cli.auth_runtime` imports only the CLI collaborators `error_handler` and the
-  `helpers` facade for call-time patching.
+- `cli.auth_runtime` imports only the peer CLI collaborators `error_handler`
+  and the `helpers` facade for call-time patching.
 - `cli.resolve` stays off `helpers`, runtime/auth, `notebooklm.auth`, and
   command modules.
 - `cli.options` keeps live completion auth/client/runtime work delegated to


### PR DESCRIPTION
## Summary
- Add the T12.9 final Phase 10 verification and Phase 11 handoff artifact.
- Refresh the final helper facade import inventory against the merged #745 result.
- Document Phase 11 blockers, including the missing phase-10.md input gap.

## Task
- T12.9 final verification and Phase 11 handoff.
- Originally stacked on #745; rebased and retargeted to main after #745 merged at 9626761.

## Verification
- rtk uv sync --frozen --extra browser --extra dev --extra markdown
- rtk uv run pytest tests/unit/test_cli_boundary.py -q: 36 passed
- rtk uv run pytest -n auto: 4772 passed, 12 skipped
- rtk uv run ruff check .: passed
- rtk uv run mypy src/notebooklm: passed, 100 source files
- rtk uv run pre-commit run --all-files: passed
- rtk git diff --check origin/main...HEAD: passed after rebase

## Polish / Review
- Step 4.1 code-simplifier fallback: no changes needed
- Step 4.2 triple review: Claude/Codex/Gemini; 0 critical; 2 important fixed before PR creation
- PR review found one circular wording issue in the handoff artifact; fixed in the current rebased head.

## Deferred / Blocked
- The requested .sisyphus/phases/architecture-remediation/phase-10.md file is absent from #745, origin/main, and local worktrees; the artifact records this input gap.
- Phase 11 T13.0 remains blocked until this T12.9 handoff and #746 security scrub are merged/audited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture and verification documentation to record Phase 10 final verification status and Phase 11 handoff requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->