### PR TITLE
fix(core): strip content-encoding on buffered RPC response (#769)

### DIFF
--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -29,6 +29,15 @@ MAX_RETRY_AFTER_SECONDS = 300
 # read loop can read it without creating an import cycle through ``_core``.
 MAX_RPC_RESPONSE_BYTES = 50 * 1024 * 1024
 
+# Headers that must NOT survive onto a Response rebuilt from already-decoded
+# body bytes. ``content-encoding`` would make ``httpx.Response.__init__``
+# re-run the gzip/brotli/zstd decoder on bytes that ``aiter_bytes()`` already
+# decoded once, raising ``DecodingError: Error -3 ... incorrect header check``.
+# ``content-length`` advertises the compressed size from the wire and no
+# longer matches the decoded buffer we hand to the rebuilt Response. Compared
+# against ``key.lower()`` so case variants from the wire all match.
+_STRIP_HEADERS_ON_REBUFFER = frozenset({"content-encoding", "content-length"})
+
 
 def _parse_retry_after(value: str | None) -> int | None:
     """Parse RFC 7231 Retry-After: integer-seconds OR HTTP-date.
@@ -177,14 +186,17 @@ async def _stream_post_with_size_cap(
         # over so log/repr surfaces still point at the originating request.
         #
         # ``response.aiter_bytes()`` above yields already-decoded body chunks,
-        # so the buffered payload is plain bytes. Strip ``content-encoding``
-        # (and the now-mismatched ``content-length``) before handing the
-        # headers to a fresh ``httpx.Response`` — otherwise its ``__init__``
-        # re-runs the gzip/brotli/zstd decoder on already-decoded bytes and
-        # raises ``DecodingError: Error -3 ... incorrect header check``.
-        rebuilt_headers = httpx.Headers(response.headers)
-        rebuilt_headers.pop("content-encoding", None)
-        rebuilt_headers.pop("content-length", None)
+        # so the buffered payload is plain bytes. Filter out
+        # ``content-encoding`` (and the now-mismatched ``content-length``) via
+        # a dict comprehension — ``httpx.Headers`` inherits from
+        # :class:`collections.abc.Mapping`, NOT ``MutableMapping``, so we
+        # avoid relying on ``.pop()`` (which is not part of the documented
+        # contract and could change across the ``>=0.27,<0.29`` httpx pin).
+        # ``httpx.Response(headers=...)`` accepts a plain ``dict`` of
+        # ``str -> str`` so this is the documented input shape.
+        rebuilt_headers = {
+            k: v for k, v in response.headers.items() if k.lower() not in _STRIP_HEADERS_ON_REBUFFER
+        }
         return httpx.Response(
             status_code=response.status_code,
             headers=rebuilt_headers,

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -175,9 +175,19 @@ async def _stream_post_with_size_cap(
         # (``_core_rpc.py`` decode path) can use ``.text`` / ``.content``
         # without dealing with stream state. The request handle is carried
         # over so log/repr surfaces still point at the originating request.
+        #
+        # ``response.aiter_bytes()`` above yields already-decoded body chunks,
+        # so the buffered payload is plain bytes. Strip ``content-encoding``
+        # (and the now-mismatched ``content-length``) before handing the
+        # headers to a fresh ``httpx.Response`` — otherwise its ``__init__``
+        # re-runs the gzip/brotli/zstd decoder on already-decoded bytes and
+        # raises ``DecodingError: Error -3 ... incorrect header check``.
+        rebuilt_headers = httpx.Headers(response.headers)
+        rebuilt_headers.pop("content-encoding", None)
+        rebuilt_headers.pop("content-length", None)
         return httpx.Response(
             status_code=response.status_code,
-            headers=response.headers,
+            headers=rebuilt_headers,
             content=bytes(buffer),
             request=response.request,
         )

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -1281,6 +1281,78 @@ async def test_streaming_raise_for_status_propagates_before_size_check(monkeypat
         await client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkeypatch):
+    """Regression for #769.
+
+    ``response.aiter_bytes()`` yields already-decoded chunks, so the buffered
+    payload is plain bytes. If the upstream ``Content-Encoding`` header (e.g.
+    ``gzip``) is carried over verbatim onto the rebuilt :class:`httpx.Response`,
+    its ``__init__`` re-runs the decoder on already-decoded bytes and raises
+    ``DecodingError: Error -3 ... incorrect header check``.
+
+    The wrapper must strip ``content-encoding`` (and ``content-length``) before
+    handing headers back so downstream ``.text`` access stays a plain charset
+    decode — no double decompression.
+    """
+    from contextlib import asynccontextmanager
+
+    from notebooklm._core_transport import _stream_post_with_size_cap
+
+    # Realistic batchexecute prefix; only the bytes matter, not the framing.
+    decoded_payload = b')]}\'\n\n[["wrb.fr",null,"[1]",null,null,null,"generic"]]'
+
+    class _FakeResponse:
+        status_code = 200
+        # Upstream advertises gzip — the kind of header that flowed through the
+        # transport at production time and bit issue #769.
+        headers = {
+            "content-type": "application/json; charset=UTF-8",
+            "content-encoding": "gzip",
+            # Length of the compressed body upstream — also a lie for the
+            # rebuilt response, since we hold the decoded bytes now.
+            "content-length": "9999",
+        }
+        request = httpx.Request("POST", "https://example.test/x")
+
+        def raise_for_status(self) -> None:
+            return None
+
+        async def aiter_bytes(self):
+            yield decoded_payload
+
+    @asynccontextmanager
+    async def fake_stream(method, url, **kwargs):
+        yield _FakeResponse()
+
+    client = httpx.AsyncClient()
+    try:
+        monkeypatch.setattr(client, "stream", fake_stream)
+
+        # Pre-fix this call raised httpx.DecodingError during Response.__init__.
+        response = await _stream_post_with_size_cap(
+            client,
+            "https://example.test/x",
+            body=b"",
+            headers=None,
+        )
+
+        # Body round-trips as the decoded payload, both as bytes and text.
+        assert response.content == decoded_payload
+        assert response.text == decoded_payload.decode("utf-8")
+        # The misleading content-encoding header must NOT survive — otherwise
+        # any downstream consumer that re-streams or re-reads the response
+        # would hit the same double-decode trap.
+        assert "content-encoding" not in response.headers
+        # httpx may auto-repopulate content-length to match the buffered body,
+        # which is fine — what matters is that it doesn't carry the stale
+        # upstream value (9999) that misrepresented the decoded payload.
+        if "content-length" in response.headers:
+            assert response.headers["content-length"] == str(len(decoded_payload))
+    finally:
+        await client.aclose()
+
+
 def test_max_rpc_response_bytes_constant_lives_in_transport_module():
     """Constant is owned by ``_core_transport`` (not ``_core``) to avoid an
     import cycle — ``_core`` already imports from ``_core_transport``."""


### PR DESCRIPTION
## Summary

Closes #769 — every RPC fails with `Error -3 while decompressing data: incorrect header check` on current `main`.

`_stream_post_with_size_cap` (introduced in #751) reads response chunks via `response.aiter_bytes()`, which yields **already-decoded** body bytes, then rebuilds a fresh `httpx.Response` with `headers=response.headers`. The copied headers still carry `Content-Encoding: gzip` (the default for `batchexecute`), so the rebuilt Response's `__init__` calls `self.read()` → `iter_bytes()` → gzip decoder on bytes that have already been decompressed, raising `DecodingError`.

Minimal repro (no network):

```python
import httpx
httpx.Response(
    status_code=200,
    headers={"content-encoding": "gzip"},
    content=b"[[\"hello\"]]",
)
# zlib.error: Error -3 while decompressing data: incorrect header check
```

The reporter's manual `httpx.post` worked because it's a single Response object — content-encoding is consumed exactly once.

## Fix

Strip `content-encoding` and the now-mismatched `content-length` from the headers before constructing the buffered Response. The body is already decoded at that point, so the rebuilt Response should not advertise either.

## Tests

- New: `test_streaming_strips_content_encoding_to_prevent_double_decode` — exercises the gzip-header path directly. Pre-fix this raised `DecodingError` inside `Response.__init__`; post-fix the buffered Response round-trips `.text` cleanly and no `content-encoding` survives onto it.
- Existing transport / size-cap tests still pass (36/36 in `test_core_transport.py`).

## Test plan

- [x] `uv run ruff format` clean
- [x] `uv run ruff check` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest tests/unit` clean ignoring the playwright-gated session/windows suites (4211 passed, 5 skipped)
- [ ] CI: full suite

@claude review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented double-decoding and length mismatches for compressed streaming responses by removing misleading encoding/length headers from rebuilt responses, improving content delivery reliability.
* **Tests**
  * Added a unit test to verify streaming responses decode correctly and that misleading encoding/length headers are stripped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->