### PR TITLE
refactor(core): audit public surface and tighten _core module (D1 final)

### DIFF
--- a/docs/auth-keepalive.md
+++ b/docs/auth-keepalive.md
@@ -528,8 +528,11 @@ reading `auth.py` against the lifecycle of `NotebookLMClient` /
 
 #### 3.4.1 Stale in-memory clobbers fresh disk (the "few-hours" pattern)
 
-> **Resolved in #361.** ``ClientCore`` now captures an open-time
-> ``CookieSnapshotKey -> CookieSnapshotValue`` snapshot of its jar; ``save_cookies_to_storage``
+> **Resolved in #361.** ``CookiePersistence`` (see
+> ``src/notebooklm/_core_cookie_persistence.py``; driven by ``ClientLifecycle``
+> at open-time, ``src/notebooklm/_core_lifecycle.py``) now captures an
+> open-time ``CookieSnapshotKey -> CookieSnapshotValue`` snapshot of its jar;
+> ``save_cookies_to_storage``
 > accepts an ``original_snapshot=...`` kwarg and, when provided, writes only
 > the deltas (cookies whose persisted tuple differs from the snapshot) plus deletions
 > (cookies present in the snapshot but absent from the jar) — both arms

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,8 +305,7 @@ longer read timeout accommodates slow server responses. Both are exposed as
 constructor arguments on `NotebookLMClient` (`timeout=` and `connect_timeout=`)
 for callers that need to tune them per-workload — see the
 `DEFAULT_TIMEOUT` / `DEFAULT_CONNECT_TIMEOUT` constants in
-`src/notebooklm/_core.py` and `MAX_CONVERSATION_CACHE_SIZE` in
-`src/notebooklm/_core_cache.py`. The chat streaming endpoint
+`src/notebooklm/_core.py`. The chat streaming endpoint
 (`ChatAPI.ask`) keeps its own longer per-stream deadlines because individual
 chat responses can exceed 30 seconds; refer to the Python API reference for
 its `timeout=` argument.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,8 +303,10 @@ default, with a tighter **10-second** connection-establishment timeout. The
 shorter connect timeout helps surface network-level issues quickly while the
 longer read timeout accommodates slow server responses. Both are exposed as
 constructor arguments on `NotebookLMClient` (`timeout=` and `connect_timeout=`)
-for callers that need to tune them per-workload — see
-`src/notebooklm/_core.py:55-57, 278-295`. The chat streaming endpoint
+for callers that need to tune them per-workload — see the
+`DEFAULT_TIMEOUT` / `DEFAULT_CONNECT_TIMEOUT` constants in
+`src/notebooklm/_core.py` and `MAX_CONVERSATION_CACHE_SIZE` in
+`src/notebooklm/_core_cache.py`. The chat streaming endpoint
 (`ChatAPI.ask`) keeps its own longer per-stream deadlines because individual
 chat responses can exceed 30 seconds; refer to the Python API reference for
 its `timeout=` argument.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -7,7 +7,6 @@ import random  # noqa: F401 - tests patch this for _backoff jitter
 import threading
 import time
 import warnings
-import weakref
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, nullcontext
 from pathlib import Path
@@ -508,11 +507,12 @@ class ClientCore:
         # the keepalive background task all live on ``self._lifecycle``
         # (constructed below alongside the other extracted helpers so the
         # inter-helper dependency order is obvious). Compat properties further
-        # down preserve the legacy ``_timeout`` / ``_connect_timeout`` /
-        # ``_limits`` / ``_http_client`` / ``_bound_loop`` /
-        # ``_keepalive_task`` / ``_keepalive_interval`` /
+        # down preserve the legacy ``_timeout`` / ``_http_client`` /
+        # ``_bound_loop`` / ``_keepalive_task`` / ``_keepalive_interval`` /
         # ``_keepalive_storage_path`` ivar names for tests and first-party
-        # callers that probe or assign them directly.
+        # callers that probe or assign them directly. The
+        # ``_connect_timeout`` / ``_limits`` bridges were dropped in
+        # D1-audit-full; access them via ``self._lifecycle`` if needed.
         _resolved_limits = limits if limits is not None else ConnectionLimits()
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
@@ -578,18 +578,22 @@ class ClientCore:
         self._metrics_obj = ClientMetrics(on_rpc_event=on_rpc_event)
         # Transport drain bookkeeping (in-flight posts, drain condition,
         # per-task operation depth, draining flag). Compat properties below
-        # (``_in_flight_posts`` / ``_drain_condition`` / ``_operation_depths``
-        # / ``_draining``) bridge the legacy ivar names back into this
-        # helper. The helper's ``__init__`` is event-loop-agnostic; the
+        # (``_in_flight_posts`` / ``_drain_condition`` / ``_draining``)
+        # bridge the legacy ivar names back into this helper. The
+        # ``_operation_depths`` bridge was dropped in D1-audit-full; access
+        # the WeakKeyDictionary on ``self._drain_tracker`` directly. The
+        # helper's ``__init__`` is event-loop-agnostic; the
         # ``asyncio.Condition`` is created lazily on first
         # ``get_drain_condition`` call.
         self._drain_tracker = TransportDrainTracker()
         # Request ID counter for chat API (must be unique per request).
         # The :class:`ReqidCounter` helper owns the monotonic ``_value`` and
         # the lazily-allocated ``asyncio.Lock`` that serialises mutation.
-        # Compat properties below (``_reqid_counter`` /
-        # ``_reqid_counter_value`` / ``_reqid_lock``) bridge the legacy ivar
-        # names back into this helper. The ``on_lock_wait`` hook keeps the
+        # The ``_reqid_counter`` compat property below bridges the legacy
+        # ivar name back into this helper; ``_reqid_counter_value`` and
+        # ``_reqid_lock`` bridges were dropped in D1-audit-full (access
+        # ``self._reqid.value`` / ``self._reqid._lock`` directly if needed).
+        # The ``on_lock_wait`` hook keeps the
         # cumulative ``lock_wait_seconds_*`` metrics ticking inside
         # ``self._metrics_obj`` even though the counter is now extracted.
         self._reqid = ReqidCounter(on_lock_wait=self._record_lock_wait)
@@ -597,8 +601,11 @@ class ClientCore:
         # serialization, and cookie-jar sync. The coordinator owns
         # ``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``, and
         # ``_auth_snapshot_lock``; field names match the legacy
-        # ``ClientCore`` ivars so the compat properties below delegate
-        # cleanly. The ``_auth_snapshot_lock`` is intentionally distinct
+        # ``ClientCore`` ivars so the surviving compat properties
+        # (``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``)
+        # delegate cleanly. The ``_auth_snapshot_lock`` bridge was dropped
+        # in D1-audit-full; the live lock is reachable via
+        # :meth:`_get_auth_snapshot_lock`. The auth snapshot lock is intentionally distinct
         # from ``_refresh_lock`` — mixing them would re-introduce the
         # reentrancy ambiguity that snapshot-side serialization was added
         # to avoid. The attribute name ``_auth_coord`` is part of the
@@ -737,15 +744,8 @@ class ClientCore:
         self._ensure_observability_state()
         self._drain_tracker._drain_condition = value
 
-    @property
-    def _operation_depths(self) -> weakref.WeakKeyDictionary[asyncio.Task[Any], int]:
-        self._ensure_observability_state()
-        return self._drain_tracker._operation_depths
-
-    @_operation_depths.setter
-    def _operation_depths(self, value: weakref.WeakKeyDictionary[asyncio.Task[Any], int]) -> None:
-        self._ensure_observability_state()
-        self._drain_tracker._operation_depths = value
+    # ``_operation_depths`` compat bridge dropped (D1-audit-full): zero
+    # external callers; direct ivar lives on ``self._drain_tracker``.
 
     # ------------------------------------------------------------------
     # ``AuthRefreshCoordinator`` compat bridges. Refresh/auth-snapshot state
@@ -812,27 +812,21 @@ class ClientCore:
         self._ensure_auth_coord()
         self._auth_coord._refresh_callback = value
 
-    @property
-    def _auth_snapshot_lock(self) -> asyncio.Lock | None:
-        self._ensure_auth_coord()
-        return self._auth_coord._auth_snapshot_lock
-
-    @_auth_snapshot_lock.setter
-    def _auth_snapshot_lock(self, value: asyncio.Lock | None) -> None:
-        self._ensure_auth_coord()
-        self._auth_coord._auth_snapshot_lock = value
+    # ``_auth_snapshot_lock`` compat bridge dropped (D1-audit-full): zero
+    # external callers. Live accessor remains ``_get_auth_snapshot_lock()`` /
+    # ``AuthRefreshCoordinator.get_auth_snapshot_lock()``.
 
     # ------------------------------------------------------------------
     # ``ClientLifecycle`` compat bridges. HTTP-client lifecycle state now
-    # lives on ``self._lifecycle``; the eight legacy ivar names (
-    # ``_http_client``, ``_bound_loop``, ``_keepalive_task``,
-    # ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``,
-    # ``_connect_timeout``, ``_limits``) are preserved here as
-    # ``@property`` bridges. ``_http_client`` and ``_bound_loop`` carry
-    # writeable setters because tests SET them directly (15+ sites for
-    # ``_http_client``; ``_bound_loop`` setter is required by the master
-    # plan for future C1 access patterns). The other six are getter-only
-    # because no SET sites were found in the test surface.
+    # lives on ``self._lifecycle``; the six surviving legacy ivar names
+    # (``_http_client``, ``_bound_loop``, ``_keepalive_task``,
+    # ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``)
+    # are preserved here as ``@property`` bridges. The
+    # ``_connect_timeout`` / ``_limits`` bridges were dropped in
+    # D1-audit-full (zero external callers). The ``_timeout`` bridge is
+    # retained because ``RpcExecutor`` (``_core_rpc.py``) reads
+    # ``self._owner._timeout`` via the :class:`RpcOwner` Protocol; removing
+    # it would surface as ``AttributeError`` on every RPC call.
     # ``_ensure_lifecycle`` mirrors the ``_ensure_observability_state`` /
     # ``_ensure_auth_coord`` backfill so ``__new__``-built fixtures (no
     # ``__init__`` ran) still resolve cleanly.
@@ -936,25 +930,10 @@ class ClientCore:
         self._ensure_lifecycle()
         self._lifecycle._timeout = value
 
-    @property
-    def _connect_timeout(self) -> float:
-        self._ensure_lifecycle()
-        return self._lifecycle._connect_timeout
-
-    @_connect_timeout.setter
-    def _connect_timeout(self, value: float) -> None:
-        self._ensure_lifecycle()
-        self._lifecycle._connect_timeout = value
-
-    @property
-    def _limits(self) -> "ConnectionLimits":
-        self._ensure_lifecycle()
-        return self._lifecycle._limits
-
-    @_limits.setter
-    def _limits(self, value: "ConnectionLimits") -> None:
-        self._ensure_lifecycle()
-        self._lifecycle._limits = value
+    # ``_connect_timeout`` and ``_limits`` compat bridges dropped
+    # (D1-audit-full): zero external callers; live values remain on
+    # ``self._lifecycle`` (and the lifecycle helper reads them as plain
+    # ivars when it builds the ``httpx.AsyncClient``).
 
     # ------------------------------------------------------------------
     # Request-id counter (chat API requires a monotonic ``_reqid`` URL param).
@@ -965,14 +944,15 @@ class ClientCore:
     # values that Google rejects.
     #
     # New contract: ``await core.next_reqid()`` performs the increment under
-    # ``_reqid_lock`` and returns the post-increment value. The state lives in
-    # :class:`notebooklm._core_reqid.ReqidCounter` (``self._reqid``); the
-    # properties below are read/write bridges that keep the legacy
-    # ``_reqid_counter`` / ``_reqid_counter_value`` / ``_reqid_lock`` ivar
-    # names observable for existing tests and first-party callers. Direct
-    # mutation of ``_reqid_counter`` still works for backwards compatibility
-    # but emits ``DeprecationWarning`` — bypass the warning for legitimate
-    # test setup by writing to ``_reqid_counter_value`` instead.
+    # ``ReqidCounter._lock`` and returns the post-increment value. The state
+    # lives in :class:`notebooklm._core_reqid.ReqidCounter` (``self._reqid``);
+    # the ``_reqid_counter`` property below is the last surviving read/write
+    # bridge — direct mutation of ``_reqid_counter`` still works for
+    # backwards compatibility but emits ``DeprecationWarning``. The
+    # ``_reqid_counter_value`` / ``_reqid_lock`` compat bridges were dropped
+    # (D1-audit-full): zero external callers; tests that need to seed the
+    # counter or substitute the lock should reach through ``self._reqid``
+    # directly.
     # ------------------------------------------------------------------
 
     @property
@@ -991,34 +971,6 @@ class ClientCore:
             stacklevel=2,
         )
         self._reqid.set_value(value)
-
-    @property
-    def _reqid_counter_value(self) -> int:
-        """Bypass-warning bridge for tests that seed the counter directly.
-
-        Writing through ``_reqid_counter`` emits a ``DeprecationWarning``;
-        test fixtures that legitimately need to set the counter without
-        paying that tax write to ``_reqid_counter_value`` instead.
-        """
-        return self._reqid.value
-
-    @_reqid_counter_value.setter
-    def _reqid_counter_value(self, value: int) -> None:
-        self._reqid.set_value(value)
-
-    @property
-    def _reqid_lock(self) -> asyncio.Lock | None:
-        """Bridge to the lazily-allocated reqid lock.
-
-        Historically a plain ivar; preserved as a property with a setter so
-        test fixtures that inject their own ``asyncio.Lock`` (or reset it to
-        ``None`` to force re-allocation) continue to work.
-        """
-        return self._reqid._lock
-
-    @_reqid_lock.setter
-    def _reqid_lock(self, value: asyncio.Lock | None) -> None:
-        self._reqid._lock = value
 
     @property
     def _pending_polls(self) -> PendingPolls:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -605,8 +605,9 @@ class ClientCore:
         # (``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``)
         # delegate cleanly. The ``_auth_snapshot_lock`` bridge was dropped
         # in D1-audit-full; the live lock is reachable via
-        # :meth:`_get_auth_snapshot_lock`. The auth snapshot lock is intentionally distinct
-        # from ``_refresh_lock`` — mixing them would re-introduce the
+        # :meth:`_get_auth_snapshot_lock`.
+        # The auth snapshot lock is intentionally distinct from
+        # ``_refresh_lock`` — mixing them would re-introduce the
         # reentrancy ambiguity that snapshot-side serialization was added
         # to avoid. The attribute name ``_auth_coord`` is part of the
         # inter-helper contract for the upcoming B2/C1 extractions; do not

--- a/src/notebooklm/_core_auth.py
+++ b/src/notebooklm/_core_auth.py
@@ -233,9 +233,9 @@ class AuthRefreshCoordinator:
             raise RuntimeError(
                 "AuthRefreshCoordinator.await_refresh called without a "
                 "refresh_callback configured — wire one via "
-                "ClientCore(refresh_callback=...) or "
-                "self._auth_coord._refresh_callback = ... before triggering "
-                "an auth refresh."
+                "AuthRefreshCoordinator(refresh_callback=...) (or by "
+                "constructing ClientCore with refresh_callback=...) before "
+                "triggering an auth refresh."
             )
 
         # Lazy-init the lock on first refresh attempt. Every concurrent

--- a/src/notebooklm/_core_drain.py
+++ b/src/notebooklm/_core_drain.py
@@ -34,10 +34,12 @@ Design constraints (load-bearing — see
   fully inside the ``async with condition`` block.
 
 Field names are deliberately the same as the legacy ``ClientCore`` ivars
-(``_in_flight_posts``, ``_draining``, ``_drain_condition``,
-``_operation_depths``) so the compat ``@property`` bridges on
-``ClientCore`` can delegate via ``return self._drain_tracker._<attr>``
-and stay readable.
+(``_in_flight_posts``, ``_draining``, ``_drain_condition``) so the
+surviving compat ``@property`` bridges on ``ClientCore`` can delegate via
+``return self._drain_tracker._<attr>`` and stay readable. The
+``_operation_depths`` compat bridge on ``ClientCore`` was dropped in
+D1-audit-full once its callers migrated; the field itself remains on
+``TransportDrainTracker`` because the drain bookkeeping needs it.
 """
 
 from __future__ import annotations

--- a/src/notebooklm/_core_reqid.py
+++ b/src/notebooklm/_core_reqid.py
@@ -60,11 +60,12 @@ def _noop_record_lock_wait(_wait_seconds: float) -> None:
 class ReqidCounter:
     """Monotonic request-id counter with lazy ``asyncio.Lock`` serialisation.
 
-    Field names are deliberately the same as the legacy ``ClientCore`` ivars
-    (``_value`` mirroring ``_reqid_counter_value``, ``_lock`` mirroring
-    ``_reqid_lock``) so the compat ``@property`` bridges on ``ClientCore`` can
-    delegate with ``return self._reqid._<attr>`` / write through with
-    ``self._reqid._<attr> = value`` and stay readable.
+    The canonical accessor surface is ``self._reqid._value`` and
+    ``self._reqid._lock`` on ``ClientCore``. The ``_reqid_counter_value`` /
+    ``_reqid_lock`` compat ``@property`` bridges on ``ClientCore`` that
+    previously delegated here were dropped in D1-audit-full once their
+    callers migrated; the field names persist for direct access from
+    ``ClientCore`` and from unit-test fixtures.
     """
 
     def __init__(
@@ -74,9 +75,9 @@ class ReqidCounter:
         on_lock_wait: Callable[[float], None] | None = None,
     ) -> None:
         # Plain int; mutated only inside :meth:`next_reqid` under ``_lock`` or
-        # via the ``ClientCore._reqid_counter_value`` writethrough used by
-        # test fixtures that want to seed the counter without paying the
-        # deprecation-warning tax on the public ``_reqid_counter`` setter.
+        # via direct ``self._reqid._value = …`` writethrough from test fixtures
+        # that want to seed the counter without paying the deprecation-warning
+        # tax on the public ``_reqid_counter`` setter on ``ClientCore``.
         self._value: int = baseline
         # Lazily-created — ``asyncio.Lock()`` needs a running loop in some
         # Python versions, and this object is constructed inside


### PR DESCRIPTION
## Summary

Phase 4 audit subset of the core-decomposition mini-phase. The docs / conformance / claude-cleanup subsets shipped separately as #790, #794, #792. **No behavior changes** — pure cleanup.

- Drop 6 zero-caller compat properties (`_operation_depths`, `_auth_snapshot_lock`, `_connect_timeout`, `_limits`, `_reqid_counter_value`, `_reqid_lock`) introduced as A1-B2 transitional shims. Net **-48 lines** on `_core.py`.
- Fix 2 stale docs (`configuration.md:307` line numbers, `auth-keepalive.md:531` ClientCore→ClientLifecycle attribution).
- Fix orphan claude-bot finding on #793 (`_core_auth.py:236-238` error message no longer leaks `self._auth_coord._refresh_callback` as a recommended workaround).

## Compat-shim removal evidence

| Property | Grep cmd | Hits | Decision |
|---|---|---:|---|
| `_operation_depths` | `grep -rEn "core\._operation_depths\b\|self\._core\._operation_depths\b" src/ tests/` | 0 | DROP |
| `_auth_snapshot_lock` | (same shape) | 0 | DROP |
| `_connect_timeout` | (same shape) | 0 | DROP |
| `_limits` | (same shape) | 0 | DROP |
| `_reqid_counter_value` | (same shape) | 0 | DROP |
| `_reqid_lock` | (same shape) | 0 | DROP |

Every other `@property` on `ClientCore` retains ≥1 caller (20+ remain, listed in the commit message). Kept unchanged per the spec.

## Module-level surface

All 19 importables from the spec resolve cleanly. `get_source_ids` facade preserved (26+ test callers).

## LOC: 1526 (target was <600)

Headline LOC target not met. Driving below 600 requires a behavior-touching refactor (collapsing the surviving property bridges or merging `_snapshot` / `update_auth_tokens` with their helper counterparts) — explicitly out of scope for D1-audit-full.

Per the spec (`Do NOT block the PR if LOC > 600; maintainer files follow-up issue manually`), shipping as-is. Recommend filing a follow-up issue tracking the bridge-collapse refactor against the surviving `update_auth_tokens` in-place assignment surface that 30+ tests depend on.

## Verification

- ruff format / check / mypy clean
- pytest: **5143 passed, 25 skipped** (full suite + integration)
- 19-symbol module surface smoke test: OK

## Test plan

- [x] `uv run ruff format src/notebooklm tests docs`
- [x] `uv run ruff check src/notebooklm tests`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run pytest tests/unit tests/integration`
- [x] `uv run pytest tests/unit/test_capabilities_conformance.py -v`
- [x] Module-level smoke test (19 importables from `notebooklm._core`)
- [x] Per-property grep evidence captured (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication persistence behavior, HTTP timeout/connection tuning guidance and related configuration constants; also updated wording around auth-refresh guidance.
* **Refactor**
  * Removed legacy backward-compatibility bridges from core client APIs to simplify the public surface and maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->