### PR TITLE
fix(tests): adapt integration mocks to streaming POST (regression from #751)

### DIFF
--- a/tests/integration/_streaming_mock.py
+++ b/tests/integration/_streaming_mock.py
@@ -1,0 +1,93 @@
+"""Bridge legacy ``http_client.post`` mocks to the streaming POST API.
+
+The RPC POST path now uses :meth:`httpx.AsyncClient.stream` so the
+running size guard in :data:`notebooklm._core_transport.MAX_RPC_RESPONSE_BYTES`
+can fire. Many integration tests in this tree predate that switch and
+still express intent as ``client._http_client.post = fake_post`` or
+``patch.object(..., "post", side_effect=err)``. This module exposes the
+same ``install_post_as_stream`` helper as ``tests/unit/conftest.py`` so
+both test trees can adapt legacy mocks without rewriting each call site.
+
+Why a sibling module instead of putting this in ``conftest.py``: the
+``tests/integration/concurrency/`` subdirectory has its own ``conftest.py``,
+and ``from conftest import ...`` from a test in that subdir resolves to
+the closer conftest. Pytest adds ``tests/integration/`` to ``sys.path``
+when collecting any of its tests (because ``conftest.py`` lives here),
+so ``from _streaming_mock import install_post_as_stream`` works from
+both ``tests/integration/`` and ``tests/integration/concurrency/`` without
+``sys.path`` hackery.
+"""
+
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+
+def install_post_as_stream(
+    monkeypatch: pytest.MonkeyPatch | None,
+    http_client: Any,
+    fake_post: Callable[..., Awaitable[Any]],
+) -> None:
+    """Adapt a ``fake_post(...) -> Response`` mock to the streaming API.
+
+    Installs an ``async with client.stream(...)``-compatible fake on
+    ``http_client.stream`` that delegates to ``fake_post``, preserving
+    call-count side effects, raised exceptions, and returned responses.
+
+    For ``MagicMock`` responses lacking real ``aiter_bytes`` plumbing,
+    the helper re-wraps them into a real :class:`httpx.Response` carrying
+    the canned text so the streaming wrapper's ``aiter_bytes`` + rebuild
+    path works on it. Real :class:`httpx.Response` instances are passed
+    through unchanged.
+    """
+
+    @asynccontextmanager
+    async def fake_stream(method: str, url: str, **kwargs: Any) -> Any:
+        # ``fake_post`` historically takes ``(url, **kwargs)`` — match that
+        # call site exactly so existing argument-introspection in tests keeps
+        # working unchanged.
+        response = await fake_post(url, **kwargs)
+        # ``type(...) is`` — not ``isinstance(...)`` — because ``MagicMock(
+        # spec=httpx.Response)`` passes the isinstance check, which would
+        # leave the streaming wrapper trying to read ``response.headers`` and
+        # other spec-enforced attributes the test never set, raising
+        # ``AttributeError`` deep inside production code instead of going
+        # through the friendly rewrap branch below.
+        if type(response) is httpx.Response:
+            yield response
+            return
+
+        # Non-``httpx.Response`` (MagicMock-style): re-wrap into a real
+        # :class:`httpx.Response` carrying the canned text so the streaming
+        # wrapper's ``aiter_bytes`` + rebuild path works on it.
+        text = getattr(response, "text", "")
+        payload = text.encode("utf-8") if isinstance(text, str) else bytes(text or b"")
+        raw_status = getattr(response, "status_code", 200)
+        # MagicMock auto-mocks attributes, so ``status_code`` might be a Mock
+        # whose ``__int__`` returns 1. Only treat real ints as set; otherwise
+        # default to 200 (the canonical "no error" status the success-path
+        # tests are implicitly asserting against).
+        status = raw_status if isinstance(raw_status, int) else 200
+        try:
+            raw_headers = getattr(response, "headers", None)
+        except AttributeError:
+            raw_headers = None
+        try:
+            headers = dict(raw_headers) if raw_headers else None
+        except (TypeError, AttributeError):
+            headers = None
+        wrapped = httpx.Response(
+            status_code=status,
+            headers=headers,
+            content=payload,
+            request=httpx.Request("POST", url),
+        )
+        yield wrapped
+
+    if monkeypatch is not None:
+        monkeypatch.setattr(http_client, "stream", fake_stream)
+    else:
+        http_client.stream = fake_stream

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -32,6 +32,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from _streaming_mock import install_post_as_stream
 
 from notebooklm import NotebookLMClient, RateLimitError
 from notebooklm.rpc import RPCMethod
@@ -89,6 +90,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
@@ -118,6 +120,7 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
@@ -157,6 +160,7 @@ async def test_default_retries_use_exponential_backoff_when_header_missing(
     client = NotebookLMClient(auth_tokens)
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     sleep_calls: list[float] = []
@@ -205,6 +209,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
+    install_post_as_stream(None, mock_http, mock_post)
     client._core._http_client = mock_http
 
     def _build_request(_snap):

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from _streaming_mock import install_post_as_stream
 
 from notebooklm import NotebookLMClient
 from notebooklm.auth import AuthTokens
@@ -78,6 +79,7 @@ class TestAutoRefreshIntegration:
 
         async with client:
             client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             with patch("notebooklm._core.decode_response") as mock_decode:
                 mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
@@ -125,6 +127,7 @@ class TestAutoRefreshIntegration:
 
         async with client:
             client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             with patch("notebooklm._core.decode_response", side_effect=mock_decode):
                 await client.notebooks.list()
@@ -164,6 +167,7 @@ class TestAutoRefreshIntegration:
 
         async with client:
             client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             start_time = asyncio.get_event_loop().time()
 
@@ -200,6 +204,7 @@ class TestAutoRefreshIntegration:
 
         async with client:
             client._core._http_client.post = mock_post
+            install_post_as_stream(None, client._core._http_client, mock_post)
 
             # Should raise the original HTTP error with refresh failure as cause
             with pytest.raises(httpx.HTTPStatusError) as exc_info:

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from _streaming_mock import install_post_as_stream
 
 from notebooklm import AuthTokens, NotebookLMClient
 from notebooklm._core import MAX_CONVERSATION_CACHE_SIZE, ClientCore, is_auth_error
@@ -149,6 +150,7 @@ class TestRPCCallHTTPErrors:
                 patch.object(core._http_client, "post", side_effect=error),
                 pytest.raises(RateLimitError) as exc_info,
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
             assert exc_info.value.retry_after == 60
 
@@ -169,6 +171,7 @@ class TestRPCCallHTTPErrors:
                 patch.object(core._http_client, "post", side_effect=error),
                 pytest.raises(RateLimitError) as exc_info,
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
             assert exc_info.value.retry_after is None
 
@@ -189,6 +192,7 @@ class TestRPCCallHTTPErrors:
                 patch.object(core._http_client, "post", side_effect=error),
                 pytest.raises(RateLimitError) as exc_info,
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
             assert exc_info.value.retry_after is None
 
@@ -212,6 +216,7 @@ class TestRPCCallHTTPErrors:
                 patch.object(core._http_client, "post", side_effect=error),
                 pytest.raises(ClientError),
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -230,6 +235,7 @@ class TestRPCCallHTTPErrors:
                 patch.object(core._http_client, "post", side_effect=error),
                 pytest.raises(ServerError),
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -262,6 +268,7 @@ class TestRPCCallHTTPErrors:
                 ),
                 pytest.raises(RPCTimeoutError),
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     @pytest.mark.asyncio
@@ -323,6 +330,7 @@ class TestRPCCallAuthRetry:
                     ],
                 ),
             ):
+                install_post_as_stream(None, core._http_client, core._http_client.post)
                 result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
             assert result == ["result_data"]


### PR DESCRIPTION
## Summary

Main is currently red on 15 integration tests after #751 merged. PR #749 (and presumably every other in-flight PR) inherits the breakage on every CI run.

#751 switched the RPC POST path from \`client.post(...)\` to \`client.stream(\"POST\", ...)\` so the new \`MAX_RPC_RESPONSE_BYTES\` size guard could fire chunk-by-chunk. The companion \`install_post_as_stream\` adapter was wired into \`tests/unit/conftest.py\` only — 15 integration tests under \`tests/integration/\` still mock \`http_client.post\` and surface as two distinct symptoms:

- **11 tests** in \`test_auto_refresh.py\` / \`test_core.py\`: \`Error -3 while decompressing data: incorrect header check\` — the legacy \`http_client.post\` mock never fires, \`client.stream()\` falls through to a default response with a mismatched content-encoding header.
- **4 tests** in \`concurrency/test_rate_limit_default.py\`: \`TypeError: 'async for' requires an object with __aiter__ method, got coroutine\` — \`AsyncMock(spec=httpx.AsyncClient).stream(...)\` returns a coroutine, not an async context manager.

Confirmed identical 15-test failure cluster on main HEAD (\`c5d1ce3c\`, Test run \`25988127281\`) and on PR #749's latest commit. No production code changes — pure test-side adaptation matching the unit-tree pattern #751 already introduced.

## Changes

- New \`tests/integration/_streaming_mock.py\` exposing the same \`install_post_as_stream\` helper as \`tests/unit/conftest.py\`. Lives as a sibling of \`conftest.py\` rather than inside it so \`tests/integration/concurrency/\` (which has its own \`conftest.py\`) can also import it via \`tests/integration/\` already being on \`sys.path\`.
- Each of the 15 failing tests calls \`install_post_as_stream(None, http_client, fake_post)\` immediately after wiring up \`http_client.post\` so the streaming wrapper sees the same mocked behavior.

## Test plan

- [x] Targeted: \`pytest tests/integration/test_core.py tests/integration/test_auto_refresh.py tests/integration/concurrency/test_rate_limit_default.py\` → **58 passed** (was 15 failed before).
- [x] Full suite: \`pytest\` → **4809 passed, 12 skipped, 0 failed** (was 4794 passed, 15 failed).
- [x] \`ruff format\`, \`ruff check\`, \`mypy src/notebooklm --ignore-missing-imports\` all clean.
- [ ] CI matrix should now go fully green; rebase / re-run PR #749 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test infrastructure to properly support streaming HTTP client mocking, ensuring consistent behavior validation across rate-limiting, token refresh, and RPC call scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->