### PR TITLE
docs(claude): update Layered Design + Repository Structure for seam modules (D1 partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ CLI Layer (cli/)
     ↓
 Client Layer (client.py, _*.py APIs)
     ↓
-Core Layer (_core.py)
+Core Layer (_core.py + _core_*.py seam modules)
     ↓
 RPC Layer (rpc/)
 ```
@@ -60,10 +60,13 @@ RPC Layer (rpc/)
    - `encoder.py`: Request encoding
    - `decoder.py`: Response parsing
 
-2. **Core Layer** (`src/notebooklm/_core.py`):
-   - HTTP client management
-   - RPC call abstraction
-   - Request counter handling
+2. **Core Layer** (`src/notebooklm/_core.py` + `_core_*.py` seam modules):
+   - `_core.py`: `NotebookLMClient` orchestration (will shrink further as Phase 2 lands)
+   - `_core_transport.py`, `_core_rpc.py`: HTTP client + RPC call abstraction
+   - `_core_auth.py`, `_core_cookie_persistence.py`: Auth refresh + cookie storage
+   - `_core_metrics.py`, `_core_drain.py`, `_core_reqid.py`: Telemetry, drain coordination, request-counter handling
+   - `_core_cache.py`, `_core_polling.py`: Conversation cache + artifact polling helpers
+   - `_capabilities.py`: Capability adapters for feature APIs
 
 3. **Client Layer** (`src/notebooklm/client.py`, `_*.py`):
    - `NotebookLMClient`: Main async client with namespaced APIs
@@ -91,33 +94,44 @@ RPC Layer (rpc/)
 
 ```
 src/notebooklm/
-├── __init__.py          # Public exports
-├── client.py            # NotebookLMClient
-├── auth.py              # Authentication
-├── types.py             # Dataclasses
-├── _core.py             # Core infrastructure
-├── _notebooks.py        # NotebooksAPI
-├── _sources.py          # SourcesAPI
-├── _artifacts.py        # ArtifactsAPI
-├── _chat.py             # ChatAPI
-├── _research.py         # ResearchAPI
-├── _notes.py            # NotesAPI
-├── notebooklm_cli.py    # Entry-point assembler — imports + registers cli/ groups
-├── rpc/                 # RPC protocol layer
-│   ├── types.py         # Method IDs and enums
-│   ├── encoder.py       # Request encoding
-│   └── decoder.py       # Response parsing
-└── cli/                 # CLI implementation
+├── __init__.py                  # Public exports
+├── client.py                    # NotebookLMClient
+├── auth.py                      # Authentication
+├── types.py                     # Dataclasses
+├── _core.py                     # Core orchestration (NotebookLMClient internals)
+├── _core_transport.py           # HTTP client + transport-layer concerns
+├── _core_rpc.py                 # RPC call abstraction
+├── _core_auth.py                # Auth refresh seam
+├── _core_cookie_persistence.py  # Cookie storage seam
+├── _core_metrics.py             # Telemetry / metrics seam
+├── _core_drain.py               # In-flight drain coordinator
+├── _core_reqid.py               # Request-counter / request-id helpers
+├── _core_cache.py               # Conversation cache seam
+├── _core_polling.py             # Artifact polling helpers
+│                                # (Phase 2 in progress: _core_lifecycle.py — open/close lifecycle seam)
+├── _capabilities.py             # Capability adapters for feature APIs
+├── _notebooks.py                # NotebooksAPI
+├── _sources.py                  # SourcesAPI
+├── _artifacts.py                # ArtifactsAPI
+├── _chat.py                     # ChatAPI
+├── _research.py                 # ResearchAPI
+├── _notes.py                    # NotesAPI
+├── notebooklm_cli.py            # Entry-point assembler — imports + registers cli/ groups
+├── rpc/                         # RPC protocol layer
+│   ├── types.py                 # Method IDs and enums
+│   ├── encoder.py               # Request encoding
+│   └── decoder.py               # Response parsing
+└── cli/                         # CLI implementation
     ├── __init__.py
-    ├── helpers.py       # Shared utilities
-    ├── session.py       # login, use, status, clear
-    ├── notebook.py      # list, create, delete, rename
-    ├── source.py        # source add, list, delete
-    ├── artifact.py      # artifact commands
-    ├── generate.py      # generate audio, video, etc.
-    ├── download.py      # download commands
-    ├── chat.py          # ask, configure, history
-    └── note.py          # note commands
+    ├── helpers.py               # Shared utilities
+    ├── session.py               # login, use, status, clear
+    ├── notebook.py              # list, create, delete, rename
+    ├── source.py                # source add, list, delete
+    ├── artifact.py              # artifact commands
+    ├── generate.py              # generate audio, video, etc.
+    ├── download.py              # download commands
+    ├── chat.py                  # ask, configure, history
+    └── note.py                  # note commands
 ```
 
 ## API Patterns


### PR DESCRIPTION
## Summary

Addresses the **deferred finding** from PR #790 claude bot review: CLAUDE.md's Layered Design diagram + Repository Structure tree still showed single \`_core.py\` and didn't reflect the seam-module split that landed in Phase 1 (PRs #778, #785, #786) + B1 (PR #789).

This is the **claude-cleanup subset of original Phase 4 D1**, dispatched in parallel with the in-flight B2 / D1-conformance-test / D1-audit-full.

## Changes

- **Layered Design diagram**: \`Core Layer (_core.py)\` → \`Core Layer (_core.py + _core_*.py seam modules)\`
- **Core Layer narrative**: per-module bullet list (transport, rpc, auth, cookie persistence, metrics, drain, reqid, cache, polling, capabilities)
- **Repository Structure tree**: add the existing \`_core_*.py\` modules

\`_core_lifecycle.py\` is hedged as \"(Phase 2 in progress)\" since B2 may merge concurrently.

## Test plan

- [x] \`uv run ruff format --check\` — 362 files unchanged
- [x] \`uv run ruff check\` — all checks pass
- [x] \`uv run mypy src/notebooklm\` — 114 files, no issues
- [ ] CI: full pytest matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation detailing core module decomposition and repository structure. These updates provide clarity on the current system organization and component hierarchy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->