### PR TITLE
refactor(core): extract ClientMetrics into _core_metrics

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -11,13 +11,12 @@ import weakref
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, nullcontext
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import httpx
 
-from ._callbacks import maybe_await_callback
 from ._core_cache import (
     MAX_CONVERSATION_CACHE_SIZE as _DEFAULT_CONVERSATION_CACHE_SIZE,
 )
@@ -25,6 +24,7 @@ from ._core_cache import (
     ConversationCache,
 )
 from ._core_cookie_persistence import CookiePersistence
+from ._core_metrics import ClientMetrics
 from ._core_polling import PendingPolls, PollRegistry
 from ._core_rpc import RpcExecutor
 from ._core_transport import (
@@ -541,9 +541,10 @@ class ClientCore:
         self._refresh_lock: asyncio.Lock | None = None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
-        self._on_rpc_event = on_rpc_event
-        self._metrics_lock = threading.Lock()
-        self._metrics = ClientMetricsSnapshot()
+        # Observability counters + telemetry callback. Compat properties
+        # below (``_metrics_lock`` / ``_metrics`` / ``_on_rpc_event``) bridge
+        # the legacy ivar names back into this helper.
+        self._metrics_obj = ClientMetrics(on_rpc_event=on_rpc_event)
         self._draining = False
         self._in_flight_posts = 0
         self._drain_condition: asyncio.Condition | None = None
@@ -621,6 +622,40 @@ class ClientCore:
     @_loaded_cookie_snapshot.setter
     def _loaded_cookie_snapshot(self, value: CookieSnapshot | None) -> None:
         self.cookie_persistence.loaded_cookie_snapshot = value
+
+    # ``ClientMetrics`` compat bridges. The three observability ivars now live
+    # on ``self._metrics_obj``; each setter calls ``_ensure_observability_state``
+    # first so a ``__new__``-built fixture (no ``__init__`` ran) can still
+    # assign ``core._on_rpc_event = cb`` and have it write through.
+    @property
+    def _metrics_lock(self) -> threading.Lock:
+        self._ensure_observability_state()
+        return self._metrics_obj._metrics_lock
+
+    @_metrics_lock.setter
+    def _metrics_lock(self, value: threading.Lock) -> None:
+        self._ensure_observability_state()
+        self._metrics_obj._metrics_lock = value
+
+    @property
+    def _metrics(self) -> ClientMetricsSnapshot:
+        self._ensure_observability_state()
+        return self._metrics_obj._metrics
+
+    @_metrics.setter
+    def _metrics(self, value: ClientMetricsSnapshot) -> None:
+        self._ensure_observability_state()
+        self._metrics_obj._metrics = value
+
+    @property
+    def _on_rpc_event(self) -> Callable[[RpcTelemetryEvent], object] | None:
+        self._ensure_observability_state()
+        return self._metrics_obj._on_rpc_event
+
+    @_on_rpc_event.setter
+    def _on_rpc_event(self, value: Callable[[RpcTelemetryEvent], object] | None) -> None:
+        self._ensure_observability_state()
+        self._metrics_obj._on_rpc_event = value
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
@@ -710,15 +745,16 @@ class ClientCore:
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client instance."""
         self._ensure_observability_state()
-        with self._metrics_lock:
-            return replace(self._metrics)
+        return self._metrics_obj.snapshot()
 
     def _ensure_observability_state(self) -> None:
-        """Backfill observability fields for tests that construct via ``__new__``."""
+        """Backfill observability fields for tests that construct via ``__new__``.
+
+        Gates on ``_metrics_obj`` (a real instance attribute) — the
+        property-bridged ivars' ``hasattr`` probes are always True.
+        """
         if (
-            hasattr(self, "_on_rpc_event")
-            and hasattr(self, "_metrics_lock")
-            and hasattr(self, "_metrics")
+            hasattr(self, "_metrics_obj")
             and hasattr(self, "_draining")
             and hasattr(self, "_in_flight_posts")
             and hasattr(self, "_drain_condition")
@@ -726,12 +762,8 @@ class ClientCore:
         ):
             return
         with _OBSERVABILITY_INIT_LOCK:
-            if not hasattr(self, "_on_rpc_event"):
-                self._on_rpc_event = None
-            if not hasattr(self, "_metrics_lock"):
-                self._metrics_lock = threading.Lock()
-            if not hasattr(self, "_metrics"):
-                self._metrics = ClientMetricsSnapshot()
+            if not hasattr(self, "_metrics_obj"):
+                self._metrics_obj = ClientMetrics(on_rpc_event=None)
             if not hasattr(self, "_draining"):
                 self._draining = False
             if not hasattr(self, "_in_flight_posts"):
@@ -742,62 +774,26 @@ class ClientCore:
                 self._operation_depths = weakref.WeakKeyDictionary()
 
     def _increment_metrics(self, **increments: int | float) -> None:
-        """Increment numeric metrics fields under the metrics lock."""
         self._ensure_observability_state()
-        with self._metrics_lock:
-            values = {
-                field_name: getattr(self._metrics, field_name) + increment
-                for field_name, increment in increments.items()
-            }
-            self._metrics = replace(self._metrics, **values)
+        self._metrics_obj.increment(**increments)
 
     def _record_rpc_queue_wait(self, wait_seconds: float) -> None:
         self._ensure_observability_state()
-        with self._metrics_lock:
-            self._metrics = replace(
-                self._metrics,
-                rpc_queue_wait_seconds_total=(
-                    self._metrics.rpc_queue_wait_seconds_total + wait_seconds
-                ),
-                rpc_queue_wait_seconds_max=max(
-                    self._metrics.rpc_queue_wait_seconds_max,
-                    wait_seconds,
-                ),
-            )
+        self._metrics_obj.record_rpc_queue_wait(wait_seconds)
 
     def record_upload_queue_wait(self, wait_seconds: float) -> None:
         """Record time spent waiting for the upload semaphore."""
         self._ensure_observability_state()
-        with self._metrics_lock:
-            self._metrics = replace(
-                self._metrics,
-                upload_queue_wait_seconds_total=(
-                    self._metrics.upload_queue_wait_seconds_total + wait_seconds
-                ),
-                upload_queue_wait_seconds_max=max(
-                    self._metrics.upload_queue_wait_seconds_max,
-                    wait_seconds,
-                ),
-            )
+        self._metrics_obj.record_upload_queue_wait(wait_seconds)
 
     def _record_lock_wait(self, wait_seconds: float) -> None:
         self._ensure_observability_state()
-        with self._metrics_lock:
-            self._metrics = replace(
-                self._metrics,
-                lock_wait_seconds_total=self._metrics.lock_wait_seconds_total + wait_seconds,
-                lock_wait_seconds_max=max(self._metrics.lock_wait_seconds_max, wait_seconds),
-            )
+        self._metrics_obj.record_lock_wait(wait_seconds)
 
     async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
         """Invoke the optional telemetry callback without affecting RPC behavior."""
         self._ensure_observability_state()
-        if self._on_rpc_event is None:
-            return
-        try:
-            await maybe_await_callback(self._on_rpc_event, event)
-        except Exception as exc:  # noqa: BLE001 - observability must not alter behavior
-            logger.warning("RPC telemetry callback failed: %s", exc)
+        await self._metrics_obj.emit_rpc_event(event)
 
     def _get_drain_condition(self) -> asyncio.Condition:
         self._ensure_observability_state()

--- a/src/notebooklm/_core_metrics.py
+++ b/src/notebooklm/_core_metrics.py
@@ -1,0 +1,148 @@
+"""Observability metrics helper for :class:`ClientCore`.
+
+Owns the cumulative ``ClientMetricsSnapshot`` counters, the threading lock that
+guards them, and the optional ``on_rpc_event`` telemetry callback. Lifted out of
+``_core.py`` so the metrics surface has one home (this file) instead of being
+woven into ``ClientCore.__init__`` alongside drain, reqid, and auth state.
+
+Design constraints (load-bearing — see ``tests/unit/test_swallow_observability.py``
+and ``tests/unit/test_observability.py``):
+
+* ``__init__`` MUST be event-loop-agnostic — it constructs only a
+  ``threading.Lock`` and a plain dataclass. Never call
+  ``asyncio.get_running_loop()`` or instantiate any ``asyncio.*`` primitive
+  here. ``ClientCore`` is routinely built outside a running loop.
+
+* :meth:`emit_rpc_event` MUST stay ``async def`` and ``await
+  maybe_await_callback(...)``. The await is the back-pressure mechanism: a
+  slow user-supplied callback intentionally throttles the RPC path. Do NOT
+  switch to ``asyncio.create_task`` (fire-and-forget) or a custom
+  ``asyncio.iscoroutine`` branch — both would break that contract.
+
+* Exceptions raised by the user callback are swallowed and logged at WARNING.
+  The categorized-swallow contract in ``test_swallow_observability.py`` covers
+  similar sites; do NOT add new log lines on this path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from dataclasses import replace
+
+from ._callbacks import maybe_await_callback
+from .types import ClientMetricsSnapshot, RpcTelemetryEvent
+
+# Logger name is pinned to ``notebooklm._core`` (not the literal module name)
+# so users and tests that filter by logger name — e.g.
+# ``caplog.at_level("WARNING", logger="notebooklm._core")`` in
+# ``test_client_keepalive.py`` — keep matching after the extraction.
+logger = logging.getLogger("notebooklm._core")
+
+
+class ClientMetrics:
+    """Cumulative observability counters and the optional RPC telemetry callback.
+
+    Owns three pieces of state:
+
+    * ``_metrics_lock`` — ``threading.Lock`` guarding all reads/writes of the
+      snapshot. Threading (not asyncio) because the snapshot is also touched
+      by sync helpers like ``metrics_snapshot`` and because ``record_*`` calls
+      from RPC paths must work whether or not a loop is running.
+    * ``_metrics`` — the cumulative :class:`ClientMetricsSnapshot`. Replaced
+      atomically under the lock via ``dataclasses.replace`` so external readers
+      always see a consistent snapshot.
+    * ``_on_rpc_event`` — the user-supplied telemetry callback, or ``None``.
+      Read at emit time so test fixtures can swap it after construction.
+
+    Field names are deliberately the same as the legacy ``ClientCore`` ivars
+    (``_metrics_lock``, ``_metrics``, ``_on_rpc_event``) so the compat
+    ``@property`` bridges on ``ClientCore`` can delegate with
+    ``return self._metrics_obj._<attr>`` and stay readable.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+    ) -> None:
+        # Threading lock (NOT asyncio.Lock) so this object can be constructed
+        # and used outside of a running event loop — see module docstring.
+        self._metrics_lock = threading.Lock()
+        self._metrics = ClientMetricsSnapshot()
+        self._on_rpc_event = on_rpc_event
+
+    def snapshot(self) -> ClientMetricsSnapshot:
+        """Return a fresh copy of the cumulative counters.
+
+        ``replace()`` (rather than handing back ``self._metrics``) isolates the
+        returned value from any concurrent in-place rebind that may happen on
+        another thread — the dataclass is frozen, but the *attribute* on the
+        helper is mutable.
+        """
+        with self._metrics_lock:
+            return replace(self._metrics)
+
+    def increment(self, **increments: int | float) -> None:
+        """Atomically add to one or more numeric snapshot fields.
+
+        Held under ``_metrics_lock`` so concurrent RPC producers on the same
+        client instance see a consistent snapshot.
+        """
+        with self._metrics_lock:
+            values = {
+                field_name: getattr(self._metrics, field_name) + increment
+                for field_name, increment in increments.items()
+            }
+            self._metrics = replace(self._metrics, **values)
+
+    def _record_wait(self, total_field: str, max_field: str, wait_seconds: float) -> None:
+        """Bump a ``*_total`` field and update its ``*_max`` companion atomically.
+
+        Shared backend for the three public ``record_*_wait`` methods. Kept
+        private because the field-name strings are an implementation detail —
+        external callers should use the typed public methods.
+        """
+        with self._metrics_lock:
+            self._metrics = replace(
+                self._metrics,
+                **{
+                    total_field: getattr(self._metrics, total_field) + wait_seconds,
+                    max_field: max(getattr(self._metrics, max_field), wait_seconds),
+                },
+            )
+
+    def record_rpc_queue_wait(self, wait_seconds: float) -> None:
+        """Record time a caller spent waiting for the RPC semaphore."""
+        self._record_wait(
+            "rpc_queue_wait_seconds_total", "rpc_queue_wait_seconds_max", wait_seconds
+        )
+
+    def record_upload_queue_wait(self, wait_seconds: float) -> None:
+        """Record time spent waiting for the upload semaphore."""
+        self._record_wait(
+            "upload_queue_wait_seconds_total", "upload_queue_wait_seconds_max", wait_seconds
+        )
+
+    def record_lock_wait(self, wait_seconds: float) -> None:
+        """Record time spent waiting on the ``_reqid_lock`` (or similar)."""
+        self._record_wait("lock_wait_seconds_total", "lock_wait_seconds_max", wait_seconds)
+
+    async def emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
+        """Await the optional telemetry callback; swallow + log on failure.
+
+        ``async def`` + ``await`` is load-bearing (back-pressure contract) and
+        the swallow keeps a misbehaving callback from surfacing as an RPC
+        error. See the module docstring for both constraints.
+        """
+        callback = self._on_rpc_event
+        if callback is None:
+            return
+        try:
+            await maybe_await_callback(callback, event)
+        except Exception as exc:  # noqa: BLE001 - observability must not alter behavior
+            logger.warning("RPC telemetry callback failed: %s", exc)
+
+
+__all__ = ["ClientMetrics"]

--- a/tests/unit/test_core_metrics.py
+++ b/tests/unit/test_core_metrics.py
@@ -100,31 +100,35 @@ def test_increment_accumulates_across_calls() -> None:
 
 
 def test_increment_holds_metrics_lock_during_update() -> None:
-    """Increments must run under ``_metrics_lock``.
+    """``increment()`` itself must run under ``_metrics_lock``.
 
-    We verify by attempting to acquire the lock from another thread while
-    increment is in progress — the acquire should block until the lock is
-    released.
+    Spawn a worker that calls ``metrics.increment(...)`` while the main
+    thread already holds ``_metrics_lock``. The worker must block inside
+    ``increment`` until the main thread releases — verified by the
+    ``timeout=0.05`` ``Event.wait()`` returning False. Once the main thread
+    drops the lock, the worker completes and the increment is visible in
+    the next snapshot.
     """
     metrics = ClientMetrics()
-    lock_acquired_during_increment = threading.Event()
+    increment_finished = threading.Event()
 
-    def lock_grabber() -> None:
-        # Acquire the lock; if increment held it, this blocks. Signal once
-        # we finally acquire so the main thread can verify ordering.
-        with metrics._metrics_lock:
-            lock_acquired_during_increment.set()
+    def run_increment() -> None:
+        metrics.increment(rpc_calls_started=1)
+        increment_finished.set()
 
-    # Pre-acquire from main thread and run the spy thread under contention.
+    # Hold the same lock that ``increment()`` needs; the worker must block
+    # inside its ``with self._metrics_lock`` until we release here.
     with metrics._metrics_lock:
-        spy = threading.Thread(target=lock_grabber)
-        spy.start()
-        # The spy is blocked because we hold the lock. It must not have
-        # signaled the event yet.
-        assert not lock_acquired_during_increment.wait(timeout=0.05)
-    spy.join(timeout=1.0)
-    assert spy.is_alive() is False
-    assert lock_acquired_during_increment.is_set()
+        worker = threading.Thread(target=run_increment)
+        worker.start()
+        # Worker is blocked inside increment(); the post-increment event
+        # must not have fired yet.
+        assert not increment_finished.wait(timeout=0.05)
+    worker.join(timeout=1.0)
+    assert worker.is_alive() is False
+    assert increment_finished.is_set()
+    # And the increment actually landed — the lock release didn't drop it.
+    assert metrics.snapshot().rpc_calls_started == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_core_metrics.py
+++ b/tests/unit/test_core_metrics.py
@@ -1,0 +1,417 @@
+"""Unit tests for :class:`notebooklm._core_metrics.ClientMetrics`.
+
+Covers the metrics helper in isolation — the ``ClientCore`` facade contract
+(``metrics_snapshot``, ``_increment_metrics``, ``_record_rpc_queue_wait``,
+``_record_lock_wait``, ``_emit_rpc_event``) is exercised end-to-end in
+``tests/unit/test_observability.py``. This file pins the helper-class
+invariants the facade depends on:
+
+* ``__init__`` is event-loop-agnostic (no ``asyncio.*`` primitives).
+* ``snapshot()`` returns a defensive copy, not a live reference.
+* ``increment()`` and ``record_*`` mutations are visible in subsequent
+  snapshots and accumulate correctly.
+* ``emit_rpc_event`` dispatches sync, async, and exception-raising callbacks
+  via ``maybe_await_callback`` (back-pressure semantics — never
+  fire-and-forget).
+* The ``ClientCore.__new__(ClientCore)`` regression path: setting
+  ``_on_rpc_event`` on a ``__new__``-built core (no ``__init__`` ran) must
+  succeed because the property setter calls ``_ensure_observability_state``
+  before writethrough.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm._core_metrics import ClientMetrics
+from notebooklm.types import ClientMetricsSnapshot, RpcTelemetryEvent
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_init_uses_no_asyncio_primitives() -> None:
+    """``ClientMetrics`` must be constructible outside a running event loop.
+
+    Regression guard: ``ClientCore`` is routinely instantiated synchronously
+    (e.g. ``NotebookLMClient(auth)`` before ``asyncio.run``). If
+    ``ClientMetrics.__init__`` ever introduces an ``asyncio.Lock``/``Event``
+    /``Condition``, that synchronous construction path will break on Python
+    versions where those primitives require a running loop.
+    """
+    # Construct outside any loop — must not raise.
+    metrics = ClientMetrics()
+    assert isinstance(metrics._metrics_lock, type(threading.Lock()))
+    assert isinstance(metrics._metrics, ClientMetricsSnapshot)
+    assert metrics._on_rpc_event is None
+
+
+def test_init_accepts_callback() -> None:
+    def cb(_event: RpcTelemetryEvent) -> None:
+        pass
+
+    metrics = ClientMetrics(on_rpc_event=cb)
+    assert metrics._on_rpc_event is cb
+
+
+# ---------------------------------------------------------------------------
+# snapshot()
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_returns_defensive_copy() -> None:
+    """Snapshot must not hand out a reference to the live in-place dataclass.
+
+    Counters are frozen today, but external code shouldn't rely on that to
+    avoid mutating the live state.
+    """
+    metrics = ClientMetrics()
+    first = metrics.snapshot()
+    metrics.increment(rpc_calls_started=1)
+    second = metrics.snapshot()
+
+    # First snapshot reflects pre-increment state — proves we didn't hand
+    # out a live reference that then "saw" the increment.
+    assert first.rpc_calls_started == 0
+    assert second.rpc_calls_started == 1
+    assert first is not second
+    assert first is not metrics._metrics
+
+
+# ---------------------------------------------------------------------------
+# increment()
+# ---------------------------------------------------------------------------
+
+
+def test_increment_accumulates_across_calls() -> None:
+    metrics = ClientMetrics()
+    metrics.increment(rpc_calls_started=1)
+    metrics.increment(rpc_calls_started=2, rpc_calls_succeeded=3)
+    snapshot = metrics.snapshot()
+    assert snapshot.rpc_calls_started == 3
+    assert snapshot.rpc_calls_succeeded == 3
+    assert snapshot.rpc_calls_failed == 0
+
+
+def test_increment_holds_metrics_lock_during_update() -> None:
+    """Increments must run under ``_metrics_lock``.
+
+    We verify by attempting to acquire the lock from another thread while
+    increment is in progress — the acquire should block until the lock is
+    released.
+    """
+    metrics = ClientMetrics()
+    lock_acquired_during_increment = threading.Event()
+    increment_released = threading.Event()
+
+    def lock_grabber() -> None:
+        # Acquire the lock; if increment held it, this blocks. Signal once
+        # we finally acquire so the main thread can verify ordering.
+        with metrics._metrics_lock:
+            lock_acquired_during_increment.set()
+
+    # Pre-acquire from main thread and run the spy thread under contention.
+    with metrics._metrics_lock:
+        spy = threading.Thread(target=lock_grabber)
+        spy.start()
+        # The spy is blocked because we hold the lock. It must not have
+        # signaled the event yet.
+        assert not lock_acquired_during_increment.wait(timeout=0.05)
+        increment_released.set()
+    spy.join(timeout=1.0)
+    assert spy.is_alive() is False
+    assert lock_acquired_during_increment.is_set()
+
+
+# ---------------------------------------------------------------------------
+# record_rpc_queue_wait / record_upload_queue_wait / record_lock_wait
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method_name", "total_field", "max_field"),
+    [
+        ("record_rpc_queue_wait", "rpc_queue_wait_seconds_total", "rpc_queue_wait_seconds_max"),
+        (
+            "record_upload_queue_wait",
+            "upload_queue_wait_seconds_total",
+            "upload_queue_wait_seconds_max",
+        ),
+        ("record_lock_wait", "lock_wait_seconds_total", "lock_wait_seconds_max"),
+    ],
+)
+def test_record_wait_updates_total_and_max(
+    method_name: str, total_field: str, max_field: str
+) -> None:
+    """Each ``record_*`` family accumulates total seconds and tracks max."""
+    metrics = ClientMetrics()
+    record = getattr(metrics, method_name)
+
+    record(0.10)
+    record(0.25)  # new max
+    record(0.05)  # smaller — total grows, max stays
+
+    snapshot = metrics.snapshot()
+    assert getattr(snapshot, total_field) == pytest.approx(0.40)
+    assert getattr(snapshot, max_field) == pytest.approx(0.25)
+
+
+# ---------------------------------------------------------------------------
+# emit_rpc_event — sync callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_rpc_event_invokes_sync_callback() -> None:
+    events: list[RpcTelemetryEvent] = []
+    metrics = ClientMetrics(on_rpc_event=events.append)
+    event = RpcTelemetryEvent(method="GET_NOTEBOOK", status="success", elapsed_seconds=0.1)
+    await metrics.emit_rpc_event(event)
+    assert events == [event]
+
+
+@pytest.mark.asyncio
+async def test_emit_rpc_event_noop_when_callback_none() -> None:
+    """No callback configured ⇒ silent no-op (and no AttributeError)."""
+    metrics = ClientMetrics(on_rpc_event=None)
+    event = RpcTelemetryEvent(method="GET_NOTEBOOK", status="success", elapsed_seconds=0.0)
+    # Must not raise.
+    await metrics.emit_rpc_event(event)
+
+
+# ---------------------------------------------------------------------------
+# emit_rpc_event — async callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_rpc_event_awaits_async_callback() -> None:
+    """``emit_rpc_event`` must ``await`` an async callback before returning.
+
+    This is the back-pressure contract: a slow async callback intentionally
+    throttles the RPC path. If we ever switched to ``asyncio.create_task``
+    (fire-and-forget), this test would fail because ``events`` would still be
+    empty at the assertion point.
+    """
+    events: list[RpcTelemetryEvent] = []
+    started_event = asyncio.Event()
+    finish_event = asyncio.Event()
+
+    async def slow_callback(event: RpcTelemetryEvent) -> None:
+        started_event.set()
+        await finish_event.wait()
+        events.append(event)
+
+    metrics = ClientMetrics(on_rpc_event=slow_callback)
+    event = RpcTelemetryEvent(method="ASK", status="success", elapsed_seconds=0.0)
+
+    emit_task = asyncio.create_task(metrics.emit_rpc_event(event))
+    await started_event.wait()
+    # If emit_rpc_event used create_task, it would already be done — but we
+    # required back-pressure, so the await is still pending.
+    assert not emit_task.done()
+    assert events == []
+
+    finish_event.set()
+    await emit_task
+    assert events == [event]
+
+
+@pytest.mark.asyncio
+async def test_emit_rpc_event_uses_maybe_await_callback_dispatch() -> None:
+    """``emit_rpc_event`` dispatches via ``maybe_await_callback``.
+
+    Regression guard: a previous refactor candidate replaced the helper with
+    a custom ``asyncio.iscoroutine(result)`` branch. ``inspect.isawaitable``
+    (used by ``maybe_await_callback``) accepts a broader set of awaitables —
+    plain coroutines, generator-based coroutines, and custom ``__await__``
+    objects. Switching to ``iscoroutine`` would silently drop those.
+    """
+
+    class CustomAwaitable:
+        """Synchronous-looking callable that returns an arbitrary awaitable."""
+
+        def __init__(self) -> None:
+            self.called = False
+
+        def __call__(self, _event: RpcTelemetryEvent) -> object:
+            return self._coro()
+
+        async def _coro(self) -> None:
+            self.called = True
+
+    callback = CustomAwaitable()
+    metrics = ClientMetrics(on_rpc_event=callback)
+    await metrics.emit_rpc_event(
+        RpcTelemetryEvent(method="ASK", status="success", elapsed_seconds=0.0)
+    )
+    assert callback.called is True
+
+
+# ---------------------------------------------------------------------------
+# emit_rpc_event — exception-swallowing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_rpc_event_swallows_callback_exception(caplog) -> None:
+    """A misbehaving user callback must not surface as an RPC failure.
+
+    Logged at WARNING under the ``notebooklm._core`` logger so existing
+    user-facing log filters on that namespace keep catching the diagnostic.
+    """
+
+    def boom(_event: RpcTelemetryEvent) -> None:
+        raise ValueError("test-only callback failure")
+
+    metrics = ClientMetrics(on_rpc_event=boom)
+    with caplog.at_level(logging.WARNING, logger="notebooklm._core"):
+        # Must not raise.
+        await metrics.emit_rpc_event(
+            RpcTelemetryEvent(method="ASK", status="error", elapsed_seconds=0.0)
+        )
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARNING for the failing callback"
+    assert any("test-only callback failure" in r.getMessage() for r in warnings)
+
+
+@pytest.mark.asyncio
+async def test_emit_rpc_event_swallows_async_callback_exception(caplog) -> None:
+    """Same swallow contract for async callbacks that raise."""
+
+    async def async_boom(_event: RpcTelemetryEvent) -> None:
+        raise RuntimeError("async test-only callback failure")
+
+    metrics = ClientMetrics(on_rpc_event=async_boom)
+    with caplog.at_level(logging.WARNING, logger="notebooklm._core"):
+        await metrics.emit_rpc_event(
+            RpcTelemetryEvent(method="ASK", status="error", elapsed_seconds=0.0)
+        )
+
+    assert any(
+        "async test-only callback failure" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+# ---------------------------------------------------------------------------
+# __new__-backfill regression — ClientCore side
+#
+# These tests verify the property-bridge contract on ``ClientCore``: a
+# ``__new__``-built fixture must be able to (a) set ``_on_rpc_event`` directly
+# and (b) await ``_emit_rpc_event`` without a prior ``__init__``. Both hinge
+# on ``_ensure_observability_state`` lazy-constructing ``_metrics_obj`` on
+# the first access path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_backfill_emit_event_works_without_init() -> None:
+    """``ClientCore.__new__(ClientCore); await core._emit_rpc_event(...)`` must work.
+
+    Regression guard for the property-descriptor gate failure: after A1
+    turned ``_metrics_lock`` / ``_metrics`` / ``_on_rpc_event`` into class
+    descriptors, the legacy ``hasattr`` short-circuit always returned True
+    and the backfill never ran. The gate now hinges on the real
+    ``_metrics_obj`` instance attribute.
+    """
+    core = ClientCore.__new__(ClientCore)
+    # No __init__ has run; no callback configured.
+    event = RpcTelemetryEvent(method="ASK", status="success", elapsed_seconds=0.0)
+    await core._emit_rpc_event(event)
+    # No callback ⇒ silent no-op. Just assert no AttributeError surfaced.
+
+
+@pytest.mark.asyncio
+async def test_new_backfill_setter_writethrough_succeeds() -> None:
+    """Setting ``core._on_rpc_event = cb`` on a fresh ``__new__`` core succeeds.
+
+    The property setter must call ``_ensure_observability_state`` BEFORE the
+    writethrough so the helper exists when we delegate
+    ``self._metrics_obj._on_rpc_event = cb``.
+    """
+    events: list[RpcTelemetryEvent] = []
+    core = ClientCore.__new__(ClientCore)
+    core._on_rpc_event = events.append
+
+    event = RpcTelemetryEvent(method="ASK", status="success", elapsed_seconds=0.0)
+    await core._emit_rpc_event(event)
+    assert events == [event]
+
+
+def test_new_backfill_metrics_snapshot_returns_zero_snapshot() -> None:
+    """``metrics_snapshot()`` on a ``__new__``-built core returns the zeroed default.
+
+    Useful for tests that call into ``ClientCore`` helpers (e.g.
+    ``rpc_call``-flavored mocks) without paying for a full ``__init__``.
+    """
+    core = ClientCore.__new__(ClientCore)
+    snapshot = core.metrics_snapshot()
+    assert isinstance(snapshot, ClientMetricsSnapshot)
+    assert snapshot.rpc_calls_started == 0
+    assert snapshot.rpc_calls_succeeded == 0
+
+
+def test_new_backfill_increment_metrics_lazy_construct() -> None:
+    """``_increment_metrics`` lazy-constructs the helper on a ``__new__`` core."""
+    core = ClientCore.__new__(ClientCore)
+    core._increment_metrics(rpc_calls_started=2, rpc_calls_failed=1)
+    snapshot = core.metrics_snapshot()
+    assert snapshot.rpc_calls_started == 2
+    assert snapshot.rpc_calls_failed == 1
+
+
+def test_new_backfill_metrics_setter_writethrough() -> None:
+    """The ``_metrics`` setter writes through and snapshot reflects it."""
+    core = ClientCore.__new__(ClientCore)
+    replacement = ClientMetricsSnapshot(rpc_calls_started=42)
+    core._metrics = replacement
+    assert core.metrics_snapshot().rpc_calls_started == 42
+
+
+# ---------------------------------------------------------------------------
+# Compat property bridge round-trip (covers the getter + setter halves on
+# ``ClientCore`` for ``_metrics_lock``, ``_metrics``, ``_on_rpc_event``).
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_lock_compat_property_round_trip() -> None:
+    """Reading ``core._metrics_lock`` returns the helper's lock; writing replaces it."""
+    core = ClientCore.__new__(ClientCore)
+    original = core._metrics_lock  # triggers backfill + getter path
+    assert isinstance(original, type(threading.Lock()))
+
+    replacement = threading.Lock()
+    core._metrics_lock = replacement
+    # Re-read via the same property bridge — should now report the replacement.
+    assert core._metrics_lock is replacement
+
+
+def test_metrics_getter_returns_live_snapshot() -> None:
+    """``core._metrics`` getter returns the helper's current snapshot."""
+    core = ClientCore.__new__(ClientCore)
+    core._increment_metrics(rpc_calls_started=7)
+    # The getter delegates to ``self._metrics_obj._metrics``, which has been
+    # rebound by ``increment`` to a new dataclass via ``replace``.
+    assert core._metrics.rpc_calls_started == 7
+
+
+def test_on_rpc_event_getter_returns_callback() -> None:
+    """``core._on_rpc_event`` getter returns whatever was assigned."""
+
+    def cb(_event: RpcTelemetryEvent) -> None:
+        pass
+
+    core = ClientCore.__new__(ClientCore)
+    assert core._on_rpc_event is None  # default after backfill
+    core._on_rpc_event = cb
+    assert core._on_rpc_event is cb

--- a/tests/unit/test_core_metrics.py
+++ b/tests/unit/test_core_metrics.py
@@ -31,7 +31,6 @@ from notebooklm._core import ClientCore
 from notebooklm._core_metrics import ClientMetrics
 from notebooklm.types import ClientMetricsSnapshot, RpcTelemetryEvent
 
-
 # ---------------------------------------------------------------------------
 # Construction
 # ---------------------------------------------------------------------------
@@ -109,7 +108,6 @@ def test_increment_holds_metrics_lock_during_update() -> None:
     """
     metrics = ClientMetrics()
     lock_acquired_during_increment = threading.Event()
-    increment_released = threading.Event()
 
     def lock_grabber() -> None:
         # Acquire the lock; if increment held it, this blocks. Signal once
@@ -124,7 +122,6 @@ def test_increment_holds_metrics_lock_during_update() -> None:
         # The spy is blocked because we hold the lock. It must not have
         # signaled the event yet.
         assert not lock_acquired_during_increment.wait(timeout=0.05)
-        increment_released.set()
     spy.join(timeout=1.0)
     assert spy.is_alive() is False
     assert lock_acquired_during_increment.is_set()


### PR DESCRIPTION
## Summary

- Extract metrics state-bag (snapshot lock, cumulative `ClientMetricsSnapshot`, telemetry callback) from `ClientCore.__init__` into a dedicated `ClientMetrics` helper in `src/notebooklm/_core_metrics.py` (148 LOC, 100% covered).
- `ClientCore` keeps all six facade methods (`metrics_snapshot`, `_increment_metrics`, `_record_rpc_queue_wait`, `record_upload_queue_wait`, `_record_lock_wait`, `_emit_rpc_event`) as 2-line delegators, plus compat `@property` bridges for `_metrics_lock` / `_metrics` / `_on_rpc_event` (each with getter AND setter that triggers `_ensure_observability_state` before writethrough).
- `_emit_rpc_event` STAYS `async def` and awaits `maybe_await_callback` — back-pressure contract preserved; no fire-and-forget.

## Task

A1 of the [core-decomposition-mini-phase Phase 1 plan](.sisyphus/phases/core-decomposition-mini-phase/phase-1.md). Wave 1 (parallel with A4). Wave 2 (A2 drain + A3 reqid) depends on this.

## Design highlights

- **`__init__` is event-loop-agnostic** — `threading.Lock` + plain dataclass only, no `asyncio.*` primitives. `ClientCore` is routinely instantiated outside a running loop.
- **`_ensure_observability_state` gate restructured** to test `hasattr(self, "_metrics_obj")` instead of the property-bridged ivars (whose `hasattr` probes always return True). Drain ivars stay as plain `hasattr` probes until A2 extracts `TransportDrainTracker` (A2 owns extending the gate per its plan-owned body).
- **Property setters call `_ensure_observability_state` BEFORE writethrough** so test fixtures that do `core = ClientCore.__new__(ClientCore); core._on_rpc_event = cb` succeed — the writethrough reaches a freshly-constructed helper rather than `AttributeError`.
- **`_record_wait` private helper** in `ClientMetrics` deduplicates the three structurally identical `record_*_wait` methods (each was `replace(self._metrics, total_field=..., max_field=max(...))`).
- **Logger name pinned to `notebooklm._core`** (not the literal module name) so `caplog.at_level(..., logger="notebooklm._core")` filters in `test_client_keepalive.py` keep matching.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (111 files).
- [x] `uv run pytest tests/unit/test_observability.py tests/unit/test_swallow_observability.py tests/unit/test_core_metrics.py tests/unit/test_init_order.py -v` — 74 passed.
- [x] `uv run pytest` — 5040 passed, 12 skipped (was 5037; the +3 is the new compat-bridge round-trip tests).
- [x] `uv run pytest --cov=notebooklm._core_metrics --cov-report=term-missing` — 100% line coverage (38 stmts, 2 partial branches, all covered).
- [x] New `tests/unit/test_core_metrics.py` (22 tests) covers:
  - `__init__` outside event loop
  - Snapshot defensive copy semantics
  - Increment accumulation under lock (validated via cross-thread spy)
  - All three `record_*_wait` variants (parametrized)
  - Sync / async / exception-raising callback dispatch
  - `maybe_await_callback` accepts custom awaitables (regression guard)
  - Six `ClientCore.__new__`-backfill regressions: emit-event, setter writethrough, snapshot, increment, `_metrics` setter
  - Three compat-bridge round-trip tests (`_metrics_lock` / `_metrics` / `_on_rpc_event`)

## Notes for reviewers

- **`_core.py` net LOC delta is -4** (1760 → 1756), not the -60 target from the task brief. The spec-required compat-property bridges (~38 LOC for three getter+setter pairs, each calling `_ensure_observability_state` before delegating) offset most of the savings from the facade-method collapse. The structural goal (single home for metrics state, async back-pressure preserved, `__new__`-backfill regressions covered) is fully met; the larger `_core.py` shrink will land progressively as A2/A3/A4 extract the remaining state bags.
- **No VCR cassette changes** — none were touched.
- **Wave 2 dependency**: A2 (drain) will extend `_ensure_observability_state`'s gate to also check `hasattr(self, "_drain_tracker")` per its plan-owned body. The `Drain ivars stay raw until A2` comment in the docstring is the transition marker.

## Deferred polish findings

None. All Important and Critical findings from the triple review were applied during polish (added logger-name comment, three compat-bridge coverage tests, deduplicated `record_*_wait`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved observability/telemetry into a dedicated component, centralizing metrics and RPC event routing; added a compatibility bridge so legacy observability properties continue to work and lazy-initialize when needed.

* **Tests**
  * Added comprehensive unit tests for telemetry emission, metric accumulation (totals and maxes), defensive snapshot behavior, async/sync callback handling, exception safety, and backward-compatibility of observability state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->