### PR TITLE
refactor(types): extract common type primitives

### DIFF
--- a/src/notebooklm/_types/__init__.py
+++ b/src/notebooklm/_types/__init__.py
@@ -1,0 +1,1 @@
+"""Private type implementation package."""

--- a/src/notebooklm/_types/common.py
+++ b/src/notebooklm/_types/common.py
@@ -1,0 +1,125 @@
+"""Common private implementations for public NotebookLM types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    import httpx
+
+
+class UnknownTypeWarning(UserWarning):
+    """Emitted when encountering unrecognized type codes from Google API.
+
+    This warning indicates the API returned a type code that this version
+    of notebooklm-py doesn't recognize. Consider updating to the latest version.
+    """
+
+
+@dataclass(frozen=True)
+class ConnectionLimits:
+    """HTTP connection-pool tuning for the underlying httpx transport.
+
+    Wraps the subset of ``httpx.Limits`` we expose so the public API
+    doesn't leak the httpx type directly (and stays stable across httpx
+    minor versions). Defaults are sized for the typical batchexecute
+    fan-out: a few dozen concurrent RPCs against a single host with
+    keep-alives held for the duration of an interactive session.
+
+    Constraint: ``max_concurrent_rpcs`` must satisfy
+    ``max_concurrent_rpcs <= max_connections`` - otherwise the
+    semaphore lets requests through that the pool can't fulfill.
+    The constructor for ``NotebookLMClient`` enforces this when both
+    are set.
+    """
+
+    max_connections: int = 100
+    """Hard cap on total concurrent connections in the pool."""
+
+    max_keepalive_connections: int = 50
+    """Cap on idle connections held open between requests."""
+
+    keepalive_expiry: float = 30.0
+    """Seconds an idle connection stays in the pool before being closed."""
+
+    def to_httpx_limits(self) -> httpx.Limits:
+        """Map to ``httpx.Limits`` (lazy import to keep common types dep-light)."""
+        import httpx
+
+        return httpx.Limits(
+            max_connections=self.max_connections,
+            max_keepalive_connections=self.max_keepalive_connections,
+            keepalive_expiry=self.keepalive_expiry,
+        )
+
+
+@dataclass(frozen=True)
+class RpcTelemetryEvent:
+    """One logical RPC completion event emitted by ``NotebookLMClient``.
+
+    The event is intentionally backend-agnostic: applications can forward it
+    to Prometheus, OpenTelemetry, logs, or a custom counter without this
+    package taking a dependency on any metrics framework.
+    """
+
+    method: str
+    status: Literal["success", "error"]
+    elapsed_seconds: float
+    request_id: str | None = None
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class ClientMetricsSnapshot:
+    """Cumulative in-process observability counters for a client instance."""
+
+    rpc_calls_started: int = 0
+    rpc_calls_succeeded: int = 0
+    rpc_calls_failed: int = 0
+    rpc_rate_limit_retries: int = 0
+    rpc_server_error_retries: int = 0
+    rpc_auth_retries: int = 0
+    rpc_latency_seconds_total: float = 0.0
+    rpc_queue_wait_seconds_total: float = 0.0
+    rpc_queue_wait_seconds_max: float = 0.0
+    upload_queue_wait_seconds_total: float = 0.0
+    upload_queue_wait_seconds_max: float = 0.0
+    lock_wait_seconds_total: float = 0.0
+    lock_wait_seconds_max: float = 0.0
+
+
+@dataclass(frozen=True)
+class AccountLimits:
+    """Account-level limits returned by NotebookLM user settings."""
+
+    notebook_limit: int | None = None
+    source_limit: int | None = None
+    raw_limits: tuple[Any, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class AccountTier:
+    """Raw NotebookLM tier metadata returned by the homepage tier RPC."""
+
+    tier: str | None = None
+    plan_name: str | None = None
+
+
+@dataclass(frozen=True)
+class CitedSourceSelection:
+    """Result of applying cited-only filtering to research sources."""
+
+    sources: list[dict[str, Any]]
+    cited_url_count: int
+    matched_url_source_count: int
+    used_fallback: bool = False
+
+
+def _datetime_from_timestamp(value: Any, *, datetime_type: type[datetime] = datetime) -> datetime | None:
+    """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
+    try:
+        return datetime_type.fromtimestamp(value)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -13,13 +13,22 @@ import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import Any, Optional
 from urllib.parse import quote
 
-if TYPE_CHECKING:
-    import httpx
-
 from ._env import get_base_url
+from ._types.common import (
+    AccountLimits,
+    AccountTier,
+    CitedSourceSelection,
+    ClientMetricsSnapshot,
+    ConnectionLimits,
+    RpcTelemetryEvent,
+    UnknownTypeWarning,
+)
+from ._types.common import (
+    _datetime_from_timestamp as _common_datetime_from_timestamp,
+)
 
 # Import exceptions from centralized module (re-export for backward compatibility)
 from .exceptions import (
@@ -66,115 +75,6 @@ from .rpc.types import (
 # =============================================================================
 # User-facing Type Enums (str enums for .kind property)
 # =============================================================================
-
-
-class UnknownTypeWarning(UserWarning):
-    """Emitted when encountering unrecognized type codes from Google API.
-
-    This warning indicates the API returned a type code that this version
-    of notebooklm-py doesn't recognize. Consider updating to the latest version.
-    """
-
-    pass
-
-
-@dataclass(frozen=True)
-class ConnectionLimits:
-    """HTTP connection-pool tuning for the underlying httpx transport.
-
-    Wraps the subset of ``httpx.Limits`` we expose so the public API
-    doesn't leak the httpx type directly (and stays stable across httpx
-    minor versions). Defaults are sized for the typical batchexecute
-    fan-out: a few dozen concurrent RPCs against a single host with
-    keep-alives held for the duration of an interactive session.
-
-    Constraint: ``max_concurrent_rpcs`` must satisfy
-    ``max_concurrent_rpcs <= max_connections`` — otherwise the
-    semaphore lets requests through that the pool can't fulfill.
-    The constructor for ``NotebookLMClient`` enforces this when both
-    are set.
-    """
-
-    max_connections: int = 100
-    """Hard cap on total concurrent connections in the pool."""
-
-    max_keepalive_connections: int = 50
-    """Cap on idle connections held open between requests."""
-
-    keepalive_expiry: float = 30.0
-    """Seconds an idle connection stays in the pool before being closed."""
-
-    def to_httpx_limits(self) -> "httpx.Limits":
-        """Map to ``httpx.Limits`` (lazy import to keep types.py dep-light)."""
-        import httpx
-
-        return httpx.Limits(
-            max_connections=self.max_connections,
-            max_keepalive_connections=self.max_keepalive_connections,
-            keepalive_expiry=self.keepalive_expiry,
-        )
-
-
-@dataclass(frozen=True)
-class RpcTelemetryEvent:
-    """One logical RPC completion event emitted by ``NotebookLMClient``.
-
-    The event is intentionally backend-agnostic: applications can forward it
-    to Prometheus, OpenTelemetry, logs, or a custom counter without this
-    package taking a dependency on any metrics framework.
-    """
-
-    method: str
-    status: Literal["success", "error"]
-    elapsed_seconds: float
-    request_id: str | None = None
-    error_type: str | None = None
-
-
-@dataclass(frozen=True)
-class ClientMetricsSnapshot:
-    """Cumulative in-process observability counters for a client instance."""
-
-    rpc_calls_started: int = 0
-    rpc_calls_succeeded: int = 0
-    rpc_calls_failed: int = 0
-    rpc_rate_limit_retries: int = 0
-    rpc_server_error_retries: int = 0
-    rpc_auth_retries: int = 0
-    rpc_latency_seconds_total: float = 0.0
-    rpc_queue_wait_seconds_total: float = 0.0
-    rpc_queue_wait_seconds_max: float = 0.0
-    upload_queue_wait_seconds_total: float = 0.0
-    upload_queue_wait_seconds_max: float = 0.0
-    lock_wait_seconds_total: float = 0.0
-    lock_wait_seconds_max: float = 0.0
-
-
-@dataclass(frozen=True)
-class AccountLimits:
-    """Account-level limits returned by NotebookLM user settings."""
-
-    notebook_limit: int | None = None
-    source_limit: int | None = None
-    raw_limits: tuple[Any, ...] = field(default_factory=tuple)
-
-
-@dataclass(frozen=True)
-class AccountTier:
-    """Raw NotebookLM tier metadata returned by the homepage tier RPC."""
-
-    tier: str | None = None
-    plan_name: str | None = None
-
-
-@dataclass(frozen=True)
-class CitedSourceSelection:
-    """Result of applying cited-only filtering to research sources."""
-
-    sources: list[dict[str, Any]]
-    cited_url_count: int
-    matched_url_source_count: int
-    used_fallback: bool = False
 
 
 class SourceType(str, Enum):
@@ -385,10 +285,7 @@ def _extract_source_url(metadata: Any, *, allow_bare_http: bool = True) -> str |
 
 def _datetime_from_timestamp(value: Any) -> datetime | None:
     """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
-    try:
-        return datetime.fromtimestamp(value)
-    except (TypeError, ValueError, OSError, OverflowError):
-        return None
+    return _common_datetime_from_timestamp(value, datetime_type=datetime)
 
 
 def _extract_source_created_at(metadata: Any) -> datetime | None:
@@ -561,6 +458,19 @@ __all__ = [
     "artifact_status_to_str",
     "source_status_to_str",
 ]
+
+
+for _public_common_type in (
+    AccountLimits,
+    AccountTier,
+    CitedSourceSelection,
+    ClientMetricsSnapshot,
+    ConnectionLimits,
+    RpcTelemetryEvent,
+    UnknownTypeWarning,
+):
+    _public_common_type.__module__ = __name__
+del _public_common_type
 
 
 # =============================================================================

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -582,6 +582,36 @@ def test_types_private_state_seams_are_live_objects(monkeypatch: pytest.MonkeyPa
     assert (7654322, None) in artifact_warnings
 
 
+def test_facade_unknown_type_warning_filter_suppresses_parser_warnings() -> None:
+    """Filters using notebooklm.types.UnknownTypeWarning still catch parser warnings."""
+    import notebooklm.types as public_types
+
+    public_types._warned_source_types.clear()
+    public_types._warned_artifact_types.clear()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.filterwarnings("ignore", category=public_types.UnknownTypeWarning)
+
+        assert (
+            public_types.Source(id="source", _type_code=8765432).kind
+            is public_types.SourceType.UNKNOWN
+        )
+        assert (
+            public_types.Artifact(
+                id="artifact",
+                title="Artifact",
+                _artifact_type=8765433,
+                status=3,
+            ).kind
+            is public_types.ArtifactType.UNKNOWN
+        )
+
+    assert caught == []
+    assert 8765432 in public_types._warned_source_types
+    assert (8765433, None) in public_types._warned_artifact_types
+
+
 def test_deprecated_top_level_studio_content_type_import_warns_and_caches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Stack / Blocker

Stacked behind #752 (`architecture-remediation/t13-0-promotion-audit-contract-freeze`). This PR is blocked and must not merge until #752 merges.

## Files Changed

- `src/notebooklm/_types/__init__.py`
- `src/notebooklm/_types/common.py`
- `src/notebooklm/types.py`
- `tests/unit/test_public_shims.py`

## Contract Preservation

- Added marker-only private `_types` package with common type implementations in `_types/common.py`.
- Kept `notebooklm.types` as the public facade for moved common names.
- Preserved `notebooklm.types.datetime` monkeypatch behavior through the facade `_datetime_from_timestamp(...)` wrapper.
- Preserved moved public class inspection/pickle identity with `__module__ == "notebooklm.types"`.
- Preserved top-level `notebooklm` identity re-exports and warning filter behavior for `notebooklm.types.UnknownTypeWarning`.
- Left source/artifact/notebook/chat/sharing domain types in `types.py`; no T13.2/T13.3 moves included.

## Verification

- `rtk uv run --extra dev pytest -n auto tests/unit/test_types.py::TestTimestampParsing tests/unit/test_public_shims.py tests/unit/test_observability.py tests/unit/test_user_settings_api.py tests/unit/test_exceptions.py tests/integration/concurrency/test_pool_tuning.py tests/integration/concurrency/test_max_concurrent_rpcs.py tests/unit/test_env_base_url.py` - passed, 346 passed
- `rtk uv run --extra dev ruff check src/notebooklm/types.py src/notebooklm/_types tests/unit/test_public_shims.py tests/unit/test_types.py` - passed
- `rtk uv run --extra dev mypy src/notebooklm` - passed
