### PR TITLE
test(types): guard private type boundaries

### DIFF
--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -59,9 +59,7 @@ def _cli_private_types_import_offenders(path: Path) -> list[str]:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name == "notebooklm._types" or alias.name.startswith(
-                    "notebooklm._types."
-                ):
+                if alias.name == "notebooklm._types" or alias.name.startswith("notebooklm._types."):
                     offenders.append(f"line {node.lineno}: {_import_statement_text(node)}")
             continue
 
@@ -81,7 +79,11 @@ def _cli_private_types_import_offenders(path: Path) -> list[str]:
             or (not module_parts and any(alias.name == "_types" for alias in node.names))
         )
 
-        if is_absolute_private_types or is_from_notebooklm_import_types or is_relative_private_types:
+        if (
+            is_absolute_private_types
+            or is_from_notebooklm_import_types
+            or is_relative_private_types
+        ):
             offenders.append(f"line {node.lineno}: {_import_statement_text(node)}")
 
     return offenders

--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -1,0 +1,293 @@
+"""Guardrails for the private ``notebooklm._types`` implementation boundary."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import os
+import pkgutil
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = PROJECT_ROOT / "src" / "notebooklm"
+TYPES_PATH = SRC_ROOT / "types.py"
+PRIVATE_TYPES_ROOT = SRC_ROOT / "_types"
+CLI_ROOT = SRC_ROOT / "cli"
+PUBLIC_DOC_ROOTS = (PROJECT_ROOT / "README.md", PROJECT_ROOT / "docs")
+
+ALLOWED_TYPES_WRAPPER_BODIES = {"_datetime_from_timestamp"}
+PRIVATE_TYPES_IMPORT_RE = re.compile(
+    r"\b(?:from\s+notebooklm(?:\._types|\s+import\s+_types)\b|import\s+notebooklm\._types\b)"
+)
+
+
+def _iter_private_type_module_names() -> list[str]:
+    """Return importable private type implementation modules that have landed."""
+    import notebooklm._types as private_types
+
+    return sorted(
+        module_info.name
+        for module_info in pkgutil.iter_modules(private_types.__path__)
+        if not module_info.ispkg
+    )
+
+
+def _private_type_module_qualname(module_name: str) -> str:
+    return f"notebooklm._types.{module_name}"
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    return sorted(path for path in root.rglob("*.py") if "__pycache__" not in path.parts)
+
+
+def _import_statement_text(node: ast.Import | ast.ImportFrom) -> str:
+    return ast.unparse(node)
+
+
+def _cli_private_types_import_offenders(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    relative_parts = path.relative_to(CLI_ROOT).parts
+    cli_package_level = len(relative_parts)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "notebooklm._types" or alias.name.startswith(
+                    "notebooklm._types."
+                ):
+                    offenders.append(f"line {node.lineno}: {_import_statement_text(node)}")
+            continue
+
+        if not isinstance(node, ast.ImportFrom):
+            continue
+
+        module = node.module or ""
+        module_parts = module.split(".") if module else []
+        is_absolute_private_types = module_parts[:2] == ["notebooklm", "_types"]
+        is_from_notebooklm_import_types = (
+            node.level == 0
+            and module_parts == ["notebooklm"]
+            and any(alias.name == "_types" for alias in node.names)
+        )
+        is_relative_private_types = node.level > cli_package_level and (
+            module_parts[:1] == ["_types"]
+            or (not module_parts and any(alias.name == "_types" for alias in node.names))
+        )
+
+        if is_absolute_private_types or is_from_notebooklm_import_types or is_relative_private_types:
+            offenders.append(f"line {node.lineno}: {_import_statement_text(node)}")
+
+    return offenders
+
+
+def _iter_public_docs() -> list[Path]:
+    docs: list[Path] = []
+    for root in PUBLIC_DOC_ROOTS:
+        if root.is_file():
+            docs.append(root)
+        elif root.is_dir():
+            docs.extend(root.rglob("*.md"))
+    return sorted(docs)
+
+
+def _public_docs_private_type_import_offenders() -> list[str]:
+    offenders: list[str] = []
+    for path in _iter_public_docs():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if PRIVATE_TYPES_IMPORT_RE.search(line):
+                relative = path.relative_to(PROJECT_ROOT)
+                offenders.append(f"{relative}:{lineno}: {line.strip()}")
+    return offenders
+
+
+def _top_level_name(target: ast.expr) -> str | None:
+    return target.id if isinstance(target, ast.Name) else None
+
+
+def _assignment_target_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
+    if isinstance(node, ast.AnnAssign):
+        name = _top_level_name(node.target)
+        return [name] if name else []
+    return [name for target in node.targets if (name := _top_level_name(target))]
+
+
+def _module_attribute_alias(value: ast.AST | None, target_name: str) -> bool:
+    """Return True for compatibility aliases like ``_safe = _source_types._safe``."""
+    return (
+        isinstance(value, ast.Attribute)
+        and value.attr == target_name
+        and isinstance(value.value, ast.Name)
+        and value.value.id.startswith("_")
+        and value.value.id.endswith("_types")
+    )
+
+
+def _private_type_module_symbols() -> tuple[set[str], set[str]]:
+    public_type_names: set[str] = set()
+    private_helper_names: set[str] = set()
+
+    for path in sorted(PRIVATE_TYPES_ROOT.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+                public_type_names.add(node.name)
+            elif isinstance(node, ast.FunctionDef) and node.name.startswith("_"):
+                private_helper_names.add(node.name)
+            elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+                for name in _assignment_target_names(node):
+                    if name.startswith("_") and not name.startswith("__"):
+                        private_helper_names.add(name)
+
+    return public_type_names, private_helper_names
+
+
+def _types_facade_body_offenders() -> list[str]:
+    public_type_names, private_helper_names = _private_type_module_symbols()
+    tree = ast.parse(TYPES_PATH.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name in public_type_names:
+            offenders.append(f"{node.name} (ClassDef line {node.lineno})")
+            continue
+
+        if isinstance(node, ast.FunctionDef) and node.name in private_helper_names:
+            if node.name not in ALLOWED_TYPES_WRAPPER_BODIES:
+                offenders.append(f"{node.name} (FunctionDef line {node.lineno})")
+            continue
+
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            target_names = _assignment_target_names(node)
+            for name in target_names:
+                if name not in private_helper_names:
+                    continue
+                if _module_attribute_alias(node.value, name):
+                    continue
+                offenders.append(f"{name} ({type(node).__name__} line {node.lineno})")
+
+    return sorted(offenders)
+
+
+def _types_all_names() -> list[str]:
+    tree = ast.parse(TYPES_PATH.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets):
+            value = ast.literal_eval(node.value)
+            assert isinstance(value, list)
+            return [str(item) for item in value]
+    raise AssertionError("notebooklm.types.__all__ assignment not found")
+
+
+@pytest.mark.parametrize("module_name", _iter_private_type_module_names())
+def test_private_type_modules_import_directly(module_name: str) -> None:
+    """Each landed ``_types`` module is independently importable."""
+    module = importlib.import_module(_private_type_module_qualname(module_name))
+
+    assert isinstance(module, ModuleType)
+
+
+def test_private_type_modules_import_directly_in_clean_interpreter() -> None:
+    """Smoke test the landed private type modules from a fresh import graph."""
+    module_names = [
+        _private_type_module_qualname(module_name)
+        for module_name in _iter_private_type_module_names()
+    ]
+    code = "\n".join(
+        [
+            "import importlib",
+            f"modules = {module_names!r}",
+            "for module in modules:",
+            "    importlib.import_module(module)",
+        ]
+    )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        f"{PROJECT_ROOT / 'src'}{os.pathsep}{env['PYTHONPATH']}"
+        if env.get("PYTHONPATH")
+        else str(PROJECT_ROOT / "src")
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=PROJECT_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_types_facade_identity_reexports_for_landed_private_types() -> None:
+    """``notebooklm.types`` must return the canonical objects from landed modules."""
+    import notebooklm.types as public_types
+
+    public_type_names, _ = _private_type_module_symbols()
+    checked: list[str] = []
+    for module_name in _iter_private_type_module_names():
+        module = importlib.import_module(_private_type_module_qualname(module_name))
+        for name in sorted(public_type_names):
+            if not hasattr(module, name):
+                continue
+            assert getattr(public_types, name) is getattr(module, name), (
+                f"notebooklm.types.{name} must be an identity re-export from "
+                f"{module.__name__}.{name}"
+            )
+            checked.append(f"{module.__name__}.{name}")
+
+    assert checked, "No landed private type identities were checked"
+
+
+def test_types_all_does_not_export_private_helper_names() -> None:
+    """The public ``types.__all__`` surface must not expose compatibility seams."""
+    private_exports = [name for name in _types_all_names() if name.startswith("_")]
+
+    assert private_exports == []
+
+
+def test_types_facade_has_no_landed_implementation_bodies() -> None:
+    """Landed boundaries live in ``_types``; ``types.py`` keeps only facade aliases."""
+    offenders = _types_facade_body_offenders()
+
+    assert not offenders, (
+        "notebooklm.types regained implementation bodies for landed _types symbols. "
+        "Move implementations back to their private modules, or add only an explicit "
+        f"compatibility wrapper. Offending AST node names: {offenders}"
+    )
+
+
+def test_cli_modules_do_not_import_private_type_modules() -> None:
+    """CLI code consumes type objects through ``notebooklm.types`` only."""
+    offenders: list[str] = []
+    for path in _iter_python_files(CLI_ROOT):
+        path_offenders = _cli_private_types_import_offenders(path)
+        offenders.extend(
+            f"{path.relative_to(PROJECT_ROOT)}: {offender}" for offender in path_offenders
+        )
+
+    assert offenders == [], (
+        "CLI modules must not import notebooklm._types directly; use notebooklm.types. "
+        f"Offenders: {offenders}"
+    )
+
+
+def test_public_docs_do_not_recommend_private_type_imports() -> None:
+    """User-facing docs should never present ``notebooklm._types`` as an import path."""
+    offenders = _public_docs_private_type_import_offenders()
+
+    assert offenders == [], (
+        "Public docs must document notebooklm.types, not private notebooklm._types imports. "
+        f"Offenders: {offenders}"
+    )

--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -21,6 +21,8 @@ PRIVATE_TYPES_ROOT = SRC_ROOT / "_types"
 CLI_ROOT = SRC_ROOT / "cli"
 PUBLIC_DOC_ROOTS = (PROJECT_ROOT / "README.md", PROJECT_ROOT / "docs")
 
+# Add names here only for explicit facade wrappers that must keep a public
+# monkeypatch seam while delegating implementation to a private _types module.
 ALLOWED_TYPES_WRAPPER_BODIES = {"_datetime_from_timestamp"}
 PRIVATE_TYPES_IMPORT_RE = re.compile(
     r"\b(?:from\s+notebooklm(?:\._types(?:\.\w+)*|\s+import\s+_types)\b"
@@ -73,6 +75,9 @@ def _cli_private_types_import_offenders(path: Path) -> list[str]:
             and module_parts == ["notebooklm"]
             and any(alias.name == "_types" for alias in node.names)
         )
+        # A root CLI module needs ``..`` to reach notebooklm; a nested CLI module
+        # needs one more dot per package segment, so only levels above this depth
+        # can resolve to notebooklm._types rather than a hypothetical cli._types.
         is_relative_private_types = node.level > cli_package_level and (
             module_parts[:1] == ["_types"]
             or (not module_parts and any(alias.name == "_types" for alias in node.names))
@@ -207,7 +212,8 @@ def _types_all_names() -> list[str]:
             continue
         if any(isinstance(target, ast.Name) and target.id == "__all__" for target in node.targets):
             value = ast.literal_eval(node.value)
-            assert isinstance(value, list)
+            if not isinstance(value, list):
+                raise AssertionError("notebooklm.types.__all__ must be assigned a list literal")
             return [str(item) for item in value]
     raise AssertionError("notebooklm.types.__all__ assignment not found")
 

--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -23,18 +23,17 @@ PUBLIC_DOC_ROOTS = (PROJECT_ROOT / "README.md", PROJECT_ROOT / "docs")
 
 ALLOWED_TYPES_WRAPPER_BODIES = {"_datetime_from_timestamp"}
 PRIVATE_TYPES_IMPORT_RE = re.compile(
-    r"\b(?:from\s+notebooklm(?:\._types|\s+import\s+_types)\b|import\s+notebooklm\._types\b)"
+    r"\b(?:from\s+notebooklm(?:\._types(?:\.\w+)*|\s+import\s+_types)\b"
+    r"|import\s+notebooklm\._types(?:\.\w+)*\b)"
 )
 
 
 def _iter_private_type_module_names() -> list[str]:
     """Return importable private type implementation modules that have landed."""
-    import notebooklm._types as private_types
-
     return sorted(
         module_info.name
-        for module_info in pkgutil.iter_modules(private_types.__path__)
-        if not module_info.ispkg
+        for module_info in pkgutil.iter_modules([str(PRIVATE_TYPES_ROOT)])
+        if not module_info.ispkg and module_info.name != "__init__"
     )
 
 
@@ -120,14 +119,31 @@ def _assignment_target_names(node: ast.Assign | ast.AnnAssign) -> list[str]:
     return [name for target in node.targets if (name := _top_level_name(target))]
 
 
-def _module_attribute_alias(value: ast.AST | None, target_name: str) -> bool:
+def _private_type_module_aliases(tree: ast.Module) -> set[str]:
+    aliases: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if (node.level == 1 and module == "_types") or (
+                node.level == 0 and module == "notebooklm._types"
+            ):
+                aliases.update(alias.asname or alias.name for alias in node.names)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("notebooklm._types."):
+                    aliases.add(alias.asname or alias.name.rsplit(".", maxsplit=1)[-1])
+    return aliases
+
+
+def _module_attribute_alias(
+    value: ast.AST | None, target_name: str, private_type_module_aliases: set[str]
+) -> bool:
     """Return True for compatibility aliases like ``_safe = _source_types._safe``."""
     return (
         isinstance(value, ast.Attribute)
         and value.attr == target_name
         and isinstance(value.value, ast.Name)
-        and value.value.id.startswith("_")
-        and value.value.id.endswith("_types")
+        and value.value.id in private_type_module_aliases
     )
 
 
@@ -142,7 +158,9 @@ def _private_type_module_symbols() -> tuple[set[str], set[str]]:
         for node in tree.body:
             if isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
                 public_type_names.add(node.name)
-            elif isinstance(node, ast.FunctionDef) and node.name.startswith("_"):
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+                "_"
+            ):
                 private_helper_names.add(node.name)
             elif isinstance(node, (ast.Assign, ast.AnnAssign)):
                 for name in _assignment_target_names(node):
@@ -155,6 +173,7 @@ def _private_type_module_symbols() -> tuple[set[str], set[str]]:
 def _types_facade_body_offenders() -> list[str]:
     public_type_names, private_helper_names = _private_type_module_symbols()
     tree = ast.parse(TYPES_PATH.read_text(encoding="utf-8"))
+    private_type_module_aliases = _private_type_module_aliases(tree)
     offenders: list[str] = []
 
     for node in tree.body:
@@ -162,9 +181,11 @@ def _types_facade_body_offenders() -> list[str]:
             offenders.append(f"{node.name} (ClassDef line {node.lineno})")
             continue
 
-        if isinstance(node, ast.FunctionDef) and node.name in private_helper_names:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+            node.name in private_helper_names
+        ):
             if node.name not in ALLOWED_TYPES_WRAPPER_BODIES:
-                offenders.append(f"{node.name} (FunctionDef line {node.lineno})")
+                offenders.append(f"{node.name} ({type(node).__name__} line {node.lineno})")
             continue
 
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
@@ -172,7 +193,7 @@ def _types_facade_body_offenders() -> list[str]:
             for name in target_names:
                 if name not in private_helper_names:
                     continue
-                if _module_attribute_alias(node.value, name):
+                if _module_attribute_alias(node.value, name, private_type_module_aliases):
                     continue
                 offenders.append(f"{name} ({type(node).__name__} line {node.lineno})")
 
@@ -237,7 +258,7 @@ def test_types_facade_identity_reexports_for_landed_private_types() -> None:
     import notebooklm.types as public_types
 
     public_type_names, _ = _private_type_module_symbols()
-    checked: list[str] = []
+    checked: set[str] = set()
     for module_name in _iter_private_type_module_names():
         module = importlib.import_module(_private_type_module_qualname(module_name))
         for name in sorted(public_type_names):
@@ -247,9 +268,12 @@ def test_types_facade_identity_reexports_for_landed_private_types() -> None:
                 f"notebooklm.types.{name} must be an identity re-export from "
                 f"{module.__name__}.{name}"
             )
-            checked.append(f"{module.__name__}.{name}")
+            checked.add(name)
 
-    assert checked, "No landed private type identities were checked"
+    assert checked == public_type_names, (
+        "Not every landed private type identity was checked. "
+        f"Missing: {sorted(public_type_names - checked)}"
+    )
 
 
 def test_types_all_does_not_export_private_helper_names() -> None:


### PR DESCRIPTION
## Summary

- Add static guardrails for the landed `notebooklm._types` boundaries on current `main` (`common`, `notebooks`, `sources`).
- Verify CLI modules stay on the public `notebooklm.types` boundary and public docs do not recommend `notebooklm._types` imports.
- Add direct import smoke coverage and facade identity checks for landed private type modules/classes.

## Notes

- This intentionally does not add artifact/note/chat/sharing TODO guardrails while those modules are not yet on `main`.
- The facade-body guard derives landed boundaries from `src/notebooklm/_types/*.py`, so it should start covering T13.3 modules after that work lands or this branch rebases on it.

## Verification

- `rtk uv run --extra dev pytest -n auto tests/unit/test_public_shims.py tests/unit/test_init_order.py tests/unit/test_cli_boundary.py tests/unit/test_type_boundaries.py tests/unit/test_types.py tests/unit/test_source_status.py tests/unit/test_sharing_types.py`
- `rtk uv run ruff check src/notebooklm/types.py src/notebooklm/_types tests/unit/test_public_shims.py tests/unit/test_init_order.py tests/unit/test_cli_boundary.py tests/unit/test_types.py tests/unit/test_type_boundaries.py`
- `rtk uv run mypy src/notebooklm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests enforcing a strict boundary between public type facade and private implementation.
  * Verifies private modules remain importable but are only re-exported via the public facade (including clean-interpreter checks).
  * Enforces export hygiene (no private/helper symbols exported) and prohibits landed implementation bodies in the facade.
  * Scans CLI code and public docs to prevent recommending or importing private type modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->