### PR TITLE
test(types): freeze public type facade contract

### DIFF
--- a/.sisyphus/phases/architecture-remediation/runs/phase-11-t13-type-contract-freeze.md
+++ b/.sisyphus/phases/architecture-remediation/runs/phase-11-t13-type-contract-freeze.md
@@ -1,0 +1,174 @@
+# Phase 11 T13.0 - Promotion Audit And Contract Freeze
+
+Date: 2026-05-17
+Branch: `architecture-remediation/t13-0-promotion-audit-contract-freeze`
+Base: `origin/main` (`c5d1ce3`, after `#746` merged)
+Status: open/blocked only on final handoff readiness
+
+## Blockers
+
+- `#745` / T12.8 and `#746` are merged into `origin/main`.
+- `#750` is a documentation-only handoff PR on `main`. This T13.0 slice does not edit the same handoff file and does not block on it; re-check if later T13/T14 work touches that file or relies on the final docs contract.
+- This checkout does not contain `.sisyphus/phases/architecture-remediation/state.json`, so the required `jq` and `rg` state refresh commands cannot complete on this base. Treat the missing state file as a recorded refresh gap.
+- No runtime source behavior changed in this slice.
+
+## Refreshed Snapshot
+
+- `src/notebooklm/types.py`: 1543 lines.
+- `src/notebooklm/__init__.py`: 290 lines.
+- `tests/unit/test_types.py`: 1513 lines before this task.
+- `tests/unit/test_public_shims.py`: 681 lines before this task.
+- `tests/unit/test_init_order.py`: 877 lines.
+- `tests/unit/test_source_status.py`: 443 lines.
+- `tests/unit/test_sharing_types.py`: 303 lines.
+- No `src/notebooklm/_types/` package exists on this base.
+- T13.0 conflict check was clean for owned target files on this worktree.
+
+## Frozen `notebooklm.types.__all__`
+
+```python
+[
+    "CitedSourceSelection",
+    "ConnectionLimits",
+    "ClientMetricsSnapshot",
+    "RpcTelemetryEvent",
+    "Notebook",
+    "NotebookDescription",
+    "NotebookMetadata",
+    "SuggestedTopic",
+    "Source",
+    "SourceFulltext",
+    "SourceSummary",
+    "Artifact",
+    "GenerationStatus",
+    "ReportSuggestion",
+    "Note",
+    "ConversationTurn",
+    "ChatReference",
+    "AskResult",
+    "ChatMode",
+    "SharedUser",
+    "ShareStatus",
+    "SourceError",
+    "SourceAddError",
+    "SourceProcessingError",
+    "SourceTimeoutError",
+    "SourceNotFoundError",
+    "ArtifactError",
+    "ArtifactNotFoundError",
+    "ArtifactNotReadyError",
+    "ArtifactParseError",
+    "ArtifactDownloadError",
+    "UnknownTypeWarning",
+    "SourceType",
+    "ArtifactType",
+    "ArtifactStatus",
+    "AudioFormat",
+    "AudioLength",
+    "VideoFormat",
+    "VideoStyle",
+    "QuizQuantity",
+    "QuizDifficulty",
+    "InfographicOrientation",
+    "InfographicDetail",
+    "InfographicStyle",
+    "SlideDeckFormat",
+    "SlideDeckLength",
+    "ReportFormat",
+    "ChatGoal",
+    "ChatResponseLength",
+    "DriveMimeType",
+    "ExportType",
+    "SourceStatus",
+    "ShareAccess",
+    "ShareViewLevel",
+    "SharePermission",
+    "artifact_status_to_str",
+    "source_status_to_str",
+]
+```
+
+## Frozen Top-Level Type Exports
+
+`notebooklm.__all__` must continue to include and resolve these names as identity re-exports from `notebooklm.types`:
+
+`AccountLimits`, `AccountTier`, `Artifact`, `ArtifactType`, `AskResult`, `AudioFormat`, `AudioLength`, `ChatGoal`, `ChatMode`, `ChatReference`, `ChatResponseLength`, `CitedSourceSelection`, `ClientMetricsSnapshot`, `ConnectionLimits`, `ConversationTurn`, `DriveMimeType`, `ExportType`, `GenerationStatus`, `InfographicDetail`, `InfographicOrientation`, `InfographicStyle`, `Note`, `Notebook`, `NotebookDescription`, `NotebookMetadata`, `QuizDifficulty`, `QuizQuantity`, `ReportFormat`, `ReportSuggestion`, `RpcTelemetryEvent`, `ShareAccess`, `SharedUser`, `SharePermission`, `ShareStatus`, `ShareViewLevel`, `SlideDeckFormat`, `SlideDeckLength`, `Source`, `SourceFulltext`, `SourceStatus`, `SourceSummary`, `SourceType`, `SuggestedTopic`, `UnknownTypeWarning`, `VideoFormat`, `VideoStyle`.
+
+`StudioContentType` remains a deprecated top-level shim only. `from notebooklm import StudioContentType` warns once, returns canonical `notebooklm.rpc.types.ArtifactTypeCode`, and caches the global.
+
+## Frozen Identities
+
+Exception re-exports from `notebooklm.types` must be identity aliases of `notebooklm.exceptions`: `SourceError`, `SourceAddError`, `SourceProcessingError`, `SourceTimeoutError`, `SourceNotFoundError`, `ArtifactError`, `ArtifactNotFoundError`, `ArtifactNotReadyError`, `ArtifactParseError`, `ArtifactDownloadError`.
+
+Top-level exception exports in `notebooklm.__all__` must be identity aliases of `notebooklm.exceptions`: `ArtifactDownloadError`, `ArtifactError`, `ArtifactNotFoundError`, `ArtifactNotReadyError`, `ArtifactParseError`, `AuthError`, `AuthExtractionError`, `ChatError`, `ClientError`, `ConfigurationError`, `DecodingError`, `NetworkError`, `NonIdempotentRetryError`, `NotebookError`, `NotebookLimitError`, `NotebookLMError`, `NotebookNotFoundError`, `RateLimitError`, `ResearchTaskMismatchError`, `RPCError`, `RPCTimeoutError`, `ServerError`, `SourceAddError`, `SourceError`, `SourceNotFoundError`, `SourceProcessingError`, `SourceTimeoutError`, `UnknownRPCMethodError`, `ValidationError`.
+
+RPC enum re-exports from `notebooklm.types` must be identity aliases of `notebooklm.rpc.types`: `ArtifactStatus`, `AudioFormat`, `AudioLength`, `ChatGoal`, `ChatResponseLength`, `DriveMimeType`, `ExportType`, `InfographicDetail`, `InfographicOrientation`, `InfographicStyle`, `QuizDifficulty`, `QuizQuantity`, `ReportFormat`, `ShareAccess`, `SharePermission`, `ShareViewLevel`, `SlideDeckFormat`, `SlideDeckLength`, `SourceStatus`, `VideoFormat`, `VideoStyle`.
+
+RPC helper re-exports must remain identity aliases of `notebooklm.rpc.types.artifact_status_to_str` and `notebooklm.rpc.types.source_status_to_str`.
+
+## Frozen Non-`__all__` Facade Attributes
+
+- `notebooklm.types.ArtifactTypeCode` is present and is `notebooklm.rpc.types.ArtifactTypeCode`.
+- `notebooklm.types.StudioContentType` is absent.
+- `notebooklm.types.RPCMethod` is absent.
+- `AccountLimits` and `AccountTier` remain present on `notebooklm.types` and top-level `notebooklm`, even though they are not in `notebooklm.types.__all__` on this base.
+
+## Frozen Private Helper Seams
+
+First-party imports from `notebooklm.types` remain live aliases for:
+
+`_SOURCE_TYPE_COMPAT_MAP`, `_datetime_from_timestamp`, `_extract_artifact_url`, `_extract_audio_artifact_url`, `_extract_infographic_artifact_url`, `_extract_slide_deck_artifact_url`, `_extract_source_created_at`, `_extract_source_url`, `_extract_video_artifact_url`, `_is_valid_artifact_url`, `_warned_artifact_types`, `_warned_source_types`.
+
+The live state objects `_SOURCE_TYPE_COMPAT_MAP`, `_warned_artifact_types`, and `_warned_source_types` must remain the objects used by parsing and warning de-duplication.
+
+The helper seam manifest is checked against current first-party imports from `src/notebooklm/` and `tests/` so later slices cannot add a private import from `notebooklm.types` without updating the freeze.
+
+## Frozen `__module__` Policy
+
+Default policy for public dataclasses and user-facing enums that move in T13.1-T13.3: preserve `__module__ == "notebooklm.types"`.
+
+Pinned movable classes/enums: `AccountLimits`, `AccountTier`, `Artifact`, `ArtifactType`, `AskResult`, `ChatMode`, `ChatReference`, `CitedSourceSelection`, `ClientMetricsSnapshot`, `ConnectionLimits`, `ConversationTurn`, `GenerationStatus`, `Note`, `Notebook`, `NotebookDescription`, `NotebookMetadata`, `ReportSuggestion`, `RpcTelemetryEvent`, `SharedUser`, `ShareStatus`, `Source`, `SourceFulltext`, `SourceSummary`, `SourceType`, `SuggestedTopic`.
+
+Representative dataclass pickle round trips are pinned for common, notebook, source, artifact, note, chat, and sharing instances.
+
+## Direct `notebooklm.types` Consumers
+
+Current source consumers include `__init__.py`, `_artifact_downloads.py`, `_artifact_formatters.py`, `_artifact_generation.py`, `_artifact_listing.py`, `_artifact_polling.py`, `_artifacts.py`, `_chat.py`, `_chat_protocol.py`, `_core.py`, `_mind_map.py`, `_notebook_metadata.py`, `_notebooks.py`, `_notes.py`, `_research.py`, `_settings.py`, `_sharing.py`, `_source_add.py`, `_source_content.py`, `_source_listing.py`, `_source_polling.py`, `_source_upload.py`, `_sources.py`, `client.py`, and `research.py`.
+
+Docs mentioning public type imports or raw RPC paths: `docs/python-api.md`, `docs/stability.md`, `docs/development.md`, `docs/rpc-development.md`, `docs/rpc-reference.md`, `docs/troubleshooting.md`, and `docs/configuration.md`.
+
+Existing unit/integration consumers are broad; later T13 verification must include at least the targeted type/public-shim/source/sharing/init-order tests from this task plus service-specific unit tests for any modules changed in each slice.
+
+## T13.1-T13.5 Target File Freeze
+
+- T13.1 common skeleton: `src/notebooklm/_types/__init__.py`, `src/notebooklm/_types/common.py`, `src/notebooklm/types.py`, `tests/unit/test_public_shims.py`, `tests/unit/test_types.py`, `tests/unit/test_observability.py`, `tests/unit/test_user_settings_api.py`, `tests/unit/test_exceptions.py`, `tests/integration/concurrency/test_pool_tuning.py`, `tests/integration/concurrency/test_max_concurrent_rpcs.py`, `tests/unit/test_env_base_url.py`.
+- T13.2 source/notebook split: `src/notebooklm/_types/sources.py`, `src/notebooklm/_types/notebooks.py`, `src/notebooklm/types.py`, `src/notebooklm/_sources.py`, `src/notebooklm/_source_listing.py`, `src/notebooklm/_source_polling.py`, `src/notebooklm/_source_add.py`, `src/notebooklm/_source_upload.py`, `src/notebooklm/_source_content.py`, `src/notebooklm/_notebook_metadata.py`, `src/notebooklm/_notebooks.py`, `src/notebooklm/cli/source.py`, `src/notebooklm/cli/notebook.py`, and related source/notebook unit tests.
+- T13.3 artifact/note/chat/sharing split: `src/notebooklm/_types/artifacts.py`, `src/notebooklm/_types/notes.py`, `src/notebooklm/_types/chat.py`, `src/notebooklm/_types/sharing.py`, `src/notebooklm/types.py`, `src/notebooklm/_artifacts.py`, `src/notebooklm/_artifact_listing.py`, `src/notebooklm/_artifact_polling.py`, `src/notebooklm/_artifact_generation.py`, `src/notebooklm/_artifact_downloads.py`, `src/notebooklm/_artifact_formatters.py`, `src/notebooklm/_notes.py`, `src/notebooklm/_chat.py`, `src/notebooklm/_chat_protocol.py`, `src/notebooklm/_sharing.py`, `src/notebooklm/_mind_map.py`, and related unit tests.
+- T13.4 type boundary guardrails: static guardrail tests only after `_types` exists; do not force unlanded boundaries.
+- T13.5 final verification: run the full T13-focused test matrix plus `ruff`, `mypy`, and any upstream-added Phase 10 handoff checks.
+
+## Verification Matrix For This Freeze
+
+```bash
+rtk uv run --extra dev pytest -n auto tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_sharing_types.py tests/unit/test_init_order.py
+rtk uv run --extra dev python - <<'PY'
+import notebooklm
+import notebooklm.exceptions as exc
+import notebooklm.types as t
+import notebooklm.rpc.types as rpc_types
+
+for name in [
+    "SourceError", "SourceAddError", "SourceProcessingError",
+    "SourceTimeoutError", "SourceNotFoundError", "ArtifactError",
+    "ArtifactNotFoundError", "ArtifactNotReadyError", "ArtifactParseError",
+    "ArtifactDownloadError",
+]:
+    assert getattr(t, name) is getattr(exc, name)
+assert t.artifact_status_to_str is rpc_types.artifact_status_to_str
+assert t.source_status_to_str is rpc_types.source_status_to_str
+for name in notebooklm.__all__:
+    getattr(notebooklm, name)
+PY
+rtk uv run --extra dev ruff check src/notebooklm/types.py src/notebooklm/__init__.py tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_sharing_types.py tests/unit/test_init_order.py
+rtk uv run --extra dev mypy src/notebooklm
+```

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import ast
 import importlib
 import logging
 import warnings
+from pathlib import Path
 from types import ModuleType
 from unittest.mock import AsyncMock
 
@@ -217,6 +219,177 @@ _REEXPORTED_RPC_ENUMS = [
     "VideoStyle",
 ]
 
+_FROZEN_TYPES_ALL = [
+    "CitedSourceSelection",
+    "ConnectionLimits",
+    "ClientMetricsSnapshot",
+    "RpcTelemetryEvent",
+    "Notebook",
+    "NotebookDescription",
+    "NotebookMetadata",
+    "SuggestedTopic",
+    "Source",
+    "SourceFulltext",
+    "SourceSummary",
+    "Artifact",
+    "GenerationStatus",
+    "ReportSuggestion",
+    "Note",
+    "ConversationTurn",
+    "ChatReference",
+    "AskResult",
+    "ChatMode",
+    "SharedUser",
+    "ShareStatus",
+    "SourceError",
+    "SourceAddError",
+    "SourceProcessingError",
+    "SourceTimeoutError",
+    "SourceNotFoundError",
+    "ArtifactError",
+    "ArtifactNotFoundError",
+    "ArtifactNotReadyError",
+    "ArtifactParseError",
+    "ArtifactDownloadError",
+    "UnknownTypeWarning",
+    "SourceType",
+    "ArtifactType",
+    "ArtifactStatus",
+    "AudioFormat",
+    "AudioLength",
+    "VideoFormat",
+    "VideoStyle",
+    "QuizQuantity",
+    "QuizDifficulty",
+    "InfographicOrientation",
+    "InfographicDetail",
+    "InfographicStyle",
+    "SlideDeckFormat",
+    "SlideDeckLength",
+    "ReportFormat",
+    "ChatGoal",
+    "ChatResponseLength",
+    "DriveMimeType",
+    "ExportType",
+    "SourceStatus",
+    "ShareAccess",
+    "ShareViewLevel",
+    "SharePermission",
+    "artifact_status_to_str",
+    "source_status_to_str",
+]
+
+_TOP_LEVEL_TYPE_EXPORTS = [
+    "AccountLimits",
+    "AccountTier",
+    "Artifact",
+    "ArtifactType",
+    "AskResult",
+    "AudioFormat",
+    "AudioLength",
+    "ChatGoal",
+    "ChatMode",
+    "ChatReference",
+    "ChatResponseLength",
+    "CitedSourceSelection",
+    "ClientMetricsSnapshot",
+    "ConnectionLimits",
+    "ConversationTurn",
+    "DriveMimeType",
+    "ExportType",
+    "GenerationStatus",
+    "InfographicDetail",
+    "InfographicOrientation",
+    "InfographicStyle",
+    "Note",
+    "Notebook",
+    "NotebookDescription",
+    "NotebookMetadata",
+    "QuizDifficulty",
+    "QuizQuantity",
+    "ReportFormat",
+    "ReportSuggestion",
+    "RpcTelemetryEvent",
+    "ShareAccess",
+    "SharedUser",
+    "SharePermission",
+    "ShareStatus",
+    "ShareViewLevel",
+    "SlideDeckFormat",
+    "SlideDeckLength",
+    "Source",
+    "SourceFulltext",
+    "SourceStatus",
+    "SourceSummary",
+    "SourceType",
+    "SuggestedTopic",
+    "UnknownTypeWarning",
+    "VideoFormat",
+    "VideoStyle",
+]
+
+_TYPES_EXCEPTION_REEXPORTS = [
+    "SourceError",
+    "SourceAddError",
+    "SourceProcessingError",
+    "SourceTimeoutError",
+    "SourceNotFoundError",
+    "ArtifactError",
+    "ArtifactNotFoundError",
+    "ArtifactNotReadyError",
+    "ArtifactParseError",
+    "ArtifactDownloadError",
+]
+
+_TOP_LEVEL_EXCEPTION_EXPORTS = [
+    "ArtifactDownloadError",
+    "ArtifactError",
+    "ArtifactNotFoundError",
+    "ArtifactNotReadyError",
+    "ArtifactParseError",
+    "AuthError",
+    "AuthExtractionError",
+    "ChatError",
+    "ClientError",
+    "ConfigurationError",
+    "DecodingError",
+    "NetworkError",
+    "NonIdempotentRetryError",
+    "NotebookError",
+    "NotebookLimitError",
+    "NotebookLMError",
+    "NotebookNotFoundError",
+    "RateLimitError",
+    "ResearchTaskMismatchError",
+    "RPCError",
+    "RPCTimeoutError",
+    "ServerError",
+    "SourceAddError",
+    "SourceError",
+    "SourceNotFoundError",
+    "SourceProcessingError",
+    "SourceTimeoutError",
+    "UnknownRPCMethodError",
+    "ValidationError",
+]
+
+_TYPES_PRIVATE_HELPER_SEAMS = [
+    "_SOURCE_TYPE_COMPAT_MAP",
+    "_datetime_from_timestamp",
+    "_extract_artifact_url",
+    "_extract_audio_artifact_url",
+    "_extract_infographic_artifact_url",
+    "_extract_slide_deck_artifact_url",
+    "_extract_source_created_at",
+    "_extract_source_url",
+    "_extract_video_artifact_url",
+    "_is_valid_artifact_url",
+    "_warned_artifact_types",
+    "_warned_source_types",
+]
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
 
 @pytest.mark.parametrize("enum_name", _REEXPORTED_RPC_ENUMS)
 def test_rpc_enum_reexports_are_identical(enum_name: str) -> None:
@@ -230,6 +403,162 @@ def test_rpc_enum_reexports_are_identical(enum_name: str) -> None:
         f"notebooklm.types.{enum_name} must be the same object as "
         f"notebooklm.rpc.types.{enum_name} (identity, not equality)"
     )
+
+
+def test_types_all_contract_is_frozen_in_order() -> None:
+    """T13 type moves must preserve the exact public types.__all__ ordering."""
+    import notebooklm.types as public_types
+
+    assert list(public_types.__all__) == _FROZEN_TYPES_ALL
+    for name in _FROZEN_TYPES_ALL:
+        assert hasattr(public_types, name), f"notebooklm.types.__all__ misses {name!r}"
+
+
+@pytest.mark.parametrize("name", _TOP_LEVEL_TYPE_EXPORTS)
+def test_top_level_type_exports_are_identity_reexports(name: str) -> None:
+    """Top-level type exports must remain identical to notebooklm.types objects."""
+    import notebooklm
+    import notebooklm.types as public_types
+
+    assert name in notebooklm.__all__, f"notebooklm.__all__ dropped {name!r}"
+    assert getattr(notebooklm, name) is getattr(public_types, name)
+
+
+@pytest.mark.parametrize("name", _TYPES_EXCEPTION_REEXPORTS)
+def test_types_exception_reexports_are_canonical_identities(name: str) -> None:
+    """notebooklm.types exception compatibility aliases point at exceptions.py."""
+    import notebooklm.exceptions as canonical
+    import notebooklm.types as public_types
+
+    assert getattr(public_types, name) is getattr(canonical, name)
+
+
+@pytest.mark.parametrize("name", _TOP_LEVEL_EXCEPTION_EXPORTS)
+def test_top_level_exception_reexports_are_canonical_identities(name: str) -> None:
+    """Top-level exception exports point directly at exceptions.py canonical classes."""
+    import notebooklm
+    import notebooklm.exceptions as canonical
+
+    assert name in notebooklm.__all__, f"notebooklm.__all__ dropped {name!r}"
+    assert getattr(notebooklm, name) is getattr(canonical, name)
+
+
+def test_rpc_helper_reexports_are_canonical_identities() -> None:
+    """Status helper re-exports must stay identical to rpc.types helpers."""
+    import notebooklm.rpc.types as rpc_types
+    import notebooklm.types as public_types
+
+    assert public_types.artifact_status_to_str is rpc_types.artifact_status_to_str
+    assert public_types.source_status_to_str is rpc_types.source_status_to_str
+
+
+def test_types_non_all_facade_attributes_are_frozen() -> None:
+    """Freeze compatibility attributes that exist outside notebooklm.types.__all__."""
+    import notebooklm.rpc.types as rpc_types
+    import notebooklm.types as public_types
+
+    assert "ArtifactTypeCode" not in public_types.__all__
+    assert public_types.ArtifactTypeCode is rpc_types.ArtifactTypeCode
+    assert "StudioContentType" not in public_types.__all__
+    assert not hasattr(public_types, "StudioContentType")
+    assert "RPCMethod" not in public_types.__all__
+    assert not hasattr(public_types, "RPCMethod")
+
+
+@pytest.mark.parametrize("name", _TYPES_PRIVATE_HELPER_SEAMS)
+def test_types_private_helper_seams_remain_importable(name: str) -> None:
+    """First-party private imports from notebooklm.types stay live during T13 moves."""
+    import notebooklm.types as public_types
+
+    imported = getattr(__import__("notebooklm.types", fromlist=[name]), name)
+    assert imported is getattr(public_types, name)
+    assert name not in public_types.__all__
+
+
+def test_types_private_helper_seam_manifest_matches_first_party_imports() -> None:
+    """The private seam manifest tracks all first-party notebooklm.types imports."""
+    imported_private_names: set[str] = set()
+    for root in [_PROJECT_ROOT / "src" / "notebooklm", _PROJECT_ROOT / "tests"]:
+        for path in root.rglob("*.py"):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                if node.module == "notebooklm.types" or (
+                    node.level > 0
+                    and node.module == "types"
+                    and path.is_relative_to(_PROJECT_ROOT / "src" / "notebooklm")
+                ):
+                    imported_private_names.update(
+                        alias.name
+                        for alias in node.names
+                        if alias.name.startswith("_") and not alias.name.startswith("__")
+                    )
+
+    assert imported_private_names == set(_TYPES_PRIVATE_HELPER_SEAMS)
+
+
+def test_types_private_state_seams_are_live_objects() -> None:
+    """Warning de-duplication and compat maps must remain live facade aliases."""
+    import notebooklm.types as public_types
+    from notebooklm.types import (
+        _SOURCE_TYPE_COMPAT_MAP,
+        Artifact,
+        ArtifactType,
+        Source,
+        SourceType,
+        UnknownTypeWarning,
+        _warned_artifact_types,
+        _warned_source_types,
+    )
+
+    assert _SOURCE_TYPE_COMPAT_MAP is public_types._SOURCE_TYPE_COMPAT_MAP
+    assert _warned_artifact_types is public_types._warned_artifact_types
+    assert _warned_source_types is public_types._warned_source_types
+
+    _warned_source_types.clear()
+    _warned_artifact_types.clear()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UnknownTypeWarning)
+        assert Source(id="source", _type_code=7654321).kind is SourceType.UNKNOWN
+        assert (
+            Artifact(id="artifact", title="Artifact", _artifact_type=7654322, status=3).kind
+            is ArtifactType.UNKNOWN
+        )
+
+    assert 7654321 in _warned_source_types
+    assert (7654322, None) in _warned_artifact_types
+
+
+def test_deprecated_top_level_studio_content_type_import_warns_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """from notebooklm import StudioContentType keeps the deprecated shim contract."""
+    import notebooklm
+    from notebooklm.rpc.types import ArtifactTypeCode
+
+    monkeypatch.delitem(notebooklm.__dict__, "StudioContentType", raising=False)
+    assert "StudioContentType" in notebooklm.__all__
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        namespace: dict[str, object] = {}
+        exec("from notebooklm import StudioContentType", namespace)
+
+    assert namespace["StudioContentType"] is ArtifactTypeCode
+    assert notebooklm.__dict__["StudioContentType"] is ArtifactTypeCode
+    assert [str(warning.message) for warning in caught] == [
+        "StudioContentType is deprecated, use ArtifactType instead. Will be removed in v0.5.0."
+    ]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        namespace = {}
+        exec("from notebooklm import StudioContentType", namespace)
+
+    assert namespace["StudioContentType"] is ArtifactTypeCode
+    assert caught == []
 
 
 def test_rpc_enum_reexport_list_matches_public_all() -> None:

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -390,13 +390,19 @@ _TYPES_PRIVATE_HELPER_SEAMS = [
 ]
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
-_TYPES_PRIVATE_HELPER_IMPORT_FILES = [
-    _PROJECT_ROOT / "src/notebooklm/_artifact_polling.py",
-    _PROJECT_ROOT / "src/notebooklm/_artifacts.py",
-    _PROJECT_ROOT / "src/notebooklm/_source_content.py",
-    _PROJECT_ROOT / "src/notebooklm/_source_listing.py",
-    _PROJECT_ROOT / "tests/unit/test_types.py",
-]
+
+
+def _iter_types_private_helper_import_files() -> list[Path]:
+    """Return first-party Python files that may import private notebooklm.types seams."""
+    roots = (
+        _PROJECT_ROOT / "src" / "notebooklm",
+        _PROJECT_ROOT / "tests" / "unit",
+    )
+    paths: list[Path] = []
+    for root in roots:
+        assert root.exists(), f"tracked private seam scan root disappeared: {root}"
+        paths.extend(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+    return sorted(paths)
 
 
 @pytest.mark.parametrize("enum_name", _REEXPORTED_RPC_ENUMS)
@@ -497,8 +503,7 @@ def test_types_private_helper_seam_manifest_matches_first_party_imports() -> Non
         return []
 
     imported_private_names: set[str] = set()
-    for path in _TYPES_PRIVATE_HELPER_IMPORT_FILES:
-        assert path.exists(), f"tracked private seam importer disappeared: {path}"
+    for path in _iter_types_private_helper_import_files():
         tree = ast.parse(path.read_text(encoding="utf-8"))
         type_module_aliases: set[str] = set()
         for node in ast.walk(tree):
@@ -533,7 +538,11 @@ def test_types_private_helper_seam_manifest_matches_first_party_imports() -> Non
                     alias.asname or alias.name for alias in node.names if alias.name == "types"
                 )
                 continue
-            if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr.startswith("_")
+                and not node.attr.startswith("__")
+            ):
                 qualifier = attribute_path(node.value)
                 if qualifier == ["notebooklm", "types"] or (
                     len(qualifier) == 1 and qualifier[0] in type_module_aliases

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -485,23 +485,59 @@ def test_types_private_helper_seams_remain_importable(name: str) -> None:
 
 def test_types_private_helper_seam_manifest_matches_first_party_imports() -> None:
     """The private seam manifest tracks known first-party notebooklm.types imports."""
+    def attribute_path(node: ast.AST) -> list[str]:
+        parts: list[str] = []
+        while isinstance(node, ast.Attribute):
+            parts.append(node.attr)
+            node = node.value
+        if isinstance(node, ast.Name):
+            parts.append(node.id)
+            return list(reversed(parts))
+        return []
+
     imported_private_names: set[str] = set()
     for path in _TYPES_PRIVATE_HELPER_IMPORT_FILES:
         assert path.exists(), f"tracked private seam importer disappeared: {path}"
         tree = ast.parse(path.read_text(encoding="utf-8"))
+        type_module_aliases: set[str] = set()
         for node in ast.walk(tree):
-            if not isinstance(node, ast.ImportFrom):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "notebooklm.types" and alias.asname:
+                        type_module_aliases.add(alias.asname)
                 continue
-            if node.module == "notebooklm.types" or (
-                node.level > 0
-                and node.module == "types"
-                and path.is_relative_to(_PROJECT_ROOT / "src" / "notebooklm")
+            if isinstance(node, ast.ImportFrom) and (
+                node.module == "notebooklm.types"
+                or (
+                    node.level > 0
+                    and node.module == "types"
+                    and path.is_relative_to(_PROJECT_ROOT / "src" / "notebooklm")
+                )
             ):
                 imported_private_names.update(
                     alias.name
                     for alias in node.names
                     if alias.name.startswith("_") and not alias.name.startswith("__")
                 )
+                continue
+            if isinstance(node, ast.ImportFrom) and (
+                (node.module == "notebooklm" and any(alias.name == "types" for alias in node.names))
+                or (
+                    node.level > 0
+                    and node.module is None
+                    and path.is_relative_to(_PROJECT_ROOT / "src" / "notebooklm")
+                )
+            ):
+                type_module_aliases.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "types"
+                )
+                continue
+            if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
+                qualifier = attribute_path(node.value)
+                if qualifier == ["notebooklm", "types"] or (
+                    len(qualifier) == 1 and qualifier[0] in type_module_aliases
+                ):
+                    imported_private_names.add(node.attr)
 
     assert imported_private_names == set(_TYPES_PRIVATE_HELPER_SEAMS)
 

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -485,6 +485,7 @@ def test_types_private_helper_seams_remain_importable(name: str) -> None:
 
 def test_types_private_helper_seam_manifest_matches_first_party_imports() -> None:
     """The private seam manifest tracks known first-party notebooklm.types imports."""
+
     def attribute_path(node: ast.AST) -> list[str]:
         parts: list[str] = []
         while isinstance(node, ast.Attribute):

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import enum
 import importlib
 import logging
 import warnings
@@ -389,6 +390,13 @@ _TYPES_PRIVATE_HELPER_SEAMS = [
 ]
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_TYPES_PRIVATE_HELPER_IMPORT_FILES = [
+    _PROJECT_ROOT / "src/notebooklm/_artifact_polling.py",
+    _PROJECT_ROOT / "src/notebooklm/_artifacts.py",
+    _PROJECT_ROOT / "src/notebooklm/_source_content.py",
+    _PROJECT_ROOT / "src/notebooklm/_source_listing.py",
+    _PROJECT_ROOT / "tests/unit/test_types.py",
+]
 
 
 @pytest.mark.parametrize("enum_name", _REEXPORTED_RPC_ENUMS)
@@ -476,29 +484,29 @@ def test_types_private_helper_seams_remain_importable(name: str) -> None:
 
 
 def test_types_private_helper_seam_manifest_matches_first_party_imports() -> None:
-    """The private seam manifest tracks all first-party notebooklm.types imports."""
+    """The private seam manifest tracks known first-party notebooklm.types imports."""
     imported_private_names: set[str] = set()
-    for root in [_PROJECT_ROOT / "src" / "notebooklm", _PROJECT_ROOT / "tests"]:
-        for path in root.rglob("*.py"):
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.ImportFrom):
-                    continue
-                if node.module == "notebooklm.types" or (
-                    node.level > 0
-                    and node.module == "types"
-                    and path.is_relative_to(_PROJECT_ROOT / "src" / "notebooklm")
-                ):
-                    imported_private_names.update(
-                        alias.name
-                        for alias in node.names
-                        if alias.name.startswith("_") and not alias.name.startswith("__")
-                    )
+    for path in _TYPES_PRIVATE_HELPER_IMPORT_FILES:
+        assert path.exists(), f"tracked private seam importer disappeared: {path}"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module == "notebooklm.types" or (
+                node.level > 0
+                and node.module == "types"
+                and path.is_relative_to(_PROJECT_ROOT / "src" / "notebooklm")
+            ):
+                imported_private_names.update(
+                    alias.name
+                    for alias in node.names
+                    if alias.name.startswith("_") and not alias.name.startswith("__")
+                )
 
     assert imported_private_names == set(_TYPES_PRIVATE_HELPER_SEAMS)
 
 
-def test_types_private_state_seams_are_live_objects() -> None:
+def test_types_private_state_seams_are_live_objects(monkeypatch: pytest.MonkeyPatch) -> None:
     """Warning de-duplication and compat maps must remain live facade aliases."""
     import notebooklm.types as public_types
     from notebooklm.types import (
@@ -508,16 +516,13 @@ def test_types_private_state_seams_are_live_objects() -> None:
         Source,
         SourceType,
         UnknownTypeWarning,
-        _warned_artifact_types,
-        _warned_source_types,
     )
 
     assert _SOURCE_TYPE_COMPAT_MAP is public_types._SOURCE_TYPE_COMPAT_MAP
-    assert _warned_artifact_types is public_types._warned_artifact_types
-    assert _warned_source_types is public_types._warned_source_types
-
-    _warned_source_types.clear()
-    _warned_artifact_types.clear()
+    source_warnings: set[int] = set()
+    artifact_warnings: set[tuple[int | None, int | None]] = set()
+    monkeypatch.setattr(public_types, "_warned_source_types", source_warnings)
+    monkeypatch.setattr(public_types, "_warned_artifact_types", artifact_warnings)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UnknownTypeWarning)
@@ -527,8 +532,8 @@ def test_types_private_state_seams_are_live_objects() -> None:
             is ArtifactType.UNKNOWN
         )
 
-    assert 7654321 in _warned_source_types
-    assert (7654322, None) in _warned_artifact_types
+    assert 7654321 in source_warnings
+    assert (7654322, None) in artifact_warnings
 
 
 def test_deprecated_top_level_studio_content_type_import_warns_and_caches(
@@ -570,13 +575,14 @@ def test_rpc_enum_reexport_list_matches_public_all() -> None:
     import notebooklm.rpc.types as rpc_types
     import notebooklm.types as public_types
 
-    # Names that appear in both __all__ and rpc.types — i.e. the actual
-    # re-exported RPC enums.
     declared = set(public_types.__all__)
     rpc_names = {name for name in dir(rpc_types) if not name.startswith("_")}
-    expected = declared & rpc_names
-    # Drop helper functions (not enums) from the comparison.
-    expected -= {"artifact_status_to_str", "source_status_to_str"}
+    expected = {
+        name
+        for name in declared & rpc_names
+        if isinstance(getattr(rpc_types, name), type)
+        and issubclass(getattr(rpc_types, name), enum.Enum)
+    }
 
     listed = set(_REEXPORTED_RPC_ENUMS)
     missing = expected - listed
@@ -787,7 +793,11 @@ def test_auth_secondary_binding_reset_syncs_to_cookie_policy(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Resetting notebooklm.auth._SECONDARY_BINDING_WARNED still controls validation."""
+    """Resetting the facade warning flag controls validation.
+
+    The private module starts in the opposite state to prove the delegated
+    implementation still reads the compatibility facade's warning flag.
+    """
     import notebooklm.auth as auth
     from notebooklm._auth import cookie_policy
 
@@ -821,7 +831,7 @@ def test_auth_validation_preserves_private_warning_state(
 def test_auth_validation_uses_facade_policy_rebindings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Validation keeps auth.py monkeypatch compatibility after delegation."""
+    """Validation accepts a single cookie only when the facade policy is rebound."""
     import notebooklm.auth as auth
 
     monkeypatch.setattr(auth, "MINIMUM_REQUIRED_COOKIES", {"SID"})

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -199,6 +199,7 @@ def test_representative_public_dataclasses_pickle_round_trip():
             _type_code=2,
             status=SourceStatus.READY.value,
         ),
+        source_summary,
         SourceFulltext(
             source_id="src_1",
             title="Source",

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1,5 +1,6 @@
 """Unit tests for types module dataclasses and parsing."""
 
+import pickle
 import warnings
 from unittest.mock import patch
 
@@ -72,6 +73,147 @@ class TestTimestampParsing:
         from notebooklm.types import _datetime_from_timestamp
 
         assert _datetime_from_timestamp(value) is None
+
+
+_PUBLIC_MOVABLE_CLASSES = [
+    "AccountLimits",
+    "AccountTier",
+    "Artifact",
+    "ArtifactType",
+    "AskResult",
+    "ChatMode",
+    "ChatReference",
+    "CitedSourceSelection",
+    "ClientMetricsSnapshot",
+    "ConnectionLimits",
+    "ConversationTurn",
+    "GenerationStatus",
+    "Note",
+    "Notebook",
+    "NotebookDescription",
+    "NotebookMetadata",
+    "ReportSuggestion",
+    "RpcTelemetryEvent",
+    "SharedUser",
+    "ShareStatus",
+    "Source",
+    "SourceFulltext",
+    "SourceSummary",
+    "SourceType",
+    "SuggestedTopic",
+]
+
+
+@pytest.mark.parametrize("name", _PUBLIC_MOVABLE_CLASSES)
+def test_public_movable_types_keep_notebooklm_types_module(name):
+    """Moved public dataclasses/enums must preserve inspection and pickle identity."""
+    import notebooklm.types as public_types
+
+    assert getattr(public_types, name).__module__ == "notebooklm.types"
+
+
+def test_representative_public_dataclasses_pickle_round_trip():
+    """Representative public dataclasses/enums keep pickle compatibility through T13 moves."""
+    from notebooklm.rpc.types import ArtifactStatus, ArtifactTypeCode
+    from notebooklm.types import (
+        AccountLimits,
+        AccountTier,
+        Artifact,
+        AskResult,
+        ChatReference,
+        CitedSourceSelection,
+        ClientMetricsSnapshot,
+        ConnectionLimits,
+        ConversationTurn,
+        GenerationStatus,
+        Note,
+        Notebook,
+        NotebookDescription,
+        NotebookMetadata,
+        ReportSuggestion,
+        RpcTelemetryEvent,
+        ShareAccess,
+        SharedUser,
+        SharePermission,
+        ShareStatus,
+        ShareViewLevel,
+        Source,
+        SourceFulltext,
+        SourceStatus,
+        SourceSummary,
+        SourceType,
+        SuggestedTopic,
+    )
+
+    source_summary = SourceSummary(kind=SourceType.PDF, title="doc.pdf")
+    notebook = Notebook(id="nb_1", title="Notebook")
+    chat_reference = ChatReference(source_id="src_1", citation_number=1, cited_text="quoted")
+    shared_user = SharedUser(email="reader@example.com", permission=SharePermission.VIEWER)
+    instances = [
+        AccountLimits(notebook_limit=10, source_limit=50, raw_limits=("raw",)),
+        AccountTier(tier="plus", plan_name="Plus"),
+        Artifact(
+            id="artifact_1",
+            title="Audio",
+            _artifact_type=ArtifactTypeCode.AUDIO.value,
+            status=ArtifactStatus.COMPLETED,
+            url="https://example.com/audio.mp3",
+        ),
+        AskResult(
+            answer="Answer",
+            conversation_id="conversation_1",
+            turn_number=1,
+            is_follow_up=False,
+            references=[chat_reference],
+            raw_response="raw",
+        ),
+        CitedSourceSelection(
+            sources=[{"url": "https://example.com"}],
+            cited_url_count=1,
+            matched_url_source_count=1,
+        ),
+        ClientMetricsSnapshot(rpc_calls_started=2, rpc_calls_succeeded=1),
+        ConnectionLimits(max_connections=10, max_keepalive_connections=5),
+        ConversationTurn(query="Question", answer="Answer", turn_number=1),
+        GenerationStatus(task_id="task_1", status="completed", url="https://example.com/file"),
+        Note(id="note_1", notebook_id="nb_1", title="Note", content="Body"),
+        NotebookDescription(
+            summary="Summary",
+            suggested_topics=[SuggestedTopic(question="Q?", prompt="Ask Q")],
+        ),
+        NotebookMetadata(notebook=notebook, sources=[source_summary]),
+        ReportSuggestion(title="Briefing", description="Desc", prompt="Prompt"),
+        RpcTelemetryEvent(method="GET_NOTEBOOK", status="success", elapsed_seconds=0.01),
+        ShareStatus(
+            notebook_id="nb_1",
+            is_public=True,
+            access=ShareAccess.ANYONE_WITH_LINK,
+            view_level=ShareViewLevel.FULL_NOTEBOOK,
+            shared_users=[shared_user],
+            share_url="https://notebooklm.google.com/notebook/nb_1",
+        ),
+        Source(
+            id="src_1",
+            title="Source",
+            url="https://example.com",
+            _type_code=2,
+            status=SourceStatus.READY.value,
+        ),
+        SourceFulltext(
+            source_id="src_1",
+            title="Source",
+            content="Full indexed text",
+            _type_code=2,
+            url="https://example.com",
+            char_count=17,
+        ),
+    ]
+
+    for instance in instances:
+        assert pickle.loads(pickle.dumps(instance)) == instance
+
+    for enum_member in [SourceType.PDF, ArtifactType.AUDIO, ChatMode.DEFAULT]:
+        assert pickle.loads(pickle.dumps(enum_member)) is enum_member
 
 
 class TestNotebook:


### PR DESCRIPTION
## Summary
- Adds T13.0 characterization tests for the public type facade with no runtime behavior changes.
- Freezes `notebooklm.types.__all__`, top-level type/export identity, exception identities, RPC enum/helper identities, private helper seams, non-`__all__` attributes, deprecated `StudioContentType`, pickle round trips, and `__module__` policy.
- Adds `.sisyphus/phases/architecture-remediation/runs/phase-11-t13-type-contract-freeze.md` with the inventory, target-file freeze, test matrix, and blocker notes.

## Status / Dependencies
This PR is now rebased onto `origin/main` at `c5d1ce3` after #746 merged. #745 / T12.8 and #746 are no longer blockers.

#750 is a documentation-only handoff PR on `main`; this T13.0 slice does not edit the same handoff file and should not wait on it. Re-check #750 only if a later T13/T14 slice edits the same handoff file or depends on the final docs contract.

Do not merge until CI and requested bot reviews are terminal. This remains Phase 11 T13.0 implementation-prep/contract-freeze work only.

## Contract Manifest
`notebooklm.types.__all__` is frozen in order as:
`CitedSourceSelection`, `ConnectionLimits`, `ClientMetricsSnapshot`, `RpcTelemetryEvent`, `Notebook`, `NotebookDescription`, `NotebookMetadata`, `SuggestedTopic`, `Source`, `SourceFulltext`, `SourceSummary`, `Artifact`, `GenerationStatus`, `ReportSuggestion`, `Note`, `ConversationTurn`, `ChatReference`, `AskResult`, `ChatMode`, `SharedUser`, `ShareStatus`, `SourceError`, `SourceAddError`, `SourceProcessingError`, `SourceTimeoutError`, `SourceNotFoundError`, `ArtifactError`, `ArtifactNotFoundError`, `ArtifactNotReadyError`, `ArtifactParseError`, `ArtifactDownloadError`, `UnknownTypeWarning`, `SourceType`, `ArtifactType`, `ArtifactStatus`, `AudioFormat`, `AudioLength`, `VideoFormat`, `VideoStyle`, `QuizQuantity`, `QuizDifficulty`, `InfographicOrientation`, `InfographicDetail`, `InfographicStyle`, `SlideDeckFormat`, `SlideDeckLength`, `ReportFormat`, `ChatGoal`, `ChatResponseLength`, `DriveMimeType`, `ExportType`, `SourceStatus`, `ShareAccess`, `ShareViewLevel`, `SharePermission`, `artifact_status_to_str`, `source_status_to_str`.

Top-level type exports frozen as identity re-exports from `notebooklm.types`:
`AccountLimits`, `AccountTier`, `Artifact`, `ArtifactType`, `AskResult`, `AudioFormat`, `AudioLength`, `ChatGoal`, `ChatMode`, `ChatReference`, `ChatResponseLength`, `CitedSourceSelection`, `ClientMetricsSnapshot`, `ConnectionLimits`, `ConversationTurn`, `DriveMimeType`, `ExportType`, `GenerationStatus`, `InfographicDetail`, `InfographicOrientation`, `InfographicStyle`, `Note`, `Notebook`, `NotebookDescription`, `NotebookMetadata`, `QuizDifficulty`, `QuizQuantity`, `ReportFormat`, `ReportSuggestion`, `RpcTelemetryEvent`, `ShareAccess`, `SharedUser`, `SharePermission`, `ShareStatus`, `ShareViewLevel`, `SlideDeckFormat`, `SlideDeckLength`, `Source`, `SourceFulltext`, `SourceStatus`, `SourceSummary`, `SourceType`, `SuggestedTopic`, `UnknownTypeWarning`, `VideoFormat`, `VideoStyle`.

Exception identities frozen:
- `notebooklm.types`: `SourceError`, `SourceAddError`, `SourceProcessingError`, `SourceTimeoutError`, `SourceNotFoundError`, `ArtifactError`, `ArtifactNotFoundError`, `ArtifactNotReadyError`, `ArtifactParseError`, `ArtifactDownloadError` resolve to `notebooklm.exceptions`.
- top-level `notebooklm`: all exception exports in `notebooklm.__all__` resolve to `notebooklm.exceptions`.

RPC identities frozen: re-exported RPC enums resolve to `notebooklm.rpc.types`; `artifact_status_to_str` and `source_status_to_str` are canonical helper identities. `RPCMethod` remains absent from `notebooklm.types`.

Non-`__all__` facade attributes frozen: `notebooklm.types.ArtifactTypeCode` is present and canonical; `notebooklm.types.StudioContentType` is absent; `AccountLimits` / `AccountTier` remain top-level and `notebooklm.types` attributes despite not being in `notebooklm.types.__all__`.

Private helper seams frozen and checked against current first-party imports:
`_SOURCE_TYPE_COMPAT_MAP`, `_datetime_from_timestamp`, `_extract_artifact_url`, `_extract_audio_artifact_url`, `_extract_infographic_artifact_url`, `_extract_slide_deck_artifact_url`, `_extract_source_created_at`, `_extract_source_url`, `_extract_video_artifact_url`, `_is_valid_artifact_url`, `_warned_artifact_types`, `_warned_source_types`.

`__module__` policy: public dataclasses and user-facing enums that move in later T13 slices must preserve `__module__ == "notebooklm.types"`. Representative dataclass and enum pickle round trips are pinned.

## Test Plan
- [x] `rtk uv run --extra dev pytest -n auto tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_sharing_types.py tests/unit/test_init_order.py`
- [x] `rtk uv run --extra dev python - <<PY ... identity smoke ... PY`
- [x] `rtk uv run --extra dev ruff check src/notebooklm/types.py src/notebooklm/__init__.py tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_sharing_types.py tests/unit/test_init_order.py`
- [x] `rtk uv run --extra dev mypy src/notebooklm`

## Notes
- `.sisyphus/phases/architecture-remediation/state.json` is absent on the current checkout, so the formal phase-state refresh commands cannot complete. The missing state file is recorded in the run artifact.
- No edits to `docs/stability.md`, `docs/python-api.md`, runtime source files, or `_types/*`.
- Deferred polish findings: exact `__all__` ordering is intentionally frozen; any future docs-handoff dependency should be reassessed only if this work begins touching #750-owned files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Phase 11 contract-freeze runbook documenting the frozen public API surface, explicit export rules, private-helper seam requirements, and a verification matrix for validating compatibility.

* **Tests**
  * Hardened tests to enforce the frozen public export list, identity-preservation of re-exports, enum/function aliasing, and pickle compatibility for movable types.
  * Added checks for deprecated-shim warning behavior and seam/import sanity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->