### PR TITLE
refactor(artifacts): inject MindMapService into ArtifactsAPI

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -165,7 +165,9 @@ class ArtifactsAPI:
         # working through the deprecation cycle.
         del notes_api
         self._storage_path = storage_path
-        self._mind_map_service = mind_map_service or _mind_map.MindMapService(core)
+        self._mind_map_service = (
+            _mind_map.MindMapService(core) if mind_map_service is None else mind_map_service
+        )
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
         self._downloads = ArtifactDownloadService(self)

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -139,6 +139,8 @@ class ArtifactsAPI:
         core: ClientCoreCapabilities,
         notes_api: "NotesAPI | None" = None,
         storage_path: Path | None = None,
+        *,
+        mind_map_service: _mind_map.MindMapService | None = None,
     ):
         """Initialize the artifacts API.
 
@@ -147,11 +149,14 @@ class ArtifactsAPI:
             notes_api: Deprecated. Retained as an optional, ignored
                 keyword for backward compatibility — ``ArtifactsAPI`` no
                 longer depends on :class:`NotesAPI`. Mind-map RPC
-                primitives are accessed directly through the
-                :mod:`_mind_map` module, so the construction order of
-                ``client.artifacts`` and ``client.notes`` is no longer
-                significant.
+                primitives are accessed through the injected
+                :class:`_mind_map.MindMapService`, so the construction
+                order of ``client.artifacts`` and ``client.notes`` is no
+                longer significant.
             storage_path: Path to storage state file for loading download cookies.
+            mind_map_service: Optional private service for note-backed
+                mind-map operations. Keyword-only so the public positional
+                constructor contract stays unchanged.
         """
         self._core = core
         self._capabilities = core
@@ -160,6 +165,7 @@ class ArtifactsAPI:
         # working through the deprecation cycle.
         del notes_api
         self._storage_path = storage_path
+        self._mind_map_service = mind_map_service or _mind_map.MindMapService(core)
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
         self._downloads = ArtifactDownloadService(self)
@@ -842,10 +848,8 @@ class ArtifactsAPI:
         return await self._generation._call_generate(notebook_id, params)
 
     async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
-        """Get raw mind-map rows through the patchable module seam."""
-        # Resolve the module seam at call time so tests patching
-        # ``notebooklm._artifacts._mind_map`` affect public listing paths.
-        return await _mind_map.list_mind_maps(self._core, notebook_id)
+        """Get raw mind-map rows via the injected mind-map service."""
+        return await self._mind_map_service.list_mind_maps(notebook_id)
 
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw artifact list data."""

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -419,8 +419,8 @@ class TestArtifactsAPI:
         assert result == artifact_rows
 
     @pytest.mark.asyncio
-    async def test_list_uses_facade_list_raw_callback_and_mind_map_patch_seam(self):
-        """list() resolves facade and mind-map seams at call time."""
+    async def test_list_uses_facade_list_raw_callback_and_mind_map_service(self):
+        """list() resolves facade _list_raw and the injected mind-map service."""
         core = MagicMock()
         api = ArtifactsAPI(ClientCoreCapabilities(core))
         studio_artifact = ["art_001", "My Report", 2, None, 3]
@@ -433,15 +433,16 @@ class TestArtifactsAPI:
             patch.object(
                 api, "_list_raw", new=AsyncMock(return_value=[studio_artifact])
             ) as list_raw,
-            patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            patch.object(
+                api._mind_map_service,
+                "list_mind_maps",
                 new=AsyncMock(return_value=[mind_map]),
             ) as list_mind_maps,
         ):
             artifacts = await api.list("nb_123")
 
         list_raw.assert_awaited_once_with("nb_123")
-        list_mind_maps.assert_awaited_once_with(api._core, "nb_123")
+        list_mind_maps.assert_awaited_once_with("nb_123")
         assert [artifact.id for artifact in artifacts] == ["art_001", "mind_map_001"]
 
     @pytest.mark.asyncio
@@ -453,8 +454,9 @@ class TestArtifactsAPI:
 
         with (
             patch.object(api, "_list_raw", new=AsyncMock(return_value=[studio_artifact])),
-            patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            patch.object(
+                api._mind_map_service,
+                "list_mind_maps",
                 new=AsyncMock(),
             ) as list_mind_maps,
         ):
@@ -1352,11 +1354,12 @@ class TestListMindMapErrorHandling:
         httpx_mock.add_response(content=list_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            # After the mind-map relocation, ArtifactsAPI reaches mind maps through the
-            # shared ``_mind_map`` module rather than an injected
-            # NotesAPI. Patch the primitive at its consumer-side import.
-            with patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            # After issue #691, ArtifactsAPI reaches mind-map rows through the
+            # injected MindMapService. Patch the service's list_mind_maps so
+            # the simulated error reaches ArtifactsAPI.list().
+            with patch.object(
+                client.artifacts._mind_map_service,
+                "list_mind_maps",
                 new=AsyncMock(side_effect=RPCError("mind map fetch failed")),
             ):
                 result = await client.artifacts.list("nb_123")
@@ -1381,8 +1384,9 @@ class TestListMindMapErrorHandling:
         httpx_mock.add_response(content=list_response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            with patch.object(
+                client.artifacts._mind_map_service,
+                "list_mind_maps",
                 new=AsyncMock(side_effect=httpx.HTTPError("connection failed")),
             ):
                 result = await client.artifacts.list("nb_123")

--- a/tests/integration/test_empty_results_vcr.py
+++ b/tests/integration/test_empty_results_vcr.py
@@ -90,8 +90,9 @@ class TestEmptyResults:
 
         Covers both wings of the unified ``list`` implementation: the studio
         ``LIST_ARTIFACTS`` RPC (audio/video/reports/quizzes/...) AND the
-        mind-map sidecar via :func:`notebooklm._artifacts._mind_map.list_mind_maps`.
-        A brand-new notebook has neither, so the merged return must be ``[]``.
+        mind-map sidecar via the injected
+        :class:`notebooklm._mind_map.MindMapService`. A brand-new notebook
+        has neither, so the merged return must be ``[]``.
         """
         notebook_id = _get_scratch_notebook_id()
         auth = await get_vcr_auth()

--- a/tests/unit/test_artifacts_mind_map_injection.py
+++ b/tests/unit/test_artifacts_mind_map_injection.py
@@ -1,12 +1,8 @@
-"""Tests for ``MindMapService`` injection into ``ArtifactsAPI`` (issue #691).
+"""Tests for ``MindMapService`` injection into ``ArtifactsAPI``.
 
-PR #690 introduced ``MindMapService`` and wired it into ``NotesAPI`` via a
-keyword-only constructor parameter. Issue #691 brings ``ArtifactsAPI`` onto
-the same explicit service-injection boundary so both facades depend on the
-mind-map service through a constructor seam rather than the module-level
-``_mind_map.list_mind_maps()`` wrapper.
-
-These tests pin three contracts:
+``ArtifactsAPI`` and ``NotesAPI`` both depend on the mind-map service
+through a constructor seam rather than the module-level
+``_mind_map.list_mind_maps()`` wrapper. These tests pin three contracts:
 
 1. ``_list_mind_maps()`` delegates to the injected service and does not
    re-enter the module-level ``_mind_map.list_mind_maps`` wrapper.

--- a/tests/unit/test_artifacts_mind_map_injection.py
+++ b/tests/unit/test_artifacts_mind_map_injection.py
@@ -1,0 +1,62 @@
+"""Tests for ``MindMapService`` injection into ``ArtifactsAPI`` (issue #691).
+
+PR #690 introduced ``MindMapService`` and wired it into ``NotesAPI`` via a
+keyword-only constructor parameter. Issue #691 brings ``ArtifactsAPI`` onto
+the same explicit service-injection boundary so both facades depend on the
+mind-map service through a constructor seam rather than the module-level
+``_mind_map.list_mind_maps()`` wrapper.
+
+These tests pin three contracts:
+
+1. ``_list_mind_maps()`` delegates to the injected service and does not
+   re-enter the module-level ``_mind_map.list_mind_maps`` wrapper.
+2. When no ``mind_map_service`` is injected, ``ArtifactsAPI`` installs a
+   default ``MindMapService(core)``.
+3. ``mind_map_service`` is keyword-only so the positional constructor
+   contract stays unchanged.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm import _mind_map
+from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._capabilities import ClientCoreCapabilities
+
+
+@pytest.mark.asyncio
+async def test_list_mind_maps_delegates_to_injected_service(monkeypatch):
+    """``_list_mind_maps`` calls the injected service and does not re-enter
+    the module-level ``_mind_map.list_mind_maps`` wrapper."""
+    core = ClientCoreCapabilities(MagicMock())
+    fake_service = MagicMock(spec=_mind_map.MindMapService)
+    fake_service.list_mind_maps = AsyncMock(return_value=["sentinel-row"])
+
+    module_seam = AsyncMock(return_value=["should-not-see-this"])
+    monkeypatch.setattr(_mind_map, "list_mind_maps", module_seam)
+
+    api = ArtifactsAPI(core, mind_map_service=fake_service)
+    result = await api._list_mind_maps("nb_abc")
+
+    assert result == ["sentinel-row"]
+    fake_service.list_mind_maps.assert_awaited_once_with("nb_abc")
+    module_seam.assert_not_awaited()
+
+
+def test_default_mind_map_service_installed_when_not_injected():
+    """``ArtifactsAPI(core)`` installs a default ``MindMapService(core)``."""
+    core = ClientCoreCapabilities(MagicMock())
+    api = ArtifactsAPI(core)
+    assert isinstance(api._mind_map_service, _mind_map.MindMapService)
+
+
+def test_mind_map_service_is_keyword_only():
+    """``mind_map_service`` is keyword-only so the positional constructor
+    contract (``core, notes_api, storage_path``) stays unchanged."""
+    core = ClientCoreCapabilities(MagicMock())
+    fake_service = MagicMock(spec=_mind_map.MindMapService)
+    with pytest.raises(TypeError):
+        # Attempting to pass mind_map_service positionally must fail because
+        # the constructor declares it after ``*``.
+        ArtifactsAPI(core, None, None, fake_service)  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Follow-up to merged PR #690 (extracted `MindMapService` and wired it into `NotesAPI`). Brings `ArtifactsAPI` onto the same explicit service-injection boundary so both facades depend on the mind-map service through a constructor seam instead of the module-level wrapper.

- Adds keyword-only `mind_map_service: _mind_map.MindMapService | None = None` to `ArtifactsAPI.__init__`. Defaults to a fresh `MindMapService(core)` when omitted. Mirrors `NotesAPI.__init__` from #690.
- Routes `ArtifactsAPI._list_mind_maps()` through the injected service.
- Preserves the module-level `_mind_map.list_mind_maps()` wrapper — `ArtifactDownloadService.download_mind_map()` still uses it (and is intentionally out of scope here; a future PR can flip that path too).

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (110 files)
- [x] `uv run pytest tests/unit tests/integration` → **5021 passed / 12 skipped** (43s)
- [x] `git diff --check` clean
- [x] New `tests/unit/test_artifacts_mind_map_injection.py` (3 tests) pins: delegation to injected service, default-service installation, keyword-only enforcement
- [x] Four integration tests in `test_artifacts_integration.py` migrated to the new seam (`patch.object(client.artifacts._mind_map_service, "list_mind_maps", ...)`)
- [x] Existing `tests/unit/test_artifact_downloads.py::TestDownloadMindMap` (3 tests) and `tests/integration/concurrency/test_download_blocks_loop.py` (5 tests) still pass unchanged — they patch the module wrapper for the download path, which deliberately retains the wrapper

## Polish notes

Run through `/polish` (code-simplifier + claude+codex+gemini triple review + ultrathink):

- **Critical (applied)**: Codex caught that the `list()`-path patches in `tests/integration/test_artifacts_integration.py` (4 tests) target the module-level seam that this PR retires. Migrated them.
- **Suggestions (deferred)**:
  - `mind_map_service or _mind_map.MindMapService(core)` vs `mind_map_service if mind_map_service is not None else ...` — deferred. Mirrors the `NotesAPI` shape introduced in #690 exactly; `MindMapService` instances and `MagicMock(spec=...)` are both truthy. Switching idiom here would create asymmetry with the just-landed reference shape.
  - Asserting the default service was constructed with the supplied `core` (e.g. `api._mind_map_service._rpc is core`) — deferred; marginal value for a 3-test pin and would couple the test to a private attribute.
- **Nits (deferred)**: sphinx `:class:` qualification on a private module, `[misc]` vs `[call-arg]` mypy code on a deliberate-bad-positional-call test.

Refs #691, follows #690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved artifact processing to support an injectable mind‑map service for more reliable mind‑map handling.

* **Tests**
  * Expanded and updated tests for mind‑map service integration, injection behavior, and error scenarios; ensures artifact results still return when mind‑map fetches fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->