### PR TITLE
ci(workflows): pin Playwright install dir to a workspace path

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+    env:
+      # Pin Playwright's browser install dir to a single workspace-relative
+      # path on every OS — see test.yml for the rationale (sidesteps the
+      # actions/cache@v5 Windows dual-path restore flake).
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
 
     concurrency:
       group: nightly-${{ needs.resolve-branch.outputs.branch }}-${{ matrix.os }}
@@ -105,10 +110,10 @@ jobs:
     - name: Cache Playwright browsers
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/ms-playwright
-          ~/AppData/Local/ms-playwright
-        key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}
+        path: ${{ github.workspace }}/.playwright-browsers
+        # ``-ws`` suffix invalidates archives keyed to the prior dual-path
+        # stanza so first restores after this change land on the new path.
+        key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}-ws
 
     - name: Install Playwright browsers
       run: playwright install chromium

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    env:
+      # Pin Playwright's browser install dir to a single workspace-relative
+      # path on every OS. The previous dual-path cache stanza (``~/.cache``
+      # + ``~/AppData/Local``) intermittently failed the cache restore on
+      # Windows with ``actions/cache@v5`` — the missing Linux path tripped
+      # the post-restore validation on a cache hit. Pinning the path here
+      # lets the cache stanza below carry exactly one entry on every OS.
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
 
     steps:
     - uses: actions/checkout@v6
@@ -98,10 +106,10 @@ jobs:
     - name: Cache Playwright browsers
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/ms-playwright
-          ~/AppData/Local/ms-playwright
-        key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}
+        path: ${{ github.workspace }}/.playwright-browsers
+        # ``-ws`` suffix invalidates archives keyed to the prior dual-path
+        # stanza so first restores after this change land on the new path.
+        key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}-ws
 
     - name: Install Playwright browsers
       run: uv run playwright install chromium

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ worktrees/
 
 # Investigation artifacts
 investigate*.py
+
+# Playwright browser binaries when PLAYWRIGHT_BROWSERS_PATH is set to a
+# workspace-relative path (used by CI; harmless locally if it ever lands).
+.playwright-browsers/
 INVESTIGATION*.md
 investigation_output/
 downloads/


### PR DESCRIPTION
## Summary

Both `test.yml` (matrix test job) and `nightly.yml` (e2e job) cached Playwright browsers with a dual-path stanza:

```yaml
path: |
  ~/.cache/ms-playwright          # Linux/macOS
  ~/AppData/Local/ms-playwright   # Windows
```

The Linux path never resolves to a real directory on Windows runners. `actions/cache@v5` intermittently fails its post-restore validation on Windows when one of the requested paths is missing — even on a cache hit. Symptom in the job log:

```
##[group]Run actions/cache@v5
...
Cache hit for: playwright-windows-latest-1.57.0
Post job cleanup.
```

(no `Install Playwright` / `Run tests` lines — downstream steps skipped). Surfaced in #784's CI as a Windows 3.13 `Test` failure at 28s; reproduces sporadically across other Windows + Python combinations.

## Fix

Set `PLAYWRIGHT_BROWSERS_PATH` at **job level** to `${{ github.workspace }}/.playwright-browsers` so Playwright installs to one workspace-relative path on every OS, then point the cache stanza at that single path:

```yaml
env:
  PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
...
- name: Cache Playwright browsers
  uses: actions/cache@v5
  with:
    path: ${{ github.workspace }}/.playwright-browsers
    key: playwright-${{ matrix.os }}-${{ steps.playwright-version.outputs.version }}-ws
```

The cache key carries a `-ws` suffix to invalidate archives saved against the old dual-path layout — **first restore after this lands will miss-and-rebuild** (one-time ~1–2 min per matrix entry); subsequent runs hit normally.

`verify-package.yml` uses Playwright without a cache stanza (always fresh install) and is untouched.

`.gitignore` adds `.playwright-browsers/` as defense in depth for any local dev who ever runs the workflow via `act` or similar.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(...)"` on both edited workflows — parse clean
- [x] `uv run python scripts/check_workflow_permissions.py` — permissions guard still passes (no permissions stanza added or removed)
- [x] `pre-commit run --all-files` — clean

Once merged, both `test.yml` (every PR) and `nightly.yml` (nightly) will rebuild the Playwright cache on first run; subsequent runs should hit consistently across all OS × Python combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to standardize browser testing infrastructure caching and installation paths across all testing environments, improving consistency and reducing redundant downloads during pipeline execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->