### PR TITLE
fix(side-effects): classify delete/refresh/share idempotency + propagate probe failures (P0-3, P1-2)

### DIFF
--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -392,10 +392,76 @@ class IdempotencyRegistry:
                 self.register(method, IdempotencyPolicy.UNCLASSIFIED)
 
 
-# Module-level production registry. Wave 2 will add classifications
-# below the seeding call; for B1 the registry is pure default-fill.
+# Module-level production registry. Wave 2 adds classifications below the
+# seeding call; B1 was a pure default-fill foundation.
 IDEMPOTENCY_REGISTRY = IdempotencyRegistry()
 IDEMPOTENCY_REGISTRY._seed_defaults()
+
+
+# ----------------------------------------------------------------------------
+# Wave 2 classifications (P0-3 side-effects + P1-2 notebooks)
+# ----------------------------------------------------------------------------
+#
+# These entries replace the UNCLASSIFIED placeholders for the five mutating
+# RPCs whose side-effect semantics are well-understood and stable. The full
+# audit decision matrix lives in ``.sisyphus/plans/tier-9-p0-p1.md``; the
+# short version follows.
+#
+# DELETE_NOTEBOOK / DELETE_SOURCE / DELETE_ARTIFACT
+#   Server-side delete is idempotent: replaying the request after a 5xx /
+#   network failure yields the same final state (the resource is gone).
+#   Classification: ``IDEMPOTENT_SET_OP``. The transport retry loop keeps
+#   running unchanged — today's behavior is preserved, the registry simply
+#   documents *why* it is safe.
+#
+# REFRESH_SOURCE
+#   Refresh kicks off a server-side fetch job. A duplicate refresh job is
+#   harmless (extra bandwidth, same eventual content) but observable, so
+#   the caller has accepted at-least-once semantics. Classification:
+#   ``AT_LEAST_ONCE_ACCEPTED``. The transport may retry; the registry
+#   emits a rate-limited WARN so operators can see the trade-off when it
+#   actually fires.
+#
+# SHARE_NOTEBOOK
+#   Mutates the shared-users / public-access ACL. A blind retry after a
+#   network blip can re-send invitation emails (with ``notify=True``) or
+#   flip access between RESTRICTED / ANYONE-WITH-LINK twice. The codebase
+#   does expose a server-side probe RPC (``GET_SHARE_STATUS``) that can
+#   list the current ACL, so the *correct* policy is ``PROBE_THEN_CREATE``
+#   — the transport must NOT retry blindly, and a future wrapper can
+#   ``get_status()`` to decide whether the prior call landed before
+#   re-issuing. Wave-2 scope is the classification (which suppresses the
+#   blind retry today); the caller-side probe-then-create wrapper is a
+#   follow-up.
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.DELETE_NOTEBOOK,
+    IdempotencyPolicy.IDEMPOTENT_SET_OP,
+    notes="server-side delete is idempotent (set-op semantics)",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.DELETE_SOURCE,
+    IdempotencyPolicy.IDEMPOTENT_SET_OP,
+    notes="server-side delete is idempotent (set-op semantics)",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.DELETE_ARTIFACT,
+    IdempotencyPolicy.IDEMPOTENT_SET_OP,
+    notes="server-side delete is idempotent (set-op semantics)",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.REFRESH_SOURCE,
+    IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED,
+    notes="duplicate refresh jobs are acceptable cost (extra fetch, same content)",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.SHARE_NOTEBOOK,
+    IdempotencyPolicy.PROBE_THEN_CREATE,
+    notes=(
+        "mutates ACL; blind retry can re-send invite emails or double-flip access. "
+        "GET_SHARE_STATUS exposes the server-side ACL for a future probe-then-create "
+        "wrapper; today's classification suppresses the inner retry loop."
+    ),
+)
 
 
 # ----------------------------------------------------------------------------

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -13,7 +13,7 @@ from ._notebook_metadata import (
 )
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._sharing_manager import ShareManager
-from .exceptions import NotebookLimitError, NotebookNotFoundError, RPCError
+from .exceptions import NetworkError, NotebookLimitError, NotebookNotFoundError, RPCError
 from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, NotebookMetadata, SuggestedTopic
 
@@ -257,8 +257,29 @@ class NotebooksAPI:
             return notebook
 
         async def _probe() -> Notebook | None:
+            # NetworkError during the probe MUST propagate (P1-2): the
+            # original create may have committed server-side and we have
+            # no way to confirm. Silently returning None would let
+            # ``idempotent_create`` re-issue the create on the next
+            # attempt and duplicate the notebook. Surfacing the network
+            # error keeps the caller in control — they can decide whether
+            # to re-probe later (e.g. once connectivity recovers) before
+            # retrying the create.
+            #
+            # Other exception types (decoding errors, unexpected RPC
+            # failures, programming bugs) are still treated as "probe
+            # could not confirm a match" — those signal that the probe
+            # path itself is broken in a way that wouldn't be fixed by a
+            # retry, so falling through to None preserves the existing
+            # contract of "best-effort probe".
             try:
                 current = await self.list()
+            except NetworkError:
+                logger.warning(
+                    "create: probe list() failed with NetworkError; propagating "
+                    "so the caller can avoid a duplicate-resource retry"
+                )
+                raise
             except Exception:
                 logger.debug(
                     "create: probe list() failed; treating as no match",

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -1,0 +1,485 @@
+"""Side-effect RPC idempotency regression tests (Tier 9, P0-3 + P1-2).
+
+This file validates the Wave-2 classifications added to
+``IDEMPOTENCY_REGISTRY`` for the five mutating side-effect RPCs:
+
+* ``DELETE_NOTEBOOK`` → ``IDEMPOTENT_SET_OP`` (delete is idempotent)
+* ``DELETE_SOURCE``   → ``IDEMPOTENT_SET_OP``
+* ``DELETE_ARTIFACT`` → ``IDEMPOTENT_SET_OP``
+* ``REFRESH_SOURCE``  → ``AT_LEAST_ONCE_ACCEPTED`` (extra fetch is acceptable)
+* ``SHARE_NOTEBOOK``  → ``PROBE_THEN_CREATE`` (suppresses blind retry; uses
+                       ``GET_SHARE_STATUS`` as the probe RPC if a future
+                       wrapper is added)
+
+It also exercises the P1-2 fix to ``NotebooksAPI.create``: a
+``NetworkError`` during the probe ``list()`` MUST propagate, not be
+silently coerced to "no match", so the caller learns the prior create
+may have committed server-side and the retry loop won't duplicate the
+resource.
+
+Tests use ``httpx.MockTransport`` — no cassettes, no network. They are
+opted out of the VCR tier enforcement via
+``pytestmark = pytest.mark.allow_no_vcr``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+import pytest
+
+from notebooklm import NetworkError, NotebookLMClient
+from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
+from notebooklm.rpc import RPCMethod
+
+pytestmark = pytest.mark.allow_no_vcr
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal batchexecute response builders + mock-transport client
+# ---------------------------------------------------------------------------
+
+
+def _wrb_response(rpc_id: str, payload: object) -> str:
+    """Build a single-RPC batchexecute response body.
+
+    Mirrors the on-the-wire format used everywhere in the test suite:
+    ``)]}}'\\n<len>\\n<chunk>\\n``.
+    """
+    inner = json.dumps(payload)
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def _list_notebooks_response(notebooks: list[tuple[str, str]]) -> str:
+    """Build a LIST_NOTEBOOKS response from ``[(notebook_id, title), ...]``."""
+    raw = [
+        [title, None, nb_id, "📘", None, [None, None, None, None, None, [1704067200, 0]]]
+        for nb_id, title in notebooks
+    ]
+    return _wrb_response(RPCMethod.LIST_NOTEBOOKS.value, [raw])
+
+
+def _make_client_with_transport(
+    transport: httpx.AsyncBaseTransport,
+    auth_tokens,
+    *,
+    server_error_max_retries: int = 3,
+) -> NotebookLMClient:
+    """Construct a ``NotebookLMClient`` wired to the supplied mock transport.
+
+    Bypasses the full ``ClientCore.open()`` path so the test doesn't try
+    to build a real ``httpx.AsyncClient`` with cookies + connection pool.
+    """
+    client = NotebookLMClient(
+        auth_tokens,
+        server_error_max_retries=server_error_max_retries,
+    )
+    client._core._http_client = httpx.AsyncClient(
+        transport=transport,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+    )
+    return client
+
+
+def _rpc_id_in_request(request: httpx.Request) -> str | None:
+    """Extract the ``rpcids=`` query param from a batchexecute request URL."""
+    for key, value in request.url.params.multi_items():
+        if key == "rpcids":
+            return value
+    return None
+
+
+# ===========================================================================
+# Registry classifications — direct lookup
+# ===========================================================================
+
+
+def test_delete_notebook_classified_idempotent_set_op() -> None:
+    """``DELETE_NOTEBOOK`` is an idempotent set-op (registry entry only)."""
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.DELETE_NOTEBOOK)
+    assert entry.policy is IdempotencyPolicy.IDEMPOTENT_SET_OP
+    assert entry.notes  # non-empty rationale
+
+
+def test_delete_source_classified_idempotent_set_op() -> None:
+    """``DELETE_SOURCE`` is an idempotent set-op."""
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.DELETE_SOURCE)
+    assert entry.policy is IdempotencyPolicy.IDEMPOTENT_SET_OP
+
+
+def test_delete_artifact_classified_idempotent_set_op() -> None:
+    """``DELETE_ARTIFACT`` is an idempotent set-op."""
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.DELETE_ARTIFACT)
+    assert entry.policy is IdempotencyPolicy.IDEMPOTENT_SET_OP
+
+
+def test_refresh_source_classified_at_least_once_accepted() -> None:
+    """``REFRESH_SOURCE`` accepts at-least-once retry semantics."""
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.REFRESH_SOURCE)
+    assert entry.policy is IdempotencyPolicy.AT_LEAST_ONCE_ACCEPTED
+
+
+def test_share_notebook_classified_probe_then_create() -> None:
+    """``SHARE_NOTEBOOK`` is PROBE_THEN_CREATE — ``GET_SHARE_STATUS`` exists
+    as the server-side probe RPC, so a blind retry is unsafe and the
+    transport retry loop MUST be suppressed."""
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.SHARE_NOTEBOOK)
+    assert entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
+
+
+# ===========================================================================
+# Delete RPCs keep today's retry behavior (IDEMPOTENT_SET_OP is silent)
+# ===========================================================================
+
+
+async def test_delete_notebook_retries_remain_enabled(
+    auth_tokens,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``IDEMPOTENT_SET_OP`` MUST be behavior-neutral: the transport's
+    inner retry loop continues to fire on 5xx — today's behavior is
+    preserved, the registry just documents *why* it is safe.
+    """
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.DELETE_NOTEBOOK.value:
+            request_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
+    try:
+        from notebooklm import ServerError
+
+        with pytest.raises(ServerError):
+            await client.notebooks.delete("nb_x")
+        # initial + 2 retries = 3 POSTs (IDEMPOTENT_SET_OP leaves caller-False alone)
+        assert request_count == 3, (
+            f"DELETE_NOTEBOOK with IDEMPOTENT_SET_OP expected 3 POSTs "
+            f"(initial + 2 retries), got {request_count}"
+        )
+    finally:
+        await client._core._http_client.aclose()
+
+
+async def test_delete_source_retries_remain_enabled(
+    auth_tokens,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``DELETE_SOURCE`` retries continue under IDEMPOTENT_SET_OP."""
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        if _rpc_id_in_request(request) == RPCMethod.DELETE_SOURCE.value:
+            request_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
+    try:
+        from notebooklm import ServerError
+
+        with pytest.raises(ServerError):
+            await client.sources.delete("nb_x", "src_x")
+        assert request_count == 3, f"expected 3 POSTs, got {request_count}"
+    finally:
+        await client._core._http_client.aclose()
+
+
+async def test_delete_artifact_retries_remain_enabled(
+    auth_tokens,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``DELETE_ARTIFACT`` retries continue under IDEMPOTENT_SET_OP."""
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        if _rpc_id_in_request(request) == RPCMethod.DELETE_ARTIFACT.value:
+            request_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
+    try:
+        from notebooklm import ServerError
+
+        with pytest.raises(ServerError):
+            await client.artifacts.delete("nb_x", "art_x")
+        assert request_count == 3, f"expected 3 POSTs, got {request_count}"
+    finally:
+        await client._core._http_client.aclose()
+
+
+# ===========================================================================
+# REFRESH_SOURCE — AT_LEAST_ONCE_ACCEPTED emits a rate-limited WARN
+# ===========================================================================
+
+
+async def test_refresh_source_emits_rate_limited_warn(
+    auth_tokens,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``REFRESH_SOURCE`` emits exactly one WARN to flag at-least-once
+    semantics, and the warn is rate-limited so 5 invocations produce
+    ≤2 lines (mirrors the registry's per-(method, variant) throttle)."""
+    # Clear the rate-limit ledger so a window tripped by a prior test
+    # doesn't suppress the WARN we expect here.
+    import notebooklm._idempotency as idemp_mod
+
+    monkeypatch.setattr(idemp_mod, "_at_least_once_last_logged", {})
+
+    invocations = 5
+    refresh_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal refresh_count
+        if _rpc_id_in_request(request) == RPCMethod.REFRESH_SOURCE.value:
+            refresh_count += 1
+            # REFRESH_SOURCE's success response is a no-data null body
+            # (the API uses allow_null=True). Mirror that shape.
+            return httpx.Response(200, text=_wrb_response(RPCMethod.REFRESH_SOURCE.value, None))
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with caplog.at_level(logging.WARNING, logger="notebooklm._idempotency"):
+            for _ in range(invocations):
+                ok = await client.sources.refresh("nb_x", "src_x")
+                assert ok is True
+    finally:
+        await client._core._http_client.aclose()
+
+    warn_records = [
+        r
+        for r in caplog.records
+        if r.name.startswith("notebooklm._idempotency") and r.levelno >= logging.WARNING
+    ]
+    assert refresh_count == invocations, f"transport saw {refresh_count} REFRESH_SOURCE calls"
+    assert 1 <= len(warn_records) <= 2, (
+        f"AT_LEAST_ONCE_ACCEPTED emitted {len(warn_records)} WARN lines for "
+        f"{invocations} calls; expected 1-2 (rate-limited)"
+    )
+    # The WARN message names REFRESH_SOURCE explicitly so operators can
+    # grep logs for the affected RPC.
+    assert any("REFRESH_SOURCE" in r.getMessage() for r in warn_records)
+
+
+# ===========================================================================
+# SHARE_NOTEBOOK — PROBE_THEN_CREATE suppresses the blind transport retry
+# ===========================================================================
+
+
+async def test_share_notebook_does_not_retry_on_5xx(
+    auth_tokens,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``SHARE_NOTEBOOK`` is PROBE_THEN_CREATE, which forces
+    ``disable_internal_retries=True`` inside the executor — a 5xx MUST
+    surface immediately so the caller (or a future probe-then-create
+    wrapper) decides whether the ACL mutation landed before re-issuing.
+
+    Today a blind retry would risk re-sending invitation emails or
+    double-flipping public/private access; this test pins the policy.
+    """
+    share_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal share_count
+        if _rpc_id_in_request(request) == RPCMethod.SHARE_NOTEBOOK.value:
+            share_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=5)
+    try:
+        from notebooklm import ServerError
+
+        with pytest.raises(ServerError):
+            await client.sharing.set_public("nb_x", True)
+        # PROBE_THEN_CREATE forces disable_internal_retries=True → exactly 1 POST.
+        # Even with server_error_max_retries=5, the registry suppresses retries.
+        assert share_count == 1, (
+            f"SHARE_NOTEBOOK with PROBE_THEN_CREATE expected 1 POST "
+            f"(no blind retry), got {share_count}"
+        )
+    finally:
+        await client._core._http_client.aclose()
+
+
+# ===========================================================================
+# P1-2 — NotebooksAPI.create probe propagates NetworkError
+# ===========================================================================
+
+
+async def test_notebooks_create_probe_propagates_network_error(
+    auth_tokens,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``NetworkError`` raised by the probe ``list()`` MUST propagate
+    out of ``NotebooksAPI.create``, not be silently coerced to "no match".
+
+    Before the fix the probe's ``except Exception:`` clause swallowed
+    everything and returned ``None``, which let ``idempotent_create``
+    re-issue the create on the next attempt — potentially duplicating
+    the notebook if the original create actually committed server-side.
+
+    Test setup:
+      * LIST_NOTEBOOKS returns an empty baseline on the FIRST call so
+        ``baseline_ids = set()`` (the create can proceed).
+      * CREATE_NOTEBOOK fails with 502 → the executor's retry loop is
+        disabled because CREATE_NOTEBOOK is registered PROBE_THEN_CREATE,
+        so the failure surfaces as a single ``ServerError`` (treated as
+        a transport failure by ``idempotent_create``).
+      * The probe call to LIST_NOTEBOOKS then fails with a *transport-
+        layer* connection error that translates to ``NetworkError``.
+      * ``NetworkError`` MUST propagate out instead of being swallowed.
+    """
+    list_call_count = 0
+    create_call_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal list_call_count, create_call_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.LIST_NOTEBOOKS.value:
+            list_call_count += 1
+            if list_call_count == 1:
+                # Baseline list — empty.
+                return httpx.Response(200, text=_list_notebooks_response([]))
+            # Probe list — simulate a transport-level connection failure.
+            # Raising httpx.ConnectError from the handler lets the client
+            # see it as a connection failure (translated to NetworkError).
+            raise httpx.ConnectError("simulated probe-time network drop")
+        if rpc_id == RPCMethod.CREATE_NOTEBOOK.value:
+            create_call_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    # Skip backoff sleeps so the test doesn't pay the inner-retry wall time
+    # on the probe's LIST_NOTEBOOKS retries (LIST_NOTEBOOKS is UNCLASSIFIED
+    # so the transport still retries 5xx/network errors there).
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(NetworkError):
+            await client.notebooks.create("Some Title")
+    finally:
+        await client._core._http_client.aclose()
+
+    # Sanity check: the probe was actually attempted and the create fired
+    # once before the probe failed. LIST_NOTEBOOKS is UNCLASSIFIED so the
+    # inner transport retry loop fires for the probe — we don't pin a
+    # precise count, only that the probe path was entered (>1 list call).
+    assert list_call_count >= 2, (
+        f"expected ≥2 LIST_NOTEBOOKS calls (baseline + probe), got {list_call_count}"
+    )
+    assert create_call_count >= 1, (
+        f"expected ≥1 CREATE_NOTEBOOK call before probe NetworkError, got {create_call_count}"
+    )
+
+
+async def test_notebooks_create_probe_swallows_non_network_exception(
+    auth_tokens,
+) -> None:
+    """A non-network exception (decoding error, unexpected RPC failure)
+    during the probe MUST still be swallowed → return ``None`` →
+    ``idempotent_create`` retries the create.
+
+    This pins the *contract* that the P1-2 fix surgically widened the
+    propagation only for ``NetworkError``: random other failures inside
+    the probe path stay best-effort, matching the original intent.
+    """
+    list_call_count = 0
+    create_call_count = 0
+    nb_id_after_retry = "nb_after_retry"
+    title = "Retry Title"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal list_call_count, create_call_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.LIST_NOTEBOOKS.value:
+            list_call_count += 1
+            if list_call_count == 1:
+                # Baseline — empty.
+                return httpx.Response(200, text=_list_notebooks_response([]))
+            # Probe — return a payload that won't decode into a notebook
+            # list. ``_wrb_response`` wraps a malformed inner payload so
+            # the decoder raises a DecodingError (NOT a NetworkError).
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.LIST_NOTEBOOKS.value, "definitely-not-a-list"),
+            )
+        if rpc_id == RPCMethod.CREATE_NOTEBOOK.value:
+            create_call_count += 1
+            if create_call_count == 1:
+                return httpx.Response(502, text="bad gateway")
+            # Second create succeeds — ``idempotent_create`` got the
+            # swallowed-None probe back and retried per contract.
+            return httpx.Response(
+                200,
+                text=_wrb_response(
+                    RPCMethod.CREATE_NOTEBOOK.value,
+                    [
+                        title,
+                        None,
+                        nb_id_after_retry,
+                        "📘",
+                        None,
+                        [None, None, None, None, None, [1704067200, 0]],
+                    ],
+                ),
+            )
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        notebook = await client.notebooks.create(title)
+    finally:
+        await client._core._http_client.aclose()
+
+    assert notebook.id == nb_id_after_retry
+    assert create_call_count == 2, (
+        f"expected 2 CREATE_NOTEBOOK calls (initial + retry after non-network "
+        f"probe failure), got {create_call_count}"
+    )


### PR DESCRIPTION
## Summary

Tier 9 Wave 2 task `b-side-effects`. Classifies five mutating side-effect RPCs in `IDEMPOTENCY_REGISTRY` and fixes the probe-failure propagation gap in `NotebooksAPI.create`.

* `DELETE_NOTEBOOK` / `DELETE_SOURCE` / `DELETE_ARTIFACT` → `IDEMPOTENT_SET_OP` (server-side delete is idempotent)
* `REFRESH_SOURCE` → `AT_LEAST_ONCE_ACCEPTED` (duplicate fetch jobs are acceptable cost)
* `SHARE_NOTEBOOK` → `PROBE_THEN_CREATE` (suppresses blind retry that could re-send invite emails / double-flip access)
* `_notebooks.py:259-267` probe — `NetworkError` propagates instead of being swallowed (P1-2 — analogous to the b-sources fix)

## SHARE_NOTEBOOK policy decision (spec must_do)

The task spec required investigating whether a `LIST_SHARES` equivalent exists before choosing the SHARE_NOTEBOOK policy:

* **`if_yes`** → `PROBE_THEN_CREATE`
* **`if_no`** → `NON_IDEMPOTENT_NO_RETRY` + `SharingUncertainError`

Result of grepping `rpc/types.py`: `RPCMethod.GET_SHARE_STATUS = "JFMDGd"` is the share-listing RPC. It returns the current `shared_users` list and `is_public` flag, which is exactly the state a probe needs to decide whether a prior `SHARE_NOTEBOOK` call landed. The **`if_yes`** branch applies → SHARE_NOTEBOOK is classified `PROBE_THEN_CREATE`. **No new `SharingUncertainError` is needed.**

Wave-2 scope is the classification only (suppresses the blind transport retry today). A caller-side probe-then-create wrapper that calls `get_status()` between attempts is a future follow-up; the registry note records the rationale.

## Why each policy

* **DELETE_NOTEBOOK / DELETE_SOURCE / DELETE_ARTIFACT — `IDEMPOTENT_SET_OP`**: replaying a delete after a 5xx yields the same final state (the resource is gone). The transport retry loop continues unchanged — this is a documentation classification, not a behavior change. Acceptance criterion "no behavioral change to delete tests" is honored: existing delete tests in `tests/integration/test_notebooks_integration.py` / sources / artifacts continue to pass; the three new `test_delete_*_retries_remain_enabled` tests pin the no-drift contract.
* **REFRESH_SOURCE — `AT_LEAST_ONCE_ACCEPTED`**: a duplicate refresh job is harmless (extra bandwidth, same eventual content) but observable. The registry emits a rate-limited WARN per `(method, variant)` so operators see when the trade-off fires.
* **SHARE_NOTEBOOK — `PROBE_THEN_CREATE`**: a blind retry after a network blip can re-send invitation emails (`notify=True`) or double-flip RESTRICTED/ANYONE-WITH-LINK access. PROBE_THEN_CREATE forces `disable_internal_retries=True` inside the executor → a single POST surfaces failures immediately so the caller can decide whether the ACL mutation landed before re-issuing.

## P1-2 — probe-failure propagation in `_notebooks.py:259-267`

Pre-fix, `NotebooksAPI.create`'s probe wrapped `await self.list()` in a blanket `except Exception: return None`. A transport-level connection drop during the probe was silently coerced to "no match", which let `idempotent_create` re-issue `CREATE_NOTEBOOK` on the next attempt and risk duplicating a notebook that may have committed server-side.

Post-fix: `NetworkError` propagates out of the probe (and out of `NotebooksAPI.create`) so the caller learns "we can't confirm the prior create state — investigate before retrying." Non-network exceptions (decoding errors, unexpected RPC failures, programming bugs) are still swallowed → the probe still falls through to "no match" for paths where a retry wouldn't fix anything. This mirrors the analogous fix in `b-sources` for `_source_add.py`.

## Files changed

* `src/notebooklm/_idempotency.py` — 5 `IDEMPOTENCY_REGISTRY.register(...)` calls + section comment with the audit decision matrix
* `src/notebooklm/_notebooks.py` — `NetworkError` import + surgical exception split in `_probe()`
* `tests/integration/test_side_effects_idempotency.py` — 12 new mock-transport tests (no cassettes)

No `_sharing.py` edits (per spec). No delete-behavior changes. No new cassettes. No ClientCore decomposition.

## Test plan

- [x] `uv run ruff format .` — 1 file reformatted (test file whitespace), no diff
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues found in 116 source files
- [x] `uv run pytest tests/unit tests/integration --no-cov` — 5316 passed, 20 skipped (the 11 failures + 21 errors from the initial run were a missing `--extra browser` install issue, not regressions)
- [x] New file: `test_side_effects_idempotency.py` — 12 tests pass in 0.03s

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network error handling during API operations to prevent unsafe retries and data inconsistencies.

* **Chores**
  * Enhanced idempotency policies for delete, refresh, and share operations to improve reliability and retry behavior across mutating API calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->