### PR TITLE
refactor(core): collapse rpc_call + query_post body into RpcExecutor (C1 partial)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -36,14 +36,19 @@ from ._core_transport import (
     AuthedTransport,
     _AuthSnapshot,
     _BuildRequest,
-    _TransportAuthExpired,
-    _TransportRateLimited,
-    _TransportServerError,
 )
 from ._core_transport import (
     _parse_retry_after as _parse_retry_after,
 )
-from ._logging import get_request_id, reset_request_id, set_request_id
+from ._core_transport import (
+    _TransportAuthExpired as _TransportAuthExpired,
+)
+from ._core_transport import (
+    _TransportRateLimited as _TransportRateLimited,
+)
+from ._core_transport import (
+    _TransportServerError as _TransportServerError,
+)
 from ._sources import fetch_source_ids
 from .auth import (
     AuthTokens,
@@ -1433,89 +1438,17 @@ class ClientCore:
         build_request: _BuildRequest,
         parse_label: str,
     ) -> httpx.Response:
-        """Chat-side semantic owner around :meth:`_perform_authed_post`.
+        """Compatibility wrapper around :meth:`RpcExecutor.query_post`.
 
-        Wraps the shared transport pipeline with chat-flavored exception
-        mapping: transport-layer auth failures become
-        :class:`~notebooklm.exceptions.ChatError`, and transport-layer
-        network/rate-limit failures become
-        :class:`~notebooklm.exceptions.NetworkError` /
-        :class:`~notebooklm.exceptions.ChatError` respectively. This keeps
-        ChatAPI free of HTTP-status branching and matches the historical
-        contract of ``ChatAPI.ask`` (a planned follow-up will migrate that caller).
-
-        Args:
-            build_request: See :meth:`_perform_authed_post`.
-            parse_label: Caller-friendly label used in log lines and error
-                messages (e.g. ``"chat.ask"``).
+        The chat-flavored exception mapping (``ChatError`` / ``NetworkError``
+        translation, drain-aware operation-token bookkeeping) lives on the
+        executor; this facade preserves the method shape so callers and tests
+        can mock ``core.query_post = AsyncMock(...)`` by attribute.
         """
-        # Import here to avoid a circular import: exceptions imports from
-        # this module's siblings.
-        from .exceptions import ChatError, NetworkError
-
-        operation_token = await self._begin_transport_post(parse_label)
-        try:
-            try:
-                return await self._perform_authed_post(
-                    build_request=build_request,
-                    log_label=parse_label,
-                )
-            except _TransportAuthExpired as exc:
-                raise ChatError(
-                    f"{parse_label} failed: authentication expired and refresh did not recover"
-                ) from exc
-            except _TransportRateLimited as exc:
-                raise ChatError(
-                    f"{parse_label} rate-limited (HTTP 429)."
-                    + (
-                        f" Retry after {exc.retry_after} seconds."
-                        if exc.retry_after is not None
-                        else ""
-                    )
-                ) from exc
-            except _TransportServerError as exc:
-                if isinstance(exc.original, httpx.HTTPStatusError):
-                    raise ChatError(
-                        f"{parse_label} failed with HTTP {exc.original.response.status_code} "
-                        f"after retries: {exc.original}"
-                    ) from exc
-                # Network-layer failure (RequestError / Timeout).
-                # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
-                # ``_TransportServerError`` on the network path; this guard keeps
-                # the contract enforced under ``python -O`` (where ``assert``
-                # would be stripped) and gives a clear diagnostic if the
-                # invariant ever drifts.
-                if not isinstance(exc.original, httpx.RequestError):
-                    raise TypeError(
-                        f"Unexpected _TransportServerError.original type: {type(exc.original)}"
-                    ) from exc
-                # Preserve the timeout-specific message: TimeoutException is a
-                # subclass of RequestError, so without this branch read/connect
-                # timeouts would surface as a generic "network error after
-                # retries" line and lose the "timed out" signal callers rely on.
-                if isinstance(exc.original, httpx.TimeoutException):
-                    raise NetworkError(
-                        f"{parse_label} timed out after retries: {exc.original}",
-                        original_error=exc.original,
-                    ) from exc
-                raise NetworkError(
-                    f"{parse_label} network error after retries: {exc.original}",
-                    original_error=exc.original,
-                ) from exc
-            except httpx.HTTPStatusError as exc:
-                # Non-5xx / non-401 / non-429 status errors fall through
-                # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
-                # or unhandled 4xx).
-                raise ChatError(
-                    f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
-                ) from exc
-        finally:
-            await self._finish_transport_post(operation_token)
-        # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
-        # handlers were removed here because ``_perform_authed_post`` always
-        # either retries those errors or wraps them in
-        # ``_TransportServerError`` (handled above), so they cannot reach
-        # this scope.
+        return await self._get_rpc_executor().query_post(
+            build_request=build_request,
+            parse_label=parse_label,
+        )
 
     async def rpc_call(
         self,
@@ -1527,97 +1460,25 @@ class ClientCore:
         *,
         disable_internal_retries: bool = False,
     ) -> Any:
-        """Make an RPC call to the NotebookLM API.
+        """Compatibility wrapper around :meth:`RpcExecutor.execute_with_telemetry`.
 
-        Automatically refreshes authentication tokens and retries once if an
-        auth failure is detected and a refresh_callback was provided.
-
-        Args:
-            method: The RPC method to call.
-            params: Parameters for the RPC call (nested list structure).
-            source_path: The source path parameter (usually /notebook/{id}).
-            allow_null: If True, don't raise error when response is null.
-            _is_retry: Internal flag to prevent infinite decode-time retries.
-            disable_internal_retries: When True, suppresses the inner 5xx /
-                429 / network retry loop in ``_perform_authed_post`` so that
-                the first transport-level failure surfaces immediately. Used
-                by declared mutating create RPCs: a naive re-POST
-                after a server-side commit would duplicate the resource, so
-                the API-layer ``_idempotency.idempotent_create`` wrapper
-                owns the probe-then-retry loop instead. The auth-refresh
-                path is unaffected (a 401 → refresh → retry is still legal
-                because the request was rejected, not accepted).
-
-        Returns:
-            Decoded response data.
-
-        Raises:
-            RuntimeError: If client is not initialized (not in context manager).
-            httpx.HTTPStatusError: If HTTP request fails.
-            RPCError: If RPC call fails or returns unexpected data.
+        The executor owns the telemetry, reqid, drain, and decode-time
+        refresh-and-retry plumbing; this facade preserves the method shape so
+        the 30+ tests that mock ``core.rpc_call = AsyncMock(...)`` by
+        attribute keep working. See
+        :meth:`notebooklm._core_rpc.RpcExecutor.execute_with_telemetry` for
+        the full contract (kwargs ``_is_retry`` / ``disable_internal_retries``
+        flow through unchanged; ``RuntimeError`` is raised if the client is
+        not initialized).
         """
-        if not self._http_client:
-            raise RuntimeError("Client not initialized. Use 'async with' context.")
-
-        # Only the outer rpc_call mints a request id; the decode-time retry
-        # path (``_is_retry=True``) inherits the parent's id so a single
-        # decode-error → refresh → retry sequence appears under one
-        # ``[req=<id>]`` in the logs. HTTP-status retries (auth + 429) happen
-        # inside ``_perform_authed_post`` without recursion, so they don't
-        # need this guard.
-        if _is_retry:
-            return await self._rpc_call_impl(
-                method,
-                params,
-                source_path,
-                allow_null,
-                _is_retry,
-                disable_internal_retries=disable_internal_retries,
-            )
-
-        method_name = getattr(method, "name", str(method))
-        operation_token = await self._begin_transport_post(f"RPC {method_name}")
-        self._increment_metrics(rpc_calls_started=1)
-        start = time.perf_counter()
-        _reqid_token = None if get_request_id() is not None else set_request_id()
-        try:
-            result = await self._rpc_call_impl(
-                method,
-                params,
-                source_path,
-                allow_null,
-                _is_retry,
-                disable_internal_retries=disable_internal_retries,
-            )
-        except Exception as exc:
-            elapsed = time.perf_counter() - start
-            self._increment_metrics(rpc_calls_failed=1, rpc_latency_seconds_total=elapsed)
-            await self._emit_rpc_event(
-                RpcTelemetryEvent(
-                    method=method_name,
-                    status="error",
-                    elapsed_seconds=elapsed,
-                    request_id=get_request_id(),
-                    error_type=type(exc).__name__,
-                )
-            )
-            raise
-        else:
-            elapsed = time.perf_counter() - start
-            self._increment_metrics(rpc_calls_succeeded=1, rpc_latency_seconds_total=elapsed)
-            await self._emit_rpc_event(
-                RpcTelemetryEvent(
-                    method=method_name,
-                    status="success",
-                    elapsed_seconds=elapsed,
-                    request_id=get_request_id(),
-                )
-            )
-            return result
-        finally:
-            if _reqid_token is not None:
-                reset_request_id(_reqid_token)
-            await self._finish_transport_post(operation_token)
+        return await self._get_rpc_executor().execute_with_telemetry(
+            method,
+            params,
+            source_path,
+            allow_null,
+            _is_retry,
+            disable_internal_retries=disable_internal_retries,
+        )
 
     async def _rpc_call_impl(
         self,

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -20,7 +20,9 @@ from ._core_transport import (
     _TransportServerError,
 )
 from ._env import get_default_language
+from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import format_authuser_value
+from .exceptions import ChatError
 from .rpc import (
     ClientError,
     NetworkError,
@@ -34,6 +36,7 @@ from .rpc import (
     get_batchexecute_url,
     resolve_rpc_id,
 )
+from .types import RpcTelemetryEvent
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +49,7 @@ class RpcOwner(Protocol):
     _timeout: float
     _refresh_callback: Callable[[], Awaitable[Any]] | None
     _refresh_retry_delay: float
+    _http_client: Any
 
     async def _perform_authed_post(
         self,
@@ -68,6 +72,25 @@ class RpcOwner(Protocol):
         disable_internal_retries: bool = False,
     ) -> Any: ...
 
+    async def _rpc_call_impl(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str,
+        allow_null: bool,
+        _is_retry: bool,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any: ...
+
+    async def _begin_transport_post(self, log_label: str) -> Any: ...
+
+    async def _finish_transport_post(self, token: Any) -> None: ...
+
+    def _increment_metrics(self, **increments: int | float) -> None: ...
+
+    async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None: ...
+
 
 class RpcExecutor:
     """Owns raw batchexecute RPC encode, transport dispatch, decode, and retry."""
@@ -84,6 +107,187 @@ class RpcExecutor:
         self._decode_response = decode_response_late_bound
         self._is_auth_error = is_auth_error
         self._sleep = sleep
+
+    async def execute_with_telemetry(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str,
+        allow_null: bool,
+        _is_retry: bool,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> Any:
+        """Run an RPC wrapped with telemetry, reqid, and drain bookkeeping.
+
+        This is the outer entry point that ``ClientCore.rpc_call`` routes
+        through. The body owns the operation-token + metrics + request-id
+        wiring that surrounds the raw RPC dispatch. Pure relocation from
+        ``ClientCore.rpc_call``: no behavior changes.
+
+        Dispatches through ``self._owner._rpc_call_impl(...)`` (rather than
+        the executor's own :meth:`execute` directly) so the long-standing
+        ``core._rpc_call_impl = fake`` swap point keeps working for tests
+        and any private callers that override the impl by attribute.
+
+        The ``_is_retry`` flag suppresses telemetry/reqid wrapping so the
+        decode-time refresh-and-retry leg inherits the parent's
+        request id and reports under one ``[req=<id>]`` line in logs.
+        """
+        if not self._owner._http_client:
+            raise RuntimeError("Client not initialized. Use 'async with' context.")
+
+        # Only the outer call mints a request id; the decode-time retry path
+        # (``_is_retry=True``) inherits the parent's id so a single
+        # decode-error → refresh → retry sequence appears under one
+        # ``[req=<id>]`` in the logs. HTTP-status retries (auth + 429) happen
+        # inside ``_perform_authed_post`` without recursion, so they don't
+        # need this guard.
+        if _is_retry:
+            return await self._owner._rpc_call_impl(
+                method,
+                params,
+                source_path,
+                allow_null,
+                _is_retry,
+                disable_internal_retries=disable_internal_retries,
+            )
+
+        method_name = getattr(method, "name", str(method))
+        operation_token = await self._owner._begin_transport_post(f"RPC {method_name}")
+        self._owner._increment_metrics(rpc_calls_started=1)
+        start = time.perf_counter()
+        _reqid_token = None if get_request_id() is not None else set_request_id()
+        try:
+            result = await self._owner._rpc_call_impl(
+                method,
+                params,
+                source_path,
+                allow_null,
+                _is_retry,
+                disable_internal_retries=disable_internal_retries,
+            )
+        except Exception as exc:
+            elapsed = time.perf_counter() - start
+            self._owner._increment_metrics(
+                rpc_calls_failed=1,
+                rpc_latency_seconds_total=elapsed,
+            )
+            await self._owner._emit_rpc_event(
+                RpcTelemetryEvent(
+                    method=method_name,
+                    status="error",
+                    elapsed_seconds=elapsed,
+                    request_id=get_request_id(),
+                    error_type=type(exc).__name__,
+                )
+            )
+            raise
+        else:
+            elapsed = time.perf_counter() - start
+            self._owner._increment_metrics(
+                rpc_calls_succeeded=1,
+                rpc_latency_seconds_total=elapsed,
+            )
+            await self._owner._emit_rpc_event(
+                RpcTelemetryEvent(
+                    method=method_name,
+                    status="success",
+                    elapsed_seconds=elapsed,
+                    request_id=get_request_id(),
+                )
+            )
+            return result
+        finally:
+            if _reqid_token is not None:
+                reset_request_id(_reqid_token)
+            await self._owner._finish_transport_post(operation_token)
+
+    async def query_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        parse_label: str,
+    ) -> httpx.Response:
+        """Chat-side semantic owner around :meth:`_perform_authed_post`.
+
+        Wraps the shared transport pipeline with chat-flavored exception
+        mapping: transport-layer auth failures become
+        :class:`~notebooklm.exceptions.ChatError`, and transport-layer
+        network/rate-limit failures become
+        :class:`~notebooklm.exceptions.NetworkError` /
+        :class:`~notebooklm.exceptions.ChatError` respectively. This keeps
+        ChatAPI free of HTTP-status branching and matches the historical
+        contract of ``ChatAPI.ask`` (a planned follow-up will migrate that caller).
+
+        Args:
+            build_request: See :meth:`_perform_authed_post`.
+            parse_label: Caller-friendly label used in log lines and error
+                messages (e.g. ``"chat.ask"``).
+        """
+        operation_token = await self._owner._begin_transport_post(parse_label)
+        try:
+            try:
+                return await self._owner._perform_authed_post(
+                    build_request=build_request,
+                    log_label=parse_label,
+                )
+            except _TransportAuthExpired as exc:
+                raise ChatError(
+                    f"{parse_label} failed: authentication expired and refresh did not recover"
+                ) from exc
+            except _TransportRateLimited as exc:
+                raise ChatError(
+                    f"{parse_label} rate-limited (HTTP 429)."
+                    + (
+                        f" Retry after {exc.retry_after} seconds."
+                        if exc.retry_after is not None
+                        else ""
+                    )
+                ) from exc
+            except _TransportServerError as exc:
+                if isinstance(exc.original, httpx.HTTPStatusError):
+                    raise ChatError(
+                        f"{parse_label} failed with HTTP {exc.original.response.status_code} "
+                        f"after retries: {exc.original}"
+                    ) from exc
+                # Network-layer failure (RequestError / Timeout).
+                # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
+                # ``_TransportServerError`` on the network path; this guard keeps
+                # the contract enforced under ``python -O`` (where ``assert``
+                # would be stripped) and gives a clear diagnostic if the
+                # invariant ever drifts.
+                if not isinstance(exc.original, httpx.RequestError):
+                    raise TypeError(
+                        f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                    ) from exc
+                # Preserve the timeout-specific message: TimeoutException is a
+                # subclass of RequestError, so without this branch read/connect
+                # timeouts would surface as a generic "network error after
+                # retries" line and lose the "timed out" signal callers rely on.
+                if isinstance(exc.original, httpx.TimeoutException):
+                    raise NetworkError(
+                        f"{parse_label} timed out after retries: {exc.original}",
+                        original_error=exc.original,
+                    ) from exc
+                raise NetworkError(
+                    f"{parse_label} network error after retries: {exc.original}",
+                    original_error=exc.original,
+                ) from exc
+            except httpx.HTTPStatusError as exc:
+                # Non-5xx / non-401 / non-429 status errors fall through
+                # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
+                # or unhandled 4xx).
+                raise ChatError(
+                    f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
+                ) from exc
+        finally:
+            await self._owner._finish_transport_post(operation_token)
+        # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
+        # handlers were removed here because ``_perform_authed_post`` always
+        # either retries those errors or wraps them in
+        # ``_TransportServerError`` (handled above), so they cannot reach
+        # this scope.
 
     async def execute(
         self,


### PR DESCRIPTION
## Summary

Lift the outer telemetry/reqid/drain wrapper around RPC dispatch and the chat-flavored exception remap out of `ClientCore` into `RpcExecutor`. Pure relocation — no behavior changes.

- `ClientCore.rpc_call` body relocates into `RpcExecutor.execute_with_telemetry()`. The wrapper keeps the `_is_retry` short-circuit and dispatches through `self._owner._rpc_call_impl(...)` so the long-standing `core._rpc_call_impl = fake` swap point used by `test_logging_correlation` / `test_observability` keeps working.
- `ClientCore.query_post` body relocates into `RpcExecutor.query_post()`. Every chat-flavored exception arm (`ChatError` / `NetworkError` translation, the `_TransportServerError.original` invariant guard, the `httpx.TimeoutException` subclass-of-`RequestError` branch) moves verbatim.
- Both facades remain regular `async def` (NOT `@property`) so the 30+ tests that do `core.rpc_call = AsyncMock(...)` keep working.
- `_is_retry` and `disable_internal_retries` kwargs preserved on every dispatch-path facade.

## Task

Phase 3 C1 partial — see `.sisyphus/phases/core-decomposition-mini-phase/phase-3.md`. **Out of scope for C1a** (deferred):
- C1b: `_await_refresh` body relocation (waits on B1's `AuthRefreshCoordinator` shape — now merged in #789, so C1b can proceed).
- C1c: event-loop affinity check refactor (waits on B2).

## Test plan

- [x] `uv run ruff format src/notebooklm tests` — clean
- [x] `uv run ruff check src/notebooklm tests` — all checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues across 114 source files
- [x] `uv run pytest tests/unit/test_core_rpc.py tests/integration/test_core.py -v` — 67 passed
- [x] `uv run pytest tests/unit/test_rate_limit_retry.py tests/unit/test_retry_after.py tests/unit/test_vcr_config.py -v` — 72 passed
- [x] `uv run pytest tests/unit/test_artifacts_coverage.py tests/unit/test_notebook_api.py tests/unit/test_api_coverage.py -v` — 91 passed
- [x] `git status tests/cassettes/` — clean (no cassette diffs)
- [x] `uv run pytest` — 5106 passed, 20 skipped
- [x] `wc -l src/notebooklm/_core.py` — 1567 (down ~246 LOC from post-B1 baseline)

## Deferred polish findings

- D1 follow-up candidate: the `execute_with_telemetry → _owner._rpc_call_impl (facade) → _get_rpc_executor().execute` indirection exists only to preserve the `core._rpc_call_impl = fake` test swap pattern. A future cleanup pass could either migrate those tests to monkeypatch `core._get_rpc_executor().execute` directly or remove `_rpc_call_impl` as a swap seam. Not a C1a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of RPC execution layer to centralize request handling, metrics tracking, and telemetry emission. Public API signatures remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->