### PR TITLE
fix(auth): privacy bundle — repr/refresh-cmd redaction, Playwright domain filter, atomic profile-state (P1-1/17/18/20)

### DIFF
--- a/src/notebooklm/_auth/account.py
+++ b/src/notebooklm/_auth/account.py
@@ -14,7 +14,7 @@ from urllib.parse import urlencode
 import httpx
 from filelock import FileLock
 
-from .._atomic_io import atomic_update_json, atomic_write_json
+from .._atomic_io import atomic_write_json
 from .._env import get_base_url
 from .._url_utils import is_google_auth_redirect
 
@@ -199,31 +199,50 @@ async def enumerate_accounts(
 
 _ACCOUNT_CONTEXT_KEY = "account"
 
+# P1-20: the unified atomic profile-state format embeds account metadata
+# inside ``storage_state.json`` under a ``notebooklm`` namespace key, so
+# a single ``atomic_write_json`` covers both cookies and account in one
+# crash-safe commit. ``version`` is bumped only when the in-band schema
+# changes incompatibly — version 1 is the initial shape.
+_STORAGE_NAMESPACE_KEY = "notebooklm"
+_STORAGE_NAMESPACE_VERSION = 1
+
 
 def _account_context_path(storage_path: Path) -> Path:
-    """Return the context.json path that annotates ``storage_path``."""
+    """Return the context.json path that annotates ``storage_path``.
+
+    Legacy two-file layout: this sibling held ``account`` metadata before
+    P1-20 unified it into ``storage_state.json``. Post-migration, it keeps
+    CLI context state (``notebook_id``, ``conversation_id``) but no longer
+    stores the ``account`` key.
+    """
     return storage_path.with_name("context.json")
 
 
-def read_account_metadata(storage_path: Path | None) -> dict[str, Any]:
-    """Read profile account metadata from ``context.json``.
+def _read_in_band_account(storage_path: Path) -> dict[str, Any]:
+    """Read account metadata from inside ``storage_state.json``.
 
-    The ``account`` object records the Google ``authuser`` index used when
-    the profile was authenticated. Profiles from before this feature shipped
-    (and profiles for users with a single Google account) have no account
-    metadata and use ``authuser=0``.
-
-    Args:
-        storage_path: Path to ``storage_state.json``. The sibling
-            ``context.json`` stores account metadata. ``None`` means the
-            profile is loaded from ``NOTEBOOKLM_AUTH_JSON``.
-
-    Returns:
-        Parsed metadata dict, or ``{}`` if the file is missing, unreadable,
-        or malformed. Callers should treat a missing ``authuser`` key as 0.
+    Returns ``{}`` when the namespace key is missing, malformed, or the file
+    cannot be read. Callers fall back to the legacy sibling ``context.json``.
     """
-    if storage_path is None:
+    if not storage_path.exists():
         return {}
+    try:
+        data = json.loads(storage_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("in-band account read failed at %s: %s", storage_path, e)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    namespace = data.get(_STORAGE_NAMESPACE_KEY)
+    if not isinstance(namespace, dict):
+        return {}
+    account = namespace.get(_ACCOUNT_CONTEXT_KEY)
+    return account if isinstance(account, dict) else {}
+
+
+def _read_legacy_account(storage_path: Path) -> dict[str, Any]:
+    """Read account metadata from the legacy sibling ``context.json``."""
     context_path = _account_context_path(storage_path)
     if not context_path.exists():
         return {}
@@ -236,6 +255,34 @@ def read_account_metadata(storage_path: Path | None) -> dict[str, Any]:
         return {}
     account = data.get(_ACCOUNT_CONTEXT_KEY)
     return account if isinstance(account, dict) else {}
+
+
+def read_account_metadata(storage_path: Path | None) -> dict[str, Any]:
+    """Read profile account metadata, preferring the unified in-band record.
+
+    P1-20 unified layout: account metadata lives inside ``storage_state.json``
+    under the ``notebooklm`` namespace key. Legacy two-file installs are
+    still supported via fallback to sibling ``context.json``; the next write
+    will migrate them in-band.
+
+    The ``account`` object records the Google ``authuser`` index used when
+    the profile was authenticated. Profiles from before account-binding
+    shipped (and profiles for users with a single Google account) have no
+    account metadata and use ``authuser=0``.
+
+    Args:
+        storage_path: Path to ``storage_state.json``. ``None`` means the
+            profile is loaded from ``NOTEBOOKLM_AUTH_JSON``.
+
+    Returns:
+        Parsed metadata dict, or ``{}`` if no record is present.
+    """
+    if storage_path is None:
+        return {}
+    in_band = _read_in_band_account(storage_path)
+    if in_band:
+        return in_band
+    return _read_legacy_account(storage_path)
 
 
 def get_authuser_for_storage(storage_path: Path | None) -> int:
@@ -283,68 +330,150 @@ def authuser_query(authuser: int = 0, account_email: str | None = None) -> str:
     return urlencode({"authuser": format_authuser_value(authuser, account_email)})
 
 
-def write_account_metadata(storage_path: Path, *, authuser: int, email: str | None = None) -> None:
-    """Persist profile account metadata inside sibling ``context.json``.
+def _drop_legacy_account_key(storage_path: Path) -> None:
+    """Migration helper: remove ``account`` from sibling ``context.json``.
 
-    Uses :func:`atomic_update_json` so concurrent CLI invocations (e.g., a
-    ``login`` while ``use`` is in flight) cannot lose updates by writing
-    stale snapshots of ``context.json`` over each other.
-
-    Args:
-        storage_path: Path to ``storage_state.json``. The sibling
-            ``context.json`` is created or updated.
-        authuser: ``authuser`` index used when extracting cookies for this
-            profile (0 for the default account).
-        email: Optional account email to record alongside the index.
+    Preserves all other CLI context state (``notebook_id``,
+    ``conversation_id``, …). Best-effort: a failure here does not abort the
+    in-band write because the reader prefers the in-band record (legacy
+    fallback only kicks in when in-band is absent).
     """
-    context_path = _account_context_path(storage_path)
-    payload: dict[str, Any] = {"authuser": authuser}
-    if email:
-        payload["email"] = email
-
-    def _set_account(data: dict[str, Any]) -> dict[str, Any]:
-        data[_ACCOUNT_CONTEXT_KEY] = payload
-        return data
-
-    # ``recover_from_corrupt=True`` keeps the empty-dict fallback **inside**
-    # the file lock. An outside-the-lock unlink-and-retry would race a
-    # concurrent process that wrote a valid payload between our raise and
-    # our retry, causing us to delete their good write (see PR #465 review).
-    # Account metadata is unrecoverable from corrupt JSON, so silent reset
-    # under the lock is the right behaviour.
-    atomic_update_json(context_path, _set_account, recover_from_corrupt=True)
-
-
-def clear_account_metadata(storage_path: Path | None) -> None:
-    """Remove account metadata from sibling ``context.json`` if present.
-
-    Holds the same sibling ``.lock`` file used by :func:`atomic_update_json`
-    so concurrent ``write_account_metadata`` / context-mutation calls don't
-    lose updates against our clear-and-maybe-delete.
-    """
-    if storage_path is None:
-        return
     context_path = _account_context_path(storage_path)
     if not context_path.exists():
         return
     lock_path = context_path.with_suffix(context_path.suffix + ".lock")
-    context_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with FileLock(str(lock_path), timeout=10.0):
+            if not context_path.exists():
+                return
+            try:
+                data = json.loads(context_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as e:
+                logger.debug("legacy account-key cleanup skipped at %s: %s", context_path, e)
+                return
+            if not isinstance(data, dict) or _ACCOUNT_CONTEXT_KEY not in data:
+                return
+            del data[_ACCOUNT_CONTEXT_KEY]
+            if data:
+                atomic_write_json(context_path, data)
+            else:
+                context_path.unlink()
+    except OSError as e:
+        # Best-effort migration; the in-band reader wins.
+        logger.debug("legacy account-key cleanup failed at %s: %s", context_path, e)
+
+
+def write_account_metadata(storage_path: Path, *, authuser: int, email: str | None = None) -> None:
+    """Persist account metadata atomically inside ``storage_state.json`` (P1-20).
+
+    The account record lands under the ``notebooklm`` namespace key so the
+    (cookies, account) pair commits together via a single
+    :func:`atomic_write_json`. An external reader observing the file
+    mid-update sees either the fully-old or fully-new commit — never a mix.
+
+    The legacy sibling ``context.json[account]`` is best-effort cleaned up
+    after the in-band write succeeds. CLI context state in the same file
+    (``notebook_id`` / ``conversation_id``) is preserved.
+
+    Args:
+        storage_path: Path to ``storage_state.json``. The file is created
+            with empty ``cookies`` / ``origins`` arrays if missing — matching
+            the pre-P1-20 semantics of "writing account metadata never fails
+            because cookies haven't been written yet."
+        authuser: ``authuser`` index used when extracting cookies for this
+            profile (0 for the default account).
+        email: Optional account email to record alongside the index.
+    """
+    account_payload: dict[str, Any] = {"authuser": authuser}
+    if email:
+        account_payload["email"] = email
+
+    # Acquire a sibling-lock so concurrent callers serialize correctly during
+    # the migration window. ``filelock`` reuses the lock file across
+    # invocations; the file is zero-byte and cheap to leave on disk.
+    lock_path = storage_path.with_suffix(storage_path.suffix + ".lock")
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
     with FileLock(str(lock_path), timeout=10.0):
-        # Re-check existence under the lock — another writer may have
-        # removed it between the early-return check and the lock acquire.
-        if not context_path.exists():
-            return
-        try:
-            data = json.loads(context_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as e:
-            logger.debug("account metadata clear skipped for %s: %s", context_path, e)
-            return
-        if not isinstance(data, dict) or _ACCOUNT_CONTEXT_KEY not in data:
-            return
-        del data[_ACCOUNT_CONTEXT_KEY]
-        if data:
-            # atomic_update_json would re-acquire the lock; use the atomic
-            # write directly since we already hold the lock here.
-            atomic_write_json(context_path, data)
-        else:
-            context_path.unlink()
+        # Read-modify-write under the lock to avoid losing concurrent updates.
+        data = _load_storage_state_for_write(storage_path)
+        namespace = data.get(_STORAGE_NAMESPACE_KEY)
+        if not isinstance(namespace, dict):
+            namespace = {}
+        namespace["version"] = _STORAGE_NAMESPACE_VERSION
+        namespace[_ACCOUNT_CONTEXT_KEY] = account_payload
+        data[_STORAGE_NAMESPACE_KEY] = namespace
+        atomic_write_json(storage_path, data)
+
+    # Best-effort: drop the legacy account key from sibling context.json so
+    # the next reader doesn't see the same data in two places.
+    _drop_legacy_account_key(storage_path)
+
+
+def _load_storage_state_for_write(storage_path: Path) -> dict[str, Any]:
+    """Read ``storage_state.json`` for a read-modify-write under the lock.
+
+    Returns a synthetic empty document if the file is missing — matches
+    pre-P1-20 semantics where account writes never failed just because the
+    cookie file hadn't been written yet. Corruption is fatal because the
+    primary cookie data can't be recovered from account metadata; surface
+    a ``RuntimeError`` so the caller can prompt the user to re-run login.
+    """
+    if not storage_path.exists():
+        return {"cookies": [], "origins": []}
+    try:
+        loaded = json.loads(storage_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"storage state at {storage_path} is corrupted: {e}") from e
+    if not isinstance(loaded, dict):
+        raise RuntimeError(
+            f"storage state at {storage_path} has unexpected shape: {type(loaded).__name__}"
+        )
+    return loaded
+
+
+def clear_account_metadata(storage_path: Path | None) -> None:
+    """Remove account metadata from both in-band and legacy locations (P1-20).
+
+    Holds a sibling ``.lock`` file via :class:`filelock.FileLock` so
+    concurrent ``write_account_metadata`` calls serialize against the
+    migration cleanup.
+    """
+    if storage_path is None:
+        return
+    # 1. Strip the in-band record from ``storage_state.json``.
+    _clear_in_band_account(storage_path)
+    # 2. Strip the legacy sibling record too (back-compat with old installs).
+    _drop_legacy_account_key(storage_path)
+
+
+def _clear_in_band_account(storage_path: Path) -> None:
+    """Remove the ``notebooklm.account`` key from ``storage_state.json``.
+
+    No-op if the file is missing, unreadable, or doesn't carry an in-band
+    record. When the only remaining key inside the namespace is ``version``,
+    drop the namespace block entirely so the file stays compact.
+    """
+    if not storage_path.exists():
+        return
+    lock_path = storage_path.with_suffix(storage_path.suffix + ".lock")
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with FileLock(str(lock_path), timeout=10.0):
+            try:
+                data = json.loads(storage_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as e:
+                logger.debug("in-band account clear skipped at %s: %s", storage_path, e)
+                return
+            if not isinstance(data, dict):
+                return
+            namespace = data.get(_STORAGE_NAMESPACE_KEY)
+            if not isinstance(namespace, dict) or _ACCOUNT_CONTEXT_KEY not in namespace:
+                return
+            del namespace[_ACCOUNT_CONTEXT_KEY]
+            if set(namespace.keys()) <= {"version"}:
+                del data[_STORAGE_NAMESPACE_KEY]
+            else:
+                data[_STORAGE_NAMESPACE_KEY] = namespace
+            atomic_write_json(storage_path, data)
+    except OSError as e:
+        logger.debug("in-band account clear failed at %s: %s", storage_path, e)

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -1002,11 +1002,16 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
         # Two-channel disclosure: the user sees only exit code + executable
         # basename; developers running with ``-vv`` get the full output
         # through the package's redacting DEBUG logger.
-        executable_basename = (
-            os.path.basename(run_target[0])
-            if isinstance(run_target, list) and run_target
-            else "shell"
-        )
+        # Claude bot review feedback: in shell-mode ``run_target`` is the raw
+        # command STRING, not a list. Extract the basename of its first token
+        # so users still see a useful script name (the string is user-supplied
+        # and not a secret — its argv[0] equivalent is safe to surface).
+        if isinstance(run_target, list) and run_target:
+            executable_basename = os.path.basename(run_target[0])
+        elif isinstance(run_target, str) and run_target.strip():
+            executable_basename = os.path.basename(run_target.split()[0])
+        else:
+            executable_basename = "shell"
         logger.debug(
             "%s exited %d. stdout=%r stderr=%r",
             NOTEBOOKLM_REFRESH_CMD_ENV,

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -40,7 +40,7 @@ import time
 import weakref
 from collections.abc import Iterator
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
 from typing import Any, TypeAlias
@@ -294,13 +294,18 @@ class AuthTokens:
             of snapshotting the already-mutated jar as clean state.
     """
 
-    cookies: DomainCookieMap
-    csrf_token: str
-    session_id: str
+    # Secret fields are excluded from the dataclass-generated ``__repr__`` via
+    # ``field(repr=False)`` and re-surfaced as redacted placeholders by the
+    # custom ``__repr__`` below (P1-1). This prevents accidental secret
+    # leakage through ``logger.debug("%r", auth)``, ``pytest -vv`` failure
+    # diffs, and any third-party tooling that calls ``repr()`` on the dataclass.
+    cookies: DomainCookieMap = field(repr=False)
+    csrf_token: str = field(repr=False)
+    session_id: str = field(repr=False)
     storage_path: Path | None = None
-    cookie_jar: httpx.Cookies | None = None
+    cookie_jar: httpx.Cookies | None = field(default=None, repr=False)
     authuser: int = 0
-    cookie_snapshot: CookieSnapshot | None = None
+    cookie_snapshot: CookieSnapshot | None = field(default=None, repr=False)
     account_email: str | None = None
 
     def __post_init__(self) -> None:
@@ -308,6 +313,32 @@ class AuthTokens:
         self.cookies = normalize_cookie_map(self.cookies)
         if self.cookie_jar is None:
             self.cookie_jar = build_cookie_jar(cookies=self.cookies, storage_path=self.storage_path)
+
+    def __repr__(self) -> str:
+        """Return a redacted representation safe for logs and pytest diffs.
+
+        Cookie values, CSRF + session tokens, the live ``cookie_jar``, and the
+        ``cookie_snapshot`` are all credential-equivalent and never appear
+        verbatim. The cookie count is preserved so reprs remain useful for
+        debugging (e.g. "expected 4 cookies, got 2"). Non-secret identity
+        fields (``authuser``, ``account_email``, ``storage_path``) are kept
+        for the same reason — they help identify *which* profile is involved
+        without leaking *how to impersonate it*.
+        """
+        jar_summary = "<redacted>" if self.cookie_jar is not None else "None"
+        snapshot_summary = "<redacted>" if self.cookie_snapshot is not None else "None"
+        return (
+            "AuthTokens("
+            f"cookies=<{len(self.cookies)} redacted>, "
+            "csrf_token=<redacted>, "
+            "session_id=<redacted>, "
+            f"storage_path={self.storage_path!r}, "
+            f"cookie_jar={jar_summary}, "
+            f"authuser={self.authuser!r}, "
+            f"cookie_snapshot={snapshot_summary}, "
+            f"account_email={self.account_email!r}"
+            ")"
+        )
 
     @property
     def cookie_header(self) -> str:
@@ -962,8 +993,32 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
             f"{NOTEBOOKLM_REFRESH_CMD_ENV} failed to execute: {refresh_err}"
         ) from refresh_err
     if result.returncode != 0:
-        output = (result.stderr or result.stdout).strip()
-        raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} exited {result.returncode}: {output}")
+        # P1-18: do NOT interpolate stdout/stderr into the user-facing raise.
+        # Subprocesses commonly print bearer tokens, cookies, and absolute
+        # paths into a user's credentials directory. ``RuntimeError`` bubbles
+        # up through ``cli.error_handler`` and lands on stderr (or a JSON
+        # envelope), which is the wrong audience for that material.
+        #
+        # Two-channel disclosure: the user sees only exit code + executable
+        # basename; developers running with ``-vv`` get the full output
+        # through the package's redacting DEBUG logger.
+        executable_basename = (
+            os.path.basename(run_target[0])
+            if isinstance(run_target, list) and run_target
+            else "shell"
+        )
+        logger.debug(
+            "%s exited %d. stdout=%r stderr=%r",
+            NOTEBOOKLM_REFRESH_CMD_ENV,
+            result.returncode,
+            result.stdout,
+            result.stderr,
+        )
+        raise RuntimeError(
+            f"{NOTEBOOKLM_REFRESH_CMD_ENV} exited {result.returncode} "
+            f"(executable: {executable_basename}). "
+            f"Run with --verbose to see captured stdout/stderr in the debug log."
+        )
     logger.info("NotebookLM cookies refreshed via %s", NOTEBOOKLM_REFRESH_CMD_ENV)
 
 

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -194,7 +194,12 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
         # subprocess output, response bodies, etc.). Pinning to ``args[0]``
         # keeps the contract: raise sites are responsible for producing a
         # safe message; the handler does not re-render.
-        primary = e.args[0] if e.args else type(e).__name__
+        # Claude bot review feedback: third-party exceptions can put non-string
+        # objects in ``args[0]`` (e.g. ``ValueError(42)``, ``SomeErr({"code":
+        # 404})``). The f-string below would call ``str()`` implicitly anyway,
+        # but the explicit cast makes the contract obvious and avoids surprises
+        # if the f-string is ever replaced with a different formatter.
+        primary = str(e.args[0]) if e.args else type(e).__name__
         # Route the full exception (with cause chain + traceback) to the
         # redacting DEBUG logger so ``-vv`` users can still diagnose.
         logger.debug("Unexpected CLI exception", exc_info=True)

--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -5,6 +5,7 @@ across all CLI commands.
 """
 
 import json
+import logging
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any, NoReturn
@@ -22,6 +23,8 @@ from ..exceptions import (
     ValidationError,
 )
 from ._encoding import safe_echo
+
+logger = logging.getLogger(__name__)
 
 
 def _output_error(
@@ -184,8 +187,19 @@ def handle_errors(verbose: bool = False, json_output: bool = False) -> Generator
         # Let Click handle its own exceptions (--help, bad args, etc.)
         raise
     except Exception as e:
+        # P1-18: emit only the exception's primary message (``args[0]``) to
+        # the user. ``str(e)`` would walk Python's default representation,
+        # which for some third-party exceptions includes repr of every arg
+        # — surfacing whatever the raise site put in (potentially full
+        # subprocess output, response bodies, etc.). Pinning to ``args[0]``
+        # keeps the contract: raise sites are responsible for producing a
+        # safe message; the handler does not re-render.
+        primary = e.args[0] if e.args else type(e).__name__
+        # Route the full exception (with cause chain + traceback) to the
+        # redacting DEBUG logger so ``-vv`` users can still diagnose.
+        logger.debug("Unexpected CLI exception", exc_info=True)
         _output_error(
-            f"Unexpected error: {e}",
+            f"Unexpected error: {primary}",
             "UNEXPECTED_ERROR",
             json_output,
             2,

--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -393,6 +393,70 @@ def _build_google_cookie_domains(
         )
 
 
+def _filter_storage_state_cookies_by_domain_policy(
+    state: dict[str, Any],
+    *,
+    include_optional: bool = False,
+    include_domains: set[str] | None = None,
+) -> dict[str, Any]:
+    """Filter a Playwright ``storage_state`` dict to the configured cookie-domain policy (P1-17).
+
+    The rookiepy / ``--browser-cookies`` extraction path asks Chrome only for
+    cookies on the explicit domain allowlist from
+    :func:`_build_google_cookie_domains` — so sibling-product cookies the user
+    happens to be signed into (``mail.google.com``, ``myaccount.google.com``,
+    ``docs.google.com``, ``.youtube.com``) never reach ``storage_state.json``
+    unless the user opts in via ``--include-domains=...``.
+
+    The Playwright login flow, by contrast, captures every cookie the browser
+    context holds. Without this filter, sibling-product cookies leak into the
+    persisted ``storage_state.json`` and inflate the blast radius if the file
+    is ever read by an attacker. This helper applies the same allowlist at
+    write time so both login paths produce equivalent on-disk state.
+
+    The match is exact-against-allowlist with leading-dot/no-dot equivalence
+    (``http.cookiejar`` may normalize either form). Sibling-product subdomains
+    are deliberately not matched by a broad ``.google.com`` suffix check —
+    that's the bug we're fixing.
+
+    Args:
+        state: Playwright ``storage_state`` dict (output of
+            ``BrowserContext.storage_state()``).
+        include_optional: When ``True``, opt in to every label in
+            :data:`notebooklm._auth.cookie_policy.OPTIONAL_COOKIE_DOMAINS_BY_LABEL`.
+        include_domains: Set of optional-domain labels to opt in. ``"all"``
+            is accepted as a shortcut for every label. Mirrors the rookiepy
+            path semantics.
+
+    Returns:
+        A new ``storage_state`` dict with ``cookies`` filtered and ``origins``
+        copied verbatim. The input dict is not mutated.
+    """
+    allowed_list = _build_google_cookie_domains(
+        include_optional=include_optional, include_domains=include_domains
+    )
+    # Set membership for O(1) lookup over the (modest but non-trivial) regional
+    # ccTLD list. Build a strip-leading-dot equivalence set so cookies stored
+    # with the opposite dot prefix still match. ``http.cookiejar`` normalization
+    # is the reason both ``accounts.google.com`` and ``.accounts.google.com``
+    # are listed verbatim in :data:`REQUIRED_COOKIE_DOMAINS`; the equivalence
+    # set is a defense-in-depth check in case a Playwright capture stores a
+    # cookie with only one of the two forms.
+    allowed: frozenset[str] = frozenset(allowed_list)
+    allowed_stripped: frozenset[str] = frozenset(d.lstrip(".") for d in allowed_list)
+
+    def _is_allowed(domain: str) -> bool:
+        return domain in allowed or domain.lstrip(".") in allowed_stripped
+
+    filtered_cookies = [
+        cookie for cookie in state.get("cookies", []) if _is_allowed(cookie.get("domain", ""))
+    ]
+    return {
+        "cookies": filtered_cookies,
+        "origins": list(state.get("origins", [])),
+    }
+
+
 def _split_chromium_profile_browser_spec(browser_name: str) -> tuple[str, str] | None:
     with _patched_login_service_dependencies():
         return login_service._split_chromium_profile_browser_spec(browser_name)
@@ -664,6 +728,7 @@ def _run_playwright_login(
     browser: str,
     browser_profile: Path,
     storage_path: Path,
+    include_domains: set[str] | None = None,
 ) -> None:
     """Drive the Playwright-based Google login and persist storage state.
 
@@ -671,8 +736,14 @@ def _run_playwright_login(
     on ImportError), runs the chromium pre-flight when the bundled browser is
     selected, opens a persistent context, retries navigation on transient
     connection errors, waits for login completion, pins ``.google.com``
-    cookies, atomically writes ``storage_state.json``, and clears stale
-    account metadata.
+    cookies, applies the cookie-domain allowlist filter (P1-17), atomically
+    writes ``storage_state.json``, and clears stale account metadata.
+
+    Args:
+        include_domains: Optional set of ``--include-domains`` labels. When
+            ``None`` or empty, only :data:`REQUIRED_COOKIE_DOMAINS` and the
+            regional ccTLDs survive the filter. Mirrors the rookiepy path so
+            both login surfaces produce equivalent on-disk state.
     """
     try:
         from playwright.sync_api import Error as PlaywrightError
@@ -850,8 +921,21 @@ def _run_playwright_login(
 
             # Atomic write with chmod 0o600 — Playwright's path= argument
             # writes directly (non-atomic + world-readable window).
-            state = context.storage_state()
-            atomic_write_json(storage_path, state)
+            #
+            # P1-17: apply the same cookie-domain allowlist that the rookiepy
+            # path uses (``_build_google_cookie_domains``) so sibling-product
+            # cookies (mail, myaccount, docs, youtube) the user happens to be
+            # signed into in the same browser session don't leak into
+            # ``storage_state.json``. Opt-in via ``--include-domains=...``
+            # mirrors the rookiepy semantics.
+            # Playwright's ``storage_state()`` returns a ``TypedDict``-shaped
+            # value; widen to a plain ``dict[str, Any]`` for the filter helper
+            # (which is independently testable without the Playwright import).
+            playwright_state = context.storage_state()
+            filtered_state: dict[str, Any] = _filter_storage_state_cookies_by_domain_policy(
+                dict(playwright_state), include_domains=include_domains
+            )
+            atomic_write_json(storage_path, filtered_state)
             from ..auth import clear_account_metadata
 
             try:
@@ -1084,23 +1168,17 @@ def register_session_commands(cli):
                 )
                 return
 
-            # Playwright path does not consult ``_build_google_cookie_domains``
-            # (the browser owns its own cookie jar via persistent context), so
-            # ``--include-domains`` is a no-op here. Warn rather than silently
-            # ignore so a user doesn't think it took effect.
-            if include_domains:
-                console.print(
-                    "[yellow]Warning: --include-domains has no effect without "
-                    "--browser-cookies (the Playwright login flow saves whatever "
-                    "cookies the browser context already holds).[/yellow]"
-                )
-
+            # P1-17: the Playwright path now applies the same cookie-domain
+            # allowlist as the rookiepy path. ``--include-domains`` opts the
+            # named sibling-product domains back in; default keeps only
+            # ``REQUIRED_COOKIE_DOMAINS`` + regional ccTLDs.
             profile = ctx.obj.get("profile") if ctx.obj else None
             storage_path, browser_profile = _prepare_login_paths(profile, storage, fresh)
             _run_playwright_login(
                 browser=browser,
                 browser_profile=browser_profile,
                 storage_path=storage_path,
+                include_domains=include_domains,
             )
             console.print(f"\n[green]Authentication saved to:[/green] {storage_path}")
 

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -18,6 +18,25 @@ from notebooklm.types import Notebook
 from .conftest import create_mock_client, patch_main_cli_client
 
 
+def _read_account(storage_path: Path) -> dict:
+    """Test-suite helper: read account metadata via the canonical reader.
+
+    Post-P1-20 the account record lives inside ``storage_state.json`` under
+    the ``notebooklm`` namespace key; ``read_account_metadata`` handles both
+    the new in-band layout and the legacy sibling ``context.json`` fallback,
+    so tests that previously read ``context.json`` directly can route through
+    this helper without caring which on-disk shape they hit.
+    """
+    from notebooklm.auth import read_account_metadata
+
+    return read_account_metadata(storage_path)
+
+
+def _account_exists(storage_path: Path) -> bool:
+    """Test-suite helper: True iff any non-empty account record is present."""
+    return bool(_read_account(storage_path))
+
+
 @pytest.fixture
 def runner():
     return CliRunner()
@@ -3023,7 +3042,7 @@ class TestAuthRefreshCommand:
         assert result.exit_code == 0, result.output
         assert "bob@gmail.com" in result.output
         assert "authuser" not in result.output
-        assert json.loads((storage.parent / "context.json").read_text())["account"] == {
+        assert _read_account(storage) == {
             "authuser": 0,
             "email": "bob@gmail.com",
         }
@@ -3063,7 +3082,10 @@ class TestAuthRefreshCommand:
         assert "bob@gmail.com" in result.output
         assert "not signed in" in result.output.lower()
         assert "alice@example.com" in result.output
-        assert json.loads((storage.parent / "context.json").read_text())["account"] == {
+        # In this test the storage file was pre-seeded with a sibling
+        # context.json (legacy layout). The reader falls back to that record
+        # because no in-band write has occurred — assertion stays unchanged.
+        assert _read_account(storage) == {
             "authuser": 1,
             "email": "bob@gmail.com",
         }
@@ -3216,9 +3238,9 @@ class TestLoginMultiAccount:
             )
 
         assert result.exit_code == 0, result.output
-        context_json = target_dir / "context.json"
-        assert context_json.exists()
-        assert json.loads(context_json.read_text())["account"] == {
+        storage_file = target_dir / "storage_state.json"
+        assert _account_exists(storage_file)
+        assert _read_account(storage_file) == {
             "authuser": 1,
             "email": "bob@gmail.com",
         }
@@ -3301,8 +3323,8 @@ class TestLoginMultiAccount:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--all-accounts"])
 
         assert result.exit_code == 0, result.output
-        alice_meta = json.loads((target_root / "alice" / "context.json").read_text())["account"]
-        bob_meta = json.loads((target_root / "bob" / "context.json").read_text())["account"]
+        alice_meta = _read_account(target_root / "alice" / "storage_state.json")
+        bob_meta = _read_account(target_root / "bob" / "storage_state.json")
         assert alice_meta == {"authuser": 0, "email": "alice@example.com"}
         assert bob_meta == {"authuser": 1, "email": "bob@gmail.com"}
 
@@ -3380,8 +3402,9 @@ class TestLoginMultiAccount:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--all-accounts"])
 
         assert result.exit_code == 0, result.output
-        assert (target_root / "alice-2" / "context.json").exists()
-        assert json.loads((target_root / "alice-2" / "context.json").read_text())["account"] == {
+        alice2_storage = target_root / "alice-2" / "storage_state.json"
+        assert _account_exists(alice2_storage)
+        assert _read_account(alice2_storage) == {
             "authuser": 0,
             "email": "alice@example.com",
         }
@@ -3431,7 +3454,7 @@ class TestLoginMultiAccount:
 
         assert first.exit_code == 0, first.output
         assert second.exit_code == 0, second.output
-        assert json.loads((target_root / "bob" / "context.json").read_text())["account"] == {
+        assert _read_account(target_root / "bob" / "storage_state.json") == {
             "authuser": 0,
             "email": "bob@gmail.com",
         }
@@ -3541,9 +3564,10 @@ class TestLoginAllAccountsUpdate:
             preexisting={"alice": None},
         )
         assert result.exit_code == 0, result.output
-        assert (root / "alice" / "context.json").exists()
+        alice_storage = root / "alice" / "storage_state.json"
+        assert _account_exists(alice_storage)
         assert (root / "alice-2").exists() is False
-        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+        assert _read_account(alice_storage) == {
             "authuser": 0,
             "email": "alice@example.com",
         }
@@ -3559,8 +3583,12 @@ class TestLoginAllAccountsUpdate:
             preexisting={"alice": None},
         )
         assert result.exit_code == 0, result.output
-        assert (root / "alice-2" / "context.json").exists()
-        # alice still exists but unchanged (no context.json was written there).
+        # P1-20: the new profile lands in alice-2/ with an in-band account
+        # record in its storage_state.json.
+        assert _account_exists(root / "alice-2" / "storage_state.json")
+        # alice still exists but was never touched — no account record either
+        # in-band or in the (absent) sibling context.json.
+        assert not _account_exists(root / "alice" / "storage_state.json")
         assert (root / "alice" / "context.json").exists() is False
 
     def test_update_does_not_clobber_profile_bound_to_different_email(self, runner, tmp_path):
@@ -3575,9 +3603,10 @@ class TestLoginAllAccountsUpdate:
             preexisting={"alice": {"account": {"authuser": 0, "email": "alice@OTHER.com"}}},
         )
         assert result.exit_code == 0, result.output
-        assert (root / "alice-2" / "context.json").exists()
-        # Existing alice metadata must be untouched.
-        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+        # The new profile lands in alice-2 with an in-band record.
+        assert _account_exists(root / "alice-2" / "storage_state.json")
+        # Existing alice metadata (legacy sibling context.json) is untouched.
+        assert _read_account(root / "alice" / "storage_state.json") == {
             "authuser": 0,
             "email": "alice@OTHER.com",
         }
@@ -3596,7 +3625,11 @@ class TestLoginAllAccountsUpdate:
         )
         assert result.exit_code == 0, result.output
         assert sorted(p.name for p in root.iterdir()) == ["alice"]
-        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+        # P1-20: --update re-writes account metadata in-band; the read goes
+        # through ``read_account_metadata`` which prefers the in-band record
+        # when present and falls back to the legacy sibling context.json
+        # otherwise. Either way the assertion is on the canonical reader.
+        assert _read_account(root / "alice" / "storage_state.json") == {
             "authuser": 0,
             "email": "alice@example.com",
         }
@@ -3627,8 +3660,10 @@ class TestLoginAllAccountsUpdate:
         # No alice-2 — the existing alice profile was reused despite the
         # casing mismatch.
         assert (root / "alice-2").exists() is False
-        # Re-stamped metadata uses the email as Google reports it now.
-        assert json.loads((root / "alice" / "context.json").read_text())["account"] == {
+        # Re-stamped metadata uses the email as Google reports it now. The
+        # in-band reader takes precedence over the legacy sibling record so
+        # the casefold-and-rewrite test sees the new value.
+        assert _read_account(root / "alice" / "storage_state.json") == {
             "authuser": 0,
             "email": "alice@gmail.com",
         }
@@ -3971,9 +4006,9 @@ class TestChromiumFanoutAllAccounts:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--all-accounts"])
 
         assert result.exit_code == 0, result.output
-        assert (target_root / "alice" / "context.json").exists()
-        assert (target_root / "bob" / "context.json").exists()
-        assert (target_root / "carol" / "context.json").exists()
+        assert _account_exists(target_root / "alice" / "storage_state.json")
+        assert _account_exists(target_root / "bob" / "storage_state.json")
+        assert _account_exists(target_root / "carol" / "storage_state.json")
         # Cookies written for "bob" must come from Profile 1, not Default —
         # this is the core bug the fan-out fixes.
         bob_storage = json.loads((target_root / "bob" / "storage_state.json").read_text())
@@ -4063,8 +4098,8 @@ class TestChromiumFanoutAllAccounts:
             result = runner.invoke(cli, ["login", "--browser-cookies", "chrome", "--all-accounts"])
 
         assert result.exit_code == 0, result.output
-        assert (target_root / "alice" / "context.json").exists()
-        assert (target_root / "carol" / "context.json").exists()
+        assert _account_exists(target_root / "alice" / "storage_state.json")
+        assert _account_exists(target_root / "carol" / "storage_state.json")
         # No profile written for the signed-out Profile 1.
         assert not any(p.name not in {"alice", "carol"} for p in target_root.iterdir())
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -3919,7 +3919,14 @@ class TestAccountMetadata:
         write_account_metadata(storage, authuser=2, email="bob@gmail.com")
         assert get_authuser_for_storage(storage) == 2
 
-    def test_write_updates_context_file_with_metadata(self, tmp_path):
+    def test_write_updates_storage_state_with_in_band_account(self, tmp_path):
+        """Post-P1-20: account metadata lands in ``storage_state.json``.
+
+        The legacy two-file behavior (account in ``context.json``) is replaced
+        by a unified atomic record under the ``notebooklm`` namespace key.
+        Non-account context state in ``context.json`` (e.g. ``notebook_id``)
+        is preserved untouched.
+        """
         from notebooklm.auth import read_account_metadata, write_account_metadata
 
         storage = tmp_path / "storage_state.json"
@@ -3929,9 +3936,13 @@ class TestAccountMetadata:
         write_account_metadata(storage, authuser=1, email="alice@example.com")
         meta = read_account_metadata(storage)
         assert meta == {"authuser": 1, "email": "alice@example.com"}
+        # P1-20: account record now lives inside storage_state.json.
+        in_band = json.loads(storage.read_text())["notebooklm"]
+        assert in_band["version"] == 1
+        assert in_band["account"] == {"authuser": 1, "email": "alice@example.com"}
+        # CLI context state in context.json survives the write.
         assert json.loads((tmp_path / "context.json").read_text()) == {
             "notebook_id": "nb_existing",
-            "account": {"authuser": 1, "email": "alice@example.com"},
         }
 
     def test_get_authuser_ignores_negative(self, tmp_path):

--- a/tests/unit/test_auth_repr_redaction.py
+++ b/tests/unit/test_auth_repr_redaction.py
@@ -1,0 +1,152 @@
+"""Unit tests for ``AuthTokens.__repr__`` secret redaction (P1-1).
+
+Secret values that must never appear in ``repr(AuthTokens(...))``:
+
+* Cookie values (``__Secure-1PSID``, ``__Secure-1PSIDTS``, ``SID``, …).
+* ``csrf_token`` (the ``SNlM0e`` value).
+* ``session_id`` (the ``FdrFJe`` value).
+* Cookie values held inside the ``cookie_jar`` (``httpx.Cookies``).
+* Cookie values held inside ``cookie_snapshot``.
+
+Non-secret fields that SHOULD appear (so logs remain debuggable):
+
+* The class name and a redacted summary indicating field presence.
+* ``authuser`` index and ``account_email`` — neither is credential-equivalent
+  and both help identify which profile is involved.
+* ``storage_path`` (typically already in user-facing log lines).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from notebooklm.auth import AuthTokens
+
+_SECRET_PSID = "secret-psid-value-deadbeefcafe"
+_SECRET_PSIDTS = "secret-psidts-cafefeedface"
+_SECRET_SID = "secret-sid-value-12345"
+_SECRET_CSRF = "secret-csrf-token-SNlM0e-abc"
+_SECRET_SESSION = "secret-session-id-FdrFJe-xyz"
+
+
+def _build_auth_with_secrets() -> AuthTokens:
+    """Build an ``AuthTokens`` populated with the canonical secret fixtures."""
+    cookies = {
+        ("__Secure-1PSID", ".google.com", "/"): _SECRET_PSID,
+        ("__Secure-1PSIDTS", ".google.com", "/"): _SECRET_PSIDTS,
+        ("SID", ".google.com", "/"): _SECRET_SID,
+    }
+    jar = httpx.Cookies()
+    jar.set("__Secure-1PSID", _SECRET_PSID, domain=".google.com")
+    jar.set("__Secure-1PSIDTS", _SECRET_PSIDTS, domain=".google.com")
+    jar.set("SID", _SECRET_SID, domain=".google.com")
+    return AuthTokens(
+        cookies=cookies,
+        csrf_token=_SECRET_CSRF,
+        session_id=_SECRET_SESSION,
+        storage_path=Path("/tmp/storage.json"),
+        cookie_jar=jar,
+        authuser=1,
+        account_email="alice@example.com",
+    )
+
+
+def test_repr_does_not_leak_cookie_values() -> None:
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    assert _SECRET_PSID not in rendered
+    assert _SECRET_PSIDTS not in rendered
+    assert _SECRET_SID not in rendered
+
+
+def test_repr_does_not_leak_csrf_or_session() -> None:
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    assert _SECRET_CSRF not in rendered
+    assert _SECRET_SESSION not in rendered
+
+
+def test_repr_does_not_leak_cookie_jar_values() -> None:
+    """The cookie_jar holds the same secrets in a different container."""
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    # ``httpx.Cookies`` iterates names; reach into the underlying
+    # ``http.cookiejar.CookieJar`` for the (name, value) pairs.
+    for cookie in auth.cookie_jar.jar:  # type: ignore[union-attr]
+        assert cookie.value not in rendered, f"Cookie value for {cookie.name} leaked into repr"
+
+
+def test_repr_identifies_class_and_safe_metadata() -> None:
+    """Redacted repr still names the class and shows non-secret debug info."""
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    assert rendered.startswith("AuthTokens(")
+    # authuser is not credential-equivalent — surface it for debuggability.
+    assert "authuser=1" in rendered
+    # account_email is identity-equivalent (sub-PII) but already exposed
+    # in user-facing CLI output (`notebooklm status`), so it stays.
+    assert "alice@example.com" in rendered
+
+
+def test_repr_marks_secret_fields_as_redacted() -> None:
+    """The redaction is explicit so a reader knows fields exist + are hidden."""
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    assert "redacted" in rendered.lower()
+    # The three secret-shaped fields should each show up as redacted.
+    assert "csrf_token" in rendered
+    assert "session_id" in rendered
+    assert "cookies" in rendered
+
+
+def test_repr_cookie_count_reflects_actual_size() -> None:
+    """The placeholder includes the cookie count so reprs aid debugging."""
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    # 3 cookies in the fixture above.
+    assert "3" in rendered
+
+
+def test_repr_handles_empty_cookies_and_no_jar() -> None:
+    """Edge case: empty cookies, no jar override — repr should not raise."""
+    auth = AuthTokens(
+        cookies={},
+        csrf_token="",
+        session_id="",
+    )
+    rendered = repr(auth)
+    assert rendered.startswith("AuthTokens(")
+    assert "redacted" in rendered.lower()
+
+
+def test_repr_does_not_leak_cookie_snapshot_values() -> None:
+    """``cookie_snapshot`` mirrors the live jar and must also be redacted."""
+    from notebooklm.auth import snapshot_cookie_jar
+
+    auth = _build_auth_with_secrets()
+    snapshot = snapshot_cookie_jar(auth.cookie_jar)  # type: ignore[arg-type]
+    auth_with_snapshot = AuthTokens(
+        cookies=auth.cookies,
+        csrf_token=_SECRET_CSRF,
+        session_id=_SECRET_SESSION,
+        cookie_jar=auth.cookie_jar,
+        cookie_snapshot=snapshot,
+    )
+    rendered = repr(auth_with_snapshot)
+    assert _SECRET_PSID not in rendered
+    assert _SECRET_PSIDTS not in rendered
+    assert _SECRET_SID not in rendered
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [_SECRET_PSID, _SECRET_PSIDTS, _SECRET_SID, _SECRET_CSRF, _SECRET_SESSION],
+)
+def test_repr_redacts_every_canonical_secret(secret: str) -> None:
+    """Belt-and-suspenders: parametrized check across all fixture secrets."""
+    auth = _build_auth_with_secrets()
+    rendered = repr(auth)
+    assert secret not in rendered, f"Secret {secret!r} leaked into repr"

--- a/tests/unit/test_cookie_domain_split.py
+++ b/tests/unit/test_cookie_domain_split.py
@@ -525,26 +525,26 @@ class TestLoginCliFlag:
         assert result.exit_code == 0, result.output
         assert "sibling-product cookies not included" not in result.output
 
-    def test_login_include_domains_without_browser_cookies_warns(self, monkeypatch, tmp_path):
-        """``--include-domains`` on the Playwright path is a no-op — warn.
+    def test_login_include_domains_on_playwright_path_no_longer_warns(self, monkeypatch, tmp_path):
+        """``--include-domains`` now applies on the Playwright path (P1-17).
 
-        Claude review feedback: a user who runs ``notebooklm login
-        --include-domains=youtube`` (no ``--browser-cookies``) gets no
-        signal that the flag did nothing. Mirror the symmetric warning
-        ``--fresh`` already prints when combined with ``--browser-cookies``.
+        Prior to P1-17 the Playwright login flow ignored ``--include-domains``
+        and emitted a "no effect" warning. Now the flag drives the
+        write-time cookie-domain allowlist filter so sibling-product cookies
+        only get persisted when the user explicitly opts in. Confirm the
+        legacy warning is gone — the test guarding the old behavior is
+        repurposed as a regression guard so we don't reintroduce it.
         """
         monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
         monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
         runner = CliRunner()
 
-        # Stub Playwright import to break out before any real browser launch.
-        # We only care that the warning is printed before the Playwright path
-        # is attempted, so we let the import fail (no playwright in scope)
-        # and the function will SystemExit afterwards.
+        # Stub Playwright import to break out before any real browser launch;
+        # we only care about the pre-launch warning emission path.
         with patch.dict("sys.modules", {"playwright": None, "playwright.sync_api": None}):
             result = runner.invoke(cli, ["login", "--include-domains", "youtube"])
 
-        assert "--include-domains has no effect without --browser-cookies" in result.output
+        assert "--include-domains has no effect without --browser-cookies" not in result.output
 
 
 class TestAuthRefreshCliFlag:

--- a/tests/unit/test_cookie_domain_split.py
+++ b/tests/unit/test_cookie_domain_split.py
@@ -544,6 +544,12 @@ class TestLoginCliFlag:
         with patch.dict("sys.modules", {"playwright": None, "playwright.sync_api": None}):
             result = runner.invoke(cli, ["login", "--include-domains", "youtube"])
 
+        # CodeRabbit feedback: pin the failure path so the test cannot pass
+        # spuriously if the warning never fired (e.g. if Playwright became
+        # available via some other import shim). The Playwright-not-installed
+        # branch in ``_run_playwright_login`` exits 1 with a clear message.
+        assert result.exit_code == 1
+        assert "Playwright not installed" in result.output
         assert "--include-domains has no effect without --browser-cookies" not in result.output
 
 

--- a/tests/unit/test_playwright_domain_filter.py
+++ b/tests/unit/test_playwright_domain_filter.py
@@ -1,0 +1,215 @@
+"""Unit tests for the Playwright storage-state domain filter (P1-17).
+
+The Playwright login flow (``cli.session._run_playwright_login``) writes
+``storage_state.json`` directly from ``context.storage_state()``. Without
+filtering, that captures every cookie Playwright observed during the login —
+including sibling Google products the user happens to be signed into in the
+same browser session (``mail.google.com``, ``myaccount.google.com``,
+``docs.google.com``, ``.youtube.com``, …). Those cookies are not exercised
+by any NotebookLM code path and inflate the blast radius if
+``storage_state.json`` is ever leaked.
+
+The rookiepy / ``--browser-cookies`` path has applied this extraction-time
+filter since the cookie-domain split landed (#360). This test suite locks in
+parity for the Playwright path:
+
+1. Cookies whose domain is in ``REQUIRED_COOKIE_DOMAINS`` are kept.
+2. Cookies whose domain matches a regional ``.google.com.<ccTLD>`` variant
+   are kept.
+3. Cookies on optional sibling-product domains (mail, myaccount, docs,
+   youtube) are rejected by default.
+4. ``--include-domains=mail`` (etc.) opts them back in.
+5. ``--include-domains=all`` opts in every optional label.
+6. The ``origins`` array is left untouched — it carries localStorage / IndexedDB
+   keys per origin and is not part of the cookie blast-radius reduction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _filter() -> Any:
+    """Lazily import the helper so red-phase failures are import-clean.
+
+    The helper does not exist yet in red phase; pytest's collection still
+    succeeds because the import is deferred to call time.
+    """
+    from notebooklm.cli.session import _filter_storage_state_cookies_by_domain_policy
+
+    return _filter_storage_state_cookies_by_domain_policy
+
+
+def _state(
+    cookies: list[dict[str, Any]], origins: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    return {"cookies": cookies, "origins": origins or []}
+
+
+def _names(state: dict[str, Any]) -> set[str]:
+    return {c["name"] for c in state["cookies"]}
+
+
+def test_keeps_required_google_com_cookies() -> None:
+    state = _state(
+        [
+            {"name": "SID", "value": "v1", "domain": ".google.com", "path": "/"},
+            {"name": "__Secure-1PSID", "value": "v2", "domain": ".google.com", "path": "/"},
+            {
+                "name": "OSID",
+                "value": "v3",
+                "domain": "accounts.google.com",
+                "path": "/",
+            },
+        ]
+    )
+    out = _filter()(state)
+    assert _names(out) == {"SID", "__Secure-1PSID", "OSID"}
+
+
+def test_keeps_notebooklm_host_cookies() -> None:
+    state = _state(
+        [
+            {
+                "name": "NID",
+                "value": "v1",
+                "domain": "notebooklm.google.com",
+                "path": "/",
+            },
+            {
+                "name": "Secure-LM",
+                "value": "v2",
+                "domain": ".notebooklm.cloud.google.com",
+                "path": "/",
+            },
+        ]
+    )
+    out = _filter()(state)
+    assert _names(out) == {"NID", "Secure-LM"}
+
+
+def test_keeps_regional_cctld_cookies() -> None:
+    state = _state(
+        [
+            {"name": "REG_SG", "value": "v1", "domain": ".google.com.sg", "path": "/"},
+            {"name": "REG_UK", "value": "v2", "domain": ".google.co.uk", "path": "/"},
+            {"name": "REG_DE", "value": "v3", "domain": ".google.de", "path": "/"},
+        ]
+    )
+    out = _filter()(state)
+    assert _names(out) == {"REG_SG", "REG_UK", "REG_DE"}
+
+
+def test_rejects_mail_google_com_by_default() -> None:
+    """Acceptance criterion (P1-17): mail.google.com is dropped by default."""
+    state = _state(
+        [
+            {"name": "MAIL_SID", "value": "v1", "domain": "mail.google.com", "path": "/"},
+            {"name": "MAIL_SID2", "value": "v2", "domain": ".mail.google.com", "path": "/"},
+        ]
+    )
+    out = _filter()(state)
+    assert _names(out) == set()
+
+
+def test_rejects_other_sibling_product_domains_by_default() -> None:
+    state = _state(
+        [
+            {"name": "Y_SID", "value": "v1", "domain": ".youtube.com", "path": "/"},
+            {"name": "MYA_SID", "value": "v2", "domain": "myaccount.google.com", "path": "/"},
+            {"name": "DOCS_SID", "value": "v3", "domain": "docs.google.com", "path": "/"},
+        ]
+    )
+    out = _filter()(state)
+    assert _names(out) == set()
+
+
+def test_rejects_lookalike_domains() -> None:
+    """A cookie on ``evil-google.com`` must never pass the filter."""
+    state = _state(
+        [
+            {"name": "EVIL", "value": "v1", "domain": "evil-google.com", "path": "/"},
+            {"name": "EVIL2", "value": "v2", "domain": "google.com.evil.com", "path": "/"},
+        ]
+    )
+    out = _filter()(state)
+    assert _names(out) == set()
+
+
+def test_include_domains_mail_opts_in_mail_google_com() -> None:
+    state = _state(
+        [
+            {"name": "MAIL_SID", "value": "v1", "domain": "mail.google.com", "path": "/"},
+            {"name": "Y_SID", "value": "v2", "domain": ".youtube.com", "path": "/"},
+        ]
+    )
+    out = _filter()(state, include_domains={"mail"})
+    assert _names(out) == {"MAIL_SID"}  # mail in, youtube still out
+
+
+def test_include_domains_all_opts_in_every_optional_label() -> None:
+    state = _state(
+        [
+            {"name": "MAIL_SID", "value": "v1", "domain": "mail.google.com", "path": "/"},
+            {"name": "Y_SID", "value": "v2", "domain": ".youtube.com", "path": "/"},
+            {"name": "MYA_SID", "value": "v3", "domain": "myaccount.google.com", "path": "/"},
+            {"name": "DOCS_SID", "value": "v4", "domain": "docs.google.com", "path": "/"},
+        ]
+    )
+    out = _filter()(state, include_domains={"all"})
+    assert _names(out) == {"MAIL_SID", "Y_SID", "MYA_SID", "DOCS_SID"}
+
+
+def test_origins_array_preserved_verbatim() -> None:
+    state = _state(
+        [{"name": "SID", "value": "v1", "domain": ".google.com", "path": "/"}],
+        origins=[
+            {
+                "origin": "https://notebooklm.google.com",
+                "localStorage": [{"name": "k", "value": "v"}],
+            }
+        ],
+    )
+    out = _filter()(state)
+    assert out["origins"] == state["origins"]
+
+
+def test_empty_storage_state_round_trips() -> None:
+    out = _filter()({"cookies": [], "origins": []})
+    assert out == {"cookies": [], "origins": []}
+
+
+def test_filter_does_not_mutate_input() -> None:
+    """The helper must return a new dict so the caller can compare before/after."""
+    state = _state(
+        [
+            {"name": "SID", "value": "v1", "domain": ".google.com", "path": "/"},
+            {"name": "MAIL_SID", "value": "v2", "domain": "mail.google.com", "path": "/"},
+        ]
+    )
+    original_cookies = list(state["cookies"])
+    _filter()(state)
+    # Source dict unchanged.
+    assert state["cookies"] == original_cookies
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        "mail.google.com",
+        ".mail.google.com",
+        "myaccount.google.com",
+        ".myaccount.google.com",
+        "docs.google.com",
+        ".docs.google.com",
+        ".youtube.com",
+        "youtube.com",
+        "accounts.youtube.com",
+    ],
+)
+def test_acceptance_sibling_domains_all_rejected_by_default(domain: str) -> None:
+    state = _state([{"name": "C", "value": "v", "domain": domain, "path": "/"}])
+    out = _filter()(state)
+    assert _names(out) == set()

--- a/tests/unit/test_playwright_domain_filter.py
+++ b/tests/unit/test_playwright_domain_filter.py
@@ -26,6 +26,7 @@ parity for the Playwright path:
 
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import pytest
@@ -182,16 +183,22 @@ def test_empty_storage_state_round_trips() -> None:
 
 
 def test_filter_does_not_mutate_input() -> None:
-    """The helper must return a new dict so the caller can compare before/after."""
+    """The helper must return a new dict so the caller can compare before/after.
+
+    CodeRabbit feedback: deep-copy each cookie dict, not just the outer list,
+    so any in-place mutation of an individual cookie dict (e.g. accidental
+    ``cookie["domain"] = …`` inside the filter) is caught — a shallow
+    ``list(state["cookies"])`` would let nested mutations slip through.
+    """
     state = _state(
         [
             {"name": "SID", "value": "v1", "domain": ".google.com", "path": "/"},
             {"name": "MAIL_SID", "value": "v2", "domain": "mail.google.com", "path": "/"},
         ]
     )
-    original_cookies = list(state["cookies"])
+    original_cookies = copy.deepcopy(state["cookies"])
     _filter()(state)
-    # Source dict unchanged.
+    # Source dict unchanged at every depth.
     assert state["cookies"] == original_cookies
 
 

--- a/tests/unit/test_profile_atomic_write.py
+++ b/tests/unit/test_profile_atomic_write.py
@@ -1,0 +1,336 @@
+"""Unit tests for unified atomic profile-state write (P1-20).
+
+The pre-P1-20 layout stored Google auth state across two files:
+
+* ``storage_state.json`` — Playwright cookie/origin state.
+* ``context.json`` — sibling JSON with ``{"account": {"authuser", "email"}}``
+  and CLI notebook/conversation context.
+
+Each file was atomically written on its own. Between the two writes there was
+a window in which an external reader (e.g. a long-running ``notebooklm chat``
+in a sibling shell) could see either the new cookies bundled with the old
+account metadata, or vice versa. Tier-9 P1-20 closes this by bundling the
+``account`` record INTO ``storage_state.json`` under a ``notebooklm``
+namespace key:
+
+    {
+      "cookies": [...],
+      "origins": [...],
+      "notebooklm": {"version": 1, "account": {"authuser": 1, "email": "..."}}
+    }
+
+A single ``atomic_write_json`` is now the only commit point for the
+(cookies, account) pair. ``context.json`` keeps holding non-account CLI
+state (``notebook_id``, ``conversation_id``); the account key, if still
+present from legacy installs, is migrated lazily on next write.
+
+This module covers:
+
+1. Round-trip of the new unified record.
+2. Migration: a legacy two-file fixture reads cleanly under the new reader.
+3. Migration: writing account metadata after a legacy read drops the
+   ``account`` key from ``context.json`` (preserving other CLI state).
+4. Torn-write fault injection: if ``storage_state.json`` write fails after
+   cookies + account were serialized into the same temp file, the original
+   on-disk file is preserved untouched (no half-written state).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from notebooklm._auth.account import (
+    clear_account_metadata,
+    get_account_email_for_storage,
+    get_authuser_for_storage,
+    read_account_metadata,
+    write_account_metadata,
+)
+
+
+def _write_storage_state(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _read_storage_state(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _context_path(storage_path: Path) -> Path:
+    return storage_path.with_name("context.json")
+
+
+def test_write_account_metadata_lands_inline_in_storage_state(tmp_path: Path) -> None:
+    """The post-P1-20 writer puts account inside storage_state.json."""
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(
+        storage_path,
+        {
+            "cookies": [{"name": "SID", "value": "v", "domain": ".google.com", "path": "/"}],
+            "origins": [],
+        },
+    )
+    write_account_metadata(storage_path, authuser=1, email="alice@example.com")
+    payload = _read_storage_state(storage_path)
+    assert payload["notebooklm"]["version"] == 1
+    assert payload["notebooklm"]["account"] == {"authuser": 1, "email": "alice@example.com"}
+
+
+def test_read_account_metadata_prefers_in_band_record(tmp_path: Path) -> None:
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(
+        storage_path,
+        {
+            "cookies": [],
+            "origins": [],
+            "notebooklm": {
+                "version": 1,
+                "account": {"authuser": 2, "email": "bob@example.com"},
+            },
+        },
+    )
+    assert get_authuser_for_storage(storage_path) == 2
+    assert get_account_email_for_storage(storage_path) == "bob@example.com"
+
+
+def test_legacy_two_file_fixture_reads_cleanly(tmp_path: Path) -> None:
+    """ACCEPTANCE-CRITICAL: existing two-file profile loads under new reader.
+
+    If this migration test breaks for any existing user, they will lose their
+    account binding (authuser/email) on the next CLI run — Tier-9 P1-20 PR
+    body must surface this.
+    """
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(
+        storage_path,
+        {
+            "cookies": [{"name": "SID", "value": "v", "domain": ".google.com", "path": "/"}],
+            "origins": [],
+        },
+    )
+    # Legacy sibling context.json with account but no in-band record.
+    _context_path(storage_path).write_text(
+        json.dumps(
+            {
+                "account": {"authuser": 3, "email": "charlie@example.com"},
+                "notebook_id": "nb-123",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert get_authuser_for_storage(storage_path) == 3
+    assert get_account_email_for_storage(storage_path) == "charlie@example.com"
+    assert read_account_metadata(storage_path) == {
+        "authuser": 3,
+        "email": "charlie@example.com",
+    }
+
+
+def test_migration_on_write_removes_legacy_account_key_only(tmp_path: Path) -> None:
+    """After upgrade write, ``context.json`` keeps non-account state.
+
+    ``context.json`` also holds ``notebook_id`` / ``conversation_id`` —
+    migration must NOT clobber those.
+    """
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(storage_path, {"cookies": [], "origins": []})
+    _context_path(storage_path).write_text(
+        json.dumps(
+            {
+                "account": {"authuser": 4, "email": "dana@example.com"},
+                "notebook_id": "nb-456",
+                "conversation_id": "conv-789",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Trigger a unified write; this should migrate the legacy record.
+    write_account_metadata(storage_path, authuser=5, email="erin@example.com")
+
+    in_band = _read_storage_state(storage_path)["notebooklm"]["account"]
+    assert in_band == {"authuser": 5, "email": "erin@example.com"}
+
+    # Non-account context state preserved.
+    legacy = json.loads(_context_path(storage_path).read_text(encoding="utf-8"))
+    assert "account" not in legacy
+    assert legacy.get("notebook_id") == "nb-456"
+    assert legacy.get("conversation_id") == "conv-789"
+
+
+def test_in_band_account_overrides_legacy_account(tmp_path: Path) -> None:
+    """When both forms exist, in-band wins."""
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(
+        storage_path,
+        {
+            "cookies": [],
+            "origins": [],
+            "notebooklm": {
+                "version": 1,
+                "account": {"authuser": 7, "email": "new@example.com"},
+            },
+        },
+    )
+    _context_path(storage_path).write_text(
+        json.dumps({"account": {"authuser": 1, "email": "stale@example.com"}}),
+        encoding="utf-8",
+    )
+
+    assert get_authuser_for_storage(storage_path) == 7
+    assert get_account_email_for_storage(storage_path) == "new@example.com"
+
+
+def test_clear_account_metadata_clears_in_band(tmp_path: Path) -> None:
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(
+        storage_path,
+        {
+            "cookies": [],
+            "origins": [],
+            "notebooklm": {
+                "version": 1,
+                "account": {"authuser": 9, "email": "zoe@example.com"},
+            },
+        },
+    )
+    clear_account_metadata(storage_path)
+    # Either the namespace is gone, or its account is gone — either way the
+    # reader reports no account. The file itself remains valid JSON.
+    _read_storage_state(storage_path)  # sanity-check the file still parses
+    assert read_account_metadata(storage_path) == {}
+    assert get_authuser_for_storage(storage_path) == 0
+    assert get_account_email_for_storage(storage_path) is None
+
+
+def test_clear_account_metadata_clears_legacy_two_file(tmp_path: Path) -> None:
+    """Backward compat: clearing still removes legacy ``context.json`` account."""
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(storage_path, {"cookies": [], "origins": []})
+    _context_path(storage_path).write_text(
+        json.dumps(
+            {
+                "account": {"authuser": 8, "email": "leah@example.com"},
+                "notebook_id": "nb-keep",
+            }
+        ),
+        encoding="utf-8",
+    )
+    clear_account_metadata(storage_path)
+    # Non-account context preserved.
+    legacy = json.loads(_context_path(storage_path).read_text(encoding="utf-8"))
+    assert "account" not in legacy
+    assert legacy.get("notebook_id") == "nb-keep"
+
+
+def test_torn_write_fault_injection_preserves_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ACCEPTANCE-CRITICAL: writer crash between cookies+metadata is recoverable.
+
+    If we crash during the unified write, the original on-disk
+    ``storage_state.json`` must remain valid and unchanged — no half-written
+    state mixing new cookies with old account or vice versa.
+    """
+    storage_path = tmp_path / "storage_state.json"
+    original_payload = {
+        "cookies": [{"name": "SID", "value": "old-v", "domain": ".google.com", "path": "/"}],
+        "origins": [],
+        "notebooklm": {
+            "version": 1,
+            "account": {"authuser": 1, "email": "original@example.com"},
+        },
+    }
+    _write_storage_state(storage_path, original_payload)
+
+    # Inject a crash mid-write: the next ``os.replace`` raises.
+    import notebooklm._atomic_io as atomic_io_mod
+
+    original_replace = atomic_io_mod.os.replace
+
+    def _boom(src: Any, dst: Any) -> None:
+        raise OSError("simulated crash during atomic replace")
+
+    monkeypatch.setattr(atomic_io_mod.os, "replace", _boom)
+
+    with pytest.raises(OSError, match="simulated crash"):
+        write_account_metadata(storage_path, authuser=99, email="never@example.com")
+
+    monkeypatch.setattr(atomic_io_mod.os, "replace", original_replace)
+
+    # Original file untouched: reader sees the OLD record consistently.
+    assert _read_storage_state(storage_path) == original_payload
+    assert get_authuser_for_storage(storage_path) == 1
+    assert get_account_email_for_storage(storage_path) == "original@example.com"
+
+    # No temp files leaked beside the storage file.
+    leftover_temps = list(tmp_path.glob(".storage_state.json.*"))
+    assert leftover_temps == [], f"Temp file leaked: {leftover_temps}"
+
+
+def test_torn_write_reader_never_sees_mixed_state(tmp_path: Path) -> None:
+    """Property: at any observation point, reader sees old XOR new — never mixed.
+
+    Atomicity comes from ``atomic_write_json``'s single ``os.replace``: until
+    the rename commits, the reader sees only the previous on-disk version.
+    This test asserts the contract is exercised by the unified write path —
+    after a successful write, both cookies and account come from the same
+    commit; if the write fails, neither rolls forward.
+    """
+    storage_path = tmp_path / "storage_state.json"
+    # Round 1: write old state.
+    write_account_metadata(storage_path, authuser=10, email="round1@example.com")
+    # Sanity: the file now exists with the round-1 record.
+    payload_1 = _read_storage_state(storage_path)
+    assert payload_1["notebooklm"]["account"]["email"] == "round1@example.com"
+
+    # Round 2: overwrite with a new account record.
+    write_account_metadata(storage_path, authuser=20, email="round2@example.com")
+    payload_2 = _read_storage_state(storage_path)
+    # The reader sees exactly one record — never a merge.
+    assert payload_2["notebooklm"]["account"] == {
+        "authuser": 20,
+        "email": "round2@example.com",
+    }
+    # The non-account file structure round-trips unchanged.
+    assert payload_2.get("cookies") == payload_1.get("cookies")
+
+
+def test_unified_format_version_is_pinned_to_one(tmp_path: Path) -> None:
+    """Pin the version number so any future bump is intentional."""
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(storage_path, {"cookies": [], "origins": []})
+    write_account_metadata(storage_path, authuser=1, email="v@example.com")
+    payload = _read_storage_state(storage_path)
+    assert payload["notebooklm"]["version"] == 1
+
+
+def test_write_without_email_omits_email_field(tmp_path: Path) -> None:
+    """Default-account login: authuser=0, no email — record omits email."""
+    storage_path = tmp_path / "storage_state.json"
+    _write_storage_state(storage_path, {"cookies": [], "origins": []})
+    write_account_metadata(storage_path, authuser=0, email=None)
+    payload = _read_storage_state(storage_path)
+    assert payload["notebooklm"]["account"] == {"authuser": 0}
+
+
+def test_write_preserves_cookies_and_origins(tmp_path: Path) -> None:
+    """Writing account metadata MUST NOT touch cookies / origins."""
+    storage_path = tmp_path / "storage_state.json"
+    cookies = [
+        {"name": "SID", "value": "v1", "domain": ".google.com", "path": "/"},
+        {"name": "HSID", "value": "v2", "domain": ".google.com", "path": "/"},
+    ]
+    origins = [
+        {"origin": "https://notebooklm.google.com", "localStorage": [{"name": "k", "value": "v"}]}
+    ]
+    _write_storage_state(storage_path, {"cookies": cookies, "origins": origins})
+    write_account_metadata(storage_path, authuser=1, email="alice@example.com")
+    payload = _read_storage_state(storage_path)
+    assert payload["cookies"] == cookies
+    assert payload["origins"] == origins

--- a/tests/unit/test_refresh_cmd_redaction.py
+++ b/tests/unit/test_refresh_cmd_redaction.py
@@ -1,0 +1,180 @@
+"""Unit tests for ``NOTEBOOKLM_REFRESH_CMD`` failure redaction (P1-18).
+
+The refresh-command subprocess can print arbitrary content to stdout/stderr,
+including bearer tokens, cookies, full URLs with query-string credentials,
+and absolute paths into a user's home/credentials directory. Surfacing that
+output verbatim through ``RuntimeError`` (which then bubbles up through
+``handle_errors`` and lands on stderr or in a JSON envelope) leaks secrets.
+
+The contract:
+
+1. The exception message must contain only:
+   - The env-var name (``NOTEBOOKLM_REFRESH_CMD``)
+   - The integer exit code
+   - The executable's basename (no absolute path)
+2. The exception message must NOT contain stdout/stderr content.
+3. The full stdout/stderr is routed to ``logger.debug`` at the package's
+   redacting logger so ``-vv`` users with the redaction filter installed can
+   still diagnose failures.
+4. ``cli.error_handler`` prints only ``exc.args[0]`` (the redacted message)
+   for the catch-all ``Exception`` branch; full traceback goes to
+   ``logger.debug`` only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from notebooklm import auth as auth_module
+
+_SECRET_STDOUT = "Bearer ya29.SECRET-TOKEN-IN-STDOUT-deadbeef"
+_SECRET_STDERR = "rotate-cookie failed: SID=SECRET-SID-VALUE-cafefeed"
+_REFRESH_EXECUTABLE_PATH = "/home/user/.secret-credentials-dir/refresh-cookies.sh"
+
+
+@pytest.fixture
+def refresh_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Set NOTEBOOKLM_REFRESH_CMD to a known absolute path."""
+    monkeypatch.setenv(auth_module.NOTEBOOKLM_REFRESH_CMD_ENV, _REFRESH_EXECUTABLE_PATH)
+    monkeypatch.delenv("NOTEBOOKLM_REFRESH_CMD_USE_SHELL", raising=False)
+    yield
+
+
+def _stub_subprocess_run_with_leaky_output(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    returncode: int = 1,
+) -> None:
+    """Replace ``subprocess.run`` so it returns secret-laden stdout/stderr."""
+
+    class _Result:
+        def __init__(self) -> None:
+            self.returncode = returncode
+            self.stdout = _SECRET_STDOUT
+            self.stderr = _SECRET_STDERR
+
+    def _fake_run(*_args: Any, **_kwargs: Any) -> _Result:
+        return _Result()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+
+def test_refresh_failure_message_omits_stdout_secrets(
+    refresh_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_subprocess_run_with_leaky_output(monkeypatch)
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(auth_module._run_refresh_cmd())
+    message = exc_info.value.args[0]
+    assert _SECRET_STDOUT not in message
+    assert "ya29." not in message
+
+
+def test_refresh_failure_message_omits_stderr_secrets(
+    refresh_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_subprocess_run_with_leaky_output(monkeypatch)
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(auth_module._run_refresh_cmd())
+    message = exc_info.value.args[0]
+    assert _SECRET_STDERR not in message
+    assert "SECRET-SID" not in message
+
+
+def test_refresh_failure_message_shows_exit_code_and_basename(
+    refresh_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_subprocess_run_with_leaky_output(monkeypatch, returncode=42)
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(auth_module._run_refresh_cmd())
+    message = exc_info.value.args[0]
+    assert "42" in message
+    # basename, not the absolute path
+    assert "refresh-cookies.sh" in message
+    assert "/home/user/.secret-credentials-dir" not in message
+
+
+def test_refresh_failure_routes_full_output_to_debug_log(
+    refresh_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Full stdout/stderr is available at DEBUG level for diagnosis.
+
+    The package logger has a redaction filter installed at import time, so
+    even when we capture the raw record here the user-facing handler scrubs
+    well-known token shapes. This test confirms the data path exists; the
+    redaction filter is unit-tested separately in ``test_logging.py``.
+    """
+    _stub_subprocess_run_with_leaky_output(monkeypatch)
+    with caplog.at_level(logging.DEBUG, logger="notebooklm.auth"), pytest.raises(RuntimeError):
+        asyncio.run(auth_module._run_refresh_cmd())
+
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    debug_text = "\n".join(r.getMessage() for r in debug_records)
+    # The secret output should be present in the DEBUG-level data path so
+    # developers can diagnose subprocess failures with ``--verbose``.
+    assert _SECRET_STDOUT in debug_text or _SECRET_STDERR in debug_text, (
+        "Expected refresh-cmd stdout/stderr to be routed to DEBUG log"
+    )
+
+
+def test_error_handler_prints_only_exc_args_for_unexpected_exception(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI's catch-all branch surfaces only the redacted message."""
+    from notebooklm.cli.error_handler import handle_errors
+
+    redacted_message = (
+        f"{auth_module.NOTEBOOKLM_REFRESH_CMD_ENV} exited 1 (executable: refresh-cookies.sh)"
+    )
+    # Use the same structure as the real refresh-cmd raise: a RuntimeError
+    # whose args[0] is the redacted message. The handler should print that
+    # message and not touch any other attributes.
+    err = RuntimeError(redacted_message)
+    # Attach a fake __cause__ that has secret stuff; the handler must NOT
+    # walk the cause chain into the user-facing output.
+    err.__cause__ = RuntimeError(_SECRET_STDOUT)
+
+    with pytest.raises(SystemExit) as exc_info, handle_errors():
+        raise err
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert _SECRET_STDOUT not in combined
+    assert redacted_message in combined
+
+
+def test_error_handler_routes_traceback_to_debug(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tracebacks for unexpected exceptions go to DEBUG, not stderr."""
+    from notebooklm.cli.error_handler import handle_errors
+
+    redacted_message = "REFRESH_CMD exited 1 (executable: refresh.sh)"
+    err = RuntimeError(redacted_message)
+    err.__cause__ = RuntimeError(_SECRET_STDOUT)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger="notebooklm.cli.error_handler"),
+        pytest.raises(SystemExit),
+        handle_errors(),
+    ):
+        raise err
+
+    debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+    assert debug_records, "Expected at least one DEBUG record from error_handler"
+    debug_text = "\n".join((r.getMessage() + "\n" + (r.exc_text or "")) for r in debug_records)
+    # The full exception (with its cause chain) is what DEBUG-level captures
+    # for developers; this is the place secrets COULD legitimately surface
+    # for diagnosis. We assert the DEBUG path exists, not that it scrubs —
+    # the redaction filter (tested separately) handles scrubbing on the way out.
+    assert "RuntimeError" in debug_text or err.__class__.__name__ in debug_text

--- a/tests/unit/test_refresh_cmd_redaction.py
+++ b/tests/unit/test_refresh_cmd_redaction.py
@@ -152,6 +152,22 @@ def test_error_handler_prints_only_exc_args_for_unexpected_exception(
     assert redacted_message in combined
 
 
+def test_error_handler_handles_non_string_first_arg(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Claude bot review feedback: ``e.args[0]`` may be non-string for
+    third-party exceptions (e.g. ``ValueError(42)``). Confirm the handler
+    str-casts defensively rather than relying on f-string implicit ``str()``.
+    """
+    from notebooklm.cli.error_handler import handle_errors
+
+    with pytest.raises(SystemExit) as exc_info, handle_errors():
+        raise ValueError(42)
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert "Unexpected error: 42" in (captured.out + captured.err)
+
+
 def test_error_handler_routes_traceback_to_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -195,14 +195,16 @@ def test_migration_config_unparseable_logs_debug(caplog, tmp_path, monkeypatch):
     )
 
 
-def test_auth_context_unreadable_recovers_under_lock(tmp_path):
-    """auth.py — unreadable account context is recovered under the lock.
+def test_auth_corrupt_legacy_context_does_not_block_in_band_write(tmp_path):
+    """auth.py — corrupt legacy ``context.json`` no longer blocks account writes.
 
-    Previously the recovery path lived outside the lock and emitted a DEBUG
-    log before unlink-and-retry. After PR #465 the recovery is silent and
-    happens inside :func:`atomic_update_json` via ``recover_from_corrupt``,
-    so the structural assertion is now: the corrupt file is rewritten in
-    place with a valid payload containing only our new metadata.
+    Pre-P1-20, account metadata was written into ``context.json`` itself, so
+    a corrupt file there had to be recoverable inline. P1-20 moves the write
+    target into ``storage_state.json`` under the ``notebooklm`` namespace key,
+    so a corrupt sibling ``context.json`` is now irrelevant to the write
+    path — it's only consulted by the read fallback and skipped on
+    JSONDecodeError. This test pins the new contract: the in-band write
+    completes successfully even when the legacy sibling is unreadable.
     """
     import json as _json
 
@@ -215,11 +217,13 @@ def test_auth_context_unreadable_recovers_under_lock(tmp_path):
 
     auth.write_account_metadata(storage, authuser=0, email=None)
 
-    # File is now valid JSON, and only contains the account-metadata key —
-    # proving recovery treated the corrupt payload as an empty dict.
-    data = _json.loads(ctx_path.read_text(encoding="utf-8"))
-    assert auth._ACCOUNT_CONTEXT_KEY in data
-    assert data[auth._ACCOUNT_CONTEXT_KEY]["authuser"] == 0
+    # The in-band record landed in storage_state.json.
+    storage_data = _json.loads(storage.read_text(encoding="utf-8"))
+    assert storage_data["notebooklm"]["account"]["authuser"] == 0
+    # The corrupt legacy file is untouched (we don't try to recover what we
+    # no longer write to) — readers' fallback path silently treats it as
+    # empty via the ``read_account_metadata`` corruption-tolerance branch.
+    assert ctx_path.read_text(encoding="utf-8") == "{ malformed "
 
 
 def test_stream_parser_debug_guarded_by_isenabledfor(caplog):


### PR DESCRIPTION
## Summary

Tier-9 P1 privacy bundle covering four findings: `P1-1`, `P1-17`, `P1-18`, `P1-20`.

- **P1-1** — `AuthTokens.__repr__` redacts cookies / csrf_token / session_id / cookie_jar / cookie_snapshot.
- **P1-18** — `NOTEBOOKLM_REFRESH_CMD` subprocess output now reaches the user as `exit_code + executable basename` only; the full stdout/stderr goes to the package's redacting DEBUG logger. `cli.error_handler` emits `exc.args[0]` only and routes tracebacks to DEBUG.
- **P1-17** — The Playwright login path applies the same cookie-domain allowlist (`_build_google_cookie_domains`) the rookiepy path has used since #360. Sibling-product cookies (`mail.google.com`, `myaccount.google.com`, `docs.google.com`, `.youtube.com`) the user happens to be signed into in the same browser session no longer leak into `storage_state.json` by default. `--include-domains=…` now takes effect on the Playwright path.
- **P1-20** — Account metadata moves into `storage_state.json` under a `notebooklm` namespace key (`{"version": 1, "account": {"authuser": N, "email": "…"}}`) so the (cookies, account) pair commits atomically. The legacy sibling `context.json[account]` is still read as a fallback and best-effort migrated on next write; non-account CLI state (`notebook_id`, `conversation_id`) is preserved.

## ACCEPTANCE-CRITICAL — Migration

If the migration breaks for any existing user, they lose auth on next CLI run. The acceptance test `test_legacy_two_file_fixture_reads_cleanly` exercises the exact legacy → unified read path; `test_migration_on_write_removes_legacy_account_key_only` exercises the next-write upgrade while preserving sibling state.

**Surfaced caveats** (also documented inline in code comments):

1. **Mixed-version concern.** Users running pre-P1-20 and post-P1-20 CLI in parallel against the same profile may observe the older version losing its account binding after the new version migrates the on-disk format. Do not downgrade after upgrading.
2. **External tooling.** `storage_state.json` now has an extra top-level `notebooklm` key. Playwright itself ignores unknown keys; most third-party cookie inspectors tolerate them too.

## Atomicity

`test_torn_write_fault_injection_preserves_original` exercises the fault-injection contract: when `os.replace` raises mid-write, the original on-disk file is preserved unchanged — no half-written state mixing new cookies with old account or vice versa. `test_torn_write_reader_never_sees_mixed_state` locks in the cross-commit property at the API level.

## Test plan

- [x] `uv run ruff format .` — no formatting drift
- [x] `uv run ruff check .` — all checks pass
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues across 115 source files
- [x] `uv run pytest tests/unit tests/integration` — 5199 passed, 20 skipped (51 new tests across 4 new files)
- [x] `repr(AuthTokens(...))` contains NONE of the canonical secrets (parametrized across PSID/PSIDTS/SID/csrf/session)
- [x] Refresh-cmd failure surfaces `exit_code` + basename only; full output routed to DEBUG
- [x] Playwright filter rejects `mail.google.com` / `myaccount.google.com` / `docs.google.com` / `.youtube.com` by default; `--include-domains=mail` opts them back in
- [x] Migration: legacy two-file fixture loads cleanly under unified reader
- [x] Torn-write: reader sees consistent state on writer crash

## Plan reference

`.claude/worktrees/tier-9-orchestrator/.sisyphus/plans/tier-9-p0-p1.md` — section E (~line 379-420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended --include-domains support to the Playwright login path so persisted cookies can include optional sibling-product domains.

* **Bug Fixes**
  * Subprocess failure messages redact stdout/stderr, showing only exit code and executable; full output goes to DEBUG logs.
  * CLI error handler prints a concise primary message and logs full exception info at DEBUG.

* **Improvements**
  * Account metadata now stored in a unified in-band format with legacy fallback, atomic writes, and migration/cleanup behavior.

* **Tests**
  * Added/updated tests for cookie domain filtering, account migration and atomic writes, secret-redaction, and error-handler behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/803?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->