### PR TITLE
feat(idempotency): 6-policy registry with operation variants + RpcExecutor consultation (B1)

### DIFF
--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -18,9 +18,10 @@ class CoreRPCProvider(Protocol):
 
     Mirrors :meth:`ClientCore.rpc_call` exactly, including the kw-only
     ``disable_internal_retries`` flag used by mutating-create RPCs that
-    must skip the inner 5xx/429 retry loop. Sub-clients that only need
-    to issue RPC calls type their constructor on this provider rather
-    than on the concrete ``ClientCore``.
+    must skip the inner 5xx/429 retry loop and the ``operation_variant``
+    kwarg consulted by the mutating-RPC idempotency registry. Sub-clients
+    that only need to issue RPC calls type their constructor on this
+    provider rather than on the concrete ``ClientCore``.
     """
 
     async def rpc_call(
@@ -32,6 +33,7 @@ class CoreRPCProvider(Protocol):
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any: ...
 
 
@@ -154,6 +156,7 @@ class ClientCoreCapabilities(
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         return await self._core.rpc_call(
             method,
@@ -162,6 +165,7 @@ class ClientCoreCapabilities(
             allow_null=allow_null,
             _is_retry=_is_retry,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -1419,6 +1419,7 @@ class ClientCore:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         """Compatibility wrapper around :meth:`RpcExecutor.execute_with_telemetry`.
 
@@ -1428,8 +1429,8 @@ class ClientCore:
         attribute keep working. See
         :meth:`notebooklm._core_rpc.RpcExecutor.execute_with_telemetry` for
         the full contract (kwargs ``_is_retry`` / ``disable_internal_retries``
-        flow through unchanged; ``RuntimeError`` is raised if the client is
-        not initialized).
+        / ``operation_variant`` flow through unchanged; ``RuntimeError`` is
+        raised if the client is not initialized).
         """
         return await self._get_rpc_executor().execute_with_telemetry(
             method,
@@ -1438,6 +1439,7 @@ class ClientCore:
             allow_null,
             _is_retry,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     async def _rpc_call_impl(
@@ -1449,6 +1451,7 @@ class ClientCore:
         _is_retry: bool,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         """Compatibility wrapper around :class:`RpcExecutor`."""
         return await self._get_rpc_executor().execute(
@@ -1458,6 +1461,7 @@ class ClientCore:
             allow_null,
             _is_retry,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     def _raise_rpc_error_from_http_status(
@@ -1485,6 +1489,7 @@ class ClientCore:
         original_error: Exception,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any | None:
         """Compatibility wrapper around :class:`RpcExecutor`."""
         return await self._get_rpc_executor().try_refresh_and_retry(
@@ -1494,6 +1499,7 @@ class ClientCore:
             allow_null,
             original_error,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     def get_http_client(self) -> httpx.AsyncClient:

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -20,6 +20,11 @@ from ._core_transport import (
     _TransportServerError,
 )
 from ._env import get_default_language
+from ._idempotency import (
+    IDEMPOTENCY_REGISTRY,
+    maybe_inject_client_token,
+    resolve_effective_disable_internal_retries,
+)
 from ._logging import get_request_id, reset_request_id, set_request_id
 from .auth import format_authuser_value
 from .exceptions import ChatError
@@ -70,6 +75,7 @@ class RpcOwner(Protocol):
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any: ...
 
     async def _rpc_call_impl(
@@ -81,6 +87,7 @@ class RpcOwner(Protocol):
         _is_retry: bool,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any: ...
 
     async def _begin_transport_post(self, log_label: str) -> Any: ...
@@ -117,6 +124,7 @@ class RpcExecutor:
         _is_retry: bool,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         """Run an RPC wrapped with telemetry, reqid, and drain bookkeeping.
 
@@ -133,6 +141,12 @@ class RpcExecutor:
         The ``_is_retry`` flag suppresses telemetry/reqid wrapping so the
         decode-time refresh-and-retry leg inherits the parent's
         request id and reports under one ``[req=<id>]`` line in logs.
+
+        The ``operation_variant`` kwarg (default ``None``) routes through
+        the :class:`IdempotencyRegistry` lookup in :meth:`execute` so the
+        executor can pick a method-variant-specific policy. Currently
+        every method default-resolves to ``UNCLASSIFIED`` (silent + no
+        behavior change); Wave 2 will populate variant entries.
         """
         if not self._owner._http_client:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
@@ -151,6 +165,7 @@ class RpcExecutor:
                 allow_null,
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
+                operation_variant=operation_variant,
             )
 
         method_name = getattr(method, "name", str(method))
@@ -166,6 +181,7 @@ class RpcExecutor:
                 allow_null,
                 _is_retry,
                 disable_internal_retries=disable_internal_retries,
+                operation_variant=operation_variant,
             )
         except Exception as exc:
             elapsed = time.perf_counter() - start
@@ -298,9 +314,39 @@ class RpcExecutor:
         _is_retry: bool,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         start = time.perf_counter()
         logger.debug("RPC %s starting", method.name)
+
+        # Consult the idempotency registry. The registry is the single
+        # source of truth for "how should this RPC behave under retry?";
+        # the caller's explicit ``disable_internal_retries=True`` always
+        # wins (caller intent > policy). For UNCLASSIFIED entries (the
+        # B1-foundation default for every method), the effective value
+        # equals the caller's value and no log is emitted — today's
+        # retries fire identically.
+        #
+        # The registry call also raises ``IdempotencyVariantError`` if
+        # the caller passed an unknown ``operation_variant`` to a method
+        # with an explicit variant table.
+        effective_disable_internal_retries = resolve_effective_disable_internal_retries(
+            IDEMPOTENCY_REGISTRY,
+            method,
+            caller_disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
+        )
+
+        # For CLIENT_TOKEN_DEDUPE policies, inject a fresh ``uuid4().hex``
+        # into the registry-named param field UNLESS the caller already
+        # populated it. No-op for every other policy, so this is a
+        # zero-cost call for the UNCLASSIFIED-everywhere B1 default.
+        maybe_inject_client_token(
+            IDEMPOTENCY_REGISTRY,
+            method,
+            params,
+            operation_variant=operation_variant,
+        )
 
         # Resolve once per logical call so URL, body, and decode use the same
         # override-aware RPC id.
@@ -316,7 +362,7 @@ class RpcExecutor:
             response = await self._owner._perform_authed_post(
                 build_request=_build,
                 log_label=f"RPC {method.name}",
-                disable_internal_retries=disable_internal_retries,
+                disable_internal_retries=effective_disable_internal_retries,
             )
         except _TransportAuthExpired as exc:
             # Preserve the historical raw transport exception on refresh failure.
@@ -384,6 +430,7 @@ class RpcExecutor:
                     allow_null,
                     exc,
                     disable_internal_retries=disable_internal_retries,
+                    operation_variant=operation_variant,
                 )
                 return refreshed
 
@@ -505,6 +552,7 @@ class RpcExecutor:
         original_error: Exception,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any | None:
         """Refresh auth after a decode-time auth error and retry once."""
         logger.info("RPC %s auth error detected, attempting token refresh", method.name)
@@ -526,4 +574,5 @@ class RpcExecutor:
             allow_null,
             _is_retry=True,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -1,32 +1,55 @@
-"""Idempotency wrapper for create-RPC patterns.
+"""Idempotency layer for mutating-RPC patterns.
 
-A create RPC like ``NotebooksAPI.create`` or ``SourcesAPI.add_url`` is a
-mutating POST: the *server may have committed the write* even if the
-client sees a 5xx or network error. Naive retries duplicate the
-resource. This helper inverts the retry direction:
+This module hosts two cooperating pieces:
 
-  1. Run ``create()`` with internal-retries disabled.
-  2. If ``create()`` raises a retryable transport error (5xx / 429 /
-     ``RequestError``), call ``probe()`` to ask the server "did the
-     write land anyway?" If yes, return the existing resource. If no,
-     retry the create.
-  3. After ``max_attempts`` of (create + probe), give up and re-raise.
+1. :func:`idempotent_create` — the existing per-API probe-then-retry
+   wrapper for create-RPC patterns. A create RPC like
+   ``NotebooksAPI.create`` or ``SourcesAPI.add_url`` is a mutating POST:
+   the *server may have committed the write* even if the client sees a
+   5xx or network error. Naive retries duplicate the resource; the
+   wrapper inverts the direction: run with internal-retries disabled,
+   then probe for a server-side commit before re-issuing.
 
-Per-API probes are caller-supplied because there is no universal probe
-key (notebooks: title + baseline-diff; sources: url-match;
-``add_text``: no probe possible — see ``NonIdempotentRetryError``).
+2. :class:`IdempotencyRegistry` — the 6-policy classification layer that
+   :class:`~notebooklm._core_rpc.RpcExecutor` consults to compute the
+   *effective* ``disable_internal_retries`` value (and, for
+   ``CLIENT_TOKEN_DEDUPE`` policies, inject a fresh client-token into
+   request params before encoding). The registry is a single source of
+   truth that future RPCs can be classified against without touching the
+   executor.
 
-This module is private (``_idempotency.py``) — call sites live in the
-domain APIs (``_notebooks.py``, ``_sources.py``).
+   This foundation is intentionally **behavior-neutral**: every method
+   defaults to :attr:`IdempotencyPolicy.UNCLASSIFIED`, which is silent
+   and reproduces today's retry behavior. Wave 2 classifies individual
+   RPCs.
+
+Per-API probes used by :func:`idempotent_create` are caller-supplied
+because there is no universal probe key (notebooks: title +
+baseline-diff; sources: url-match; ``add_text``: no probe possible — see
+:class:`~notebooklm.exceptions.NonIdempotentRetryError`).
+
+This module is private (``_idempotency.py``); call sites live in the
+domain APIs (``_notebooks.py``, ``_sources.py``) and the RPC executor
+(``_core_rpc.py``).
 """
 
 from __future__ import annotations
 
 import logging
+import time
+import uuid
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, TypeVar
 
-from .exceptions import NetworkError, RateLimitError, ServerError
+from .exceptions import (
+    IdempotencyVariantError,
+    NetworkError,
+    RateLimitError,
+    ServerError,
+)
+from .rpc.types import RPCMethod
 
 logger = logging.getLogger(__name__)
 
@@ -134,3 +157,374 @@ async def idempotent_create(
         max_attempts,
     )
     raise last_error
+
+
+# ============================================================================
+# Mutating-RPC idempotency registry (B1 foundation — P0-3 + P1-2)
+# ============================================================================
+#
+# The registry is the single source of truth for "how should this RPC behave
+# under retry?" It is consulted by ``RpcExecutor`` at five sites to compute
+# the *effective* ``disable_internal_retries`` value, and (for
+# ``CLIENT_TOKEN_DEDUPE`` policies) to inject a fresh client-token into
+# request params before encoding.
+#
+# IMPORTANT — behavior-neutral foundation:
+#   This module is a foundation only. Every ``RPCMethod`` default-populates
+#   to ``IdempotencyPolicy.UNCLASSIFIED`` with the Wave-2 placeholder note.
+#   UNCLASSIFIED is silent (no log emission, no behavior change) and
+#   resolves to ``effective_disable_internal_retries=False`` so today's
+#   retries continue to fire identically. Wave 2 will classify individual
+#   RPCs without changing the executor.
+
+
+class IdempotencyPolicy(str, Enum):
+    """Classification axis for mutating-RPC retry safety.
+
+    Six policies — no more, no fewer. The axis was sized to cover all
+    realistic NotebookLM RPC shapes without inventing per-method special
+    cases. See ``.sisyphus/plans/tier-9-p0-p1.md`` (B1 section) for the
+    derivation.
+
+    Policies fall into three retry-safety bands:
+
+    * **Safe to retry inside the transport**:
+      :attr:`UNCLASSIFIED` (placeholder — preserves today's retries),
+      :attr:`IDEMPOTENT_SET_OP` (rename / delete — server is the
+      idempotence anchor), :attr:`CLIENT_TOKEN_DEDUPE` (server
+      deduplicates by injected token), :attr:`AT_LEAST_ONCE_ACCEPTED`
+      (caller has accepted at-least-once semantics; WARN logged).
+
+    * **NOT safe to retry inside the transport**:
+      :attr:`PROBE_THEN_CREATE` (callers own the probe loop; transport
+      retry would race the probe), :attr:`NON_IDEMPOTENT_NO_RETRY`
+      (e.g. ``add_text`` — no probe key, must surface the first
+      failure).
+
+    The ``str`` mixin keeps the enum JSON-serializable and consistent
+    with :class:`~notebooklm.rpc.RPCMethod` (which also uses ``str,
+    Enum`` rather than ``StrEnum`` for 3.10 compatibility).
+    """
+
+    UNCLASSIFIED = "unclassified"
+    PROBE_THEN_CREATE = "probe_then_create"
+    IDEMPOTENT_SET_OP = "idempotent_set_op"
+    CLIENT_TOKEN_DEDUPE = "client_token_dedupe"
+    AT_LEAST_ONCE_ACCEPTED = "at_least_once_accepted"
+    NON_IDEMPOTENT_NO_RETRY = "non_idempotent_no_retry"
+
+
+# Policies that force ``effective_disable_internal_retries`` to True even
+# when the caller passed False. These RPCs cannot tolerate the transport's
+# inner retry loop because either (a) the caller owns a probe state
+# machine that races a blind retry (PROBE_THEN_CREATE), or (b) the write
+# has no server-side dedupe key and a retry would create a duplicate
+# (NON_IDEMPOTENT_NO_RETRY).
+_POLICIES_THAT_FORCE_DISABLE: frozenset[IdempotencyPolicy] = frozenset(
+    {
+        IdempotencyPolicy.PROBE_THEN_CREATE,
+        IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    }
+)
+
+
+# ProbeKeyFn signature: takes the encoded ``params`` list and returns an
+# opaque, hashable probe key the caller can use to identify "is this the
+# write I issued?" Currently informational — Wave 2 plumbs it into the
+# create-probe state machines. ``None`` is the no-probe sentinel.
+ProbeKeyFn = Callable[[list[Any]], Any]
+
+
+@dataclass(frozen=True)
+class IdempotencyEntry:
+    """One row in :class:`IdempotencyRegistry`.
+
+    Attributes:
+        policy: Classification for the ``(RPCMethod, operation_variant)``
+            row this entry describes.
+        probe_key_fn: Optional probe-key extractor for PROBE_THEN_CREATE
+            entries. ``None`` for policies that don't probe. Wave 2 wires
+            this into the per-API probe loops.
+        client_token_field: For CLIENT_TOKEN_DEDUPE entries, the name of
+            the parameter slot that receives the auto-injected
+            ``uuid4().hex`` token. ``None`` for other policies, or for
+            CLIENT_TOKEN_DEDUPE entries whose params use a positional
+            slot (Wave 2 will extend the type to ``str | int`` if
+            positional access is needed).
+        notes: Free-form human-readable note. UNCLASSIFIED entries
+            registered without an explicit ``notes`` value receive the
+            placeholder marker that flags them for Wave 2 classification;
+            all other policies default to an empty string.
+    """
+
+    policy: IdempotencyPolicy
+    probe_key_fn: ProbeKeyFn | None = None
+    client_token_field: str | None = None
+    notes: str = ""
+
+
+_UNCLASSIFIED_PLACEHOLDER_NOTE = "placeholder — Wave 2 must classify"
+
+
+class IdempotencyRegistry:
+    """Registry of :class:`IdempotencyEntry` keyed by
+    ``(RPCMethod, operation_variant | None)``.
+
+    Look-up semantics:
+
+    * ``get_entry(method)`` → returns the ``(method, None)`` entry.
+    * ``get_entry(method, operation_variant=v)`` with a variant entry
+      present → returns that variant entry.
+    * ``get_entry(method, operation_variant=v)`` when ``method`` has
+      ONLY a ``(method, None)`` entry (no variant table at all) →
+      silently falls back to ``(method, None)``.
+    * ``get_entry(method, operation_variant=v)`` when ``method`` has
+      explicit variant entries but ``v`` is not among them → raises
+      :class:`~notebooklm.exceptions.IdempotencyVariantError`. The
+      explicit variant table signals "Wave 2 has classified this method
+      by variant" — an unknown variant is almost certainly a caller typo
+      or API drift, not safe to mask via silent fallback.
+
+    Thread/loop-safety: the registry is populated at import time and is
+    intended to be effectively immutable in production. Tests may
+    construct fresh instances. There is no internal lock — concurrent
+    writes during a process's lifetime are not supported.
+    """
+
+    def __init__(self) -> None:
+        # Two-level shape: ``method`` → ``operation_variant | None`` →
+        # entry. The inner dict ALWAYS contains a ``None`` key (the
+        # default), populated by either :meth:`register` or
+        # :meth:`_seed_defaults`.
+        self._entries: dict[RPCMethod, dict[str | None, IdempotencyEntry]] = {}
+
+    def register(
+        self,
+        method: RPCMethod,
+        policy: IdempotencyPolicy,
+        *,
+        variant: str | None = None,
+        probe_key_fn: ProbeKeyFn | None = None,
+        client_token_field: str | None = None,
+        notes: str | None = None,
+    ) -> None:
+        """Register (or overwrite) the entry for ``(method, variant)``.
+
+        Wave 2 will call this once per method/variant at module import.
+        Tests may call it ad-hoc on a fresh :class:`IdempotencyRegistry`
+        instance to exercise specific policies.
+
+        Effective notes default: when ``policy == UNCLASSIFIED`` and the
+        caller did not pass ``notes=...``, the placeholder marker
+        ``"placeholder — Wave 2 must classify"`` is used. Any other
+        policy defaults to ``""``.
+        """
+        if notes is None:
+            notes = (
+                _UNCLASSIFIED_PLACEHOLDER_NOTE if policy is IdempotencyPolicy.UNCLASSIFIED else ""
+            )
+        entry = IdempotencyEntry(
+            policy=policy,
+            probe_key_fn=probe_key_fn,
+            client_token_field=client_token_field,
+            notes=notes,
+        )
+        self._entries.setdefault(method, {})[variant] = entry
+
+    def get_entry(
+        self,
+        method: RPCMethod,
+        operation_variant: str | None = None,
+    ) -> IdempotencyEntry:
+        """Return the entry for ``(method, operation_variant)``.
+
+        See class docstring for fallback semantics. Raises
+        :class:`~notebooklm.exceptions.IdempotencyVariantError` when an
+        unknown non-None variant is requested on a method that has
+        explicit variant entries.
+        """
+        method_entries = self._entries.get(method)
+        if method_entries is None:
+            # Shouldn't happen with the seeded production registry, but
+            # makes the contract explicit for hand-built instances.
+            raise KeyError(
+                f"IdempotencyRegistry has no entry for {method.name!r}; "
+                "missing default (method, None) registration"
+            )
+
+        # Variant-specific lookup wins when present.
+        if operation_variant is not None:
+            variant_entry = method_entries.get(operation_variant)
+            if variant_entry is not None:
+                return variant_entry
+            # Unknown variant on a method that has an explicit variant
+            # table is treated as a caller typo / API drift; raise rather
+            # than silently fall back to (method, None). Methods that
+            # ONLY have a (method, None) entry tolerate any variant
+            # name (no typo to catch).
+            known = sorted(k for k in method_entries if k is not None)
+            if known:
+                raise IdempotencyVariantError(
+                    f"Unknown operation_variant {operation_variant!r} for "
+                    f"{method.name}; known variants: {known}"
+                )
+
+        # Fall back to the (method, None) default. Seeding guarantees it
+        # exists; raise loudly if a hand-built instance is missing it.
+        default = method_entries.get(None)
+        if default is None:
+            raise KeyError(f"IdempotencyRegistry has no (method, None) default for {method.name!r}")
+        return default
+
+    def _seed_defaults(self) -> None:
+        """Populate every :class:`~notebooklm.rpc.RPCMethod` with the
+        UNCLASSIFIED placeholder at ``variant=None``.
+
+        Called once at module import to guarantee the registry is a
+        total function over ``RPCMethod``. Wave 2 will replace these
+        placeholders one at a time as it classifies each RPC.
+        """
+        for method in RPCMethod:
+            # ``setdefault`` would lose the placeholder note if a future
+            # caller pre-registers a non-default entry. Use explicit
+            # absence check so we never overwrite a real Wave 2 entry.
+            if method not in self._entries or None not in self._entries[method]:
+                self.register(method, IdempotencyPolicy.UNCLASSIFIED)
+
+
+# Module-level production registry. Wave 2 will add classifications
+# below the seeding call; for B1 the registry is pure default-fill.
+IDEMPOTENCY_REGISTRY = IdempotencyRegistry()
+IDEMPOTENCY_REGISTRY._seed_defaults()
+
+
+# ----------------------------------------------------------------------------
+# AT_LEAST_ONCE_ACCEPTED rate-limited WARN logger
+# ----------------------------------------------------------------------------
+#
+# Per-method timestamp ledger so the WARN log fires at most once per
+# ``_AT_LEAST_ONCE_LOG_INTERVAL`` seconds per ``(method, variant)``. This
+# keeps the foundation behavior-neutral under load: even if Wave 2
+# classifies several hot-path RPCs as AT_LEAST_ONCE_ACCEPTED, callers
+# won't drown in WARN spam. The choice of 30s mirrors the cadence of
+# similar advisory-log throttles elsewhere in the codebase.
+_AT_LEAST_ONCE_LOG_INTERVAL: float = 30.0
+_at_least_once_last_logged: dict[tuple[RPCMethod, str | None], float] = {}
+
+
+def _maybe_log_at_least_once(method: RPCMethod, variant: str | None) -> None:
+    """Emit a rate-limited WARN that this RPC is AT_LEAST_ONCE_ACCEPTED.
+
+    Per-key throttle: at most one WARN per
+    ``_AT_LEAST_ONCE_LOG_INTERVAL`` seconds per ``(method, variant)``.
+    The first call always emits; subsequent calls inside the window are
+    silent. Tests rely on this to assert that 100 calls produce ≤2 lines.
+    """
+    key = (method, variant)
+    now = time.monotonic()
+    last = _at_least_once_last_logged.get(key)
+    if last is not None and (now - last) < _AT_LEAST_ONCE_LOG_INTERVAL:
+        return
+    _at_least_once_last_logged[key] = now
+    logger.warning(
+        "RPC %s%s classified AT_LEAST_ONCE_ACCEPTED — transport retries "
+        "may cause duplicate server-side commits; caller has opted in",
+        method.name,
+        f" (variant={variant!r})" if variant is not None else "",
+    )
+
+
+def resolve_effective_disable_internal_retries(
+    registry: IdempotencyRegistry,
+    method: RPCMethod,
+    *,
+    caller_disable_internal_retries: bool,
+    operation_variant: str | None,
+) -> bool:
+    """Resolve the effective ``disable_internal_retries`` flag for an RPC.
+
+    Precedence (caller wins):
+
+    1. ``caller_disable_internal_retries=True`` → returns True
+       regardless of policy. Explicit caller intent dominates registry
+       classification.
+    2. Policy is :attr:`IdempotencyPolicy.PROBE_THEN_CREATE` or
+       :attr:`IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY` → returns True.
+       These RPCs cannot tolerate the inner retry loop.
+    3. Policy is :attr:`IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED` →
+       emits a rate-limited WARN and returns ``caller_disable_internal_retries``
+       unchanged. Caller has accepted at-least-once semantics; retries
+       remain enabled.
+    4. All other policies (UNCLASSIFIED, IDEMPOTENT_SET_OP,
+       CLIENT_TOKEN_DEDUPE) → returns ``caller_disable_internal_retries``
+       unchanged. UNCLASSIFIED is silent (no log emission).
+
+    Raises :class:`~notebooklm.exceptions.IdempotencyVariantError` for
+    unknown variants on methods with explicit variant tables.
+    """
+    if caller_disable_internal_retries:
+        return True
+
+    entry = registry.get_entry(method, operation_variant=operation_variant)
+    policy = entry.policy
+
+    if policy in _POLICIES_THAT_FORCE_DISABLE:
+        return True
+
+    if policy is IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED:
+        _maybe_log_at_least_once(method, operation_variant)
+        return caller_disable_internal_retries
+
+    # UNCLASSIFIED / IDEMPOTENT_SET_OP / CLIENT_TOKEN_DEDUPE: silent,
+    # caller value passes through unchanged.
+    return caller_disable_internal_retries
+
+
+def maybe_inject_client_token(
+    registry: IdempotencyRegistry,
+    method: RPCMethod,
+    params: Any,
+    *,
+    operation_variant: str | None,
+) -> None:
+    """Inject a fresh ``uuid4().hex`` client-token for CLIENT_TOKEN_DEDUPE
+    methods, when (and only when) the caller did not already populate the
+    token field.
+
+    ``params`` is mutated in place. The expected shape is a ``dict`` keyed
+    by field name; non-dict params are skipped (a future Wave 2 variant
+    may extend this to positional injection — out of scope for B1).
+
+    No-op for policies other than ``CLIENT_TOKEN_DEDUPE``, for entries
+    without a ``client_token_field``, and for entries where ``params``
+    already contains a non-empty value at that field. Raises
+    :class:`~notebooklm.exceptions.IdempotencyVariantError` for unknown
+    variants on methods with explicit variant tables.
+    """
+    entry = registry.get_entry(method, operation_variant=operation_variant)
+    if entry.policy is not IdempotencyPolicy.CLIENT_TOKEN_DEDUPE:
+        return
+    field_name = entry.client_token_field
+    if field_name is None:
+        return
+    if not isinstance(params, dict):
+        # Positional client-token injection is intentionally deferred;
+        # see docstring. Wave 2 may revisit if a positional RPC ever
+        # needs CLIENT_TOKEN_DEDUPE.
+        return
+    if params.get(field_name):
+        # Caller-provided token wins.
+        return
+    params[field_name] = uuid.uuid4().hex
+
+
+__all__ = [
+    "idempotent_create",
+    "IdempotencyPolicy",
+    "IdempotencyEntry",
+    "IdempotencyRegistry",
+    "IDEMPOTENCY_REGISTRY",
+    "ProbeKeyFn",
+    "resolve_effective_disable_internal_retries",
+    "maybe_inject_client_token",
+]

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -245,12 +245,12 @@ class IdempotencyEntry:
         probe_key_fn: Optional probe-key extractor for PROBE_THEN_CREATE
             entries. ``None`` for policies that don't probe. Wave 2 wires
             this into the per-API probe loops.
-        client_token_field: For CLIENT_TOKEN_DEDUPE entries, the name of
-            the parameter slot that receives the auto-injected
-            ``uuid4().hex`` token. ``None`` for other policies, or for
-            CLIENT_TOKEN_DEDUPE entries whose params use a positional
-            slot (Wave 2 will extend the type to ``str | int`` if
-            positional access is needed).
+        client_token_field: For CLIENT_TOKEN_DEDUPE entries, the slot
+            in the params payload that receives the auto-injected
+            ``uuid4().hex`` token. ``str`` keys are used when the RPC
+            params are a dict; ``int`` keys are used to inject into a
+            positional slot inside the list-shaped params that the
+            batchexecute encoder consumes. ``None`` for other policies.
         notes: Free-form human-readable note. UNCLASSIFIED entries
             registered without an explicit ``notes`` value receive the
             placeholder marker that flags them for Wave 2 classification;
@@ -259,7 +259,7 @@ class IdempotencyEntry:
 
     policy: IdempotencyPolicy
     probe_key_fn: ProbeKeyFn | None = None
-    client_token_field: str | None = None
+    client_token_field: str | int | None = None
     notes: str = ""
 
 
@@ -305,7 +305,7 @@ class IdempotencyRegistry:
         *,
         variant: str | None = None,
         probe_key_fn: ProbeKeyFn | None = None,
-        client_token_field: str | None = None,
+        client_token_field: str | int | None = None,
         notes: str | None = None,
     ) -> None:
         """Register (or overwrite) the entry for ``(method, variant)``.
@@ -489,33 +489,69 @@ def maybe_inject_client_token(
 ) -> None:
     """Inject a fresh ``uuid4().hex`` client-token for CLIENT_TOKEN_DEDUPE
     methods, when (and only when) the caller did not already populate the
-    token field.
+    token slot.
 
-    ``params`` is mutated in place. The expected shape is a ``dict`` keyed
-    by field name; non-dict params are skipped (a future Wave 2 variant
-    may extend this to positional injection — out of scope for B1).
+    ``params`` is mutated in place. Two shapes are supported, matching
+    the two shapes that ``RpcExecutor.execute`` is asked to encode:
+
+    * ``dict``-shaped params with a ``str`` ``client_token_field`` key:
+      ``params[field_name] = uuid4().hex`` if the key is absent or maps
+      to a falsy value.
+    * ``list``-shaped params (the batchexecute-typical shape) with an
+      ``int`` ``client_token_field`` index: ``params[index] = uuid4().hex``
+      when ``0 <= index < len(params)`` and the existing slot is falsy
+      (``None``, empty string). If the index is out of range the
+      function logs a warning and returns without raising — this is a
+      foundation safety guard so a mis-registered entry doesn't crash a
+      live RPC; Wave 2 owns the per-method registration audit.
 
     No-op for policies other than ``CLIENT_TOKEN_DEDUPE``, for entries
-    without a ``client_token_field``, and for entries where ``params``
-    already contains a non-empty value at that field. Raises
+    without a ``client_token_field``, for entries where the slot already
+    holds a non-falsy value (caller-provided token wins), and for params
+    whose shape doesn't match the field type (``int`` field on a non-list
+    or ``str`` field on a non-dict). Raises
     :class:`~notebooklm.exceptions.IdempotencyVariantError` for unknown
     variants on methods with explicit variant tables.
     """
     entry = registry.get_entry(method, operation_variant=operation_variant)
     if entry.policy is not IdempotencyPolicy.CLIENT_TOKEN_DEDUPE:
         return
-    field_name = entry.client_token_field
-    if field_name is None:
+    field_key = entry.client_token_field
+    if field_key is None:
         return
-    if not isinstance(params, dict):
-        # Positional client-token injection is intentionally deferred;
-        # see docstring. Wave 2 may revisit if a positional RPC ever
-        # needs CLIENT_TOKEN_DEDUPE.
+
+    if isinstance(field_key, str):
+        if not isinstance(params, dict):
+            # Shape mismatch — registry registered a dict-style field
+            # but caller passed a list. No-op rather than crash.
+            return
+        if params.get(field_key):
+            # Caller-provided token wins.
+            return
+        params[field_key] = uuid.uuid4().hex
         return
-    if params.get(field_name):
-        # Caller-provided token wins.
+
+    # Positional injection into list params (batchexecute typical shape).
+    if not isinstance(params, list):
+        # Shape mismatch — registry registered a positional slot but
+        # caller passed a dict / scalar. No-op.
         return
-    params[field_name] = uuid.uuid4().hex
+    if not (0 <= field_key < len(params)):
+        # Out-of-range index — likely a Wave 2 mis-registration. Don't
+        # crash a live RPC; log once and let the caller surface it via
+        # logs rather than via exception.
+        logger.warning(
+            "CLIENT_TOKEN_DEDUPE for RPC %s has out-of-range "
+            "client_token_field=%d for params of length %d; skipping injection",
+            method.name,
+            field_key,
+            len(params),
+        )
+        return
+    if params[field_key]:
+        # Caller-provided token (or other truthy value) wins.
+        return
+    params[field_key] = uuid.uuid4().hex
 
 
 __all__ = [

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -67,6 +67,7 @@ class RpcCaller(Protocol):
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any: ...
 
 

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -159,6 +159,7 @@ class SourcesAPI:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         """Delegate through the current core RPC method for late-bound test overrides."""
         return await self._core.rpc_call(
@@ -168,6 +169,7 @@ class SourcesAPI:
             allow_null=allow_null,
             _is_retry=_is_retry,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     def _resolve_upload_timeout(self, default: httpx.Timeout) -> httpx.Timeout:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -370,6 +370,7 @@ class NotebookLMClient:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         """Make a raw NotebookLM RPC call.
 
@@ -380,6 +381,10 @@ class NotebookLMClient:
         exposed only to mirror ``ClientCore.rpc_call`` exactly; callers should
         leave it at the default unless they are intentionally reproducing core
         retry behavior.
+
+        The optional ``operation_variant`` selects a method-variant-specific
+        policy in the mutating-RPC idempotency registry. Most callers should
+        leave it ``None`` (the default) — Wave 2 will add variant entries.
         """
         return await self._core.rpc_call(
             method=method,
@@ -388,6 +393,7 @@ class NotebookLMClient:
             allow_null=allow_null,
             _is_retry=_is_retry,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     @property

--- a/src/notebooklm/exceptions.py
+++ b/src/notebooklm/exceptions.py
@@ -59,6 +59,7 @@ __all__ = [
     "RPCResponseTooLargeError",
     # Idempotency
     "NonIdempotentRetryError",
+    "IdempotencyVariantError",
     # Domain: Notebooks
     "NotebookError",
     "NotebookNotFoundError",
@@ -527,6 +528,23 @@ class NonIdempotentRetryError(NotebookLMError):
 
     See ``docs/python-api.md#idempotency`` for guidance on building
     idempotent text-source workflows.
+    """
+
+
+class IdempotencyVariantError(NotebookLMError):
+    """Raised when an unknown ``operation_variant`` is requested for an RPC
+    that has explicit variant-table entries.
+
+    The mutating-RPC idempotency registry keys policies on
+    ``(RPCMethod, operation_variant | None)``. When a method has variant
+    entries (e.g. ``"upsert"``, ``"overwrite"``) AND the caller supplies a
+    variant name that is not in that table, the registry MUST raise this
+    error rather than silently falling back to the ``(method, None)``
+    default — silent fallback would hide caller typos and API drift.
+
+    Methods that only have a ``(method, None)`` entry tolerate any variant
+    name (the variant table is effectively empty, so there is no typo to
+    catch). See :func:`notebooklm._idempotency.IdempotencyRegistry.get_entry`.
     """
 
 

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -401,6 +401,7 @@ class TestArtifactsAPI:
             allow_null=True,
             _is_retry=False,
             disable_internal_retries=False,
+            operation_variant=None,
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -100,6 +100,7 @@ class _Owner:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         self.rpc_retry_calls.append(
             {
@@ -109,6 +110,7 @@ class _Owner:
                 "allow_null": allow_null,
                 "_is_retry": _is_retry,
                 "disable_internal_retries": disable_internal_retries,
+                "operation_variant": operation_variant,
             }
         )
         return self.rpc_retry_result
@@ -239,9 +241,15 @@ async def test_client_core_rpc_wrappers_delegate_to_rpc_executor(monkeypatch) ->
         "request_error",
         "try_refresh",
     ]
-    assert calls[0][2] == {"disable_internal_retries": True}
+    assert calls[0][2] == {
+        "disable_internal_retries": True,
+        "operation_variant": None,
+    }
     assert calls[1][2] == {"rpc_id_override": None}
-    assert calls[-1][2] == {"disable_internal_retries": True}
+    assert calls[-1][2] == {
+        "disable_internal_retries": True,
+        "operation_variant": None,
+    }
 
 
 @pytest.mark.asyncio
@@ -363,6 +371,7 @@ async def test_decode_time_auth_retry_uses_injected_collaborators() -> None:
             "allow_null": True,
             "_is_retry": True,
             "disable_internal_retries": True,
+            "operation_variant": None,
         }
     ]
 
@@ -422,6 +431,7 @@ async def test_core_sleep_monkeypatch_after_executor_construction(monkeypatch) -
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> dict[str, bool]:
         assert method is RPCMethod.LIST_NOTEBOOKS
         assert params == ["param"]
@@ -429,6 +439,7 @@ async def test_core_sleep_monkeypatch_after_executor_construction(monkeypatch) -
         assert allow_null is True
         assert _is_retry is True
         assert disable_internal_retries is True
+        assert operation_variant is None
         return {"ok": True}
 
     async def fake_sleep(seconds: float) -> None:

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -357,6 +357,124 @@ def test_client_token_dedupe_respects_caller_provided_token() -> None:
     assert params["client_token"] == "caller-provided-token"
 
 
+def test_client_token_dedupe_positional_injection_into_list_params() -> None:
+    """When ``client_token_field`` is an int, the registry MUST inject into
+    the list-shaped params at that index (batchexecute typical shape)."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    registry = IdempotencyRegistry()
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field=2,  # positional slot
+    )
+
+    params: list[Any] = ["notebook_id", "title", None, "extra"]
+    maybe_inject_client_token(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        params,
+        operation_variant=None,
+    )
+
+    token = params[2]
+    assert isinstance(token, str)
+    assert len(token) == 32
+    # Surrounding slots untouched
+    assert params[0] == "notebook_id"
+    assert params[1] == "title"
+    assert params[3] == "extra"
+
+
+def test_client_token_dedupe_positional_respects_caller_value() -> None:
+    """Caller-populated positional client-token MUST NOT be overwritten."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    registry = IdempotencyRegistry()
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field=2,
+    )
+
+    params: list[Any] = ["nb", "t", "caller-token", "extra"]
+    maybe_inject_client_token(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        params,
+        operation_variant=None,
+    )
+
+    assert params[2] == "caller-token"
+
+
+def test_client_token_dedupe_positional_out_of_range_warns_and_noops(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Out-of-range positional index MUST log a warning and no-op
+    (foundation safety guard — don't crash a live RPC over registry drift)."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    registry = IdempotencyRegistry()
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field=99,  # out of range
+    )
+
+    params: list[Any] = ["only", "two"]
+    with caplog.at_level(logging.WARNING, logger="notebooklm._idempotency"):
+        maybe_inject_client_token(
+            registry,
+            RPCMethod.LIST_NOTEBOOKS,
+            params,
+            operation_variant=None,
+        )
+
+    # Params unchanged
+    assert params == ["only", "two"]
+    # Warning emitted
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name.startswith("notebooklm._idempotency") and r.levelno >= logging.WARNING
+    ]
+    assert len(warn_records) == 1
+    assert "out-of-range" in warn_records[0].message
+
+
+def test_client_token_dedupe_field_shape_mismatch_noops() -> None:
+    """A ``str`` ``client_token_field`` with list-shaped params (or an
+    ``int`` field with dict-shaped params) MUST no-op rather than crash."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    # str field, list params → no-op
+    registry = IdempotencyRegistry()
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field="client_token",
+    )
+    list_params: list[Any] = ["a", "b"]
+    maybe_inject_client_token(
+        registry, RPCMethod.LIST_NOTEBOOKS, list_params, operation_variant=None
+    )
+    assert list_params == ["a", "b"]
+
+    # int field, dict params → no-op
+    registry2 = IdempotencyRegistry()
+    registry2.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field=0,
+    )
+    dict_params: dict[str, Any] = {"foo": "bar"}
+    maybe_inject_client_token(
+        registry2, RPCMethod.LIST_NOTEBOOKS, dict_params, operation_variant=None
+    )
+    assert dict_params == {"foo": "bar"}
+
+
 def test_client_token_dedupe_is_noop_for_other_policies() -> None:
     """Token injection MUST be skipped for non-CLIENT_TOKEN_DEDUPE policies."""
     from notebooklm._idempotency import maybe_inject_client_token

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -1,0 +1,498 @@
+"""Tests for the mutating-RPC idempotency registry foundation.
+
+This is the B1 foundation (P0-3 + P1-2): a 6-policy classification layer
+with operation variants that the ``RpcExecutor`` consults to compute
+``effective_disable_internal_retries`` and optional client-token injection.
+
+Behavioral classifications for individual RPCs are intentionally deferred
+to Wave 2 — every method default-populates to
+:attr:`~notebooklm._idempotency.IdempotencyPolicy.UNCLASSIFIED` and the
+executor MUST stay silent + reproduce today's retry behavior for those
+entries (regression-protect the "no behavioral drift" acceptance).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from notebooklm._idempotency import (
+    IDEMPOTENCY_REGISTRY,
+    IdempotencyEntry,
+    IdempotencyPolicy,
+    IdempotencyRegistry,
+    resolve_effective_disable_internal_retries,
+)
+from notebooklm.exceptions import IdempotencyVariantError
+from notebooklm.rpc import RPCMethod
+
+# ---------------------------------------------------------------------------
+# Coverage: every RPCMethod has a (method, None) entry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_covers_every_rpc_method_at_variant_none() -> None:
+    """Every RPCMethod MUST have a (method, None) entry — the default fallback.
+
+    Wave 2 will classify each method individually. Until then, every method
+    resolves to UNCLASSIFIED with the placeholder note so the registry is
+    a total function over ``RPCMethod``.
+    """
+    for method in RPCMethod:
+        entry = IDEMPOTENCY_REGISTRY.get_entry(method)
+        assert entry is not None, f"{method.name} has no (method, None) registry entry"
+        assert isinstance(entry, IdempotencyEntry)
+        assert isinstance(entry.policy, IdempotencyPolicy)
+
+
+def test_registry_defaults_to_unclassified_placeholder() -> None:
+    """Default placeholder MUST be UNCLASSIFIED with the Wave 2 marker note."""
+    # Pick a stable method that Wave 2 hasn't classified yet.
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.LIST_NOTEBOOKS)
+    assert entry.policy is IdempotencyPolicy.UNCLASSIFIED
+    assert "placeholder" in entry.notes.lower()
+    assert "wave 2" in entry.notes.lower()
+
+
+# ---------------------------------------------------------------------------
+# 6-policy enum
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_policy_has_all_six_values() -> None:
+    """The classification axis is 6-way; nothing else."""
+    expected = {
+        "UNCLASSIFIED",
+        "PROBE_THEN_CREATE",
+        "IDEMPOTENT_SET_OP",
+        "CLIENT_TOKEN_DEDUPE",
+        "AT_LEAST_ONCE_ACCEPTED",
+        "NON_IDEMPOTENT_NO_RETRY",
+    }
+    actual = {p.name for p in IdempotencyPolicy}
+    assert actual == expected
+
+
+# ---------------------------------------------------------------------------
+# Variant lookup + fallback semantics
+# ---------------------------------------------------------------------------
+
+
+def test_variant_lookup_returns_variant_specific_entry() -> None:
+    """Looking up ``(method, variant)`` MUST hit the variant-specific entry."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.IDEMPOTENT_SET_OP,
+        variant="upsert",
+    )
+
+    entry = registry.get_entry(RPCMethod.LIST_NOTEBOOKS, operation_variant="upsert")
+    assert entry.policy is IdempotencyPolicy.IDEMPOTENT_SET_OP
+
+
+def test_variant_lookup_falls_back_to_method_none_when_no_variant_table() -> None:
+    """A method with NO variant entries falls back to ``(method, None)``."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
+
+    # No variant table for LIST_NOTEBOOKS exists at all — fall back silently.
+    entry = registry.get_entry(RPCMethod.LIST_NOTEBOOKS, operation_variant="anything")
+    assert entry.policy is IdempotencyPolicy.UNCLASSIFIED
+
+
+def test_unknown_variant_with_explicit_variant_entries_raises() -> None:
+    """If a method HAS variant entries but the caller supplies an unknown one,
+    the registry MUST raise :class:`IdempotencyVariantError` rather than
+    silently fall back to ``(method, None)``. Silent fallback would hide
+    typos / API drift in caller code."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.IDEMPOTENT_SET_OP,
+        variant="upsert",
+    )
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+        variant="overwrite",
+    )
+
+    with pytest.raises(IdempotencyVariantError) as exc_info:
+        registry.get_entry(RPCMethod.LIST_NOTEBOOKS, operation_variant="frobnicate")
+
+    assert "frobnicate" in str(exc_info.value)
+    assert "LIST_NOTEBOOKS" in str(exc_info.value)
+
+
+def test_unknown_variant_with_no_variant_entries_falls_back_quietly() -> None:
+    """A method with ONLY the ``(method, None)`` entry MUST tolerate any
+    variant name (silent fallback). This keeps the foundation behavior-neutral
+    until Wave 2 adds variant tables."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
+
+    entry = registry.get_entry(RPCMethod.LIST_NOTEBOOKS, operation_variant="anything-goes")
+    assert entry.policy is IdempotencyPolicy.UNCLASSIFIED
+
+
+def test_none_variant_returns_method_default() -> None:
+    """``operation_variant=None`` MUST return the ``(method, None)`` entry."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.IDEMPOTENT_SET_OP)
+
+    entry = registry.get_entry(RPCMethod.LIST_NOTEBOOKS, operation_variant=None)
+    assert entry.policy is IdempotencyPolicy.IDEMPOTENT_SET_OP
+
+
+# ---------------------------------------------------------------------------
+# Effective disable_internal_retries precedence
+# ---------------------------------------------------------------------------
+
+
+def test_caller_disable_true_always_wins() -> None:
+    """Caller-passed ``disable_internal_retries=True`` MUST always win,
+    regardless of policy. Explicit caller intent dominates policy."""
+    registry = IdempotencyRegistry()
+    # Even an IDEMPOTENT_SET_OP policy (which would leave retries enabled)
+    # must not flip the caller's True back to False.
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.IDEMPOTENT_SET_OP)
+
+    effective = resolve_effective_disable_internal_retries(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        caller_disable_internal_retries=True,
+        operation_variant=None,
+    )
+    assert effective is True
+
+
+def test_probe_then_create_disables_internal_retries() -> None:
+    """PROBE_THEN_CREATE methods are NOT safe to retry inside the transport —
+    the executor must surface failures so the caller's probe-then-create
+    state machine handles them."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.PROBE_THEN_CREATE)
+
+    effective = resolve_effective_disable_internal_retries(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        caller_disable_internal_retries=False,
+        operation_variant=None,
+    )
+    assert effective is True
+
+
+def test_non_idempotent_no_retry_disables_internal_retries() -> None:
+    """NON_IDEMPOTENT_NO_RETRY is a hard "never retry" — disables the
+    transport retry loop unconditionally (caller-False is overridden upward)."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY)
+
+    effective = resolve_effective_disable_internal_retries(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        caller_disable_internal_retries=False,
+        operation_variant=None,
+    )
+    assert effective is True
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        IdempotencyPolicy.UNCLASSIFIED,
+        IdempotencyPolicy.IDEMPOTENT_SET_OP,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED,
+    ],
+)
+def test_safe_policies_leave_caller_false_untouched(
+    policy: IdempotencyPolicy,
+) -> None:
+    """Policies that are safe to retry (or that handle retries via other
+    mechanisms) MUST NOT flip caller-False to True."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, policy)
+
+    effective = resolve_effective_disable_internal_retries(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        caller_disable_internal_retries=False,
+        operation_variant=None,
+    )
+    assert effective is False
+
+
+# ---------------------------------------------------------------------------
+# Silent placeholder: UNCLASSIFIED emits zero log lines
+# ---------------------------------------------------------------------------
+
+
+def test_unclassified_emits_no_log_lines_across_1000_calls(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """UNCLASSIFIED MUST be 100% silent — the foundation cannot spam logs
+    while Wave 2 hasn't classified the bulk of the registry. 1000 calls
+    is enough to catch any per-call WARN/INFO leak."""
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
+
+    with caplog.at_level(logging.DEBUG, logger="notebooklm._idempotency"):
+        for _ in range(1000):
+            resolve_effective_disable_internal_retries(
+                registry,
+                RPCMethod.LIST_NOTEBOOKS,
+                caller_disable_internal_retries=False,
+                operation_variant=None,
+            )
+
+    idempotency_records = [
+        r for r in caplog.records if r.name.startswith("notebooklm._idempotency")
+    ]
+    assert idempotency_records == []
+
+
+# ---------------------------------------------------------------------------
+# AT_LEAST_ONCE_ACCEPTED: rate-limited WARN
+# ---------------------------------------------------------------------------
+
+
+def test_at_least_once_accepted_rate_limits_warn_log(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AT_LEAST_ONCE_ACCEPTED methods MUST emit a WARN to flag that the
+    caller is accepting at-least-once semantics, but the log MUST be
+    rate-limited to avoid spamming under load (100 calls → ≤2 log lines)."""
+    # Clear the module-level rate-limit ledger so a previously-tripped
+    # window from another test doesn't suppress the first WARN here.
+    import notebooklm._idempotency as idemp_mod
+
+    monkeypatch.setattr(idemp_mod, "_at_least_once_last_logged", {})
+
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED)
+
+    with caplog.at_level(logging.WARNING, logger="notebooklm._idempotency"):
+        for _ in range(100):
+            resolve_effective_disable_internal_retries(
+                registry,
+                RPCMethod.LIST_NOTEBOOKS,
+                caller_disable_internal_retries=False,
+                operation_variant=None,
+            )
+
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name.startswith("notebooklm._idempotency") and r.levelno >= logging.WARNING
+    ]
+    assert len(warn_records) <= 2, (
+        f"AT_LEAST_ONCE_ACCEPTED emitted {len(warn_records)} WARN lines for 100 "
+        "calls; expected ≤2 (rate-limited)"
+    )
+    assert len(warn_records) >= 1, "AT_LEAST_ONCE_ACCEPTED emitted 0 WARN lines; expected ≥1"
+
+
+# ---------------------------------------------------------------------------
+# CLIENT_TOKEN_DEDUPE: token injection
+# ---------------------------------------------------------------------------
+
+
+def test_client_token_dedupe_injects_uuid_when_field_missing() -> None:
+    """CLIENT_TOKEN_DEDUPE policy MUST inject a fresh ``uuid4().hex`` token
+    into the field named by ``IdempotencyEntry.client_token_field`` when the
+    caller did NOT pre-populate it."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    registry = IdempotencyRegistry()
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field="client_token",
+    )
+
+    params: dict[str, Any] = {"foo": "bar"}
+    maybe_inject_client_token(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        params,
+        operation_variant=None,
+    )
+
+    assert "client_token" in params
+    token = params["client_token"]
+    assert isinstance(token, str)
+    assert len(token) == 32  # uuid4().hex is 32 hex chars
+    assert int(token, 16) >= 0  # parseable as hex
+
+
+def test_client_token_dedupe_respects_caller_provided_token() -> None:
+    """If the caller already pre-populated the client-token field, the
+    registry MUST NOT overwrite it. Caller intent wins."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    registry = IdempotencyRegistry()
+    registry.register(
+        RPCMethod.LIST_NOTEBOOKS,
+        IdempotencyPolicy.CLIENT_TOKEN_DEDUPE,
+        client_token_field="client_token",
+    )
+
+    params: dict[str, Any] = {"client_token": "caller-provided-token"}
+    maybe_inject_client_token(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        params,
+        operation_variant=None,
+    )
+
+    assert params["client_token"] == "caller-provided-token"
+
+
+def test_client_token_dedupe_is_noop_for_other_policies() -> None:
+    """Token injection MUST be skipped for non-CLIENT_TOKEN_DEDUPE policies."""
+    from notebooklm._idempotency import maybe_inject_client_token
+
+    registry = IdempotencyRegistry()
+    registry.register(RPCMethod.LIST_NOTEBOOKS, IdempotencyPolicy.UNCLASSIFIED)
+
+    params: dict[str, Any] = {"foo": "bar"}
+    maybe_inject_client_token(
+        registry,
+        RPCMethod.LIST_NOTEBOOKS,
+        params,
+        operation_variant=None,
+    )
+
+    assert "client_token" not in params
+
+
+# ---------------------------------------------------------------------------
+# RpcExecutor consultation: behavioral equivalence with default registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _build_rpc_executor() -> Any:
+    """Build a minimally-wired RpcExecutor for behavioral-equivalence tests.
+
+    The executor is driven via its ``execute()`` method (the lowest of the
+    five consultation sites). The fixture stubs the transport so we can
+    assert on the ``disable_internal_retries`` value that the executor
+    actually hands to ``_perform_authed_post``.
+    """
+    from notebooklm._core_rpc import RpcExecutor
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_perform_authed_post(
+        *,
+        build_request: Any,
+        log_label: str,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response:
+        captured["disable_internal_retries"] = disable_internal_retries
+        captured["log_label"] = log_label
+        return httpx.Response(200, text=")]}'\n[]")
+
+    owner = MagicMock()
+    owner._timeout = 30.0
+    owner._refresh_callback = None
+    owner._refresh_retry_delay = 0.0
+    owner._http_client = MagicMock()
+    owner._perform_authed_post = AsyncMock(side_effect=_fake_perform_authed_post)
+    owner._await_refresh = AsyncMock()
+    owner._begin_transport_post = AsyncMock(return_value=object())
+    owner._finish_transport_post = AsyncMock()
+    owner._increment_metrics = MagicMock()
+    owner._emit_rpc_event = AsyncMock()
+    owner.rpc_call = AsyncMock()
+    owner._rpc_call_impl = AsyncMock()
+
+    def _decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
+        return []
+
+    async def _sleep(_: float) -> None:
+        return None
+
+    def _is_auth_error(_: Exception) -> bool:
+        return False
+
+    executor = RpcExecutor(
+        owner,
+        decode_response_late_bound=_decode,
+        is_auth_error=_is_auth_error,
+        sleep=_sleep,
+    )
+    return executor, owner, captured
+
+
+@pytest.mark.asyncio
+async def test_default_registry_preserves_today_behavior(
+    _build_rpc_executor: Any,
+) -> None:
+    """Behavioral equivalence: with the production registry's default
+    UNCLASSIFIED policy for every method, an unspecified
+    ``disable_internal_retries`` MUST resolve to False — exactly today's
+    behavior. No drift."""
+    executor, owner, captured = _build_rpc_executor
+
+    await executor.execute(
+        RPCMethod.LIST_NOTEBOOKS,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+    )
+
+    assert captured["disable_internal_retries"] is False
+
+
+@pytest.mark.asyncio
+async def test_caller_disable_true_propagates_through_executor(
+    _build_rpc_executor: Any,
+) -> None:
+    """Explicit caller ``disable_internal_retries=True`` MUST reach the
+    transport regardless of policy (caller wins)."""
+    executor, owner, captured = _build_rpc_executor
+
+    await executor.execute(
+        RPCMethod.LIST_NOTEBOOKS,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=True,
+    )
+
+    assert captured["disable_internal_retries"] is True
+
+
+@pytest.mark.asyncio
+async def test_operation_variant_kwarg_threads_through_executor(
+    _build_rpc_executor: Any,
+) -> None:
+    """``operation_variant`` MUST be accepted as a kwarg on
+    ``RpcExecutor.execute()`` without breaking the call. Wave 2 will wire
+    behavioral effects; this PR only adds the seam."""
+    executor, owner, captured = _build_rpc_executor
+
+    # Should not raise — kwarg is accepted everywhere.
+    await executor.execute(
+        RPCMethod.LIST_NOTEBOOKS,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        operation_variant="some-variant",
+    )
+
+    assert captured["disable_internal_retries"] is False

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -248,6 +248,7 @@ async def test_retry_inherits_parent_request_id():
         rate_limit_retries=0,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ):
         captured_ids.append(get_request_id())
         # First call: raise to trigger retry path; second call: succeed.

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1024,6 +1024,7 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
         allow_null=True,
         _is_retry=True,
         disable_internal_retries=True,
+        operation_variant=None,
     )
 
 
@@ -1055,6 +1056,7 @@ async def test_client_rpc_call_forwards_default_arguments() -> None:
         allow_null=False,
         _is_retry=False,
         disable_internal_retries=False,
+        operation_variant=None,
     )
 
 


### PR DESCRIPTION
## Summary

Build the **mutating-RPC idempotency registry foundation** for Tier 9 (P0-3 + P1-2). This PR is **behavior-neutral**: every `RPCMethod` defaults to `UNCLASSIFIED` (silent, today's retries fire identically). Wave 2 will classify individual RPCs without touching the executor.

- 6-policy `IdempotencyPolicy` enum (`UNCLASSIFIED`, `PROBE_THEN_CREATE`, `IDEMPOTENT_SET_OP`, `CLIENT_TOKEN_DEDUPE`, `AT_LEAST_ONCE_ACCEPTED`, `NON_IDEMPOTENT_NO_RETRY`) + `IdempotencyEntry` dataclass + `IdempotencyRegistry` keyed on `(RPCMethod, operation_variant | None)`.
- `RpcExecutor` consults the registry inside `execute()` to compute the effective `disable_internal_retries` flag and (for `CLIENT_TOKEN_DEDUPE` policies) inject a fresh `uuid4().hex` into request params before encoding.
- New `operation_variant: str | None = None` kwarg threaded through all 5 RpcExecutor sites + `ClientCore.rpc_call` / `_rpc_call_impl` / `_try_refresh_and_retry` + `NotebookLMClient.rpc_call` + `CoreRPCProvider` / `RpcCaller` Protocols + `SourcesAPI._rpc_call`.
- New `IdempotencyVariantError` (NotebookLMError subclass) raised on unknown variants for methods with explicit variant tables — guards against caller typos and API drift. Methods with only a `(method, None)` entry tolerate any variant name (silent fallback).

## Precedence (caller wins)

1. `disable_internal_retries=True` from caller → always wins.
2. `PROBE_THEN_CREATE` / `NON_IDEMPOTENT_NO_RETRY` policy → force-disable retries.
3. `AT_LEAST_ONCE_ACCEPTED` policy → emit rate-limited WARN (1 per 30s per `(method, variant)`), then pass caller-False through.
4. `UNCLASSIFIED` / `IDEMPOTENT_SET_OP` / `CLIENT_TOKEN_DEDUPE` → pass caller-False through silently.

## Test plan

- [x] `tests/unit/test_idempotency_registry.py` — 23 new tests covering: registry coverage (all 40 RPCMethod members), 6-policy enum sanity, variant lookup + fallback (5 cases), caller-True precedence, force-disable policies, parametrized safe-policy passthrough, `UNCLASSIFIED` silent across 1000 calls, `AT_LEAST_ONCE_ACCEPTED` ≤2 WARN lines per 100 calls (with monkeypatched cache isolation), client-token injection (auto + caller-respects + no-op for other policies), behavioral equivalence at the `RpcExecutor` level.
- [x] Updated 4 existing delegation-shape assertions to reflect the new `operation_variant` kwarg.
- [x] Full unit + integration suite: **5171 passed, 20 skipped**.
- [x] `uv run ruff format` clean.
- [x] `uv run ruff check` clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues across 115 modules.

## Wave 2 follow-up

This PR is foundation-only. Wave 2 PRs will:
- Classify individual `RPCMethod` entries (replacing `UNCLASSIFIED` placeholders).
- Add variant tables to methods with multiple operation modes.
- Wire `probe_key_fn` callbacks into the per-API create-probe state machines.

## Polish gate

- [x] Step 4.1 — code-simplifier (deduplicated `get_entry` default-lookup).
- [x] Step 4.2 — triple review (claude/codex/gemini lenses; 0 critical, 1 nit fixed: `IdempotencyEntry.notes` docstring).
- [x] Step 4.3 — ultrathink (12-point sanity sweep; no concerns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client RPC now accepts an optional operation-variant parameter to enable variant-specific idempotency and retry behavior.
  * New IdempotencyVariantError surfaced for unknown operation variants.

* **Behavior**
  * Variant-aware idempotency can influence retry decisions and client-token injection for uploads and mutating calls.

* **Tests**
  * Expanded tests to cover variant handling, registry rules, and propagation through RPC layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->