### PR TITLE
test(vcr): gzipped cassette coverage to catch #769-class regressions

### DIFF
--- a/tests/cassettes/gzip_coverage/artifacts_revise_slide_gzipped.yaml
+++ b/tests/cassettes/gzip_coverage/artifacts_revise_slide_gzipped.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: f.req=%5B%5B%5B%22KmcKPe%22%2C%22%5B%5B2%5D%2C%5C%22e52e81c5-613b-43ec-8f45-66a120644a26%5C%22%2C%5B%5B%5B0%2C%5C%22Move%20the%20title%20up%5C%22%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF%3A1778848153629&
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '241'
+      Content-Type:
+      - application/x-www-form-urlencoded;charset=UTF-8
+      Cookie:
+      - NID=SCRUBBED; SID=SCRUBBED; __Secure-1PSID=SCRUBBED; __Secure-3PSID=SCRUBBED;
+        HSID=SCRUBBED; SSID=SCRUBBED; APISID=SCRUBBED; SAPISID=SCRUBBED; __Secure-1PAPISID=SCRUBBED;
+        __Secure-3PAPISID=SCRUBBED; __Secure-1PSIDTS=SCRUBBED; __Secure-3PSIDTS=SCRUBBED;
+        SIDCC=SCRUBBED; __Secure-1PSIDCC=SCRUBBED; __Secure-3PSIDCC=SCRUBBED; OSID=SCRUBBED;
+        __Secure-OSID=SCRUBBED; _gcl_au=1.1.1583381276.1778846987; _ga=GA1.1.1567240762.1778846987;
+        _ga_W0LDH41ZCB=GS2.1.s1778846986$o1$g0$t1778846986$j60$l0$h0
+      Host:
+      - notebooklm.google.com
+      User-Agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?rpcids=KmcKPe&source-path=%2Fnotebook%2Fbb00c9e3-656c-4fd2-b890-2b71e1cf3814&f.sid=SCRUBBED&hl=en&rt=c
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/51RS0/DMAy+91dUucCkZMrDCelvGEOIa5pDHs5W0a1T1cGJ/046LgjEhYOfnz/b
+        sjf+465pQMjGOfI+x22ZCSW7U9o9Y3Wc60m0kACNYQkfIgMVLQvJGmZ5siFnVYJUPaE9eZoWjNP0
+        +rhvXzBjGc6Y23u5qaClbm0FxsQOUbEkEjLQWJg1IjGRIZaUO9WF3BPvPRX0fB3HfyjnbqYnZa5z
+        BRX+jzLHa9F+esN2OVYZlhHb6+U2/Relro5aohVJMyPUegVMzBaooQlCcgMQpLmRyU8yOeAZ5yER
+        Tx3JQ11Ka7n6oWyPy3KZT18pSowWwI21nCvggnMjZIW4941U63/qR+BbY9Ar9Al+l1NiwgEAAA==
+    headers:
+      Accept-CH:
+      - Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Full-Version, Sec-CH-UA-Full-Version-List,
+        Sec-CH-UA-Model, Sec-CH-UA-WoW64, Sec-CH-UA-Form-Factors, Sec-CH-UA-Platform,
+        Sec-CH-UA-Platform-Version
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Disposition:
+      - attachment; filename="response.bin"; filename*=UTF-8''response.bin
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - require-trusted-types-for 'script';report-uri /_/LabsTailwindUi/cspreport
+      Content-Type:
+      - application/json; charset=utf-8
+      Cross-Origin-Opener-Policy:
+      - same-origin-allow-popups
+      Cross-Origin-Resource-Policy:
+      - same-site
+      Date:
+      - Fri, 15 May 2026 12:29:13 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Permissions-Policy:
+      - ch-ua-arch=*, ch-ua-bitness=*, ch-ua-full-version=*, ch-ua-full-version-list=*,
+        ch-ua-model=*, ch-ua-wow64=*, ch-ua-form-factors=*, ch-ua-platform=*, ch-ua-platform-version=*
+      Pragma:
+      - no-cache
+      Server:
+      - ESF
+      Set-Cookie:
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      - SIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/; domain=.google.com;
+        priority=high
+      - __Secure-1PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high
+      - __Secure-3PSIDCC=SCRUBBED; expires=Sat, 15-May-2027 12:29:15 GMT; path=/;
+        domain=.google.com; Secure; HttpOnly; priority=high; SameSite=none
+      Vary:
+      - Sec-Fetch-Dest, Sec-Fetch-Mode, Sec-Fetch-Site
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/test_gzip_cassette_replay.py
+++ b/tests/integration/test_gzip_cassette_replay.py
@@ -31,6 +31,12 @@ import vcr
 
 from notebooklm._core_transport import _stream_post_with_size_cap
 
+# Required by the tier-enforcement rule in :mod:`tests.integration.conftest`
+# — every integration test must carry ``@pytest.mark.vcr``, be decorated
+# with ``@notebooklm_vcr.use_cassette``, or opt out via
+# ``@pytest.mark.allow_no_vcr``. We use a scoped ``vcr.VCR`` instance below
+# (not ``notebooklm_vcr``), so the marker is the only path to satisfy the
+# rule without spawning a no-op cassette on the project's default config.
 pytestmark = pytest.mark.vcr
 
 
@@ -43,6 +49,12 @@ GZIP_COVERAGE_DIR = REPO_ROOT / "tests" / "cassettes" / "gzip_coverage"
 # defeating the regression. The match rules mirror ``notebooklm_vcr`` so
 # request matching stays consistent with how the source cassette was
 # recorded.
+# ``match_on`` deliberately omits the query string. The cassette has a
+# single batchexecute interaction so the default ``method/scheme/host/
+# port/path`` tuple identifies it uniquely. If more interactions are
+# ever added under ``gzip_coverage/``, switch to the ``rpcids`` matcher
+# (see ``tests.vcr_config._rpcids_matcher``) so the wrong recording can
+# never be served on replay.
 _gzip_replay_vcr = vcr.VCR(
     cassette_library_dir=str(GZIP_COVERAGE_DIR),
     record_mode="none",

--- a/tests/integration/test_gzip_cassette_replay.py
+++ b/tests/integration/test_gzip_cassette_replay.py
@@ -1,0 +1,104 @@
+"""Replay a gzipped cassette through ``_stream_post_with_size_cap``.
+
+#769 was a real production bug — every RPC failed with ``Error -3 while
+decompressing data: incorrect header check`` — that slipped through the
+existing VCR suite because every cassette dropped ``Content-Encoding``
+on record (``decode_compressed_response=True`` in
+:mod:`tests.vcr_config`). This module is the cassette half of the
+follow-up regression coverage for issue #773: a derived cassette under
+``tests/cassettes/gzip_coverage/`` carries a gzipped response body
+plus ``Content-Encoding: gzip``, replayed through the production
+streaming transport. Reverting the
+``_STRIP_HEADERS_ON_REBUFFER`` filter in #771 makes this test fail with
+``httpx.DecodingError`` on the rebuild step.
+
+A scoped :class:`vcr.VCR` instance with
+``decode_compressed_response=False`` is used because vcrpy applies the
+decode filter at cassette-LOAD time (not just on record) — see
+``vcr.cassette.Cassette._load`` calling ``append`` which runs the
+``before_record_response`` chain. The project's ``notebooklm_vcr``
+instance leaves that flag on so cassettes stay diff-readable, so this
+file pins a no-decode instance scoped to the gzipped cassettes only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import vcr
+
+from notebooklm._core_transport import _stream_post_with_size_cap
+
+pytestmark = pytest.mark.vcr
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GZIP_COVERAGE_DIR = REPO_ROOT / "tests" / "cassettes" / "gzip_coverage"
+
+# Pin a no-decode VCR instance: vcrpy applies ``decode_response`` filter at
+# load time when ``decode_compressed_response`` is True, which would gunzip
+# the cassette body and strip ``Content-Encoding`` before the test sees it,
+# defeating the regression. The match rules mirror ``notebooklm_vcr`` so
+# request matching stays consistent with how the source cassette was
+# recorded.
+_gzip_replay_vcr = vcr.VCR(
+    cassette_library_dir=str(GZIP_COVERAGE_DIR),
+    record_mode="none",
+    match_on=["method", "scheme", "host", "port", "path"],
+    decode_compressed_response=False,
+)
+
+
+# Replayed POST coordinates pulled from the source recording
+# ``tests/cassettes/artifacts_revise_slide.yaml``. We do not match on
+# ``f.req`` or rpcids here because the cassette has a single batchexecute
+# interaction — the default ``method/scheme/host/port/path`` matchers
+# already pin it uniquely.
+_REVISE_SLIDE_URL = (
+    "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute"
+    "?rpcids=KmcKPe"
+    "&source-path=%2Fnotebook%2Fbb00c9e3-656c-4fd2-b890-2b71e1cf3814"
+    "&f.sid=SCRUBBED&hl=en&rt=c"
+)
+_REVISE_SLIDE_BODY = (
+    "f.req=%5B%5B%5B%22KmcKPe%22%2C%22%5B%5B2%5D%2C%5C%22e52e81c5-613b-43ec-"
+    "8f45-66a120644a26%5C%22%2C%5B%5B%5B0%2C%5C%22Move%20the%20title%20up"
+    "%5C%22%5D%5D%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D&at=SCRUBBED_CSRF"
+    "%3A1778848153629&"
+)
+
+
+@pytest.mark.asyncio
+async def test_gzipped_cassette_replays_without_double_decode() -> None:
+    """The streaming wrapper must rebuild the response without re-running
+    the gzip decoder on already-decoded bytes.
+
+    Without the ``_STRIP_HEADERS_ON_REBUFFER`` guard from #771, this test
+    fails inside ``httpx.Response.__init__`` with
+    ``DecodingError: Error -3 ... incorrect header check`` because the
+    rebuilt response carries the upstream ``Content-Encoding: gzip`` over
+    the decoded payload.
+    """
+    with _gzip_replay_vcr.use_cassette("artifacts_revise_slide_gzipped.yaml"):
+        async with httpx.AsyncClient() as client:
+            response = await _stream_post_with_size_cap(
+                client,
+                _REVISE_SLIDE_URL,
+                body=_REVISE_SLIDE_BODY,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+                },
+            )
+
+    assert response.status_code == 200
+    # Body decodes once — the XSSI prefix and a recognizable RPC envelope
+    # marker confirm the gzip was decoded exactly once, not zero times
+    # (raw gzip bytes) and not twice (DecodingError).
+    assert response.text.startswith(")]}'")
+    assert '"wrb.fr","KmcKPe"' in response.text
+    # The misleading upstream ``Content-Encoding`` must not survive onto the
+    # rebuilt response — otherwise downstream consumers that re-read or
+    # re-stream would hit the same double-decode trap.
+    assert "content-encoding" not in response.headers

--- a/tests/scripts/inject_gzip_into_cassette.py
+++ b/tests/scripts/inject_gzip_into_cassette.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Re-encode a recorded cassette so its response body is gzip-compressed
+and the response advertises ``Content-Encoding: gzip``.
+
+Why this exists
+---------------
+``decode_compressed_response=True`` in :mod:`tests.vcr_config` strips
+``Content-Encoding`` from the headers on record (after VCR transparently
+gunzips the body), so 89/89 cassettes in ``tests/cassettes/`` carry NO
+encoding header and a plaintext body. That hid issue #769 — every RPC
+failed in production with ``Error -3 while decompressing data: incorrect
+header check`` because :func:`notebooklm._core_transport._stream_post_with_size_cap`
+rebuilt the response with the upstream ``Content-Encoding: gzip`` header
+attached to *already-decoded* body bytes, triggering a second gzip-decode
+inside :class:`httpx.Response.__init__`. Cassettes that don't carry the
+header on replay simply skip that branch and pass.
+
+This script ports a cassette to the production wire shape: gzip the
+response body, restore the ``Content-Encoding: gzip`` header, and strip
+the now-meaningless ``Transfer-Encoding`` and ``Content-Length`` headers
+(the originals described the chunked / decoded wire form, not the gzipped
+buffer we hand to vcrpy on replay).
+
+Run from the repo root::
+
+    uv run python tests/scripts/inject_gzip_into_cassette.py \\
+        tests/cassettes/artifacts_revise_slide.yaml \\
+        tests/cassettes/gzip_coverage/artifacts_revise_slide_gzipped.yaml
+
+Idempotent: re-running on a cassette that already advertises
+``Content-Encoding: gzip`` rewrites it from scratch using the gzipped
+body that vcrpy has already deserialized to ``bytes``, so a second pass
+produces a byte-identical file.
+
+Library use:
+    Other tooling can ``from tests.scripts.inject_gzip_into_cassette
+    import inject_gzip_into_cassette`` and pass a cassette dict in
+    memory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Use the SAFE loader: cassettes are arbitrary YAML on disk and a malicious
+# ``!!python/object/apply`` tag would execute code under the full Loader.
+# ``!!binary`` (the encoding we rely on for gzipped bodies) is part of the
+# core YAML schema so it works under ``CSafeLoader`` / ``SafeLoader``.
+try:
+    from yaml import CDumper as Dumper
+    from yaml import CSafeLoader as Loader
+except ImportError:  # pragma: no cover — libyaml is bundled with PyYAML wheels
+    from yaml import Dumper  # type: ignore[assignment]
+    from yaml import SafeLoader as Loader
+
+
+# Headers stripped from the response when we rewrite the body. The recorded
+# Transfer-Encoding / Content-Length values described the chunked / decoded
+# wire form; once we re-gzip the body, neither matches reality and leaving
+# them in confuses httpx on replay. Content-Encoding is included so the
+# rewrite always re-adds the canonical-cased header regardless of how the
+# cassette was originally recorded.
+_STRIP_RESPONSE_HEADERS = frozenset(
+    {
+        "transfer-encoding",
+        "content-length",
+        "content-encoding",
+    }
+)
+
+_CONTENT_ENCODING_HEADER = "Content-Encoding"
+
+
+def _has_content_encoding(headers: dict[str, list[str]]) -> bool:
+    """Case-insensitive check for ``Content-Encoding`` in a cassette
+    header dict."""
+    return any(k.lower() == "content-encoding" for k in headers)
+
+
+def _coerce_body_to_bytes(body_string: Any) -> bytes:
+    """Normalize the recorded ``response.body.string`` to ``bytes``.
+
+    PyYAML deserializes ``!!binary`` blobs as :class:`bytes` and plain
+    block scalars as :class:`str`. The cassette format permits either,
+    so accept both and return raw bytes.
+    """
+    if isinstance(body_string, bytes):
+        return body_string
+    if isinstance(body_string, str):
+        return body_string.encode("utf-8")
+    raise TypeError(
+        f"Unexpected response.body.string type {type(body_string).__name__}; expected bytes or str."
+    )
+
+
+def _inject_into_response(response: dict[str, Any]) -> bool:
+    """Mutate ``response`` in place so the body is gzip-compressed and
+    ``Content-Encoding: gzip`` is set.
+
+    Returns ``True`` when the response was rewritten, ``False`` when the
+    cassette already carried a ``Content-Encoding`` header (in which case
+    the body is re-gzipped from its decoded form so the rewrite is
+    idempotent).
+    """
+    body = response.get("body") or {}
+    if "string" not in body:
+        return False
+
+    raw = body["string"]
+    if raw is None:
+        return False
+
+    body_bytes = _coerce_body_to_bytes(raw)
+
+    headers = response.setdefault("headers", {})
+    already_encoded = _has_content_encoding(headers)
+
+    if already_encoded:
+        # The body on disk is already gzipped — gunzip first so the
+        # rewrite produces a byte-identical file on a second pass.
+        try:
+            body_bytes = gzip.decompress(body_bytes)
+        except OSError as exc:  # pragma: no cover — defensive
+            raise ValueError(
+                "Response already advertises Content-Encoding but body is not valid gzip."
+            ) from exc
+
+    # ``gzip.compress`` writes one byte that varies across Python releases
+    # (the OS field at offset 9): 3.10 picks an OS-dependent constant
+    # while 3.11+ pins it to ``0xff`` (unknown). Pin ``mtime=0`` and
+    # overwrite the OS field so the same source cassette produces a
+    # byte-identical artifact under every Python in the CI matrix
+    # (``3.10`` – ``3.14``). ``0xff`` is the documented "unknown" value
+    # from RFC 1952 §2.3.1 and round-trips through every gzip decoder.
+    gzipped = bytearray(gzip.compress(body_bytes, mtime=0))
+    gzipped[9] = 0xFF
+    body["string"] = bytes(gzipped)
+
+    # Drop any case-variant of the headers in _STRIP_RESPONSE_HEADERS
+    # (including Content-Encoding) so the rewrite re-adds the canonical
+    # header name below.
+    for key in list(headers):
+        if key.lower() in _STRIP_RESPONSE_HEADERS:
+            del headers[key]
+    headers[_CONTENT_ENCODING_HEADER] = ["gzip"]
+
+    return True
+
+
+def inject_gzip_into_cassette(cassette: dict[str, Any]) -> int:
+    """Rewrite every batchexecute-style response in ``cassette`` to be
+    gzip-encoded.
+
+    Only responses whose request is a POST to a path containing
+    ``batchexecute`` are touched — those are the ones that flow through
+    :func:`notebooklm._core_transport._stream_post_with_size_cap` and
+    exercise the rebuild step that bit #769. SPA-shell GET responses are
+    left alone so the cassette diff stays focused.
+
+    Returns the number of responses that were rewritten.
+    """
+    rewritten = 0
+    for interaction in cassette.get("interactions", []) or []:
+        request = interaction.get("request") or {}
+        if request.get("method", "").upper() != "POST":
+            continue
+        uri = request.get("uri", "") or ""
+        if "batchexecute" not in uri:
+            continue
+        response = interaction.get("response") or {}
+        if _inject_into_response(response):
+            rewritten += 1
+    return rewritten
+
+
+def _load_cassette(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.load(fh, Loader=Loader)
+
+
+def _dump_cassette(cassette: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.dump(cassette, fh, Dumper=Dumper)
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path, help="cassette to read")
+    parser.add_argument(
+        "destination",
+        type=Path,
+        help="destination path (may equal source for in-place rewrite)",
+    )
+    args = parser.parse_args(argv)
+
+    cassette = _load_cassette(args.source)
+    rewritten = inject_gzip_into_cassette(cassette)
+    if rewritten == 0:
+        print(
+            f"warning: no batchexecute POST interactions found in {args.source}",
+            file=sys.stderr,
+        )
+        return 1
+
+    _dump_cassette(cassette, args.destination)
+    print(f"rewrote {rewritten} response(s) in {args.destination}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tests/scripts/inject_gzip_into_cassette.py
+++ b/tests/scripts/inject_gzip_into_cassette.py
@@ -53,10 +53,10 @@ import yaml
 # ``!!binary`` (the encoding we rely on for gzipped bodies) is part of the
 # core YAML schema so it works under ``CSafeLoader`` / ``SafeLoader``.
 try:
-    from yaml import CDumper as Dumper
+    from yaml import CSafeDumper as Dumper
     from yaml import CSafeLoader as Loader
 except ImportError:  # pragma: no cover — libyaml is bundled with PyYAML wheels
-    from yaml import Dumper  # type: ignore[assignment]
+    from yaml import SafeDumper as Dumper  # type: ignore[assignment]
     from yaml import SafeLoader as Loader
 
 
@@ -103,10 +103,11 @@ def _inject_into_response(response: dict[str, Any]) -> bool:
     """Mutate ``response`` in place so the body is gzip-compressed and
     ``Content-Encoding: gzip`` is set.
 
-    Returns ``True`` when the response was rewritten, ``False`` when the
-    cassette already carried a ``Content-Encoding`` header (in which case
-    the body is re-gzipped from its decoded form so the rewrite is
-    idempotent).
+    Returns ``True`` when the body was (re)written; ``False`` only when
+    the response has no ``body.string`` to process (missing key or
+    ``None``). A response that already advertises ``Content-Encoding``
+    is gunzipped first and then re-gzipped from the decoded form so the
+    rewrite is idempotent — still a rewrite, still ``True``.
     """
     body = response.get("body") or {}
     if "string" not in body:

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -564,30 +564,6 @@ def test_audit_repair_list_entries_exist() -> None:
 # under ``tests/scripts/inject_gzip_into_cassette.py``) trips CI loudly.
 
 
-def _response_headers_iter(cassette: Path) -> list[dict[str, list[str]]]:
-    """Return every response's ``headers`` dict from a cassette."""
-    data, _ = _load_cassette(cassette)
-    out: list[dict[str, list[str]]] = []
-    for interaction in data.get("interactions") or []:
-        response = interaction.get("response") or {}
-        headers = response.get("headers") or {}
-        if isinstance(headers, dict):
-            out.append(headers)
-    return out
-
-
-def _response_advertises_gzip(headers: dict[str, list[str]]) -> bool:
-    """Return True if any case-variant ``Content-Encoding`` header in
-    ``headers`` names gzip."""
-    for key, raw_values in headers.items():
-        if key.lower() != "content-encoding":
-            continue
-        values = [raw_values] if isinstance(raw_values, str) else raw_values
-        if any("gzip" in v.lower() for v in values):
-            return True
-    return False
-
-
 def _all_cassettes_recursive() -> list[Path]:
     """Every cassette under ``tests/cassettes``, including subdirectories
     like ``gzip_coverage/``.
@@ -600,6 +576,21 @@ def _all_cassettes_recursive() -> list[Path]:
     return sorted(CASSETTE_DIR.rglob("*.yaml"))
 
 
+# Cassette header lines for ``Content-Encoding: gzip`` follow the vcrpy
+# YAML serialization shape: the case-insensitive header name on one line
+# followed by ``- gzip`` (with optional surrounding whitespace) on the
+# next. Anchored to ``^`` so the pattern does not match `gzip` mentioned
+# in a request URL or response body. Compiled at module scope so the
+# walk-the-cassette test stays cheap on Windows runners where libyaml
+# isn't available and structural ``yaml.safe_load`` is ~10× slower —
+# the original load-every-cassette implementation timed out at 60s on
+# Windows Python 3.11 / 3.12.
+_CONTENT_ENCODING_GZIP_RE = re.compile(
+    r"^[ \t]*[Cc]ontent-[Ee]ncoding:\s*\n[ \t]*-\s*gzip\b",
+    re.MULTILINE,
+)
+
+
 def test_at_least_one_cassette_advertises_content_encoding_gzip() -> None:
     """At least one cassette must carry ``Content-Encoding: gzip`` in a
     response header.
@@ -610,11 +601,14 @@ def test_at_least_one_cassette_advertises_content_encoding_gzip() -> None:
     cassettes from canonical recordings. If this assertion ever fails
     again, regenerate the gzip-coverage cassettes — do not silence the
     test.
+
+    Scans raw cassette text rather than ``yaml.safe_load``-ing every
+    cassette — see ``_CONTENT_ENCODING_GZIP_RE`` for why.
     """
     matches = [
         c
         for c in _all_cassettes_recursive()
-        if any(_response_advertises_gzip(h) for h in _response_headers_iter(c))
+        if _CONTENT_ENCODING_GZIP_RE.search(c.read_text(encoding="utf-8"))
     ]
     assert matches, (
         "No cassette under tests/cassettes/ advertises Content-Encoding: gzip "
@@ -640,13 +634,16 @@ def test_gzip_coverage_cassettes_round_trip_through_helper() -> None:
     """
     import importlib.util
 
-    # Safe loader — cassettes are arbitrary YAML on disk; ``!!binary`` works
-    # under the safe schema so we don't need the full Loader.
+    # Safe loader + dumper — cassettes are arbitrary YAML on disk and we
+    # never need to serialize Python-specific tags here, so the safe
+    # schema is the symmetric and audit-friendly choice. ``!!binary``
+    # (the encoding gzipped bodies rely on) is part of the core YAML
+    # schema and round-trips through ``CSafeLoader`` / ``CSafeDumper``.
     try:
-        from yaml import CDumper as Dumper
+        from yaml import CSafeDumper as Dumper
         from yaml import CSafeLoader as Loader
     except ImportError:  # pragma: no cover — libyaml ships with PyYAML wheels
-        from yaml import Dumper  # type: ignore[assignment]
+        from yaml import SafeDumper as Dumper  # type: ignore[assignment]
         from yaml import SafeLoader as Loader
 
     # ``tests/`` is not a Python package, so import the helper by file path —

--- a/tests/unit/test_cassette_shapes.py
+++ b/tests/unit/test_cassette_shapes.py
@@ -546,3 +546,139 @@ def test_audit_repair_list_entries_exist() -> None:
     """
     missing = [name for name in AUDIT_REPAIR_LIST if not (CASSETTE_DIR / name).exists()]
     assert not missing, f"AUDIT_REPAIR_LIST references cassettes that no longer exist: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Encoding-header coverage (issue #773 follow-up to #769 / #771)
+# ---------------------------------------------------------------------------
+# ``decode_compressed_response=True`` in :mod:`tests.vcr_config` strips
+# ``Content-Encoding`` from every recorded response. Pre-#751 that was fine
+# because the response went through ``client.post`` once and decoded
+# exactly once; #751 introduced the streaming rebuild path in
+# :func:`notebooklm._core_transport._stream_post_with_size_cap`, and the
+# combination of an upstream gzip header re-applied to already-decoded
+# bytes is what bit #769 in production. The existing cassette suite
+# couldn't surface that regression because no cassette carried the
+# header. This lint pins a floor on the encoding-header coverage so a
+# future cassette wipe (or a regression in the gzip-injection workflow
+# under ``tests/scripts/inject_gzip_into_cassette.py``) trips CI loudly.
+
+
+def _response_headers_iter(cassette: Path) -> list[dict[str, list[str]]]:
+    """Return every response's ``headers`` dict from a cassette."""
+    data, _ = _load_cassette(cassette)
+    out: list[dict[str, list[str]]] = []
+    for interaction in data.get("interactions") or []:
+        response = interaction.get("response") or {}
+        headers = response.get("headers") or {}
+        if isinstance(headers, dict):
+            out.append(headers)
+    return out
+
+
+def _response_advertises_gzip(headers: dict[str, list[str]]) -> bool:
+    """Return True if any case-variant ``Content-Encoding`` header in
+    ``headers`` names gzip."""
+    for key, raw_values in headers.items():
+        if key.lower() != "content-encoding":
+            continue
+        values = [raw_values] if isinstance(raw_values, str) else raw_values
+        if any("gzip" in v.lower() for v in values):
+            return True
+    return False
+
+
+def _all_cassettes_recursive() -> list[Path]:
+    """Every cassette under ``tests/cassettes``, including subdirectories
+    like ``gzip_coverage/``.
+
+    Kept separate from :func:`_real_cassettes` (which is non-recursive on
+    purpose — the existing shape lint targets the canonical recorded
+    cassettes only, not derived sibling cassettes that may carry binary
+    bodies or other non-canonical shapes).
+    """
+    return sorted(CASSETTE_DIR.rglob("*.yaml"))
+
+
+def test_at_least_one_cassette_advertises_content_encoding_gzip() -> None:
+    """At least one cassette must carry ``Content-Encoding: gzip`` in a
+    response header.
+
+    Closes the test-coverage gap that hid #769. The fix lives in
+    ``tests/cassettes/gzip_coverage/`` plus the helper in
+    ``tests/scripts/inject_gzip_into_cassette.py`` that re-derives those
+    cassettes from canonical recordings. If this assertion ever fails
+    again, regenerate the gzip-coverage cassettes — do not silence the
+    test.
+    """
+    matches = [
+        c
+        for c in _all_cassettes_recursive()
+        if any(_response_advertises_gzip(h) for h in _response_headers_iter(c))
+    ]
+    assert matches, (
+        "No cassette under tests/cassettes/ advertises Content-Encoding: gzip "
+        "on any response. The streaming rebuild path in "
+        "notebooklm._core_transport._stream_post_with_size_cap is invisible to "
+        "VCR replay without it (see #769/#771). Regenerate the gzip-coverage "
+        "cassette(s) via:\n"
+        "    uv run python tests/scripts/inject_gzip_into_cassette.py "
+        "tests/cassettes/<source>.yaml "
+        "tests/cassettes/gzip_coverage/<source>_gzipped.yaml"
+    )
+
+
+def test_gzip_coverage_cassettes_round_trip_through_helper() -> None:
+    """Every cassette under ``gzip_coverage/`` must be a fixed point of
+    the gzip-injection helper.
+
+    Catches drift between the committed cassettes and the helper's
+    current encoding choices (compression level, header casing,
+    stripped headers). Re-running the helper on a fixed cassette must
+    produce a byte-identical file; otherwise the helper changed shape
+    and the cassettes need regenerating in the same PR.
+    """
+    import importlib.util
+
+    # Safe loader — cassettes are arbitrary YAML on disk; ``!!binary`` works
+    # under the safe schema so we don't need the full Loader.
+    try:
+        from yaml import CDumper as Dumper
+        from yaml import CSafeLoader as Loader
+    except ImportError:  # pragma: no cover — libyaml ships with PyYAML wheels
+        from yaml import Dumper  # type: ignore[assignment]
+        from yaml import SafeLoader as Loader
+
+    # ``tests/`` is not a Python package, so import the helper by file path —
+    # same pattern :mod:`tests.vcr_config` uses for sibling modules.
+    helper_path = REPO_ROOT / "tests" / "scripts" / "inject_gzip_into_cassette.py"
+    spec = importlib.util.spec_from_file_location(
+        "tests_scripts_inject_gzip_into_cassette", helper_path
+    )
+    assert spec is not None and spec.loader is not None
+    helper_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(helper_module)
+    inject_gzip_into_cassette = helper_module.inject_gzip_into_cassette
+
+    coverage_dir = CASSETTE_DIR / "gzip_coverage"
+    cassettes = sorted(coverage_dir.glob("*.yaml")) if coverage_dir.is_dir() else []
+    assert cassettes, (
+        "No gzip-coverage cassettes found under tests/cassettes/gzip_coverage/. "
+        "test_at_least_one_cassette_advertises_content_encoding_gzip should "
+        "have failed first — investigate that failure before this one."
+    )
+    drifted: list[str] = []
+    for cassette in cassettes:
+        original = cassette.read_text(encoding="utf-8")
+        data = yaml.load(original, Loader=Loader)
+        rewritten = inject_gzip_into_cassette(data)
+        if rewritten == 0:
+            drifted.append(f"{cassette.name}: helper did not match any response")
+            continue
+        regen = yaml.dump(data, Dumper=Dumper)
+        if regen != original:
+            drifted.append(
+                f"{cassette.name}: not a fixed point of inject_gzip_into_cassette. "
+                "Regenerate via the helper and commit."
+            )
+    assert not drifted, "\n  - ".join(["gzip-coverage cassette drift:"] + drifted)

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -1281,8 +1281,18 @@ async def test_streaming_raise_for_status_propagates_before_size_check(monkeypat
         await client.aclose()
 
 
+@pytest.mark.parametrize(
+    "encoding",
+    # Every codec httpx wires into its content-decoder chain. ``gzip`` is
+    # the one #769 hit in production; ``br`` and ``zstd`` ship with httpx
+    # whenever the optional ``brotli`` / ``zstandard`` packages are
+    # installed, and ``deflate`` is always available. Parametrizing all
+    # four guards against a future codec going through the same rebuild
+    # path with an unstripped Content-Encoding header.
+    ["gzip", "br", "zstd", "deflate"],
+)
 @pytest.mark.asyncio
-async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkeypatch):
+async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkeypatch, encoding):
     """Regression for #769.
 
     ``response.aiter_bytes()`` yields already-decoded chunks, so the buffered
@@ -1293,8 +1303,19 @@ async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkey
 
     The wrapper must strip ``content-encoding`` (and ``content-length``) before
     handing headers back so downstream ``.text`` access stays a plain charset
-    decode — no double decompression.
+    decode — no double decompression. Parametrized across every codec httpx
+    knows about so adding a new ``Content-Encoding`` value in the future
+    cannot silently regress this branch.
     """
+    # ``br`` / ``zstd`` only re-trigger ``Response.__init__``'s decoder when
+    # the optional ``brotli`` / ``zstandard`` packages are present. Without
+    # them httpx no-ops the encoding and the test would pass even WITHOUT
+    # the strip — defeating the regression. Skip the variant rather than
+    # silently lie about coverage.
+    if encoding == "br":
+        pytest.importorskip("brotli")
+    elif encoding == "zstd":
+        pytest.importorskip("zstandard")
     from contextlib import asynccontextmanager
 
     from notebooklm._core_transport import _stream_post_with_size_cap
@@ -1304,11 +1325,11 @@ async def test_streaming_strips_content_encoding_to_prevent_double_decode(monkey
 
     class _FakeResponse:
         status_code = 200
-        # Upstream advertises gzip — the kind of header that flowed through the
-        # transport at production time and bit issue #769.
+        # Upstream advertises the parametrized encoding — the kind of header
+        # that flowed through the transport at production time and bit #769.
         headers = {
             "content-type": "application/json; charset=UTF-8",
-            "content-encoding": "gzip",
+            "content-encoding": encoding,
             # Length of the compressed body upstream — also a lie for the
             # rebuilt response, since we hold the decoded bytes now.
             "content-length": "9999",


### PR DESCRIPTION
## Summary
Closes #773. Adds VCR coverage for the gzip-rebuild path so #769-class double-decode regressions can't silently land again.

- `_stream_post_with_size_cap` rebuilds an `httpx.Response` from already-decoded body bytes. Pre-#771 it carried the upstream `Content-Encoding: gzip` over, and `Response.__init__` re-ran the decoder → `DecodingError`.
- The cassette suite was blind to this because `decode_compressed_response=True` strips the header on record. 89/89 cassettes had no encoding header, so the rebuild branch never fired on replay.
- This PR ports one cassette (`artifacts_revise_slide`) to the production wire shape (gzipped body + `Content-Encoding: gzip`), replays it through `_stream_post_with_size_cap`, and pins a floor on encoding-header coverage in the shape lint.

### Scope note
The issue acceptance criteria call for "one cassette per major RPC family" (7 cassettes). After discussion, scope was reduced to a single cassette: the rebuild path is shared across every RPC family, so one cassette plus the lint floor catches the same regression class with ~85% less artifact churn.

## Files
- `tests/scripts/inject_gzip_into_cassette.py` — idempotent gzip-injection helper. Normalizes the gzip OS byte (offset 9) to `0xff` so the artifact is byte-identical across Python 3.10–3.14. Uses `CSafeLoader`/`SafeLoader` (review feedback).
- `tests/cassettes/gzip_coverage/artifacts_revise_slide_gzipped.yaml` — derived cassette. Generated artifact; regenerate via the helper if the source recording changes.
- `tests/integration/test_gzip_cassette_replay.py` — replays the gzipped cassette through `_stream_post_with_size_cap`. Uses a scoped `vcr.VCR(decode_compressed_response=False)` because vcrpy applies the decode filter at cassette LOAD time, not just on record (see `vcr.cassette.Cassette._load` → `self.append` → `before_record_response` chain).
- `tests/unit/test_core_transport.py` — parametrizes the existing `test_streaming_strips_content_encoding_to_prevent_double_decode` over `gzip` / `br` / `zstd` / `deflate`. `br` / `zstd` use `pytest.importorskip` so they don't silently pass when the optional decoder package isn't installed.
- `tests/unit/test_cassette_shapes.py` — adds two new asserts: ≥1 cassette must advertise `Content-Encoding: gzip`, and every cassette under `gzip_coverage/` must be a fixed point of the helper.

## Acceptance criteria
- [x] ≥1 cassette carries `Content-Encoding: gzip` and is internally consistent on replay.
- [x] Cassette shape lint asserts encoding-header coverage and would fail if all cassettes drop it.
- [x] `test_streaming_*` parametrized over gzip / br / zstd / deflate (br / zstd skip honestly when decoder unavailable).
- [x] `git revert <#771-fix-commit>` against the suite fails. Manually verified by monkey-patching `_stream_post_with_size_cap` to the pre-#771 form and replaying the gzipped cassette — produced `httpx.DecodingError: Error -3 while decompressing data: incorrect header check`, the exact #769 error.

## Test plan
- [x] `uv run ruff format --check .` clean.
- [x] `uv run ruff check .` clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` 0 issues.
- [x] `uv run pytest` — 5022 passed, 14 skipped (the 2 new br/zstd skips reflect dev-env lacking those optional decoders).
- [x] Manually verified revert-of-#771 reproduces #769 error against the new integration test.

## Deferred polish findings (cosmetic only)
- Hard-coded URL / body in the integration test mirror the source cassette. If `artifacts_revise_slide.yaml` is ever re-recorded, regenerate the gzipped sibling via the helper (already documented in the test module docstring).
- `if raw is None: return False` in the helper is defensive — unreachable for real batchexecute responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration and unit tests ensuring gzipped HTTP responses replay correctly and preventing double-decode regressions; extended transport tests to cover gzip, brotli, zstd and deflate.
  * Added a canned gzipped cassette to exercise replay scenarios and a suite that verifies cassette round-trip stability.
* **Tools**
  * Added a utility script to inject deterministic gzip encoding into test cassettes for coverage and regeneration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->