### PR TITLE
fix(core): async-safety bundle (P0-1, P0-2, P1-12, P1-19)

### DIFF
--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -11,7 +11,8 @@ from typing import Any, Protocol
 
 from ._backoff import compute_backoff_delay
 from ._callbacks import maybe_await_callback
-from ._capabilities import PollRegistryProvider, TransportOperationProvider
+from ._capabilities import LoopAffinityProvider, PollRegistryProvider, TransportOperationProvider
+from ._loop_affinity import assert_bound_loop
 from .rpc import (
     ArtifactStatus,
     ArtifactTypeCode,
@@ -45,7 +46,12 @@ ArtifactErrorCallback = Callable[[builtins.list[Any]], str | None]
 StatusChangeCallback = Callable[[GenerationStatus], object]
 
 
-class ArtifactPollingCapabilities(PollRegistryProvider, TransportOperationProvider, Protocol):
+class ArtifactPollingCapabilities(
+    PollRegistryProvider,
+    TransportOperationProvider,
+    LoopAffinityProvider,
+    Protocol,
+):
     """Capabilities required by the artifact polling boundary."""
 
 
@@ -130,6 +136,10 @@ class ArtifactPollingService:
         deprecation_warning_stacklevel: int = 2,
     ) -> GenerationStatus:
         """Wait for a generation task to complete using a shared poll loop."""
+        # P0-2: catch cross-loop wait_for_completion before touching the
+        # poll registry (which holds futures bound to the registering
+        # loop) or spawning a poll task on a foreign loop.
+        assert_bound_loop(self._capabilities.bound_loop)
         # Backward compatibility: poll_interval overrides initial_interval.
         if poll_interval is not None:
             import warnings

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -125,6 +125,25 @@ class UploadConcurrencyProvider(Protocol):
         ...
 
 
+class LoopAffinityProvider(Protocol):
+    """Provider for the open-time captured event-loop reference.
+
+    Sub-clients that issue ``async`` calls touching loop-bound primitives
+    (locks, semaphores, ``httpx.AsyncClient`` pools, condition variables)
+    consult this property and forward it to
+    :func:`notebooklm._loop_affinity.assert_bound_loop` so a cross-loop
+    call surfaces an actionable ``RuntimeError`` at the call site rather
+    than hanging on a lock bound to a dead loop.
+    """
+
+    @property
+    def bound_loop(self) -> asyncio.AbstractEventLoop | None:
+        """Return the loop ``ClientLifecycle.open`` captured, or ``None``
+        if the client has not yet been opened.
+        """
+        ...
+
+
 class ClientCoreCapabilities(
     CoreRPCProvider,
     SourceListProvider,
@@ -135,6 +154,7 @@ class ClientCoreCapabilities(
     CookieJarProvider,
     TransportOperationProvider,
     UploadConcurrencyProvider,
+    LoopAffinityProvider,
 ):
     """Narrow capability adapter around a ``ClientCore``-shaped object.
 
@@ -220,3 +240,31 @@ class ClientCoreCapabilities(
 
     def record_upload_queue_wait(self, wait_seconds: float) -> None:
         self._core.record_upload_queue_wait(wait_seconds)
+
+    @property
+    def bound_loop(self) -> asyncio.AbstractEventLoop | None:
+        """Return the underlying core's open-time captured event loop.
+
+        Reads through to ``ClientCore._lifecycle.get_bound_loop()`` so the
+        capability adapter stays decoupled from the lifecycle helper's
+        internal attribute layout. Returns ``None`` when the underlying
+        core has no lifecycle (e.g. a ``MagicMock``-backed test fixture)
+        or returns a non-loop value, so the affinity helper falls back to
+        its silent no-op path rather than misclassifying a mock as a
+        cross-loop call.
+        """
+        # ``ClientLifecycle.get_bound_loop()`` returns ``None`` if open()
+        # has not been called; the affinity helper treats ``None`` as a
+        # silent no-op, so this property is safe before open().
+        lifecycle = getattr(self._core, "_lifecycle", None)
+        if lifecycle is None:
+            return None
+        loop = lifecycle.get_bound_loop()
+        # Defensive ``isinstance`` so a ``MagicMock``-shaped fixture
+        # whose ``_lifecycle`` auto-vivifies into a mock doesn't
+        # synthesize a fake loop object that the affinity helper would
+        # otherwise treat as a real (mismatched) loop. Production paths
+        # always store either ``None`` or a real ``AbstractEventLoop``.
+        if isinstance(loop, asyncio.AbstractEventLoop):
+            return loop
+        return None

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -25,6 +25,7 @@ from ._chat_protocol import (
 from ._core import _AuthSnapshot
 from ._core_cache import ConversationCache
 from ._logging import get_request_id, reset_request_id, set_request_id
+from ._loop_affinity import assert_bound_loop
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import (
     ChatGoal,
@@ -207,6 +208,13 @@ class ChatAPI:
             dedicated ``create conversation`` RPC that has not been
             reverse-engineered. See issue #659.
         """
+        # P0-2: catch cross-loop ``ask`` before any work — particularly
+        # before acquiring the per-conversation lock below, which would
+        # otherwise hang on a lock bound to a dead loop. The transport
+        # guard at ``_core_transport.py:258-262`` only catches misuse on
+        # the POST itself, which is *after* the conversation lock is
+        # already held — too late.
+        assert_bound_loop(self._core.bound_loop)
         logger.debug(
             "Asking question in notebook %s (conversation=%s)",
             notebook_id,

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -192,6 +192,50 @@ def _get_error_injection_mode() -> str | None:
     return normalized
 
 
+def _refuse_synthetic_error_outside_test_context() -> None:
+    """Refuse :class:`ClientCore` instantiation when the test-only env var leaks.
+
+    P1-12: ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is documented as test-only — it
+    substitutes synthetic error responses for every batchexecute RPC. Before
+    this guard, a leaked deploy env (e.g. an unset-on-prod CI variable that
+    slipped through) would silently wrap the production transport in
+    :class:`_SyntheticErrorTransport`, returning fake 429/5xx/expired_csrf
+    responses to live callers.
+
+    The guard fires only when:
+
+    1. :func:`_get_error_injection_mode` returns a non-``None`` mode (so an
+       empty / unrecognized env-var value still allows production startup),
+       AND
+    2. ``PYTEST_CURRENT_TEST`` is unset (pytest sets this for the lifetime
+       of every test, including the ``@pytest.mark.synthetic_error`` fixture
+       path that *does* legitimately set the env var).
+
+    On refusal we log at WARNING with the env-var name and raise
+    ``RuntimeError`` with the same env-var name so an operator can grep
+    deploy configs and unset the offending variable.
+    """
+    import os
+
+    mode = _get_error_injection_mode()
+    if mode is None:
+        return
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        # Legitimate pytest run — the ``@pytest.mark.synthetic_error``
+        # fixture sets the env var inside a test context. Allow.
+        return
+    message = (
+        f"{ERROR_INJECT_ENV_VAR}={mode!r} is set but no pytest context was "
+        f"detected (PYTEST_CURRENT_TEST unset). This env var is test-only — "
+        f"it substitutes synthetic error responses for every batchexecute "
+        f"RPC and must not be set in production. Unset {ERROR_INJECT_ENV_VAR} "
+        f"to restore normal behavior, or run under pytest if synthetic-error "
+        f"recording is intended."
+    )
+    logger.warning(message)
+    raise RuntimeError(message)
+
+
 class _SyntheticErrorTransport(httpx.AsyncBaseTransport):
     """Test-only httpx transport that substitutes synthetic error responses.
 
@@ -497,7 +541,17 @@ class ClientCore:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a
                 positive finite number, or if ``max_concurrent_uploads`` /
                 ``max_concurrent_rpcs`` is a non-positive integer.
+            RuntimeError: If ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to a
+                recognised mode without a ``PYTEST_CURRENT_TEST`` environment
+                marker. The env var is test-only — see
+                :func:`_refuse_synthetic_error_outside_test_context`.
         """
+        # P1-12: refuse instantiation if the test-only synthetic-error env var
+        # is set without pytest context. Catches leaked deploy envs at the
+        # earliest opportunity, before any HTTP client is constructed. The
+        # guard is a no-op for the normal production path (env var unset)
+        # and for legitimate pytest contexts (PYTEST_CURRENT_TEST set).
+        _refuse_synthetic_error_outside_test_context()
         # Lazy import to break the types.py -> _core.py cycle.
         from .types import ConnectionLimits
 

--- a/src/notebooklm/_core_auth.py
+++ b/src/notebooklm/_core_auth.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 import httpx
 
 from ._core_transport import _AuthSnapshot
+from ._loop_affinity import assert_bound_loop
 from .auth import AuthTokens
 
 if TYPE_CHECKING:
@@ -101,6 +102,21 @@ class AuthRefreshCoordinator:
         self._refresh_callback: Callable[[], Awaitable[AuthTokens]] | None = refresh_callback
         # Distinct from ``_refresh_lock`` — see module docstring.
         self._auth_snapshot_lock: asyncio.Lock | None = None
+        # P0-2: loop-affinity guard. Set by :meth:`ClientLifecycle.open`
+        # so :meth:`await_refresh` can short-circuit cross-loop misuse
+        # before touching the lazily-built ``_refresh_lock`` (bound to
+        # the loop the lock was first acquired under). ``None`` is a
+        # silent no-op for standalone fixtures.
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
+
+    def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Capture or clear the event-loop binding for the affinity guard.
+
+        :meth:`ClientLifecycle.open` propagates the captured loop here.
+        Passing ``None`` clears the binding for the next ``open()``
+        (which will rebind to a fresh loop).
+        """
+        self._bound_loop = loop
 
     # ------------------------------------------------------------------
     # Lazy lock accessors. Both follow the same race-free check-then-assign
@@ -229,6 +245,11 @@ class AuthRefreshCoordinator:
         intact across the cancellation and is replaced only on the next
         refresh wave once the current task transitions to ``done()``.
         """
+        # P0-2: catch cross-loop refresh before touching ``_refresh_lock``.
+        # The lock is lazily bound to the loop that first awaited
+        # ``get_refresh_lock`` — a cross-loop call would hang on the
+        # ``await lock.acquire()`` if we let it through.
+        assert_bound_loop(self._bound_loop)
         if self._refresh_callback is None:
             raise RuntimeError(
                 "AuthRefreshCoordinator.await_refresh called without a "

--- a/src/notebooklm/_core_drain.py
+++ b/src/notebooklm/_core_drain.py
@@ -49,6 +49,8 @@ import weakref
 from dataclasses import dataclass
 from typing import Any
 
+from ._loop_affinity import assert_bound_loop
+
 
 @dataclass(frozen=True)
 class _TransportOperationToken:
@@ -99,6 +101,21 @@ class TransportDrainTracker:
         self._operation_depths: weakref.WeakKeyDictionary[asyncio.Task[Any], int] = (
             weakref.WeakKeyDictionary()
         )
+        # P0-2: loop-affinity guard. Set by :meth:`ClientLifecycle.open`
+        # so :meth:`drain` can short-circuit cross-loop misuse before
+        # touching the lazily-built ``_drain_condition`` (which is bound
+        # to the loop that constructed it). ``None`` is a silent no-op
+        # for standalone fixtures.
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
+
+    def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Capture or clear the event-loop binding for the affinity guard.
+
+        :meth:`ClientLifecycle.open` propagates the captured loop here so
+        :meth:`drain` can short-circuit cross-loop misuse. Passing ``None``
+        clears the binding for the next ``open()`` (which will rebind).
+        """
+        self._bound_loop = loop
 
     def get_drain_condition(self) -> asyncio.Condition:
         """Return the per-instance drain ``asyncio.Condition``, creating it lazily.
@@ -195,6 +212,11 @@ class TransportDrainTracker:
         tracker remains in draining mode so shutdown callers do not
         accidentally admit new work after a missed deadline.
         """
+        # P0-2: catch cross-loop drain before touching ``_drain_condition``.
+        # The condition is lazily bound to the loop that first awaited
+        # ``get_drain_condition`` — a cross-loop call would hang on
+        # ``async with condition`` if we let it through.
+        assert_bound_loop(self._bound_loop)
         if timeout is not None and timeout < 0:
             raise ValueError(f"timeout must be >= 0 or None, got {timeout!r}")
         condition = self.get_drain_condition()

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     from ._core_drain import TransportDrainTracker
     from ._core_metrics import ClientMetrics
     from ._core_polling import PollRegistry
+    from ._core_reqid import ReqidCounter
     from ._core_rpc import RpcExecutor
     from ._core_transport import AuthedTransport
     from .types import ConnectionLimits
@@ -108,6 +109,7 @@ class _LifecycleHost(Protocol):
     _metrics_obj: ClientMetrics
     _drain_tracker: TransportDrainTracker
     _auth_coord: AuthRefreshCoordinator
+    _reqid: ReqidCounter
     cookie_persistence: CookiePersistence
     poll_registry: PollRegistry
     _authed_transport: AuthedTransport | None
@@ -205,6 +207,19 @@ class ClientLifecycle:
         # so the binding is consistent with the loop that owns every primitive
         # constructed below.
         self._bound_loop = asyncio.get_running_loop()
+        # P0-2: propagate the captured loop into every helper that owns a
+        # loop-bound primitive (lock / condition / task slot). Each helper
+        # consults its own ``_bound_loop`` at the top of its async entry
+        # points (``drain``, ``next_reqid``, ``await_refresh``) so a
+        # cross-loop call surfaces an actionable ``RuntimeError`` at the
+        # call site rather than hanging on a primitive bound to a dead
+        # loop. ``ChatAPI`` / ``ArtifactPollingService`` reach the bound
+        # loop through ``ClientCoreCapabilities.bound_loop`` (which reads
+        # ``ClientLifecycle.get_bound_loop()``) so no further propagation
+        # is needed there.
+        host._drain_tracker.set_bound_loop(self._bound_loop)
+        host._reqid.set_bound_loop(self._bound_loop)
+        host._auth_coord.set_bound_loop(self._bound_loop)
         # Reset the drain flag so a previously-drained-then-reopened client
         # admits new transport work again. Direct attribute write mirrors the
         # legacy ``self._draining = False`` line.
@@ -335,6 +350,21 @@ class ClientLifecycle:
                 self._keepalive_task.cancel()
                 await asyncio.gather(self._keepalive_task, return_exceptions=True)
                 self._keepalive_task = None
+
+            # P0-1: cancel any in-flight auth refresh task BEFORE the cookie
+            # save or shielded ``aclose()``. Without this, a slow refresh
+            # racing against close would survive the close path and continue
+            # holding the now-torn-down ``httpx.AsyncClient``, surfacing as a
+            # confusing httpx error or a "coroutine was never awaited" GC
+            # warning. ``gather(..., return_exceptions=True)`` absorbs the
+            # ``CancelledError`` so close itself stays non-raising. We check
+            # both ``is None`` (no refresh has ever fired) and ``done()`` (a
+            # successful refresh wave already finished) so the cancel is a
+            # true no-op outside the racing case.
+            refresh_task = host._auth_coord._refresh_task
+            if refresh_task is not None and not refresh_task.done():
+                refresh_task.cancel()
+                await asyncio.gather(refresh_task, return_exceptions=True)
 
             # Drain in-flight artifact poll tasks. Snapshot first so concurrent
             # registry mutations (a finishing leader removing its entry) don't

--- a/src/notebooklm/_core_reqid.py
+++ b/src/notebooklm/_core_reqid.py
@@ -39,6 +39,8 @@ import asyncio
 import time
 from collections.abc import Callable
 
+from ._loop_affinity import assert_bound_loop
+
 # Baseline counter value (matches the chat-API expectation of a large positive
 # integer). Module-level constant so tests / future callers can reference it
 # instead of hard-coding ``100000``.
@@ -90,6 +92,25 @@ class ReqidCounter:
         self._on_lock_wait: Callable[[float], None] = (
             on_lock_wait if on_lock_wait is not None else _noop_record_lock_wait
         )
+        # P0-2: loop-affinity guard. Captured at ``ClientLifecycle.open()``
+        # time via :meth:`set_bound_loop` and consulted by
+        # :meth:`next_reqid` so a cross-loop call raises an actionable
+        # ``RuntimeError`` rather than hanging on ``_lock`` (which is
+        # bound to the loop the lock was first acquired under). ``None``
+        # is a silent no-op — standalone fixtures and never-opened
+        # counters skip the check.
+        self._bound_loop: asyncio.AbstractEventLoop | None = None
+
+    def set_bound_loop(self, loop: asyncio.AbstractEventLoop | None) -> None:
+        """Capture or clear the event-loop binding for the affinity guard.
+
+        Called by :meth:`ClientLifecycle.open` after it captures the
+        running loop, so :meth:`next_reqid` can short-circuit cross-loop
+        misuse before touching :attr:`_lock`. Passing ``None`` clears the
+        binding (useful when a client is closed and the next ``open()``
+        will rebind to a fresh loop).
+        """
+        self._bound_loop = loop
 
     @property
     def value(self) -> int:
@@ -139,6 +160,12 @@ class ReqidCounter:
             raise TypeError(f"step must be int, got {type(step).__name__}")
         if step <= 0:
             raise ValueError(f"step must be positive, got {step!r}")
+        # P0-2 loop-affinity guard. Runs BEFORE the lazy ``Lock()`` allocation
+        # so a cross-loop call (counter created under loop A, awaited from
+        # loop B) raises ``RuntimeError`` at the call site instead of binding
+        # the lazy lock to the wrong loop. The check is a silent no-op when
+        # ``_bound_loop is None`` (standalone fixtures / unopened helpers).
+        assert_bound_loop(self._bound_loop)
         # Safe: no await between check and assign, so no other coroutine can
         # race us here. Allocating ``asyncio.Lock()`` requires a running loop
         # in some Python versions; we're already awaited so we know one is
@@ -147,20 +174,24 @@ class ReqidCounter:
             self._lock = asyncio.Lock()
         wait_start = time.perf_counter()
         await self._lock.acquire()
-        # Wrap latency recording AND the increment inside the same
-        # ``try``/``finally`` that releases the lock so a misbehaving
-        # ``on_lock_wait`` callback (in practice always
-        # ``ClientCore._record_lock_wait``, which can't raise — but the
-        # extraction makes this callback injection point reusable) cannot
-        # leak the acquisition. Tighter than the pre-extraction shape in
-        # ``ClientCore.next_reqid``, which did the recording before the
-        # ``try`` block; defense-in-depth for arbitrary future callbacks.
+        # P1-19: lock release MUST happen before the ``on_lock_wait``
+        # callback runs. A misbehaving callback (slow telemetry sink,
+        # accidental re-entry, or one that itself awaits) must not widen
+        # the critical section by holding ``_lock`` while it executes.
+        # The increment + read happens under the lock; the wait-time
+        # recording happens AFTER release. Tests:
+        # ``tests/unit/concurrency/test_reqid_callback_outside_lock.py``.
         try:
-            self._on_lock_wait(time.perf_counter() - wait_start)
             self._value += step
-            return self._value
+            new_value = self._value
         finally:
             self._lock.release()
+        # Lock is released; safe to invoke arbitrary user-supplied
+        # telemetry. Exceptions from the callback propagate to the caller
+        # (the existing contract — ``ClientCore._record_lock_wait`` can't
+        # raise, but the API surface keeps this defensive).
+        self._on_lock_wait(time.perf_counter() - wait_start)
+        return new_value
 
 
 __all__ = ["DEFAULT_BASELINE", "DEFAULT_STEP", "ReqidCounter"]

--- a/src/notebooklm/_loop_affinity.py
+++ b/src/notebooklm/_loop_affinity.py
@@ -1,0 +1,65 @@
+"""Free-function event-loop affinity guard.
+
+A single small helper that compares a previously-captured event loop reference
+against ``asyncio.get_running_loop()`` and raises an actionable
+:class:`RuntimeError` on mismatch. Lives in its own module so the helpers
+that need to call it (``_core_drain.py`` / ``_core_reqid.py`` /
+``_core_auth.py`` / ``_artifact_polling.py`` / ``_chat.py``) can import it
+without dragging in :class:`notebooklm._core.ClientCore` — none of those
+modules currently have a direct ``ClientCore`` reference and adding one
+just to reach a bound-loop attribute would re-couple them.
+
+Design constraints:
+
+* Module-private helper, intentionally tiny. The body is a single
+  ``is``-comparison so the per-call cost on the hot path (e.g.
+  :meth:`ReqidCounter.next_reqid` is called once per chat ask) stays
+  negligible.
+
+* ``bound_loop is None`` is a silent no-op so callers that haven't yet
+  observed an ``open()`` (most notably standalone fixtures that construct
+  the helpers directly without a :class:`ClientCore`) keep working without
+  a special-case branch on every call site.
+
+* The error message is intentionally identical in spirit to the inline
+  guard at ``_core_transport.py:258-262`` so downstream call sites can
+  surface a uniform diagnostic regardless of which seam the cross-loop
+  call hit first.
+
+Test coverage lives in ``tests/unit/concurrency/test_loop_affinity_guard.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def assert_bound_loop(bound_loop: asyncio.AbstractEventLoop | None) -> None:
+    """Raise ``RuntimeError`` if the current running loop is not ``bound_loop``.
+
+    Args:
+        bound_loop: The loop the owning client / helper captured at
+            ``open()`` time, or ``None`` if no binding has happened yet.
+            ``None`` is a silent no-op — callers reach the helper before a
+            binding exists (standalone fixtures, lazy-init paths) and the
+            guard's job is to catch *cross-loop* misuse, not to enforce
+            that a binding is present.
+
+    Raises:
+        RuntimeError: When ``bound_loop`` is non-``None`` and differs from
+            ``asyncio.get_running_loop()``. The message mirrors the inline
+            guard in ``_core_transport.AuthedTransport.perform_authed_post``
+            so callers see a consistent diagnostic regardless of which
+            entry point caught the mismatch.
+    """
+    if bound_loop is None:
+        return
+    current = asyncio.get_running_loop()
+    if bound_loop is not current:
+        raise RuntimeError(
+            "NotebookLMClient is bound to a different event loop. "
+            "Each client is per-loop; create a new client in the target loop."
+        )
+
+
+__all__ = ["assert_bound_loop"]

--- a/tests/unit/concurrency/test_core_close_refresh_race.py
+++ b/tests/unit/concurrency/test_core_close_refresh_race.py
@@ -1,0 +1,201 @@
+"""Regression tests for the close-cancels-refresh-task contract (P0-1).
+
+Before P0-1, ``ClientLifecycle.close`` cancelled the keepalive task and
+drained the poll registry but did NOT cancel ``host._auth_coord._refresh_task``.
+A slow refresh racing against ``close()`` would survive the shielded
+``aclose()`` — the task kept holding the now-closed ``httpx.AsyncClient``
+and surfaced as a confusing ``RuntimeError`` from inside httpx, or as a
+lingering coroutine that pytest's
+"coroutine was never awaited" detector flagged at GC time.
+
+The fix is a small block in :meth:`ClientLifecycle.close` between
+keepalive teardown and ``save_cookies``:
+
+    if host._auth_coord._refresh_task and not host._auth_coord._refresh_task.done():
+        host._auth_coord._refresh_task.cancel()
+        await asyncio.gather(host._auth_coord._refresh_task, return_exceptions=True)
+
+That block:
+1. Cancels the in-flight refresh task so the shared single-flight refresh
+   wave unwinds cleanly.
+2. Awaits the cancellation via ``gather(..., return_exceptions=True)`` so
+   ``CancelledError`` does not propagate out of ``close()``.
+3. Sits BEFORE the cookie save / shielded aclose so the refresh callback
+   never observes a half-closed transport.
+
+These tests exercise both the cancel and the no-cancel-needed paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from notebooklm._core_auth import AuthRefreshCoordinator
+from notebooklm._core_drain import TransportDrainTracker
+from notebooklm._core_lifecycle import ClientLifecycle
+from notebooklm._core_metrics import ClientMetrics
+from notebooklm.auth import AuthTokens
+from notebooklm.types import ConnectionLimits
+
+
+def _make_auth() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "x", "__Secure-1PSIDTS": "y"},
+        csrf_token="csrf",
+        session_id="sid",
+    )
+
+
+class _StubHost:
+    """Minimal :class:`_LifecycleHost` stand-in for the close path.
+
+    Tests assign ``_auth_coord._refresh_task`` directly when they need to
+    exercise the in-flight-refresh branch; the default of ``None`` matches
+    the post-``__init__``-real-host shape (no refresh has fired yet).
+    """
+
+    def __init__(self) -> None:
+        self.auth = _make_auth()
+        self._metrics_obj = ClientMetrics(on_rpc_event=None)
+        self._drain_tracker = TransportDrainTracker()
+        self._auth_coord = AuthRefreshCoordinator(refresh_callback=None)
+        self.cookie_persistence = MagicMock()
+        self.cookie_persistence.save = AsyncMock()
+        self.cookie_persistence.capture_open_snapshot = MagicMock()
+        self.poll_registry = MagicMock()
+        self.poll_registry.active_tasks = MagicMock(return_value=[])
+        self._authed_transport = None
+        self._rpc_executor = None
+
+
+def _make_lifecycle() -> ClientLifecycle:
+    return ClientLifecycle(
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        keepalive_interval=None,
+        keepalive_storage_path=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_in_flight_refresh_task() -> None:
+    """A slow refresh racing against ``close()`` must be cancelled and awaited.
+
+    Setup:
+    - Lifecycle is opened so the shielded aclose has a real client to tear
+      down.
+    - The host's ``_auth_coord._refresh_task`` is a long-sleeping task that
+      models a refresh callback parked on Google's identity surface.
+    - Close is driven.
+
+    Expected:
+    - The task is ``cancelled()`` once close returns.
+    - No ``CancelledError`` propagates out of ``close()`` itself
+      (``gather(..., return_exceptions=True)`` absorbs it).
+    - The lifecycle's ``_http_client`` is ``None`` (the standard close
+      contract is preserved).
+    """
+    lifecycle = _make_lifecycle()
+
+    # Open with a stub transport so the close path has a real client to
+    # tear down. We use a no-op MockTransport so no real network is touched.
+    host = _StubHost()
+    transport = httpx.MockTransport(lambda req: httpx.Response(200))
+
+    # Monkey-patch the construction: we need lifecycle._http_client to be a
+    # real AsyncClient so close()'s aclose runs. Easiest: build it inline
+    # since ClientLifecycle.open expects to read an httpx client mode from
+    # _core which we can't easily stub here.
+    lifecycle._http_client = httpx.AsyncClient(transport=transport)
+    lifecycle._bound_loop = asyncio.get_running_loop()
+
+    # Park a long-sleeping task on the auth coordinator — models a refresh
+    # callback waiting on Google's identity surface.
+    async def _slow_refresh() -> Any:
+        try:
+            await asyncio.sleep(60.0)
+        except asyncio.CancelledError:
+            raise
+
+    slow_task = asyncio.create_task(_slow_refresh())
+    host._auth_coord._refresh_task = slow_task  # type: ignore[assignment]
+
+    # Yield briefly so the task actually starts and reaches the sleep.
+    await asyncio.sleep(0)
+
+    assert not slow_task.done(), "test setup: refresh task should be in-flight"
+
+    # Drive close. Must NOT raise.
+    await lifecycle.close(host)
+
+    # Yield to let the cancellation propagate. ``gather`` inside ``close``
+    # already awaited, so the task should be done by now.
+    assert slow_task.cancelled() or slow_task.done()
+    if not slow_task.cancelled():
+        # If the task somehow completed by other means, that's still a
+        # P0-1 contract violation — refresh during close must be cancelled.
+        raise AssertionError("refresh task should have been cancelled by close()")
+
+    assert lifecycle._http_client is None
+
+
+@pytest.mark.asyncio
+async def test_close_with_no_refresh_task_is_a_noop_on_that_path() -> None:
+    """``close()`` without an in-flight refresh task must not raise.
+
+    The new guard checks ``host._auth_coord._refresh_task`` for both
+    ``None`` and ``done()``. A freshly-opened client never triggered a
+    refresh, so ``_refresh_task is None`` — close must take the
+    short-circuit branch and not blow up trying to ``.cancel()`` a
+    ``None``.
+    """
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+    transport = httpx.MockTransport(lambda req: httpx.Response(200))
+    lifecycle._http_client = httpx.AsyncClient(transport=transport)
+    lifecycle._bound_loop = asyncio.get_running_loop()
+
+    assert host._auth_coord._refresh_task is None
+
+    # Must not raise.
+    await lifecycle.close(host)
+    assert lifecycle._http_client is None
+
+
+@pytest.mark.asyncio
+async def test_close_with_completed_refresh_task_does_not_recancel() -> None:
+    """A refresh task that already finished must be left untouched.
+
+    ``done()`` short-circuits the cancel+gather so a successfully-completed
+    refresh wave doesn't have its task re-cancelled (which would be a
+    no-op but would still log noise via ``gather(return_exceptions=True)``).
+    """
+    lifecycle = _make_lifecycle()
+    host = _StubHost()
+    transport = httpx.MockTransport(lambda req: httpx.Response(200))
+    lifecycle._http_client = httpx.AsyncClient(transport=transport)
+    lifecycle._bound_loop = asyncio.get_running_loop()
+
+    async def _quick_refresh() -> str:
+        return "done"
+
+    done_task = asyncio.create_task(_quick_refresh())
+    # Let it complete.
+    result = await done_task
+    assert result == "done"
+    assert done_task.done()
+    assert not done_task.cancelled()
+
+    host._auth_coord._refresh_task = done_task  # type: ignore[assignment]
+
+    # Close must not re-cancel a done task.
+    await lifecycle.close(host)
+
+    assert not done_task.cancelled()
+    assert done_task.done()

--- a/tests/unit/concurrency/test_loop_affinity_guard.py
+++ b/tests/unit/concurrency/test_loop_affinity_guard.py
@@ -1,0 +1,211 @@
+"""Unit tests for the loop-affinity guard (P0-2).
+
+The free helper :func:`notebooklm._loop_affinity.assert_bound_loop` is the
+new shared chokepoint that every async entry point on the seam helpers
+(``_core_drain.TransportDrainTracker.drain``,
+``_core_reqid.ReqidCounter.next_reqid``,
+``_core_auth.AuthRefreshCoordinator.await_refresh``,
+``_artifact_polling.ArtifactPollingService.wait_for_completion``,
+``_chat.ChatAPI.ask``) now consults so a cross-loop call surfaces an
+actionable ``RuntimeError`` at the call site rather than hanging on a
+lock bound to a dead loop.
+
+The inline guard at ``_core_transport.py:258-262`` already covers the
+transport-POST path. The new guard extends the same contract to the four
+async entry points that don't pass through that POST path (drain, reqid,
+auth refresh, artifact polling) and to the chat-ask lock that
+``_perform_authed_post`` only catches *after* the per-conversation lock
+acquire — too late.
+
+Acceptance:
+- ``bound_loop=None`` is a silent no-op (lazy / unopened helpers).
+- ``bound_loop=<current loop>`` is a silent no-op (steady state).
+- ``bound_loop=<a different loop>`` raises ``RuntimeError`` with the same
+  diagnostic the transport guard uses.
+- Each of the 5 guarded entry points calls :func:`assert_bound_loop` with
+  its own bound-loop reference before any awaits that touch loop-bound
+  primitives (so cross-loop misuse never hits the lock-wait path).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from notebooklm._artifact_polling import ArtifactPollingService
+from notebooklm._core_auth import AuthRefreshCoordinator
+from notebooklm._core_drain import TransportDrainTracker
+from notebooklm._core_reqid import ReqidCounter
+from notebooklm._loop_affinity import assert_bound_loop
+
+# ---------------------------------------------------------------------------
+# Free helper — the building block.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assert_bound_loop_none_is_noop() -> None:
+    """``bound_loop=None`` must never raise.
+
+    Standalone fixtures and lazy-init paths construct the seam helpers
+    without ever observing an ``open()``. The guard's job is to catch
+    cross-loop misuse, not to enforce that a binding has happened.
+    """
+    # Should not raise.
+    assert_bound_loop(None)
+
+
+@pytest.mark.asyncio
+async def test_assert_bound_loop_matching_loop_is_noop() -> None:
+    """Steady-state: same loop as the captured binding → no raise."""
+    current = asyncio.get_running_loop()
+    # Should not raise.
+    assert_bound_loop(current)
+
+
+def test_assert_bound_loop_mismatch_raises_runtime_error() -> None:
+    """Cross-loop call → ``RuntimeError`` with the canonical message.
+
+    Runs the guard under a fresh ``asyncio.run`` while passing in the
+    *other* loop reference; the mismatch must be caught and surfaced as
+    ``RuntimeError`` containing the canonical "bound to a different event
+    loop" phrase used by the transport guard for diagnostic consistency.
+    """
+    other_loop = asyncio.new_event_loop()
+    try:
+
+        async def inner() -> None:
+            # ``other_loop`` is NOT the loop currently running ``inner()``;
+            # ``asyncio.run`` below builds its own loop.
+            assert_bound_loop(other_loop)
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+    finally:
+        other_loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Per-seam wiring — each guarded entry point consults its own bound-loop.
+# ---------------------------------------------------------------------------
+
+
+def test_drain_guards_against_cross_loop_call() -> None:
+    """``TransportDrainTracker.drain`` must raise on cross-loop misuse.
+
+    Bind the tracker to loop A, then drive ``drain()`` from a fresh loop B
+    via ``asyncio.run``. The cross-loop guard at the top of ``drain``
+    must catch the mismatch before the condition acquire would otherwise
+    hang on a lock bound to loop A.
+    """
+    tracker = TransportDrainTracker()
+    other_loop = asyncio.new_event_loop()
+    try:
+        tracker.set_bound_loop(other_loop)
+
+        async def inner() -> None:
+            await tracker.drain()
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+    finally:
+        other_loop.close()
+
+
+def test_next_reqid_guards_against_cross_loop_call() -> None:
+    """``ReqidCounter.next_reqid`` must raise on cross-loop misuse."""
+    counter = ReqidCounter()
+    other_loop = asyncio.new_event_loop()
+    try:
+        counter.set_bound_loop(other_loop)
+
+        async def inner() -> int:
+            return await counter.next_reqid()
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+    finally:
+        other_loop.close()
+
+
+def test_await_refresh_guards_against_cross_loop_call() -> None:
+    """``AuthRefreshCoordinator.await_refresh`` must raise on cross-loop misuse."""
+
+    async def _refresh_cb() -> Any:
+        raise AssertionError("refresh callback should not run on cross-loop call")
+
+    coord = AuthRefreshCoordinator(refresh_callback=_refresh_cb)
+    other_loop = asyncio.new_event_loop()
+    try:
+        coord.set_bound_loop(other_loop)
+
+        # Minimal host mock; ``await_refresh`` only touches
+        # ``host._metrics_obj.record_lock_wait`` on the happy path, which
+        # the cross-loop guard short-circuits before reaching.
+        host = MagicMock()
+
+        async def inner() -> None:
+            await coord.await_refresh(host)
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+    finally:
+        other_loop.close()
+
+
+def test_wait_for_completion_guards_against_cross_loop_call() -> None:
+    """``ArtifactPollingService.wait_for_completion`` must raise on cross-loop misuse.
+
+    The service routes the guard through its capability adapter
+    (``self._capabilities.bound_loop``). A capability fake bound to loop
+    A and a fresh loop B for the call site reproduces the mismatch.
+    """
+    capabilities = MagicMock()
+    other_loop = asyncio.new_event_loop()
+    try:
+        capabilities.bound_loop = other_loop
+
+        service = ArtifactPollingService(capabilities)
+
+        async def _unused_poll(_nb: str, _task: str) -> Any:
+            raise AssertionError("poll_status should not run on cross-loop call")
+
+        async def inner() -> None:
+            await service.wait_for_completion(
+                "nb-id",
+                "task-id",
+                poll_status=_unused_poll,
+            )
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+    finally:
+        other_loop.close()
+
+
+def test_chat_ask_guards_against_cross_loop_call() -> None:
+    """``ChatAPI.ask`` must raise on cross-loop misuse.
+
+    The chat entry consults its core capability's ``bound_loop`` *before*
+    acquiring the per-conversation lock so a cross-loop follow-up doesn't
+    hang on a lock bound to a dead loop.
+    """
+    from notebooklm._chat import ChatAPI
+
+    capabilities = MagicMock()
+    other_loop = asyncio.new_event_loop()
+    try:
+        capabilities.bound_loop = other_loop
+
+        chat = ChatAPI(capabilities)
+
+        async def inner() -> None:
+            await chat.ask("nb-id", "question", source_ids=["src-1"])
+
+        with pytest.raises(RuntimeError, match="different event loop"):
+            asyncio.run(inner())
+    finally:
+        other_loop.close()

--- a/tests/unit/concurrency/test_reqid_callback_outside_lock.py
+++ b/tests/unit/concurrency/test_reqid_callback_outside_lock.py
@@ -1,0 +1,123 @@
+"""Regression tests for the reqid-callback-outside-lock contract (P1-19).
+
+Before P1-19, :meth:`ReqidCounter.next_reqid` invoked the ``on_lock_wait``
+callback under :attr:`ReqidCounter._lock`. A misbehaving callback —
+slow telemetry sink, attempted re-entry, ``asyncio.sleep(0)`` that
+yielded to another coroutine waiting on the same reqid lock — would
+serialise the lock-wait recording with the increment itself,
+unnecessarily widening the critical section.
+
+The fix reorders so the callback fires AFTER ``_lock.release()``:
+
+1. Acquire lock + measure wait time.
+2. Mutate ``_value`` under the lock.
+3. Release the lock.
+4. Invoke the ``on_lock_wait`` callback with the measured wait time.
+
+The increment semantics (monotonic, distinct values under concurrent
+``asyncio.gather``) are unchanged. The reorder is purely a
+"don't-hold-the-lock-while-emitting-telemetry" hardening pass.
+
+Acceptance:
+- The callback observes a *releasable* lock (i.e. can acquire it itself
+  in the callback body without deadlocking) → proves the release happened
+  first.
+- The pre-increment-value snapshot the callback sees is the
+  *post-increment* value (proves increment happened first).
+- ``next_reqid`` is still atomic under ``asyncio.gather``: two
+  concurrent calls produce distinct values.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from notebooklm._core_reqid import ReqidCounter
+
+
+@pytest.mark.asyncio
+async def test_on_lock_wait_runs_after_lock_release() -> None:
+    """The callback must observe a releasable lock.
+
+    Set up a callback that tries to acquire ``counter._lock`` itself. If
+    the callback ran *inside* the lock, the re-entry would deadlock; the
+    test fails via timeout. If the callback runs *outside* the lock (the
+    P1-19 fix), the re-acquire succeeds immediately.
+    """
+    counter = ReqidCounter()
+
+    callback_could_acquire: list[bool] = []
+
+    def on_lock_wait(_wait_seconds: float) -> None:
+        # If we got here while ``_lock`` was still held, this acquire
+        # would block forever. Use ``locked()`` — a synchronous probe —
+        # to capture the state without blocking.
+        lock = counter._lock
+        assert lock is not None
+        callback_could_acquire.append(not lock.locked())
+
+    counter._on_lock_wait = on_lock_wait
+
+    await counter.next_reqid()
+
+    assert callback_could_acquire == [True], (
+        "on_lock_wait callback observed the lock as STILL HELD — "
+        "the callback must run AFTER lock.release(), not before."
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_lock_wait_observes_post_increment_value() -> None:
+    """The increment must happen under the lock, before the callback.
+
+    Capture the counter value from inside the callback. The fix's
+    ordering — ``_value += step`` *inside* the lock, callback *outside* —
+    means the callback sees the already-incremented value.
+
+    This guards against a "fix" that releases the lock too early and
+    races the increment with the callback.
+    """
+    counter = ReqidCounter()
+    baseline = counter.value
+
+    observed_values: list[int] = []
+
+    def on_lock_wait(_wait_seconds: float) -> None:
+        observed_values.append(counter.value)
+
+    counter._on_lock_wait = on_lock_wait
+
+    new_value = await counter.next_reqid()
+
+    assert new_value == baseline + 100000  # default step
+    assert observed_values == [new_value], (
+        f"callback observed counter={observed_values}, "
+        f"expected post-increment value [{new_value}]. "
+        "The increment must complete under the lock before the callback fires."
+    )
+
+
+@pytest.mark.asyncio
+async def test_next_reqid_remains_atomic_under_gather() -> None:
+    """The lock-ordering fix must not break concurrent monotonicity.
+
+    Two ``asyncio.gather``-ed ``next_reqid`` calls must still produce
+    distinct, monotonic values. This is the existing contract — added
+    here as a regression guard that the P1-19 reorder doesn't widen any
+    race window in ``_value += step``.
+    """
+    counter = ReqidCounter()
+    baseline = counter.value
+
+    results = await asyncio.gather(
+        counter.next_reqid(),
+        counter.next_reqid(),
+        counter.next_reqid(),
+    )
+
+    assert len(set(results)) == 3, f"expected 3 distinct values, got {results}"
+    assert sorted(results) == [baseline + i * 100000 for i in (1, 2, 3)], (
+        f"expected monotonic +100000 sequence after baseline {baseline}, got {sorted(results)}"
+    )

--- a/tests/unit/concurrency/test_synthetic_error_transport_guard.py
+++ b/tests/unit/concurrency/test_synthetic_error_transport_guard.py
@@ -1,0 +1,131 @@
+"""Tests for the synthetic-error transport env-var gate (P1-12).
+
+Before P1-12, ``NOTEBOOKLM_VCR_RECORD_ERRORS`` was a fully open env var:
+setting it outside a pytest run would silently wrap the production HTTP
+transport in :class:`_SyntheticErrorTransport`, substituting synthetic
+error responses for real RPC calls. The transport's docstring warned
+about this but nothing actually gated against accidental production
+exposure (e.g. a leaked environment variable in a deployment).
+
+P1-12 closes that hole: ``ClientCore.__init__`` (the constructor
+consultation site) refuses instantiation when the env var is set without
+``PYTEST_CURRENT_TEST`` in the environment, logging a WARNING and raising
+``RuntimeError`` with remediation guidance. Tests legitimately set the
+env var via the ``@pytest.mark.synthetic_error("…")`` fixture; pytest
+always sets ``PYTEST_CURRENT_TEST`` during a test run, so the gate is
+transparent in CI / unit test contexts.
+
+Acceptance:
+- Env var set + no ``PYTEST_CURRENT_TEST`` → ``RuntimeError`` from
+  ``ClientCore`` instantiation.
+- Env var set + ``PYTEST_CURRENT_TEST`` set → instantiation succeeds
+  (the pytest path remains unchanged).
+- Env var unset → instantiation succeeds (baseline production path).
+- The refusal is logged at WARNING with the env-var name and remediation
+  hint so an unexpected refusal surfaces in operator logs.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from notebooklm._core import ClientCore
+from notebooklm.auth import AuthTokens
+
+
+def _make_auth() -> AuthTokens:
+    return AuthTokens(
+        cookies={"SID": "x", "__Secure-1PSIDTS": "y"},
+        csrf_token="csrf",
+        session_id="sid",
+    )
+
+
+def test_synthetic_error_env_var_without_pytest_context_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Setting the env var without pytest context must raise.
+
+    The test simulates a production process accidentally inheriting
+    ``NOTEBOOKLM_VCR_RECORD_ERRORS=1`` (e.g. a leaked deploy env) by
+    setting the env var and *unsetting* ``PYTEST_CURRENT_TEST`` for the
+    constructor call. The refusal:
+
+    1. Raises ``RuntimeError`` so the broken configuration surfaces at
+       import / instantiation time rather than silently subbing in
+       synthetic responses later.
+    2. Mentions the env-var name in the error so the operator can
+       grep deploy configs.
+    3. Logs at WARNING so the refusal is visible in operator logs.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD_ERRORS", "5xx")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="notebooklm._core"),
+        pytest.raises(RuntimeError, match="NOTEBOOKLM_VCR_RECORD_ERRORS"),
+    ):
+        ClientCore(_make_auth())
+
+    # WARNING must mention the env var so an operator can find the source.
+    assert any(
+        "NOTEBOOKLM_VCR_RECORD_ERRORS" in record.message and record.levelname == "WARNING"
+        for record in caplog.records
+    ), (
+        "expected WARNING log mentioning the env var; "
+        f"got records={[(r.levelname, r.message) for r in caplog.records]}"
+    )
+
+
+def test_synthetic_error_env_var_with_pytest_context_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pytest context (PYTEST_CURRENT_TEST set) keeps instantiation working.
+
+    The synthetic-error transport is a test-only opt-in path; pytest always
+    sets ``PYTEST_CURRENT_TEST``, so the legitimate
+    ``@pytest.mark.synthetic_error("…")`` fixture path must remain a
+    no-op for the new gate.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD_ERRORS", "5xx")
+    # PYTEST_CURRENT_TEST is set by pytest itself; assert it for clarity.
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "fake_test")
+
+    # Must NOT raise.
+    core = ClientCore(_make_auth())
+    assert core is not None
+
+
+def test_synthetic_error_env_var_unset_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Baseline production path — env var unset, instantiation works.
+
+    No env var → :func:`_get_error_injection_mode` returns ``None`` and
+    the new gate is bypassed. The synthetic transport is never wrapped.
+    """
+    monkeypatch.delenv("NOTEBOOKLM_VCR_RECORD_ERRORS", raising=False)
+    # Even when pytest IS running (PYTEST_CURRENT_TEST set), no env var
+    # means no gate check at all.
+    core = ClientCore(_make_auth())
+    assert core is not None
+
+
+def test_synthetic_error_env_var_empty_string_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env var set to empty string must NOT trigger the gate.
+
+    ``_get_error_injection_mode`` returns ``None`` for empty/whitespace,
+    so the synthetic transport never engages. The new gate must use the
+    same predicate so accidental ``export NOTEBOOKLM_VCR_RECORD_ERRORS=``
+    (empty value) does not block production startup.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_VCR_RECORD_ERRORS", "")
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    core = ClientCore(_make_auth())
+    assert core is not None

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -11,6 +11,12 @@ from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 
 
 class _FakeTransportProvider:
+    # ``ArtifactPollingService.wait_for_completion`` calls
+    # ``assert_bound_loop(self._capabilities.bound_loop)`` (P0-2). ``None``
+    # is the documented silent-no-op value for the affinity helper, so
+    # this stub stays correct without binding to a real loop.
+    bound_loop = None
+
     def __init__(
         self,
         *,

--- a/tests/unit/test_capabilities_conformance.py
+++ b/tests/unit/test_capabilities_conformance.py
@@ -1,4 +1,4 @@
-"""Structural conformance tests for the 9 base Protocols in ``_capabilities.py``.
+"""Structural conformance tests for the 10 base Protocols in ``_capabilities.py``.
 
 These tests are pure structural checks: they assert that
 ``ClientCoreCapabilities`` (the adapter) — and, where applicable,
@@ -11,7 +11,7 @@ the test must run with zero runtime side-effects, so we bypass
 ``ClientCore.__init__`` entirely.
 
 This test is intentionally noisy when a Protocol is added or removed —
-the 9-Protocol count guard at the top forces future contributors to
+the 10-Protocol count guard at the top forces future contributors to
 update ``_BASE_PROTOCOLS`` in lockstep.
 """
 
@@ -31,6 +31,7 @@ from notebooklm._capabilities import (
     CookieJarProvider,
     CoreReqIdProvider,
     CoreRPCProvider,
+    LoopAffinityProvider,
     PollRegistryProvider,
     SourceListProvider,
     TransportOperationProvider,
@@ -45,7 +46,7 @@ _CAPABILITIES_SRC = Path(__file__).resolve().parents[2] / "src/notebooklm/_capab
 # checks only see the surface each *Provider* Protocol actually adds.
 _PROTOCOL_BASE_DIR: frozenset[str] = frozenset(dir(Protocol))
 
-# All 9 base Protocols, mirroring the bases of ``ClientCoreCapabilities``.
+# All 10 base Protocols, mirroring the bases of ``ClientCoreCapabilities``.
 _BASE_PROTOCOLS: tuple[type, ...] = (
     CoreRPCProvider,
     SourceListProvider,
@@ -56,9 +57,10 @@ _BASE_PROTOCOLS: tuple[type, ...] = (
     CookieJarProvider,
     TransportOperationProvider,
     UploadConcurrencyProvider,
+    LoopAffinityProvider,
 )
 
-# Members of the 9 Protocols that ``ClientCore`` itself directly exposes today.
+# Members of the 10 Protocols that ``ClientCore`` itself directly exposes today.
 # The remaining members are deliberately adapter-only on main HEAD: they are
 # either un-prefixed renames of underscored core helpers
 # (e.g. ``begin_transport_post`` → ``ClientCore._begin_transport_post``),
@@ -129,14 +131,14 @@ def _ast_class_directly_inherits_protocol(node: ast.ClassDef) -> bool:
     return False
 
 
-def test_capabilities_module_declares_exactly_nine_provider_protocols() -> None:
+def test_capabilities_module_declares_exactly_ten_provider_protocols() -> None:
     """Guard against silent Protocol additions/removals.
 
     Scans the **top-level** AST of ``_capabilities.py`` for class
     definitions whose name ends with ``Provider`` AND which directly
     inherit from ``Protocol``. Both conditions matter: a stray non-Protocol
     ``FooProvider`` helper, or a Protocol renamed away from the ``Provider``
-    suffix, would silently miscount. Future contributors who add a 10th
+    suffix, would silently miscount. Future contributors who add an 11th
     Protocol must also extend ``_BASE_PROTOCOLS`` in this test so the
     conformance loops cover it; the assertions force that.
     """
@@ -149,13 +151,13 @@ def test_capabilities_module_declares_exactly_nine_provider_protocols() -> None:
         and node.name.endswith("Provider")
         and _ast_class_directly_inherits_protocol(node)
     ]
-    assert len(provider_classes) == 9, (
-        f"Expected exactly 9 *Provider Protocols in _capabilities.py, found "
+    assert len(provider_classes) == 10, (
+        f"Expected exactly 10 *Provider Protocols in _capabilities.py, found "
         f"{len(provider_classes)}: {provider_classes}. Update _BASE_PROTOCOLS "
         "in this test if a Protocol was added or removed."
     )
-    assert len(_BASE_PROTOCOLS) == 9, (
-        "_BASE_PROTOCOLS drifted from the 9 *Provider classes in "
+    assert len(_BASE_PROTOCOLS) == 10, (
+        "_BASE_PROTOCOLS drifted from the 10 *Provider classes in "
         "_capabilities.py; update the tuple."
     )
     # Defence-in-depth: the AST-discovered names must match the imported tuple.
@@ -176,7 +178,7 @@ def test_client_core_capabilities_satisfies_protocol_structurally(
 
     Uses ``name in caps_cls.__dict__`` (concrete definition on the adapter
     itself) rather than ``hasattr(caps_cls, name)``. This matters because
-    ``ClientCoreCapabilities`` inherits from all 9 Protocols, and ``typing.
+    ``ClientCoreCapabilities`` inherits from all 10 Protocols, and ``typing.
     Protocol`` installs abstract stubs on its subclasses. A bare ``hasattr``
     would happily fall back to the inherited Protocol stub, masking a
     forgotten or accidentally-removed concrete implementation. The
@@ -239,7 +241,7 @@ def test_client_core_exposes_native_protocol_surface(
             )
 
 
-def test_client_core_capabilities_inherits_all_nine_protocols() -> None:
+def test_client_core_capabilities_inherits_all_ten_protocols() -> None:
     """``ClientCoreCapabilities`` must declare every base Protocol in its MRO.
 
     Inheriting the Protocols is what makes the adapter usable as a typed

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -58,9 +58,11 @@ class _StubHost:
 
     * ``auth`` — a real :class:`AuthTokens` so :meth:`ClientLifecycle.open`
       can read ``cookies`` / ``cookie_jar`` / ``storage_path``.
-    * ``_metrics_obj`` / ``_drain_tracker`` / ``_auth_coord`` —
-      ``MagicMock``s; the lifecycle only touches
-      ``_drain_tracker._draining = False`` from the open() path.
+    * ``_metrics_obj`` / ``_drain_tracker`` / ``_auth_coord`` / ``_reqid`` —
+      ``MagicMock``s; the lifecycle touches
+      ``_drain_tracker._draining = False`` and calls ``set_bound_loop`` on
+      each of the three helpers (drain / reqid / auth_coord) from the
+      open() path so cross-loop misuse can be caught.
     * ``cookie_persistence`` — a ``MagicMock`` with an async ``save``
       coroutine; assertions check it was called with the right args.
     * ``poll_registry`` — a ``MagicMock`` with ``active_tasks()`` returning
@@ -80,6 +82,12 @@ class _StubHost:
         self._drain_tracker = MagicMock()
         self._drain_tracker._draining = True  # so we can assert open() resets it
         self._auth_coord = MagicMock()
+        # ``_auth_coord._refresh_task`` is checked by ``close()`` (P0-1).
+        # Default to ``None`` so the cancel branch is skipped; tests that
+        # exercise the in-flight-refresh path overwrite it.
+        self._auth_coord._refresh_task = None
+        # ``_reqid`` is targeted by ``set_bound_loop`` from open() (P0-2).
+        self._reqid = MagicMock()
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()


### PR DESCRIPTION
## Summary

First PR in **Tier 9 Wave 1** — closes 2 P0s and 2 P1s from the [consolidated gap audit](https://github.com/teng-lin/notebooklm-py/blob/main/.sisyphus/reports/gap-audit-2026-05-17-CONSOLIDATED.md).

- **P0-1** — Cancel `_auth_coord._refresh_task` in `close()` before `save_cookies` to prevent in-flight refresh from racing `aclose()` and setting exceptions on a torn-down transport.
- **P0-2** — New module `_loop_affinity.py` with free helper `assert_bound_loop()`; called from every public async entry point that lazily allocates an asyncio primitive (`drain`, `next_reqid`, `await_refresh`, `wait_for_completion`, `chat.ask`). Eliminates silent cross-loop deadlock. Inline guard at `_core_transport.py:258-262` preserved.
- **P1-12** — `_SyntheticErrorTransport` now refuses to wire in if `NOTEBOOKLM_VCR_RECORD_ERRORS` is set outside a recognized test context. Closes the env-var-leak-into-installed-wheel exfil path.
- **P1-19** — `_core_reqid.next_reqid()` reordered so `on_lock_wait` callback runs after `_lock.release()` rather than inside the `finally` block.

`ClientCoreCapabilities` gained a `bound_loop` property so seam modules can access the host loop without coupling to `ClientCore` (Gemini iter-2 critique).

## Test plan
- [x] 4 new test files in `tests/unit/concurrency/` (refresh-race, loop-affinity, reqid-callback, synthetic-transport)
- [x] 24 concurrency tests pass
- [x] Full suite: 5168 tests pass, 20 skipped, 0 failures
- [x] `ruff format` + `ruff check` + `mypy` all clean
- [x] `_core_transport.py:258-262` inline guard unchanged

## Audit refs
- P0-1, P0-2, P1-12, P1-19 in `.sisyphus/reports/gap-audit-2026-05-17-CONSOLIDATED.md`
- Plan: `.sisyphus/plans/tier-9-p0-p1.md` Bundle A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection when the client is used from an incorrect event loop context, with clear guidance to create a new client for the target loop.
  * Enhanced client shutdown to properly cancel in-flight operations before cleanup, preventing race conditions.
  * Added validation guards across async entry points to fail fast on cross-loop misuse and prevent potential hangs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->