### PR TITLE
docs(api): sync CLAUDE.md pre-commit + add __all__ to client/auth + document NOTEBOOKLM_REFRESH_CMD (C3, I18, I19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,20 +31,14 @@ uv run pytest tests/e2e -m e2e
 uv run notebooklm --help
 ```
 
-## Pre-Commit Checks (REQUIRED before committing)
+## Pre-Commit Checks
 
-**IMPORTANT:** Always run these checks before committing to avoid CI failures:
+The pre-commit hook (`.pre-commit-config.yaml`) runs ruff formatting + linting automatically on staged files.
 
+Before pushing, also run mypy + pytest manually to avoid CI failures:
 ```bash
-uv run ruff format .
-uv run ruff check .
 uv run mypy src/notebooklm --ignore-missing-imports
 uv run pytest
-```
-
-Or use this one-liner:
-```bash
-uv run ruff format . && uv run ruff check . && uv run mypy src/notebooklm --ignore-missing-imports && uv run pytest
 ```
 
 ## Architecture

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,7 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_DEBUG` | Show untruncated RPC response bodies in error messages instead of the default 80-char preview (verbose; intended for deep debugging) | `0` |
 | `NOTEBOOKLM_STRICT_DECODE` | Raise `UnknownRPCMethodError` on schema drift instead of warn-and-fallback | `0` |
 | `NOTEBOOKLM_RPC_OVERRIDES` | JSON object mapping `RPCMethod` enum names to RPC ID strings (community self-patch when Google rotates a method ID; e.g. `{"LIST_NOTEBOOKS":"AbC123"}`) | - |
+| `NOTEBOOKLM_REFRESH_CMD` | Optional shell command (or argv) invoked when auth refresh is required, replacing the default browser-cookie path. Must emit a new `AuthTokens` JSON on stdout | - |
 | `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True` execution. Default `shell=False` (argv list) — set to `1`/`true` only when the refresh command requires shell metacharacters | `0` |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | Disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry | `0` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress stderr deprecation notices for deprecated CLI flags | - |
@@ -151,6 +152,7 @@ be audited from one location.
 | `NOTEBOOKLM_BASE_URL` | NotebookLM base URL. Constrained to `https://notebooklm.google.com` (personal) or `https://notebooklm.cloud.google.com` (enterprise); other schemes/hosts/paths raise `ValueError`. | Process env on every base-URL lookup. | `_env.get_base_url` |
 | `NOTEBOOKLM_BL` | `bl` (build label) URL parameter sent on the chat streaming endpoint (`ChatAPI.ask`). Pins the frontend build the request is attributed to. | Process env on every chat stream call; whitespace-only falls back to `_env.DEFAULT_BL`. | `_env.get_default_bl` |
 | `NOTEBOOKLM_DEBUG` | When `1`, RPC error messages include the **full** untruncated response body instead of the default 80-char preview. Verbose; intended for deep debugging only. | Process env on each error formatting call. | `exceptions._truncate_response_preview` |
+| `NOTEBOOKLM_REFRESH_CMD` | Optional command invoked when auth refresh is required, replacing the default browser-cookie path. Must emit a new `AuthTokens` JSON on stdout. Parsing honors `NOTEBOOKLM_REFRESH_CMD_USE_SHELL`. | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (see `auth.py:623`, `NOTEBOOKLM_REFRESH_CMD_ENV`) |
 | `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the optional `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True`. Default `shell=False` parses the command with `shlex.split` and invokes it as an argv list (safer; resists shell-injection footguns when the env var is sourced from CI configs or container env files). | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (see `auth.py:2482-2510`) |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | When `1`, disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry. Useful when running behind a proxy that rejects the extra request, or in offline test fixtures. | Process env on every keepalive check. | `auth` keepalive guards (see `auth.py:2899-2977`) |
 
@@ -221,6 +223,15 @@ notebooklm list  # Works without any file on disk
 5. `~/.notebooklm/storage_state.json` (legacy fallback)
 
 **Note:** Cannot run `notebooklm login` when `NOTEBOOKLM_AUTH_JSON` is set.
+
+### `NOTEBOOKLM_REFRESH_CMD`
+
+Optional. If set, this command is invoked when auth refresh is required
+(replacing the default browser-cookie path). The command must produce a new
+`AuthTokens` JSON on stdout. Read at `auth.py:623`
+(`NOTEBOOKLM_REFRESH_CMD_ENV`).
+
+See also `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` to interpret as shell vs argv list.
 
 ### NOTEBOOKLM_HL
 

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -114,6 +114,59 @@ _is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
 _is_allowed_cookie_domain = _cookie_policy._is_allowed_cookie_domain
 
 
+# Public surface for ``from notebooklm.auth import *`` and for downstream
+# static-analysis tools (mypy, ruff F401 checks). This is the audited set of
+# names externally imported by the package, tests, docs, and the CLI as of
+# 2026-05-17. Underscore-prefixed names remain accessible on the module — some
+# tests reach for them as whitebox affordances — but are intentionally NOT
+# blessed here. See ``tests/unit/test_public_surface.py`` for the
+# audit-enforcement test that keeps this list and the externally-imported set
+# in lockstep.
+__all__ = [
+    "Account",
+    "advance_cookie_snapshot_after_save",
+    "ALLOWED_COOKIE_DOMAINS",
+    "AuthTokens",
+    "authuser_query",
+    "build_cookie_jar",
+    "build_httpx_cookies_from_storage",
+    "clear_account_metadata",
+    "convert_rookiepy_cookies_to_storage_state",
+    "CookieSaveResult",
+    "CookieSnapshot",
+    "CookieSnapshotKey",
+    "CookieSnapshotValue",
+    "enumerate_accounts",
+    "extract_cookies_from_storage",
+    "extract_cookies_with_domains",
+    "extract_csrf_from_html",
+    "extract_email_from_html",
+    "extract_session_id_from_html",
+    "extract_wiz_field",
+    "fetch_tokens",
+    "fetch_tokens_with_domains",
+    "format_authuser_value",
+    "get_account_email_for_storage",
+    "get_authuser_for_storage",
+    "GOOGLE_REGIONAL_CCTLDS",
+    "KEEPALIVE_ROTATE_URL",
+    "load_auth_from_storage",
+    "load_httpx_cookies",
+    "MINIMUM_REQUIRED_COOKIES",
+    "normalize_cookie_map",
+    "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
+    "NOTEBOOKLM_REFRESH_CMD_ENV",
+    "NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
+    "OPTIONAL_COOKIE_DOMAINS",
+    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+    "read_account_metadata",
+    "REQUIRED_COOKIE_DOMAINS",
+    "save_cookies_to_storage",
+    "snapshot_cookie_jar",
+    "write_account_metadata",
+]
+
+
 _AUTH_STORAGE_FACADE_NAMES = {
     "CookieSnapshotKey",
     "CookieSnapshotValue",

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -58,6 +58,8 @@ from .auth import authuser_query as authuser_query
 from .auth import extract_wiz_field as extract_wiz_field
 from .exceptions import AuthExtractionError as AuthExtractionError
 
+__all__ = ["NotebookLMClient"]
+
 logger = logging.getLogger(__name__)
 
 

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -1,0 +1,151 @@
+"""Enforce the declared ``__all__`` on ``client.py`` and ``auth.py``.
+
+Both modules curate a public surface that the rest of the codebase, the
+documented API, and external integrators depend on. ``__all__`` is the
+machine-checkable contract:
+
+* ``notebooklm.client`` exports exactly ``NotebookLMClient``. Other names in
+  that module are pulled in for typing / re-export reasons but are not part of
+  the public surface.
+
+* ``notebooklm.auth`` exports the audited set of names externally imported
+  across ``src/``, ``tests/``, ``docs/`` as of 2026-05-17. Underscore-prefixed
+  names remain accessible on the module — some tests poke at them as whitebox
+  affordances — but are intentionally excluded from ``__all__``.
+
+This test pins both lists so a future refactor that drops a name from
+``__all__`` (silently breaking ``from notebooklm.auth import *`` callers, or
+making the symbol invisible to static-analysis surfacing) fails loudly here
+with the specific name that went missing.
+"""
+
+from __future__ import annotations
+
+import notebooklm.auth as auth_module
+import notebooklm.client as client_module
+
+# ---------------------------------------------------------------------------
+# Expected public surface — keep in sync with the audited externally-imported
+# set. When adding a new public name to one of these modules, add it to this
+# test in the same PR.
+# ---------------------------------------------------------------------------
+
+EXPECTED_CLIENT_ALL: list[str] = ["NotebookLMClient"]
+
+EXPECTED_AUTH_ALL: list[str] = [
+    "Account",
+    "advance_cookie_snapshot_after_save",
+    "ALLOWED_COOKIE_DOMAINS",
+    "AuthTokens",
+    "authuser_query",
+    "build_cookie_jar",
+    "build_httpx_cookies_from_storage",
+    "clear_account_metadata",
+    "convert_rookiepy_cookies_to_storage_state",
+    "CookieSaveResult",
+    "CookieSnapshot",
+    "CookieSnapshotKey",
+    "CookieSnapshotValue",
+    "enumerate_accounts",
+    "extract_cookies_from_storage",
+    "extract_cookies_with_domains",
+    "extract_csrf_from_html",
+    "extract_email_from_html",
+    "extract_session_id_from_html",
+    "extract_wiz_field",
+    "fetch_tokens",
+    "fetch_tokens_with_domains",
+    "format_authuser_value",
+    "get_account_email_for_storage",
+    "get_authuser_for_storage",
+    "GOOGLE_REGIONAL_CCTLDS",
+    "KEEPALIVE_ROTATE_URL",
+    "load_auth_from_storage",
+    "load_httpx_cookies",
+    "MINIMUM_REQUIRED_COOKIES",
+    "normalize_cookie_map",
+    "NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV",
+    "NOTEBOOKLM_REFRESH_CMD_ENV",
+    "NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV",
+    "OPTIONAL_COOKIE_DOMAINS",
+    "OPTIONAL_COOKIE_DOMAINS_BY_LABEL",
+    "read_account_metadata",
+    "REQUIRED_COOKIE_DOMAINS",
+    "save_cookies_to_storage",
+    "snapshot_cookie_jar",
+    "write_account_metadata",
+]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_client_module_has_expected_all() -> None:
+    """``notebooklm.client.__all__`` is exactly ``["NotebookLMClient"]``."""
+    assert hasattr(client_module, "__all__"), (
+        "notebooklm.client must declare __all__ to pin its public surface."
+    )
+    assert list(client_module.__all__) == EXPECTED_CLIENT_ALL
+
+
+def test_client_all_entries_resolve_on_module() -> None:
+    """Every name in ``client.__all__`` must be importable from the module."""
+    for name in client_module.__all__:
+        assert hasattr(client_module, name), (
+            f"{name!r} listed in client.__all__ but not present on the module"
+        )
+
+
+def test_auth_module_has_expected_all() -> None:
+    """``notebooklm.auth.__all__`` matches the audited externally-imported set.
+
+    This test is the canonical record of what the audit found on 2026-05-17.
+    If you intentionally add or remove a public name from ``auth.py``, update
+    ``EXPECTED_AUTH_ALL`` above to match and re-run the audit to confirm no
+    external caller is broken (search for ``from notebooklm.auth import`` and
+    ``from ..auth import`` across ``src/``, ``tests/``, ``docs/``).
+    """
+    assert hasattr(auth_module, "__all__"), (
+        "notebooklm.auth must declare __all__ to pin its public surface."
+    )
+    actual = list(auth_module.__all__)
+    assert actual == EXPECTED_AUTH_ALL, (
+        "auth.__all__ drift detected.\n"
+        f"  missing from __all__: {sorted(set(EXPECTED_AUTH_ALL) - set(actual))}\n"
+        f"  unexpected in __all__: {sorted(set(actual) - set(EXPECTED_AUTH_ALL))}"
+    )
+
+
+def test_auth_all_entries_resolve_on_module() -> None:
+    """Every name in ``auth.__all__`` must be importable from the module.
+
+    The facade-module ``__getattribute__`` proxy in ``auth.py`` means a stale
+    ``__all__`` entry would not surface as a normal ``AttributeError`` at
+    import time. Force-evaluate every entry here so the test catches drift.
+    """
+    sentinel = object()
+    for name in auth_module.__all__:
+        value = getattr(auth_module, name, sentinel)
+        assert value is not sentinel, (
+            f"{name!r} listed in auth.__all__ but not present on the module"
+        )
+
+
+def test_auth_all_is_sorted_case_insensitively() -> None:
+    """Keep ``auth.__all__`` reviewable — alphabetized case-insensitively."""
+    actual = list(auth_module.__all__)
+    expected_sorted = sorted(actual, key=str.lower)
+    assert actual == expected_sorted, (
+        "auth.__all__ must be alphabetized (case-insensitive) for diff review"
+    )
+
+
+def test_auth_all_has_no_duplicates() -> None:
+    """``auth.__all__`` must not contain duplicate entries."""
+    actual = list(auth_module.__all__)
+    assert len(actual) == len(set(actual)), (
+        "auth.__all__ contains duplicate entries: "
+        f"{sorted({n for n in actual if actual.count(n) > 1})}"
+    )


### PR DESCRIPTION
## Summary

Closes Tier-9 audit findings **C3** (CLAUDE.md falsely claims the pre-commit hook runs mypy + pytest — it only runs ruff format/check), **I18** (\`client.py\` and \`auth.py\` have no \`__all__\`), and **I19** (\`NOTEBOOKLM_REFRESH_CMD\` env var is read by \`auth.py:594\` but undocumented).

## Changes

- **CLAUDE.md**: replace the Pre-Commit Checks section with an accurate version (hook = ruff only; mypy + pytest stay manual).
- **\`client.py\`**: \`__all__ = ["NotebookLMClient"]\` (audited; no other public name externally imported).
- **\`auth.py\`**: \`__all__\` covers exactly the 24+ externally-imported names. Audited fresh on HEAD \`c5d1ce3\`. \`_safe_url\` (added by PR-C) stays private (leading underscore).
- **\`docs/configuration.md\`**: new \`### NOTEBOOKLM_REFRESH_CMD\` entry near the existing \`NOTEBOOKLM_REFRESH_CMD_USE_SHELL\` docs.
- **\`tests/unit/test_public_surface.py\`** (new): enforces the declared \`__all__\` matches expected lists for both modules. Future drift fails CI.

## Test plan

- [x] \`uv run ruff format .\` clean (351 files)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` clean (100 source files)
- [x] \`test_public_surface.py\`: 6 passed
- [ ] CI: full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)