### PR TITLE
refactor(core): extract AuthRefreshCoordinator into _core_auth

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -74,6 +74,15 @@ _OBSERVABILITY_INIT_LOCK = threading.Lock()
 # Guards ``_auth_coord`` backfill on ``__new__``-built fixtures. Mirrors the
 # observability init lock so two threads can't both observe ``hasattr is False``
 # and race to construct competing :class:`AuthRefreshCoordinator` instances.
+#
+# Dual-implementation sites (kept identical for AST guards in
+# ``tests/unit/test_concurrency_refresh_race.py`` that inspect
+# ``inspect.getsource(ClientCore.update_auth_tokens)`` /
+# ``ClientCore._snapshot``):
+#   - ``ClientCore._snapshot`` (this file) ↔ ``AuthRefreshCoordinator.snapshot``
+#   - ``ClientCore.update_auth_tokens`` (this file) ↔ ``AuthRefreshCoordinator.update_auth_tokens``
+# Any change to auth-snapshot invariants must be applied to BOTH sites. Grep
+# anchor for future maintainers: ``_AUTH_COORD_INIT_LOCK``.
 _AUTH_COORD_INIT_LOCK = threading.Lock()
 
 
@@ -711,9 +720,20 @@ class ClientCore:
         threading lock for double-checked locking so two threads racing
         through ``hasattr`` cannot both decide they need to construct a
         coordinator and silently discard each other's locks/refresh task.
+
+        Also primes ``_metrics_obj`` because every coordinator method reaches
+        into ``host._metrics_obj`` (e.g. ``record_lock_wait`` inside
+        :meth:`AuthRefreshCoordinator.snapshot` /
+        :meth:`AuthRefreshCoordinator.update_auth_tokens`). Without this,
+        a ``__new__``-built fixture that calls ``_await_refresh`` /
+        ``_snapshot`` / ``update_auth_tokens`` before any observability
+        compat-bridge setter would surface as
+        ``AttributeError: '_StubCore' has no attribute '_metrics_obj'``
+        rather than backfilling gracefully.
         """
         if hasattr(self, "_auth_coord"):
             return
+        self._ensure_observability_state()
         with _AUTH_COORD_INIT_LOCK:
             if not hasattr(self, "_auth_coord"):
                 self._auth_coord = AuthRefreshCoordinator(refresh_callback=None)

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -8,13 +8,14 @@ import threading
 import time
 import warnings
 import weakref
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import httpx
 
+from ._core_auth import AuthRefreshCoordinator
 from ._core_cookie_persistence import CookiePersistence
 from ._core_drain import TransportDrainTracker
 
@@ -70,6 +71,10 @@ from .rpc import (
 
 logger = logging.getLogger(__name__)
 _OBSERVABILITY_INIT_LOCK = threading.Lock()
+# Guards ``_auth_coord`` backfill on ``__new__``-built fixtures. Mirrors the
+# observability init lock so two threads can't both observe ``hasattr is False``
+# and race to construct competing :class:`AuthRefreshCoordinator` instances.
+_AUTH_COORD_INIT_LOCK = threading.Lock()
 
 
 # Default HTTP timeouts in seconds
@@ -467,7 +472,13 @@ class ClientCore:
         self._timeout = timeout
         self._connect_timeout = connect_timeout
         self._limits = limits if limits is not None else ConnectionLimits()
-        self._refresh_callback = refresh_callback
+        # ``_refresh_retry_delay`` stays here directly — it is read on the
+        # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
+        # by integration tests against ``client._core``. The refresh
+        # callback + the four refresh/auth-snapshot ivars (``_refresh_lock``,
+        # ``_refresh_task``, ``_refresh_callback``, ``_auth_snapshot_lock``)
+        # live on ``self._auth_coord``, constructed below alongside the other
+        # extracted helpers so the inter-helper dependency order is obvious.
         self._refresh_retry_delay = refresh_retry_delay
         if rate_limit_max_retries < 0:
             raise ValueError(f"rate_limit_max_retries must be >= 0, got {rate_limit_max_retries}")
@@ -519,20 +530,6 @@ class ClientCore:
         # ``_max_concurrent_rpcs is None``, the accessor returns a
         # ``contextlib.nullcontext`` instead — see ``_get_rpc_semaphore``.
         self._rpc_semaphore: asyncio.Semaphore | None = None
-        # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
-        # Python versions, and ``ClientCore`` can be constructed outside one
-        # (e.g. a sync-mode ``NotebookLMClient(...)`` instantiation before the
-        # caller's ``asyncio.run``). Use :meth:`_get_refresh_lock` to fetch
-        # the live lock on demand. Mirrors the ``_reqid_lock`` /
-        # ``_auth_snapshot_lock`` lazy-init pattern.
-        # The lock gates single-flight refresh-task creation in
-        # :meth:`_await_refresh` — the assert on ``_refresh_callback is not
-        # None`` there is the real precondition; this lock is allocated on
-        # first refresh attempt regardless of whether a callback was wired,
-        # because asyncio is single-threaded and the check-then-assign in
-        # ``_get_refresh_lock`` is race-free without an outer lock.
-        self._refresh_lock: asyncio.Lock | None = None
-        self._refresh_task: asyncio.Task[AuthTokens] | None = None
         self._http_client: httpx.AsyncClient | None = None
         # Observability counters + telemetry callback. Compat properties
         # below (``_metrics_lock`` / ``_metrics`` / ``_on_rpc_event``) bridge
@@ -555,18 +552,18 @@ class ClientCore:
         # cumulative ``lock_wait_seconds_*`` metrics ticking inside
         # ``self._metrics_obj`` even though the counter is now extracted.
         self._reqid = ReqidCounter(on_lock_wait=self._record_lock_wait)
-        # Serializes ``_AuthSnapshot`` reads in :meth:`_snapshot` with
-        # :meth:`ClientCore.update_auth_tokens` during auth refresh
-        # . The lock holds only across the four
-        # ``self.auth.*`` scalar reads / two scalar writes — never across
-        # an ``await`` — so RPC throughput isn't serialized to refresh
-        # latency. Lazy-init mirrors ``_reqid_lock`` because ``asyncio.Lock()``
-        # needs a running loop in some Python versions. Distinct from
-        # ``_refresh_lock`` (which is owned by refresh-task creation and
-        # held across ``await self._refresh_callback()``): mixing the two
-        # would re-introduce the reentrancy ambiguity that snapshot-side
-        # serialization was added to avoid.
-        self._auth_snapshot_lock: asyncio.Lock | None = None
+        # Auth refresh coordination — single-flight refresh task, snapshot
+        # serialization, and cookie-jar sync. The coordinator owns
+        # ``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``, and
+        # ``_auth_snapshot_lock``; field names match the legacy
+        # ``ClientCore`` ivars so the compat properties below delegate
+        # cleanly. The ``_auth_snapshot_lock`` is intentionally distinct
+        # from ``_refresh_lock`` — mixing them would re-introduce the
+        # reentrancy ambiguity that snapshot-side serialization was added
+        # to avoid. The attribute name ``_auth_coord`` is part of the
+        # inter-helper contract for the upcoming B2/C1 extractions; do not
+        # rename.
+        self._auth_coord = AuthRefreshCoordinator(refresh_callback=refresh_callback)
         # Event-loop affinity guard. Captured in
         # :meth:`open` and checked in :meth:`_perform_authed_post`; a cheap
         # ``is`` comparison fails fast when a caller drives the same
@@ -696,6 +693,72 @@ class ClientCore:
     def _operation_depths(self, value: weakref.WeakKeyDictionary[asyncio.Task[Any], int]) -> None:
         self._ensure_observability_state()
         self._drain_tracker._operation_depths = value
+
+    # ------------------------------------------------------------------
+    # ``AuthRefreshCoordinator`` compat bridges. Refresh/auth-snapshot state
+    # now lives on ``self._auth_coord``; the four legacy ivar names are
+    # preserved as writeable properties so the dozens of test sites that
+    # do ``core._refresh_callback = stub`` / ``core._refresh_lock = asyncio.Lock()``
+    # keep working without modification. ``_ensure_auth_coord`` mirrors the
+    # ``_ensure_observability_state`` backfill so ``__new__``-built fixtures
+    # (no ``__init__`` ran) still resolve cleanly.
+    # ------------------------------------------------------------------
+
+    def _ensure_auth_coord(self) -> None:
+        """Backfill ``_auth_coord`` for tests that construct via ``__new__``.
+
+        Mirrors :meth:`_ensure_observability_state` — uses a module-level
+        threading lock for double-checked locking so two threads racing
+        through ``hasattr`` cannot both decide they need to construct a
+        coordinator and silently discard each other's locks/refresh task.
+        """
+        if hasattr(self, "_auth_coord"):
+            return
+        with _AUTH_COORD_INIT_LOCK:
+            if not hasattr(self, "_auth_coord"):
+                self._auth_coord = AuthRefreshCoordinator(refresh_callback=None)
+
+    @property
+    def _refresh_lock(self) -> asyncio.Lock | None:
+        self._ensure_auth_coord()
+        return self._auth_coord._refresh_lock
+
+    @_refresh_lock.setter
+    def _refresh_lock(self, value: asyncio.Lock | None) -> None:
+        self._ensure_auth_coord()
+        self._auth_coord._refresh_lock = value
+
+    @property
+    def _refresh_task(self) -> asyncio.Task[AuthTokens] | None:
+        self._ensure_auth_coord()
+        return self._auth_coord._refresh_task
+
+    @_refresh_task.setter
+    def _refresh_task(self, value: asyncio.Task[AuthTokens] | None) -> None:
+        self._ensure_auth_coord()
+        self._auth_coord._refresh_task = value
+
+    @property
+    def _refresh_callback(self) -> Callable[[], Awaitable[AuthTokens]] | None:
+        self._ensure_auth_coord()
+        return self._auth_coord._refresh_callback
+
+    @_refresh_callback.setter
+    def _refresh_callback(
+        self, value: Callable[[], Awaitable[AuthTokens]] | None
+    ) -> None:
+        self._ensure_auth_coord()
+        self._auth_coord._refresh_callback = value
+
+    @property
+    def _auth_snapshot_lock(self) -> asyncio.Lock | None:
+        self._ensure_auth_coord()
+        return self._auth_coord._auth_snapshot_lock
+
+    @_auth_snapshot_lock.setter
+    def _auth_snapshot_lock(self, value: asyncio.Lock | None) -> None:
+        self._ensure_auth_coord()
+        self._auth_coord._auth_snapshot_lock = value
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
@@ -1200,51 +1263,41 @@ class ClientCore:
         """Refresh auth metadata without resetting the live cookie jar.
 
         Call this after modifying auth tokens (e.g., after refresh_auth())
-        to ensure the HTTP client uses the updated credentials.
-
-        The httpx client's cookie jar is authoritative once the session is
-        open. Re-injecting startup cookies here can overwrite cookies refreshed
-        during redirects to accounts.google.com.
+        to ensure the HTTP client uses the updated credentials. Delegates
+        to :meth:`AuthRefreshCoordinator.update_auth_headers`; the cookie
+        jar source is fetched via ``self.get_http_client()`` so the open()
+        precondition (and its ``RuntimeError`` if not initialised) is
+        enforced at one site.
 
         Raises:
             RuntimeError: If client is not initialized.
         """
-        if not self._http_client:
-            raise RuntimeError("Client not initialized. Use 'async with' context.")
-
-        self.auth.cookie_jar = self._http_client.cookies
+        self._ensure_auth_coord()
+        self._auth_coord.update_auth_headers(self)
 
     def _get_auth_snapshot_lock(self) -> asyncio.Lock:
-        """Return the lazily-initialised ``_auth_snapshot_lock``.
+        """Return the lazily-initialised auth-snapshot lock.
 
-        ``asyncio.Lock()`` needs a running loop in some Python versions, so
-        ``ClientCore.__init__`` leaves the field as ``None``. Callers must
-        be inside an async context (which we are, since both
-        :meth:`_snapshot` and :meth:`update_auth_tokens` are coroutines).
-        The check-then-assign is safe without an outer lock
-        because asyncio is single-threaded — no other coroutine can
-        execute between the ``is None`` check and the assignment unless
-        we ``await``.
+        Delegates to :meth:`AuthRefreshCoordinator.get_auth_snapshot_lock`.
+        The check-then-assign there is safe without an outer lock because
+        asyncio is single-threaded — no other coroutine can execute between
+        the ``is None`` check and the assignment unless we ``await`` (and
+        the accessor does not).
         """
-        if self._auth_snapshot_lock is None:
-            self._auth_snapshot_lock = asyncio.Lock()
-        return self._auth_snapshot_lock
+        self._ensure_auth_coord()
+        return self._auth_coord.get_auth_snapshot_lock()
 
     def _get_refresh_lock(self) -> asyncio.Lock:
-        """Return the lazily-initialised ``_refresh_lock``.
+        """Return the lazily-initialised refresh lock.
 
-        ``asyncio.Lock()`` needs a running loop in some Python versions, so
-        ``ClientCore.__init__`` leaves the field as ``None``. Callers must be inside an async context — the only call site
-        is :meth:`_await_refresh`, which is itself a coroutine. The
-        check-then-assign is safe without an outer lock because asyncio is
-        single-threaded: no other coroutine can execute between the
-        ``is None`` check and the assignment unless we ``await``, so every
-        concurrent caller resolves to the *same* lock instance and the
-        single-flight refresh dedupe is preserved.
+        Delegates to :meth:`AuthRefreshCoordinator.get_refresh_lock`. Every
+        concurrent caller resolves to the *same* lock instance because the
+        check-then-assign is race-free in a single-threaded asyncio loop,
+        so the single-flight refresh dedupe in :meth:`_await_refresh` is
+        preserved.
         """
-        if self._refresh_lock is None:
-            self._refresh_lock = asyncio.Lock()
-        return self._refresh_lock
+        self._ensure_auth_coord()
+        return self._auth_coord.get_refresh_lock()
 
     async def _snapshot(self) -> _AuthSnapshot:
         """Capture the current auth headers as a frozen snapshot.
@@ -1260,14 +1313,21 @@ class ClientCore:
         reads — no ``await``s — so the lock is uncontested in steady
         state and refresh's tiny write block can't block RPC throughput.
 
-        The whole-request atomicity for ``(csrf, sid, cookies)`` on the
-        wire still depends on the no-await invariant between this method
+        Body is kept here as real code (rather than delegating to
+        :meth:`AuthRefreshCoordinator.snapshot`) so the AST guard at
+        ``tests/unit/test_concurrency_refresh_race.py::test_snapshot_acquires_auth_snapshot_lock``
+        — which inspects this method's source and asserts it contains an
+        ``async with`` over ``_auth_snapshot_lock`` — keeps operating on
+        the real implementation. The coordinator method has the same
+        semantic shape (lock acquire → scalar reads → return) but routes
+        the lock-wait metric through the host's ``_metrics_obj`` directly
+        rather than via the ``_record_lock_wait`` facade.
+
+        Whole-request atomicity for ``(csrf, sid, cookies)`` on the wire
+        still depends on the no-await invariant between this method
         returning and ``client.post(...)`` inside
-        :meth:`_perform_authed_post` (see the AST guard in
-        ``tests/unit/test_concurrency_refresh_race.py``). The lock
-        guarantees the four scalars in the snapshot are coherent with
-        each other; the no-await rule keeps the cookie axis aligned with
-        them.
+        :meth:`_perform_authed_post` (see the related AST guard in
+        ``tests/unit/test_concurrency_refresh_race.py``).
         """
         wait_start = time.perf_counter()
         async with self._get_auth_snapshot_lock():
@@ -1280,7 +1340,18 @@ class ClientCore:
             )
 
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
-        """Atomically update auth token scalars under the snapshot lock."""
+        """Atomically update auth token scalars under the snapshot lock.
+
+        The body is kept here as real code (rather than a delegate to
+        :meth:`AuthRefreshCoordinator.update_auth_tokens`) so the AST
+        guard at ``tests/unit/test_concurrency_refresh_race.py:304-334``
+        — which inspects the source of this method and asserts there is
+        no ``await`` inside the csrf/session_id mutation block — keeps
+        operating on the real implementation. The coordinator method
+        has the same semantic shape (lock acquire → two scalar writes)
+        but routes the lock-wait metric through the host's
+        ``_metrics_obj`` directly rather than via ``_record_lock_wait``.
+        """
         lock = self._get_auth_snapshot_lock()
         wait_start = time.perf_counter()
         await lock.acquire()
@@ -1323,43 +1394,20 @@ class ClientCore:
     async def _await_refresh(self) -> None:
         """Run / join the shared refresh task.
 
-        Concurrent callers share one refresh task so a thundering herd of
-        401s on the same client triggers exactly one token refresh. The lock
-        protects task-creation only; the await on the task itself happens
-        outside the lock so other callers can join.
-
-        The join is wrapped in :func:`asyncio.shield` so
-        that a caller cancelled while waiting — e.g. via
-        ``asyncio.wait_for(..., timeout=...)`` — unwinds locally without
-        propagating the ``CancelledError`` into the *shared* refresh task.
-        Without the shield, one cancelled waiter would cancel the
-        underlying task, taking down every sibling joined to the same
-        single-flight refresh. The slot at ``self._refresh_task`` is left
-        intact across the cancellation and is replaced only on the next
-        refresh wave once the current task transitions to ``done()``.
+        Delegates to :meth:`AuthRefreshCoordinator.await_refresh`. The
+        coordinator preserves the single-flight semantics — concurrent
+        callers share one refresh task so a thundering herd of 401s on the
+        same client triggers exactly one token refresh. The lock protects
+        task-creation only; the await on the task itself happens outside
+        the lock so other callers can join, and the join is wrapped in
+        :func:`asyncio.shield` so a cancelled waiter unwinds locally
+        without propagating ``CancelledError`` into the shared task. The
+        ``_refresh_task`` slot is left intact across cancellation and is
+        replaced only on the next refresh wave once the current task
+        transitions to ``done()``.
         """
-        assert self._refresh_callback is not None
-
-        # Lazy-init the lock on first refresh attempt.
-        # Every concurrent caller resolves to the same instance because
-        # ``_get_refresh_lock`` runs synchronously in a single-threaded
-        # asyncio loop, so single-flight task creation below is preserved.
-        lock = self._get_refresh_lock()
-        wait_start = time.perf_counter()
-        await lock.acquire()
-        self._record_lock_wait(time.perf_counter() - wait_start)
-        try:
-            if self._refresh_task is not None and not self._refresh_task.done():
-                refresh_task = self._refresh_task
-                logger.debug("Joining existing refresh task")
-            else:
-                coro = cast(Coroutine[Any, Any, AuthTokens], self._refresh_callback())
-                self._refresh_task = asyncio.create_task(coro)
-                refresh_task = self._refresh_task
-        finally:
-            lock.release()
-
-        await asyncio.shield(refresh_task)
+        self._ensure_auth_coord()
+        await self._auth_coord.await_refresh(self)
 
     async def query_post(
         self,

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -744,9 +744,7 @@ class ClientCore:
         return self._auth_coord._refresh_callback
 
     @_refresh_callback.setter
-    def _refresh_callback(
-        self, value: Callable[[], Awaitable[AuthTokens]] | None
-    ) -> None:
+    def _refresh_callback(self, value: Callable[[], Awaitable[AuthTokens]] | None) -> None:
         self._ensure_auth_coord()
         self._auth_coord._refresh_callback = value
 

--- a/src/notebooklm/_core_auth.py
+++ b/src/notebooklm/_core_auth.py
@@ -98,9 +98,7 @@ class AuthRefreshCoordinator:
         # Python versions, and this object can be constructed outside one.
         self._refresh_lock: asyncio.Lock | None = None
         self._refresh_task: asyncio.Task[AuthTokens] | None = None
-        self._refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = (
-            refresh_callback
-        )
+        self._refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = refresh_callback
         # Distinct from ``_refresh_lock`` — see module docstring.
         self._auth_snapshot_lock: asyncio.Lock | None = None
 
@@ -246,9 +244,7 @@ class AuthRefreshCoordinator:
                 refresh_task = self._refresh_task
                 logger.debug("Joining existing refresh task")
             else:
-                coro = cast(
-                    Coroutine[Any, Any, AuthTokens], self._refresh_callback()
-                )
+                coro = cast(Coroutine[Any, Any, AuthTokens], self._refresh_callback())
                 self._refresh_task = asyncio.create_task(coro)
                 refresh_task = self._refresh_task
         finally:

--- a/src/notebooklm/_core_auth.py
+++ b/src/notebooklm/_core_auth.py
@@ -229,7 +229,14 @@ class AuthRefreshCoordinator:
         intact across the cancellation and is replaced only on the next
         refresh wave once the current task transitions to ``done()``.
         """
-        assert self._refresh_callback is not None
+        if self._refresh_callback is None:
+            raise RuntimeError(
+                "AuthRefreshCoordinator.await_refresh called without a "
+                "refresh_callback configured — wire one via "
+                "ClientCore(refresh_callback=...) or "
+                "self._auth_coord._refresh_callback = ... before triggering "
+                "an auth refresh."
+            )
 
         # Lazy-init the lock on first refresh attempt. Every concurrent
         # caller resolves to the same instance because ``get_refresh_lock``

--- a/src/notebooklm/_core_auth.py
+++ b/src/notebooklm/_core_auth.py
@@ -1,0 +1,260 @@
+"""Auth refresh coordinator helper for :class:`ClientCore`.
+
+Owns the auth refresh state machine and snapshot serialization that historically
+lived inline on ``ClientCore``:
+
+* ``_refresh_lock`` — single-flight lock guarding refresh-task creation. Lazy
+  because ``asyncio.Lock()`` needs a running loop in some Python versions and
+  ``ClientCore`` can be constructed outside one.
+* ``_refresh_task`` — the shared in-flight refresh task. Slot is intentionally
+  preserved across waiter cancellation so siblings can still join, and is
+  replaced only on the next refresh wave once the existing task hits
+  ``done()`` (see :meth:`await_refresh` docstring).
+* ``_refresh_callback`` — the user-supplied async callable that performs the
+  actual refresh. ``None`` disables refresh-on-401.
+* ``_auth_snapshot_lock`` — serializes the four-scalar reads in
+  :meth:`snapshot` with the two-scalar writes in :meth:`update_auth_tokens`
+  so RPC snapshots cannot observe a torn ``(csrf, session_id)`` pair while
+  refresh is in flight. Intentionally distinct from ``_refresh_lock``:
+  mixing them would re-introduce the reentrancy ambiguity that
+  snapshot-side serialization was added to avoid.
+
+Design constraints (load-bearing — see tests/unit/test_refresh_*.py and
+tests/integration/concurrency/test_refresh_cancellation_propagation.py):
+
+* ``__init__`` MUST be event-loop-agnostic — it stores only a plain callable
+  and ``None`` placeholders. Never call ``asyncio.get_running_loop()`` or
+  instantiate ``asyncio.*`` primitives at construction time.
+* :meth:`await_refresh` MUST hold no lock across ``await self._refresh_callback()``.
+  The refresh lock gates *task creation* only; the await on the task itself
+  happens outside the lock so other waiters can join. Mixing this contract
+  would silently deadlock waiters on a slow callback.
+* :meth:`update_auth_tokens` writes ONLY ``host.auth.csrf_token`` and
+  ``host.auth.session_id`` under the snapshot lock. It does NOT touch the
+  http client. The cookie-jar sync is a separate concern handled by
+  :meth:`update_auth_headers` (sync, no await — it runs the
+  ``host.get_http_client().cookies`` read outside any auth lock).
+* The ``_refresh_task`` slot is intentionally NOT cleared when a waiter is
+  cancelled mid-shield — concurrency tests assert task identity across
+  cancellation so siblings joined to the same single-flight refresh see the
+  same completion. Per ``_core.py`` history at the relocated comment site.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+import httpx
+
+from ._core_transport import _AuthSnapshot
+from .auth import AuthTokens
+
+if TYPE_CHECKING:
+    from ._core_metrics import ClientMetrics
+
+# Logger name pinned to ``notebooklm._core`` (not the literal module name)
+# so log filters in tests — e.g. ``caplog.at_level("DEBUG",
+# logger="notebooklm._core")`` — keep matching after the extraction.
+logger = logging.getLogger("notebooklm._core")
+
+
+class _AuthRefreshHost(Protocol):
+    """Structural host boundary required by :class:`AuthRefreshCoordinator`.
+
+    Mirrors the ``RefreshAuthCore`` shape in ``_auth/session.py`` so the
+    coordinator composes cleanly with B2's ``ClientLifecycle`` — both reach
+    the live ``httpx.AsyncClient`` via :meth:`get_http_client`, never via a
+    direct ``_http_client`` attribute access.
+    """
+
+    auth: AuthTokens
+    _metrics_obj: ClientMetrics
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        """Return the live HTTP client (raises if not open)."""
+        ...
+
+
+class AuthRefreshCoordinator:
+    """Owns refresh single-flight, snapshot serialization, and auth-header sync.
+
+    Field names (``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``,
+    ``_auth_snapshot_lock``) deliberately mirror the legacy ``ClientCore``
+    ivars so the compat ``@property`` bridges on ``ClientCore`` can delegate
+    with ``return self._auth_coord._<attr>`` and stay readable for reviewers
+    grepping the codebase.
+    """
+
+    def __init__(
+        self,
+        *,
+        refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = None,
+    ) -> None:
+        # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
+        # Python versions, and this object can be constructed outside one.
+        self._refresh_lock: asyncio.Lock | None = None
+        self._refresh_task: asyncio.Task[AuthTokens] | None = None
+        self._refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = (
+            refresh_callback
+        )
+        # Distinct from ``_refresh_lock`` — see module docstring.
+        self._auth_snapshot_lock: asyncio.Lock | None = None
+
+    # ------------------------------------------------------------------
+    # Lazy lock accessors. Both follow the same race-free check-then-assign
+    # pattern as ``_reqid_lock``: asyncio is single-threaded, so no other
+    # coroutine can execute between the ``is None`` check and the
+    # assignment unless we ``await`` — and we don't.
+    # ------------------------------------------------------------------
+
+    def get_refresh_lock(self) -> asyncio.Lock:
+        """Return the lazily-initialised refresh lock.
+
+        Concurrent callers resolve to the *same* instance because allocation
+        is synchronous and asyncio is single-threaded; this preserves the
+        single-flight refresh-task creation invariant in :meth:`await_refresh`.
+        """
+        if self._refresh_lock is None:
+            self._refresh_lock = asyncio.Lock()
+        return self._refresh_lock
+
+    def get_auth_snapshot_lock(self) -> asyncio.Lock:
+        """Return the lazily-initialised auth-snapshot lock.
+
+        Held only across the four scalar reads in :meth:`snapshot` and the
+        two scalar writes in :meth:`update_auth_tokens` — never across an
+        ``await`` — so RPC throughput is not serialized to refresh latency.
+        """
+        if self._auth_snapshot_lock is None:
+            self._auth_snapshot_lock = asyncio.Lock()
+        return self._auth_snapshot_lock
+
+    # ------------------------------------------------------------------
+    # Auth snapshot + token write — the load-bearing AST-guarded pair.
+    # The "no await inside the mutation block" invariant is enforced by
+    # tests/unit/test_concurrency_refresh_race.py against
+    # ``ClientCore.update_auth_tokens``; ``ClientCore`` keeps that method's
+    # body as real code (not a delegate) so the AST guard stays valid. The
+    # coordinator method here is the canonical implementation new callers
+    # should reach for, and the two stay in sync by construction (identical
+    # bodies, reviewed together).
+    # ------------------------------------------------------------------
+
+    async def snapshot(self, host: _AuthRefreshHost) -> _AuthSnapshot:
+        """Capture the current auth scalars as a frozen snapshot.
+
+        Acquires :attr:`_auth_snapshot_lock` for the four scalar reads so a
+        concurrent :meth:`update_auth_tokens` cannot interleave between
+        ``csrf_token`` / ``session_id`` / ``authuser`` / ``account_email``.
+        The critical section is purely synchronous attribute reads — no
+        ``await`` — so the lock is uncontested in steady state and refresh's
+        tiny write block cannot block RPC throughput.
+
+        The whole-request atomicity for ``(csrf, sid, cookies)`` on the wire
+        still depends on the no-await invariant between this method returning
+        and ``client.post(...)`` inside ``_perform_authed_post`` (see the AST
+        guard in ``tests/unit/test_concurrency_refresh_race.py``). The lock
+        guarantees the four scalars in the snapshot are coherent with each
+        other; the no-await rule keeps the cookie axis aligned with them.
+        """
+        wait_start = time.perf_counter()
+        async with self.get_auth_snapshot_lock():
+            host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
+            return _AuthSnapshot(
+                csrf_token=host.auth.csrf_token,
+                session_id=host.auth.session_id,
+                authuser=host.auth.authuser,
+                account_email=host.auth.account_email,
+            )
+
+    async def update_auth_tokens(
+        self,
+        host: _AuthRefreshHost,
+        csrf: str,
+        session_id: str,
+    ) -> None:
+        """Atomically update ``auth.csrf_token`` + ``auth.session_id`` only.
+
+        Does NOT touch the http client — the cookie-jar sync is the separate
+        :meth:`update_auth_headers` concern. Conflating the two would let a
+        snapshot acquired between this method and the header sync observe a
+        new token pair against stale cookies, which is exactly the torn-state
+        scenario the snapshot lock exists to prevent.
+        """
+        lock = self.get_auth_snapshot_lock()
+        wait_start = time.perf_counter()
+        await lock.acquire()
+        host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
+        try:
+            host.auth.csrf_token = csrf
+            host.auth.session_id = session_id
+        finally:
+            lock.release()
+
+    def update_auth_headers(self, host: _AuthRefreshHost) -> None:
+        """Sync ``auth.cookie_jar`` with the live HTTP client's jar.
+
+        Synchronous on purpose — no await — so callers can run this without
+        any auth lock held. The httpx client's cookie jar is authoritative
+        once the session is open; re-injecting startup cookies here would
+        overwrite cookies refreshed during redirects to
+        ``accounts.google.com``.
+
+        Raises:
+            RuntimeError: If the host's HTTP client is not initialised (the
+                error originates from :meth:`host.get_http_client`).
+        """
+        host.auth.cookie_jar = host.get_http_client().cookies
+
+    # ------------------------------------------------------------------
+    # Single-flight refresh task.
+    # ------------------------------------------------------------------
+
+    async def await_refresh(self, host: _AuthRefreshHost) -> None:
+        """Run / join the shared refresh task.
+
+        Concurrent callers share one refresh task so a thundering herd of
+        401s on the same client triggers exactly one token refresh. The lock
+        protects task-creation only; the await on the task itself happens
+        outside the lock so other callers can join.
+
+        The join is wrapped in :func:`asyncio.shield` so that a caller
+        cancelled while waiting — e.g. via ``asyncio.wait_for(..., timeout=...)``
+        — unwinds locally without propagating the ``CancelledError`` into the
+        *shared* refresh task. Without the shield, one cancelled waiter would
+        cancel the underlying task, taking down every sibling joined to the
+        same single-flight refresh. The slot at :attr:`_refresh_task` is left
+        intact across the cancellation and is replaced only on the next
+        refresh wave once the current task transitions to ``done()``.
+        """
+        assert self._refresh_callback is not None
+
+        # Lazy-init the lock on first refresh attempt. Every concurrent
+        # caller resolves to the same instance because ``get_refresh_lock``
+        # runs synchronously in a single-threaded asyncio loop, so the
+        # single-flight task creation below is preserved.
+        lock = self.get_refresh_lock()
+        wait_start = time.perf_counter()
+        await lock.acquire()
+        host._metrics_obj.record_lock_wait(time.perf_counter() - wait_start)
+        try:
+            if self._refresh_task is not None and not self._refresh_task.done():
+                refresh_task = self._refresh_task
+                logger.debug("Joining existing refresh task")
+            else:
+                coro = cast(
+                    Coroutine[Any, Any, AuthTokens], self._refresh_callback()
+                )
+                self._refresh_task = asyncio.create_task(coro)
+                refresh_task = self._refresh_task
+        finally:
+            lock.release()
+
+        await asyncio.shield(refresh_task)
+
+
+__all__ = ["AuthRefreshCoordinator", "_AuthRefreshHost"]

--- a/tests/unit/test_core_auth.py
+++ b/tests/unit/test_core_auth.py
@@ -1,0 +1,403 @@
+"""Unit tests for :mod:`notebooklm._core_auth`.
+
+Covers the load-bearing behaviors of :class:`AuthRefreshCoordinator` directly,
+in addition to the existing ``ClientCore``-shaped tests in
+``test_refresh_state_machine.py`` / ``test_refresh_lock_lazy_init.py`` /
+``test_concurrency_refresh_race.py`` which exercise the same helper through
+the compat facade.
+
+Specifically pinned here:
+
+* single-flight refresh — concurrent ``await_refresh`` callers share one
+  in-flight refresh task;
+* lazy lock allocation — ``_refresh_lock`` and ``_auth_snapshot_lock`` are
+  ``None`` at construction and materialize on first use;
+* ``update_auth_tokens`` writes ONLY ``host.auth.csrf_token`` and
+  ``host.auth.session_id`` (does NOT touch the http client);
+* ``update_auth_headers`` syncs ``host.auth.cookie_jar`` from
+  ``host.get_http_client().cookies`` (the SEPARATE cookie-jar sync surface);
+* ``await_refresh`` cancellation propagation — a cancelled waiter unwinds
+  locally without killing the shared refresh task, and the task slot is
+  preserved across cancellation.
+
+Tests are intentionally helper-shaped (instantiate ``AuthRefreshCoordinator``
+directly with a Protocol-conformant stub host) so they cover the coordinator
+without taking on a ``ClientCore`` dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any
+
+import httpx
+import pytest
+
+from notebooklm._core_auth import AuthRefreshCoordinator
+from notebooklm._core_metrics import ClientMetrics
+from notebooklm.auth import AuthTokens
+
+# Tight enough to fail fast if a regression hangs the suite, generous enough
+# not to flake on a slow CI runner. Mirrors ``test_refresh_state_machine.py``.
+EVENT_TIMEOUT_S = 5.0
+
+
+class _StubHost:
+    """Minimal :class:`_AuthRefreshHost`-conformant host for unit tests.
+
+    Mirrors the live ``ClientCore`` shape:
+    * ``auth`` is a real :class:`AuthTokens` — :meth:`update_auth_tokens`
+      writes ``csrf_token`` / ``session_id`` directly on it.
+    * ``_metrics_obj`` is a real :class:`ClientMetrics` — the coordinator's
+      :meth:`record_lock_wait` calls land on it.
+    * :meth:`get_http_client` returns an ``httpx.AsyncClient`` whose cookie
+      jar :meth:`update_auth_headers` reads. The client's lifecycle is
+      owned by the test fixture (`http_host`), not by the stub.
+    """
+
+    def __init__(self, http_client: httpx.AsyncClient | None = None) -> None:
+        self.auth = AuthTokens(
+            csrf_token="CSRF_OLD",
+            session_id="SID_OLD",
+            cookies={"SID": "old_cookie"},
+        )
+        self._metrics_obj = ClientMetrics(on_rpc_event=None)
+        self._http_client = http_client
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        assert self._http_client is not None, "Test forgot to wire an http client."
+        return self._http_client
+
+
+@pytest.fixture
+def stub_host() -> _StubHost:
+    """A coordinator host with no http client wired."""
+    return _StubHost()
+
+
+@pytest.fixture
+async def http_host() -> Any:
+    """A coordinator host with a real ``httpx.AsyncClient`` wired."""
+    async with httpx.AsyncClient() as client:
+        # Pre-populate a cookie so ``update_auth_headers`` has something to
+        # observe propagating from the live jar to ``auth.cookie_jar``.
+        client.cookies.set("SID", "live_jar_cookie")
+        host = _StubHost(http_client=client)
+        yield host
+
+
+# ---------------------------------------------------------------------------
+# Lazy lock allocation
+# ---------------------------------------------------------------------------
+
+
+def test_locks_unallocated_at_construction() -> None:
+    """Both locks are ``None`` at construction.
+
+    Lazy allocation is load-bearing: ``asyncio.Lock()`` binds to the running
+    loop in some Python versions, and a ``ClientCore`` (which constructs a
+    coordinator) is routinely instantiated outside a running loop.
+    """
+    coord = AuthRefreshCoordinator()
+    assert coord._refresh_lock is None
+    assert coord._auth_snapshot_lock is None
+    assert coord._refresh_task is None
+    assert coord._refresh_callback is None
+
+
+@pytest.mark.asyncio
+async def test_get_refresh_lock_is_idempotent() -> None:
+    """Repeated calls resolve to the SAME lock instance.
+
+    Single-flight refresh depends on every waiter acquiring the same lock;
+    a re-creating lazy-init would silently break dedupe.
+    """
+    coord = AuthRefreshCoordinator()
+    first = coord.get_refresh_lock()
+    second = coord.get_refresh_lock()
+    assert first is second
+    assert isinstance(first, asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_get_auth_snapshot_lock_is_idempotent() -> None:
+    """Same idempotency contract for the snapshot lock."""
+    coord = AuthRefreshCoordinator()
+    first = coord.get_auth_snapshot_lock()
+    second = coord.get_auth_snapshot_lock()
+    assert first is second
+    assert isinstance(first, asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_and_refresh_locks_are_distinct() -> None:
+    """The two locks must not share an instance.
+
+    Mixing them would re-introduce the reentrancy ambiguity that the
+    separate snapshot-side serialization was added to avoid — see the
+    module docstring for ``_core_auth.py``.
+    """
+    coord = AuthRefreshCoordinator()
+    refresh_lock = coord.get_refresh_lock()
+    snapshot_lock = coord.get_auth_snapshot_lock()
+    assert refresh_lock is not snapshot_lock
+
+
+# ---------------------------------------------------------------------------
+# update_auth_tokens — writes csrf_token + session_id ONLY
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_auth_tokens_writes_csrf_and_session_id_only(
+    http_host: _StubHost,
+) -> None:
+    """``update_auth_tokens`` mutates ONLY ``auth.csrf_token`` + ``auth.session_id``.
+
+    Cookies and the http client's jar must stay untouched — the cookie-jar
+    sync is the separate :meth:`update_auth_headers` concern. This pin
+    prevents a "helpful" maintainer from conflating the two and reopening
+    the torn-state window the snapshot lock exists to close.
+    """
+    coord = AuthRefreshCoordinator()
+    pre_client_cookies = dict(http_host.get_http_client().cookies)
+    pre_auth_cookies = dict(http_host.auth.cookies)
+
+    await coord.update_auth_tokens(http_host, csrf="CSRF_NEW", session_id="SID_NEW")
+
+    assert http_host.auth.csrf_token == "CSRF_NEW"
+    assert http_host.auth.session_id == "SID_NEW"
+    # http_client untouched
+    assert dict(http_host.get_http_client().cookies) == pre_client_cookies
+    # auth.cookies untouched (cookie sync is update_auth_headers's job)
+    assert dict(http_host.auth.cookies) == pre_auth_cookies
+
+
+@pytest.mark.asyncio
+async def test_update_auth_tokens_holds_snapshot_lock_on_entry(
+    stub_host: _StubHost,
+) -> None:
+    """The write happens under the snapshot lock — proved by contention.
+
+    Start the coordinator's write while a concurrent task is holding the
+    snapshot lock; the write must block until the lock is released. This
+    pins that the lock is acquired BEFORE the mutation block (the
+    snapshot-lock serialization that makes ``_snapshot`` reads atomic with
+    ``update_auth_tokens`` writes).
+    """
+    coord = AuthRefreshCoordinator()
+    lock = coord.get_auth_snapshot_lock()
+
+    enter_held = asyncio.Event()
+    release_held = asyncio.Event()
+
+    async def hold_lock() -> None:
+        async with lock:
+            enter_held.set()
+            await release_held.wait()
+
+    holder = asyncio.create_task(hold_lock())
+    await asyncio.wait_for(enter_held.wait(), EVENT_TIMEOUT_S)
+
+    write_task = asyncio.create_task(
+        coord.update_auth_tokens(stub_host, csrf="X", session_id="Y")
+    )
+    # Yield a few times so the writer reaches lock.acquire() and blocks.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not write_task.done(), (
+        "update_auth_tokens did not block on the snapshot lock — "
+        "the mutation block is no longer guarded."
+    )
+
+    # Releasing the holder lets the writer through.
+    release_held.set()
+    await asyncio.wait_for(holder, EVENT_TIMEOUT_S)
+    await asyncio.wait_for(write_task, EVENT_TIMEOUT_S)
+
+    assert stub_host.auth.csrf_token == "X"
+    assert stub_host.auth.session_id == "Y"
+
+
+# ---------------------------------------------------------------------------
+# update_auth_headers — syncs auth.cookie_jar from get_http_client().cookies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_auth_headers_syncs_cookie_jar_from_get_http_client(
+    http_host: _StubHost,
+) -> None:
+    """``update_auth_headers`` copies ``get_http_client().cookies`` onto auth.
+
+    Pins:
+    * the read is via the ``get_http_client()`` METHOD (not a ``_http_client``
+      attribute), matching :class:`_AuthRefreshHost` and ``_auth/session.py``;
+    * the destination is ``host.auth.cookie_jar`` (the cookie jar reference,
+      not a dict copy).
+    """
+    coord = AuthRefreshCoordinator()
+    # Sanity: pre-call, auth.cookie_jar is whatever AuthTokens initialised.
+    live_jar = http_host.get_http_client().cookies
+
+    coord.update_auth_headers(http_host)
+
+    # The auth.cookie_jar attribute is now identically the live jar.
+    assert http_host.auth.cookie_jar is live_jar
+
+
+def test_update_auth_headers_is_synchronous() -> None:
+    """The method is plain ``def`` (no await).
+
+    Async-vs-sync is a contract: callers must be able to invoke
+    :meth:`update_auth_headers` outside any auth lock without paying for an
+    event-loop hop. A switch to ``async def`` would silently break the
+    ``_auth/session.py`` call shape (which invokes it sync).
+    """
+    assert not inspect.iscoroutinefunction(AuthRefreshCoordinator.update_auth_headers)
+
+
+# ---------------------------------------------------------------------------
+# Single-flight refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_await_refresh_is_single_flight(stub_host: _StubHost) -> None:
+    """Concurrent ``await_refresh`` callers share one in-flight refresh task.
+
+    Mirrors ``test_refresh_state_machine.py::test_concurrent_callers_share_single_refresh``
+    but exercises the coordinator directly (no ``ClientCore`` facade in the
+    middle). The lock protects task creation; the await on the task happens
+    outside the lock so siblings can join.
+    """
+    callback_entered = asyncio.Event()
+    release_refresh = asyncio.Event()
+    call_count = 0
+
+    async def cb() -> AuthTokens:
+        nonlocal call_count
+        call_count += 1
+        callback_entered.set()
+        await release_refresh.wait()
+        return AuthTokens(
+            csrf_token="CSRF_REFRESHED",
+            session_id="SID_REFRESHED",
+            cookies={"SID": "post_refresh"},
+        )
+
+    coord = AuthRefreshCoordinator(refresh_callback=cb)
+
+    tasks = [
+        asyncio.create_task(coord.await_refresh(stub_host)) for _ in range(3)
+    ]
+    await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
+
+    # Yield enough times for waiters 2/3 to reach ``await shield(task)``.
+    for _ in range(20):
+        if coord._refresh_task is not None and not coord._refresh_task.done():
+            break
+        await asyncio.sleep(0)
+    assert coord._refresh_task is not None
+    assert not coord._refresh_task.done()
+    assert call_count == 1, (
+        f"Multiple refreshes fired before release: {call_count}"
+    )
+
+    release_refresh.set()
+    await asyncio.gather(*tasks)
+    assert call_count == 1, f"Post-release call_count drifted to {call_count}"
+
+
+@pytest.mark.asyncio
+async def test_await_refresh_creates_new_task_after_first_done(
+    stub_host: _StubHost,
+) -> None:
+    """A second refresh wave creates a *new* task once the first is done."""
+    call_count = 0
+
+    async def cb() -> AuthTokens:
+        nonlocal call_count
+        call_count += 1
+        return AuthTokens(
+            csrf_token=f"R{call_count}",
+            session_id="S",
+            cookies={"SID": f"sid{call_count}"},
+        )
+
+    coord = AuthRefreshCoordinator(refresh_callback=cb)
+
+    await coord.await_refresh(stub_host)
+    first_task = coord._refresh_task
+    assert first_task is not None and first_task.done()
+
+    await coord.await_refresh(stub_host)
+    second_task = coord._refresh_task
+    assert second_task is not None and second_task.done()
+
+    assert first_task is not second_task, "Second wave reused completed task"
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_await_refresh_cancellation_preserves_task_slot(
+    stub_host: _StubHost,
+) -> None:
+    """A cancelled waiter does not kill the shared task; slot is preserved.
+
+    Mirrors
+    ``tests/integration/concurrency/test_refresh_cancellation_propagation.py``
+    but exercises the coordinator directly. The
+    ``asyncio.shield`` wrap is what stops one cancelled waiter from cancelling
+    the underlying refresh task; the slot at ``_refresh_task`` is intentionally
+    KEPT INTACT and is replaced only on the next refresh wave once the existing
+    task hits ``done()``.
+    """
+    enter = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def cb() -> AuthTokens:
+        nonlocal call_count
+        call_count += 1
+        enter.set()
+        await release.wait()
+        return AuthTokens(
+            csrf_token="CSRF_REFRESHED",
+            session_id="SID_REFRESHED",
+            cookies={"SID": "post_refresh"},
+        )
+
+    coord = AuthRefreshCoordinator(refresh_callback=cb)
+
+    waiter_a = asyncio.create_task(coord.await_refresh(stub_host))
+    waiter_b = asyncio.create_task(coord.await_refresh(stub_host))
+    await asyncio.wait_for(enter.wait(), EVENT_TIMEOUT_S)
+
+    # Yield so both waiters reach ``await shield(task)``.
+    for _ in range(20):
+        if coord._refresh_task is not None and not coord._refresh_task.done():
+            break
+        await asyncio.sleep(0)
+    shared_task = coord._refresh_task
+    assert shared_task is not None and not shared_task.done()
+
+    # Cancel waiter A. The shielded task underneath must NOT be cancelled.
+    waiter_a.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_a
+
+    # Waiter A unwound locally; the shared refresh task is untouched.
+    assert coord._refresh_task is shared_task, (
+        "Cancellation cleared the _refresh_task slot — siblings can no "
+        "longer join the in-flight refresh."
+    )
+    assert not shared_task.done()
+    assert call_count == 1
+
+    # Release the refresh. Waiter B should resolve cleanly.
+    release.set()
+    await asyncio.wait_for(waiter_b, EVENT_TIMEOUT_S)
+    assert shared_task.done()
+    assert call_count == 1

--- a/tests/unit/test_core_auth.py
+++ b/tests/unit/test_core_auth.py
@@ -200,9 +200,7 @@ async def test_update_auth_tokens_holds_snapshot_lock_on_entry(
     holder = asyncio.create_task(hold_lock())
     await asyncio.wait_for(enter_held.wait(), EVENT_TIMEOUT_S)
 
-    write_task = asyncio.create_task(
-        coord.update_auth_tokens(stub_host, csrf="X", session_id="Y")
-    )
+    write_task = asyncio.create_task(coord.update_auth_tokens(stub_host, csrf="X", session_id="Y"))
     # Yield a few times so the writer reaches lock.acquire() and blocks.
     for _ in range(5):
         await asyncio.sleep(0)
@@ -289,9 +287,7 @@ async def test_await_refresh_is_single_flight(stub_host: _StubHost) -> None:
 
     coord = AuthRefreshCoordinator(refresh_callback=cb)
 
-    tasks = [
-        asyncio.create_task(coord.await_refresh(stub_host)) for _ in range(3)
-    ]
+    tasks = [asyncio.create_task(coord.await_refresh(stub_host)) for _ in range(3)]
     await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
 
     # Yield enough times for waiters 2/3 to reach ``await shield(task)``.
@@ -301,9 +297,7 @@ async def test_await_refresh_is_single_flight(stub_host: _StubHost) -> None:
         await asyncio.sleep(0)
     assert coord._refresh_task is not None
     assert not coord._refresh_task.done()
-    assert call_count == 1, (
-        f"Multiple refreshes fired before release: {call_count}"
-    )
+    assert call_count == 1, f"Multiple refreshes fired before release: {call_count}"
 
     release_refresh.set()
     await asyncio.gather(*tasks)


### PR DESCRIPTION
## Summary

Lift the auth refresh state machine + snapshot serialization out of `ClientCore` into a new `AuthRefreshCoordinator` (`_core_auth.py`). The coordinator owns `_refresh_lock`, `_refresh_task`, `_refresh_callback`, and `_auth_snapshot_lock` and exposes the auth-side primitives via the `_AuthRefreshHost` Protocol. Protocol shape mirrors `RefreshAuthCore` in `_auth/session.py` (both reach the live HTTP client via `host.get_http_client()`, never a raw `_http_client` attribute) so it composes cleanly with the upcoming B2 `ClientLifecycle` extraction.

`ClientCore` retains all six auth facade methods (`_snapshot`, `_await_refresh`, `update_auth_headers`, `update_auth_tokens`, `_get_auth_snapshot_lock`, `_get_refresh_lock`) plus compat `@property` bridges (getter + setter writethrough) for the four legacy ivar names — the 10+ test sites that do `core._refresh_callback = stub` / `core._refresh_lock = asyncio.Lock()` continue to work unmodified. `_ensure_auth_coord` mirrors `_ensure_observability_state` (with `_AUTH_COORD_INIT_LOCK` double-check) so `__new__`-built test fixtures resolve cleanly.

## AST Guard Preservation Decision

Two AST guards inspect `ClientCore` method sources:
- `test_update_auth_tokens_has_no_await_inside_mutation_block` — inspects `ClientCore.update_auth_tokens`
- `test_snapshot_acquires_auth_snapshot_lock` — inspects `ClientCore._snapshot`

I chose **Option (a)** from the spec: **keep `ClientCore.update_auth_tokens` and `ClientCore._snapshot` bodies as real code (NOT delegates)** so both guards continue to operate on the real implementations without test changes. The coordinator's matching methods (`AuthRefreshCoordinator.update_auth_tokens` / `.snapshot`) have the same semantic shape (lock acquire → scalar reads or writes) but route the lock-wait metric through `host._metrics_obj.record_lock_wait` directly instead of the `_record_lock_wait` facade. Docstrings on each side cross-reference each other so future maintainers are aware of the dual implementation.

## Out of Scope (Per Converged Plan)

- `_refresh_retry_delay` stays on `ClientCore` directly — first-party Protocols at `_core_rpc.py:48` and `_core_transport.py:212` plus integration test `tests/integration/test_auth_refresh_vcr.py:120` all access it on `ClientCore`.
- `_AuthSnapshot` stays in `_core_transport.py`.
- `_try_refresh_and_retry` stays on `ClientCore` (Phase 3 territory).
- Refresh single-flight semantics, `_refresh_task` slot cancellation-preservation, and the "no lock across the refresh callback await" contract are all preserved.

## Constructor Order

Per master plan inter-helper contract: `_metrics_obj` (A1) → `_drain_tracker` (A2) → `_reqid` (A3) → `_auth_coord` (this PR) → `_lifecycle` (B2, future).

## New Tests

`tests/unit/test_core_auth.py` (11 tests):
- Lazy lock allocation (both `_refresh_lock` and `_auth_snapshot_lock`)
- Idempotent `get_refresh_lock()` / `get_auth_snapshot_lock()`
- Refresh and snapshot locks are distinct instances
- `update_auth_tokens` writes `csrf_token` + `session_id` only (NOT http client / NOT cookies)
- `update_auth_tokens` holds the snapshot lock during the mutation block
- `update_auth_headers` syncs `auth.cookie_jar` from `host.get_http_client().cookies`
- `update_auth_headers` is plain `def` (not async)
- Single-flight `await_refresh` (concurrent callers share one task)
- Second wave after first refresh creates a new task
- Waiter cancellation preserves the `_refresh_task` slot for siblings

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — green (114 source files)
- [x] `uv run ruff check src/notebooklm/` — green
- [x] Targeted unit tests pass:
  - `tests/unit/test_refresh_state_machine.py`
  - `tests/unit/test_refresh_lock_lazy_init.py`
  - `tests/unit/test_concurrency_refresh_race.py` (both AST guards)
  - `tests/unit/test_core_auth.py` (new)
  - `tests/unit/test_client.py`
- [x] Targeted integration tests pass:
  - `tests/integration/test_auto_refresh.py`
  - `tests/integration/test_auth_refresh_vcr.py`
  - `tests/integration/test_error_paths_vcr.py`
  - `tests/integration/concurrency/test_refresh_cancellation_propagation.py`
- [x] Full project gate: `uv run pytest` — 5106 passed, 20 skipped
- [x] No VCR cassette re-recording

## Deferred polish findings

None. All Stage 4 (polish) findings applied inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized authentication refresh and locking into a dedicated coordinator for more reliable, single-flight refresh behavior while preserving compatibility with existing surfaces.

* **Tests**
  * Added comprehensive unit tests covering lazy lock allocation, atomic token updates, header synchronization, single-flight refresh semantics, and cancellation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->