### PR TITLE
refactor(types): extract source and notebook models

### DIFF
--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -1,0 +1,136 @@
+"""Private notebook type implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from .common import _datetime_from_timestamp
+from .sources import SourceType
+
+
+@dataclass
+class SourceSummary:
+    """Simplified source information for metadata export."""
+
+    kind: SourceType
+    title: str | None = None
+    url: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "type": self.kind.value,
+            "title": self.title,
+            "url": self.url,
+        }
+
+
+def _extract_notebook_sources_count(data: list[Any]) -> int:
+    """Extract the embedded source count from a notebook API payload."""
+    sources = data[1] if len(data) > 1 else None
+    return len(sources) if isinstance(sources, list) else 0
+
+
+@dataclass
+class Notebook:
+    """Represents a NotebookLM notebook."""
+
+    id: str
+    title: str
+    created_at: datetime | None = None
+    sources_count: int = 0
+    is_owner: bool = True
+
+    @classmethod
+    def from_api_response(cls, data: list[Any]) -> Notebook:
+        """Parse notebook from API response."""
+        raw_title = data[0] if len(data) > 0 and isinstance(data[0], str) else ""
+        title = raw_title.replace("thought\n", "").strip()
+        sources_count = _extract_notebook_sources_count(data)
+        notebook_id = data[2] if len(data) > 2 and isinstance(data[2], str) else ""
+
+        created_at = None
+        if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 5:
+            ts_data = data[5][5]
+            if isinstance(ts_data, list) and len(ts_data) > 0:
+                created_at = _datetime_from_timestamp(ts_data[0], datetime_type=datetime)
+
+        is_owner = True
+        if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 1:
+            is_owner = data[5][1] is False
+
+        return cls(
+            id=notebook_id,
+            title=title,
+            created_at=created_at,
+            sources_count=sources_count,
+            is_owner=is_owner,
+        )
+
+
+@dataclass
+class SuggestedTopic:
+    """A suggested topic/question for the notebook."""
+
+    question: str
+    prompt: str
+
+
+@dataclass
+class NotebookDescription:
+    """AI-generated description and suggested topics for a notebook."""
+
+    summary: str
+    suggested_topics: list[SuggestedTopic] = field(default_factory=list)
+
+    @classmethod
+    def from_api_response(cls, data: dict[str, Any]) -> NotebookDescription:
+        """Parse from get_notebook_description() response."""
+        topics = [
+            SuggestedTopic(question=t.get("question", ""), prompt=t.get("prompt", ""))
+            for t in data.get("suggested_topics", [])
+        ]
+        return cls(
+            summary=data.get("summary", ""),
+            suggested_topics=topics,
+        )
+
+
+@dataclass
+class NotebookMetadata:
+    """Combined notebook metadata with sources list."""
+
+    notebook: Notebook
+    sources: list[SourceSummary] = field(default_factory=list)
+
+    @property
+    def id(self) -> str:
+        """Get notebook ID."""
+        return self.notebook.id
+
+    @property
+    def title(self) -> str:
+        """Get notebook title."""
+        return self.notebook.title
+
+    @property
+    def created_at(self) -> datetime | None:
+        """Get creation timestamp."""
+        return self.notebook.created_at
+
+    @property
+    def is_owner(self) -> bool:
+        """Get owner status."""
+        return self.notebook.is_owner
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "is_owner": self.is_owner,
+            "sources": [s.to_dict() for s in self.sources],
+        }

--- a/src/notebooklm/_types/notebooks.py
+++ b/src/notebooklm/_types/notebooks.py
@@ -59,6 +59,7 @@ class Notebook:
 
         is_owner = True
         if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 1:
+            # The API sends False in this slot for owner notebooks; truthy values mean shared.
             is_owner = data[5][1] is False
 
         return cls(

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -78,6 +78,8 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 
 
 def _source_warning_state() -> set[int]:
+    # Read through the public facade so monkeypatch.setattr(notebooklm.types, ...)
+    # rebinding is reflected in this private implementation.
     public_types = sys.modules.get("notebooklm.types")
     if public_types is not None:
         public_state = getattr(public_types, "_warned_source_types", None)
@@ -87,6 +89,8 @@ def _source_warning_state() -> set[int]:
 
 
 def _source_compat_map() -> dict[SourceType, str]:
+    # Read through the public facade so monkeypatch.setattr(notebooklm.types, ...)
+    # rebinding is reflected in this private implementation.
     public_types = sys.modules.get("notebooklm.types")
     if public_types is not None:
         public_map = getattr(public_types, "_SOURCE_TYPE_COMPAT_MAP", None)
@@ -203,6 +207,7 @@ class Source:
                     entry = data[0][0]
                     source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
                     title = entry[1] if len(entry) > 1 else None
+                    # Fall through to the shared metadata parser below.
                 else:
                     # Medium nested: [[['id'], 'title', ...]]
                     entry = data[0]

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -1,0 +1,300 @@
+"""Private source type implementations."""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from ..rpc.types import SourceStatus
+from .common import UnknownTypeWarning, _datetime_from_timestamp
+
+
+class SourceType(str, Enum):
+    """User-facing source types.
+
+    This is a str enum, so comparisons work with both enum members and strings:
+        source.kind == SourceType.WEB_PAGE  # True
+        source.kind == "web_page"           # Also True
+    """
+
+    GOOGLE_DOCS = "google_docs"
+    GOOGLE_SLIDES = "google_slides"
+    GOOGLE_SPREADSHEET = "google_spreadsheet"
+    PDF = "pdf"
+    PASTED_TEXT = "pasted_text"
+    WEB_PAGE = "web_page"
+    GOOGLE_DRIVE_AUDIO = "google_drive_audio"
+    GOOGLE_DRIVE_VIDEO = "google_drive_video"
+    YOUTUBE = "youtube"
+    MARKDOWN = "markdown"
+    DOCX = "docx"
+    CSV = "csv"
+    EPUB = "epub"
+    IMAGE = "image"
+    MEDIA = "media"
+    UNKNOWN = "unknown"
+
+
+_warned_source_types: set[int] = set()
+
+
+_SOURCE_TYPE_CODE_MAP: dict[int, SourceType] = {
+    1: SourceType.GOOGLE_DOCS,
+    2: SourceType.GOOGLE_SLIDES,  # Was GOOGLE_OTHER, now more specific
+    3: SourceType.PDF,
+    4: SourceType.PASTED_TEXT,
+    5: SourceType.WEB_PAGE,
+    8: SourceType.MARKDOWN,
+    9: SourceType.YOUTUBE,
+    10: SourceType.MEDIA,
+    11: SourceType.DOCX,
+    13: SourceType.IMAGE,
+    14: SourceType.GOOGLE_SPREADSHEET,
+    16: SourceType.CSV,
+    17: SourceType.EPUB,
+}
+
+
+_SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
+    SourceType.GOOGLE_DOCS: "text",
+    SourceType.GOOGLE_SLIDES: "text",
+    SourceType.GOOGLE_SPREADSHEET: "text",
+    SourceType.PDF: "text_file",
+    SourceType.PASTED_TEXT: "text",
+    SourceType.WEB_PAGE: "url",
+    SourceType.YOUTUBE: "youtube",
+    SourceType.MARKDOWN: "text_file",
+    SourceType.DOCX: "text_file",
+    SourceType.CSV: "text",
+    SourceType.EPUB: "text_file",
+    SourceType.IMAGE: "text",
+    SourceType.MEDIA: "text",
+    SourceType.UNKNOWN: "text",
+}
+
+
+def _source_warning_state() -> set[int]:
+    public_types = sys.modules.get("notebooklm.types")
+    if public_types is not None:
+        public_state = getattr(public_types, "_warned_source_types", None)
+        if isinstance(public_state, set):
+            return public_state
+    return _warned_source_types
+
+
+def _source_compat_map() -> dict[SourceType, str]:
+    public_types = sys.modules.get("notebooklm.types")
+    if public_types is not None:
+        public_map = getattr(public_types, "_SOURCE_TYPE_COMPAT_MAP", None)
+        if isinstance(public_map, dict):
+            return public_map
+    return _SOURCE_TYPE_COMPAT_MAP
+
+
+def _safe_source_type(type_code: int | None) -> SourceType:
+    """Convert internal type code to user-facing SourceType enum."""
+    if type_code is None:
+        return SourceType.UNKNOWN
+
+    result = _SOURCE_TYPE_CODE_MAP.get(type_code)
+    if result is None:
+        warned_source_types = _source_warning_state()
+        if type_code not in warned_source_types:
+            warned_source_types.add(type_code)
+            warnings.warn(
+                f"Unknown source type code {type_code}. "
+                "Consider updating notebooklm-py to the latest version.",
+                UnknownTypeWarning,
+                stacklevel=3,
+            )
+        return SourceType.UNKNOWN
+    return result
+
+
+def _extract_source_url(metadata: Any, *, allow_bare_http: bool = True) -> str | None:
+    """Extract a source URL from a ``src[2]`` metadata array."""
+    if not isinstance(metadata, list):
+        return None
+    url: str | None = None
+    if len(metadata) > 7:
+        url_list = metadata[7]
+        if isinstance(url_list, list) and len(url_list) > 0:
+            url = url_list[0]
+    if not url and len(metadata) > 5:
+        yt_data = metadata[5]
+        if isinstance(yt_data, list) and len(yt_data) > 0 and isinstance(yt_data[0], str):
+            url = yt_data[0]
+    if not url and allow_bare_http and len(metadata) > 0:
+        candidate = metadata[0]
+        if isinstance(candidate, str) and candidate.startswith("http"):
+            url = candidate
+    return url
+
+
+def _extract_source_created_at(metadata: Any) -> datetime | None:
+    """Extract a source creation timestamp from a ``src[2]`` metadata array."""
+    if not isinstance(metadata, list) or len(metadata) <= 2:
+        return None
+
+    timestamp_list = metadata[2]
+    if not isinstance(timestamp_list, list) or not timestamp_list:
+        return None
+
+    return _datetime_from_timestamp(timestamp_list[0], datetime_type=datetime)
+
+
+@dataclass
+class Source:
+    """Represents a NotebookLM source."""
+
+    id: str
+    title: str | None = None
+    url: str | None = None
+    _type_code: int | None = field(default=None, repr=False)
+    created_at: datetime | None = None
+    status: int = SourceStatus.READY
+
+    @property
+    def kind(self) -> SourceType:
+        """Get source type as SourceType enum."""
+        return _safe_source_type(self._type_code)
+
+    @property
+    def source_type(self) -> str:
+        """Deprecated: Use .kind instead."""
+        warnings.warn(
+            "Source.source_type is deprecated, use .kind instead. Will be removed in v0.5.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _source_compat_map().get(self.kind, "text")
+
+    @property
+    def is_ready(self) -> bool:
+        """Check if source is ready for use (status=READY)."""
+        return self.status == SourceStatus.READY
+
+    @property
+    def is_processing(self) -> bool:
+        """Check if source is still being processed (status=PROCESSING)."""
+        return self.status == SourceStatus.PROCESSING
+
+    @property
+    def is_error(self) -> bool:
+        """Check if source processing failed (status=ERROR)."""
+        return self.status == SourceStatus.ERROR
+
+    @classmethod
+    def from_api_response(cls, data: list[Any], notebook_id: str | None = None) -> Source:
+        """Parse source data from various API response formats."""
+        if not data or not isinstance(data, list):
+            raise ValueError(f"Invalid source data: {data}")
+
+        # Try deeply nested format: [[[[id], title, metadata, ...]]]
+        if isinstance(data[0], list) and len(data[0]) > 0:
+            if isinstance(data[0][0], list) and len(data[0][0]) > 0:
+                # Check if deeply nested vs medium nested
+                if isinstance(data[0][0][0], list):
+                    # Deeply nested: [[[[id], title, ...]]]
+                    entry = data[0][0]
+                    source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
+                    title = entry[1] if len(entry) > 1 else None
+                else:
+                    # Medium nested: [[['id'], 'title', ...]]
+                    entry = data[0]
+                    source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
+                    title = entry[1] if len(entry) > 1 else None
+
+                    metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
+                    url = _extract_source_url(metadata, allow_bare_http=False)
+                    type_code = (
+                        metadata[4]
+                        if metadata is not None
+                        and len(metadata) > 4
+                        and isinstance(metadata[4], int)
+                        else None
+                    )
+                    created_at = _extract_source_created_at(metadata)
+
+                    return cls(
+                        id=str(source_id),
+                        title=title,
+                        url=url,
+                        _type_code=type_code,
+                        created_at=created_at,
+                    )
+
+                metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
+                url = _extract_source_url(metadata)
+                type_code = (
+                    metadata[4]
+                    if metadata is not None and len(metadata) > 4 and isinstance(metadata[4], int)
+                    else None
+                )
+                created_at = _extract_source_created_at(metadata)
+
+                return cls(
+                    id=str(source_id),
+                    title=title,
+                    url=url,
+                    _type_code=type_code,
+                    created_at=created_at,
+                )
+
+        # Simple flat format: [id, title] or [id, title, ...]
+        source_id = data[0] if len(data) > 0 else ""
+        title = data[1] if len(data) > 1 else None
+        return cls(id=str(source_id), title=title, _type_code=None)
+
+
+@dataclass
+class SourceFulltext:
+    """Full text content of a source as indexed by NotebookLM."""
+
+    source_id: str
+    title: str
+    content: str
+    _type_code: int | None = field(default=None, repr=False)
+    url: str | None = None
+    char_count: int = 0
+
+    @property
+    def kind(self) -> SourceType:
+        """Get source type as SourceType enum."""
+        return _safe_source_type(self._type_code)
+
+    @property
+    def source_type(self) -> str:
+        """Deprecated: Use .kind instead."""
+        warnings.warn(
+            "SourceFulltext.source_type is deprecated, use .kind instead. "
+            "Will be removed in v0.5.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _source_compat_map().get(self.kind, "text")
+
+    def find_citation_context(
+        self,
+        cited_text: str,
+        context_chars: int = 200,
+    ) -> list[tuple[str, int]]:
+        """Search for citation text and return matching contexts."""
+        if not cited_text or not self.content:
+            return []
+
+        search_text = cited_text[: min(40, len(cited_text))]
+
+        matches = []
+        pos = 0
+        while (idx := self.content.find(search_text, pos)) != -1:
+            start = max(0, idx - context_chars)
+            end = min(len(self.content), idx + len(search_text) + context_chars)
+            matches.append((self.content[start:end], idx))
+            pos = idx + len(search_text)
+
+        return matches

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -17,6 +17,8 @@ from typing import Any, Optional
 from urllib.parse import quote
 
 from ._env import get_base_url
+from ._types import notebooks as _notebook_types
+from ._types import sources as _source_types
 from ._types.common import (
     AccountLimits,
     AccountTier,
@@ -28,6 +30,18 @@ from ._types.common import (
 )
 from ._types.common import (
     _datetime_from_timestamp as _common_datetime_from_timestamp,
+)
+from ._types.notebooks import (
+    Notebook,
+    NotebookDescription,
+    NotebookMetadata,
+    SourceSummary,
+    SuggestedTopic,
+)
+from ._types.sources import (
+    Source,
+    SourceFulltext,
+    SourceType,
 )
 
 # Import exceptions from centralized module (re-export for backward compatibility)
@@ -72,35 +86,17 @@ from .rpc.types import (
     source_status_to_str,
 )
 
+_SOURCE_TYPE_CODE_MAP = _source_types._SOURCE_TYPE_CODE_MAP
+_SOURCE_TYPE_COMPAT_MAP = _source_types._SOURCE_TYPE_COMPAT_MAP
+_extract_notebook_sources_count = _notebook_types._extract_notebook_sources_count
+_extract_source_created_at = _source_types._extract_source_created_at
+_extract_source_url = _source_types._extract_source_url
+_safe_source_type = _source_types._safe_source_type
+_warned_source_types = _source_types._warned_source_types
+
 # =============================================================================
 # User-facing Type Enums (str enums for .kind property)
 # =============================================================================
-
-
-class SourceType(str, Enum):
-    """User-facing source types.
-
-    This is a str enum, so comparisons work with both enum members and strings:
-        source.kind == SourceType.WEB_PAGE  # True
-        source.kind == "web_page"           # Also True
-    """
-
-    GOOGLE_DOCS = "google_docs"
-    GOOGLE_SLIDES = "google_slides"
-    GOOGLE_SPREADSHEET = "google_spreadsheet"
-    PDF = "pdf"
-    PASTED_TEXT = "pasted_text"
-    WEB_PAGE = "web_page"
-    GOOGLE_DRIVE_AUDIO = "google_drive_audio"
-    GOOGLE_DRIVE_VIDEO = "google_drive_video"
-    YOUTUBE = "youtube"
-    MARKDOWN = "markdown"
-    DOCX = "docx"
-    CSV = "csv"
-    EPUB = "epub"
-    IMAGE = "image"
-    MEDIA = "media"
-    UNKNOWN = "unknown"
 
 
 class ArtifactType(str, Enum):
@@ -126,27 +122,8 @@ class ArtifactType(str, Enum):
     UNKNOWN = "unknown"
 
 
-# Module-level sets for warning deduplication
-_warned_source_types: set[int] = set()
 _warned_artifact_types: set[tuple[int, int | None]] = set()
 
-
-# Mapping from internal int codes to SourceType enum
-_SOURCE_TYPE_CODE_MAP: dict[int, SourceType] = {
-    1: SourceType.GOOGLE_DOCS,
-    2: SourceType.GOOGLE_SLIDES,  # Was GOOGLE_OTHER, now more specific
-    3: SourceType.PDF,
-    4: SourceType.PASTED_TEXT,
-    5: SourceType.WEB_PAGE,
-    8: SourceType.MARKDOWN,
-    9: SourceType.YOUTUBE,
-    10: SourceType.MEDIA,
-    11: SourceType.DOCX,
-    13: SourceType.IMAGE,
-    14: SourceType.GOOGLE_SPREADSHEET,
-    16: SourceType.CSV,
-    17: SourceType.EPUB,
-}
 
 # Mapping from internal int codes to ArtifactType enum
 _ARTIFACT_TYPE_CODE_MAP: dict[int, ArtifactType] = {
@@ -158,54 +135,6 @@ _ARTIFACT_TYPE_CODE_MAP: dict[int, ArtifactType] = {
     8: ArtifactType.SLIDE_DECK,
     9: ArtifactType.DATA_TABLE,
 }
-
-# Backward-compatible mapping from SourceType to old source_type strings
-# Used by deprecated Source.source_type property
-# Old values were heuristic: "text", "url", "youtube", "text_file"
-# Only includes types that _SOURCE_TYPE_CODE_MAP can produce
-_SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
-    SourceType.GOOGLE_DOCS: "text",
-    SourceType.GOOGLE_SLIDES: "text",
-    SourceType.GOOGLE_SPREADSHEET: "text",
-    SourceType.PDF: "text_file",
-    SourceType.PASTED_TEXT: "text",
-    SourceType.WEB_PAGE: "url",
-    SourceType.YOUTUBE: "youtube",
-    SourceType.MARKDOWN: "text_file",
-    SourceType.DOCX: "text_file",
-    SourceType.CSV: "text",
-    SourceType.EPUB: "text_file",
-    SourceType.IMAGE: "text",
-    SourceType.MEDIA: "text",
-    SourceType.UNKNOWN: "text",
-}
-
-
-def _safe_source_type(type_code: int | None) -> SourceType:
-    """Convert internal type code to user-facing SourceType enum.
-
-    Args:
-        type_code: Integer type code from API response.
-
-    Returns:
-        SourceType enum member. Returns UNKNOWN for unrecognized codes.
-    """
-    if type_code is None:
-        return SourceType.UNKNOWN
-
-    result = _SOURCE_TYPE_CODE_MAP.get(type_code)
-    if result is None:
-        if type_code not in _warned_source_types:
-            _warned_source_types.add(type_code)
-            warnings.warn(
-                f"Unknown source type code {type_code}. "
-                "Consider updating notebooklm-py to the latest version.",
-                UnknownTypeWarning,
-                stacklevel=3,
-            )
-        return SourceType.UNKNOWN
-    return result
-
 
 def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     """Convert internal artifact type and variant to user-facing ArtifactType.
@@ -250,54 +179,9 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     return result
 
 
-def _extract_source_url(metadata: Any, *, allow_bare_http: bool = True) -> str | None:
-    """Extract a source URL from a ``src[2]`` metadata array.
-
-    NotebookLM stores source URLs at different indices of the metadata array
-    depending on the source type:
-
-    - ``metadata[7]`` → ``[url]`` for web page / PDF sources
-    - ``metadata[5]`` → ``[url, video_id, channel_name]`` for YouTube sources
-    - ``metadata[0]`` → bare URL string for some older/alternate shapes
-
-    Precedence is ``[7] > [5] > [0]``. The ``[0]`` fallback is gated by
-    ``allow_bare_http`` because medium-nested ``from_api_response`` shapes
-    don't support it (``metadata[0]`` can pack unrelated data there).
-    Returns ``None`` if ``metadata`` is not a list or no probe matches.
-    """
-    if not isinstance(metadata, list):
-        return None
-    url: str | None = None
-    if len(metadata) > 7:
-        url_list = metadata[7]
-        if isinstance(url_list, list) and len(url_list) > 0:
-            url = url_list[0]
-    if not url and len(metadata) > 5:
-        yt_data = metadata[5]
-        if isinstance(yt_data, list) and len(yt_data) > 0 and isinstance(yt_data[0], str):
-            url = yt_data[0]
-    if not url and allow_bare_http and len(metadata) > 0:
-        candidate = metadata[0]
-        if isinstance(candidate, str) and candidate.startswith("http"):
-            url = candidate
-    return url
-
-
 def _datetime_from_timestamp(value: Any) -> datetime | None:
     """Convert an API seconds timestamp to ``datetime``, returning ``None`` if invalid."""
     return _common_datetime_from_timestamp(value, datetime_type=datetime)
-
-
-def _extract_source_created_at(metadata: Any) -> datetime | None:
-    """Extract a source creation timestamp from a ``src[2]`` metadata array."""
-    if not isinstance(metadata, list) or len(metadata) <= 2:
-        return None
-
-    timestamp_list = metadata[2]
-    if not isinstance(timestamp_list, list) or not timestamp_list:
-        return None
-
-    return _datetime_from_timestamp(timestamp_list[0])
 
 
 def _is_valid_artifact_url(value: Any) -> bool:
@@ -473,6 +357,20 @@ for _public_common_type in (
 del _public_common_type
 
 
+for _public_moved_type in (
+    Notebook,
+    NotebookDescription,
+    NotebookMetadata,
+    Source,
+    SourceFulltext,
+    SourceSummary,
+    SourceType,
+    SuggestedTopic,
+):
+    _public_moved_type.__module__ = __name__
+del _public_moved_type
+
+
 # =============================================================================
 # Chat Mode Enum (service-level, not RPC-level)
 # =============================================================================
@@ -485,416 +383,6 @@ class ChatMode(Enum):
     LEARNING_GUIDE = "learning_guide"  # Educational focus
     CONCISE = "concise"  # Brief responses
     DETAILED = "detailed"  # Verbose responses
-
-
-# =============================================================================
-# Notebook Types
-# =============================================================================
-
-
-@dataclass
-class SourceSummary:
-    """Simplified source information for metadata export.
-
-    This type provides a minimal representation of a source for
-    notebook metadata export, focusing on the most commonly needed fields.
-
-    Attributes:
-        kind: Source type (e.g., "pdf", "web_page", "youtube").
-        title: Source title if available.
-        url: Source URL if applicable (web/YouTube sources).
-    """
-
-    kind: SourceType
-    title: str | None = None
-    url: str | None = None
-
-    def to_dict(self) -> dict[str, str | None]:
-        """Convert to dictionary for JSON serialization.
-
-        Always includes all keys with null for missing values
-        to ensure consistent schema across all source entries.
-        """
-        return {
-            "type": self.kind.value,
-            "title": self.title,
-            "url": self.url,
-        }
-
-
-def _extract_notebook_sources_count(data: list[Any]) -> int:
-    """Extract the embedded source count from a notebook API payload."""
-    sources = data[1] if len(data) > 1 else None
-    return len(sources) if isinstance(sources, list) else 0
-
-
-@dataclass
-class Notebook:
-    """Represents a NotebookLM notebook."""
-
-    id: str
-    title: str
-    created_at: datetime | None = None
-    sources_count: int = 0
-    is_owner: bool = True
-
-    @classmethod
-    def from_api_response(cls, data: list[Any]) -> "Notebook":
-        """Parse notebook from API response.
-
-        Args:
-            data: Raw API response list.
-
-        Returns:
-            Notebook instance.
-        """
-        raw_title = data[0] if len(data) > 0 and isinstance(data[0], str) else ""
-        title = raw_title.replace("thought\n", "").strip()
-        sources_count = _extract_notebook_sources_count(data)
-        notebook_id = data[2] if len(data) > 2 and isinstance(data[2], str) else ""
-
-        created_at = None
-        if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 5:
-            ts_data = data[5][5]
-            if isinstance(ts_data, list) and len(ts_data) > 0:
-                created_at = _datetime_from_timestamp(ts_data[0])
-
-        # Extract ownership - data[5][1] = False means owner, True means shared
-        is_owner = True
-        if len(data) > 5 and isinstance(data[5], list) and len(data[5]) > 1:
-            is_owner = data[5][1] is False
-
-        return cls(
-            id=notebook_id,
-            title=title,
-            created_at=created_at,
-            sources_count=sources_count,
-            is_owner=is_owner,
-        )
-
-
-@dataclass
-class SuggestedTopic:
-    """A suggested topic/question for the notebook."""
-
-    question: str
-    prompt: str
-
-
-@dataclass
-class NotebookDescription:
-    """AI-generated description and suggested topics for a notebook."""
-
-    summary: str
-    suggested_topics: list[SuggestedTopic] = field(default_factory=list)
-
-    @classmethod
-    def from_api_response(cls, data: dict[str, Any]) -> "NotebookDescription":
-        """Parse from get_notebook_description() response."""
-        topics = [
-            SuggestedTopic(question=t.get("question", ""), prompt=t.get("prompt", ""))
-            for t in data.get("suggested_topics", [])
-        ]
-        return cls(
-            summary=data.get("summary", ""),
-            suggested_topics=topics,
-        )
-
-
-@dataclass
-class NotebookMetadata:
-    """Combined notebook metadata with sources list.
-
-    This composes a Notebook with a list of simplified source information
-    for export/overview purposes.
-
-    Attributes:
-        notebook: The notebook object with all its details.
-        sources: List of simplified source information.
-    """
-
-    notebook: Notebook
-    sources: list[SourceSummary] = field(default_factory=list)
-
-    @property
-    def id(self) -> str:
-        """Get notebook ID."""
-        return self.notebook.id
-
-    @property
-    def title(self) -> str:
-        """Get notebook title."""
-        return self.notebook.title
-
-    @property
-    def created_at(self) -> datetime | None:
-        """Get creation timestamp."""
-        return self.notebook.created_at
-
-    @property
-    def is_owner(self) -> bool:
-        """Get owner status."""
-        return self.notebook.is_owner
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for JSON serialization.
-
-        Flattens notebook fields for backward compatibility with issue spec.
-        """
-        return {
-            "id": self.id,
-            "title": self.title,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "is_owner": self.is_owner,
-            "sources": [s.to_dict() for s in self.sources],
-        }
-
-
-# =============================================================================
-# Source Types
-# =============================================================================
-
-
-@dataclass
-class Source:
-    """Represents a NotebookLM source.
-
-    Attributes:
-        id: Unique source identifier.
-        title: Source title (may be URL if not yet processed).
-        url: Original URL for web/YouTube sources.
-        kind: Source type as SourceType enum (str enum, comparable to strings).
-        created_at: When the source was added.
-        status: Processing status (1=processing, 2=ready, 3=error).
-
-    Example:
-        source.kind == SourceType.WEB_PAGE  # True
-        source.kind == "web_page"           # Also True (str enum)
-        f"Type: {source.kind}"              # "Type: web_page"
-    """
-
-    id: str
-    title: str | None = None
-    url: str | None = None
-    _type_code: int | None = field(default=None, repr=False)
-    created_at: datetime | None = None
-    status: int = SourceStatus.READY  # Default to READY (2)
-
-    @property
-    def kind(self) -> SourceType:
-        """Get source type as SourceType enum.
-
-        Returns:
-            SourceType enum member. Returns SourceType.UNKNOWN for
-            unrecognized type codes (with a warning on first occurrence).
-        """
-        return _safe_source_type(self._type_code)
-
-    @property
-    def source_type(self) -> str:
-        """Deprecated: Use .kind instead.
-
-        Returns the old-style source type string for backward compatibility.
-        Values: "text", "url", "youtube", "text_file"
-
-        .. deprecated:: 0.3.0
-            Use the ``.kind`` property which returns a ``SourceType`` enum.
-            Will be removed in v0.5.0.
-        """
-        warnings.warn(
-            "Source.source_type is deprecated, use .kind instead. Will be removed in v0.5.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return _SOURCE_TYPE_COMPAT_MAP.get(self.kind, "text")
-
-    @property
-    def is_ready(self) -> bool:
-        """Check if source is ready for use (status=READY)."""
-        return self.status == SourceStatus.READY
-
-    @property
-    def is_processing(self) -> bool:
-        """Check if source is still being processed (status=PROCESSING)."""
-        return self.status == SourceStatus.PROCESSING
-
-    @property
-    def is_error(self) -> bool:
-        """Check if source processing failed (status=ERROR)."""
-        return self.status == SourceStatus.ERROR
-
-    @classmethod
-    def from_api_response(cls, data: list[Any], notebook_id: str | None = None) -> "Source":
-        """Parse source data from various API response formats.
-
-        The API returns different structures for different operations:
-        - add_source: [[[[id], title, metadata]]] (deeply nested)
-        - list_sources: [[[id], title, metadata], ...] (one level less nesting)
-        - rename_source: May return simpler structure
-
-        Note:
-            This method does NOT parse the source status field. Sources created
-            via this method will have status=READY by default. To get accurate
-            status information (PROCESSING, READY, or ERROR), use
-            `client.sources.list()` or `client.sources.get()` which parse
-            status from the full notebook response structure.
-        """
-        if not data or not isinstance(data, list):
-            raise ValueError(f"Invalid source data: {data}")
-
-        # Try deeply nested format: [[[[id], title, metadata, ...]]]
-        if isinstance(data[0], list) and len(data[0]) > 0:
-            if isinstance(data[0][0], list) and len(data[0][0]) > 0:
-                # Check if deeply nested vs medium nested
-                if isinstance(data[0][0][0], list):
-                    # Deeply nested: [[[[id], title, ...]]]
-                    entry = data[0][0]
-                    source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
-                    title = entry[1] if len(entry) > 1 else None
-                else:
-                    # Medium nested: [[['id'], 'title', ...]]
-                    entry = data[0]
-                    source_id = entry[0][0] if isinstance(entry[0], list) else entry[0]
-                    title = entry[1] if len(entry) > 1 else None
-
-                    # Extract URL and type code from entry[2] via the shared
-                    # helper. Medium-nested shapes don't support the bare-http
-                    # [0] fallback, so precedence is restricted to [7] > [5].
-                    metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
-                    url = _extract_source_url(metadata, allow_bare_http=False)
-                    type_code = (
-                        metadata[4]
-                        if metadata is not None
-                        and len(metadata) > 4
-                        and isinstance(metadata[4], int)
-                        else None
-                    )
-                    created_at = _extract_source_created_at(metadata)
-
-                    return cls(
-                        id=str(source_id),
-                        title=title,
-                        url=url,
-                        _type_code=type_code,
-                        created_at=created_at,
-                    )
-
-                # Deeply-nested shape: extract URL (via shared helper) and
-                # type code from entry[2] if present. Full precedence applies:
-                # [7] > [5] > bare-http at [0].
-                metadata = entry[2] if len(entry) > 2 and isinstance(entry[2], list) else None
-                url = _extract_source_url(metadata)
-                type_code = (
-                    metadata[4]
-                    if metadata is not None and len(metadata) > 4 and isinstance(metadata[4], int)
-                    else None
-                )
-                created_at = _extract_source_created_at(metadata)
-
-                return cls(
-                    id=str(source_id),
-                    title=title,
-                    url=url,
-                    _type_code=type_code,
-                    created_at=created_at,
-                )
-
-        # Simple flat format: [id, title] or [id, title, ...]
-        source_id = data[0] if len(data) > 0 else ""
-        title = data[1] if len(data) > 1 else None
-        return cls(id=str(source_id), title=title, _type_code=None)
-
-
-@dataclass
-class SourceFulltext:
-    """Full text content of a source as indexed by NotebookLM.
-
-    This is the raw text content that was extracted/indexed from the source,
-    along with metadata. Returned by `client.sources.get_fulltext()`.
-
-    Attributes:
-        source_id: The source UUID.
-        title: Source title.
-        content: Full indexed text content.
-        kind: Source type as SourceType enum (use .kind property).
-        url: Original URL for web/YouTube sources.
-        char_count: Number of characters in the content.
-
-    Example:
-        fulltext.kind == SourceType.WEB_PAGE  # True
-        fulltext.kind == "web_page"           # Also True (str enum)
-    """
-
-    source_id: str
-    title: str
-    content: str
-    _type_code: int | None = field(default=None, repr=False)
-    url: str | None = None
-    char_count: int = 0
-
-    @property
-    def kind(self) -> SourceType:
-        """Get source type as SourceType enum."""
-        return _safe_source_type(self._type_code)
-
-    @property
-    def source_type(self) -> str:
-        """Deprecated: Use .kind instead.
-
-        Returns the old-style source type string for backward compatibility.
-        Values: "text", "url", "youtube", "text_file"
-
-        .. deprecated:: 0.3.0
-            Use the ``.kind`` property which returns a ``SourceType`` enum.
-            Will be removed in v0.5.0.
-        """
-        warnings.warn(
-            "SourceFulltext.source_type is deprecated, use .kind instead. "
-            "Will be removed in v0.5.0.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return _SOURCE_TYPE_COMPAT_MAP.get(self.kind, "text")
-
-    def find_citation_context(
-        self,
-        cited_text: str,
-        context_chars: int = 200,
-    ) -> list[tuple[str, int]]:
-        """Search for citation text and return matching contexts.
-
-        Best-effort heuristic using substring search. May fail or return
-        incorrect matches when:
-        - cited_text appears multiple times (all occurrences returned)
-        - NotebookLM truncated the citation during chunking
-        - Formatting differs between citation and indexed content
-
-        Note: ChatReference.start_char/end_char reference NotebookLM's internal
-        chunked index, NOT positions in this fulltext. Use this method instead.
-
-        Args:
-            cited_text: Text to search for (from ChatReference.cited_text).
-            context_chars: Surrounding context to include (default 200).
-
-        Returns:
-            List of (context, position) tuples for each match found.
-            Empty list if no matches. Position is start of match in content.
-        """
-        if not cited_text or not self.content:
-            return []
-
-        # Use prefix for search (citations are often truncated)
-        search_text = cited_text[: min(40, len(cited_text))]
-
-        matches = []
-        pos = 0
-        while (idx := self.content.find(search_text, pos)) != -1:
-            start = max(0, idx - context_chars)
-            end = min(len(self.content), idx + len(search_text) + context_chars)
-            matches.append((self.content[start:end], idx))
-            pos = idx + len(search_text)  # Skip past match to avoid overlaps
-
-        return matches
 
 
 # =============================================================================

--- a/src/notebooklm/types.py
+++ b/src/notebooklm/types.py
@@ -86,6 +86,8 @@ from .rpc.types import (
     source_status_to_str,
 )
 
+# Keep private facade names that first-party tests and external callers have
+# historically imported while the implementation moves into _types modules.
 _SOURCE_TYPE_CODE_MAP = _source_types._SOURCE_TYPE_CODE_MAP
 _SOURCE_TYPE_COMPAT_MAP = _source_types._SOURCE_TYPE_COMPAT_MAP
 _extract_notebook_sources_count = _notebook_types._extract_notebook_sources_count
@@ -135,6 +137,7 @@ _ARTIFACT_TYPE_CODE_MAP: dict[int, ArtifactType] = {
     8: ArtifactType.SLIDE_DECK,
     9: ArtifactType.DATA_TABLE,
 }
+
 
 def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     """Convert internal artifact type and variant to user-facing ArtifactType.

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -389,6 +389,12 @@ _TYPES_PRIVATE_HELPER_SEAMS = [
     "_warned_source_types",
 ]
 
+_TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS = [
+    "_SOURCE_TYPE_CODE_MAP",
+    "_extract_notebook_sources_count",
+    "_safe_source_type",
+]
+
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -479,9 +485,9 @@ def test_types_non_all_facade_attributes_are_frozen() -> None:
     assert not hasattr(public_types, "RPCMethod")
 
 
-@pytest.mark.parametrize("name", _TYPES_PRIVATE_HELPER_SEAMS)
+@pytest.mark.parametrize("name", _TYPES_PRIVATE_HELPER_SEAMS + _TYPES_PRIVATE_EXTERNAL_COMPAT_SEAMS)
 def test_types_private_helper_seams_remain_importable(name: str) -> None:
-    """First-party private imports from notebooklm.types stay live during T13 moves."""
+    """Private imports from notebooklm.types stay live during T13 moves."""
     import notebooklm.types as public_types
 
     imported = getattr(__import__("notebooklm.types", fromlist=[name]), name)


### PR DESCRIPTION
## Summary
- Extract source-owned type models and parsing helpers into src/notebooklm/_types/sources.py
- Extract notebook-owned models into src/notebooklm/_types/notebooks.py
- Keep notebooklm.types as the public facade, including live private helper/state seams

## Verification
- rtk uv run pytest -n auto tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_public_shims.py tests/unit/test_notebook_api.py tests/integration/test_notebooks_integration.py tests/unit/test_source_symlink.py tests/integration/test_sources_integration.py tests/unit/cli/test_source.py tests/unit/cli/test_notebook.py tests/unit/test_json_stdout_purity.py -> 800 passed
- rtk uv run ruff check src/notebooklm/types.py src/notebooklm/_types src/notebooklm/_sources.py src/notebooklm/_notebooks.py tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/cli/test_source.py tests/unit/cli/test_notebook.py -> passed
- rtk uv run mypy src/notebooklm -> passed
- rtk git diff --check -> passed

Note: the requested pytest paths tests/unit/test_notebooks_integration.py and tests/unit/test_sources_integration.py do not exist on this base; the matching files are under tests/integration/.