### PR TITLE
chore(scripts): drop residual audit-ID leaders from script docstrings

### DIFF
--- a/scripts/check_claude_md_freshness.py
+++ b/scripts/check_claude_md_freshness.py
@@ -1,6 +1,6 @@
 """Assert CLAUDE.md repo-structure paths actually exist.
 
-Phase 6 / P6.6: prevents silent drift in the hand-maintained file map.
+Prevents silent drift in the hand-maintained file map.
 
 Usage:
     python scripts/check_claude_md_freshness.py

--- a/scripts/check_workflow_permissions.py
+++ b/scripts/check_workflow_permissions.py
@@ -1,7 +1,7 @@
 """Assert non-publish workflows have a top-level `permissions:` block.
 
-Phase 1 / T4: prevents supply-chain blast radius from default-permissive
-GITHUB_TOKEN scope on workflows that don't need it.
+Prevents supply-chain blast radius from default-permissive ``GITHUB_TOKEN``
+scopes on workflows that don't need them.
 
 Usage:
     python scripts/check_workflow_permissions.py


### PR DESCRIPTION
## Summary

Two script-docstring openers carried audit-tracker leaders (`Phase 6 / P6.6`, `Phase 1 / T4`) that re-introduced framing the post-#680 cleanup had removed elsewhere. Rewrites to describe the behavior directly:

- `scripts/check_workflow_permissions.py`: `Phase 1 / T4: prevents supply-chain blast radius from default-permissive GITHUB_TOKEN scope` → `Prevents supply-chain blast radius from default-permissive GITHUB_TOKEN scopes`.
- `scripts/check_claude_md_freshness.py`: `Phase 6 / P6.6: prevents silent drift` → `Prevents silent drift`.

`scripts/_strip_audit_refs.py` is left untouched (its audit-code refs are pattern definitions, explicitly excluded by the plan). No other audit-code hits in `scripts/` or `.github/` — the plan's third candidate (`rescrub-cassettes.py`) had only a `# noqa: E402` false-positive.

Part 3 of 3 in the audit-ref-scrub plan (`.sisyphus/plans/audit-ref-scrub-2026-05-17.md`). Wave 1: #775 (src/docs, merged). Wave 2: PR-2 (tests/) in flight + this PR-3.

## Test plan

- [x] Targeted: `uv run pytest tests/unit/test_ci_audit_scripts.py tests/unit/test_ci_install_parity.py -q` — **29 passed**
- [x] Regrep after edits: zero audit-code hits in `scripts/` or `.github/` (excluding the pattern-definition file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal script documentation to clarify descriptions. No changes to functionality or user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->