### PR TITLE
refactor(capabilities): flip 7 sub-clients to ClientCoreCapabilities (C2-minimal)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -17,7 +17,6 @@ from ._artifact_downloads import ArtifactDownloadService, DownloadResult
 from ._artifact_generation import ArtifactGenerationService
 from ._artifact_listing import ArtifactListingService
 from ._capabilities import ClientCoreCapabilities
-from ._core import ClientCore
 from .auth import load_httpx_cookies
 from .rpc import (
     ArtifactTypeCode,
@@ -137,7 +136,7 @@ class ArtifactsAPI:
 
     def __init__(
         self,
-        core: ClientCore,
+        core: ClientCoreCapabilities,
         notes_api: "NotesAPI | None" = None,
         storage_path: Path | None = None,
     ):
@@ -155,7 +154,7 @@ class ArtifactsAPI:
             storage_path: Path to storage state file for loading download cookies.
         """
         self._core = core
-        self._capabilities = ClientCoreCapabilities(core)
+        self._capabilities = core
         # ``notes_api`` is intentionally not stored — it is accepted only
         # so that existing call sites (tests, third-party code) keep
         # working through the deprecation cycle.

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -9,6 +9,35 @@ import httpx
 
 from ._core_polling import PollRegistry
 from .auth import authuser_query, format_authuser_value
+from .rpc.types import RPCMethod
+
+
+class CoreRPCProvider(Protocol):
+    """Provider for the core ``rpc_call`` entry point.
+
+    Mirrors :meth:`ClientCore.rpc_call` exactly, including the kw-only
+    ``disable_internal_retries`` flag used by mutating-create RPCs that
+    must skip the inner 5xx/429 retry loop. Sub-clients that only need
+    to issue RPC calls type their constructor on this provider rather
+    than on the concrete ``ClientCore``.
+    """
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any: ...
+
+
+class SourceListProvider(Protocol):
+    """Provider for the notebook→source-id enumeration helper."""
+
+    async def get_source_ids(self, notebook_id: str) -> list[str]: ...
 
 
 class PollRegistryProvider(Protocol):
@@ -75,6 +104,8 @@ class UploadConcurrencyProvider(Protocol):
 
 
 class ClientCoreCapabilities(
+    CoreRPCProvider,
+    SourceListProvider,
     PollRegistryProvider,
     AuthRouteProvider,
     CookieJarProvider,
@@ -89,6 +120,28 @@ class ClientCoreCapabilities(
 
     def __init__(self, core: Any) -> None:
         self._core = core
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        return await self._core.rpc_call(
+            method,
+            params,
+            source_path=source_path,
+            allow_null=allow_null,
+            _is_retry=_is_retry,
+            disable_internal_retries=disable_internal_retries,
+        )
+
+    async def get_source_ids(self, notebook_id: str) -> list[str]:
+        return await self._core.get_source_ids(notebook_id)
 
     @property
     def poll_registry(self) -> PollRegistry:

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from typing import Any
 
-from ._core import ClientCore
+from ._capabilities import ClientCoreCapabilities
 from ._idempotency import idempotent_create
 from ._notebook_metadata import (
     NotebookMetadataService,
@@ -134,7 +134,7 @@ class NotebooksAPI:
 
     def __init__(
         self,
-        core: ClientCore,
+        core: ClientCoreCapabilities,
         sources_api: NotebookSourceLister | None = None,
         *,
         metadata_service: NotebookMetadataService | None = None,

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -14,7 +14,7 @@ import logging
 from typing import Any
 
 from . import _mind_map
-from ._core import ClientCore
+from ._capabilities import ClientCoreCapabilities
 from .types import AskResult, Note
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ class NotesAPI:
 
     def __init__(
         self,
-        core: ClientCore,
+        core: ClientCoreCapabilities,
         *,
         mind_map_service: _mind_map.MindMapService | None = None,
     ):

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -9,7 +9,7 @@ import warnings
 from typing import Any
 
 from . import research as _research_pub
-from ._core import ClientCore
+from ._capabilities import ClientCoreCapabilities
 from .exceptions import ResearchTaskMismatchError, ValidationError
 from .rpc import RPCMethod, safe_index
 from .types import CitedSourceSelection
@@ -200,7 +200,7 @@ class ResearchAPI:
                 )
     """
 
-    def __init__(self, core: ClientCore):
+    def __init__(self, core: ClientCoreCapabilities):
         """Initialize the research API.
 
         Args:

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
-from ._core import ClientCore
+from ._capabilities import ClientCoreCapabilities
 from .rpc import RPCMethod
 from .types import AccountLimits, AccountTier
 
@@ -140,7 +140,7 @@ class SettingsAPI:
     _SET_LANGUAGE_PATH = (2, 4, 0)  # result[2][4][0]
     _GET_SETTINGS_PATH = (0, 2, 4, 0)  # result[0][2][4][0]
 
-    def __init__(self, core: ClientCore) -> None:
+    def __init__(self, core: ClientCoreCapabilities) -> None:
         """Initialize the settings API.
 
         Args:

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ._core import ClientCore
+from ._capabilities import ClientCoreCapabilities
 from .rpc import RPCMethod
 from .rpc.types import ShareAccess, SharePermission, ShareViewLevel
 from .types import ShareStatus
@@ -34,7 +34,7 @@ class SharingAPI:
             )
     """
 
-    def __init__(self, core: ClientCore):
+    def __init__(self, core: ClientCoreCapabilities):
         """Initialize the sharing API.
 
         Args:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -13,7 +13,6 @@ import httpx
 
 from . import _source_upload
 from ._capabilities import ClientCoreCapabilities
-from ._core import ClientCore
 from ._source_add import SourceAddService
 from ._source_content import SourceContentRenderer
 from ._source_listing import SourceLister
@@ -48,7 +47,7 @@ class SourcesAPI:
 
     def __init__(
         self,
-        core: ClientCore,
+        core: ClientCoreCapabilities,
         upload_timeout: httpx.Timeout | None = None,
     ):
         """Initialize the sources API.
@@ -67,7 +66,7 @@ class SourcesAPI:
                 avoid surprises.
         """
         self._core = core
-        self._capabilities = ClientCoreCapabilities(core)
+        self._capabilities = core
         self._adder = SourceAddService()
         self._content = SourceContentRenderer(self._rpc_call, logger=logger)
         self._lister = SourceLister(self._rpc_call)

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 from ._artifacts import ArtifactsAPI
 from ._auth.session import refresh_auth_session
+from ._capabilities import ClientCoreCapabilities
 from ._chat import ChatAPI
 from ._core import (
     DEFAULT_KEEPALIVE_MIN_INTERVAL,
@@ -264,18 +265,16 @@ class NotebookLMClient:
             on_rpc_event=on_rpc_event,
         )
 
-        # Initialize sub-client APIs.
-        # ArtifactsAPI and NotesAPI both consume the shared ``_mind_map``
-        # module for mind-map primitives, so their construction order is
-        # not significant.
-        self.sources = SourcesAPI(self._core, upload_timeout=upload_timeout)
-        self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
-        self.artifacts = ArtifactsAPI(self._core, storage_path=storage_path)
-        self.notes = NotesAPI(self._core)
+        # ``_chat`` keeps the raw core: its conversation-cache methods are not on the capability surface yet.
+        capabilities = ClientCoreCapabilities(self._core)
+        self.sources = SourcesAPI(capabilities, upload_timeout=upload_timeout)
+        self.notebooks = NotebooksAPI(capabilities, sources_api=self.sources)
+        self.artifacts = ArtifactsAPI(capabilities, storage_path=storage_path)
+        self.notes = NotesAPI(capabilities)
         self.chat = ChatAPI(self._core)
-        self.research = ResearchAPI(self._core)
-        self.settings = SettingsAPI(self._core)
-        self.sharing = SharingAPI(self._core)
+        self.research = ResearchAPI(capabilities)
+        self.settings = SettingsAPI(capabilities)
+        self.sharing = SharingAPI(capabilities)
 
     @property
     def auth(self) -> AuthTokens:

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -18,6 +18,7 @@ from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import (
     AudioFormat,
@@ -388,7 +389,7 @@ class TestArtifactsAPI:
         """_list_raw keeps the exact LIST_ARTIFACTS RPC contract."""
         core = MagicMock()
         core.rpc_call = AsyncMock(return_value=[[]])
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(ClientCoreCapabilities(core))
 
         result = await api._list_raw("nb_123")
 
@@ -398,6 +399,8 @@ class TestArtifactsAPI:
             [[2], "nb_123", 'NOT artifact.status = "ARTIFACT_STATUS_SUGGESTED"'],
             source_path="/notebook/nb_123",
             allow_null=True,
+            _is_retry=False,
+            disable_internal_retries=False,
         )
 
     @pytest.mark.asyncio
@@ -409,7 +412,7 @@ class TestArtifactsAPI:
         ]
         core = MagicMock()
         core.rpc_call = AsyncMock(return_value=artifact_rows)
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(ClientCoreCapabilities(core))
 
         result = await api._list_raw("nb_123")
 
@@ -419,7 +422,7 @@ class TestArtifactsAPI:
     async def test_list_uses_facade_list_raw_callback_and_mind_map_patch_seam(self):
         """list() resolves facade and mind-map seams at call time."""
         core = MagicMock()
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(ClientCoreCapabilities(core))
         studio_artifact = ["art_001", "My Report", 2, None, 3]
         mind_map = [
             "mind_map_001",
@@ -438,14 +441,14 @@ class TestArtifactsAPI:
             artifacts = await api.list("nb_123")
 
         list_raw.assert_awaited_once_with("nb_123")
-        list_mind_maps.assert_awaited_once_with(core, "nb_123")
+        list_mind_maps.assert_awaited_once_with(api._core, "nb_123")
         assert [artifact.id for artifact in artifacts] == ["art_001", "mind_map_001"]
 
     @pytest.mark.asyncio
     async def test_list_skips_mind_map_callback_for_non_mind_map_filter(self):
         """Filtering to studio-only kinds must not fetch mind maps."""
         core = MagicMock()
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(ClientCoreCapabilities(core))
         studio_artifact = ["art_001", "My Report", 2, None, 3]
 
         with (
@@ -464,7 +467,7 @@ class TestArtifactsAPI:
     async def test_get_uses_public_list_callback(self):
         """get() delegates through the public list callback."""
         core = MagicMock()
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(ClientCoreCapabilities(core))
         other = MagicMock()
         other.id = "art_other"
         found = MagicMock()

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc.decoder import RPCError
 from notebooklm.types import ArtifactDownloadError
@@ -33,7 +34,7 @@ def mock_artifacts_api():
     mock_note = MagicMock()
     mock_note.id = "created_note_123"
     mock_notes.create = AsyncMock(return_value=mock_note)
-    api = ArtifactsAPI(mock_core, notes_api=mock_notes)
+    api = ArtifactsAPI(ClientCoreCapabilities(mock_core), notes_api=mock_notes)
     return api, mock_core
 
 

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -5,6 +5,7 @@ import pytest
 
 from notebooklm._artifact_polling import ArtifactPollingService
 from notebooklm._artifacts import ArtifactsAPI, GenerationStatus
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 
@@ -70,7 +71,7 @@ def api():
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     notes_api = MagicMock()
-    return ArtifactsAPI(core, notes_api)
+    return ArtifactsAPI(ClientCoreCapabilities(core), notes_api)
 
 
 @pytest.mark.asyncio
@@ -318,7 +319,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
     core._pending_polls = core.poll_registry.pending
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
-    api = ArtifactsAPI(core, MagicMock())
+    api = ArtifactsAPI(ClientCoreCapabilities(core), MagicMock())
 
     poll_started = asyncio.Event()
     release_poll = asyncio.Event()

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._core import ClientCore
 from notebooklm._env import get_base_host, get_base_url
 from notebooklm._sources import SourcesAPI
@@ -100,7 +101,7 @@ async def test_upload_start_uses_enterprise_url_and_headers(monkeypatch, httpx_m
     core = ClientCore(auth)
     await core.open()
     try:
-        result = await SourcesAPI(core)._start_resumable_upload(
+        result = await SourcesAPI(ClientCoreCapabilities(core))._start_resumable_upload(
             "nb_123",
             "file.txt",
             12,

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -14,6 +14,7 @@ from notebooklm import (
     get_request_id,
 )
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._core import ClientCore
 from notebooklm._sources import SourcesAPI
 from notebooklm.auth import AuthTokens
@@ -128,7 +129,7 @@ async def test_drain_rejects_child_task_spawned_from_accepted_operation(
 @pytest.mark.asyncio
 async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> None:
     core = ClientCore(auth_tokens)
-    api = ArtifactsAPI(core)
+    api = ArtifactsAPI(ClientCoreCapabilities(core))
     first_poll_started = asyncio.Event()
     release_first_poll = asyncio.Event()
     poll_count = 0
@@ -221,7 +222,7 @@ async def test_upload_progress_callback_receives_byte_counts(
     core = ClientCore(auth_tokens)
     await core.open()
     try:
-        api = SourcesAPI(core)
+        api = SourcesAPI(ClientCoreCapabilities(core))
         test_file = tmp_path / "upload.txt"
         content = b"hello progress"
         test_file.write_bytes(content)
@@ -258,7 +259,7 @@ async def test_upload_progress_callback_receives_byte_counts(
 @pytest.mark.asyncio
 async def test_wait_for_completion_status_change_callback(auth_tokens: AuthTokens) -> None:
     core = ClientCore(auth_tokens)
-    api = ArtifactsAPI(core)
+    api = ArtifactsAPI(ClientCoreCapabilities(core))
     statuses = [
         GenerationStatus(task_id="task_1", status="in_progress"),
         GenerationStatus(task_id="task_1", status="completed", url="https://example.test/out"),

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._core_polling import PollRegistry
 from notebooklm.rpc.types import ArtifactStatus
 from notebooklm.types import GenerationStatus
@@ -39,7 +40,7 @@ def _make_api():
     notes = MagicMock()
     notes.list_mind_maps = AsyncMock(return_value=[])
     notes.create = AsyncMock(return_value=MagicMock(id="note_1"))
-    return ArtifactsAPI(core, notes_api=notes)
+    return ArtifactsAPI(ClientCoreCapabilities(core), notes_api=notes)
 
 
 def _art(artifact_id: str, status: int, artifact_type: int = 1, error_at_3: str | None = None):

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -9,6 +9,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
 from notebooklm.exceptions import NetworkError, RPCError, ValidationError
@@ -40,7 +41,7 @@ def mock_core():
 @pytest.fixture
 def sources_api(mock_core):
     """Create SourcesAPI with mocked core."""
-    return SourcesAPI(mock_core)
+    return SourcesAPI(ClientCoreCapabilities(mock_core))
 
 
 def _self_core_auth_attr_read(node: ast.AST, attr: str) -> bool:


### PR DESCRIPTION
## Summary

Phase 5 introduced the narrow `ClientCoreCapabilities` adapter in `_capabilities.py`. Nobody adopted it — all 6 audit-named sub-clients still took `core: ClientCore` (concrete class). This was the largest untouched audit finding after architecture-remediation phases 1–9.

This change closes 7 of 8 sub-clients: `_artifacts`, `_sources`, `_notebooks`, `_research`, `_notes`, `_settings`, `_sharing` now type their constructor on `ClientCoreCapabilities`. `_chat` is intentionally deferred — it reaches into 6 conversation-cache methods that aren't on any capability surface, and Protocolising them raises a design question (does that state belong on `ClientCore` or inside `_chat`?) that deserves its own change.

## What changed in `_capabilities.py`

Two new Protocols, composed into `ClientCoreCapabilities`:

- **`CoreRPCProvider`** — mirrors the full `ClientCore.rpc_call` signature including the kw-only `disable_internal_retries` flag used by mutating-create RPCs.
- **`SourceListProvider`** — `get_source_ids(notebook_id)`, surfaced because `_artifact_generation.py` reaches through `ArtifactsAPI._core` from 10 "generate-from-all-sources" sites.

Nothing else was added — the capability surface widened by exactly what the 7-client flip needs and nothing more.

## What changed in `client.py`

The wrapper is built once and passed to all 7 flipped sub-clients:

```python
capabilities = ClientCoreCapabilities(self._core)
self.sources = SourcesAPI(capabilities, upload_timeout=upload_timeout)
# ...
self.chat = ChatAPI(self._core)  # ``_chat`` keeps the raw core: its conversation-cache methods are not on the capability surface yet.
```

The previous in-constructor `self._capabilities = ClientCoreCapabilities(core)` lines in `_artifacts` / `_sources` collapse to `self._capabilities = core`.

## Test fixture updates

Test fixtures that built bare `MagicMock()` cores were relying on the sub-client to wrap them internally. They now wrap with `ClientCoreCapabilities(mock_core)` explicitly so the existing AsyncMock setup on the underscore-prefixed transport methods (`_begin_transport_post`, etc.) still flows through the real adapter's delegating layer. No test logic changed — just construction calls.

Two assertions in `tests/integration/test_artifacts_integration.py` needed semantic updates:
- `test_list_raw_preserves_rpc_call_shape` was over-asserting on the exact `rpc_call` kwarg shape; the wrapper now materialises `_is_retry=False, disable_internal_retries=False` defaults.
- `test_list_uses_facade_list_raw_callback_and_mind_map_patch_seam` was asserting `list_mind_maps` is called with the raw mock; it's now called with the wrapper (`api._core`).

## Verification

- `uv run pytest` — 5017 passed, 12 skipped (locally, Python 3.11, macOS).
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- `uv run ruff check src/notebooklm tests` — clean.

## Test plan

- [ ] CI passes the full matrix (Linux + macOS + Windows × Python 3.10–3.14).
- [ ] mypy stays clean across the matrix.
- [ ] No public API surface change — sub-client classes live in `_*.py` modules and are not exported via `__init__.py`.

## Out of scope (follow-ups)

- **C2-full**: flip `_chat` after Protocolising conversation-cache state (or moving it out of `ClientCore`).
- The 1760-line `_core.py` decomposition (I17) — separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal API client architecture to use a unified capabilities adapter pattern. All sub-APIs now receive a standardized `ClientCoreCapabilities` interface, improving consistency and extensibility of the SDK's internal structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->