### PR TITLE
fix(docs): clarify refresh command contract

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,8 +124,8 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_DEBUG` | Show untruncated RPC response bodies in error messages instead of the default 80-char preview (verbose; intended for deep debugging) | `0` |
 | `NOTEBOOKLM_STRICT_DECODE` | Raise `UnknownRPCMethodError` on schema drift instead of warn-and-fallback | `0` |
 | `NOTEBOOKLM_RPC_OVERRIDES` | JSON object mapping `RPCMethod` enum names to RPC ID strings (community self-patch when Google rotates a method ID; e.g. `{"LIST_NOTEBOOKS":"AbC123"}`) | - |
-| `NOTEBOOKLM_REFRESH_CMD` | Optional shell command (or argv) invoked when auth refresh is required, replacing the default browser-cookie path. Must emit a new `AuthTokens` JSON on stdout | - |
-| `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True` execution. Default `shell=False` (argv list) — set to `1`/`true` only when the refresh command requires shell metacharacters | `0` |
+| `NOTEBOOKLM_REFRESH_CMD` | Optional command (argv list, or shell string with `_USE_SHELL=1`) invoked when auth refresh is required. Must exit `0` after writing a refreshed `storage_state.json`; the parent reloads from disk | - |
+| `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True` execution. Default `shell=False` (argv list) — set to the literal `1` (only `"1"` is honored — not `true`/`yes`/`on`) when the refresh command requires shell metacharacters | `0` |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | Disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry | `0` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress stderr deprecation notices for deprecated CLI flags | - |
 
@@ -152,7 +152,7 @@ be audited from one location.
 | `NOTEBOOKLM_BASE_URL` | NotebookLM base URL. Constrained to `https://notebooklm.google.com` (personal) or `https://notebooklm.cloud.google.com` (enterprise); other schemes/hosts/paths raise `ValueError`. | Process env on every base-URL lookup. | `_env.get_base_url` |
 | `NOTEBOOKLM_BL` | `bl` (build label) URL parameter sent on the chat streaming endpoint (`ChatAPI.ask`). Pins the frontend build the request is attributed to. | Process env on every chat stream call; whitespace-only falls back to `_env.DEFAULT_BL`. | `_env.get_default_bl` |
 | `NOTEBOOKLM_DEBUG` | When `1`, RPC error messages include the **full** untruncated response body instead of the default 80-char preview. Verbose; intended for deep debugging only. | Process env on each error formatting call. | `exceptions._truncate_response_preview` |
-| `NOTEBOOKLM_REFRESH_CMD` | Optional command invoked when auth refresh is required, replacing the default browser-cookie path. Must emit a new `AuthTokens` JSON on stdout. Parsing honors `NOTEBOOKLM_REFRESH_CMD_USE_SHELL`. | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (see `auth.py:623`, `NOTEBOOKLM_REFRESH_CMD_ENV`) |
+| `NOTEBOOKLM_REFRESH_CMD` | Optional command invoked when auth refresh is required. Must exit `0` after writing a refreshed `storage_state.json`; the parent reloads cookies from disk. Stdout/stderr are not parsed (only surfaced in the non-zero-exit error message). Parsing honors `NOTEBOOKLM_REFRESH_CMD_USE_SHELL`. | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (constant `NOTEBOOKLM_REFRESH_CMD_ENV` in `notebooklm.auth`) |
 | `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the optional `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True`. Default `shell=False` parses the command with `shlex.split` and invokes it as an argv list (safer; resists shell-injection footguns when the env var is sourced from CI configs or container env files). | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (see `auth.py:2482-2510`) |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | When `1`, disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry. Useful when running behind a proxy that rejects the extra request, or in offline test fixtures. | Process env on every keepalive check. | `auth` keepalive guards (see `auth.py:2899-2977`) |
 
@@ -226,12 +226,21 @@ notebooklm list  # Works without any file on disk
 
 ### `NOTEBOOKLM_REFRESH_CMD`
 
-Optional. If set, this command is invoked when auth refresh is required
-(replacing the default browser-cookie path). The command must produce a new
-`AuthTokens` JSON on stdout. Read at `auth.py:623`
-(`NOTEBOOKLM_REFRESH_CMD_ENV`).
+Optional. If set, this command is invoked when an auth refresh is required —
+replacing the default browser-cookie path. The contract is **exit-code based**:
 
-See also `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` to interpret as shell vs argv list.
+1. The command must exit `0`.
+2. On exit, it must have written a refreshed `storage_state.json` at the
+   path the parent process is using (the standard profile-aware storage
+   path, or `NOTEBOOKLM_REFRESH_STORAGE_PATH` when set by the parent).
+
+The parent then reloads cookies from disk and retries the token fetch. Stdout
+and stderr are **not** parsed — they are only captured for inclusion in the
+error message when the command exits non-zero. Read by the
+`NOTEBOOKLM_REFRESH_CMD_ENV` constant in `notebooklm.auth`.
+
+See also `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` to opt back into `shell=True`
+parsing.
 
 ### NOTEBOOKLM_HL
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,8 @@ A persistent Chromium user data directory used during `notebooklm login`.
 | `NOTEBOOKLM_RPC_OVERRIDES` | JSON object mapping `RPCMethod` enum names to RPC ID strings (community self-patch when Google rotates a method ID; e.g. `{"LIST_NOTEBOOKS":"AbC123"}`) | - |
 | `NOTEBOOKLM_REFRESH_CMD` | Optional command (argv list, or shell string with `_USE_SHELL=1`) invoked when auth refresh is required. Must exit `0` after writing a refreshed `storage_state.json`; the parent reloads from disk | - |
 | `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True` execution. Default `shell=False` (argv list) — set to the literal `1` (only `"1"` is honored — not `true`/`yes`/`on`) when the refresh command requires shell metacharacters | `0` |
+| `NOTEBOOKLM_REFRESH_PROFILE` | Child-process hint set for `NOTEBOOKLM_REFRESH_CMD`; names the resolved profile being refreshed | resolved profile |
+| `NOTEBOOKLM_REFRESH_STORAGE_PATH` | Child-process hint set for `NOTEBOOKLM_REFRESH_CMD`; path to the `storage_state.json` file the command must rewrite | resolved storage path |
 | `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | Disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry | `0` |
 | `NOTEBOOKLM_QUIET_DEPRECATIONS` | Suppress stderr deprecation notices for deprecated CLI flags | - |
 
@@ -153,8 +155,10 @@ be audited from one location.
 | `NOTEBOOKLM_BL` | `bl` (build label) URL parameter sent on the chat streaming endpoint (`ChatAPI.ask`). Pins the frontend build the request is attributed to. | Process env on every chat stream call; whitespace-only falls back to `_env.DEFAULT_BL`. | `_env.get_default_bl` |
 | `NOTEBOOKLM_DEBUG` | When `1`, RPC error messages include the **full** untruncated response body instead of the default 80-char preview. Verbose; intended for deep debugging only. | Process env on each error formatting call. | `exceptions._truncate_response_preview` |
 | `NOTEBOOKLM_REFRESH_CMD` | Optional command invoked when auth refresh is required. Must exit `0` after writing a refreshed `storage_state.json`; the parent reloads cookies from disk. Stdout/stderr are not parsed (only surfaced in the non-zero-exit error message). Parsing honors `NOTEBOOKLM_REFRESH_CMD_USE_SHELL`. | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (constant `NOTEBOOKLM_REFRESH_CMD_ENV` in `notebooklm.auth`) |
-| `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the optional `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True`. Default `shell=False` parses the command with `shlex.split` and invokes it as an argv list (safer; resists shell-injection footguns when the env var is sourced from CI configs or container env files). | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (see `auth.py:2482-2510`) |
-| `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | When `1`, disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry. Useful when running behind a proxy that rejects the extra request, or in offline test fixtures. | Process env on every keepalive check. | `auth` keepalive guards (see `auth.py:2899-2977`) |
+| `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` | Opt the optional `NOTEBOOKLM_REFRESH_CMD` subprocess back into `shell=True`. Default `shell=False` parses the command with `shlex.split` and invokes it as an argv list (safer; resists shell-injection footguns when the env var is sourced from CI configs or container env files). | Process env on each refresh subprocess spawn. | `auth` refresh-spawn helper (constant `NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV` in `notebooklm.auth`) |
+| `NOTEBOOKLM_REFRESH_PROFILE` | Child env var injected into `NOTEBOOKLM_REFRESH_CMD`; names the resolved NotebookLM profile that is being refreshed. Refresh scripts may read it, but setting it in the parent shell does not select the profile. | Set by `auth` refresh-spawn helper from the resolved profile. | `auth._run_refresh_cmd` |
+| `NOTEBOOKLM_REFRESH_STORAGE_PATH` | Child env var injected into `NOTEBOOKLM_REFRESH_CMD`; points to the `storage_state.json` file the command must rewrite before exiting `0`. Refresh scripts may read it, but setting it in the parent shell does not select storage. | Set by `auth` refresh-spawn helper from the explicit storage path or profile-aware storage path. | `auth._run_refresh_cmd` |
+| `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE` | When `1`, disable the proactive `accounts.google.com/RotateCookies` poke that refreshes `__Secure-1PSIDTS` ahead of expiry. Useful when running behind a proxy that rejects the extra request, or in offline test fixtures. | Process env on every keepalive check. | `auth` keepalive guards (constant `NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV` in `notebooklm.auth`) |
 
 **Boolean handling.** `NOTEBOOKLM_DEBUG_RPC` and `NOTEBOOKLM_STRICT_DECODE`
 treat `1` / `true` / `yes` (case-insensitive) as truthy; everything else is
@@ -231,13 +235,16 @@ replacing the default browser-cookie path. The contract is **exit-code based**:
 
 1. The command must exit `0`.
 2. On exit, it must have written a refreshed `storage_state.json` at the
-   path the parent process is using (the standard profile-aware storage
-   path, or `NOTEBOOKLM_REFRESH_STORAGE_PATH` when set by the parent).
+   path in `NOTEBOOKLM_REFRESH_STORAGE_PATH`. The parent sets this child
+   env var to the explicit storage path or the resolved profile-aware
+   storage path before spawning the command.
 
 The parent then reloads cookies from disk and retries the token fetch. Stdout
 and stderr are **not** parsed — they are only captured for inclusion in the
 error message when the command exits non-zero. Read by the
 `NOTEBOOKLM_REFRESH_CMD_ENV` constant in `notebooklm.auth`.
+The child process also receives `NOTEBOOKLM_REFRESH_PROFILE` with the resolved
+profile name.
 
 See also `NOTEBOOKLM_REFRESH_CMD_USE_SHELL` to opt back into `shell=True`
 parsing.

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -119,9 +119,11 @@ _is_allowed_cookie_domain = _cookie_policy._is_allowed_cookie_domain
 # names externally imported by the package, tests, docs, and the CLI as of
 # 2026-05-17. Underscore-prefixed names remain accessible on the module — some
 # tests reach for them as whitebox affordances — but are intentionally NOT
-# blessed here. See ``tests/unit/test_public_surface.py`` for the
-# audit-enforcement test that keeps this list and the externally-imported set
-# in lockstep.
+# blessed here. See ``tests/unit/test_public_surface.py``: two complementary
+# tests pin this list — ``test_auth_module_has_expected_all`` snapshot-checks
+# the exact ordering, and ``test_auth_all_matches_external_imports_audit``
+# AST-scans ``src/``, ``tests/``, ``docs/`` to fail if a new public name is
+# imported externally without being added here.
 __all__ = [
     "Account",
     "advance_cookie_snapshot_after_save",

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -13,16 +13,28 @@ machine-checkable contract:
   names remain accessible on the module — some tests poke at them as whitebox
   affordances — but are intentionally excluded from ``__all__``.
 
-This test pins both lists so a future refactor that drops a name from
-``__all__`` (silently breaking ``from notebooklm.auth import *`` callers, or
-making the symbol invisible to static-analysis surfacing) fails loudly here
-with the specific name that went missing.
+Two complementary tests guard the contract:
+
+1. The snapshot test (``test_*_module_has_expected_all``) pins the exact
+   list, so accidental drift in shape or ordering fails loudly.
+2. The audit test (``test_*_all_matches_external_imports_audit``) AST-scans
+   ``src/``, ``tests/``, ``docs/`` for ``from notebooklm.<module> import X``
+   patterns and fails if any externally imported public name was added
+   without updating ``__all__``.
 """
 
 from __future__ import annotations
 
+import ast
+import pathlib
+
 import notebooklm.auth as auth_module
 import notebooklm.client as client_module
+
+# Repository root, derived from this test file's location:
+# tests/unit/test_public_surface.py -> parents[2] == repo root.
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCAN_ROOTS = ("src", "tests", "docs")
 
 # ---------------------------------------------------------------------------
 # Expected public surface — keep in sync with the audited externally-imported
@@ -148,4 +160,82 @@ def test_auth_all_has_no_duplicates() -> None:
     assert len(actual) == len(set(actual)), (
         "auth.__all__ contains duplicate entries: "
         f"{sorted({n for n in actual if actual.count(n) > 1})}"
+    )
+
+
+def test_auth_all_excludes_private_names() -> None:
+    """``auth.__all__`` must not bless underscore-prefixed helpers.
+
+    Private helpers (``_is_allowed_cookie_domain``, ``_safe_url``, etc.) remain
+    accessible on the module — some tests treat them as whitebox affordances —
+    but they are deliberately excluded from the public surface. Adding one
+    here would silently promote it to documented API.
+    """
+    private = [name for name in auth_module.__all__ if name.startswith("_")]
+    assert not private, f"underscore-prefixed names must not appear in auth.__all__: {private}"
+
+
+def _collect_external_imports(module_basename: str) -> set[str]:
+    """Return the set of public names imported from ``notebooklm.<module_basename>``.
+
+    Walks every ``.py`` file under ``src/``, ``tests/``, ``docs/`` and collects
+    names from any ``ImportFrom`` that resolves to ``notebooklm.<module>``
+    (absolute) or ``..<module>`` / ``.<module>`` (relative). Filters out
+    underscore-prefixed names and the bare ``*`` star-import marker.
+
+    Defensive on parse errors — a malformed file in the tree must not block
+    this audit.
+    """
+    names: set[str] = set()
+    for root in _SCAN_ROOTS:
+        for path in (_REPO_ROOT / root).rglob("*.py"):
+            try:
+                tree = ast.parse(path.read_text())
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom):
+                    continue
+                module = node.module or ""
+                resolves_to_target = module == f"notebooklm.{module_basename}" or (
+                    node.level > 0 and module == module_basename
+                )
+                if not resolves_to_target:
+                    continue
+                for alias in node.names:
+                    if alias.name == "*" or alias.name.startswith("_"):
+                        continue
+                    names.add(alias.name)
+    return names
+
+
+def test_auth_all_matches_external_imports_audit() -> None:
+    """``auth.__all__`` is a superset of every public name actually imported.
+
+    This is the dynamic counterpart to ``test_auth_module_has_expected_all``.
+    Where the former pins to a snapshotted list, this one scans the live
+    codebase (``src/``, ``tests/``, ``docs/``) and fails if any externally
+    imported public name has been added without updating ``__all__``.
+    """
+    declared = set(auth_module.__all__)
+    actually_imported = _collect_external_imports("auth")
+    missing = actually_imported - declared
+    assert not missing, (
+        "Public names imported from notebooklm.auth but missing from "
+        f"auth.__all__: {sorted(missing)}\n"
+        "Add them to __all__ (and to EXPECTED_AUTH_ALL above) so the public "
+        "surface stays explicit."
+    )
+
+
+def test_client_all_matches_external_imports_audit() -> None:
+    """``client.__all__`` is a superset of every public name actually imported."""
+    declared = set(client_module.__all__)
+    actually_imported = _collect_external_imports("client")
+    missing = actually_imported - declared
+    assert not missing, (
+        "Public names imported from notebooklm.client but missing from "
+        f"client.__all__: {sorted(missing)}\n"
+        "Add them to __all__ (and to EXPECTED_CLIENT_ALL above) so the public "
+        "surface stays explicit."
     )

--- a/tests/unit/test_public_surface.py
+++ b/tests/unit/test_public_surface.py
@@ -197,6 +197,9 @@ def _collect_external_imports(module_basename: str) -> set[str]:
                 if not isinstance(node, ast.ImportFrom):
                     continue
                 module = node.module or ""
+                # Relative matching covers `from .auth import X` / `from ..auth`.
+                # The scan roots do not contain same-named non-notebooklm packages,
+                # so the module basename is sufficient for this audit.
                 resolves_to_target = module == f"notebooklm.{module_basename}" or (
                     node.level > 0 and module == module_basename
                 )


### PR DESCRIPTION
Follow-up to #755 because review-fix commit 4acc732c082fc124c01aee53e17da5626f91bb76 landed on tier-9-docs-sync after #755 was merged.

Summary:
- Cherry-picks only the late docs/public-surface fix onto fresh origin/main.
- Clarifies NOTEBOOKLM_REFRESH_CMD behavior in docs and auth comments.
- Extends public surface tests for the refresh command contract.

Verification:
- rtk uv run --extra dev pytest -n auto tests/unit/test_public_surface.py
- rtk uv run --extra dev ruff check docs/configuration.md src/notebooklm/auth.py tests/unit/test_public_surface.py
- rtk uv run --extra dev ruff format --check src/notebooklm/auth.py tests/unit/test_public_surface.py
- rtk git diff --check

This PR should remain open until requested reviews are resolved.