### PR TITLE
refactor(chat): ChatAPI takes capabilities + owns cache (C2-full)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Commands are organized as:
 6. **Concurrency**: One `NotebookLMClient` instance is bound to its open()-time event loop. See [Concurrency contract](docs/python-api.md#concurrency-contract). Common bugs:
    - Re-using a client across threads → not supported; create one per thread.
    - Re-using a client across event loops → raises `RuntimeError` on first authed POST.
-   - Sharing across `AuthTokens` tenants → never (the `_conversation_cache` is per-instance).
+   - Sharing across `AuthTokens` tenants → never (`ChatAPI._cache` is per-instance).
 
 ## Documentation
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -354,10 +354,11 @@ the hot path raises `RuntimeError` when an instance is re-used on a
 different loop. Cold paths (`next_reqid()`, `close()`) raise an opaque
 asyncio `RuntimeError` instead — same outcome, less helpful message.
 
-**`_conversation_cache` is per-instance.** Chat-conversation IDs cached
-inside a `NotebookLMClient` are not shared across clients in the same
-process and never persisted across processes. Two clients pointed at the
-same notebook will not share follow-up context.
+**`ChatAPI._cache` is per-instance.** Chat-conversation IDs cached
+inside a `NotebookLMClient` (on the `client.chat` sub-client) are not
+shared across clients in the same process and never persisted across
+processes. Two clients pointed at the same notebook will not share
+follow-up context.
 
 **Cookies in storage are eventually-consistent across processes.** When
 multiple processes share a storage path, an OS-level file lock plus a
@@ -519,7 +520,7 @@ sites instead.
 For a service that handles multiple NotebookLM tenants (different
 `AuthTokens`, typically one per user), spin up **one
 `NotebookLMClient` per tenant**. There is no cross-tenant
-`_conversation_cache` bleed (the cache is per-instance), and the
+`ChatAPI._cache` bleed (the cache is per-instance), and the
 loop-affinity guard plus the per-instance refresh state means tenants
 cannot accidentally observe each other's auth.
 

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -48,7 +48,11 @@ class CoreReqIdProvider(Protocol):
 
 
 class ChatStreamingProvider(Protocol):
-    """Transitional chat-transport capability — chat-aware error mapping still lives on ``ClientCore.query_post`` until that is extracted into a chat-owned transport."""
+    """Transitional chat-transport capability.
+
+    Chat-aware error mapping still lives on ``ClientCore.query_post`` until
+    that is extracted into a chat-owned transport.
+    """
 
     async def query_post(
         self,

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 import httpx
 
 from ._core_polling import PollRegistry
+from ._core_transport import _BuildRequest
 from .auth import authuser_query, format_authuser_value
 from .rpc.types import RPCMethod
 
@@ -38,6 +39,31 @@ class SourceListProvider(Protocol):
     """Provider for the notebook→source-id enumeration helper."""
 
     async def get_source_ids(self, notebook_id: str) -> list[str]: ...
+
+
+class CoreReqIdProvider(Protocol):
+    """Provider for the shared request-id counter."""
+
+    async def next_reqid(self, step: int = 100000) -> int: ...
+
+
+class ChatStreamingProvider(Protocol):
+    """Provider for the chat-specific streaming POST transport.
+
+    ``query_post`` is currently chat-aware on ``ClientCore`` because it
+    maps transport-layer exceptions to ``ChatError`` / ``NetworkError``.
+    A future change will extract this into a chat-owned transport once
+    the auth-refresh wiring is decoupled from ``ClientCore``; until then
+    this Protocol carves it out on the capability surface so ``ChatAPI``
+    can take ``ClientCoreCapabilities`` without a concrete dependency.
+    """
+
+    async def query_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        parse_label: str,
+    ) -> httpx.Response: ...
 
 
 class PollRegistryProvider(Protocol):
@@ -106,6 +132,8 @@ class UploadConcurrencyProvider(Protocol):
 class ClientCoreCapabilities(
     CoreRPCProvider,
     SourceListProvider,
+    CoreReqIdProvider,
+    ChatStreamingProvider,
     PollRegistryProvider,
     AuthRouteProvider,
     CookieJarProvider,
@@ -142,6 +170,20 @@ class ClientCoreCapabilities(
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
         return await self._core.get_source_ids(notebook_id)
+
+    async def next_reqid(self, step: int = 100000) -> int:
+        return await self._core.next_reqid(step)
+
+    async def query_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        parse_label: str,
+    ) -> httpx.Response:
+        return await self._core.query_post(
+            build_request=build_request,
+            parse_label=parse_label,
+        )
 
     @property
     def poll_registry(self) -> PollRegistry:

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -48,7 +48,7 @@ class CoreReqIdProvider(Protocol):
 
 
 class ChatStreamingProvider(Protocol):
-    """Provider for the chat streaming POST transport (chat-aware error mapping still lives on ``ClientCore``)."""
+    """Transitional chat-transport capability — chat-aware error mapping still lives on ``ClientCore.query_post`` until that is extracted into a chat-owned transport."""
 
     async def query_post(
         self,

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -48,15 +48,7 @@ class CoreReqIdProvider(Protocol):
 
 
 class ChatStreamingProvider(Protocol):
-    """Provider for the chat-specific streaming POST transport.
-
-    ``query_post`` is currently chat-aware on ``ClientCore`` because it
-    maps transport-layer exceptions to ``ChatError`` / ``NetworkError``.
-    A future change will extract this into a chat-owned transport once
-    the auth-refresh wiring is decoupled from ``ClientCore``; until then
-    this Protocol carves it out on the capability surface so ``ChatAPI``
-    can take ``ClientCoreCapabilities`` without a concrete dependency.
-    """
+    """Provider for the chat streaming POST transport (chat-aware error mapping still lives on ``ClientCore``)."""
 
     async def query_post(
         self,

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -116,7 +116,7 @@ class ChatAPI:
                 other consumer).
         """
         self._core = core
-        self._cache = conversation_cache or ConversationCache()
+        self._cache = conversation_cache if conversation_cache is not None else ConversationCache()
         # Per-``conversation_id`` lock that serializes follow-up asks on the
         # same conversation. Without this, two
         # ``asyncio.gather``'d ``ask`` calls on the same conversation read

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -112,9 +112,8 @@ class ChatAPI:
         Args:
             core: The core client infrastructure.
             conversation_cache: Optional injected cache; defaults to a fresh
-                per-instance ``ConversationCache``. The cache is owned here
-                (not on ``ClientCore``) because turn history is chat-domain
-                state with no other consumer.
+                per-instance ``ConversationCache`` (chat-domain state, no
+                other consumer).
         """
         self._core = core
         self._cache = conversation_cache or ConversationCache()
@@ -122,9 +121,9 @@ class ChatAPI:
         # same conversation. Without this, two
         # ``asyncio.gather``'d ``ask`` calls on the same conversation read
         # identical pre-update history at the top, both POST that history,
-        # then race to append to ``_core._conversation_cache`` — the server
-        # sees two follow-ups both claiming to be turn N+1 and the local
-        # cache loses one turn's lineage.
+        # then race to append to ``self._cache`` — the server sees two
+        # follow-ups both claiming to be turn N+1 and the local cache loses
+        # one turn's lineage.
         #
         # ``WeakValueDictionary`` keeps the map bounded automatically:
         # callers hold a strong reference to the lock while inside

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -10,6 +10,7 @@ import logging
 import weakref
 from typing import Any
 
+from ._capabilities import ClientCoreCapabilities
 from ._chat_protocol import (
     build_streaming_chat_request,
     collect_texts_from_nested,
@@ -21,7 +22,8 @@ from ._chat_protocol import (
     parse_streaming_chat_response,
     raise_if_rate_limited,
 )
-from ._core import ClientCore, _AuthSnapshot
+from ._core import _AuthSnapshot
+from ._core_cache import ConversationCache
 from ._logging import get_request_id, reset_request_id, set_request_id
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import (
@@ -99,13 +101,23 @@ class ChatAPI:
             )
     """
 
-    def __init__(self, core: ClientCore):
+    def __init__(
+        self,
+        core: ClientCoreCapabilities,
+        *,
+        conversation_cache: ConversationCache | None = None,
+    ):
         """Initialize the chat API.
 
         Args:
             core: The core client infrastructure.
+            conversation_cache: Optional injected cache; defaults to a fresh
+                per-instance ``ConversationCache``. The cache is owned here
+                (not on ``ClientCore``) because turn history is chat-domain
+                state with no other consumer.
         """
         self._core = core
+        self._cache = conversation_cache or ConversationCache()
         # Per-``conversation_id`` lock that serializes follow-up asks on the
         # same conversation. Without this, two
         # ``asyncio.gather``'d ``ask`` calls on the same conversation read
@@ -336,10 +348,10 @@ class ChatAPI:
 
             assert conversation_id is not None  # narrowed by the branches above
 
-            turns = self._core.get_cached_conversation(conversation_id)
+            turns = self._cache.get_cached_conversation(conversation_id)
             if answer_text:
                 turn_number = len(turns) + 1
-                self._core.cache_conversation_turn(
+                self._cache.cache_conversation_turn(
                     conversation_id, question, answer_text, turn_number
                 )
             else:
@@ -518,7 +530,7 @@ class ChatAPI:
         Returns:
             List of ConversationTurn objects.
         """
-        cached = self._core.get_cached_conversation(conversation_id)
+        cached = self._cache.get_cached_conversation(conversation_id)
         return [
             ConversationTurn(
                 query=turn["query"],
@@ -537,7 +549,7 @@ class ChatAPI:
         Returns:
             True if cache was cleared.
         """
-        return self._core.clear_conversation_cache(conversation_id)
+        return self._cache.clear(conversation_id)
 
     async def configure(
         self,
@@ -606,7 +618,7 @@ class ChatAPI:
 
     def _build_conversation_history(self, conversation_id: str) -> list | None:
         """Build conversation history for follow-up requests."""
-        turns = self._core.get_cached_conversation(conversation_id)
+        turns = self._cache.get_cached_conversation(conversation_id)
         if not turns:
             return None
 

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -8,7 +8,6 @@ import threading
 import time
 import warnings
 import weakref
-from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, nullcontext
 from dataclasses import dataclass, replace
@@ -20,9 +19,6 @@ import httpx
 from ._callbacks import maybe_await_callback
 from ._core_cache import (
     MAX_CONVERSATION_CACHE_SIZE as _DEFAULT_CONVERSATION_CACHE_SIZE,
-)
-from ._core_cache import (
-    ConversationCache,
 )
 from ._core_cookie_persistence import CookiePersistence
 from ._core_polling import PendingPolls, PollRegistry
@@ -585,7 +581,6 @@ class ClientCore:
         # produces hangs and ``RuntimeError`` deep in httpx instead of an
         # actionable message at the call site.
         self._bound_loop: asyncio.AbstractEventLoop | None = None
-        self._conversation_cache_manager = ConversationCache()
         # Keepalive background task configuration
         self._keepalive_interval: float | None = _resolve_keepalive_interval(
             keepalive, keepalive_min_interval
@@ -1635,58 +1630,6 @@ class ClientCore:
         if not self._http_client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
         return self._http_client
-
-    def cache_conversation_turn(
-        self, conversation_id: str, query: str, answer: str, turn_number: int
-    ) -> None:
-        """Cache a conversation turn locally.
-
-        Uses FIFO eviction when cache exceeds MAX_CONVERSATION_CACHE_SIZE.
-
-        Args:
-            conversation_id: The conversation ID.
-            query: The user's question.
-            answer: The AI's response.
-            turn_number: The turn number in the conversation.
-        """
-        self._conversation_cache_manager.cache_conversation_turn(
-            conversation_id,
-            query,
-            answer,
-            turn_number,
-            max_size=MAX_CONVERSATION_CACHE_SIZE,
-        )
-
-    def get_cached_conversation(self, conversation_id: str) -> list[dict[str, Any]]:
-        """Get cached conversation turns.
-
-        Args:
-            conversation_id: The conversation ID.
-
-        Returns:
-            List of cached turns, or empty list if not found.
-        """
-        return self._conversation_cache_manager.get_cached_conversation(conversation_id)
-
-    def clear_conversation_cache(self, conversation_id: str | None = None) -> bool:
-        """Clear conversation cache.
-
-        Args:
-            conversation_id: Clear specific conversation, or all if None.
-
-        Returns:
-            True if cache was cleared.
-        """
-        return self._conversation_cache_manager.clear(conversation_id)
-
-    @property
-    def _conversation_cache(self) -> OrderedDict[str, list[dict[str, Any]]]:
-        """Compatibility view of the conversation cache backing mapping."""
-        return self._conversation_cache_manager.conversations
-
-    @_conversation_cache.setter
-    def _conversation_cache(self, value: OrderedDict[str, list[dict[str, Any]]]) -> None:
-        self._conversation_cache_manager = ConversationCache(value)
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
         """Extract all source IDs from a notebook.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -16,13 +16,6 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import httpx
 
-from ._callbacks import maybe_await_callback
-from ._core_cache import (
-    MAX_CONVERSATION_CACHE_SIZE as _DEFAULT_CONVERSATION_CACHE_SIZE,
-)
-from ._core_cache import (
-    ConversationCache,
-)
 from ._core_cookie_persistence import CookiePersistence
 from ._core_metrics import ClientMetrics
 from ._core_polling import PendingPolls, PollRegistry

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -17,9 +17,6 @@ from typing import TYPE_CHECKING, Any, NoReturn, cast
 import httpx
 
 from ._callbacks import maybe_await_callback
-from ._core_cache import (
-    MAX_CONVERSATION_CACHE_SIZE as _DEFAULT_CONVERSATION_CACHE_SIZE,
-)
 from ._core_cookie_persistence import CookiePersistence
 from ._core_polling import PendingPolls, PollRegistry
 from ._core_rpc import RpcExecutor
@@ -72,8 +69,6 @@ class _TransportOperationToken:
 
     task: asyncio.Task[Any] | None
 
-
-MAX_CONVERSATION_CACHE_SIZE = _DEFAULT_CONVERSATION_CACHE_SIZE
 
 # Default HTTP timeouts in seconds
 DEFAULT_TIMEOUT = 30.0

--- a/src/notebooklm/_core_cache.py
+++ b/src/notebooklm/_core_cache.py
@@ -1,4 +1,4 @@
-"""Conversation cache collaborator for :mod:`notebooklm._core`."""
+"""Conversation cache collaborator owned by :mod:`notebooklm._chat`."""
 
 from __future__ import annotations
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -265,13 +265,12 @@ class NotebookLMClient:
             on_rpc_event=on_rpc_event,
         )
 
-        # ``_chat`` keeps the raw core: its conversation-cache methods are not on the capability surface yet.
         capabilities = ClientCoreCapabilities(self._core)
         self.sources = SourcesAPI(capabilities, upload_timeout=upload_timeout)
         self.notebooks = NotebooksAPI(capabilities, sources_api=self.sources)
         self.artifacts = ArtifactsAPI(capabilities, storage_path=storage_path)
         self.notes = NotesAPI(capabilities)
-        self.chat = ChatAPI(self._core)
+        self.chat = ChatAPI(capabilities)
         self.research = ResearchAPI(capabilities)
         self.settings = SettingsAPI(capabilities)
         self.sharing = SharingAPI(capabilities)

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -1,7 +1,7 @@
 """Regression test for the per-``conversation_id`` lock for serial follow-ups.
 
 ``ChatAPI.ask`` rebuilds the conversation history from
-``_core._conversation_cache`` at the top of the request, then ``await``s
+``ChatAPI._cache`` at the top of the request, then ``await``s
 the streamed POST, then writes the new turn back to the cache. Two
 concurrent ``ask`` calls on the *same* ``conversation_id`` interleave at
 the ``await`` — both read the SAME pre-update history, both POST the
@@ -186,7 +186,7 @@ async def test_concurrent_follow_ups_serialize_on_conversation_id(auth_tokens) -
         # Seed the conversation cache so both follow-ups have at least one
         # prior turn to read. ``ask`` would normally populate this on a
         # first call but we want a known, fixed seed to assert against.
-        client._core.cache_conversation_turn(cid, "q1", "answer-1", turn_number=1)
+        client.chat._cache.cache_conversation_turn(cid, "q1", "answer-1", turn_number=1)
 
         results = await asyncio.gather(
             client.chat.ask(
@@ -292,8 +292,8 @@ async def test_different_conversation_ids_run_in_parallel(auth_tokens) -> None:
         # (the path the lock protects). New-conversation asks would
         # also fan out in parallel but for a different reason — fresh
         # UUIDs — so this test wants the follow-up path specifically.
-        client._core.cache_conversation_turn(cid_a, "q0", "a0", turn_number=1)
-        client._core.cache_conversation_turn(cid_b, "q0", "a0", turn_number=1)
+        client.chat._cache.cache_conversation_turn(cid_a, "q0", "a0", turn_number=1)
+        client.chat._cache.cache_conversation_turn(cid_b, "q0", "a0", turn_number=1)
 
         await asyncio.gather(
             client.chat.ask(notebook_id, "qA", source_ids=["src_001"], conversation_id=cid_a),

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -7,7 +7,7 @@ import pytest
 
 from conftest import install_post_as_stream
 from notebooklm import AuthTokens, NotebookLMClient
-from notebooklm._core import MAX_CONVERSATION_CACHE_SIZE, ClientCore, is_auth_error
+from notebooklm._core import ClientCore, is_auth_error
 from notebooklm.rpc import (
     AuthError,
     ClientError,
@@ -314,79 +314,6 @@ class TestGetHttpClient:
         async with NotebookLMClient(auth_tokens) as client:
             http_client = client._core.get_http_client()
             assert isinstance(http_client, httpx.AsyncClient)
-
-
-class TestConversationCacheFIFOEviction:
-    """Tests for FIFO eviction when conversation cache exceeds MAX_CONVERSATION_CACHE_SIZE."""
-
-    def test_fifo_eviction_when_cache_is_full(self, auth_tokens):
-        core = ClientCore(auth_tokens)
-
-        # Fill the cache to capacity
-        for i in range(MAX_CONVERSATION_CACHE_SIZE):
-            core.cache_conversation_turn(f"conv_{i}", f"q{i}", f"a{i}", i)
-
-        assert len(core._conversation_cache) == MAX_CONVERSATION_CACHE_SIZE
-
-        # Adding one more should evict the oldest (conv_0)
-        core.cache_conversation_turn("conv_new", "q_new", "a_new", 0)
-
-        assert len(core._conversation_cache) == MAX_CONVERSATION_CACHE_SIZE
-        assert "conv_0" not in core._conversation_cache
-        assert "conv_new" in core._conversation_cache
-
-    def test_fifo_eviction_preserves_order(self, auth_tokens):
-        core = ClientCore(auth_tokens)
-
-        # Fill cache to capacity
-        for i in range(MAX_CONVERSATION_CACHE_SIZE):
-            core.cache_conversation_turn(f"conv_{i}", f"q{i}", f"a{i}", i)
-
-        # Add two new conversations - should evict conv_0 then conv_1
-        core.cache_conversation_turn("conv_new_1", "q1", "a1", 0)
-        core.cache_conversation_turn("conv_new_2", "q2", "a2", 0)
-
-        assert "conv_0" not in core._conversation_cache
-        assert "conv_1" not in core._conversation_cache
-        assert "conv_new_1" in core._conversation_cache
-        assert "conv_new_2" in core._conversation_cache
-
-    def test_adding_turns_to_existing_conversation_does_not_evict(self, auth_tokens):
-        core = ClientCore(auth_tokens)
-
-        # Fill cache to capacity
-        for i in range(MAX_CONVERSATION_CACHE_SIZE):
-            core.cache_conversation_turn(f"conv_{i}", f"q{i}", f"a{i}", i)
-
-        # Adding a second turn to an EXISTING conversation should NOT evict anything
-        core.cache_conversation_turn("conv_0", "q_extra", "a_extra", 1)
-
-        assert len(core._conversation_cache) == MAX_CONVERSATION_CACHE_SIZE
-        assert len(core._conversation_cache["conv_0"]) == 2
-
-
-class TestClearConversationCacheNotFound:
-    """Tests for clear_conversation_cache() returning False when ID not found."""
-
-    def test_clear_nonexistent_conversation_returns_false(self, auth_tokens):
-        core = ClientCore(auth_tokens)
-        result = core.clear_conversation_cache("nonexistent_id")
-        assert result is False
-
-    def test_clear_existing_conversation_returns_true(self, auth_tokens):
-        core = ClientCore(auth_tokens)
-        core.cache_conversation_turn("conv_abc", "question", "answer", 1)
-        result = core.clear_conversation_cache("conv_abc")
-        assert result is True
-        assert "conv_abc" not in core._conversation_cache
-
-    def test_clear_all_conversations_returns_true(self, auth_tokens):
-        core = ClientCore(auth_tokens)
-        core.cache_conversation_turn("conv_1", "q1", "a1", 1)
-        core.cache_conversation_turn("conv_2", "q2", "a2", 1)
-        result = core.clear_conversation_cache()
-        assert result is True
-        assert len(core._conversation_cache) == 0
 
 
 class TestGetSourceIds:

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -26,6 +26,18 @@ pytestmark = pytest.mark.characterization
 class TestChatAPI:
     """Characterization tests for the ChatAPI."""
 
+    def test_chat_cache_is_distinct_per_client_instance(self, auth_tokens):
+        # Pins the per-tenant isolation contract: two NotebookLMClient
+        # instances must never share a conversation cache, or follow-up
+        # turns from one tenant could leak into the other's outgoing
+        # history payload. The default ``ChatAPI(conversation_cache=None)``
+        # factory path constructs a fresh ``ConversationCache`` per
+        # instance — this test would have caught a regression where
+        # someone made the default a class-level singleton.
+        client_a = NotebookLMClient(auth_tokens)
+        client_b = NotebookLMClient(auth_tokens)
+        assert client_a.chat._cache is not client_b.chat._cache
+
     @pytest.mark.asyncio
     async def test_get_conversation_id(
         self,

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1310,8 +1310,8 @@ class TestBuildConversationHistory:
     def test_build_conversation_history_returns_list_when_turns_cached(self, auth_tokens):
         """Test _build_conversation_history returns history list when turns exist."""
         client = NotebookLMClient(auth_tokens)
-        # Manually cache a turn
-        client._core.cache_conversation_turn(
+        # Manually cache a turn on the chat sub-client (cache moved off ClientCore).
+        client.chat._cache.cache_conversation_turn(
             "test-conv", "What is AI?", "AI is artificial intelligence.", 1
         )
         result = client.chat._build_conversation_history("test-conv")

--- a/tests/unit/test_chat_error_payload.py
+++ b/tests/unit/test_chat_error_payload.py
@@ -3,6 +3,7 @@
 import logging
 from unittest.mock import MagicMock
 
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._chat import ChatAPI
 
 
@@ -12,7 +13,7 @@ class MalformedErrorPayload(list):
 
 
 def test_rate_limit_payload_parse_failure_logs_debug(caplog):
-    api = ChatAPI(core=MagicMock())
+    api = ChatAPI(core=ClientCoreCapabilities(MagicMock()))
 
     with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
         api._raise_if_rate_limited(MalformedErrorPayload())

--- a/tests/unit/test_chat_refactor.py
+++ b/tests/unit/test_chat_refactor.py
@@ -28,6 +28,7 @@ import pytest
 
 from conftest import install_post_as_stream
 from notebooklm import NotebookLMClient
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._chat import ChatAPI
 from notebooklm._core import ClientCore, _AuthSnapshot
 from notebooklm.auth import AuthTokens
@@ -311,7 +312,7 @@ class TestChatRefreshRetry:
             assert core._http_client is not None
             install_post_as_stream(monkeypatch, core._http_client, fake_post)
 
-            api = ChatAPI(core)
+            api = ChatAPI(ClientCoreCapabilities(core))
             result = await api.ask("nb_x", "Q?", source_ids=["s1"])
 
             assert call_count["n"] == 2
@@ -413,8 +414,7 @@ class TestBuildChatRequestFactory:
         from unittest.mock import MagicMock
 
         core = MagicMock(spec=ClientCore)
-        core.get_cached_conversation = MagicMock(return_value=[])
-        return ChatAPI(core)
+        return ChatAPI(ClientCoreCapabilities(core))
 
     def test_build_request_omits_authuser_for_default_profile(self):
         chat = self._factory()

--- a/tests/unit/test_concurrency_cache_race.py
+++ b/tests/unit/test_concurrency_cache_race.py
@@ -12,13 +12,11 @@ import ast
 import asyncio
 import inspect
 import textwrap
-from contextlib import asynccontextmanager
 
 import pytest
 
-from notebooklm import _core
+from notebooklm import _core_cache
 from notebooklm._core_cache import ConversationCache
-from notebooklm.auth import AuthTokens
 
 
 def _assert_method_has_no_yield_points(method, label: str) -> None:
@@ -30,47 +28,20 @@ def _assert_method_has_no_yield_points(method, label: str) -> None:
     assert not is_async, f"{label} must not be `async def` (breaks atomicity guarantee)"
 
 
-@asynccontextmanager
-async def make_core():
-    auth = AuthTokens(
-        csrf_token="CSRF_OLD",
-        session_id="SID_OLD",
-        cookies={"SID": "old_sid_cookie"},
-    )
-    core = _core.ClientCore(auth=auth, refresh_retry_delay=0.0)
-    await core.open()
-    try:
-        yield core
-    finally:
-        await core.close()
-
-
 @pytest.mark.asyncio
 async def test_concurrent_cache_appends_to_same_conversation_preserve_all_turns():
-    async with make_core() as core:
-        n = 100
+    cache = ConversationCache()
+    n = 100
 
-        async def append(i):
-            core.cache_conversation_turn("conv-1", f"q{i}", f"a{i}", i)
+    async def append(i):
+        cache.cache_conversation_turn("conv-1", f"q{i}", f"a{i}", i)
 
-        await asyncio.gather(*(append(i) for i in range(n)))
+    await asyncio.gather(*(append(i) for i in range(n)))
 
-        cache = core.get_cached_conversation("conv-1")
-        assert len(cache) == n, f"Lost appends under gather: got {len(cache)}/{n}"
-        seen = {(t["query"], t["answer"], t["turn_number"]) for t in cache}
-        assert seen == {(f"q{i}", f"a{i}", i) for i in range(n)}
-
-
-def test_cache_conversation_turn_remains_synchronous():
-    """If anyone adds ``await`` to ``cache_conversation_turn``, this fails.
-
-    The cache's atomicity guarantee depends on the function having no yield
-    points.
-    """
-    _assert_method_has_no_yield_points(
-        _core.ClientCore.cache_conversation_turn,
-        "cache_conversation_turn",
-    )
+    turns = cache.get_cached_conversation("conv-1")
+    assert len(turns) == n, f"Lost appends under gather: got {len(turns)}/{n}"
+    seen = {(t["query"], t["answer"], t["turn_number"]) for t in turns}
+    assert seen == {(f"q{i}", f"a{i}", i) for i in range(n)}
 
 
 def test_conversation_cache_mutation_remains_synchronous():
@@ -81,11 +52,16 @@ def test_conversation_cache_mutation_remains_synchronous():
     )
 
 
-@pytest.mark.asyncio
-async def test_cache_eviction_preserves_invariant_size(monkeypatch):
-    monkeypatch.setattr(_core, "MAX_CONVERSATION_CACHE_SIZE", 3)
-    async with make_core() as core:
-        for i in range(10):
-            core.cache_conversation_turn(f"conv-{i}", "q", "a", 0)
-        assert len(core._conversation_cache) == 3
-        assert list(core._conversation_cache.keys()) == ["conv-7", "conv-8", "conv-9"]
+def test_cache_eviction_preserves_invariant_size(monkeypatch):
+    monkeypatch.setattr(_core_cache, "MAX_CONVERSATION_CACHE_SIZE", 3)
+    cache = ConversationCache()
+    for i in range(10):
+        cache.cache_conversation_turn(
+            f"conv-{i}",
+            "q",
+            "a",
+            0,
+            max_size=_core_cache.MAX_CONVERSATION_CACHE_SIZE,
+        )
+    assert len(cache.conversations) == 3
+    assert list(cache.conversations.keys()) == ["conv-7", "conv-8", "conv-9"]

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -73,10 +73,8 @@ class TestAsk:
         httpx_mock.add_response(content=response_body.encode(), method="POST")
 
         async with NotebookLMClient(auth_tokens) as client:
-            # Seed cache on the chat sub-client (cache moved off ClientCore).
-            client.chat._cache.conversations[_TEST_CONV_ID] = [
-                {"query": "Q1", "answer": "A1", "turn_number": 1}
-            ]
+            # Seed cache via the public helper (cache moved off ClientCore).
+            client.chat._cache.cache_conversation_turn(_TEST_CONV_ID, "Q1", "A1", 1)
 
             result = await client.chat.ask(
                 notebook_id="nb_123",

--- a/tests/unit/test_conversation.py
+++ b/tests/unit/test_conversation.py
@@ -73,8 +73,8 @@ class TestAsk:
         httpx_mock.add_response(content=response_body.encode(), method="POST")
 
         async with NotebookLMClient(auth_tokens) as client:
-            # Seed cache via core client
-            client._core._conversation_cache[_TEST_CONV_ID] = [
+            # Seed cache on the chat sub-client (cache moved off ClientCore).
+            client.chat._cache.conversations[_TEST_CONV_ID] = [
                 {"query": "Q1", "answer": "A1", "turn_number": 1}
             ]
 

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._chat import ChatAPI
 from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import InfographicStyle, VideoFormat, VideoStyle
@@ -45,7 +46,7 @@ def mock_core():
 
     core.rpc_call = AsyncMock(return_value=MagicMock())
 
-    async def _rpc_call_dispatch(method, params, *, source_path=None, allow_null=False):
+    async def _rpc_call_dispatch(method, params, **kwargs):
         if method == _RPC.GET_LAST_CONVERSATION_ID:
             return [[["mock-core-conv-id"]]]
         return core.rpc_call.return_value
@@ -62,8 +63,6 @@ def mock_core():
     core._reqid_counter = 0
     core.next_reqid = AsyncMock(return_value=100000)
     core.get_http_client = MagicMock()
-    core.get_cached_conversation = MagicMock(return_value=[])
-    core.cache_conversation_turn = MagicMock()
 
     # Default ``query_post`` stub: invokes the caller-supplied
     # ``build_request`` factory with a frozen snapshot (so the URL/body the
@@ -123,7 +122,7 @@ class TestChatSourceSelection:
     @pytest.mark.asyncio
     async def test_ask_with_explicit_source_ids(self, mock_core):
         """Test ask() with explicitly provided source_ids."""
-        api = ChatAPI(mock_core)
+        api = ChatAPI(ClientCoreCapabilities(mock_core))
 
         result = await api.ask(
             notebook_id="nb_123",
@@ -146,7 +145,7 @@ class TestChatSourceSelection:
     @pytest.mark.asyncio
     async def test_ask_with_none_fetches_all_sources(self, mock_core):
         """Test ask() with source_ids=None fetches all sources."""
-        api = ChatAPI(mock_core)
+        api = ChatAPI(ClientCoreCapabilities(mock_core))
 
         # Mock get_source_ids to return source IDs
         mock_core.get_source_ids.return_value = ["src_001", "src_002", "src_003"]
@@ -165,7 +164,7 @@ class TestChatSourceSelection:
     @pytest.mark.asyncio
     async def test_ask_source_encoding_format(self, mock_core):
         """Verify the correct encoding format for source IDs in ask()."""
-        api = ChatAPI(mock_core)
+        api = ChatAPI(ClientCoreCapabilities(mock_core))
 
         await api.ask(
             notebook_id="nb_123",
@@ -204,7 +203,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_audio_with_explicit_source_ids(self, mock_core, mock_notes_api):
         """Test generate_audio with explicitly provided source_ids."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         # Mock successful generation response
         mock_core.rpc_call.return_value = [
@@ -245,7 +244,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_audio_with_none_fetches_all_sources(self, mock_core, mock_notes_api):
         """Test generate_audio with source_ids=None fetches all sources."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         # Mock get_source_ids to return source IDs
         mock_core.get_source_ids.return_value = ["src_001", "src_002"]
@@ -275,7 +274,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_video_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_video has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
 
@@ -304,7 +303,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_video_custom_style_prompt_encoding(self, mock_core, mock_notes_api):
         """Test custom video style prompt is encoded after the style code."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
         mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
 
         await api.generate_video(
@@ -321,7 +320,7 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_video_custom_style_requires_prompt(self, mock_core, mock_notes_api):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -334,7 +333,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_rejects_empty_prompt(
         self, mock_core, mock_notes_api
     ):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -348,7 +347,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_rejects_blank_prompt(
         self, mock_core, mock_notes_api
     ):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -362,7 +361,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_style_prompt_requires_custom_style(
         self, mock_core, mock_notes_api
     ):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         with pytest.raises(ValidationError, match="style_prompt requires"):
             await api.generate_video(
@@ -374,7 +373,7 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_video_cinematic_rejects_style_prompt(self, mock_core, mock_notes_api):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         with pytest.raises(ValidationError, match="cinematic"):
             await api.generate_video(
@@ -387,7 +386,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_report_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_report has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
@@ -416,7 +415,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_report_extra_instructions_appended(self, mock_core, mock_notes_api):
         """extra_instructions is appended to the built-in prompt with \\n\\n separator."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
         await api.generate_report(
@@ -439,7 +438,7 @@ class TestArtifactsSourceSelection:
         """extra_instructions has no effect when report_format is CUSTOM."""
         from notebooklm.rpc.types import ReportFormat
 
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
         await api.generate_report(
@@ -460,7 +459,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_quiz_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_quiz has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_quiz", "Quiz", 4, None, 1]]
 
@@ -485,7 +484,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_flashcards_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_flashcards has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_fc", "Flashcards", 4, None, 1]]
 
@@ -505,7 +504,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_infographic_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_infographic has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
 
@@ -525,7 +524,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_infographic_style_encoding(self, mock_core, mock_notes_api):
         """Test generate_infographic encodes style in config slot 5."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
 
@@ -546,7 +545,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_slide_deck_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_slide_deck has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_slide", "Slides", 8, None, 1]]
 
@@ -566,7 +565,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_data_table_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_data_table has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_table", "Table", 9, None, 1]]
 
@@ -586,7 +585,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_mind_map_source_encoding(self, mock_core, mock_notes_api):
         """Test generate_mind_map has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         # Mock get_source_ids to return source IDs
         mock_core.get_source_ids.return_value = ["src_mm_1", "src_mm_2"]
@@ -621,7 +620,7 @@ class TestArtifactsSourceSelection:
         self, mock_core, mock_notes_api
     ):
         """Test generate_mind_map passes language and instructions to RPC payload."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.get_source_ids.return_value = ["src_1"]
         mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
@@ -650,7 +649,7 @@ class TestArtifactsSourceSelection:
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod
 
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         # Mock the GET_SUGGESTED_REPORTS RPC call
         # Response format: [[[title, description, null, null, prompt, audience_level], ...]]
@@ -677,7 +676,7 @@ class TestEmptySourceIds:
     @pytest.mark.asyncio
     async def test_generate_with_empty_source_list(self, mock_core, mock_notes_api):
         """Test generation with empty source_ids list produces empty arrays."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(ClientCoreCapabilities(mock_core), mock_notes_api)
 
         mock_core.rpc_call.return_value = [["artifact_empty", "Audio", 1, None, 1]]
 
@@ -700,7 +699,7 @@ class TestEmptySourceIds:
     @pytest.mark.asyncio
     async def test_ask_with_empty_source_list(self, mock_core):
         """Test ask with empty source_ids list."""
-        api = ChatAPI(mock_core)
+        api = ChatAPI(ClientCoreCapabilities(mock_core))
 
         await api.ask(
             notebook_id="nb_123",


### PR DESCRIPTION
## Summary

Closes the chat carve-out from #770 (C2-minimal) by:

1. **Relocating `ConversationCache` ownership** from `ClientCore` to `ChatAPI`. The cache is chat-domain state with no other consumer — `_chat.py` is the only file that touched the 3 cache methods on `ClientCore`. `ChatAPI.__init__` now accepts an optional `conversation_cache` (defaults to a fresh per-instance `ConversationCache()`); the 5 cache call sites switch from `self._core.*` to `self._cache.*`. `ClientCore` loses 3 thin delegators + the back-compat `_conversation_cache` property/setter + the `_conversation_cache_manager` instantiation + the now-dead `MAX_CONVERSATION_CACHE_SIZE` re-export.
2. **Adding two Protocols to `_capabilities.py`** for the remaining chat-touching surface that stays on `ClientCore`:
   - `CoreReqIdProvider` — `next_reqid` (not chat-specific; a generic request-id counter capability).
   - `ChatStreamingProvider` — `query_post`. Named explicitly to flag this is a **transitional** debt marker: chat-aware error mapping still lives on `ClientCore.query_post` and a future change will extract it into a chat-owned transport once auth-refresh wiring is decoupled.
3. **Flipping `ChatAPI`'s constructor** from `core: ClientCore` → `core: ClientCoreCapabilities`. After this PR, **all 8 sub-clients** consume the capability adapter (was 7 of 8 after #770).

Net diff: **+142 / -244** (refactor is a net deletion).

## Concurrency contract

Preserved. Cache moves from per-`ClientCore` (single-loop) to per-`ChatAPI` (also single-loop; 1:1:1 with `NotebookLMClient` on the default factory path). The atomicity guarantee on `ConversationCache.cache_conversation_turn` is unchanged — it's the same body that `ClientCore.cache_conversation_turn` previously delegated to. The new `test_chat_cache_is_distinct_per_client_instance` test pins the tenant-isolation invariant directly (previously implied by Python object semantics, now grep-able).

## Polish gate

Ran the full `/polish` pipeline: code-simplifier (Stage 1) → triple review (Stage 2: Claude + Codex + Gemini) → ultrathink (Stage 3).

**Stage 1** applied 3 simplifications: tightened `ChatStreamingProvider` docstring, compressed `conversation_cache` arg docstring, fixed a stale lock-rationale reference (`_core._conversation_cache` → `self._cache`).

**Stage 2** triple review:
- 0 critical, 1 important (Claude unique: dead `MAX_CONVERSATION_CACHE_SIZE` re-export in `_core.py:20-22, :76` — applied), 3 suggestions (2 applied, 1 declined).
- 3-of-3 consensus: `ChatStreamingProvider` docstring needed to be more explicit as a debt marker — applied (Codex's wording).
- Codex novel suggestion: pin tenant-isolation via a unit test — applied (new test at `test_chat_characterization.py::TestChatAPI::test_chat_cache_is_distinct_per_client_instance`).
- Codex suggestion declined: `_chat.py:119` defensive `is not None` over `or` — no bug today since `ConversationCache` is always truthy, and CLAUDE.md says "don't add validation for scenarios that can't happen."

**Stage 3** ultrathink: no further code changes warranted. Architectural second-order note: this PR's adapter-everywhere posture **unblocks future `_core.py` decomposition** (audit I17) — sub-clients no longer require the concrete class, so splitting `_core.py` is safer.

## Test plan

- [x] `uv run ruff check src/notebooklm tests` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run pytest --ignore=tests/unit/cli/test_session.py --ignore=tests/unit/test_windows_compatibility.py` — 4851 passed, 18 skipped (the 2 excluded files require the `browser` extra / playwright; CI runs them with the full matrix)
- [ ] CI matrix runs the full suite across 3 OS × 5 Python versions including the playwright-dependent tests

## Coverage parity for the deleted integration tests

The 75-line removal in `tests/integration/test_core.py` (`TestConversationCacheFIFOEviction` + `TestClearConversationCacheNotFound`) is fully covered by existing tests in `tests/unit/test_core_cache.py`:

| Deleted integration test | Equivalent unit test |
|---|---|
| `test_fifo_eviction_when_cache_is_full` | `test_cache_conversation_turn_fifo_evicts_only_for_new_conversations` |
| `test_fifo_eviction_preserves_order` | (same — assertion on key order) |
| `test_adding_turns_to_existing_conversation_does_not_evict` | (same — writes to existing key while at-cap) |
| `test_clear_nonexistent_conversation_returns_false` | `test_clear_specific_and_all_conversations` |
| `test_clear_existing_conversation_returns_true` | (same) |
| `test_clear_all_conversations_returns_true` | (same) |

The unit-level coverage is strictly equivalent and avoids the now-unnecessary `ClientCore` setup.

## Out of scope (follow-ups documented but deferred)

- Extract `query_post` into a chat-owned transport once auth-refresh wiring is decoupled from `ClientCore` (drops `ChatStreamingProvider` from the capability surface).
- `_core.py` decomposition (audit I17) — newly unblocked but deserves its own deliberate refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now uses a distinct per-client conversation cache and can be given an optional cache provider when constructed.
* **Documentation**
  * Clarified concurrency and caching guidance: cached conversation context is per-client-instance and not shared or persisted across processes.
* **Tests**
  * Added/updated tests to assert per-client cache isolation, cache concurrency and eviction behavior, and to align tests with the new cache location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->