### PR TITLE
refactor(core): extract TransportDrainTracker into _core_drain

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -10,13 +10,19 @@ import warnings
 import weakref
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager, nullcontext
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import httpx
 
 from ._core_cookie_persistence import CookiePersistence
+from ._core_drain import TransportDrainTracker
+
+# Re-exported so the existing import path ``from notebooklm._core import
+# _TransportOperationToken`` keeps working after the dataclass moved into
+# ``_core_drain``. ``_core_drain`` is the source of truth for the token
+# shape; the alias below is the backwards-compat anchor.
+from ._core_drain import _TransportOperationToken as _TransportOperationToken
 from ._core_metrics import ClientMetrics
 from ._core_polling import PendingPolls, PollRegistry
 from ._core_rpc import RpcExecutor
@@ -62,13 +68,6 @@ from .rpc import (
 
 logger = logging.getLogger(__name__)
 _OBSERVABILITY_INIT_LOCK = threading.Lock()
-
-
-@dataclass(frozen=True)
-class _TransportOperationToken:
-    """Token for one accepted transport operation on a specific asyncio task."""
-
-    task: asyncio.Task[Any] | None
 
 
 # Default HTTP timeouts in seconds
@@ -537,12 +536,14 @@ class ClientCore:
         # below (``_metrics_lock`` / ``_metrics`` / ``_on_rpc_event``) bridge
         # the legacy ivar names back into this helper.
         self._metrics_obj = ClientMetrics(on_rpc_event=on_rpc_event)
-        self._draining = False
-        self._in_flight_posts = 0
-        self._drain_condition: asyncio.Condition | None = None
-        self._operation_depths: weakref.WeakKeyDictionary[asyncio.Task[Any], int] = (
-            weakref.WeakKeyDictionary()
-        )
+        # Transport drain bookkeeping (in-flight posts, drain condition,
+        # per-task operation depth, draining flag). Compat properties below
+        # (``_in_flight_posts`` / ``_drain_condition`` / ``_operation_depths``
+        # / ``_draining``) bridge the legacy ivar names back into this
+        # helper. The helper's ``__init__`` is event-loop-agnostic; the
+        # ``asyncio.Condition`` is created lazily on first
+        # ``get_drain_condition`` call.
+        self._drain_tracker = TransportDrainTracker()
         # Request ID counter for chat API (must be unique per request).
         # Access via the ``next_reqid()`` async method, which guards mutation
         # under ``_reqid_lock``. Direct mutation through the ``_reqid_counter``
@@ -648,6 +649,52 @@ class ClientCore:
         self._ensure_observability_state()
         self._metrics_obj._on_rpc_event = value
 
+    # ``TransportDrainTracker`` compat bridges. The four drain ivars now live
+    # on ``self._drain_tracker``; each setter calls
+    # ``_ensure_observability_state`` first so a ``__new__``-built fixture
+    # (no ``__init__`` ran) can still assign (e.g.) ``core._draining = True``
+    # or ``core._drain_condition = asyncio.Condition()`` and have it write
+    # through to a real helper.
+    @property
+    def _in_flight_posts(self) -> int:
+        self._ensure_observability_state()
+        return self._drain_tracker._in_flight_posts
+
+    @_in_flight_posts.setter
+    def _in_flight_posts(self, value: int) -> None:
+        self._ensure_observability_state()
+        self._drain_tracker._in_flight_posts = value
+
+    @property
+    def _draining(self) -> bool:
+        self._ensure_observability_state()
+        return self._drain_tracker._draining
+
+    @_draining.setter
+    def _draining(self, value: bool) -> None:
+        self._ensure_observability_state()
+        self._drain_tracker._draining = value
+
+    @property
+    def _drain_condition(self) -> asyncio.Condition | None:
+        self._ensure_observability_state()
+        return self._drain_tracker._drain_condition
+
+    @_drain_condition.setter
+    def _drain_condition(self, value: asyncio.Condition | None) -> None:
+        self._ensure_observability_state()
+        self._drain_tracker._drain_condition = value
+
+    @property
+    def _operation_depths(self) -> weakref.WeakKeyDictionary[asyncio.Task[Any], int]:
+        self._ensure_observability_state()
+        return self._drain_tracker._operation_depths
+
+    @_operation_depths.setter
+    def _operation_depths(self, value: weakref.WeakKeyDictionary[asyncio.Task[Any], int]) -> None:
+        self._ensure_observability_state()
+        self._drain_tracker._operation_depths = value
+
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
     #
@@ -741,28 +788,17 @@ class ClientCore:
     def _ensure_observability_state(self) -> None:
         """Backfill observability fields for tests that construct via ``__new__``.
 
-        Gates on ``_metrics_obj`` (a real instance attribute) — the
-        property-bridged ivars' ``hasattr`` probes are always True.
+        Gates on ``_metrics_obj`` AND ``_drain_tracker`` (both real instance
+        attributes) — the property-bridged ivars' ``hasattr`` probes are
+        always True because the descriptors live on the class.
         """
-        if (
-            hasattr(self, "_metrics_obj")
-            and hasattr(self, "_draining")
-            and hasattr(self, "_in_flight_posts")
-            and hasattr(self, "_drain_condition")
-            and hasattr(self, "_operation_depths")
-        ):
+        if hasattr(self, "_metrics_obj") and hasattr(self, "_drain_tracker"):
             return
         with _OBSERVABILITY_INIT_LOCK:
             if not hasattr(self, "_metrics_obj"):
                 self._metrics_obj = ClientMetrics(on_rpc_event=None)
-            if not hasattr(self, "_draining"):
-                self._draining = False
-            if not hasattr(self, "_in_flight_posts"):
-                self._in_flight_posts = 0
-            if not hasattr(self, "_drain_condition"):
-                self._drain_condition = None
-            if not hasattr(self, "_operation_depths"):
-                self._operation_depths = weakref.WeakKeyDictionary()
+            if not hasattr(self, "_drain_tracker"):
+                self._drain_tracker = TransportDrainTracker()
 
     def _increment_metrics(self, **increments: int | float) -> None:
         self._ensure_observability_state()
@@ -788,30 +824,16 @@ class ClientCore:
 
     def _get_drain_condition(self) -> asyncio.Condition:
         self._ensure_observability_state()
-        if self._drain_condition is None:
-            self._drain_condition = asyncio.Condition()
-        return self._drain_condition
+        return self._drain_tracker.get_drain_condition()
 
     def _current_operation_depth(self, task: asyncio.Task[Any] | None) -> int:
-        if task is None:
-            return 0
-        return self._operation_depths.get(task, 0)
+        self._ensure_observability_state()
+        return self._drain_tracker.current_operation_depth(task)
 
     async def _begin_transport_post(self, log_label: str) -> _TransportOperationToken:
         """Reject new top-level transport work once graceful drain has started."""
-        condition = self._get_drain_condition()
-        task = asyncio.current_task()
-        depth = self._current_operation_depth(task)
-        async with condition:
-            if self._draining and depth == 0:
-                raise RuntimeError(
-                    "NotebookLMClient is draining; new client operations are not accepted "
-                    f"({log_label})."
-                )
-            if task is not None:
-                self._operation_depths[task] = depth + 1
-            self._in_flight_posts += 1
-        return _TransportOperationToken(task=task)
+        self._ensure_observability_state()
+        return await self._drain_tracker.begin_transport_post(log_label)
 
     async def _begin_transport_task(
         self,
@@ -819,30 +841,12 @@ class ClientCore:
         log_label: str,
     ) -> _TransportOperationToken:
         """Admit an internally-spawned task as part of the current operation."""
-        condition = self._get_drain_condition()
-        current_depth = self._current_operation_depth(asyncio.current_task())
-        async with condition:
-            if self._draining and current_depth == 0:
-                raise RuntimeError(
-                    "NotebookLMClient is draining; new client operations are not accepted "
-                    f"({log_label})."
-                )
-            self._operation_depths[task] = self._operation_depths.get(task, 0) + 1
-            self._in_flight_posts += 1
-        return _TransportOperationToken(task=task)
+        self._ensure_observability_state()
+        return await self._drain_tracker.begin_transport_task(task, log_label)
 
     async def _finish_transport_post(self, token: _TransportOperationToken) -> None:
-        condition = self._get_drain_condition()
-        async with condition:
-            if token.task is not None:
-                depth = self._operation_depths.get(token.task, 0)
-                if depth <= 1:
-                    self._operation_depths.pop(token.task, None)
-                else:
-                    self._operation_depths[token.task] = depth - 1
-            self._in_flight_posts -= 1
-            if self._in_flight_posts == 0:
-                condition.notify_all()
+        self._ensure_observability_state()
+        await self._drain_tracker.finish_transport_post(token)
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new client operations and wait for in-flight ones to finish.
@@ -851,17 +855,8 @@ class ClientCore:
         remains in draining mode so shutdown callers do not accidentally admit
         new work after a missed deadline.
         """
-        if timeout is not None and timeout < 0:
-            raise ValueError(f"timeout must be >= 0 or None, got {timeout!r}")
-        condition = self._get_drain_condition()
-        async with condition:
-            self._draining = True
-            if self._in_flight_posts == 0:
-                return
-            await asyncio.wait_for(
-                condition.wait_for(lambda: self._in_flight_posts == 0),
-                timeout=timeout,
-            )
+        self._ensure_observability_state()
+        await self._drain_tracker.drain(timeout)
 
     def get_upload_semaphore(self) -> asyncio.Semaphore:
         """Return the per-instance upload semaphore, creating it on first use.

--- a/src/notebooklm/_core_drain.py
+++ b/src/notebooklm/_core_drain.py
@@ -1,0 +1,209 @@
+"""Transport drain bookkeeping helper for :class:`ClientCore`.
+
+Owns the in-flight transport-operation counters, the lazy
+``asyncio.Condition`` that ``drain()`` parks on, the per-``asyncio.Task``
+operation-depth map, and the ``_draining`` flag. Lifted out of ``_core.py``
+so the drain surface has one home (this file) instead of being woven into
+``ClientCore.__init__`` alongside metrics, reqid, and auth state.
+
+Design constraints (load-bearing — see
+``tests/unit/concurrency/test_close_cancellation_leak.py``,
+``tests/unit/test_core_close.py``, and ``tests/unit/test_observability.py``):
+
+* ``__init__`` MUST be event-loop-agnostic. ``ClientCore`` is routinely
+  constructed outside a running loop (sync-mode
+  ``NotebookLMClient(auth)`` before ``asyncio.run``), so this helper may
+  not call ``asyncio.get_running_loop()`` or instantiate any ``asyncio.*``
+  primitive at construction time. The ``asyncio.Condition`` is created
+  lazily on first :meth:`get_drain_condition` call from inside a running
+  loop.
+
+* :meth:`drain` blocks on ``self._drain_condition`` while
+  ``_in_flight_posts > 0``. The ``Condition.wait_for`` pattern is the
+  whole point of the helper — never replace it with a poll loop.
+
+* :meth:`begin_transport_post` rejects new top-level work once
+  ``_draining`` is set, but allows nested begins from a task whose
+  outer operation was admitted *before* the drain started (depth > 0).
+  This is what ``test_drain_allows_nested_work_inside_accepted_operation``
+  pins down; the depth bookkeeping under the condition lock is exactly
+  what stops the close path from deadlocking.
+
+* Exceptions during :meth:`finish_transport_post` would orphan a
+  counter and stall ``drain`` forever — keep the body trivial and
+  fully inside the ``async with condition`` block.
+
+Field names are deliberately the same as the legacy ``ClientCore`` ivars
+(``_in_flight_posts``, ``_draining``, ``_drain_condition``,
+``_operation_depths``) so the compat ``@property`` bridges on
+``ClientCore`` can delegate via ``return self._drain_tracker._<attr>``
+and stay readable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class _TransportOperationToken:
+    """Token for one accepted transport operation on a specific asyncio task.
+
+    Returned from :meth:`TransportDrainTracker.begin_transport_post` /
+    :meth:`TransportDrainTracker.begin_transport_task` and consumed by
+    :meth:`TransportDrainTracker.finish_transport_post`. The ``task`` field
+    is the ``asyncio.Task`` whose operation depth was bumped on admission
+    (or ``None`` for the unusual case of a begin issued outside any task).
+
+    Re-exported from ``notebooklm._core`` for backwards compatibility —
+    keep this dataclass frozen so token equality is by value.
+    """
+
+    task: asyncio.Task[Any] | None
+
+
+class TransportDrainTracker:
+    """Track in-flight transport operations and gate graceful shutdown.
+
+    Owns four pieces of state:
+
+    * ``_in_flight_posts`` — count of currently-running transport
+      operations across all tasks. Mutated only inside the
+      ``async with condition`` block.
+    * ``_draining`` — set ``True`` by :meth:`drain`; new top-level
+      begins raise ``RuntimeError`` once this is set.
+    * ``_drain_condition`` — lazily-created ``asyncio.Condition``
+      that ``drain`` parks on; ``finish_transport_post`` notifies
+      it when ``_in_flight_posts`` drops to zero. ``None`` until the
+      first :meth:`get_drain_condition` call from inside a loop.
+    * ``_operation_depths`` —
+      ``weakref.WeakKeyDictionary[asyncio.Task, int]`` tracking per-task
+      operation depth so nested begins (e.g. an RPC issued from inside
+      a source-upload operation) don't get rejected after ``drain``
+      starts.
+    """
+
+    def __init__(self) -> None:
+        self._in_flight_posts: int = 0
+        self._draining: bool = False
+        # Lazily-created from inside a running loop — see module docstring.
+        self._drain_condition: asyncio.Condition | None = None
+        # Weak references so a finished task doesn't keep its depth entry
+        # alive forever; the entry is also explicitly popped in
+        # ``finish_transport_post`` once depth returns to zero.
+        self._operation_depths: weakref.WeakKeyDictionary[asyncio.Task[Any], int] = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def get_drain_condition(self) -> asyncio.Condition:
+        """Return the per-instance drain ``asyncio.Condition``, creating it lazily.
+
+        Lazy construction is required because ``asyncio.Condition()`` binds
+        to the running event loop in some Python versions, and ``ClientCore``
+        is routinely instantiated outside one. The check-then-assign is
+        race-free without an outer lock because asyncio is single-threaded:
+        no other coroutine can execute between the ``is None`` check and
+        the assignment unless we ``await`` (and we don't).
+        """
+        if self._drain_condition is None:
+            self._drain_condition = asyncio.Condition()
+        return self._drain_condition
+
+    def current_operation_depth(self, task: asyncio.Task[Any] | None) -> int:
+        """Return how many transport operations ``task`` currently holds."""
+        if task is None:
+            return 0
+        return self._operation_depths.get(task, 0)
+
+    async def begin_transport_post(self, log_label: str) -> _TransportOperationToken:
+        """Reject new top-level transport work once graceful drain has started.
+
+        Nested begins from a task with depth > 0 are still accepted — this
+        is what lets an in-flight source upload finish its sub-RPCs after
+        ``drain()`` starts. See
+        ``tests/unit/test_observability.py::test_drain_allows_nested_work_inside_accepted_operation``.
+        """
+        condition = self.get_drain_condition()
+        task = asyncio.current_task()
+        depth = self.current_operation_depth(task)
+        async with condition:
+            if self._draining and depth == 0:
+                raise RuntimeError(
+                    "NotebookLMClient is draining; new client operations are not accepted "
+                    f"({log_label})."
+                )
+            if task is not None:
+                self._operation_depths[task] = depth + 1
+            self._in_flight_posts += 1
+        return _TransportOperationToken(task=task)
+
+    async def begin_transport_task(
+        self,
+        task: asyncio.Task[Any],
+        log_label: str,
+    ) -> _TransportOperationToken:
+        """Admit an internally-spawned task as part of the current operation.
+
+        Unlike :meth:`begin_transport_post`, the admission gate keys on
+        ``asyncio.current_task()`` (the *spawning* task's depth) rather
+        than ``task`` (the spawned task). That way a child task spawned
+        from inside an admitted operation inherits its parent's
+        "admitted" status, but a child task spawned from outside any
+        operation (depth 0 on the spawner) is rejected once ``_draining``.
+        """
+        condition = self.get_drain_condition()
+        current_depth = self.current_operation_depth(asyncio.current_task())
+        async with condition:
+            if self._draining and current_depth == 0:
+                raise RuntimeError(
+                    "NotebookLMClient is draining; new client operations are not accepted "
+                    f"({log_label})."
+                )
+            self._operation_depths[task] = self._operation_depths.get(task, 0) + 1
+            self._in_flight_posts += 1
+        return _TransportOperationToken(task=task)
+
+    async def finish_transport_post(self, token: _TransportOperationToken) -> None:
+        """Decrement the in-flight counter and notify waiters at zero.
+
+        The notify wakes ``drain()`` once the last admitted operation
+        finishes. If this method raised, ``_in_flight_posts`` would
+        stay above zero and ``drain`` would block forever — keep the
+        body trivial.
+        """
+        condition = self.get_drain_condition()
+        async with condition:
+            if token.task is not None:
+                depth = self._operation_depths.get(token.task, 0)
+                if depth <= 1:
+                    self._operation_depths.pop(token.task, None)
+                else:
+                    self._operation_depths[token.task] = depth - 1
+            self._in_flight_posts -= 1
+            if self._in_flight_posts == 0:
+                condition.notify_all()
+
+    async def drain(self, timeout: float | None = None) -> None:
+        """Stop accepting new top-level work and wait for in-flight ops to finish.
+
+        If ``timeout`` expires, ``TimeoutError`` is raised and the
+        tracker remains in draining mode so shutdown callers do not
+        accidentally admit new work after a missed deadline.
+        """
+        if timeout is not None and timeout < 0:
+            raise ValueError(f"timeout must be >= 0 or None, got {timeout!r}")
+        condition = self.get_drain_condition()
+        async with condition:
+            self._draining = True
+            if self._in_flight_posts == 0:
+                return
+            await asyncio.wait_for(
+                condition.wait_for(lambda: self._in_flight_posts == 0),
+                timeout=timeout,
+            )
+
+
+__all__ = ["TransportDrainTracker", "_TransportOperationToken"]

--- a/tests/unit/test_core_drain.py
+++ b/tests/unit/test_core_drain.py
@@ -296,8 +296,10 @@ def test_token_is_frozen_dataclass() -> None:
     a mutable dataclass, which would break dict-keying and reduce safety
     around begin/finish pairing.
     """
+    from dataclasses import FrozenInstanceError
+
     token = _TransportOperationToken(task=None)
-    with pytest.raises(Exception):  # FrozenInstanceError subclasses Exception
+    with pytest.raises(FrozenInstanceError):
         token.task = None  # type: ignore[misc]
 
 

--- a/tests/unit/test_core_drain.py
+++ b/tests/unit/test_core_drain.py
@@ -1,0 +1,399 @@
+"""Unit tests for :class:`notebooklm._core_drain.TransportDrainTracker`.
+
+Covers the drain helper in isolation — the ``ClientCore`` facade contract
+(``drain``, ``_begin_transport_post``, ``_begin_transport_task``,
+``_finish_transport_post``, ``_current_operation_depth``,
+``_get_drain_condition``) is exercised end-to-end in
+``tests/unit/test_observability.py`` and the close-cancellation suite at
+``tests/unit/concurrency/test_close_cancellation_leak.py``. This file
+pins the helper-class invariants the facade depends on:
+
+* ``__init__`` is event-loop-agnostic (no ``asyncio.*`` primitives).
+* ``get_drain_condition`` lazily constructs the ``asyncio.Condition``
+  on first call from inside a running loop.
+* ``begin_transport_post`` / ``finish_transport_post`` correctly track
+  nested per-task depth (a child begin from inside an admitted operation
+  is itself admitted post-drain, but a fresh top-level begin is
+  rejected).
+* ``drain`` blocks until ``_in_flight_posts`` reaches zero, raises
+  ``TimeoutError`` on expiry, and leaves the tracker in draining mode
+  after timeout (so a missed deadline doesn't accidentally admit new
+  work).
+* ``current_operation_depth(None)`` returns zero (the documented
+  "outside any task" branch).
+* The ``ClientCore.__new__(ClientCore)`` regression path: the drain
+  property setters on a ``__new__``-built core (no ``__init__`` ran)
+  must succeed because the setters call
+  ``_ensure_observability_state`` before writethrough.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm._core_drain import TransportDrainTracker, _TransportOperationToken
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_init_uses_no_asyncio_primitives() -> None:
+    """``TransportDrainTracker`` must be constructible outside a running event loop.
+
+    Regression guard: ``ClientCore`` is routinely instantiated synchronously
+    (e.g. ``NotebookLMClient(auth)`` before ``asyncio.run``). If
+    ``TransportDrainTracker.__init__`` ever introduces an
+    ``asyncio.Lock``/``Event``/``Condition``, the synchronous construction
+    path will break on Python versions where those primitives require a
+    running loop.
+    """
+    tracker = TransportDrainTracker()
+
+    assert tracker._in_flight_posts == 0
+    assert tracker._draining is False
+    assert tracker._drain_condition is None
+    # ``WeakKeyDictionary`` is plain Python; no loop required.
+    assert len(tracker._operation_depths) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_drain_condition_lazy_allocates() -> None:
+    """First call inside a loop allocates; subsequent calls return same instance."""
+    tracker = TransportDrainTracker()
+    assert tracker._drain_condition is None
+
+    condition_first = tracker.get_drain_condition()
+    assert isinstance(condition_first, asyncio.Condition)
+
+    condition_second = tracker.get_drain_condition()
+    assert condition_second is condition_first
+
+
+# ---------------------------------------------------------------------------
+# Depth bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_current_operation_depth_returns_zero_for_none_task() -> None:
+    """The "outside any task" branch must not raise."""
+    tracker = TransportDrainTracker()
+    assert tracker.current_operation_depth(None) == 0
+
+
+@pytest.mark.asyncio
+async def test_current_operation_depth_reports_nested_begins() -> None:
+    """Two consecutive begins from the same task must produce depth = 2."""
+    tracker = TransportDrainTracker()
+    task = asyncio.current_task()
+    assert task is not None
+    assert tracker.current_operation_depth(task) == 0
+
+    token_outer = await tracker.begin_transport_post("outer")
+    assert tracker.current_operation_depth(task) == 1
+
+    token_inner = await tracker.begin_transport_post("inner")
+    assert tracker.current_operation_depth(task) == 2
+
+    await tracker.finish_transport_post(token_inner)
+    assert tracker.current_operation_depth(task) == 1
+
+    await tracker.finish_transport_post(token_outer)
+    assert tracker.current_operation_depth(task) == 0
+
+
+@pytest.mark.asyncio
+async def test_nested_begin_finish_returns_counter_to_zero() -> None:
+    """Symmetric begin/finish pairs must leave both counter and depth at zero."""
+    tracker = TransportDrainTracker()
+    outer = await tracker.begin_transport_post("outer")
+    inner = await tracker.begin_transport_post("inner")
+    assert tracker._in_flight_posts == 2
+
+    await tracker.finish_transport_post(inner)
+    assert tracker._in_flight_posts == 1
+    await tracker.finish_transport_post(outer)
+    assert tracker._in_flight_posts == 0
+    # Operation_depths entry for the current task should be cleaned up.
+    task = asyncio.current_task()
+    assert task is not None
+    assert task not in tracker._operation_depths
+
+
+# ---------------------------------------------------------------------------
+# Drain semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_returns_immediately_when_nothing_in_flight() -> None:
+    """No in-flight ops → ``drain`` completes synchronously and sets the flag."""
+    tracker = TransportDrainTracker()
+    await tracker.drain(timeout=1.0)
+    assert tracker._draining is True
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_blocks_until_in_flight_drops_to_zero() -> None:
+    """``drain`` must wait for the last admitted operation to finish."""
+    tracker = TransportDrainTracker()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def in_flight() -> None:
+        token = await tracker.begin_transport_post("worker")
+        started.set()
+        try:
+            await release.wait()
+        finally:
+            await tracker.finish_transport_post(token)
+
+    worker = asyncio.create_task(in_flight())
+    await started.wait()
+
+    drain_task = asyncio.create_task(tracker.drain(timeout=2.0))
+    # Yield once so drain has a chance to acquire the condition and park.
+    await asyncio.sleep(0)
+    assert not drain_task.done()
+    assert tracker._draining is True
+
+    # Releasing the worker drops in_flight to zero; drain must wake up.
+    release.set()
+    await drain_task
+    await worker
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_new_top_level_work() -> None:
+    """Once draining, fresh begins from a task with depth 0 must raise."""
+    tracker = TransportDrainTracker()
+    await tracker.drain(timeout=0.5)
+    assert tracker._draining is True
+
+    with pytest.raises(RuntimeError, match="draining"):
+        await tracker.begin_transport_post("new-after-drain")
+
+
+@pytest.mark.asyncio
+async def test_drain_allows_nested_begin_from_admitted_task() -> None:
+    """A nested begin from a task with depth > 0 must succeed even mid-drain.
+
+    This is the contract that lets an in-flight source upload finish its
+    sub-RPCs after ``drain()`` starts; otherwise close would deadlock.
+    """
+    tracker = TransportDrainTracker()
+    outer = await tracker.begin_transport_post("outer")
+    try:
+        drain_task = asyncio.create_task(tracker.drain(timeout=1.0))
+        await asyncio.sleep(0)
+        assert not drain_task.done()
+
+        # Nested begin must NOT raise because current task's depth is 1.
+        nested = await tracker.begin_transport_post("nested")
+        await tracker.finish_transport_post(nested)
+    finally:
+        await tracker.finish_transport_post(outer)
+
+    await drain_task
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_child_task_spawned_from_admitted_operation() -> None:
+    """Spawning a brand-new task from inside an admitted op must still be
+    rejected once draining — the gate keys on the *spawner*'s depth, and a
+    freshly-created task has its own depth of 0 from ``asyncio.current_task()``
+    inside its body.
+
+    Mirrors
+    ``tests/unit/test_observability.py::test_drain_rejects_child_task_spawned_from_accepted_operation``.
+    """
+    tracker = TransportDrainTracker()
+    outer = await tracker.begin_transport_post("outer")
+    try:
+        drain_task = asyncio.create_task(tracker.drain(timeout=1.0))
+        await asyncio.sleep(0)
+
+        async def child_work() -> None:
+            child_token = await tracker.begin_transport_post("child")
+            await tracker.finish_transport_post(child_token)
+
+        with pytest.raises(RuntimeError, match="draining"):
+            await asyncio.create_task(child_work())
+    finally:
+        await tracker.finish_transport_post(outer)
+
+    await drain_task
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_raises_and_keeps_draining_flag() -> None:
+    """Drain timeout must raise ``TimeoutError`` and leave the flag set.
+
+    Shutdown callers (``ClientCore.close``) must not accidentally admit new
+    work after a missed deadline. The contract is "drain mode is sticky";
+    pin it.
+    """
+    tracker = TransportDrainTracker()
+    token = await tracker.begin_transport_post("hangs-forever")
+    # Do NOT finish — drain must time out.
+    try:
+        with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+            await tracker.drain(timeout=0.05)
+    finally:
+        # Clean up so the event loop teardown doesn't see a leaked counter.
+        await tracker.finish_transport_post(token)
+
+    assert tracker._draining is True
+
+
+@pytest.mark.asyncio
+async def test_drain_rejects_negative_timeout() -> None:
+    """A negative timeout is invalid input — surface it loudly."""
+    tracker = TransportDrainTracker()
+    with pytest.raises(ValueError, match="timeout must be >= 0 or None"):
+        await tracker.drain(timeout=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# begin_transport_task — child-task admission path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_begin_transport_task_bumps_depth_on_target_task() -> None:
+    """``begin_transport_task`` keys depth on the *spawned* task, not the spawner."""
+    tracker = TransportDrainTracker()
+
+    async def child_body() -> tuple[_TransportOperationToken, int]:
+        spawned = asyncio.current_task()
+        assert spawned is not None
+        token = await tracker.begin_transport_task(spawned, "child")
+        # Depth for the spawned task should be 1.
+        depth = tracker.current_operation_depth(spawned)
+        await tracker.finish_transport_post(token)
+        return token, depth
+
+    child = asyncio.create_task(child_body())
+    token, depth = await child
+    assert depth == 1
+    assert token.task is not None
+
+
+# ---------------------------------------------------------------------------
+# Token equality
+# ---------------------------------------------------------------------------
+
+
+def test_token_is_frozen_dataclass() -> None:
+    """``_TransportOperationToken`` is frozen — value equality, not identity.
+
+    Locked down so a follow-up refactor doesn't accidentally turn this into
+    a mutable dataclass, which would break dict-keying and reduce safety
+    around begin/finish pairing.
+    """
+    token = _TransportOperationToken(task=None)
+    with pytest.raises(Exception):  # FrozenInstanceError subclasses Exception
+        token.task = None  # type: ignore[misc]
+
+
+def test_token_reexported_from_core_module() -> None:
+    """``from notebooklm._core import _TransportOperationToken`` must still work.
+
+    Master plan mandate: the legacy import path stays available after the
+    dataclass moves into ``_core_drain``.
+    """
+    from notebooklm._core import _TransportOperationToken as Aliased
+
+    assert Aliased is _TransportOperationToken
+
+
+# ---------------------------------------------------------------------------
+# ``ClientCore.__new__`` backfill regression
+# ---------------------------------------------------------------------------
+
+
+def test_new_backfill_drain_tracker_constructed_on_first_access() -> None:
+    """A ``__new__``-built core must lazy-construct the tracker on first probe.
+
+    Regression guard: ``ClientCore.__new__(ClientCore)`` skips ``__init__``,
+    so neither ``_metrics_obj`` nor ``_drain_tracker`` is set. The first
+    facade-method call must run ``_ensure_observability_state`` and
+    backfill both.
+    """
+    core = ClientCore.__new__(ClientCore)
+    assert not hasattr(core, "_drain_tracker")
+
+    core._ensure_observability_state()
+    assert isinstance(core._drain_tracker, TransportDrainTracker)
+    # The compat properties must read through cleanly.
+    assert core._in_flight_posts == 0
+    assert core._draining is False
+    assert core._drain_condition is None
+
+
+def test_new_backfill_drain_setter_writethrough_succeeds() -> None:
+    """Setting ``core._draining = True`` on a ``__new__``-built core works.
+
+    The property setter must call ``_ensure_observability_state`` BEFORE
+    the writethrough; otherwise the writethrough hits an ``AttributeError``
+    because ``_drain_tracker`` doesn't exist yet.
+    """
+    core = ClientCore.__new__(ClientCore)
+    core._draining = True
+    assert core._draining is True
+    assert core._drain_tracker._draining is True
+
+
+def test_new_backfill_drain_condition_setter_writethrough_succeeds() -> None:
+    """Tests can inject ``core._drain_condition = asyncio.Condition()`` directly.
+
+    Some legacy fixtures pre-allocate the condition; the setter must
+    accept that even on a ``__new__``-built core.
+    """
+
+    async def _scope() -> None:
+        core = ClientCore.__new__(ClientCore)
+        injected = asyncio.Condition()
+        core._drain_condition = injected
+        assert core._drain_condition is injected
+        assert core._drain_tracker._drain_condition is injected
+
+    asyncio.run(_scope())
+
+
+def test_new_backfill_in_flight_setter_writethrough_succeeds() -> None:
+    """``core._in_flight_posts = 5`` on a ``__new__``-built core writes through."""
+    core = ClientCore.__new__(ClientCore)
+    core._in_flight_posts = 5
+    assert core._in_flight_posts == 5
+    assert core._drain_tracker._in_flight_posts == 5
+
+
+# ---------------------------------------------------------------------------
+# Facade integration — exercise ClientCore delegation through the tracker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clientcore_drain_facade_delegates_to_tracker() -> None:
+    """A real ``ClientCore`` instance must route ``drain`` through the tracker.
+
+    Construction via ``__new__`` keeps the test off the full ``__init__``
+    surface (no auth, no httpx). The facade methods still rely on
+    ``_ensure_observability_state`` to backfill, which is exactly the path
+    we want to exercise here.
+    """
+    core = ClientCore.__new__(ClientCore)
+    # Begin/finish through the facade should bump and clear in-flight.
+    token = await core._begin_transport_post("facade-test")
+    assert core._in_flight_posts == 1
+    await core._finish_transport_post(token)
+    assert core._in_flight_posts == 0
+    # Drain with nothing in flight should return immediately and set flag.
+    await core.drain(timeout=0.5)
+    assert core._draining is True


### PR DESCRIPTION
## Summary

Phase 1 / Wave 2 / Task A2 of the core-decomposition mini-phase — extracts drain bookkeeping from `ClientCore` into a new `TransportDrainTracker` class in `_core_drain.py`. Pure relocation with Protocol-shim host pattern matching the existing `_core_transport`/`_core_rpc` extractions.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] Targeted tests pass: `tests/unit/test_core_drain.py` (new, 399 lines), `tests/unit/concurrency/test_close_cancellation_leak.py`, `tests/unit/test_init_order.py`
- [ ] CI: lint, type-check, full pytest

## Key behavior preservation

- Drain semantics unchanged — `drain()` still blocks on `_drain_condition` while `_in_flight_posts > 0`
- Lazy `asyncio.Condition` allocation preserved (no construction in `__init__`)
- `_TransportOperationToken` dataclass relocated to `_core_drain.py` and re-exported from `_core.py` (existing `from notebooklm._core import _TransportOperationToken` works)
- Compat `@property` bridges (getter + setter) on `ClientCore` for `_in_flight_posts`, `_drain_condition`, `_operation_depths`, `_draining`
- `_ensure_observability_state()` extends to lazy-construct `_drain_tracker` on `__new__`-built instances; early-return gate restructured to check `_metrics_obj` + `_drain_tracker` directly (avoids descriptor-true short-circuit after A1's properties landed)
- Metrics recording routes through A1's `ClientMetrics` public interface

## Wave 2 context

Runs in parallel with A3 (reqid extraction). Conflict-resolution rule: keep helper-constructor order `_metrics_obj (A1, merged)` → `_drain_tracker (this PR)` → `_reqid (A3, parallel)` → `_auth_coord (B1, parallel)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved graceful shutdown and transport-operation tracking for more reliable shutdowns and clearer observability.

* **Tests**
  * Added comprehensive tests covering shutdown behavior, nested operation handling, timeouts, lazy initialization, and facade delegation to ensure robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->