### PR TITLE
refactor(core): relocate get_source_ids to _sources module

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -42,6 +42,7 @@ from ._core_transport import (
     _parse_retry_after as _parse_retry_after,
 )
 from ._logging import get_request_id, reset_request_id, set_request_id
+from ._sources import fetch_source_ids
 from .auth import (
     AuthTokens,
     CookieSnapshot,
@@ -1691,70 +1692,14 @@ class ClientCore:
     async def get_source_ids(self, notebook_id: str) -> list[str]:
         """Extract all source IDs from a notebook.
 
-        Fetches notebook data and extracts source IDs for use with
-        chat and artifact generation when targeting specific sources.
+        Thin facade over :func:`notebooklm._sources.fetch_source_ids` —
+        retained on :class:`ClientCore` because first-party callers and the
+        test suite continue to invoke ``core.get_source_ids(...)``.
 
         Args:
             notebook_id: The notebook ID.
 
         Returns:
             List of source IDs. Empty list if no sources or on error.
-
-        Note:
-            Source IDs are triple-nested in RPC: source[0][0] contains the ID.
         """
-        params = [notebook_id, None, [2], None, 0]
-        notebook_data = await self.rpc_call(
-            RPCMethod.GET_NOTEBOOK,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-        )
-
-        source_ids: list[str] = []
-        if not notebook_data or not isinstance(notebook_data, list):
-            return source_ids
-
-        # Schema-drift detection points: log WARNING at each isinstance/len
-        # guard that fails on a non-empty response (real drift surfaces here,
-        # not at the safety-net except below).
-        try:
-            if not isinstance(notebook_data[0], list):
-                # notebook_data is already known to be a non-empty list here
-                # (guarded by `if not notebook_data` above).
-                logger.warning(
-                    "get_source_ids: notebook_data[0] shape unexpected for %s "
-                    "(schema drift?). top-type=%s",
-                    notebook_id,
-                    type(notebook_data[0]).__name__,
-                )
-                return source_ids
-
-            notebook_info = notebook_data[0]
-            if not (len(notebook_info) > 1 and isinstance(notebook_info[1], list)):
-                logger.warning(
-                    "get_source_ids: notebook_info[1] not list for %s (schema drift?). len=%d",
-                    notebook_id,
-                    len(notebook_info),
-                )
-                return source_ids
-
-            sources = notebook_info[1]
-            for source in sources:
-                if not (isinstance(source, list) and source):
-                    continue
-                first = source[0]
-                if not (isinstance(first, list) and first):
-                    continue
-                sid = first[0]
-                if isinstance(sid, str):
-                    source_ids.append(sid)
-        except (IndexError, TypeError) as e:
-            # Defense-in-depth: guards above should make this unreachable.
-            logger.warning(
-                "get_source_ids: unexpected exception despite guards for %s: %s",
-                notebook_id,
-                e,
-                exc_info=True,
-            )
-
-        return source_ids
+        return await fetch_source_ids(self, notebook_id)

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 from time import monotonic
-from typing import IO, Any, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 import httpx
@@ -25,11 +25,87 @@ from .types import (
     SourceFulltext,
 )
 
+if TYPE_CHECKING:
+    from ._core import ClientCore
+
 logger = logging.getLogger(__name__)
 
 _SOURCE_ID_UUID_PATTERN = _source_upload._SOURCE_ID_UUID_PATTERN
 _extract_register_file_source_id = _source_upload._extract_register_file_source_id
 _looks_like_id_string = _source_upload._looks_like_id_string
+
+
+async def fetch_source_ids(core: "ClientCore", notebook_id: str) -> list[str]:
+    """Extract all source IDs from a notebook.
+
+    Fetches notebook data and extracts source IDs for use with
+    chat and artifact generation when targeting specific sources.
+
+    Args:
+        core: The :class:`ClientCore` instance providing the RPC entry point.
+        notebook_id: The notebook ID.
+
+    Returns:
+        List of source IDs. Empty list if no sources or on error.
+
+    Note:
+        Source IDs are triple-nested in RPC: source[0][0] contains the ID.
+    """
+    params = [notebook_id, None, [2], None, 0]
+    notebook_data = await core.rpc_call(
+        RPCMethod.GET_NOTEBOOK,
+        params,
+        source_path=f"/notebook/{notebook_id}",
+    )
+
+    source_ids: list[str] = []
+    if not notebook_data or not isinstance(notebook_data, list):
+        return source_ids
+
+    # Schema-drift detection points: log WARNING at each isinstance/len
+    # guard that fails on a non-empty response (real drift surfaces here,
+    # not at the safety-net except below).
+    try:
+        if not isinstance(notebook_data[0], list):
+            # notebook_data is already known to be a non-empty list here
+            # (guarded by `if not notebook_data` above).
+            logger.warning(
+                "get_source_ids: notebook_data[0] shape unexpected for %s "
+                "(schema drift?). top-type=%s",
+                notebook_id,
+                type(notebook_data[0]).__name__,
+            )
+            return source_ids
+
+        notebook_info = notebook_data[0]
+        if not (len(notebook_info) > 1 and isinstance(notebook_info[1], list)):
+            logger.warning(
+                "get_source_ids: notebook_info[1] not list for %s (schema drift?). len=%d",
+                notebook_id,
+                len(notebook_info),
+            )
+            return source_ids
+
+        sources = notebook_info[1]
+        for source in sources:
+            if not (isinstance(source, list) and source):
+                continue
+            first = source[0]
+            if not (isinstance(first, list) and first):
+                continue
+            sid = first[0]
+            if isinstance(sid, str):
+                source_ids.append(sid)
+    except (IndexError, TypeError) as e:
+        # Defense-in-depth: guards above should make this unreachable.
+        logger.warning(
+            "get_source_ids: unexpected exception despite guards for %s: %s",
+            notebook_id,
+            e,
+            exc_info=True,
+        )
+
+    return source_ids
 
 
 class SourcesAPI:


### PR DESCRIPTION
## Summary

Phase 1 / Wave 1 / Task A4 of the [core-decomposition mini-phase](https://github.com/teng-lin/notebooklm-py) — relocates the `get_source_ids` implementation from `_core.py` into a new module-level `fetch_source_ids` helper in `_sources.py`. The `ClientCore.get_source_ids` method stays as a thin facade because 11 first-party call sites (10 in `_artifact_generation.py`, 1 in `_chat.py:205`) and 26+ test references depend on the `core.get_source_ids(...)` shape.

**Pure relocation** — the 3 schema-drift WARN log messages, the triple-nested source-ID unwrap, and the safety-net try/except all move verbatim.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (110 files)
- [x] `uv run pytest tests/unit/test_swallow_observability.py tests/integration/test_core.py tests/unit/test_artifact_downloads.py tests/unit/test_source_selection.py -v` — 42/42 passing
- [ ] CI: lint, type-check, full pytest

## Notes

- Logger name shifts from `notebooklm._core` to `notebooklm._sources` for the 3 WARN records. Caplog assertions in `test_swallow_observability.py` still capture them because tests target the `notebooklm` parent logger.
- `_sources.py` uses `TYPE_CHECKING` guard for the `ClientCore` parameter type to avoid an import cycle.
- One out-of-scope codex nit deferred: future PR could type `core: CoreRPCProvider` Protocol rather than `"ClientCore"` concrete; deferred per pure-relocation scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when retrieving source IDs from notebooks—the system now handles edge cases and malformed responses more gracefully without interrupting operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->