### PR TITLE
refactor(core): extract ReqidCounter into _core_reqid

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -26,6 +26,7 @@ from ._core_cache import (
 from ._core_cookie_persistence import CookiePersistence
 from ._core_metrics import ClientMetrics
 from ._core_polling import PendingPolls, PollRegistry
+from ._core_reqid import ReqidCounter
 from ._core_rpc import RpcExecutor
 from ._core_transport import (
     MAX_RETRY_AFTER_SECONDS as MAX_RETRY_AFTER_SECONDS,
@@ -553,14 +554,14 @@ class ClientCore:
             weakref.WeakKeyDictionary()
         )
         # Request ID counter for chat API (must be unique per request).
-        # Access via the ``next_reqid()`` async method, which guards mutation
-        # under ``_reqid_lock``. Direct mutation through the ``_reqid_counter``
-        # property setter emits a ``DeprecationWarning``; bypass the warning
-        # for legitimate test setup by writing to ``_reqid_counter_value``.
-        self._reqid_counter_value: int = 100000
-        # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
-        # Python versions, and this object can be constructed outside one.
-        self._reqid_lock: asyncio.Lock | None = None
+        # The :class:`ReqidCounter` helper owns the monotonic ``_value`` and
+        # the lazily-allocated ``asyncio.Lock`` that serialises mutation.
+        # Compat properties below (``_reqid_counter`` /
+        # ``_reqid_counter_value`` / ``_reqid_lock``) bridge the legacy ivar
+        # names back into this helper. The ``on_lock_wait`` hook keeps the
+        # cumulative ``lock_wait_seconds_*`` metrics ticking inside
+        # ``self._metrics_obj`` even though the counter is now extracted.
+        self._reqid = ReqidCounter(on_lock_wait=self._record_lock_wait)
         # Serializes ``_AuthSnapshot`` reads in :meth:`_snapshot` with
         # :meth:`ClientCore.update_auth_tokens` during auth refresh
         # . The lock holds only across the four
@@ -667,10 +668,14 @@ class ClientCore:
     # values that Google rejects.
     #
     # New contract: ``await core.next_reqid()`` performs the increment under
-    # ``_reqid_lock`` and returns the post-increment value. The lock is
-    # created lazily so a ``ClientCore`` can be constructed outside a running
-    # event loop. Direct mutation of ``_reqid_counter`` still works for
-    # backwards compatibility but emits ``DeprecationWarning``.
+    # ``_reqid_lock`` and returns the post-increment value. The state lives in
+    # :class:`notebooklm._core_reqid.ReqidCounter` (``self._reqid``); the
+    # properties below are read/write bridges that keep the legacy
+    # ``_reqid_counter`` / ``_reqid_counter_value`` / ``_reqid_lock`` ivar
+    # names observable for existing tests and first-party callers. Direct
+    # mutation of ``_reqid_counter`` still works for backwards compatibility
+    # but emits ``DeprecationWarning`` — bypass the warning for legitimate
+    # test setup by writing to ``_reqid_counter_value`` instead.
     # ------------------------------------------------------------------
 
     @property
@@ -678,7 +683,7 @@ class ClientCore:
         """Current request-id counter value. Read access is safe; write access
         via the property setter emits ``DeprecationWarning``.
         """
-        return self._reqid_counter_value
+        return self._reqid.value
 
     @_reqid_counter.setter
     def _reqid_counter(self, value: int) -> None:
@@ -688,7 +693,35 @@ class ClientCore:
             DeprecationWarning,
             stacklevel=2,
         )
-        self._reqid_counter_value = value
+        self._reqid.set_value(value)
+
+    @property
+    def _reqid_counter_value(self) -> int:
+        """Bypass-warning bridge for tests that seed the counter directly.
+
+        Writing through ``_reqid_counter`` emits a ``DeprecationWarning``;
+        test fixtures that legitimately need to set the counter without
+        paying that tax write to ``_reqid_counter_value`` instead.
+        """
+        return self._reqid.value
+
+    @_reqid_counter_value.setter
+    def _reqid_counter_value(self, value: int) -> None:
+        self._reqid.set_value(value)
+
+    @property
+    def _reqid_lock(self) -> asyncio.Lock | None:
+        """Bridge to the lazily-allocated reqid lock.
+
+        Historically a plain ivar; preserved as a property with a setter so
+        test fixtures that inject their own ``asyncio.Lock`` (or reset it to
+        ``None`` to force re-allocation) continue to work.
+        """
+        return self._reqid._lock
+
+    @_reqid_lock.setter
+    def _reqid_lock(self, value: asyncio.Lock | None) -> None:
+        self._reqid._lock = value
 
     @property
     def _pending_polls(self) -> PendingPolls:
@@ -707,41 +740,12 @@ class ClientCore:
     async def next_reqid(self, step: int = 100000) -> int:
         """Atomically increment the request-id counter and return the new value.
 
-        Args:
-            step: Increment applied to the counter. Defaults to ``100000`` to
-                match the historical bump used by ``ChatAPI.ask``. Must be a
-                positive ``int`` (not ``bool``); ``step <= 0`` would break
-                monotonicity / uniqueness guarantees that Google's chat
-                backend relies on.
-
-        Returns:
-            The post-increment counter value. Successive calls return strictly
-            monotonic, distinct values even under ``asyncio.gather``.
-
-        Raises:
-            TypeError: If ``step`` is not an ``int`` (bool is rejected even
-                though it is a subclass of ``int``).
-            ValueError: If ``step`` is not positive.
+        Thin facade over :meth:`ReqidCounter.next_reqid`. The default ``step``
+        matches the historical bump used by ``ChatAPI.ask``; see
+        :class:`notebooklm._core_reqid.ReqidCounter` for the full contract,
+        validation rules, and lazy-lock semantics.
         """
-        # ``bool`` is a subclass of ``int`` in Python — reject it explicitly so
-        # ``next_reqid(step=True)`` doesn't silently degrade to ``step=1``.
-        if not isinstance(step, int) or isinstance(step, bool):
-            raise TypeError(f"step must be int, got {type(step).__name__}")
-        if step <= 0:
-            raise ValueError(f"step must be positive, got {step!r}")
-        # Safe: no await between check and assign, so no other coroutine can race us here.
-        if self._reqid_lock is None:
-            # Lazy init — safe to construct here because we're already in an
-            # async context (caller is awaiting us).
-            self._reqid_lock = asyncio.Lock()
-        wait_start = time.perf_counter()
-        await self._reqid_lock.acquire()
-        self._record_lock_wait(time.perf_counter() - wait_start)
-        try:
-            self._reqid_counter_value += step
-            return self._reqid_counter_value
-        finally:
-            self._reqid_lock.release()
+        return await self._reqid.next_reqid(step)
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client instance."""

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -26,6 +26,7 @@ from ._core_cache import (
 from ._core_cookie_persistence import CookiePersistence
 from ._core_metrics import ClientMetrics
 from ._core_polling import PendingPolls, PollRegistry
+from ._core_reqid import DEFAULT_STEP as _REQID_DEFAULT_STEP
 from ._core_reqid import ReqidCounter
 from ._core_rpc import RpcExecutor
 from ._core_transport import (
@@ -737,11 +738,12 @@ class ClientCore:
     def _pending_polls(self, value: PendingPolls) -> None:
         self.poll_registry.pending = value
 
-    async def next_reqid(self, step: int = 100000) -> int:
+    async def next_reqid(self, step: int = _REQID_DEFAULT_STEP) -> int:
         """Atomically increment the request-id counter and return the new value.
 
         Thin facade over :meth:`ReqidCounter.next_reqid`. The default ``step``
-        matches the historical bump used by ``ChatAPI.ask``; see
+        is sourced from :data:`notebooklm._core_reqid.DEFAULT_STEP` so the
+        facade and the underlying helper cannot silently drift apart; see
         :class:`notebooklm._core_reqid.ReqidCounter` for the full contract,
         validation rules, and lazy-lock semantics.
         """

--- a/src/notebooklm/_core_reqid.py
+++ b/src/notebooklm/_core_reqid.py
@@ -1,0 +1,166 @@
+"""Request-id counter helper for :class:`ClientCore`.
+
+Owns the monotonic ``_reqid`` value that Google's chat backend requires per
+request, plus the lazily-allocated ``asyncio.Lock`` that serialises the
+read-modify-write under concurrent ``ChatAPI.ask`` callers. Lifted out of
+``_core.py`` so the reqid surface has one home (this file) instead of being
+woven into ``ClientCore.__init__`` alongside metrics, drain, and auth state.
+
+Design constraints (load-bearing — see ``tests/unit/test_core_reqid.py`` and
+``tests/unit/test_core_reqid_concurrent.py``):
+
+* ``__init__`` MUST be event-loop-agnostic — it must NOT instantiate
+  ``asyncio.Lock()`` eagerly. ``ClientCore`` is routinely built outside a
+  running loop (sync-mode ``NotebookLMClient(...)`` before the caller's
+  ``asyncio.run``), and ``asyncio.Lock()`` binds to the running loop on
+  construction in some Python versions. The lock is therefore allocated
+  lazily inside :meth:`next_reqid`, which is always called from an async
+  context.
+
+* Baseline ``_value`` is ``100000`` and the default ``step`` is ``100000``.
+  Both are part of the chat-API contract (the per-request ``_reqid`` URL
+  parameter must be a large positive integer); do NOT change them.
+
+* :meth:`next_reqid` rejects ``bool`` and non-positive ``step`` explicitly so
+  ``next_reqid(step=True)`` cannot silently degrade to ``step=1`` (``bool``
+  is a subclass of ``int`` in Python) and ``step=0`` / ``step<0`` cannot
+  break the chat-side uniqueness / monotonicity guarantees.
+
+* Optional ``on_lock_wait`` callback receives the seconds spent blocked on
+  :attr:`_lock`. Decouples the counter from
+  :class:`notebooklm._core_metrics.ClientMetrics` so this class is unit-
+  testable in isolation; ``ClientCore`` wires it up to
+  ``self._record_lock_wait`` at construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+
+# Baseline counter value (matches the chat-API expectation of a large positive
+# integer). Module-level constant so tests / future callers can reference it
+# instead of hard-coding ``100000``.
+DEFAULT_BASELINE: int = 100000
+# Default step applied by :meth:`ReqidCounter.next_reqid`. Matches the
+# historical bump that ``ChatAPI.ask`` performed under the legacy
+# ``self._core._reqid_counter += 100000`` contract.
+DEFAULT_STEP: int = 100000
+
+
+def _noop_record_lock_wait(_wait_seconds: float) -> None:
+    """Default ``on_lock_wait`` — does nothing.
+
+    Used when the counter is constructed standalone (e.g. in
+    ``tests/unit/test_core_reqid_unit.py``) without a metrics sink wired up.
+    """
+    return None
+
+
+class ReqidCounter:
+    """Monotonic request-id counter with lazy ``asyncio.Lock`` serialisation.
+
+    Field names are deliberately the same as the legacy ``ClientCore`` ivars
+    (``_value`` mirroring ``_reqid_counter_value``, ``_lock`` mirroring
+    ``_reqid_lock``) so the compat ``@property`` bridges on ``ClientCore`` can
+    delegate with ``return self._reqid._<attr>`` / write through with
+    ``self._reqid._<attr> = value`` and stay readable.
+    """
+
+    def __init__(
+        self,
+        *,
+        baseline: int = DEFAULT_BASELINE,
+        on_lock_wait: Callable[[float], None] | None = None,
+    ) -> None:
+        # Plain int; mutated only inside :meth:`next_reqid` under ``_lock`` or
+        # via the ``ClientCore._reqid_counter_value`` writethrough used by
+        # test fixtures that want to seed the counter without paying the
+        # deprecation-warning tax on the public ``_reqid_counter`` setter.
+        self._value: int = baseline
+        # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
+        # Python versions, and this object is constructed inside
+        # ``ClientCore.__init__`` which may run outside a loop.
+        self._lock: asyncio.Lock | None = None
+        # No-op default keeps standalone construction (unit tests) free of a
+        # ``ClientCore``-shaped dependency. ``ClientCore`` injects its own
+        # metrics-aware recorder so lock-wait latency continues to be tracked
+        # in the cumulative ``ClientMetricsSnapshot``.
+        self._on_lock_wait: Callable[[float], None] = (
+            on_lock_wait if on_lock_wait is not None else _noop_record_lock_wait
+        )
+
+    @property
+    def value(self) -> int:
+        """Snapshot of the current counter value (sync read, no lock).
+
+        Returns a point-in-time read; the value can race with a concurrent
+        :meth:`next_reqid` mutation. Callers that need an atomic post-
+        increment value MUST use :meth:`next_reqid`, which serialises the
+        read-modify-write under :attr:`_lock`. This accessor exists so
+        ``ClientCore._reqid_counter`` (read path) and test assertions
+        (``assert core._reqid_counter == ...`` after a known sequence) stay
+        lock-free.
+        """
+        return self._value
+
+    def set_value(self, new_value: int) -> None:
+        """Replace the counter value.
+
+        Used by the ``ClientCore._reqid_counter`` setter (which emits a
+        ``DeprecationWarning`` before delegating here) and by test fixtures
+        that need to seed the counter to a deterministic baseline.
+        """
+        self._value = new_value
+
+    async def next_reqid(self, step: int = DEFAULT_STEP) -> int:
+        """Atomically increment the counter and return the new value.
+
+        Args:
+            step: Increment applied to the counter. Defaults to
+                :data:`DEFAULT_STEP` to match the historical bump used by
+                ``ChatAPI.ask``. Must be a positive ``int`` (not ``bool``);
+                ``step <= 0`` would break monotonicity / uniqueness guarantees
+                that Google's chat backend relies on.
+
+        Returns:
+            The post-increment counter value. Successive calls return strictly
+            monotonic, distinct values even under ``asyncio.gather``.
+
+        Raises:
+            TypeError: If ``step`` is not an ``int`` (``bool`` is rejected
+                even though it is a subclass of ``int``).
+            ValueError: If ``step`` is not positive.
+        """
+        # ``bool`` is a subclass of ``int`` in Python — reject it explicitly so
+        # ``next_reqid(step=True)`` doesn't silently degrade to ``step=1``.
+        if not isinstance(step, int) or isinstance(step, bool):
+            raise TypeError(f"step must be int, got {type(step).__name__}")
+        if step <= 0:
+            raise ValueError(f"step must be positive, got {step!r}")
+        # Safe: no await between check and assign, so no other coroutine can
+        # race us here. Allocating ``asyncio.Lock()`` requires a running loop
+        # in some Python versions; we're already awaited so we know one is
+        # running.
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        wait_start = time.perf_counter()
+        await self._lock.acquire()
+        # Wrap latency recording AND the increment inside the same
+        # ``try``/``finally`` that releases the lock so a misbehaving
+        # ``on_lock_wait`` callback (in practice always
+        # ``ClientCore._record_lock_wait``, which can't raise — but the
+        # extraction makes this callback injection point reusable) cannot
+        # leak the acquisition. Tighter than the pre-extraction shape in
+        # ``ClientCore.next_reqid``, which did the recording before the
+        # ``try`` block; defense-in-depth for arbitrary future callbacks.
+        try:
+            self._on_lock_wait(time.perf_counter() - wait_start)
+            self._value += step
+            return self._value
+        finally:
+            self._lock.release()
+
+
+__all__ = ["DEFAULT_BASELINE", "DEFAULT_STEP", "ReqidCounter"]

--- a/src/notebooklm/_core_reqid.py
+++ b/src/notebooklm/_core_reqid.py
@@ -55,7 +55,6 @@ def _noop_record_lock_wait(_wait_seconds: float) -> None:
     Used when the counter is constructed standalone (e.g. in
     ``tests/unit/test_core_reqid_unit.py``) without a metrics sink wired up.
     """
-    return None
 
 
 class ReqidCounter:

--- a/tests/unit/test_core_reqid_unit.py
+++ b/tests/unit/test_core_reqid_unit.py
@@ -18,7 +18,6 @@ import pytest
 
 from notebooklm._core_reqid import DEFAULT_BASELINE, DEFAULT_STEP, ReqidCounter
 
-
 # ---------------------------------------------------------------------------
 # Construction / sync accessors
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_core_reqid_unit.py
+++ b/tests/unit/test_core_reqid_unit.py
@@ -1,0 +1,219 @@
+"""Unit tests for the standalone :class:`ReqidCounter` helper.
+
+Exercises the class in isolation from :class:`ClientCore` so the
+counter's invariants (monotonicity, lazy lock allocation, type/value
+validation, mutator semantics, optional ``on_lock_wait`` hook) are pinned
+down without dragging in the full client surface. The ``ClientCore``-shaped
+``DeprecationWarning`` contract continues to live in
+``tests/unit/test_core_reqid.py``; the concurrent-contention pin continues
+to live in ``tests/unit/test_core_reqid_concurrent.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+from notebooklm._core_reqid import DEFAULT_BASELINE, DEFAULT_STEP, ReqidCounter
+
+
+# ---------------------------------------------------------------------------
+# Construction / sync accessors
+# ---------------------------------------------------------------------------
+
+
+def test_default_baseline_matches_constant() -> None:
+    """Newly-constructed counter starts at :data:`DEFAULT_BASELINE`."""
+    counter = ReqidCounter()
+    assert counter.value == DEFAULT_BASELINE
+    # Also pin the literal so a silent change to ``DEFAULT_BASELINE`` is loud.
+    assert DEFAULT_BASELINE == 100000
+
+
+def test_default_step_constant_matches_signature_default() -> None:
+    """Module-level :data:`DEFAULT_STEP` mirrors the method-signature default.
+
+    Introspects ``next_reqid``'s ``step`` parameter to pin the two sources of
+    truth together — silently changing one without the other would break the
+    chat-API ``_reqid`` contract.
+    """
+    sig = inspect.signature(ReqidCounter.next_reqid)
+    assert sig.parameters["step"].default == DEFAULT_STEP
+    # And the literal — so a silent ``DEFAULT_STEP = 1`` is loud.
+    assert DEFAULT_STEP == 100000
+
+
+def test_custom_baseline() -> None:
+    """Constructor accepts a non-default baseline (used by future fixtures)."""
+    counter = ReqidCounter(baseline=42)
+    assert counter.value == 42
+
+
+def test_lock_not_allocated_at_construction() -> None:
+    """``asyncio.Lock()`` would bind to a running loop in some Python versions;
+    constructing a ``ReqidCounter`` outside one must NOT instantiate the lock.
+    """
+    counter = ReqidCounter()
+    assert counter._lock is None
+
+
+def test_set_value_mutates_counter() -> None:
+    """``set_value`` is the property-setter delegation target."""
+    counter = ReqidCounter()
+    counter.set_value(0)
+    assert counter.value == 0
+    counter.set_value(999_999)
+    assert counter.value == 999_999
+
+
+@pytest.mark.asyncio
+async def test_set_value_resets_baseline_for_next_reqid() -> None:
+    """After ``set_value(N)``, the next ``next_reqid()`` returns ``N + step``.
+
+    Pins the contract between the sync mutator and the async increment path:
+    test fixtures that seed the counter to a deterministic value (via
+    ``ClientCore._reqid_counter_value = N``) expect subsequent reqids to
+    walk forward from there, not from the original baseline.
+    """
+    counter = ReqidCounter()
+    counter.set_value(42)
+    assert await counter.next_reqid(step=1) == 43
+    assert await counter.next_reqid(step=100) == 143
+
+
+# ---------------------------------------------------------------------------
+# next_reqid — success path + monotonicity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_post_increment_default_step() -> None:
+    """Default-step bumps return strictly monotonic post-increment values."""
+    counter = ReqidCounter()
+    assert await counter.next_reqid() == DEFAULT_BASELINE + DEFAULT_STEP
+    assert await counter.next_reqid() == DEFAULT_BASELINE + 2 * DEFAULT_STEP
+    assert await counter.next_reqid() == DEFAULT_BASELINE + 3 * DEFAULT_STEP
+    assert counter.value == DEFAULT_BASELINE + 3 * DEFAULT_STEP
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_custom_step() -> None:
+    """Custom ``step`` parameter is honoured (small + large)."""
+    counter = ReqidCounter()
+    assert await counter.next_reqid(step=1) == DEFAULT_BASELINE + 1
+    assert await counter.next_reqid(step=7) == DEFAULT_BASELINE + 8
+    assert await counter.next_reqid(step=1000) == DEFAULT_BASELINE + 1008
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_allocates_lock_on_first_call() -> None:
+    """Lock is created on first invocation and re-used across calls."""
+    counter = ReqidCounter()
+    assert counter._lock is None
+    await counter.next_reqid()
+    first_lock = counter._lock
+    assert isinstance(first_lock, asyncio.Lock)
+    await counter.next_reqid()
+    # Same lock instance — never re-allocated on subsequent calls.
+    assert counter._lock is first_lock
+
+
+# ---------------------------------------------------------------------------
+# next_reqid — validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_rejects_zero_step() -> None:
+    """``step=0`` would produce duplicate reqids — must raise."""
+    counter = ReqidCounter()
+    with pytest.raises(ValueError, match="step must be positive"):
+        await counter.next_reqid(step=0)
+    assert counter.value == DEFAULT_BASELINE
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_rejects_negative_step() -> None:
+    """``step<0`` would break monotonicity — must raise."""
+    counter = ReqidCounter()
+    with pytest.raises(ValueError, match="step must be positive"):
+        await counter.next_reqid(step=-5)
+    assert counter.value == DEFAULT_BASELINE
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_rejects_bool_step() -> None:
+    """``bool`` is a subclass of ``int``; guard must reject ``True`` / ``False``
+    explicitly so ``step=True`` cannot silently degrade to ``step=1``.
+    """
+    counter = ReqidCounter()
+    with pytest.raises(TypeError, match="step must be int"):
+        await counter.next_reqid(step=True)  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="step must be int"):
+        await counter.next_reqid(step=False)  # type: ignore[arg-type]
+    assert counter.value == DEFAULT_BASELINE
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_rejects_non_int_step() -> None:
+    """Non-``int`` ``step`` (e.g. ``str``) raises ``TypeError`` before any
+    state mutation.
+    """
+    counter = ReqidCounter()
+    with pytest.raises(TypeError, match="step must be int"):
+        await counter.next_reqid(step="100")  # type: ignore[arg-type]
+    assert counter.value == DEFAULT_BASELINE
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — class-in-isolation pin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_concurrent_unique_and_monotonic() -> None:
+    """50 concurrent ``next_reqid()`` calls produce 50 distinct values that
+    sort into a contiguous arithmetic progression.
+    """
+    counter = ReqidCounter()
+    step = 100000
+    baseline = counter.value
+
+    results = await asyncio.gather(*[counter.next_reqid(step=step) for _ in range(50)])
+
+    assert len(set(results)) == 50
+    assert sorted(results) == [baseline + step * (i + 1) for i in range(50)]
+    assert counter.value == baseline + step * 50
+
+
+# ---------------------------------------------------------------------------
+# on_lock_wait callback wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_lock_wait_called_each_acquisition() -> None:
+    """The injected ``on_lock_wait`` recorder fires once per ``next_reqid``."""
+    samples: list[float] = []
+
+    counter = ReqidCounter(on_lock_wait=samples.append)
+    await counter.next_reqid()
+    await counter.next_reqid()
+    await counter.next_reqid()
+
+    assert len(samples) == 3
+    # Wait times are non-negative finite floats (perf_counter delta).
+    assert all(isinstance(s, float) and s >= 0.0 for s in samples)
+
+
+@pytest.mark.asyncio
+async def test_default_on_lock_wait_is_noop() -> None:
+    """Constructing without ``on_lock_wait`` still works — the default is a
+    silent no-op so unit tests don't have to wire up a metrics sink.
+    """
+    counter = ReqidCounter()
+    # Must not raise.
+    value = await counter.next_reqid()
+    assert value == DEFAULT_BASELINE + DEFAULT_STEP

--- a/tests/unit/test_core_reqid_unit.py
+++ b/tests/unit/test_core_reqid_unit.py
@@ -44,6 +44,21 @@ def test_default_step_constant_matches_signature_default() -> None:
     assert DEFAULT_STEP == 100000
 
 
+def test_client_core_next_reqid_default_matches_default_step() -> None:
+    """``ClientCore.next_reqid``'s ``step`` default is sourced from
+    :data:`notebooklm._core_reqid.DEFAULT_STEP`.
+
+    Pins the facade signature to the helper's constant so a silent change to
+    one cannot drift past the other. ``ClientCore`` imports
+    ``DEFAULT_STEP as _REQID_DEFAULT_STEP``; this test introspects the bound
+    default to confirm the wiring stays in lockstep.
+    """
+    from notebooklm._core import ClientCore
+
+    sig = inspect.signature(ClientCore.next_reqid)
+    assert sig.parameters["step"].default == DEFAULT_STEP
+
+
 def test_custom_baseline() -> None:
     """Constructor accepts a non-default baseline (used by future fixtures)."""
     counter = ReqidCounter(baseline=42)


### PR DESCRIPTION
## Summary

- Lifts the monotonic chat-API request-id counter out of `ClientCore.__init__` into a dedicated `_core_reqid` module — Phase 1 Wave 2 of the core-decomposition mini-phase (sibling to merged A1 `ClientMetrics`; parallel with in-flight A2 `TransportDrainTracker`).
- New `ReqidCounter` class owns `_value` (int, baseline 100000) and lazy `_lock` (`asyncio.Lock | None`); public surface: `async next_reqid(step)`, sync `value`, mutator `set_value`. Helper is constructible without a running event loop.
- `ClientCore` keeps its full back-compat surface: `_reqid_counter` (with `DeprecationWarning` setter), `_reqid_counter_value` (bypass-warning bridge), `_reqid_lock` (test-injectable) — all retain getter AND setter semantics.
- `ClientCore.next_reqid` is now a one-line facade delegating to `self._reqid.next_reqid(step)`.
- Lock-wait latency continues to tick through `ClientMetrics` via the injected `on_lock_wait=self._record_lock_wait` callback.
- Lock-wait recording is now wrapped INSIDE the `try`/`finally` (defense-in-depth over the pre-extraction shape) so a misbehaving custom callback cannot leak the lock acquisition.

## Task

`a3-extract-reqid` from [.sisyphus/phases/core-decomposition-mini-phase/phase-1.md](.sisyphus/phases/core-decomposition-mini-phase/phase-1.md) — base `main`, branch `core-decomposition-mini-phase/a3-extract-reqid`.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean.
- [x] `uv run pytest tests/unit/test_core_reqid.py tests/unit/test_core_reqid_concurrent.py tests/unit/test_core_reqid_unit.py tests/unit/test_init_order.py -v` — 58 tests pass.
- [x] `uv run pytest` — 5076 tests pass, 20 pre-existing skipped.
- [x] Existing `tests/unit/test_core_reqid.py` (DeprecationWarning contract) and `tests/unit/test_core_reqid_concurrent.py` (100-call contention) pass UNCHANGED.
- [x] New `tests/unit/test_core_reqid_unit.py` covers: baseline, lazy lock, contiguous step, custom step, all 4 validation paths (zero/neg/bool/non-int), 50-call concurrent uniqueness, `set_value` → `next_reqid` baseline interaction, `on_lock_wait` invocation, default no-op recorder, signature introspection pinning `DEFAULT_STEP` to the method default.

## Polish

Triple review (claude + codex + gemini) returned APPROVE / APPROVE_WITH_FIXES across the board. Applied:

- **Important** (claude+codex consensus): wrap `on_lock_wait` recording inside the `try`/`finally` so a raising callback cannot leak the lock acquisition. Strict improvement over the pre-extraction shape.
- **Nit** (codex): make `test_default_step_constant_matches_signature_default` actually introspect the method signature instead of only checking the constant.
- **Nit** (codex): clarify `ReqidCounter.value` docstring — "snapshot read; callers needing atomic increment use `next_reqid`" is the practical contract (replaces CPython-specific atomicity claim).
- **Nit** (gemini): use public `self._reqid.value` over private `self._reqid._value` in the `_reqid_counter_value` getter.
- **Nit** (claude, native review): add a test pinning `set_value(N)` → `next_reqid()` interaction (closes the gap between sync mutator and async increment).

No deferred findings.

## Coordination with parallel work

- **A1** (`_core_metrics.py`) is already on `main` (#778). This PR is independent.
- **A2** (`_core_drain.py`) is running in a parallel worktree and touches drain state only. No overlap with reqid. If A2 lands first, this PR's rebase preserves the plan-prescribed helper order `_metrics_obj` → `_drain_tracker` → `_reqid`. If this PR lands first, A2's rebase will handle the conflict per the wave-2 conflict-resolution rule.
- **`_ensure_observability_state`** is NOT touched by this PR — A2 owns that body per the phase plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the request-id counter into an isolated, monotonic component with simplified async incrementing and compatibility bridges for legacy access.

* **Tests**
  * Added comprehensive unit tests covering baseline/step behavior, input validation, lock allocation, concurrency uniqueness, and wait-time callback wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->