### PR TITLE
docs(core): pre-stage decomposition module map + architecture text (D1 partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,20 @@ RPC Layer (rpc/)
 | File | Purpose |
 |------|---------|
 | `client.py` | Main `NotebookLMClient` class |
-| `_core.py` | HTTP and RPC infrastructure |
+| `_core.py` | `ClientCore` orchestrator; HTTP client lifecycle; module-level constants and re-exports |
+| `_core_metrics.py` | `ClientMetrics` — `ClientMetricsSnapshot` counters + `on_rpc_event` callback |
+| `_core_drain.py` | `TransportDrainTracker` — in-flight transport counters + `_TransportOperationToken` |
+| `_core_reqid.py` | `ReqidCounter` — monotonic `_reqid` for the chat backend |
+| `_core_auth.py` | `AuthRefreshCoordinator` (Phase 2 in progress) — refresh task + auth-snapshot lock |
+| `_core_lifecycle.py` | `ClientLifecycle` (Phase 2 in progress) — loop-affinity guard + keepalive task |
+| `_core_rpc.py` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols |
+| `_core_transport.py` | Authed POST path, retry loops, `_AuthedTransportHost` Protocol |
+| `_core_cache.py` | Per-instance LRU conversation cache for `ChatAPI` |
+| `_core_polling.py` | Pending-poll registry for long-running artifact generations |
+| `_core_cookie_persistence.py` | Cookie-jar persistence + `__Secure-1PSIDTS` rotation |
+| `_capabilities.py` | Narrow capability Protocols + `ClientCoreCapabilities` adapter for sub-clients |
 | `_notebooks.py` | `client.notebooks` API |
-| `_sources.py` | `client.sources` API |
+| `_sources.py` | `client.sources` API + `fetch_source_ids` module helper |
 | `_artifacts.py` | `client.artifacts` API |
 | `_chat.py` | `client.chat` API |
 | `rpc/types.py` | RPC method IDs (source of truth) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,8 +84,37 @@ src/notebooklm/
 |-------|-------|----------------|
 | **CLI** | `cli/*.py` | User commands, input validation, Rich output |
 | **Client** | `client.py`, `_*.py` | High-level Python API, returns typed dataclasses |
-| **Core** | `_core.py` | HTTP client, request counter, RPC abstraction |
+| **Core** | `_core.py`, `_core_*.py` | `ClientCore` orchestrator + seam-module helpers (HTTP client lifecycle, RPC dispatch, metrics, drain bookkeeping, request-id counter, auth refresh, conversation cache, polling registry, cookie persistence) |
 | **RPC** | `rpc/*.py` | Protocol encoding/decoding, method IDs |
+
+#### Core-layer seam modules
+
+The `Core` layer is split across `_core.py` (orchestrator) and a family of
+single-responsibility `_core_*.py` helper modules. Each helper exposes a
+Protocol-shim host interface so it can be unit-tested against a stub `ClientCore`:
+
+| Module | Class | Responsibility |
+|---|---|---|
+| `_core.py` | `ClientCore` | Orchestrator owning the `httpx.AsyncClient` + `AuthTokens`; module-level constants and re-exports. |
+| `_core_metrics.py` | `ClientMetrics` | `ClientMetricsSnapshot` counters, queue-wait recorders, `on_rpc_event` async callback. |
+| `_core_drain.py` | `TransportDrainTracker` | In-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. |
+| `_core_reqid.py` | `ReqidCounter` | Monotonic `_reqid` counter for chat backend (baseline 100000, step 100000). |
+| `_core_auth.py` (Phase 2 in progress) | `AuthRefreshCoordinator` | Refresh-task lifecycle, refresh lock, `_AuthSnapshot` rotation. |
+| `_core_lifecycle.py` (Phase 2 in progress) | `ClientLifecycle` | Loop-affinity guard, `aclose` plumbing, keepalive task wiring. |
+| `_core_rpc.py` | `RpcExecutor` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols. |
+| `_core_transport.py` | `AuthedTransport` | Authed HTTP POST path, retry loops (429 + 5xx), error-injection seam (`_SyntheticErrorTransport`). |
+| `_core_cache.py` | `ConversationCache` | Per-instance LRU conversation cache for `ChatAPI` continuity. |
+| `_core_polling.py` | `PollRegistry` | Pending-poll registry shared by long-running artifact generations. |
+| `_core_cookie_persistence.py` | `CookiePersistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. |
+
+The capability surface that sub-clients depend on is pinned in
+`notebooklm._capabilities` via narrow Protocols (`CoreRPCProvider`,
+`SourceListProvider`, `PollRegistryProvider`, `AuthRouteProvider`,
+`CookieJarProvider`, `TransportOperationProvider`,
+`UploadConcurrencyProvider`), composed into the concrete
+`ClientCoreCapabilities` adapter. Adding or removing a method on
+`ClientCore` is a Protocol change — review `_capabilities.py` alongside
+any change to the orchestrator's public method surface.
 
 Private service modules sit inside the client layer but below the public
 facades. They own cross-facade composition without importing sibling facades:

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,26 +95,26 @@ Protocol-shim host interface so it can be unit-tested against a stub `ClientCore
 
 | Module | Class | Responsibility |
 |---|---|---|
-| `_core.py` | `ClientCore` | Orchestrator owning the `httpx.AsyncClient` + `AuthTokens`; module-level constants and re-exports. |
+| `_core.py` | `ClientCore` | Orchestrator owning the `httpx.AsyncClient` + `AuthTokens`; module-level constants and re-exports; error-injection seam (`_SyntheticErrorTransport`, `_get_error_injection_mode`) used by `_core_transport`'s retry loops via `httpx.AsyncBaseTransport` wrapping. |
 | `_core_metrics.py` | `ClientMetrics` | `ClientMetricsSnapshot` counters, queue-wait recorders, `on_rpc_event` async callback. |
 | `_core_drain.py` | `TransportDrainTracker` | In-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. |
 | `_core_reqid.py` | `ReqidCounter` | Monotonic `_reqid` counter for chat backend (baseline 100000, step 100000). |
 | `_core_auth.py` (Phase 2 in progress) | `AuthRefreshCoordinator` | Refresh-task lifecycle, refresh lock, `_AuthSnapshot` rotation. |
 | `_core_lifecycle.py` (Phase 2 in progress) | `ClientLifecycle` | Loop-affinity guard, `aclose` plumbing, keepalive task wiring. |
 | `_core_rpc.py` | `RpcExecutor` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols. |
-| `_core_transport.py` | `AuthedTransport` | Authed HTTP POST path, retry loops (429 + 5xx), error-injection seam (`_SyntheticErrorTransport`). |
+| `_core_transport.py` | `AuthedTransport` | Authed HTTP POST path, retry loops (429 + 5xx). |
 | `_core_cache.py` | `ConversationCache` | Per-instance LRU conversation cache for `ChatAPI` continuity. |
 | `_core_polling.py` | `PollRegistry` | Pending-poll registry shared by long-running artifact generations. |
 | `_core_cookie_persistence.py` | `CookiePersistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. |
 
 The capability surface that sub-clients depend on is pinned in
-`notebooklm._capabilities` via narrow Protocols (`CoreRPCProvider`,
-`SourceListProvider`, `PollRegistryProvider`, `AuthRouteProvider`,
-`CookieJarProvider`, `TransportOperationProvider`,
-`UploadConcurrencyProvider`), composed into the concrete
-`ClientCoreCapabilities` adapter. Adding or removing a method on
-`ClientCore` is a Protocol change — review `_capabilities.py` alongside
-any change to the orchestrator's public method surface.
+`notebooklm._capabilities` via 9 narrow Protocols (`CoreRPCProvider`,
+`SourceListProvider`, `CoreReqIdProvider`, `ChatStreamingProvider`,
+`PollRegistryProvider`, `AuthRouteProvider`, `CookieJarProvider`,
+`TransportOperationProvider`, `UploadConcurrencyProvider`), composed into
+the concrete `ClientCoreCapabilities` adapter. Adding or removing a
+method on `ClientCore` is a Protocol change — review `_capabilities.py`
+alongside any change to the orchestrator's public method surface.
 
 Private service modules sit inside the client layer but below the public
 facades. They own cross-facade composition without importing sibling facades:

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -560,7 +560,7 @@ particular ivar lives.
 
 | Module | Owns | Notes |
 |---|---|---|
-| `_core` | `ClientCore` orchestrator; HTTP client lifecycle; module-level constants (`MAX_CONVERSATION_CACHE_SIZE`, `MAX_RETRY_AFTER_SECONDS`, `DEFAULT_TIMEOUT`, etc.); `is_auth_error`, `save_cookies_to_storage`. | Public/internal contract — names imported from `notebooklm._core` stay stable. |
+| `_core` | `ClientCore` orchestrator; HTTP client lifecycle; module-level constants (`MAX_CONVERSATION_CACHE_SIZE`, `MAX_RETRY_AFTER_SECONDS`, `DEFAULT_TIMEOUT`, etc.); `is_auth_error`, `save_cookies_to_storage`; error-injection seam `_SyntheticErrorTransport` + `_get_error_injection_mode` consumed by `_core_transport`'s retry loops. | Public/internal contract — names imported from `notebooklm._core` stay stable. |
 | `_core_auth` (Phase 2 in progress) | `AuthRefreshCoordinator`: refresh-task lifecycle, refresh lock, `_AuthSnapshot` rotation. | Lazy `asyncio.Lock` construction; never instantiated outside a running loop. |
 | `_core_cache` | Per-instance LRU `_conversation_cache` for `ChatAPI` continuity. | Pure in-process state; not shared across `ClientCore` instances. |
 | `_core_cookie_persistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. | Exposes a `SaveCookiesToStorage` Protocol host. |
@@ -570,16 +570,16 @@ particular ivar lives.
 | `_core_polling` | Pending-poll registry shared by long-running artifact generations. | Tracked via `PollRegistryProvider` in `_capabilities.py`. |
 | `_core_reqid` | `ReqidCounter`: monotonic `_reqid` for the chat backend, lazy `asyncio.Lock` for concurrent `ChatAPI.ask` callers. | Baseline `_value=100000`, default `step=100000` — both are chat-API contract values; do not change. |
 | `_core_rpc` | RPC dispatch executor; exposes `DecodeResponse` and `RpcOwner` Protocols so callers can be unit-tested against a stub. | Phase 3 (in progress) collapses the `_core.py`-side `rpc_call` body into this module. |
-| `_core_transport` | Authed HTTP POST path, retry loops (429 + 5xx), error-injection seam (`_SyntheticErrorTransport`), `_AuthedTransportHost` Protocol. | Owns `_TransportAuthExpired` / `_TransportRateLimited` / `_TransportServerError` transport-level exceptions. |
+| `_core_transport` | Authed HTTP POST path, retry loops (429 + 5xx), `_AuthedTransportHost` Protocol. | Owns `_TransportAuthExpired` / `_TransportRateLimited` / `_TransportServerError` transport-level exceptions. |
 
 The capability surface that sub-clients depend on is pinned in
-`notebooklm._capabilities` via narrow Protocols (`CoreRPCProvider`,
-`SourceListProvider`, `PollRegistryProvider`, `AuthRouteProvider`,
-`CookieJarProvider`, `TransportOperationProvider`,
-`UploadConcurrencyProvider`), composed into the concrete
-`ClientCoreCapabilities` adapter. Adding or removing a method on
-`ClientCore` is a Protocol change — review `_capabilities.py` alongside
-any change to the orchestrator's public method surface.
+`notebooklm._capabilities` via 9 narrow Protocols (`CoreRPCProvider`,
+`SourceListProvider`, `CoreReqIdProvider`, `ChatStreamingProvider`,
+`PollRegistryProvider`, `AuthRouteProvider`, `CookieJarProvider`,
+`TransportOperationProvider`, `UploadConcurrencyProvider`), composed into
+the concrete `ClientCoreCapabilities` adapter. Adding or removing a
+method on `ClientCore` is a Protocol change — review `_capabilities.py`
+alongside any change to the orchestrator's public method surface.
 
 ---
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -545,6 +545,44 @@ floor checks). All raise `ValueError`:
 
 ---
 
+## Internal module map
+
+`ClientCore` (in `src/notebooklm/_core.py`) is the orchestrator that owns
+the `httpx.AsyncClient`, glues the authed transport to RPC dispatch, and
+holds the `AuthTokens` for the running session. The supporting state
+(metrics, drain bookkeeping, request-id counter, transport plumbing,
+conversation cache, etc.) is split across single-responsibility seam
+modules under `notebooklm._core_*`. The split is internal — first-party
+callers continue to import `ClientCore` and the documented constants
+from `notebooklm._core` — but it matters when reading the source, when
+writing unit tests against a stub host, or when tracing where a
+particular ivar lives.
+
+| Module | Owns | Notes |
+|---|---|---|
+| `_core` | `ClientCore` orchestrator; HTTP client lifecycle; module-level constants (`MAX_CONVERSATION_CACHE_SIZE`, `MAX_RETRY_AFTER_SECONDS`, `DEFAULT_TIMEOUT`, etc.); `is_auth_error`, `save_cookies_to_storage`. | Public/internal contract — names imported from `notebooklm._core` stay stable. |
+| `_core_auth` (Phase 2 in progress) | `AuthRefreshCoordinator`: refresh-task lifecycle, refresh lock, `_AuthSnapshot` rotation. | Lazy `asyncio.Lock` construction; never instantiated outside a running loop. |
+| `_core_cache` | Per-instance LRU `_conversation_cache` for `ChatAPI` continuity. | Pure in-process state; not shared across `ClientCore` instances. |
+| `_core_cookie_persistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. | Exposes a `SaveCookiesToStorage` Protocol host. |
+| `_core_drain` | `TransportDrainTracker`: in-flight transport counters, `_TransportOperationToken`, lazy `asyncio.Condition` powering `client.drain(...)`. | Construction is event-loop-agnostic; the `Condition` is allocated on first use. |
+| `_core_lifecycle` (Phase 2 in progress) | `ClientLifecycle`: loop-affinity guard, `aclose` plumbing, keepalive task wiring. | Currently inlined in `_core.py`; extraction tracked in the core-decomposition mini-phase. |
+| `_core_metrics` | `ClientMetrics`: `ClientMetricsSnapshot` counters, `_metrics_lock`, `on_rpc_event` callback, queue-wait recorders. | `__init__` is event-loop-agnostic; `emit_rpc_event` is `async` and intentionally awaits the user callback (back-pressure). |
+| `_core_polling` | Pending-poll registry shared by long-running artifact generations. | Tracked via `PollRegistryProvider` in `_capabilities.py`. |
+| `_core_reqid` | `ReqidCounter`: monotonic `_reqid` for the chat backend, lazy `asyncio.Lock` for concurrent `ChatAPI.ask` callers. | Baseline `_value=100000`, default `step=100000` — both are chat-API contract values; do not change. |
+| `_core_rpc` | RPC dispatch executor; exposes `DecodeResponse` and `RpcOwner` Protocols so callers can be unit-tested against a stub. | Phase 3 (in progress) collapses the `_core.py`-side `rpc_call` body into this module. |
+| `_core_transport` | Authed HTTP POST path, retry loops (429 + 5xx), error-injection seam (`_SyntheticErrorTransport`), `_AuthedTransportHost` Protocol. | Owns `_TransportAuthExpired` / `_TransportRateLimited` / `_TransportServerError` transport-level exceptions. |
+
+The capability surface that sub-clients depend on is pinned in
+`notebooklm._capabilities` via narrow Protocols (`CoreRPCProvider`,
+`SourceListProvider`, `PollRegistryProvider`, `AuthRouteProvider`,
+`CookieJarProvider`, `TransportOperationProvider`,
+`UploadConcurrencyProvider`), composed into the concrete
+`ClientCoreCapabilities` adapter. Adding or removing a method on
+`ClientCore` is a Protocol change — review `_capabilities.py` alongside
+any change to the orchestrator's public method surface.
+
+---
+
 ## API Reference
 
 ### NotebookLMClient


### PR DESCRIPTION
## Summary

Pre-stages the predictable docs portion of Phase 4 D1 (the core-decomposition mini-phase's audit + cleanup wave). Adds a comprehensive module-map section to `docs/python-api.md`, upgrades the Layer Responsibilities table in `docs/development.md` with a per-module Core-layer breakdown, and replaces the single `_core.py` row in `CLAUDE.md`'s Key Files table with a per-module list.

## Why now (parallel-dispatch context)

This is part of an aggressive parallel-launch strategy: while B1 (auth coordinator) and C1a (rpc_call body collapse) are in flight, this docs PR lands independently because it touches no `src/` code.

The compat-property audit + dead-shim removal (the audit subset of D1) **defers** to D1-full after Phase 3 merges, since that work needs final post-merge LOC numbers.

## Out of scope

- Compat-property audit + dead-shim removal → D1-full after Phase 3
- Module-level import-surface smoke test → D1-full
- \`docs/configuration.md:307\` stale line numbers → D1-full (LOC will shift again with B2/C1)
- \`docs/auth-keepalive.md:531\` ClientCore→ClientLifecycle reference → D1-full (waits for B2 merged)

## Hedging

\`_core_auth.py\` and \`_core_lifecycle.py\` are marked "Phase 2 in progress" in all three updated docs since these PRs may merge concurrently with this docs PR. If they land first, the "(Phase 2 in progress)" hedge becomes outdated but not factually wrong — a follow-up doc cleanup in D1-full removes the hedge.

## Test plan

- [x] \`uv run ruff format --check\` — 360 files left unchanged
- [x] \`uv run ruff check\` — all checks pass
- [x] \`uv run mypy src/notebooklm\` — 113 files, no issues
- [x] \`uv run pytest tests/unit/test_public_shims.py tests/unit/test_init_order.py\` — 281 pass
- [ ] CI: full pytest matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer and architecture documentation to provide comprehensive details about internal module organization and component responsibilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->