### PR TITLE
chore(src,docs): drop residual audit-ID leaders

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,7 +1,7 @@
 # CLI Reference
 
 **Status:** Active
-**Last Updated:** 2026-05-15 (T6 Part C)
+**Last Updated:** 2026-05-15
 
 Complete command reference for the `notebooklm` CLI—providing full programmatic access to all NotebookLM features, including capabilities not exposed in the web UI.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -351,8 +351,9 @@ Run the setup script once per Google account that records cassettes:
 uv run python tests/scripts/setup-generation-notebook.py
 ```
 
-The script is idempotent: it reuses an existing notebook titled
-`VCR Generation Notebook (Tier 8)` if one already exists, otherwise creates it.
+The script is idempotent: it reuses the notebook whose title matches
+`GENERATION_NOTEBOOK_TITLE` (defined in `tests/scripts/setup-generation-notebook.py`)
+if one already exists, otherwise creates it.
 It prints the notebook UUID and an `export` line. Copy the export line into
 your maintainer environment (e.g. `~/.zshrc` or a profile-specific `.env`
 file you do NOT commit):

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -153,16 +153,16 @@ _DEFAULT_DATEFMT = "%H:%M:%S"
 #   Cookie: (IGNORECASE)                                 -> "cookie"
 #   Set-Cookie: (IGNORECASE)                             -> "set-cookie" (also "cookie")
 #
-# Deviation notes vs. plan PR-F:
-#   - Plan's literal token list is mixed-case (``SID``, ``SAPISID``, ``CSRF``,
-#     ``Cookie``, ``Authorization``, ``Set-Cookie``). We lowercase the gate
-#     to honor ``re.IGNORECASE`` on those patterns. Token VALUES change to
-#     lowercase; the COVERAGE story (and the resulting redaction surface)
-#     is preserved.
-#   - "_token=" and "code=" extend the plan's literal token list. The plan
-#     advertises "superset of substrings in any pattern" but its own list
-#     omits OAuth anchors; without them the OAuth pattern would silently stop
-#     redacting whenever a message had no other secret marker.
+# Deviation notes vs. the originating redaction design:
+#   - The design's literal token list is mixed-case (``SID``, ``SAPISID``,
+#     ``CSRF``, ``Cookie``, ``Authorization``, ``Set-Cookie``). We lowercase
+#     the gate to honor ``re.IGNORECASE`` on those patterns. Token VALUES
+#     change to lowercase; the COVERAGE story (and the resulting redaction
+#     surface) is preserved.
+#   - "_token=" and "code=" extend the design's literal token list. The
+#     design advertises "superset of substrings in any pattern" but its own
+#     list omits OAuth anchors; without them the OAuth pattern would silently
+#     stop redacting whenever a message had no other secret marker.
 #   - "continue=" and "authuser=" are NOT in ``_REDACT_PATTERNS``. Including
 #     them is harmless: they only INCREASE the regex-sweep rate, never the
 #     redaction surface, and they hedge against future audit additions.

--- a/src/notebooklm/cli/artifact.py
+++ b/src/notebooklm/cli/artifact.py
@@ -240,8 +240,8 @@ def artifact_get(ctx, artifact_id, notebook_id, json_output, client_auth):
             # (``_output_error`` always raises) — it exists solely to narrow
             # ``art`` from ``Artifact | None`` to ``Artifact`` for mypy without
             # forcing a ``NoReturn`` annotation onto
-            # ``error_handler._output_error`` (which would touch a module the
-            # C1 spec says we must not).
+            # ``error_handler._output_error`` (which would change the shared
+            # error helper's typing contract).
             if art is None:
                 _output_error(
                     "Artifact not found",

--- a/src/notebooklm/cli/note.py
+++ b/src/notebooklm/cli/note.py
@@ -221,7 +221,7 @@ def note_get(ctx, note_id, notebook_id, json_output, client_auth):
             # (``_output_error`` always raises) — it exists solely to narrow
             # ``n`` from ``Note | None`` to ``Note`` for mypy without forcing a
             # ``NoReturn`` annotation onto ``error_handler._output_error``
-            # (which would touch a module the C1 spec says we must not).
+            # (which would change the shared error helper's typing contract).
             if not isinstance(n, Note):
                 _output_error(
                     "Note not found",

--- a/src/notebooklm/cli/notebook.py
+++ b/src/notebooklm/cli/notebook.py
@@ -123,8 +123,8 @@ def register_notebook_commands(cli):
                             "created_at": nb.created_at.isoformat() if nb.created_at else None,
                         }
                     }
-                    # I12: when --use switched the active context, surface the
-                    # new active notebook id at the top level so callers can
+                    # When --use switched the active context, surface the new
+                    # active notebook id at the top level so callers can
                     # branch on the field without scraping the "Context set
                     # to ..." prose or round-tripping through `status --json`.
                     if switch_context:

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -1144,10 +1144,10 @@ def register_session_commands(cli):
         if force:
             set_current_notebook(notebook_id)
             if json_output:
-                # I12: surface the new active notebook id as the primary
-                # signal so script callers can pipe `notebooklm use --json`
-                # straight into downstream automation. ``verified: false``
-                # mirrors the "(not verified — --force)" cell in text mode.
+                # Surface the new active notebook id as the primary signal
+                # so script callers can pipe `notebooklm use --json` straight
+                # into downstream automation. ``verified: false`` mirrors the
+                # "(not verified — --force)" cell in text mode.
                 json_output_response(
                     {
                         "active_notebook_id": notebook_id,
@@ -1168,7 +1168,7 @@ def register_session_commands(cli):
             # with an unverified ID) and route through the typed
             # ``handle_auth_error`` UX so JSON callers get the standard
             # ``AUTH_REQUIRED`` envelope and text callers get the rich
-            # multi-line "Run notebooklm login" walkthrough. (I13.)
+            # multi-line "Run notebooklm login" walkthrough.
             handle_auth_error(json_output)
             return  # unreachable — handle_auth_error raises SystemExit
         except click.ClickException:
@@ -1201,8 +1201,8 @@ def register_session_commands(cli):
             # Auth expired (e.g. SID/SSID cookies stale). Route through the
             # typed UX so the user sees "Run notebooklm login" instead of
             # the generic "Pass --force to persist without verification"
-            # catch-all that previously hid the real remediation. (Audit row
-            # I13 — see helpers.handle_auth_error for the canonical message.)
+            # catch-all that previously hid the real remediation.
+            # See ``helpers.handle_auth_error`` for the canonical message.
             handle_auth_error(json_output)
             return  # unreachable — handle_auth_error raises SystemExit
         except Exception as exc:
@@ -1218,9 +1218,9 @@ def register_session_commands(cli):
         set_current_notebook(resolved_id, nb.title, nb.is_owner, created_str)
 
         if json_output:
-            # I12: scriptable envelope surfaces the new active notebook id
-            # plus enough metadata that callers don't have to round-trip
-            # through `notebooklm status --json` to render a confirmation.
+            # Scriptable envelope surfaces the new active notebook id plus
+            # enough metadata that callers don't have to round-trip through
+            # `notebooklm status --json` to render a confirmation.
             json_output_response(
                 {
                     "active_notebook_id": resolved_id,
@@ -1845,7 +1845,7 @@ def register_session_commands(cli):
         See docs/troubleshooting.md ("Cookie freshness for long-running /
         unattended use") for launchd / systemd / cron recipes.
         """
-        # Wrap the entire body in handle_errors (I15 polish): typed exceptions
+        # Wrap the entire body in handle_errors: typed exceptions
         # (AuthError, NetworkError, ValidationError, ...) get user-friendly
         # one-liners + hints; unexpected exceptions become 'Unexpected error:
         # <msg>' (exit 2) instead of leaking ``type(exc).__name__`` into the

--- a/src/notebooklm/cli/source.py
+++ b/src/notebooklm/cli/source.py
@@ -509,8 +509,8 @@ def source_get(ctx, source_id, notebook_id, json_output, client_auth):
             # (``_output_error`` always raises) — it exists solely to narrow
             # ``src`` from ``Source | None`` to ``Source`` for mypy without
             # forcing a ``NoReturn`` annotation onto
-            # ``error_handler._output_error`` (which would touch a module the
-            # C1 spec says we must not).
+            # ``error_handler._output_error`` (which would change the shared
+            # error helper's typing contract).
             if src is None:
                 _output_error(
                     "Source not found",


### PR DESCRIPTION
## Summary

- Strips audit-tracker refs (`T6 Part C`, `Tier 8`, `I12`, `I13`, `I15`, `C1`, `PR-F`) that re-accumulated in `src/notebooklm/{_logging,cli/*}.py` and `docs/{cli-reference,development}.md` across the 38 commits since PR #680 landed the original 3-phase cleanup.
- Where the audit code was the only structuring noun, the surrounding sentence is rewritten to preserve intent (e.g. `C1 spec says we must not` → `would change the shared error helper's typing contract`).
- `Tier 1` / `Tier 2` in `_auth/cookie_policy.py` and `docs/configuration.md` are preserved — legitimate cookie-policy domain language, not audit codes.

Part 1 of 3 in the audit-ref-scrub plan (`.sisyphus/plans/audit-ref-scrub-2026-05-17.md`). Follow-ups will cover `tests/` (PR-2) and `scripts/` (PR-3).

## Test plan

- [x] `uv run pytest tests/unit` — 4385 passed / 8 skipped (no test count change; pure comment edits)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and updated inline comments and documentation across CLI commands to improve explanations of typing contracts and error handling flows.
  * Updated CLI reference metadata and development setup documentation for improved clarity.
  * No functional changes to runtime behavior or exported APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->