### PR TITLE
test(architecture): harden final boundary guardrails

### DIFF
--- a/tests/unit/test_cli_boundary.py
+++ b/tests/unit/test_cli_boundary.py
@@ -703,8 +703,19 @@ def test_completion_boundary_allows_standard_library_and_safe_relative_imports()
         ("import notebooklm._auth.tokens", "import notebooklm._auth.tokens"),
         ("from .._auth.tokens import AuthTokens", "from .._auth.tokens import ..."),
         ("from .. import _auth", "from .. import _auth"),
+        (
+            "from notebooklm._types.sources import Source",
+            "from notebooklm._types.sources import ...",
+        ),
+        ("import notebooklm._types.sources", "import notebooklm._types.sources"),
+        ("from notebooklm import _types", "from notebooklm import _types"),
+        ("from .._types.sources import Source", "from .._types.sources import ..."),
+        ("from .. import _types", "from .. import _types"),
     ],
 )
-def test_cli_boundary_blocks_auth_internal_import_shapes(source: str, expected: str) -> None:
-    """CLI auth imports must stay on notebooklm.auth, even if internals move to _auth."""
+def test_cli_boundary_blocks_private_project_import_shapes(
+    source: str,
+    expected: str,
+) -> None:
+    """CLI imports must stay on public notebooklm modules, including moved _types."""
     assert expected in _violations(ast.parse(source))

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -78,6 +78,11 @@ _DOCUMENTED_PUBLIC_IMPORTS = {
 }
 
 
+def _import_top_level_name_into_namespace(public_name: str, namespace: dict[str, object]) -> None:
+    module = __import__("notebooklm", fromlist=[public_name])
+    namespace[public_name] = getattr(module, public_name)
+
+
 @pytest.mark.parametrize(
     ("module_name", "public_name"),
     [
@@ -351,6 +356,7 @@ _TOP_LEVEL_EXCEPTION_EXPORTS = [
     "AuthError",
     "AuthExtractionError",
     "ChatError",
+    "ChatResponseParseError",
     "ClientError",
     "ConfigurationError",
     "DecodingError",
@@ -363,6 +369,7 @@ _TOP_LEVEL_EXCEPTION_EXPORTS = [
     "RateLimitError",
     "ResearchTaskMismatchError",
     "RPCError",
+    "RPCResponseTooLargeError",
     "RPCTimeoutError",
     "ServerError",
     "SourceAddError",
@@ -463,6 +470,22 @@ def test_top_level_exception_reexports_are_canonical_identities(name: str) -> No
 
     assert name in notebooklm.__all__, f"notebooklm.__all__ dropped {name!r}"
     assert getattr(notebooklm, name) is getattr(canonical, name)
+
+
+def test_top_level_exception_identity_manifest_matches_public_exception_exports() -> None:
+    """Every public top-level exception export must be covered by identity checks."""
+    import notebooklm
+    import notebooklm.exceptions as canonical
+
+    public_exception_exports = {
+        name
+        for name in notebooklm.__all__
+        if name in canonical.__all__
+        and isinstance(getattr(canonical, name), type)
+        and issubclass(getattr(canonical, name), BaseException)
+    }
+
+    assert set(_TOP_LEVEL_EXCEPTION_EXPORTS) == public_exception_exports
 
 
 def test_rpc_helper_reexports_are_canonical_identities() -> None:
@@ -633,7 +656,7 @@ def test_deprecated_top_level_studio_content_type_import_warns_and_caches(
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", DeprecationWarning)
         namespace: dict[str, object] = {}
-        exec("from notebooklm import StudioContentType", namespace)
+        _import_top_level_name_into_namespace("StudioContentType", namespace)
 
     assert namespace["StudioContentType"] is ArtifactTypeCode
     assert notebooklm.__dict__["StudioContentType"] is ArtifactTypeCode
@@ -644,9 +667,39 @@ def test_deprecated_top_level_studio_content_type_import_warns_and_caches(
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always", DeprecationWarning)
         namespace = {}
-        exec("from notebooklm import StudioContentType", namespace)
+        _import_top_level_name_into_namespace("StudioContentType", namespace)
 
     assert namespace["StudioContentType"] is ArtifactTypeCode
+    assert caught == []
+
+
+def test_deprecated_top_level_default_storage_path_import_warns_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """from notebooklm import DEFAULT_STORAGE_PATH keeps the deprecated shim contract."""
+    import notebooklm
+    from notebooklm.paths import get_storage_path
+
+    monkeypatch.delitem(notebooklm.__dict__, "DEFAULT_STORAGE_PATH", raising=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        namespace: dict[str, object] = {}
+        _import_top_level_name_into_namespace("DEFAULT_STORAGE_PATH", namespace)
+
+    assert namespace["DEFAULT_STORAGE_PATH"] == get_storage_path()
+    assert notebooklm.__dict__["DEFAULT_STORAGE_PATH"] == get_storage_path()
+    assert [str(warning.message) for warning in caught] == [
+        "DEFAULT_STORAGE_PATH is deprecated, use notebooklm.paths.get_storage_path() instead. "
+        "Will be removed in v0.5.0."
+    ]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        namespace = {}
+        _import_top_level_name_into_namespace("DEFAULT_STORAGE_PATH", namespace)
+
+    assert namespace["DEFAULT_STORAGE_PATH"] == get_storage_path()
     assert caught == []
 
 

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -9,7 +9,9 @@ mismatched ids reach the wire as malformed requests.
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -22,6 +24,9 @@ from notebooklm.rpc import RPCMethod
 from notebooklm.rpc import overrides as rpc_overrides
 from notebooklm.rpc import types as rpc_types
 from notebooklm.rpc.overrides import _load_rpc_overrides, _parse_rpc_overrides, resolve_rpc_id
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RPC_TYPES_PATH = PROJECT_ROOT / "src" / "notebooklm" / "rpc" / "types.py"
 
 
 @pytest.fixture(autouse=True)
@@ -48,6 +53,47 @@ def test_rpc_types_override_aliases_are_identity_compatible() -> None:
     assert rpc_types._parse_rpc_overrides is rpc_overrides._parse_rpc_overrides
     assert rpc_types._load_rpc_overrides is rpc_overrides._load_rpc_overrides
     assert rpc_types._logged_override_hashes is rpc_overrides._logged_override_hashes
+
+
+def test_rpc_types_keeps_override_env_parsing_out_of_protocol_enums() -> None:
+    """RPC enum definitions may expose legacy aliases, but env parsing lives in overrides.py."""
+    assert RPC_TYPES_PATH.exists(), (
+        f"Expected RPC types module at {RPC_TYPES_PATH}; update RPC_TYPES_PATH if the source "
+        "layout changed."
+    )
+    source = RPC_TYPES_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_imports: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            forbidden_imports.extend(
+                alias.name
+                for alias in node.names
+                if alias.name in {"json", "logging", "os"}
+                or alias.name.startswith(("json.", "logging.", "os."))
+            )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in {"json", "logging", "os"}:
+                forbidden_imports.append(module)
+            elif module == "functools":
+                forbidden_imports.extend(
+                    f"{module}.{alias.name}"
+                    for alias in node.names
+                    if alias.name in {"cache", "lru_cache"}
+                )
+
+    assert forbidden_imports == [], (
+        "notebooklm/rpc/types.py must not import runtime/config utilities; found: "
+        f"{forbidden_imports}"
+    )
+    assert "NOTEBOOKLM_RPC_OVERRIDES" not in source, (
+        "Env-var name NOTEBOOKLM_RPC_OVERRIDES must live in overrides.py, not rpc/types.py"
+    )
+    assert "RPC_OVERRIDES_ENV_VAR" not in source, (
+        "RPC_OVERRIDES_ENV_VAR must live in overrides.py, not rpc/types.py"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -20,13 +20,17 @@ TYPES_PATH = SRC_ROOT / "types.py"
 PRIVATE_TYPES_ROOT = SRC_ROOT / "_types"
 CLI_ROOT = SRC_ROOT / "cli"
 PUBLIC_DOC_ROOTS = (PROJECT_ROOT / "README.md", PROJECT_ROOT / "docs")
+INTERNAL_ARCHITECTURE_DOCS = {
+    PROJECT_ROOT / "docs" / "development.md",
+    PROJECT_ROOT / "docs" / "rpc-development.md",
+}
 
 # Add names here only for explicit facade wrappers that must keep a public
 # monkeypatch seam while delegating implementation to a private _types module.
 ALLOWED_TYPES_WRAPPER_BODIES = {"_datetime_from_timestamp"}
-PRIVATE_TYPES_IMPORT_RE = re.compile(
-    r"\b(?:from\s+notebooklm(?:\._types(?:\.\w+)*|\s+import\s+_types)\b"
-    r"|import\s+notebooklm\._types(?:\.\w+)*\b)"
+PRIVATE_NOTEBOOKLM_IMPORT_RE = re.compile(
+    r"\b(?:from\s+notebooklm(?:\._(?!_)\w+(?:\.\w+)*|\s+import\s+_(?!_)\w+)\b"
+    r"|import\s+notebooklm\._(?!_)\w+(?:\.\w+)*\b)"
 )
 
 
@@ -99,15 +103,17 @@ def _iter_public_docs() -> list[Path]:
         if root.is_file():
             docs.append(root)
         elif root.is_dir():
-            docs.extend(root.rglob("*.md"))
+            docs.extend(
+                path for path in root.rglob("*.md") if path not in INTERNAL_ARCHITECTURE_DOCS
+            )
     return sorted(docs)
 
 
-def _public_docs_private_type_import_offenders() -> list[str]:
+def _public_docs_private_import_offenders() -> list[str]:
     offenders: list[str] = []
     for path in _iter_public_docs():
         for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
-            if PRIVATE_TYPES_IMPORT_RE.search(line):
+            if PRIVATE_NOTEBOOKLM_IMPORT_RE.search(line):
                 relative = path.relative_to(PROJECT_ROOT)
                 offenders.append(f"{relative}:{lineno}: {line.strip()}")
     return offenders
@@ -300,6 +306,35 @@ def test_types_facade_has_no_landed_implementation_bodies() -> None:
     )
 
 
+def test_private_type_modules_keep_runtime_config_imports_limited() -> None:
+    """Only sharing.py may import get_base_url to construct public notebook share URLs."""
+    allowed = {"sharing.py": {"get_base_url"}}
+    offenders: list[str] = []
+
+    for path in sorted(PRIVATE_TYPES_ROOT.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            module = node.module or ""
+            imports_env = (node.level == 2 and module == "_env") or (
+                node.level == 0 and module == "notebooklm._env"
+            )
+            if not imports_env:
+                continue
+            imported_names = {alias.name for alias in node.names}
+            if imported_names <= allowed.get(path.name, set()):
+                continue
+            offenders.append(f"{path.name}: line {node.lineno}: {ast.unparse(node)}")
+
+    assert offenders == [], (
+        "Private _types modules must not import notebooklm._env names beyond the allowlist. "
+        f"Offenders: {offenders}"
+    )
+
+
 def test_cli_modules_do_not_import_private_type_modules() -> None:
     """CLI code consumes type objects through ``notebooklm.types`` only."""
     offenders: list[str] = []
@@ -315,11 +350,11 @@ def test_cli_modules_do_not_import_private_type_modules() -> None:
     )
 
 
-def test_public_docs_do_not_recommend_private_type_imports() -> None:
-    """User-facing docs should never present ``notebooklm._types`` as an import path."""
-    offenders = _public_docs_private_type_import_offenders()
+def test_public_docs_do_not_recommend_private_module_imports() -> None:
+    """User-facing docs should never present private notebooklm modules as imports."""
+    offenders = _public_docs_private_import_offenders()
 
     assert offenders == [], (
-        "Public docs must document notebooklm.types, not private notebooklm._types imports. "
+        "Public docs must document public notebooklm modules, not private notebooklm._* imports. "
         f"Offenders: {offenders}"
     )


### PR DESCRIPTION
## Summary
- tighten final architecture guardrails for private `_types` imports, public docs, RPC override ownership, public shim manifests, and deprecated top-level compatibility shims
- keep the checks scoped to boundaries that exist after T13/T14.0

## T14.0 / T13.5 evidence
- #764 merged into `main` at `77802dcc4461a6c45296a2b583f7146fe4d542a5`
- T13.5 final verification passed on merged `main`: smoke passed, targeted type/public-shim suite 549 passed, targeted integration/API/CLI suite 836 passed, ruff passed, mypy passed

## Verification
- `rtk uv run --extra dev pytest -n auto tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_rpc_overrides.py tests/unit/test_type_boundaries.py` -> 527 passed
- `rtk uv run --extra dev ruff check tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_rpc_overrides.py tests/unit/test_type_boundaries.py`
- `rtk uv run --extra dev ruff format --check tests/unit/test_cli_boundary.py tests/unit/test_init_order.py tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_rpc_overrides.py tests/unit/test_type_boundaries.py`

Part of Phase 11 T14.2. Do not merge until bot review is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened checks preventing public docs/tests from referencing private/internal modules
  * Broadened import-shape validation to cover moved private surfaces
  * Extended validation of top-level exception exports for consistency
  * Replaced fragile import execs with a reusable import helper for deprecation tests
  * Added assertions preventing runtime-configuration access from private type modules and RPC-type modules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->