### PR TITLE
refactor(core): extract ClientLifecycle into _core_lifecycle

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -24,6 +24,7 @@ from ._core_drain import TransportDrainTracker
 # ``_core_drain``. ``_core_drain`` is the source of truth for the token
 # shape; the alias below is the backwards-compat anchor.
 from ._core_drain import _TransportOperationToken as _TransportOperationToken
+from ._core_lifecycle import ClientLifecycle
 from ._core_metrics import ClientMetrics
 from ._core_polling import PendingPolls, PollRegistry
 from ._core_reqid import DEFAULT_STEP as _REQID_DEFAULT_STEP
@@ -50,12 +51,31 @@ from ._core_transport import (
     _TransportServerError as _TransportServerError,
 )
 from ._sources import fetch_source_ids
+
+# ``save_cookies_to_storage`` is re-exported as ``notebooklm._core.save_cookies_to_storage``
+# so existing ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+# sites in tests keep working (used in 8+ test files). The lifecycle helper
+# (``_core_lifecycle.ClientLifecycle.save_cookies``) reads the attribute via
+# ``from . import _core; _core.save_cookies_to_storage`` at call time so the
+# monkeypatched value is what runs on the live save path.
+#
+# ``_rotate_cookies`` is re-exported on the same module-level attribute surface
+# so ``tests/unit/concurrency/test_close_cancellation_leak.py:138``'s
+# ``monkeypatch.setattr("notebooklm._core._rotate_cookies", …)`` keeps
+# affecting the live keepalive loop (the lifecycle helper resolves it via
+# ``from . import _core; _core._rotate_cookies`` at call time).
 from .auth import (
     AuthTokens,
     CookieSnapshot,
-    _rotate_cookies,
-    build_cookie_jar,
-    save_cookies_to_storage,
+)
+from .auth import (
+    _rotate_cookies as _rotate_cookies,
+)
+from .auth import (
+    build_cookie_jar as build_cookie_jar,
+)
+from .auth import (
+    save_cookies_to_storage as save_cookies_to_storage,
 )
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
@@ -483,9 +503,17 @@ class ClientCore:
         from .types import ConnectionLimits
 
         self.auth = auth
-        self._timeout = timeout
-        self._connect_timeout = connect_timeout
-        self._limits = limits if limits is not None else ConnectionLimits()
+        # HTTP timeouts, connection limits, keepalive interval / storage_path,
+        # the live ``httpx.AsyncClient``, the captured ``_bound_loop``, and
+        # the keepalive background task all live on ``self._lifecycle``
+        # (constructed below alongside the other extracted helpers so the
+        # inter-helper dependency order is obvious). Compat properties further
+        # down preserve the legacy ``_timeout`` / ``_connect_timeout`` /
+        # ``_limits`` / ``_http_client`` / ``_bound_loop`` /
+        # ``_keepalive_task`` / ``_keepalive_interval`` /
+        # ``_keepalive_storage_path`` ivar names for tests and first-party
+        # callers that probe or assign them directly.
+        _resolved_limits = limits if limits is not None else ConnectionLimits()
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
         # by integration tests against ``client._core``. The refresh
@@ -544,7 +572,6 @@ class ClientCore:
         # ``_max_concurrent_rpcs is None``, the accessor returns a
         # ``contextlib.nullcontext`` instead — see ``_get_rpc_semaphore``.
         self._rpc_semaphore: asyncio.Semaphore | None = None
-        self._http_client: httpx.AsyncClient | None = None
         # Observability counters + telemetry callback. Compat properties
         # below (``_metrics_lock`` / ``_metrics`` / ``_on_rpc_event``) bridge
         # the legacy ivar names back into this helper.
@@ -578,34 +605,46 @@ class ClientCore:
         # inter-helper contract for the upcoming B2/C1 extractions; do not
         # rename.
         self._auth_coord = AuthRefreshCoordinator(refresh_callback=refresh_callback)
-        # Event-loop affinity guard. Captured in
-        # :meth:`open` and checked in :meth:`_perform_authed_post`; a cheap
-        # ``is`` comparison fails fast when a caller drives the same
-        # ``ClientCore`` from a different loop (typical mistake: instantiating
-        # under ``asyncio.run`` in one thread, then handing the client to
-        # another thread's loop). Each client is per-loop — the asyncio
-        # primitives we hold (``_reqid_lock``, ``_refresh_lock``,
-        # ``_auth_snapshot_lock``, ``_upload_semaphore``, ``_rpc_semaphore``,
-        # the ``httpx.AsyncClient`` pool, in-flight tasks like
-        # ``_refresh_task``/``_keepalive_task``) are all bound to the loop
-        # that ``open()`` ran on; reusing them under a different loop
-        # produces hangs and ``RuntimeError`` deep in httpx instead of an
-        # actionable message at the call site.
-        self._bound_loop: asyncio.AbstractEventLoop | None = None
-        # Keepalive background task configuration
-        self._keepalive_interval: float | None = _resolve_keepalive_interval(
-            keepalive, keepalive_min_interval
-        )
-        # Prefer the explicit storage_path if provided (e.g. NotebookLMClient(storage_path=...)
-        # with a manually-built AuthTokens), otherwise fall back to auth.storage_path.
-        self._keepalive_storage_path: Path | None = (
+        # HTTP-client lifecycle — owns ``_http_client``, ``_bound_loop``,
+        # ``_keepalive_task``, ``_keepalive_interval``,
+        # ``_keepalive_storage_path``, ``_timeout``, ``_connect_timeout``,
+        # ``_limits``. Compat properties further down preserve the legacy
+        # ivar names. The ``_resolve_keepalive_interval`` clamp stays in
+        # this module's preamble (see top of file) because
+        # ``tests/unit/test_vcr_config.py`` imports
+        # ``_SyntheticErrorTransport`` / ``_get_error_injection_mode`` from
+        # ``notebooklm._core`` by name, and the master plan pins the
+        # preamble surface as the public-on-private contract.
+        #
+        # Event-loop affinity guard rationale: the lifecycle captures
+        # ``asyncio.get_running_loop()`` in ``_bound_loop`` at ``open()`` time
+        # and the cross-loop check in ``_perform_authed_post`` (via
+        # :class:`AuthedTransport`) does a cheap ``is`` comparison against
+        # it. Each client is per-loop — the asyncio primitives we hold
+        # (``_reqid_lock``, ``_refresh_lock``, ``_auth_snapshot_lock``,
+        # ``_upload_semaphore``, ``_rpc_semaphore``, the ``httpx.AsyncClient``
+        # pool, in-flight tasks like ``_refresh_task`` / ``_keepalive_task``)
+        # are all bound to the loop that ``open()`` ran on; reusing them
+        # under a different loop produces hangs and ``RuntimeError`` deep
+        # in httpx instead of an actionable message at the call site.
+        #
+        # Prefer the explicit storage_path if provided (e.g.
+        # ``NotebookLMClient(storage_path=...)`` with a manually-built
+        # ``AuthTokens``), otherwise fall back to ``auth.storage_path``.
+        _resolved_storage_path: Path | None = (
             keepalive_storage_path if keepalive_storage_path is not None else auth.storage_path
         )
-        self._keepalive_task: asyncio.Task[None] | None = None
+        self._lifecycle = ClientLifecycle(
+            timeout=timeout,
+            connect_timeout=connect_timeout,
+            limits=_resolved_limits,
+            keepalive_interval=_resolve_keepalive_interval(keepalive, keepalive_min_interval),
+            keepalive_storage_path=_resolved_storage_path,
+        )
         # Owns the in-process save lock and open-time cookie baseline while
         # compatibility properties below keep the legacy private attribute
         # names observable for current tests and first-party callers.
-        self.cookie_persistence = CookiePersistence(self.auth, self._keepalive_storage_path)
+        self.cookie_persistence = CookiePersistence(self.auth, _resolved_storage_path)
         self.poll_registry: PollRegistry = PollRegistry()
         self._authed_transport: AuthedTransport | None = None
         self._rpc_executor: RpcExecutor | None = None
@@ -782,6 +821,140 @@ class ClientCore:
     def _auth_snapshot_lock(self, value: asyncio.Lock | None) -> None:
         self._ensure_auth_coord()
         self._auth_coord._auth_snapshot_lock = value
+
+    # ------------------------------------------------------------------
+    # ``ClientLifecycle`` compat bridges. HTTP-client lifecycle state now
+    # lives on ``self._lifecycle``; the eight legacy ivar names (
+    # ``_http_client``, ``_bound_loop``, ``_keepalive_task``,
+    # ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``,
+    # ``_connect_timeout``, ``_limits``) are preserved here as
+    # ``@property`` bridges. ``_http_client`` and ``_bound_loop`` carry
+    # writeable setters because tests SET them directly (15+ sites for
+    # ``_http_client``; ``_bound_loop`` setter is required by the master
+    # plan for future C1 access patterns). The other six are getter-only
+    # because no SET sites were found in the test surface.
+    # ``_ensure_lifecycle`` mirrors the ``_ensure_observability_state`` /
+    # ``_ensure_auth_coord`` backfill so ``__new__``-built fixtures (no
+    # ``__init__`` ran) still resolve cleanly.
+    # ------------------------------------------------------------------
+
+    def _ensure_lifecycle(self) -> None:
+        """Backfill ``_lifecycle`` for tests that construct via ``__new__``.
+
+        Uses a module-level threading lock (the existing
+        ``_OBSERVABILITY_INIT_LOCK``) for double-checked locking so two
+        threads racing through ``hasattr`` cannot both decide they need to
+        construct a lifecycle and silently discard each other's
+        ``_http_client`` references.
+
+        ``__new__``-built fixtures may not have the underlying timeout /
+        limits attributes; we synthesise a minimally-configured lifecycle
+        in that case (the same shape ``ClientCore.__init__`` would produce
+        for default args).
+        """
+        if hasattr(self, "_lifecycle"):
+            return
+        with _OBSERVABILITY_INIT_LOCK:
+            if not hasattr(self, "_lifecycle"):
+                # Lazy import to break the types.py -> _core.py cycle.
+                from .types import ConnectionLimits
+
+                self._lifecycle = ClientLifecycle(
+                    timeout=DEFAULT_TIMEOUT,
+                    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+                    limits=ConnectionLimits(),
+                    keepalive_interval=None,
+                    keepalive_storage_path=None,
+                )
+
+    @property
+    def _http_client(self) -> httpx.AsyncClient | None:
+        self._ensure_lifecycle()
+        return self._lifecycle._http_client
+
+    @_http_client.setter
+    def _http_client(self, value: httpx.AsyncClient | None) -> None:
+        self._ensure_lifecycle()
+        self._lifecycle._http_client = value
+
+    @property
+    def _bound_loop(self) -> asyncio.AbstractEventLoop | None:
+        self._ensure_lifecycle()
+        return self._lifecycle._bound_loop
+
+    @_bound_loop.setter
+    def _bound_loop(self, value: asyncio.AbstractEventLoop | None) -> None:
+        self._ensure_lifecycle()
+        self._lifecycle._bound_loop = value
+
+    @property
+    def _keepalive_task(self) -> asyncio.Task[None] | None:
+        self._ensure_lifecycle()
+        return self._lifecycle._keepalive_task
+
+    @_keepalive_task.setter
+    def _keepalive_task(self, value: asyncio.Task[None] | None) -> None:
+        # Setter retained because these were plain ivars pre-extraction
+        # (and Python attributes are writeable by default). No SET sites in
+        # the current test surface, but mirroring the pre-extraction
+        # contract avoids future friction.
+        self._ensure_lifecycle()
+        self._lifecycle._keepalive_task = value
+
+    @property
+    def _keepalive_interval(self) -> float | None:
+        self._ensure_lifecycle()
+        return self._lifecycle._keepalive_interval
+
+    @_keepalive_interval.setter
+    def _keepalive_interval(self, value: float | None) -> None:
+        self._ensure_lifecycle()
+        self._lifecycle._keepalive_interval = value
+
+    @property
+    def _keepalive_storage_path(self) -> Path | None:
+        self._ensure_lifecycle()
+        return self._lifecycle._keepalive_storage_path
+
+    @_keepalive_storage_path.setter
+    def _keepalive_storage_path(self, value: Path | None) -> None:
+        self._ensure_lifecycle()
+        self._lifecycle._keepalive_storage_path = value
+
+    @property
+    def _timeout(self) -> float:
+        self._ensure_lifecycle()
+        return self._lifecycle._timeout
+
+    @_timeout.setter
+    def _timeout(self, value: float) -> None:
+        # Required by ``RpcOwner`` Protocol (``_core_rpc.py``) which
+        # declares ``_timeout: float`` as a settable variable. Pre-extraction
+        # ``_timeout`` was a plain ivar so attribute assignment worked
+        # implicitly; the property bridge needs an explicit setter to
+        # preserve that contract.
+        self._ensure_lifecycle()
+        self._lifecycle._timeout = value
+
+    @property
+    def _connect_timeout(self) -> float:
+        self._ensure_lifecycle()
+        return self._lifecycle._connect_timeout
+
+    @_connect_timeout.setter
+    def _connect_timeout(self, value: float) -> None:
+        self._ensure_lifecycle()
+        self._lifecycle._connect_timeout = value
+
+    @property
+    def _limits(self) -> "ConnectionLimits":
+        self._ensure_lifecycle()
+        return self._lifecycle._limits
+
+    @_limits.setter
+    def _limits(self, value: "ConnectionLimits") -> None:
+        self._ensure_lifecycle()
+        self._lifecycle._limits = value
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
@@ -1055,232 +1228,66 @@ class ClientCore:
     async def open(self) -> None:
         """Open the HTTP client connection.
 
-        Called automatically by NotebookLMClient.__aenter__.
-        Uses httpx.Cookies jar to properly handle cross-domain redirects
-        (e.g., to accounts.google.com for auth token refresh).
-
-        Captures the running event loop in ``self._bound_loop`` so
-        :meth:`_perform_authed_post` can fail fast if the same client is
-        later driven from a different loop. Re-opening
-        on a different loop intentionally replaces the binding — ``open()``
-        is the only binding moment; ``close()`` does not unbind so an
+        Called automatically by NotebookLMClient.__aenter__. Delegates to
+        :meth:`ClientLifecycle.open` — that helper builds the
+        ``httpx.AsyncClient`` (with the opt-in
+        :class:`_SyntheticErrorTransport` wrap when
+        ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set), captures the running
+        event loop into ``self._bound_loop``, and spawns the keepalive
+        task. Idempotent — calling ``open()`` while already open is a
+        no-op. Re-opening after a prior :meth:`close` intentionally
+        replaces the loop binding; :meth:`close` does not unbind so an
         accidental cross-loop call after close still raises actionably.
         """
-        if self._http_client is None:
-            # Capture event-loop affinity before any awaitable resource is
-            # built so the binding is consistent with the loop that owns
-            # every primitive constructed below.
-            self._bound_loop = asyncio.get_running_loop()
-            self._draining = False
-            # Use granular timeouts: shorter connect timeout helps detect network issues
-            # faster, while longer read/write timeouts accommodate slow responses
-            timeout = httpx.Timeout(
-                connect=self._connect_timeout,
-                read=self._timeout,
-                write=self._timeout,
-                pool=self._timeout,
-            )
-            # Build cookies jar for cross-domain redirect support
-            # Use pre-built jar if available, otherwise build one
-            cookies = self.auth.cookie_jar or build_cookie_jar(
-                cookies=self.auth.cookies,
-                storage_path=self.auth.storage_path,
-            )
-            # Opt-in synthetic-error transport wrapper. When the env var is
-            # unset (the default) this is a no-op and the AsyncClient is
-            # constructed exactly as before. See ``_SyntheticErrorTransport``
-            # docstring at module top.
-            error_mode = _get_error_injection_mode()
-            synthetic_transport: httpx.AsyncBaseTransport | None = None
-            if error_mode is not None:
-                # When we supply a custom ``transport=`` to ``AsyncClient``,
-                # httpx no longer constructs its own internal transport from
-                # the ``limits=`` kwarg below — those limits are consumed by
-                # the inner transport here instead, so connection-pool sizing
-                # remains identical to the no-injection path.
-                inner_transport = httpx.AsyncHTTPTransport(
-                    limits=self._limits.to_httpx_limits(),
-                )
-                synthetic_transport = _SyntheticErrorTransport(error_mode, inner_transport)
-                logger.info(
-                    "synthetic-error injection enabled (mode=%s) — "
-                    "production paths will see substituted responses",
-                    error_mode,
-                )
-            self._http_client = httpx.AsyncClient(
-                headers={
-                    "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-                },
-                cookies=cookies,
-                timeout=timeout,
-                follow_redirects=True,
-                # ``limits=`` is honored when ``transport=None`` (default) —
-                # httpx builds its own default transport with these limits.
-                # When ``transport=synthetic_transport`` (error-injection
-                # record mode) this kwarg is ignored by httpx and the
-                # inner_transport above carries the limits instead. The
-                # redundant pass is harmless and avoids a branch on the
-                # AsyncClient construction site.
-                limits=self._limits.to_httpx_limits(),
-                transport=synthetic_transport,
-            )
-
-            # Capture the open-time snapshot AFTER the AsyncClient is built
-            # (httpx normalizes domains on ingest) but BEFORE any rotation
-            # could possibly fire. When AuthTokens carries a snapshot from a
-            # failed pre-client save, keep it so the unpersisted delta can be
-            # retried instead of treating the already-mutated jar as clean.
-            self.cookie_persistence.capture_open_snapshot(self._http_client.cookies)
-
-            # Spawn the keepalive task once the client is ready
-            if self._keepalive_interval is not None:
-                self._keepalive_task = asyncio.create_task(
-                    self._keepalive_loop(self._keepalive_interval)
-                )
+        self._ensure_lifecycle()
+        await self._lifecycle.open(self)
 
     async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
         """Persist a cookie jar through the shared cookie-persistence collaborator.
 
-        This remains the single chokepoint used by ``close()``, the keepalive
-        loop, and ``NotebookLMClient.refresh_auth``. The storage writer and
-        thread offload callable are resolved from this module at call time so
-        existing ``notebooklm._core`` monkeypatch paths continue to affect the
-        live save path.
+        Thin facade over :meth:`ClientLifecycle.save_cookies`. The storage
+        writer ``save_cookies_to_storage`` is resolved from this module at
+        call time inside the lifecycle helper so existing
+        ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+        sites continue to affect the live save path.
         """
-        await self.cookie_persistence.save(
-            jar,
-            path,
-            save_cookies_to_storage=save_cookies_to_storage,
-            to_thread=asyncio.to_thread,
-        )
+        self._ensure_lifecycle()
+        await self._lifecycle.save_cookies(self, jar, path)
 
     async def close(self) -> None:
         """Close the HTTP client connection.
 
-        Called automatically by NotebookLMClient.__aexit__.
+        Called automatically by NotebookLMClient.__aexit__. Delegates to
+        :meth:`ClientLifecycle.close`, which:
 
-        Cancellation safety:
-        the entire close sequence is wrapped in ``try/finally`` and the
-        final ``self._http_client.aclose()`` is wrapped in
-        ``asyncio.shield`` — without the shield, a ``CancelledError``
-        arriving during keepalive teardown or the cookie save would
-        skip ``aclose()`` and leak the underlying httpx transport.
-        ``self._http_client = None`` runs in an inner ``finally`` so
-        the instance is consistently marked closed even if the
-        shielded ``aclose`` itself raises.
-
-        Poll-task drain: in-flight artifact poll tasks held by
-        :attr:`poll_registry` are cancelled and awaited before the HTTP
-        client is torn down. Without this, a leader poll waking mid-aclose
-        would issue a request against an already-closed transport and
-        surface as a confusing httpx error in the user's logs. The drain
-        uses ``return_exceptions=True`` so a single misbehaving task can't
-        block the rest of the close sequence.
+        1. Cancels and joins the keepalive task (so the loop can't issue a
+           poke against an already-closed transport).
+        2. Drains in-flight artifact poll tasks held by ``self.poll_registry``.
+        3. Saves cookies one last time through ``save_cookies``.
+        4. Calls ``aclose()`` under :func:`asyncio.shield` so cancellation
+           arriving mid-close cannot leak the underlying httpx transport.
+        5. Nulls out ``_http_client``, ``_authed_transport`` and
+           ``_rpc_executor`` so a follow-up :meth:`open` rebuilds the
+           transport collaborators against the new ``httpx.AsyncClient``.
         """
-        try:
-            # Stop the keepalive task before tearing down the HTTP client so
-            # the loop can't issue a poke against an already-closed transport.
-            if self._keepalive_task is not None:
-                self._keepalive_task.cancel()
-                await asyncio.gather(self._keepalive_task, return_exceptions=True)
-                self._keepalive_task = None
-
-            # Drain in-flight artifact poll tasks. Snapshot first so concurrent
-            # registry mutations (a finishing leader removing its entry) don't
-            # race with the cancel/gather pair.
-            poll_tasks = self.poll_registry.active_tasks()
-            if poll_tasks:
-                for task in poll_tasks:
-                    task.cancel()
-                await asyncio.gather(*poll_tasks, return_exceptions=True)
-
-            if self._http_client:
-                try:
-                    # Single source of truth for the on-close save: takes the
-                    # in-process lock, snapshots, off-loads. Serializes
-                    # naturally with any keepalive save still finishing in a
-                    # worker thread — close() owns the freshest jar and must
-                    # win, not the older snapshot.
-                    await self.save_cookies(self._http_client.cookies)
-                except Exception as e:
-                    logger.warning("Failed to sync refreshed cookies during close: %s", e)
-        finally:
-            if self._http_client:
-                try:
-                    # Shield: cancellation arriving mid-aclose must not leak
-                    # the transport. The shielded aclose runs to completion;
-                    # ``self._http_client = None`` then makes ``is_open``
-                    # return False correctly.
-                    await asyncio.shield(self._http_client.aclose())
-                finally:
-                    self._http_client = None
+        self._ensure_lifecycle()
+        await self._lifecycle.close(self)
 
     async def _keepalive_loop(self, interval: float) -> None:
         """Background loop that periodically pokes the identity surface.
 
-        Sleeps ``interval`` seconds between iterations, then calls
-        :func:`notebooklm.auth._rotate_cookies` to elicit ``__Secure-1PSIDTS``
-        rotation. Any rotated cookies are persisted to ``storage_state.json``
-        immediately (off-loop, via :func:`asyncio.to_thread`) so a long-lived
-        client's freshness survives a crash.
-
-        Error handling is split by failure mode:
-
-        - Poke failures (network blips, ``accounts.google.com`` downtime) are
-          opportunistic and logged at DEBUG. The next iteration retries.
-        - Persistence failures hide the most important class of bug — a
-          rotated cookie that exists in memory but not on disk — so they are
-          logged at WARNING with the storage path.
-
-        Both classes never propagate; the loop only exits via
-        :class:`asyncio.CancelledError` from :meth:`close`.
+        Thin facade over :meth:`ClientLifecycle._keepalive_loop`. Retained
+        as a ``ClientCore`` method so ``test_client_keepalive`` and other
+        tests that introspect ``core._keepalive_loop`` continue to resolve.
         """
-        logger.debug("Keepalive task started (interval=%.1fs)", interval)
-        try:
-            while True:
-                await asyncio.sleep(interval)
-                client = self._http_client
-                if client is None:
-                    # Client closed concurrently; exit gracefully.
-                    return
-
-                try:
-                    # Bypass the layer-1 dedup guards: this loop is self-paced
-                    # by ``keepalive_min_interval`` and never runs concurrently
-                    # with itself. Pass the storage path so the bare call
-                    # bumps the *per-profile* in-process timestamp, letting
-                    # concurrent layer-1 callers (e.g. spawned ``fetch_tokens``
-                    # tasks on the same profile) and other keepalive loops on
-                    # the same profile see the fresh rotation and skip.
-                    await _rotate_cookies(client, self._keepalive_storage_path)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:  # noqa: BLE001 - opportunistic best-effort
-                    logger.debug("Keepalive poke failed (non-fatal): %s", exc)
-                    continue
-
-                if self._keepalive_storage_path is None:
-                    continue
-
-                try:
-                    # save_cookies handles snapshot + lock + off-load.
-                    await self.save_cookies(client.cookies)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning(
-                        "Keepalive cookie persistence to %s failed: %s",
-                        self._keepalive_storage_path,
-                        exc,
-                    )
-        except asyncio.CancelledError:
-            logger.debug("Keepalive task cancelled")
-            raise
+        self._ensure_lifecycle()
+        await self._lifecycle._keepalive_loop(self, interval)
 
     @property
     def is_open(self) -> bool:
         """Check if the HTTP client is open."""
-        return self._http_client is not None
+        self._ensure_lifecycle()
+        return self._lifecycle.is_open()
 
     def update_auth_headers(self) -> None:
         """Refresh auth metadata without resetting the live cookie jar.

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -397,6 +397,14 @@ class ClientLifecycle:
         :class:`asyncio.CancelledError` from :meth:`close`.
         """
         logger.debug("Keepalive task started (interval=%.1fs)", interval)
+        # Resolved from ``notebooklm._core`` once, before the loop, so the
+        # existing ``monkeypatch.setattr("notebooklm._core._rotate_cookies",
+        # …)`` surface in ``test_close_cancellation_leak.py`` keeps affecting
+        # the live keepalive loop after the extraction. The attribute lookup
+        # on ``_core_module._rotate_cookies`` still happens at call time, so
+        # late monkeypatches remain effective without re-importing every tick.
+        from . import _core as _core_module
+
         try:
             while True:
                 await asyncio.sleep(interval)
@@ -413,13 +421,6 @@ class ClientLifecycle:
                     # concurrent layer-1 callers (e.g. spawned ``fetch_tokens``
                     # tasks on the same profile) and other keepalive loops on
                     # the same profile see the fresh rotation and skip.
-                    #
-                    # Resolved from ``notebooklm._core`` at call time so the
-                    # existing ``monkeypatch.setattr("notebooklm._core._rotate_cookies",
-                    # …)`` surface in ``test_close_cancellation_leak.py`` keeps
-                    # affecting the live keepalive loop after the extraction.
-                    from . import _core as _core_module
-
                     await _core_module._rotate_cookies(client, self._keepalive_storage_path)
                 except asyncio.CancelledError:
                     raise

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -1,0 +1,449 @@
+"""HTTP-client lifecycle helper for :class:`ClientCore`.
+
+Owns the HTTP-client lifecycle state and behavior that historically lived
+inline on ``ClientCore``:
+
+* ``_http_client`` — the live ``httpx.AsyncClient`` (or ``None`` when closed).
+* ``_bound_loop`` — the event loop ``open()`` ran on; the cross-loop affinity
+  guard in :meth:`ClientCore._perform_authed_post` (via
+  :class:`AuthedTransport`) compares against this captured reference.
+* ``_keepalive_task`` — the optional background task that pokes
+  ``accounts.google.com/RotateCookies`` while the client is open.
+* ``_keepalive_interval`` / ``_keepalive_storage_path`` — keepalive
+  configuration; the interval is clamped against ``keepalive_min_interval``
+  via :func:`_resolve_keepalive_interval` (which stays in ``_core.py``'s
+  module preamble — see master plan).
+* ``_timeout`` / ``_connect_timeout`` / ``_limits`` — HTTP timeouts and
+  connection-pool tuning consumed in :meth:`open`.
+
+Design constraints (load-bearing — see ``tests/unit/test_client_keepalive.py``,
+``tests/unit/test_core_close.py``, ``tests/unit/test_vcr_config.py``, and
+``tests/unit/test_auth_cookie_save_race.py``):
+
+* ``__init__`` MUST be event-loop-agnostic. ``ClientCore`` is routinely
+  constructed outside a running loop (sync-mode ``NotebookLMClient(auth)``
+  before ``asyncio.run``), so this helper may not call
+  ``asyncio.get_running_loop()`` or instantiate any ``asyncio.*`` primitive
+  at construction time. The keepalive task is spawned inside :meth:`open`,
+  which runs from a coroutine.
+
+* :meth:`open` is idempotent — calling it twice with a live ``_http_client``
+  is a no-op, preserving the legacy ``ClientCore.open()`` contract.
+
+* :meth:`close` cancellation ordering: stop keepalive → drain poll tasks →
+  save cookies → shielded ``aclose()`` → null out ``_http_client``. Reversing
+  any of these reintroduces the leak modes ``test_core_close.py`` pins down.
+  The shielded ``aclose()`` is critical: without it, a ``CancelledError``
+  arriving mid-close leaks the underlying httpx transport.
+
+* :meth:`open` wraps the inner transport in
+  :class:`notebooklm._core._SyntheticErrorTransport` IFF
+  :func:`notebooklm._core._get_error_injection_mode` returns a non-``None``
+  value. Both symbols are resolved from ``notebooklm._core`` at call time
+  (not imported at module load) so the opt-in env-var path stays test-only
+  and ``test_vcr_config.py``'s ``from notebooklm._core import …`` imports
+  keep working unchanged.
+
+* :meth:`save_cookies` resolves ``save_cookies_to_storage`` from
+  ``notebooklm._core`` at call time so the
+  ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+  surface used by 8+ test files keeps affecting the live save path.
+
+* ``_bound_loop`` is bound exactly once per :meth:`open` call; :meth:`close`
+  does NOT unbind so an accidental cross-loop call after close still raises
+  actionably rather than silently re-binding on the next ``open``. (See
+  ``tests/integration/concurrency/test_cross_loop_affinity.py``.)
+
+Field names (``_http_client``, ``_bound_loop``, ``_keepalive_task``,
+``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``,
+``_connect_timeout``, ``_limits``) deliberately mirror the legacy
+``ClientCore`` ivars so the compat ``@property`` bridges on ``ClientCore``
+can delegate via ``return self._lifecycle._<attr>`` and stay readable for
+reviewers grepping the codebase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+import httpx
+
+from .auth import AuthTokens, build_cookie_jar
+
+if TYPE_CHECKING:
+    from ._core_auth import AuthRefreshCoordinator
+    from ._core_cookie_persistence import CookiePersistence
+    from ._core_drain import TransportDrainTracker
+    from ._core_metrics import ClientMetrics
+    from ._core_polling import PollRegistry
+    from ._core_rpc import RpcExecutor
+    from ._core_transport import AuthedTransport
+    from .types import ConnectionLimits
+
+# Logger name pinned to ``notebooklm._core`` (not the literal module name)
+# so log filters in tests — e.g. ``caplog.at_level("DEBUG",
+# logger="notebooklm._core")`` — keep matching after the extraction.
+logger = logging.getLogger("notebooklm._core")
+
+
+class _LifecycleHost(Protocol):
+    """Structural host boundary required by :class:`ClientLifecycle`.
+
+    The Protocol pins exactly which collaborators the lifecycle reaches into
+    on the host, so future refactors that move state around ``ClientCore``
+    surface as Protocol violations rather than silent ``AttributeError``s
+    at close-time. ``cookie_persistence`` and ``poll_registry`` mirror
+    today's public attribute names on ``ClientCore``; ``_metrics_obj``,
+    ``_drain_tracker``, and ``_auth_coord`` are the post-A1/A2/B1 helper
+    handles. ``_authed_transport`` and ``_rpc_executor`` are nulled out by
+    :meth:`ClientLifecycle.close` so a follow-up ``open()`` rebuilds them
+    against the new ``httpx.AsyncClient`` (avoids stale closures over the
+    previous client).
+    """
+
+    auth: AuthTokens
+    _metrics_obj: ClientMetrics
+    _drain_tracker: TransportDrainTracker
+    _auth_coord: AuthRefreshCoordinator
+    cookie_persistence: CookiePersistence
+    poll_registry: PollRegistry
+    _authed_transport: AuthedTransport | None
+    _rpc_executor: RpcExecutor | None
+
+
+class ClientLifecycle:
+    """Owns HTTP-client open/close, keepalive, cookie persistence on close.
+
+    Field names mirror the legacy ``ClientCore`` ivars so the compat
+    ``@property`` bridges on ``ClientCore`` can delegate with
+    ``return self._lifecycle._<attr>`` and stay readable.
+
+    Construction is event-loop-agnostic — only plain values and ``None``
+    placeholders are stored. The ``httpx.AsyncClient`` and the keepalive
+    ``asyncio.Task`` are created inside :meth:`open` from a running loop.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: float,
+        connect_timeout: float,
+        limits: ConnectionLimits,
+        keepalive_interval: float | None,
+        keepalive_storage_path: Path | None,
+    ) -> None:
+        self._timeout: float = timeout
+        self._connect_timeout: float = connect_timeout
+        # ``ConnectionLimits`` is constructed by the caller (``ClientCore``
+        # applies the ``None → ConnectionLimits()`` default before passing
+        # here). Keeping the default-resolution out of this helper avoids a
+        # types.py import cycle.
+        self._limits: ConnectionLimits = limits
+        # Pre-clamped by :func:`notebooklm._core._resolve_keepalive_interval`
+        # at the ``ClientCore`` boundary so the floor-vs-user-value branching
+        # stays in one place (the module preamble) per master plan.
+        self._keepalive_interval: float | None = keepalive_interval
+        self._keepalive_storage_path: Path | None = keepalive_storage_path
+        # Lazily set inside :meth:`open` / nulled inside :meth:`close`.
+        self._http_client: httpx.AsyncClient | None = None
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
+        self._keepalive_task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # State accessors
+    # ------------------------------------------------------------------
+
+    def is_open(self) -> bool:
+        """Return whether :meth:`open` has run without a subsequent close."""
+        return self._http_client is not None
+
+    def get_bound_loop(self) -> asyncio.AbstractEventLoop | None:
+        """Return the event loop :meth:`open` captured, or ``None`` if never opened.
+
+        Phase C1's RPC-dispatch facade uses this accessor (instead of reaching
+        for ``self._lifecycle._bound_loop`` directly) so the two-underscore
+        attribute stays an implementation detail of this helper.
+        """
+        return self._bound_loop
+
+    # ------------------------------------------------------------------
+    # Open / close
+    # ------------------------------------------------------------------
+
+    async def open(self, host: _LifecycleHost) -> None:
+        """Open the HTTP client connection.
+
+        Idempotent: if ``_http_client`` is already non-``None`` this is a
+        no-op. Captures the running event loop in ``_bound_loop`` so the
+        cross-loop affinity guard in :meth:`ClientCore._perform_authed_post`
+        fails fast if the same client is later driven from a different loop.
+        Re-opening on a different loop (after a prior :meth:`close`)
+        intentionally replaces the binding — ``open()`` is the only binding
+        moment.
+
+        Wraps the inner transport in
+        :class:`notebooklm._core._SyntheticErrorTransport` IFF
+        :func:`notebooklm._core._get_error_injection_mode` returns a
+        non-``None`` value. Both symbols are resolved from ``notebooklm._core``
+        at call time so the opt-in env-var path stays test-only and the
+        ``test_vcr_config.py`` import surface is unaffected.
+        """
+        if self._http_client is not None:
+            return
+
+        # Resolve through the parent module at call time so production paths
+        # never import the test-only synthetic-transport plumbing eagerly and
+        # so monkeypatches of ``_get_error_injection_mode`` (if any) keep
+        # working. ``_core`` import-cycles back into us only via TYPE_CHECKING
+        # so this runtime import is safe and cheap (cached after first call).
+        from . import _core as _core_module
+
+        # Capture event-loop affinity before any awaitable resource is built
+        # so the binding is consistent with the loop that owns every primitive
+        # constructed below.
+        self._bound_loop = asyncio.get_running_loop()
+        # Reset the drain flag so a previously-drained-then-reopened client
+        # admits new transport work again. Direct attribute write mirrors the
+        # legacy ``self._draining = False`` line.
+        host._drain_tracker._draining = False
+
+        # Use granular timeouts: shorter connect timeout helps detect network
+        # issues faster, while longer read/write timeouts accommodate slow
+        # responses.
+        timeout = httpx.Timeout(
+            connect=self._connect_timeout,
+            read=self._timeout,
+            write=self._timeout,
+            pool=self._timeout,
+        )
+
+        # Build cookies jar for cross-domain redirect support. Use the
+        # pre-built jar if available, otherwise build one from the persisted
+        # cookie list (or storage_path).
+        cookies = host.auth.cookie_jar or build_cookie_jar(
+            cookies=host.auth.cookies,
+            storage_path=host.auth.storage_path,
+        )
+
+        # Opt-in synthetic-error transport wrapper. When the env var is unset
+        # (the default) this is a no-op and the AsyncClient is constructed
+        # exactly as before. See ``_SyntheticErrorTransport`` docstring in
+        # ``_core.py`` module preamble.
+        error_mode = _core_module._get_error_injection_mode()
+        synthetic_transport: httpx.AsyncBaseTransport | None = None
+        if error_mode is not None:
+            # When we supply a custom ``transport=`` to ``AsyncClient``, httpx
+            # no longer constructs its own internal transport from the
+            # ``limits=`` kwarg below — those limits are consumed by the inner
+            # transport here instead, so connection-pool sizing remains
+            # identical to the no-injection path.
+            inner_transport = httpx.AsyncHTTPTransport(
+                limits=self._limits.to_httpx_limits(),
+            )
+            synthetic_transport = _core_module._SyntheticErrorTransport(error_mode, inner_transport)
+            logger.info(
+                "synthetic-error injection enabled (mode=%s) — "
+                "production paths will see substituted responses",
+                error_mode,
+            )
+
+        self._http_client = httpx.AsyncClient(
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+            cookies=cookies,
+            timeout=timeout,
+            follow_redirects=True,
+            # ``limits=`` is honored when ``transport=None`` (default) —
+            # httpx builds its own default transport with these limits.
+            # When ``transport=synthetic_transport`` (error-injection record
+            # mode) this kwarg is ignored by httpx and the inner_transport
+            # above carries the limits instead. The redundant pass is
+            # harmless and avoids a branch on the AsyncClient construction.
+            limits=self._limits.to_httpx_limits(),
+            transport=synthetic_transport,
+        )
+
+        # Capture the open-time snapshot AFTER the AsyncClient is built (httpx
+        # normalizes domains on ingest) but BEFORE any rotation could possibly
+        # fire. When AuthTokens carries a snapshot from a failed pre-client
+        # save, keep it so the unpersisted delta can be retried instead of
+        # treating the already-mutated jar as clean.
+        host.cookie_persistence.capture_open_snapshot(self._http_client.cookies)
+
+        # Spawn the keepalive task once the client is ready.
+        if self._keepalive_interval is not None:
+            self._keepalive_task = asyncio.create_task(
+                self._keepalive_loop(host, self._keepalive_interval)
+            )
+
+    async def save_cookies(
+        self,
+        host: _LifecycleHost,
+        jar: httpx.Cookies,
+        path: Path | None = None,
+    ) -> None:
+        """Persist a cookie jar through the shared cookie-persistence collaborator.
+
+        Single chokepoint used by :meth:`close`, :meth:`_keepalive_loop`, and
+        ``NotebookLMClient.refresh_auth``. The storage writer is resolved
+        from ``notebooklm._core`` at call time so the
+        ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+        surface used by 8+ test files keeps affecting the live save path.
+        """
+        from . import _core as _core_module
+
+        await host.cookie_persistence.save(
+            jar,
+            path,
+            save_cookies_to_storage=_core_module.save_cookies_to_storage,
+            to_thread=asyncio.to_thread,
+        )
+
+    async def close(self, host: _LifecycleHost) -> None:
+        """Close the HTTP client connection.
+
+        Cancellation safety: the entire close sequence is wrapped in
+        ``try/finally`` and the final ``aclose()`` is wrapped in
+        :func:`asyncio.shield` — without the shield, a ``CancelledError``
+        arriving during keepalive teardown or the cookie save would skip
+        ``aclose()`` and leak the underlying httpx transport.
+        ``self._http_client = None`` runs in an inner ``finally`` so the
+        instance is consistently marked closed even if the shielded
+        ``aclose()`` itself raises.
+
+        Poll-task drain: in-flight artifact poll tasks held by
+        ``host.poll_registry`` are cancelled and awaited before the HTTP
+        client is torn down. Without this, a leader poll waking mid-aclose
+        would issue a request against an already-closed transport and
+        surface as a confusing httpx error. The drain uses
+        ``return_exceptions=True`` so a single misbehaving task can't block
+        the rest of the close sequence.
+
+        Nulls out ``host._authed_transport`` and ``host._rpc_executor`` so a
+        follow-up :meth:`open` rebuilds the transport collaborators against
+        the new ``httpx.AsyncClient`` (the old ones close over the previous
+        client and would issue requests against the torn-down pool).
+        """
+        try:
+            # Stop the keepalive task before tearing down the HTTP client so
+            # the loop can't issue a poke against an already-closed transport.
+            if self._keepalive_task is not None:
+                self._keepalive_task.cancel()
+                await asyncio.gather(self._keepalive_task, return_exceptions=True)
+                self._keepalive_task = None
+
+            # Drain in-flight artifact poll tasks. Snapshot first so concurrent
+            # registry mutations (a finishing leader removing its entry) don't
+            # race with the cancel/gather pair.
+            poll_tasks = host.poll_registry.active_tasks()
+            if poll_tasks:
+                for task in poll_tasks:
+                    task.cancel()
+                await asyncio.gather(*poll_tasks, return_exceptions=True)
+
+            if self._http_client:
+                try:
+                    # Single source of truth for the on-close save: takes the
+                    # in-process lock, snapshots, off-loads. Serializes
+                    # naturally with any keepalive save still finishing in a
+                    # worker thread — close() owns the freshest jar and must
+                    # win, not the older snapshot.
+                    await self.save_cookies(host, self._http_client.cookies)
+                except Exception as e:
+                    logger.warning("Failed to sync refreshed cookies during close: %s", e)
+        finally:
+            if self._http_client:
+                try:
+                    # Shield: cancellation arriving mid-aclose must not leak
+                    # the transport. The shielded aclose runs to completion;
+                    # ``self._http_client = None`` then makes ``is_open``
+                    # return False correctly.
+                    await asyncio.shield(self._http_client.aclose())
+                finally:
+                    self._http_client = None
+                    # Null out the transport collaborators so a follow-up
+                    # ``open()`` rebuilds them against the new
+                    # ``httpx.AsyncClient`` (the old ones close over the
+                    # previous client).
+                    host._authed_transport = None
+                    host._rpc_executor = None
+
+    # ------------------------------------------------------------------
+    # Keepalive
+    # ------------------------------------------------------------------
+
+    async def _keepalive_loop(self, host: _LifecycleHost, interval: float) -> None:
+        """Background loop that periodically pokes the identity surface.
+
+        Sleeps ``interval`` seconds between iterations, then calls
+        :func:`notebooklm.auth._rotate_cookies` to elicit ``__Secure-1PSIDTS``
+        rotation. Any rotated cookies are persisted to ``storage_state.json``
+        immediately (off-loop, via :func:`asyncio.to_thread`) so a long-lived
+        client's freshness survives a crash.
+
+        Error handling is split by failure mode:
+
+        - Poke failures (network blips, ``accounts.google.com`` downtime) are
+          opportunistic and logged at DEBUG. The next iteration retries.
+        - Persistence failures hide the most important class of bug — a
+          rotated cookie that exists in memory but not on disk — so they are
+          logged at WARNING with the storage path.
+
+        Both classes never propagate; the loop only exits via
+        :class:`asyncio.CancelledError` from :meth:`close`.
+        """
+        logger.debug("Keepalive task started (interval=%.1fs)", interval)
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                client = self._http_client
+                if client is None:
+                    # Client closed concurrently; exit gracefully.
+                    return
+
+                try:
+                    # Bypass the layer-1 dedup guards: this loop is self-paced
+                    # by ``keepalive_min_interval`` and never runs concurrently
+                    # with itself. Pass the storage path so the bare call
+                    # bumps the *per-profile* in-process timestamp, letting
+                    # concurrent layer-1 callers (e.g. spawned ``fetch_tokens``
+                    # tasks on the same profile) and other keepalive loops on
+                    # the same profile see the fresh rotation and skip.
+                    #
+                    # Resolved from ``notebooklm._core`` at call time so the
+                    # existing ``monkeypatch.setattr("notebooklm._core._rotate_cookies",
+                    # …)`` surface in ``test_close_cancellation_leak.py`` keeps
+                    # affecting the live keepalive loop after the extraction.
+                    from . import _core as _core_module
+
+                    await _core_module._rotate_cookies(client, self._keepalive_storage_path)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - opportunistic best-effort
+                    logger.debug("Keepalive poke failed (non-fatal): %s", exc)
+                    continue
+
+                if self._keepalive_storage_path is None:
+                    continue
+
+                try:
+                    # save_cookies handles snapshot + lock + off-load.
+                    await self.save_cookies(host, client.cookies)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Keepalive cookie persistence to %s failed: %s",
+                        self._keepalive_storage_path,
+                        exc,
+                    )
+        except asyncio.CancelledError:
+            logger.debug("Keepalive task cancelled")
+            raise
+
+
+__all__ = ["ClientLifecycle", "_LifecycleHost"]

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -1,0 +1,532 @@
+"""Unit tests for :mod:`notebooklm._core_lifecycle`.
+
+Covers the load-bearing behaviors of :class:`ClientLifecycle` directly, in
+addition to the existing ``ClientCore``-shaped tests in
+``test_core_close.py`` / ``test_client_keepalive.py`` / ``test_vcr_config.py``
+which exercise the same helper through the compat facade.
+
+Specifically pinned here:
+
+* :meth:`ClientLifecycle.open` is **idempotent** — a second call while the
+  client is already open is a no-op (the first ``httpx.AsyncClient`` instance
+  is preserved).
+* :meth:`ClientLifecycle.close` **cancels and awaits the keepalive task
+  cleanly** — the task exits and is set to ``None``; the call doesn't leak a
+  ``CancelledError``.
+* ``_bound_loop`` **mismatch raises ``RuntimeError``** — the cross-loop guard
+  in :class:`AuthedTransport` reads ``_bound_loop`` through the lifecycle and
+  raises actionably when the loops differ.
+* :meth:`ClientLifecycle.save_cookies` **invokes** the host's
+  ``cookie_persistence.save`` collaborator with the right ``jar`` and
+  ``path`` arguments AND with the ``save_cookies_to_storage`` value resolved
+  from ``notebooklm._core`` at call time (so the monkeypatch surface keeps
+  working).
+* :class:`_SyntheticErrorTransport` **wrap activates only when**
+  :func:`_get_error_injection_mode` returns a non-``None`` value — the
+  default path constructs the ``AsyncClient`` with ``transport=None``.
+* :meth:`ClientLifecycle._keepalive_loop` **respects the min-interval
+  clamp** — ``_resolve_keepalive_interval`` floors the configured interval
+  at ``keepalive_min_interval`` so a sub-floor user value gets bumped up.
+
+Tests are intentionally helper-shaped (instantiate :class:`ClientLifecycle`
+directly with a Protocol-conformant stub host) so they cover the lifecycle
+without taking on a ``ClientCore`` dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from notebooklm import _core as _core_module
+from notebooklm._core import _resolve_keepalive_interval
+from notebooklm._core_lifecycle import ClientLifecycle
+from notebooklm.auth import AuthTokens
+from notebooklm.types import ConnectionLimits
+
+
+class _StubHost:
+    """Minimal :class:`_LifecycleHost`-conformant host for unit tests.
+
+    Mirrors the live ``ClientCore`` shape with simple ``MagicMock`` /
+    ``AsyncMock`` stand-ins for the collaborators the lifecycle reaches into:
+
+    * ``auth`` — a real :class:`AuthTokens` so :meth:`ClientLifecycle.open`
+      can read ``cookies`` / ``cookie_jar`` / ``storage_path``.
+    * ``_metrics_obj`` / ``_drain_tracker`` / ``_auth_coord`` —
+      ``MagicMock``s; the lifecycle only touches
+      ``_drain_tracker._draining = False`` from the open() path.
+    * ``cookie_persistence`` — a ``MagicMock`` with an async ``save``
+      coroutine; assertions check it was called with the right args.
+    * ``poll_registry`` — a ``MagicMock`` with ``active_tasks()`` returning
+      a list (defaults to empty so close() doesn't try to drain anything).
+    * ``_authed_transport`` / ``_rpc_executor`` — set to sentinel marker
+      values so tests can assert :meth:`ClientLifecycle.close` nulls them.
+    """
+
+    def __init__(self) -> None:
+        self.auth = AuthTokens(
+            csrf_token="CSRF",
+            session_id="SID",
+            cookies={"SID": "v1"},
+            storage_path=None,
+        )
+        self._metrics_obj = MagicMock()
+        self._drain_tracker = MagicMock()
+        self._drain_tracker._draining = True  # so we can assert open() resets it
+        self._auth_coord = MagicMock()
+        self.cookie_persistence = MagicMock()
+        self.cookie_persistence.save = AsyncMock()
+        self.cookie_persistence.capture_open_snapshot = MagicMock()
+        self.poll_registry = MagicMock()
+        self.poll_registry.active_tasks = MagicMock(return_value=[])
+        # Sentinels — close() nulls these out.
+        self._authed_transport: Any = "AUTHED_TRANSPORT_SENTINEL"
+        self._rpc_executor: Any = "RPC_EXECUTOR_SENTINEL"
+
+
+def _make_lifecycle(
+    *,
+    keepalive_interval: float | None = None,
+    keepalive_storage_path: Path | None = None,
+) -> ClientLifecycle:
+    """Construct a :class:`ClientLifecycle` with defaults safe for unit tests.
+
+    Default ``keepalive_interval=None`` means no background keepalive task is
+    spawned on :meth:`open` — tests that want the task pass an interval
+    explicitly.
+    """
+    return ClientLifecycle(
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        keepalive_interval=keepalive_interval,
+        keepalive_storage_path=keepalive_storage_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# open() — idempotency, bound-loop capture, AsyncClient construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_idempotent_preserves_existing_client() -> None:
+    """Second ``open()`` while already open is a no-op — same ``httpx.AsyncClient``."""
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    await lifecycle.open(host)
+    first_client = lifecycle._http_client
+    assert first_client is not None
+    assert lifecycle.is_open()
+
+    await lifecycle.open(host)
+    second_client = lifecycle._http_client
+
+    assert second_client is first_client, (
+        "open() must be idempotent — re-opening on an already-open lifecycle "
+        "should preserve the existing AsyncClient instance, not build a fresh one."
+    )
+
+    await lifecycle.close(host)
+
+
+@pytest.mark.asyncio
+async def test_open_captures_bound_loop_and_resets_drain() -> None:
+    """``open()`` binds the running loop and clears the host drain flag."""
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+    assert host._drain_tracker._draining is True
+    assert lifecycle._bound_loop is None
+
+    await lifecycle.open(host)
+
+    assert lifecycle._bound_loop is asyncio.get_running_loop()
+    assert lifecycle.get_bound_loop() is asyncio.get_running_loop()
+    assert host._drain_tracker._draining is False
+
+    await lifecycle.close(host)
+
+
+@pytest.mark.asyncio
+async def test_open_close_open_rebinds_loop() -> None:
+    """``close()`` does not unbind, but a subsequent ``open()`` re-captures
+    the current loop (used by clients that close + re-open within one loop)."""
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    await lifecycle.open(host)
+    bound_after_first_open = lifecycle._bound_loop
+    await lifecycle.close(host)
+
+    # close() does NOT clear _bound_loop — the cross-loop guard fires on the
+    # next call against a different loop if the user mistakenly hands the
+    # client off after close.
+    assert lifecycle._bound_loop is bound_after_first_open
+    assert lifecycle.is_open() is False
+
+    # Re-open on the same loop. New AsyncClient instance; same bound loop.
+    await lifecycle.open(host)
+    assert lifecycle._bound_loop is asyncio.get_running_loop()
+    assert lifecycle.is_open() is True
+    await lifecycle.close(host)
+
+
+@pytest.mark.asyncio
+async def test_open_captures_cookie_snapshot() -> None:
+    """``open()`` calls ``cookie_persistence.capture_open_snapshot`` with the
+    live ``httpx.Cookies`` jar AFTER the AsyncClient is built — preserving
+    the contract that the open-time baseline reflects httpx-normalized
+    domains.
+    """
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    await lifecycle.open(host)
+    try:
+        host.cookie_persistence.capture_open_snapshot.assert_called_once()
+        passed_jar = host.cookie_persistence.capture_open_snapshot.call_args.args[0]
+        # The jar passed to capture is the AsyncClient's live jar.
+        assert passed_jar is lifecycle._http_client.cookies  # type: ignore[union-attr]
+    finally:
+        await lifecycle.close(host)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-error transport — only wraps on opt-in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_does_not_wrap_synthetic_transport_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default path: ``_get_error_injection_mode`` returns ``None`` →
+    ``AsyncClient`` is built with no custom transport."""
+    monkeypatch.setattr(_core_module, "_get_error_injection_mode", lambda: None)
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    await lifecycle.open(host)
+    try:
+        client = lifecycle._http_client
+        assert client is not None
+        # When ``transport=None`` is passed to ``AsyncClient``, httpx builds
+        # its own default transport — never a ``_SyntheticErrorTransport``.
+        assert not isinstance(client._transport, _core_module._SyntheticErrorTransport)
+    finally:
+        await lifecycle.close(host)
+
+
+@pytest.mark.asyncio
+async def test_open_wraps_synthetic_transport_when_env_var_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in: ``_get_error_injection_mode`` returns a mode → the AsyncClient's
+    transport is a ``_SyntheticErrorTransport`` wrapping the inner transport."""
+    monkeypatch.setattr(_core_module, "_get_error_injection_mode", lambda: "429")
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    await lifecycle.open(host)
+    try:
+        client = lifecycle._http_client
+        assert client is not None
+        assert isinstance(client._transport, _core_module._SyntheticErrorTransport)
+    finally:
+        await lifecycle.close(host)
+
+
+# ---------------------------------------------------------------------------
+# close() — keepalive cancellation, sentinel null-out, idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_keepalive_cleanly() -> None:
+    """``close()`` cancels and awaits the keepalive task; no leaked exception.
+
+    Uses a very short interval (the lifecycle does not re-clamp; the caller
+    is expected to have passed the pre-clamped value) so the task has had a
+    chance to park on its ``asyncio.sleep`` before close() cancels it.
+    """
+    lifecycle = _make_lifecycle(keepalive_interval=0.01)
+    host = _StubHost()
+
+    await lifecycle.open(host)
+    task = lifecycle._keepalive_task
+    assert task is not None
+    assert not task.done()
+
+    # Yield once so the keepalive task actually parks on its sleep.
+    await asyncio.sleep(0)
+
+    await lifecycle.close(host)
+    assert lifecycle._keepalive_task is None, (
+        "close() must null out _keepalive_task after the cancel+gather."
+    )
+    assert task.cancelled() or task.done(), (
+        "keepalive task should be finished (cancelled) after close()."
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_nulls_authed_transport_and_rpc_executor() -> None:
+    """``close()`` nulls out the transport collaborator handles so a follow-up
+    ``open()`` rebuilds them against the new ``httpx.AsyncClient``.
+
+    Pre-extraction this lived inline in ``ClientCore``; the contract is
+    preserved by the lifecycle helper writing into ``host._authed_transport``
+    and ``host._rpc_executor``.
+    """
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+    await lifecycle.open(host)
+
+    # Sanity: sentinels still present pre-close.
+    assert host._authed_transport == "AUTHED_TRANSPORT_SENTINEL"
+    assert host._rpc_executor == "RPC_EXECUTOR_SENTINEL"
+
+    await lifecycle.close(host)
+
+    assert host._authed_transport is None
+    assert host._rpc_executor is None
+    assert lifecycle._http_client is None
+    assert lifecycle.is_open() is False
+
+
+@pytest.mark.asyncio
+async def test_close_when_never_opened_is_noop() -> None:
+    """Closing a never-opened lifecycle is safe and does nothing harmful."""
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    # No exception, no state churn beyond what's already None/sentinel.
+    await lifecycle.close(host)
+    assert lifecycle._http_client is None
+    assert lifecycle._keepalive_task is None
+
+
+@pytest.mark.asyncio
+async def test_close_drains_poll_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``close()`` snapshots and cancels in-flight poll tasks before tearing
+    down the HTTP client — without this, a leader poll waking mid-aclose
+    would issue a request against an already-closed transport.
+    """
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    # Build a real asyncio.Task that's parked indefinitely.
+    async def _park() -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            raise
+
+    parked = asyncio.create_task(_park())
+    # ``active_tasks`` returns the list close() should cancel.
+    host.poll_registry.active_tasks = MagicMock(return_value=[parked])
+
+    await lifecycle.open(host)
+    await lifecycle.close(host)
+
+    assert parked.cancelled() or parked.done(), (
+        "close() must cancel any active poll tasks before tearing down the client."
+    )
+
+
+# ---------------------------------------------------------------------------
+# save_cookies — invokes cookie_persistence with right args
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_cookies_invokes_cookie_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``save_cookies(host, jar, path)`` delegates to
+    ``host.cookie_persistence.save(...)`` with ``save_cookies_to_storage``
+    resolved from ``notebooklm._core`` at call time (so the
+    ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+    surface in 8+ test files keeps working).
+    """
+    # Stub out save_cookies_to_storage at the module level so we can prove
+    # the lifecycle resolved the monkeypatched value at call time.
+    sentinel = MagicMock()
+    monkeypatch.setattr(_core_module, "save_cookies_to_storage", sentinel)
+
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+    jar = httpx.Cookies()
+    jar.set("SID", "v2", domain=".google.com")
+    target_path = tmp_path / "storage_state.json"
+
+    await lifecycle.save_cookies(host, jar, target_path)
+
+    host.cookie_persistence.save.assert_awaited_once()
+    call = host.cookie_persistence.save.call_args
+    assert call.args[0] is jar
+    assert call.args[1] == target_path
+    # ``save_cookies_to_storage`` must be the monkeypatched sentinel — the
+    # lifecycle MUST resolve it from notebooklm._core at call time.
+    assert call.kwargs["save_cookies_to_storage"] is sentinel
+    assert call.kwargs["to_thread"] is asyncio.to_thread
+
+
+# ---------------------------------------------------------------------------
+# _bound_loop accessor + cross-loop guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bound_loop_get_returns_running_loop_after_open() -> None:
+    """``get_bound_loop()`` returns the captured loop after open().
+
+    The cross-loop affinity ``RuntimeError`` is raised by
+    :class:`AuthedTransport` (which reads ``_bound_loop`` via the host) on
+    actual cross-loop reuse — see
+    ``tests/integration/concurrency/test_cross_loop_affinity.py`` for the
+    end-to-end exercise. Here we only assert the lifecycle exposes the
+    captured loop via :meth:`get_bound_loop`.
+    """
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+
+    assert lifecycle.get_bound_loop() is None
+    await lifecycle.open(host)
+    try:
+        assert lifecycle.get_bound_loop() is asyncio.get_running_loop()
+    finally:
+        await lifecycle.close(host)
+
+
+def test_bound_loop_mismatch_via_clientcore_raises_runtime_error() -> None:
+    """Cross-loop reuse of a single :class:`ClientCore` raises a clean
+    ``RuntimeError`` on the second loop's first authed POST.
+
+    Reaches through the ``ClientCore`` facade (rather than ``ClientLifecycle``
+    in isolation) because the guard lives in :class:`AuthedTransport` and
+    only fires from inside an authed POST. The test runs two separate
+    ``asyncio.run`` invocations to materialise two distinct loops.
+    """
+    from notebooklm._core import ClientCore
+
+    auth = AuthTokens(csrf_token="CSRF", session_id="SID", cookies={"SID": "v1"})
+    core = ClientCore(auth=auth)
+
+    async def _open_on_loop_a() -> None:
+        await core.open()
+        # We deliberately do NOT call core.close() because close() resets
+        # _http_client (which would let loop B's open() re-bind the loop
+        # and skip the guard). The whole point is that the guard fires when
+        # _bound_loop is set from a different loop and a request is attempted
+        # without an intervening close().
+
+    def _build_request_stub(snapshot: Any) -> tuple[httpx.Request, Any]:
+        return (
+            httpx.Request(
+                "POST",
+                "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
+            ),
+            None,
+        )
+
+    async def _attempt_post_on_loop_b() -> Exception | None:
+        # ``open()`` is idempotent — since loop A left ``_http_client``
+        # populated, this is a no-op and ``_bound_loop`` stays bound to loop A.
+        await core.open()
+        try:
+            await core._perform_authed_post(
+                build_request=_build_request_stub,
+                log_label="test.cross_loop",
+            )
+        except RuntimeError as exc:
+            return exc
+        return None
+
+    asyncio.run(_open_on_loop_a())
+    exc = asyncio.run(_attempt_post_on_loop_b())
+    assert isinstance(exc, RuntimeError), (
+        f"Cross-loop authed POST must raise RuntimeError; got {exc!r}"
+    )
+    # The guard's message mentions the loop affinity invariant — match a
+    # stable substring rather than the exact phrasing.
+    assert "loop" in str(exc).lower(), f"Unexpected RuntimeError text: {exc!r}"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_keepalive_interval clamping (stays in _core.py preamble)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_keepalive_interval_clamps_to_min_floor() -> None:
+    """``_resolve_keepalive_interval`` floors a too-small user value at
+    ``min_interval`` — preserving the "accidentally rate-limiting Google's
+    identity surface" guard the lifecycle inherits from the resolver.
+
+    The resolver stays in ``_core.py``'s module preamble per the master
+    plan; this test belongs alongside the lifecycle suite because the
+    clamped value is what the lifecycle stores in ``_keepalive_interval``.
+    """
+    # User asks for 1s — much lower than the 60s default floor.
+    resolved = _resolve_keepalive_interval(keepalive=1.0, min_interval=60.0)
+    assert resolved == 60.0
+
+
+def test_resolve_keepalive_interval_passes_through_above_floor() -> None:
+    """A user value above the floor passes through unchanged."""
+    resolved = _resolve_keepalive_interval(keepalive=120.0, min_interval=60.0)
+    assert resolved == 120.0
+
+
+def test_resolve_keepalive_interval_none_disables() -> None:
+    """``None`` disables the keepalive (no background task spawned)."""
+    resolved = _resolve_keepalive_interval(keepalive=None, min_interval=60.0)
+    assert resolved is None
+
+
+def test_resolve_keepalive_interval_rejects_non_positive() -> None:
+    """Zero / negative / NaN values raise ``ValueError`` instead of silently
+    disabling — surface misconfiguration loudly at construction time."""
+    with pytest.raises(ValueError):
+        _resolve_keepalive_interval(keepalive=0, min_interval=60.0)
+    with pytest.raises(ValueError):
+        _resolve_keepalive_interval(keepalive=-1.0, min_interval=60.0)
+    with pytest.raises(ValueError):
+        _resolve_keepalive_interval(keepalive=1.0, min_interval=0)
+
+
+# ---------------------------------------------------------------------------
+# Construction-time invariants
+# ---------------------------------------------------------------------------
+
+
+def test_init_is_event_loop_agnostic() -> None:
+    """Constructing a ``ClientLifecycle`` outside a running loop must not
+    raise. The helper stores only plain values and ``None`` placeholders;
+    the ``httpx.AsyncClient`` and keepalive task are deferred to ``open()``.
+    """
+    # Outside ``asyncio.run`` — no running loop available.
+    lifecycle = ClientLifecycle(
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        keepalive_interval=60.0,
+        keepalive_storage_path=Path("/tmp/storage.json"),
+    )
+    assert lifecycle._http_client is None
+    assert lifecycle._bound_loop is None
+    assert lifecycle._keepalive_task is None
+    assert lifecycle._keepalive_interval == 60.0
+    assert lifecycle._keepalive_storage_path == Path("/tmp/storage.json")
+    assert lifecycle._timeout == 30.0
+    assert lifecycle._connect_timeout == 10.0
+    assert lifecycle.is_open() is False
+    assert lifecycle.get_bound_loop() is None


### PR DESCRIPTION
## Summary

Phase 2 / Wave 2 (B2) of the core-decomposition mini-phase. Extracts the HTTP-client lifecycle state and behavior from ``ClientCore`` into a new ``ClientLifecycle`` helper in ``src/notebooklm/_core_lifecycle.py``, following the Protocol-shim host pattern established by A1 (``ClientMetrics``), A2 (``TransportDrainTracker``), and B1 (``AuthRefreshCoordinator``).

The helper owns the 8 lifecycle ivars (``_http_client``, ``_bound_loop``, ``_keepalive_task``, ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``, ``_connect_timeout``, ``_limits``) and the 4 lifecycle methods (``open``, ``close``, ``save_cookies``, ``_keepalive_loop``) plus ``is_open()`` / ``get_bound_loop()`` accessors. ``ClientCore`` retains the four method names as thin facade delegates and exposes the 8 ivars via ``@property`` bridges.

## Task

Phase-2 plan: ``.sisyphus/phases/core-decomposition-mini-phase/phase-2.md`` (B2 task spec, lines 122-200). B1 (``AuthRefreshCoordinator`` extract) merged via PR #789 and is already in ``main`` — this PR bases on ``main`` directly (dispatch contemplated retargeting once B1 lands).

## Module-level surface preserved on ``notebooklm._core``

- ``_SyntheticErrorTransport`` / ``_get_error_injection_mode`` / ``_resolve_keepalive_interval`` STAY in ``_core.py`` preamble per master plan — ``tests/unit/test_vcr_config.py:35-36`` imports them by name.
- ``save_cookies_to_storage`` and ``_rotate_cookies`` are explicitly re-exported via ``from .auth import … as …`` so the ``monkeypatch.setattr("notebooklm._core.<name>", …)`` surface used by 9+ test files keeps working. The lifecycle helper resolves both names at call time via ``from . import _core as _core_module`` so the monkeypatched value reaches the live save / keepalive paths.

## Compat property bridges on ``ClientCore``

- ``_http_client`` — getter+setter (15+ test SET sites)
- ``_bound_loop`` — getter+setter (master plan F4/F5 finding; future C1 access)
- ``_keepalive_task`` / ``_keepalive_interval`` / ``_keepalive_storage_path`` / ``_timeout`` / ``_connect_timeout`` / ``_limits`` — getter+setter (setters added to match pre-extraction "plain ivar = writeable" semantics; ``_timeout`` setter is REQUIRED by ``RpcOwner`` Protocol's ``_timeout: float`` shape)

## Behavior addition (intentional, per dispatch acceptance criteria)

``ClientLifecycle.close()`` nulls ``host._authed_transport`` and ``host._rpc_executor`` after the shielded ``aclose()``. Pre-extraction ``ClientCore.close()`` on ``main`` did not null these (verified). The phase-2 acceptance criteria explicitly list this as "(existing behavior)" — that annotation in the plan was slightly inaccurate but the intent is clear. The collaborators close over the *host* (not the AsyncClient) and re-read ``host._http_client`` on each call, so nulling here is harmless: it forces clean lazy re-construction on the next ``_get_authed_transport`` / ``_get_rpc_executor`` access after a close → reopen cycle. Verified no test asserts the pre-existing "left intact" shape and no first-party caller relies on it.

## Test plan

- [x] ``uv run ruff format src/notebooklm tests`` — 364 files unchanged
- [x] ``uv run ruff check src/notebooklm tests`` — all checks passed
- [x] ``uv run mypy src/notebooklm --ignore-missing-imports`` — no issues in 115 source files
- [x] ``uv run pytest tests/unit/test_core_close.py tests/unit/test_client_keepalive.py tests/unit/test_env_base_url.py tests/unit/test_vcr_config.py tests/unit/test_observability.py tests/unit/test_init_order.py tests/unit/test_core_lifecycle.py -v`` — 173 passed
- [x] ``uv run pytest tests/unit/test_auth_cookie_save_race.py -v`` — 53 passed
- [x] ``uv run pytest`` — 5124 passed, 20 skipped
- [x] No VCR cassettes re-recorded

## New tests (``tests/unit/test_core_lifecycle.py``, 18 tests)

Covers all 6 acceptance criteria from the plan plus 5 additional invariants:
- ``open()`` idempotency, bound-loop capture, drain reset, cookie snapshot capture, close → reopen rebinding
- ``_SyntheticErrorTransport`` opt-in (default off / env var on)
- ``close()`` keepalive cancellation, transport collaborator null-out, no-op when never opened, poll-task drain
- ``save_cookies`` invokes ``cookie_persistence.save`` with call-time-resolved ``save_cookies_to_storage`` (monkeypatch surface guard)
- ``_bound_loop`` mismatch via ``ClientCore`` raises ``RuntimeError`` (cross-loop guard exercised through ``AuthedTransport``)
- ``_resolve_keepalive_interval`` clamping (floor / pass-through / ``None`` / non-positive rejection)
- ``__init__`` is event-loop-agnostic

## Polish gate (per ``/execute-task`` Step 4)

- **Stage 1 (code-simplifier):** 0 applied, 6 patterns reviewed and deferred with rationale (call-time module resolution for monkeypatch surface, nested try/except for cancellation safety, etc. — all load-bearing).
- **Stage 2 (triple review):** claude single-reviewer pass clean (1 critical candidate identified — close() nulling transport collaborators — verified intentional per dispatch acceptance criteria after re-reading the spec). codex CLI ran but echoed input without producing findings; gemini CLI produced empty output. Single-reviewer claude pass is documented here.
- **Stage 3 (ultrathink):** 1 minor pre-existing risk noted (``open()`` doesn't wrap ``capture_open_snapshot`` in try/except — preserves pre-extraction behavior); no critical/important findings.

## Cross-phase notes

Phase 3's C1 (RPC dispatch collapse) needs B2's ``ClientLifecycle`` for the ``_perform_authed_post`` event-loop affinity check. The ``ClientLifecycle.get_bound_loop()`` accessor was added per master plan F4 finding for clean C1 access without reaching for the two-underscore ``_bound_loop`` attribute.