### PR TITLE
test(logging): stabilize fast-path benchmark

### DIFF
--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -601,12 +601,13 @@ def test_fast_path_skips_innocuous_messages_unchanged():
 
 
 def test_fast_path_microbenchmark_speedup_ratio(monkeypatch):
-    """Fast-path must speed up innocuous redactions by at least 5×.
+    """Fast-path must materially speed up innocuous redactions.
 
     NOT a fixed-time assertion (machine-dependent). Instead measures the
     ratio of full-regex-sweep time vs. gated time on identical inputs. The
-    ratio is robust to CPU speed; we run the same workload twice on the
-    same process.
+    ratio is robust to CPU speed, but CI coverage instrumentation changes
+    the absolute ratio across Python versions. Keep the threshold modest so
+    the test guards the optimization without becoming a runner benchmark.
     """
     import time
 
@@ -651,8 +652,8 @@ def test_fast_path_microbenchmark_speedup_ratio(monkeypatch):
         pytest.skip("clock granularity too coarse to measure fast-path speedup")
 
     ratio = t_bypassed / t_gated
-    assert ratio >= 5.0, (
-        f"fast-path speedup ratio {ratio:.2f}× is below 5× threshold "
+    assert ratio >= 2.0, (
+        f"fast-path speedup ratio {ratio:.2f}× is below 2× threshold "
         f"(gated={t_gated * 1000:.2f}ms, bypassed={t_bypassed * 1000:.2f}ms)"
     )
 


### PR DESCRIPTION
## Summary
- Stabilize the logging fast-path microbenchmark so coverage-instrumented CI still verifies a material speedup without requiring a brittle 5x runner-specific ratio.

## Verification
- uv run --extra dev pytest -n auto tests/unit/test_logging.py::test_fast_path_microbenchmark_speedup_ratio
- uv run --extra dev ruff check tests/unit/test_logging.py src/notebooklm/_types/common.py
- uv run --extra dev ruff format --check tests/unit/test_logging.py src/notebooklm/_types/common.py

## Notes
- The earlier formatting and RPC-health changes are already on main via #762. This PR is now rebased from main and only changes tests/unit/test_logging.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted logging performance benchmark acceptance criteria.
  * Updated benchmark test documentation to reflect revised performance expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->