### PR TITLE
ci(security): SHA-pin third-party actions + group Dependabot updates (P0-5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Group all GitHub Actions updates into a single PR per week. Each PR
+    # touches multiple ``uses:`` lines, so grouping reduces review noise and
+    # keeps SHA-pinned third-party actions (publish/testpypi/claude/rpc-health
+    # /nightly/verify-package) moving together with their first-party
+    # ``actions/*`` peers. See ``scripts/check_action_pinning.py`` for the
+    # invariant Dependabot must keep honoring.
+    groups:
+      actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51ea8ea73a139f2a74ff649e3092c25a904aed7e  # @ v1.0.123
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,4 @@ jobs:
       run: smoke-venv/bin/pytest tests/unit -q --no-cov -x
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0

--- a/.github/workflows/rpc-health.yml
+++ b/.github/workflows/rpc-health.yml
@@ -123,7 +123,7 @@ jobs:
       if: |
         steps.health.outputs.exit_code == '1'
         && steps.dup_mismatch.outputs.open == '0'
-      uses: peter-evans/create-issue-from-file@v6
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
       with:
         title: "RPC ID Mismatch Detected"
         content-filepath: health-report.txt
@@ -148,7 +148,7 @@ jobs:
       if: |
         steps.health.outputs.exit_code == '2'
         && steps.dup_auth.outputs.open == '0'
-      uses: peter-evans/create-issue-from-file@v6
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
       with:
         title: "RPC Health Check: Authentication Failure"
         content-filepath: health-report.txt
@@ -202,7 +202,7 @@ jobs:
       if: |
         steps.health.outputs.exit_code == '3'
         && steps.dup_error.outputs.open == '0'
-      uses: peter-evans/create-issue-from-file@v6
+      uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # @ v6.0.0
       with:
         title: "RPC Health Check: Non-transient ERROR detected"
         content-filepath: error-issue-body.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,15 @@ jobs:
       # "Workflow secret gates".
       run: uv run python scripts/check_workflow_secret_gates.py
 
+    - name: Assert third-party actions in privileged workflows are SHA-pinned
+      # Supply-chain gate: every third-party action (non ``actions/*``) in
+      # publish / testpypi-publish / claude / rpc-health / nightly /
+      # verify-package must use a 40-char commit SHA, not a floating
+      # ``@v1`` / ``@release/v1`` / branch ref. Dependabot bumps the
+      # SHAs weekly via the grouped ``actions`` updates in
+      # ``.github/dependabot.yml``.
+      run: uv run python scripts/check_action_pinning.py
+
     - name: Assert coverage thresholds match
       run: uv run python scripts/check_coverage_thresholds.py
 

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -45,7 +45,7 @@ jobs:
       run: smoke-venv/bin/pytest tests/unit -q --no-cov -x
 
     - name: Upload to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0
       with:
         repository-url: https://test.pypi.org/legacy/
 

--- a/scripts/check_action_pinning.py
+++ b/scripts/check_action_pinning.py
@@ -1,0 +1,177 @@
+"""Assert third-party actions in privileged workflows are SHA-pinned.
+
+Pinning third-party GitHub Actions to a 40-character commit SHA (instead
+of a floating tag like ``@v1`` or ``@release/v1``) is a defence against
+upstream tag-hijacking and silent supply-chain compromise: a malicious
+push to a tag we trust would otherwise execute under our secrets on the
+next workflow run. This check is the static gate that keeps the
+SHA-pinning invariant from regressing.
+
+Scope:
+
+* **Privileged workflows** — the hardcoded list below — run jobs that
+  carry deploy keys, OIDC tokens, repo write scopes, or maintainer
+  credentials. Every ``uses:`` referencing a third-party repo in those
+  workflows must be SHA-pinned.
+* **First-party ``actions/*`` actions** (e.g. ``actions/checkout``,
+  ``actions/setup-python``) are owned by GitHub and may stay on floating
+  tags. Dependabot still bumps them on a weekly cadence (see
+  ``.github/dependabot.yml``).
+* Non-privileged workflows are out of scope; they don't see secrets and
+  can churn at floating-tag speed.
+
+Comment convention: when a SHA is pinned, the line should be followed by
+a human-readable tag comment so reviewers can read the intent without
+visiting GitHub. Example::
+
+    uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0
+
+The comment is advisory — this script does not enforce its presence
+(Dependabot rewrites only the SHA, and a missing comment is a polish
+finding, not a security gap). We enforce only the SHA itself.
+
+Usage::
+
+    python scripts/check_action_pinning.py
+    python scripts/check_action_pinning.py --workflow-dir custom/path
+
+Exit codes:
+    0  Every third-party action in every privileged workflow is SHA-pinned.
+    1  One or more violations found (printed to stderr with file:line).
+    2  Argument error / privileged workflow file missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+# Privileged workflows. Each one carries secrets, OIDC, or maintainer-only
+# triggers; a hijacked third-party action in any of these can exfiltrate
+# credentials or push malicious artifacts under our identity. Keep this
+# list synced with the workflows that declare an ``environment:`` gate or
+# reference ``${{ secrets.* }}`` — see ``check_workflow_secret_gates.py``
+# for the runtime companion to this static check.
+PRIVILEGED_WORKFLOWS: tuple[str, ...] = (
+    "publish.yml",
+    "testpypi-publish.yml",
+    "claude.yml",
+    "rpc-health.yml",
+    "nightly.yml",
+    "verify-package.yml",
+)
+
+# ``uses:`` lines we'll inspect. The ref (everything after ``@``) is the
+# focus of the check; we only need owner/repo to decide whether the
+# action is first-party. Composite-action paths (``./.github/...``) and
+# Docker image refs (``docker://...``) are intentionally NOT matched —
+# they're a different trust model and aren't used in this repo today.
+_USES_RE = re.compile(
+    r"""
+    ^\s*-?\s*               # optional list dash + leading indent
+    uses:\s+                # the ``uses:`` key
+    (?P<owner>[A-Za-z0-9._-]+)
+    /
+    (?P<repo>[A-Za-z0-9._/-]+?)   # repo may include path-into-monorepo
+    @
+    (?P<ref>\S+)            # whatever is after ``@`` up to next whitespace
+    """,
+    re.VERBOSE,
+)
+
+# A SHA is a 40-character lowercase hex string. Anything else — including
+# short SHAs (``@cef221``), tags (``@v1``, ``@release/v1``), branches
+# (``@main``) — is treated as a floating ref.
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# Owners we treat as first-party (GitHub-owned, no SHA pin required).
+# Mirrors the ``_ALLOWED_READ_SCOPES`` frozenset convention used by
+# ``check_workflow_permissions.py`` for similar small lookup tables.
+# ``github/*`` (e.g. ``github/codeql-action``) is GitHub-owned too but
+# lives in a separate org; expand this set deliberately if a ``github/*``
+# action ever lands in a privileged workflow.
+_FIRST_PARTY_OWNERS = frozenset({"actions"})
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--workflow-dir",
+        default=".github/workflows",
+        help="Directory containing workflow YAML files (default: .github/workflows)",
+    )
+    args = ap.parse_args()
+
+    workflow_dir = Path(args.workflow_dir)
+    if not workflow_dir.is_dir():
+        print(f"Not a directory: {workflow_dir}", file=sys.stderr)
+        return 2
+
+    missing: list[str] = []
+    for name in PRIVILEGED_WORKFLOWS:
+        if not (workflow_dir / name).is_file():
+            missing.append(name)
+    if missing:
+        # A privileged workflow disappearing is itself worth a hard fail:
+        # either the list is stale or someone deleted security infra.
+        # Surface so a maintainer either restores the file or updates
+        # PRIVILEGED_WORKFLOWS deliberately.
+        for name in missing:
+            print(
+                f"{workflow_dir / name}: privileged workflow file missing",
+                file=sys.stderr,
+            )
+        return 2
+
+    violations: list[str] = []
+    for name in PRIVILEGED_WORKFLOWS:
+        path = workflow_dir / name
+        for lineno, owner, repo, ref in _iter_uses(path):
+            if owner in _FIRST_PARTY_OWNERS:
+                # actions/* is GitHub-owned; floating tag is acceptable.
+                continue
+            if _SHA_RE.match(ref):
+                # Third-party + 40-char SHA = pinned. OK.
+                continue
+            violations.append(
+                f"{path}:{lineno}: third-party action not SHA-pinned: "
+                f"{owner}/{repo}@{ref} (expected 40-char commit SHA)"
+            )
+
+    if violations:
+        for v in violations:
+            print(v, file=sys.stderr)
+        print(
+            f"\n{len(violations)} violation(s). "
+            "Replace floating tag with the resolved commit SHA, e.g.:\n"
+            "  gh api repos/<owner>/<repo>/commits/<tag> --jq .sha\n"
+            "Then add a comment with the human-readable tag for review "
+            "readability, e.g. ``# @ v1.2.3``.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"OK: all third-party actions in {len(PRIVILEGED_WORKFLOWS)} privileged "
+        f"workflows are SHA-pinned"
+    )
+    return 0
+
+
+def _iter_uses(path: Path) -> Iterator[tuple[int, str, str, str]]:
+    """Yield ``(lineno, owner, repo, ref)`` for each ``uses:`` line in ``path``.
+
+    ``lineno`` is 1-based to match editor / grep / GitHub line numbering.
+    """
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        m = _USES_RE.match(line)
+        if not m:
+            continue
+        yield lineno, m.group("owner"), m.group("repo"), m.group("ref")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_action_pinning.py
+++ b/tests/unit/test_check_action_pinning.py
@@ -1,0 +1,300 @@
+"""Tests for ``scripts/check_action_pinning.py``.
+
+The script enforces that every third-party action (i.e. not ``actions/*``)
+in the privileged workflow set is referenced by a 40-character commit SHA
+rather than a floating tag. Tests cover:
+
+* SHA-pinned third-party action -> pass.
+* Floating-tag third-party action (e.g. ``@v1``) -> fail with the
+  offending file:line in the error.
+* Floating-tag *first-party* (``actions/checkout@v6``) -> still pass.
+* Branch / short-SHA refs treated as floating -> fail.
+* Inline ``# @ v1.2.3`` comment after the SHA is tolerated.
+* Argument errors (missing privileged workflow file, bad directory) -> rc 2.
+
+Script is imported via spec-loading to match the convention used by
+``test_check_workflow_secret_gates.py`` and ``test_check_coverage_thresholds.py``
+(``scripts/`` is not a Python package in this repo).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_action_pinning.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_action_pinning", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def script():
+    return _load_module()
+
+
+# Tiny skeleton workflow body that compiles to valid YAML and contains
+# exactly one ``uses:`` line. Tests parameterize the ref portion.
+_WORKFLOW_TEMPLATE = """
+name: example
+on: push
+permissions:
+  contents: read
+jobs:
+  example:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: {uses}
+"""
+
+
+def _write_privileged_set(
+    dir_path: Path,
+    *,
+    uses_per_file: dict[str, str] | None = None,
+    default_uses: str = "actions/checkout@v6",
+) -> None:
+    """Materialize all privileged workflows in ``dir_path``.
+
+    The script asserts every name in ``PRIVILEGED_WORKFLOWS`` exists — so
+    we have to create the whole set even if only one is interesting. The
+    name list is pulled live from the script module so a future PR that
+    adds a 7th privileged workflow doesn't silently leave the test
+    helper one short. Pass ``uses_per_file`` to override the ``uses:``
+    line for specific files.
+    """
+    uses_per_file = uses_per_file or {}
+    for name in _load_module().PRIVILEGED_WORKFLOWS:
+        body = _WORKFLOW_TEMPLATE.format(uses=uses_per_file.get(name, default_uses))
+        (dir_path / name).write_text(dedent(body).lstrip("\n"))
+
+
+def _run(script, tmp_path, monkeypatch, capsys) -> tuple[int, str, str]:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_action_pinning.py", "--workflow-dir", str(tmp_path)],
+    )
+    rc = script.main()
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_all_pinned_passes(tmp_path, monkeypatch, capsys, script):
+    """SHA-pinned third-party + floating first-party = clean."""
+    pinned = "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={"publish.yml": pinned, "testpypi-publish.yml": pinned},
+        # The rest use floating actions/checkout — first-party, allowed.
+    )
+    rc, out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 0, err
+    assert "OK" in out
+
+
+def test_first_party_floating_is_allowed(tmp_path, monkeypatch, capsys, script):
+    """``actions/*`` floating tag is explicitly OK."""
+    _write_privileged_set(tmp_path, default_uses="actions/setup-python@v6")
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 0, err
+
+
+def test_sha_with_trailing_tag_comment_passes(tmp_path, monkeypatch, capsys, script):
+    """The ``# @ v1.x`` comment after a SHA must not confuse the parser."""
+    line = "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0"
+    _write_privileged_set(tmp_path, uses_per_file={"publish.yml": line})
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 0, err
+
+
+# ---------------------------------------------------------------------------
+# Violations
+# ---------------------------------------------------------------------------
+
+
+def test_floating_third_party_tag_fails(tmp_path, monkeypatch, capsys, script):
+    """A bare ``@v1`` on a third-party action is the canonical violation."""
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={"publish.yml": "pypa/gh-action-pypi-publish@release/v1"},
+    )
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+    assert "publish.yml" in err
+    assert "pypa/gh-action-pypi-publish" in err
+    assert "release/v1" in err
+    # File:line format is required so the violation is jump-to-able.
+    assert "publish.yml:" in err
+
+
+def test_floating_third_party_v1_fails(tmp_path, monkeypatch, capsys, script):
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={"claude.yml": "anthropics/claude-code-action@v1"},
+    )
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+    assert "claude.yml" in err
+    assert "anthropics/claude-code-action" in err
+
+
+def test_short_sha_treated_as_floating(tmp_path, monkeypatch, capsys, script):
+    """7-char abbreviated SHA must NOT satisfy the gate — easy to spoof."""
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={"rpc-health.yml": "peter-evans/create-issue-from-file@cef2210"},
+    )
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+    assert "rpc-health.yml" in err
+
+
+def test_branch_ref_fails(tmp_path, monkeypatch, capsys, script):
+    """Branch refs like ``@main`` are even worse than tag refs."""
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={"nightly.yml": "peter-evans/create-issue-from-file@main"},
+    )
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+    assert "nightly.yml" in err
+
+
+def test_uppercase_sha_rejected(tmp_path, monkeypatch, capsys, script):
+    """The 40-char regex is lowercase-only — keeps the canonical form.
+
+    Git SHA output is conventionally lowercase; rejecting uppercase
+    forces the line to round-trip through ``gh api ... --jq .sha`` (or
+    equivalent) rather than a hand-typed value, which is the
+    documented look-up workflow.
+    """
+    uppercase_sha = "CEF221092ED1BACB1CC03D23A2D87D1D172E277B"
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={"publish.yml": f"pypa/gh-action-pypi-publish@{uppercase_sha}"},
+    )
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+
+
+def test_multiple_violations_all_reported(tmp_path, monkeypatch, capsys, script):
+    """Every violation, not just the first, should appear in stderr."""
+    _write_privileged_set(
+        tmp_path,
+        uses_per_file={
+            "publish.yml": "pypa/gh-action-pypi-publish@release/v1",
+            "claude.yml": "anthropics/claude-code-action@v1",
+        },
+    )
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+    assert "pypa/gh-action-pypi-publish" in err
+    assert "anthropics/claude-code-action" in err
+    assert "2 violation" in err
+
+
+# ---------------------------------------------------------------------------
+# Multiple uses: lines per file
+# ---------------------------------------------------------------------------
+
+
+def test_violation_on_second_uses_line(tmp_path, monkeypatch, capsys, script):
+    """A clean first ``uses:`` must not mask a dirty second one."""
+    # rpc-health.yml has three peter-evans/create-issue-from-file uses.
+    # Pin two, leave one floating.
+    pinned = "peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710"
+    body = dedent(
+        f"""
+        name: rpc-health
+        on: schedule
+        permissions:
+          contents: read
+        jobs:
+          ex:
+            runs-on: ubuntu-latest
+            steps:
+            - uses: actions/checkout@v6
+            - uses: {pinned}
+            - uses: {pinned}
+            - uses: peter-evans/create-issue-from-file@v6
+        """
+    ).lstrip("\n")
+    _write_privileged_set(tmp_path)
+    (tmp_path / "rpc-health.yml").write_text(body)
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 1
+    # The offending ``@v6`` line is line 12 of the body above (1-based).
+    assert "rpc-health.yml:12" in err
+
+
+# ---------------------------------------------------------------------------
+# Argument / IO errors
+# ---------------------------------------------------------------------------
+
+
+def test_missing_privileged_file_returns_rc_2(tmp_path, monkeypatch, capsys, script):
+    """Deleting a privileged workflow trips a hard fail (rc=2, not silent pass)."""
+    _write_privileged_set(tmp_path)
+    (tmp_path / "claude.yml").unlink()
+    rc, _out, err = _run(script, tmp_path, monkeypatch, capsys)
+    assert rc == 2
+    assert "claude.yml" in err
+
+
+def test_nonexistent_workflow_dir(tmp_path, monkeypatch, capsys, script):
+    bogus = tmp_path / "no-such-dir"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_action_pinning.py", "--workflow-dir", str(bogus)],
+    )
+    rc = script.main()
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "Not a directory" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Real repo guard
+# ---------------------------------------------------------------------------
+
+
+def test_real_repo_workflows_are_pinned(monkeypatch, script):
+    """End-to-end: the actual ``.github/workflows`` in the repo must pass.
+
+    This is the regression net: if anyone reverts a SHA pin to a floating
+    tag without realizing it's privileged, this test fails immediately
+    (mirrors what the CI quality job will catch on the same PR).
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_action_pinning.py",
+            "--workflow-dir",
+            str(REPO_ROOT / ".github" / "workflows"),
+        ],
+    )
+    err_buf = io.StringIO()
+    out_buf = io.StringIO()
+    with contextlib.redirect_stderr(err_buf), contextlib.redirect_stdout(out_buf):
+        rc = script.main()
+    assert rc == 0, f"Real repo failed pinning check:\n{err_buf.getvalue()}"

--- a/uv.lock
+++ b/uv.lock
@@ -572,9 +572,9 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.13,<4" },
     { name = "httpx", specifier = ">=0.27.0,<0.29" },
     { name = "markdownify", marker = "extra == 'markdown'", specifier = ">=0.14.1,<2" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0,<3" },
     { name = "notebooklm-py", extras = ["browser", "dev", "markdown"], marker = "extra == 'all'" },
-    { name = "packaging", marker = "extra == 'dev'", specifier = ">=23.0,<26" },
+    { name = "packaging", marker = "extra == 'dev'", specifier = ">=23.0,<27" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0,<2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1,<5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<10" },
@@ -585,9 +585,9 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0,<3" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6.0,<4" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.0.0,<2" },
-    { name = "rich", specifier = ">=13.0.0,<15" },
+    { name = "rich", specifier = ">=13.0.0,<16" },
     { name = "rookiepy", marker = "extra == 'cookies'", specifier = ">=0.1.0,<1" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.13" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'dev'", specifier = ">=2.0.0,<3" },
     { name = "vcrpy", marker = "extra == 'dev'", specifier = ">=6.0.0,<9" },
 ]
@@ -924,27 +924,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.12"
+version = "0.15.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
-    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
-    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
-    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
+    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Second Wave-2 PR — SHA-pins all third-party actions in the 6 privileged workflow jobs and groups github-actions Dependabot bumps.

- SHA-pinned 3rd-party actions in: `publish.yml`, `testpypi-publish.yml`, `claude.yml`, `rpc-health.yml`. (`nightly.yml` + `verify-package.yml` use only `actions/*` first-party — no third-party actions to pin.)
- First-party `actions/*` kept at floating tag (lower risk; Dependabot covers).
- New `scripts/check_action_pinning.py` fails CI if any third-party action in a privileged workflow uses a floating tag. Wired into `test.yml` quality job.
- `dependabot.yml` gains `groups: { actions: { patterns: ["*"] } }` — github-actions bumps land as one PR per ecosystem.

## Test plan
- [x] `python scripts/check_action_pinning.py` exits 0
- [x] 13 new tests in `test_check_action_pinning.py` pass
- [x] 5317 unit+integration suite passes, ruff + mypy clean

## Audit refs
- P0-5 in `.sisyphus/reports/gap-audit-2026-05-17-CONSOLIDATED.md`
- Plan: `.sisyphus/plans/tier-9-p0-p1.md` C-pins task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to pin third-party actions to specific commit SHAs
  * Configured Dependabot to group GitHub Actions updates into consolidated weekly pull requests
  * Added automated validation to enforce GitHub Actions pinning in privileged workflows

* **Tests**
  * Added comprehensive tests for GitHub Actions pinning validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->