### PR TITLE
fix(research,notes): idempotent research start/import + CREATE_NOTE (P0-3)

### DIFF
--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -440,11 +440,18 @@ IDEMPOTENCY_REGISTRY = IdempotencyRegistry()
 # the ``sources.add_text(idempotent=True)`` precedent (also
 # NON_IDEMPOTENT_NO_RETRY for the same "no reliable dedupe key" reason).
 
-_RESEARCH_NOT_IDEMPOTENT_NOTE = (
-    "research start/import: no client-token slot in params and the available "
-    "probes (ResearchAPI.poll / SourcesAPI.list) cannot reliably disambiguate "
-    "a commit-lost retry from a pre-existing peer task — surface the first "
-    "failure and let the caller poll/list to decide"
+_START_RESEARCH_NOT_IDEMPOTENT_NOTE = (
+    "research start: no client-token slot in params and ResearchAPI.poll "
+    "keyed by (notebook_id, query) is ambiguous when peer tasks exist with "
+    "the same query — surface the first failure and let the caller poll to "
+    "decide whether the write landed"
+)
+_IMPORT_RESEARCH_NOT_IDEMPOTENT_NOTE = (
+    "research import: no client-token slot in params; source rows are not "
+    "granular per-task on the wire so a post-commit-lost SourcesAPI.list "
+    "probe cannot bind URL-matched rows to this specific import batch "
+    "(collides with prior workflows that imported the same URLs) — surface "
+    "the failure and let the caller list-and-disambiguate"
 )
 _CREATE_NOTE_NOT_IDEMPOTENT_NOTE = (
     "CREATE_NOTE has no client-token slot and no client-visible note_id on "
@@ -456,17 +463,17 @@ _CREATE_NOTE_NOT_IDEMPOTENT_NOTE = (
 IDEMPOTENCY_REGISTRY.register(
     RPCMethod.START_FAST_RESEARCH,
     IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
-    notes=_RESEARCH_NOT_IDEMPOTENT_NOTE,
+    notes=_START_RESEARCH_NOT_IDEMPOTENT_NOTE,
 )
 IDEMPOTENCY_REGISTRY.register(
     RPCMethod.START_DEEP_RESEARCH,
     IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
-    notes=_RESEARCH_NOT_IDEMPOTENT_NOTE,
+    notes=_START_RESEARCH_NOT_IDEMPOTENT_NOTE,
 )
 IDEMPOTENCY_REGISTRY.register(
     RPCMethod.IMPORT_RESEARCH,
     IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
-    notes=_RESEARCH_NOT_IDEMPOTENT_NOTE,
+    notes=_IMPORT_RESEARCH_NOT_IDEMPOTENT_NOTE,
 )
 
 # CREATE_NOTE has two operation variants on the wire:

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -392,9 +392,114 @@ class IdempotencyRegistry:
                 self.register(method, IdempotencyPolicy.UNCLASSIFIED)
 
 
-# Module-level production registry. Wave 2 adds classifications below the
-# seeding call; B1 was a pure default-fill foundation.
+# Module-level production registry. Wave 2 classifies individual RPCs in
+# two passes:
+#
+#   * Some entries (research/notes from b-research-notes) are registered
+#     *before* the default-fill seeding pass so ``_seed_defaults`` skips
+#     them (it only populates ``(method, None)`` entries that are
+#     absent). Variant entries (``variant != None``) sit alongside the
+#     ``None`` default; the seeder leaves them alone.
+#   * Other entries (delete/refresh/share from b-generation) are
+#     registered *after* the seeding pass and overwrite the
+#     UNCLASSIFIED placeholders that the seeder populated.
+#
+# Both orderings yield the same final registry shape; the difference is
+# stylistic. Future Wave-2 classifications may use either approach.
 IDEMPOTENCY_REGISTRY = IdempotencyRegistry()
+
+
+# ----------------------------------------------------------------------------
+# Wave 2 classifications — P0-3 (b-research-notes)
+# ----------------------------------------------------------------------------
+#
+# Three RPCs in the research + notes family are ``NON_IDEMPOTENT_NO_RETRY``.
+# None of them accept a caller-supplied client-token slot, and the
+# probe surfaces available to the client (``ResearchAPI.poll`` /
+# ``SourcesAPI.list`` / ``GET_NOTES_AND_MIND_MAPS``) cannot reliably
+# disambiguate a commit-lost retry from a pre-existing peer resource:
+#
+# * START_FAST_RESEARCH / START_DEEP_RESEARCH — multiple in-flight
+#   research tasks for the same ``(notebook_id, query)`` are valid, so a
+#   query-based probe is ambiguous when the user has previously started
+#   the same query on the same notebook.
+# * IMPORT_RESEARCH — source URLs may already exist in the notebook
+#   from prior workflows, so a URL-based probe cannot bind to "the row
+#   this specific import committed".
+# * CREATE_NOTE — both variants. The plain 5-element variant gets no
+#   client-visible ``note_id`` on commit-lost (CREATE_NOTE failed before
+#   returning), so a probe against ``GET_NOTES_AND_MIND_MAPS`` cannot
+#   bind to the row. The 7-element saved-from-chat variant has a title
+#   but the server may apply smart-title generation, breaking
+#   title-based probes; chat-answer fingerprints are not unique enough
+#   to safely dedupe either.
+#
+# Caller recourse on failure: poll/list and decide manually (e.g.
+# ``client.research.poll(notebook_id)`` after a START_RESEARCH failure
+# returns the freshly committed task if the write landed). This mirrors
+# the ``sources.add_text(idempotent=True)`` precedent (also
+# NON_IDEMPOTENT_NO_RETRY for the same "no reliable dedupe key" reason).
+
+_RESEARCH_NOT_IDEMPOTENT_NOTE = (
+    "research start/import: no client-token slot in params and the available "
+    "probes (ResearchAPI.poll / SourcesAPI.list) cannot reliably disambiguate "
+    "a commit-lost retry from a pre-existing peer task — surface the first "
+    "failure and let the caller poll/list to decide"
+)
+_CREATE_NOTE_NOT_IDEMPOTENT_NOTE = (
+    "CREATE_NOTE has no client-token slot and no client-visible note_id on "
+    "commit-lost; title-based probes break under server-side smart-title "
+    "generation (saved_from_chat variant). Caller must list notes and "
+    "disambiguate on failure"
+)
+
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.START_FAST_RESEARCH,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=_RESEARCH_NOT_IDEMPOTENT_NOTE,
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.START_DEEP_RESEARCH,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=_RESEARCH_NOT_IDEMPOTENT_NOTE,
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.IMPORT_RESEARCH,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=_RESEARCH_NOT_IDEMPOTENT_NOTE,
+)
+
+# CREATE_NOTE has two operation variants on the wire:
+#   * ``"plain"`` — 5-element params from ``MindMapService.create_note``
+#     (default for ``notes.create()`` and mind-map row creation). The
+#     ``(CREATE_NOTE, None)`` default mirrors the same policy so callers
+#     that omit ``operation_variant`` still get NON_IDEMPOTENT_NO_RETRY.
+#   * ``"saved_from_chat"`` — 7-element params from
+#     ``save_chat_answer_as_note`` (issue #660). Used by
+#     ``notes.create_from_chat``.
+# Both variants share the policy; explicit registration documents the
+# two distinct param shapes for future-classification work.
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.CREATE_NOTE,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    notes=_CREATE_NOTE_NOT_IDEMPOTENT_NOTE,
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.CREATE_NOTE,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    variant="plain",
+    notes=_CREATE_NOTE_NOT_IDEMPOTENT_NOTE,
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.CREATE_NOTE,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    variant="saved_from_chat",
+    notes=_CREATE_NOTE_NOT_IDEMPOTENT_NOTE,
+)
+
+# Default-fill every remaining method with the UNCLASSIFIED placeholder.
+# Methods classified above are skipped by the absence check inside
+# ``_seed_defaults``.
 IDEMPOTENCY_REGISTRY._seed_defaults()
 
 

--- a/tests/integration/test_notes_idempotency.py
+++ b/tests/integration/test_notes_idempotency.py
@@ -1,0 +1,273 @@
+"""Idempotency-policy regression tests for the note creation RPC family.
+
+Tier 9 Wave 2 task ``b-research-notes`` (P0-3-notes). ``CREATE_NOTE`` is
+classified as ``NON_IDEMPOTENT_NO_RETRY`` for both operation variants:
+
+* ``"plain"`` — the default ``MindMapService.create_note`` path. Params
+  ``[notebook_id, "", [1], None, title]``. The server ignores the title
+  slot; ``UPDATE_NOTE`` follows up to set it. A 5xx mid-CREATE_NOTE
+  leaves no client-visible ``note_id``, so even a probe against
+  ``GET_NOTES_AND_MIND_MAPS`` cannot reliably bind to the row this
+  specific call committed.
+* ``"saved_from_chat"`` — the 7-element variant built by
+  ``build_save_chat_as_note_params`` (issue #660). Title is settable
+  but the server may apply smart-title generation, breaking a
+  title-based probe. Content (the chat answer) is also not a safe
+  fingerprint — chat answers can recur if the user re-saves the same
+  result twice intentionally.
+
+Both variants share the policy but are registered with explicit variant
+keys so the registry documents the two distinct param shapes. Variant
+strings: ``"plain"`` (5-element) and ``"saved_from_chat"`` (7-element).
+
+The commit-lost-response model used by these tests:
+
+1. Mock transport returns 502 on the first CREATE_NOTE request.
+2. ``effective_disable_internal_retries=True`` (forced by the policy)
+   means the inner retry loop fires zero times — the 502 surfaces as
+   ``ServerError``.
+3. Test asserts exactly ONE request landed on the wire.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from notebooklm import NotebookLMClient, ServerError
+from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import AskResult, ChatReference
+
+# Mock-transport tests; no HTTP / no cassette.
+pytestmark = pytest.mark.allow_no_vcr
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror the pattern from test_idempotency_create.py)
+# ---------------------------------------------------------------------------
+
+
+def _wrb_response(rpc_id: str, payload) -> str:
+    """Build a single-RPC batchexecute response body."""
+    inner = json.dumps(payload)
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def _make_client_with_transport(
+    transport: httpx.AsyncBaseTransport,
+    auth_tokens,
+    *,
+    server_error_max_retries: int = 3,
+) -> NotebookLMClient:
+    """Construct a ``NotebookLMClient`` wired to a mock httpx transport."""
+    client = NotebookLMClient(
+        auth_tokens,
+        server_error_max_retries=server_error_max_retries,
+    )
+    client._core._http_client = httpx.AsyncClient(
+        transport=transport,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+    )
+    return client
+
+
+def _rpc_id_in_request(request: httpx.Request) -> str | None:
+    """Extract the ``rpcids=`` query param from a batchexecute request URL."""
+    for key, value in request.url.params.multi_items():
+        if key == "rpcids":
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Registry classification — both CREATE_NOTE variants are NON_IDEMPOTENT_NO_RETRY
+# ---------------------------------------------------------------------------
+
+
+def test_create_note_default_variant_classified_non_idempotent() -> None:
+    """The default ``(CREATE_NOTE, None)`` entry is NON_IDEMPOTENT_NO_RETRY.
+
+    The plain ``MindMapService.create_note`` path uses the 5-element
+    params and is the default variant when callers don't pass an explicit
+    ``operation_variant``.
+    """
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.CREATE_NOTE)
+    assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert entry.notes
+
+
+def test_create_note_plain_variant_classified_non_idempotent() -> None:
+    """The explicit ``"plain"`` variant is NON_IDEMPOTENT_NO_RETRY.
+
+    Same policy as the default; the variant key exists to document the
+    5-element param shape distinct from the 7-element saved-from-chat
+    shape. The decoupling lets a future change classify one variant
+    differently without touching the other.
+    """
+    entry = IDEMPOTENCY_REGISTRY.get_entry(
+        RPCMethod.CREATE_NOTE,
+        operation_variant="plain",
+    )
+    assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert entry.notes
+
+
+def test_create_note_saved_from_chat_variant_classified_non_idempotent() -> None:
+    """The ``"saved_from_chat"`` variant is NON_IDEMPOTENT_NO_RETRY.
+
+    Used by ``MindMapRpc.save_chat_answer_as_note`` (issue #660). The
+    7-element params carry rich content; title-based probes break under
+    server-side smart-title generation, and chat-answer fingerprints are
+    not unique enough for safe dedupe.
+    """
+    entry = IDEMPOTENCY_REGISTRY.get_entry(
+        RPCMethod.CREATE_NOTE,
+        operation_variant="saved_from_chat",
+    )
+    assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert entry.notes
+
+
+# ---------------------------------------------------------------------------
+# Commit-lost-response behavior: exactly ONE CREATE_NOTE per call
+# ---------------------------------------------------------------------------
+
+
+async def test_create_note_plain_no_inner_retry_on_5xx(auth_tokens) -> None:
+    """A 502 on ``notes.create()`` fires exactly ONE CREATE_NOTE POST.
+
+    ``NotesAPI.create`` → ``MindMapService.create_note`` issues
+    CREATE_NOTE (and on success, a follow-up UPDATE_NOTE). With the
+    plain variant classified NON_IDEMPOTENT_NO_RETRY, the inner retry
+    loop is disabled and the CREATE_NOTE 502 surfaces immediately. The
+    UPDATE_NOTE never runs because the create raised.
+    """
+    notebook_id = "nb_test"
+    create_count = 0
+    update_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_count, update_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.CREATE_NOTE.value:
+            create_count += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.UPDATE_NOTE.value:
+            update_count += 1
+            return httpx.Response(200, text=_wrb_response(RPCMethod.UPDATE_NOTE.value, []))
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=3)
+    try:
+        with pytest.raises(ServerError):
+            await client.notes.create(notebook_id, title="My Note", content="hello")
+    finally:
+        await client._core._http_client.aclose()
+
+    assert create_count == 1, (
+        f"expected exactly 1 CREATE_NOTE (NON_IDEMPOTENT_NO_RETRY), got {create_count}"
+    )
+    # CREATE_NOTE failed, so the follow-up UPDATE_NOTE must not have run.
+    assert update_count == 0, (
+        f"expected 0 UPDATE_NOTE after CREATE_NOTE failure, got {update_count}"
+    )
+
+
+async def test_create_note_saved_from_chat_no_inner_retry_on_5xx(auth_tokens) -> None:
+    """A 502 on ``notes.create_from_chat()`` fires exactly ONE CREATE_NOTE POST.
+
+    The saved-from-chat variant is a single round-trip — no follow-up
+    UPDATE_NOTE. Classifying it NON_IDEMPOTENT_NO_RETRY forces the inner
+    retry loop off so the 502 surfaces after a single POST.
+    """
+    notebook_id = "nb_test"
+    create_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.CREATE_NOTE.value:
+            create_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=3)
+    ask_result = AskResult(
+        answer="The sky is blue [1].",
+        conversation_id="conv_test",
+        turn_number=1,
+        is_follow_up=False,
+        references=[
+            ChatReference(
+                source_id="src_a",
+                cited_text="The sky appears blue due to Rayleigh scattering.",
+                start_char=0,
+                end_char=48,
+                citation_number=1,
+                chunk_id="chunk_1",
+                passage_id=None,
+            ),
+        ],
+    )
+    try:
+        with pytest.raises(ServerError):
+            await client.notes.create_from_chat(notebook_id, ask_result, title="Chat note")
+    finally:
+        await client._core._http_client.aclose()
+
+    assert create_count == 1, (
+        f"expected exactly 1 CREATE_NOTE (saved_from_chat variant, "
+        f"NON_IDEMPOTENT_NO_RETRY), got {create_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path stays unchanged — exactly ONE CREATE_NOTE on 200
+# ---------------------------------------------------------------------------
+
+
+async def test_create_note_happy_path_one_post(auth_tokens) -> None:
+    """A successful ``notes.create()`` issues exactly ONE CREATE_NOTE.
+
+    Regression-protects the "no behavioral drift on the success path"
+    acceptance: classifying the RPC as NON_IDEMPOTENT_NO_RETRY must not
+    introduce extra requests when the call succeeds normally. The
+    follow-up UPDATE_NOTE is part of the normal create flow (one
+    persists the row, the other persists title + content).
+    """
+    notebook_id = "nb_test"
+    create_count = 0
+    update_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_count, update_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.CREATE_NOTE.value:
+            create_count += 1
+            # Response shape: [[note_id, ...]] — see MindMapService.create_note parse.
+            return httpx.Response(
+                200, text=_wrb_response(RPCMethod.CREATE_NOTE.value, [["note_xyz"]])
+            )
+        if rpc_id == RPCMethod.UPDATE_NOTE.value:
+            update_count += 1
+            return httpx.Response(200, text=_wrb_response(RPCMethod.UPDATE_NOTE.value, []))
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        note = await client.notes.create(notebook_id, title="Happy", content="body")
+    finally:
+        await client._core._http_client.aclose()
+
+    assert note.id == "note_xyz"
+    assert create_count == 1
+    assert update_count == 1  # follow-up update is the success-path norm

--- a/tests/integration/test_research_idempotency.py
+++ b/tests/integration/test_research_idempotency.py
@@ -1,0 +1,275 @@
+"""Idempotency-policy regression tests for the research RPC family.
+
+Tier 9 Wave 2 task ``b-research-notes`` (P0-3-research). Three RPCs are
+classified as ``NON_IDEMPOTENT_NO_RETRY`` because none of them accept a
+caller-supplied client-token slot and the available probe surface
+(``ResearchAPI.poll`` / ``SourcesAPI.list``) cannot reliably disambiguate
+a commit-lost retry from a pre-existing peer task:
+
+* ``START_FAST_RESEARCH`` / ``START_DEEP_RESEARCH`` — multiple in-flight
+  tasks for the same ``(notebook_id, query)`` are valid, so a query-based
+  probe is ambiguous post-commit-lost.
+* ``IMPORT_RESEARCH`` — source URLs may already exist in the notebook
+  from prior workflows, so a URL-based probe cannot bind to "the row
+  this specific import committed".
+
+For ``NON_IDEMPOTENT_NO_RETRY``, the transport's inner 5xx retry loop is
+forced off (``effective_disable_internal_retries=True``). The first
+network/5xx failure surfaces immediately; the caller decides whether to
+poll/list and retry manually.
+
+The commit-lost-response model used by these tests:
+
+1. Mock transport returns 502 on the FIRST start/import request.
+2. ``effective_disable_internal_retries=True`` means the inner retry
+   loop fires zero times — the 502 surfaces as ``ServerError``.
+3. Test asserts exactly ONE request landed on the wire (no naive
+   duplicate POST).
+
+Mirrors the pattern in ``tests/integration/concurrency/test_idempotency_create.py``
+(audit item #2, sources/notebooks PROBE_THEN_CREATE family).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from notebooklm import NotebookLMClient, ServerError
+from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
+from notebooklm.rpc import RPCMethod
+
+# Mock-transport tests; no HTTP / no cassette. Opt out of the
+# tier-enforcement hook in tests/integration/conftest.py.
+pytestmark = pytest.mark.allow_no_vcr
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror the pattern from test_idempotency_create.py)
+# ---------------------------------------------------------------------------
+
+
+def _wrb_response(rpc_id: str, payload) -> str:
+    """Build a single-RPC batchexecute response body."""
+    inner = json.dumps(payload)
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def _make_client_with_transport(
+    transport: httpx.AsyncBaseTransport,
+    auth_tokens,
+    *,
+    server_error_max_retries: int = 3,
+) -> NotebookLMClient:
+    """Construct a ``NotebookLMClient`` wired to a mock httpx transport."""
+    client = NotebookLMClient(
+        auth_tokens,
+        server_error_max_retries=server_error_max_retries,
+    )
+    client._core._http_client = httpx.AsyncClient(
+        transport=transport,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+    )
+    return client
+
+
+def _rpc_id_in_request(request: httpx.Request) -> str | None:
+    """Extract the ``rpcids=`` query param from a batchexecute request URL."""
+    for key, value in request.url.params.multi_items():
+        if key == "rpcids":
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Registry classification — every research RPC is NON_IDEMPOTENT_NO_RETRY
+# ---------------------------------------------------------------------------
+
+
+def test_start_fast_research_classified_non_idempotent() -> None:
+    """START_FAST_RESEARCH is classified ``NON_IDEMPOTENT_NO_RETRY``.
+
+    No client-token slot in the params shape ``[[query, source_type], None,
+    1, notebook_id]``, and a probe by ``(notebook_id, query)`` is ambiguous
+    when the user has previously started the same query on the same
+    notebook (the server permits multiple in-flight peer tasks).
+    """
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.START_FAST_RESEARCH)
+    assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert entry.notes  # human-readable rationale present
+
+
+def test_start_deep_research_classified_non_idempotent() -> None:
+    """START_DEEP_RESEARCH is classified ``NON_IDEMPOTENT_NO_RETRY``.
+
+    Same rationale as ``START_FAST_RESEARCH``: param shape ``[None, [1],
+    [query, source_type], 5, notebook_id]`` has no client-token slot.
+    """
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.START_DEEP_RESEARCH)
+    assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert entry.notes
+
+
+def test_import_research_classified_non_idempotent() -> None:
+    """IMPORT_RESEARCH is classified ``NON_IDEMPOTENT_NO_RETRY``.
+
+    Params ``[None, [1], task_id, notebook_id, source_array]`` correlate
+    by research task_id, but the resulting source rows are not granular
+    per-task on the wire, so a post-commit-lost ``sources.list()`` probe
+    cannot reliably distinguish "rows from this batch" from "rows from a
+    prior workflow that happened to import the same URLs".
+    """
+    entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.IMPORT_RESEARCH)
+    assert entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert entry.notes
+
+
+# ---------------------------------------------------------------------------
+# Commit-lost-response behavior: exactly ONE request per call
+# ---------------------------------------------------------------------------
+
+
+async def test_start_fast_research_no_inner_retry_on_5xx(auth_tokens) -> None:
+    """START_FAST_RESEARCH on 502 fires exactly ONE POST (no inner retry).
+
+    With ``NON_IDEMPOTENT_NO_RETRY`` the transport-layer retry loop is
+    forced off. A naive duplicate POST would either start a second
+    research task (if the first commit landed) or be benign (if it
+    didn't); the client cannot tell which, so the policy refuses the
+    retry and surfaces the first failure for the caller to act on.
+    """
+    notebook_id = "nb_test"
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.START_FAST_RESEARCH.value:
+            request_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=3)
+    try:
+        with pytest.raises(ServerError):
+            await client.research.start(notebook_id, "what is quantum computing?")
+    finally:
+        await client._core._http_client.aclose()
+
+    # NON_IDEMPOTENT_NO_RETRY forces effective_disable_internal_retries=True
+    # so the inner retry loop does not fire — exactly ONE POST.
+    assert request_count == 1, (
+        f"expected exactly 1 START_FAST_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
+    )
+
+
+async def test_start_deep_research_no_inner_retry_on_5xx(auth_tokens) -> None:
+    """START_DEEP_RESEARCH on 503 fires exactly ONE POST (no inner retry).
+
+    Same rationale as the fast-research test — deep-research shares the
+    NON_IDEMPOTENT_NO_RETRY classification.
+    """
+    notebook_id = "nb_test"
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.START_DEEP_RESEARCH.value:
+            request_count += 1
+            return httpx.Response(503, text="service unavailable")
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=3)
+    try:
+        with pytest.raises(ServerError):
+            await client.research.start(notebook_id, "deep dive query", mode="deep")
+    finally:
+        await client._core._http_client.aclose()
+
+    assert request_count == 1, (
+        f"expected exactly 1 START_DEEP_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
+    )
+
+
+async def test_import_research_no_inner_retry_on_5xx(auth_tokens) -> None:
+    """IMPORT_RESEARCH on 502 fires exactly ONE POST (no inner retry)."""
+    notebook_id = "nb_test"
+    task_id = "task_abc"
+    sources = [
+        {
+            "url": "https://example.com/article",
+            "title": "An Article",
+            "result_type": 1,
+            "research_task_id": task_id,
+        },
+    ]
+
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.IMPORT_RESEARCH.value:
+            request_count += 1
+            return httpx.Response(502, text="bad gateway")
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=3)
+    try:
+        with pytest.raises(ServerError):
+            await client.research.import_sources(notebook_id, task_id, sources)
+    finally:
+        await client._core._http_client.aclose()
+
+    assert request_count == 1, (
+        f"expected exactly 1 IMPORT_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path stays unchanged — exactly ONE POST on 200, classification
+# does NOT regress the success path.
+# ---------------------------------------------------------------------------
+
+
+async def test_start_fast_research_happy_path_one_post(auth_tokens) -> None:
+    """A successful START_FAST_RESEARCH fires exactly ONE POST.
+
+    Regression-protects the "no behavioral drift on the success path"
+    acceptance: classifying the RPC as NON_IDEMPOTENT_NO_RETRY must not
+    introduce any extra request when the call succeeds normally.
+    """
+    notebook_id = "nb_test"
+    request_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.START_FAST_RESEARCH.value:
+            request_count += 1
+            # task_data envelope: [task_id, report_id, ...]
+            return httpx.Response(
+                200,
+                text=_wrb_response(RPCMethod.START_FAST_RESEARCH.value, ["task_xyz", "report_xyz"]),
+            )
+        return httpx.Response(404, text="unexpected")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        result = await client.research.start(notebook_id, "test query")
+    finally:
+        await client._core._http_client.aclose()
+
+    assert result is not None
+    assert result["task_id"] == "task_xyz"
+    assert request_count == 1


### PR DESCRIPTION
## Summary

Tier 9 Wave 2 task `b-research-notes` (P0-3-research + P0-3-notes). Classifies three RPC families in the research + notes domain in `IDEMPOTENCY_REGISTRY` so the transport's inner 5xx retry loop is forced off on commit-lost.

- `START_FAST_RESEARCH`, `START_DEEP_RESEARCH`, `IMPORT_RESEARCH` -> `NON_IDEMPOTENT_NO_RETRY`
- `CREATE_NOTE` -> `NON_IDEMPOTENT_NO_RETRY` (default + explicit `"plain"` and `"saved_from_chat"` operation variants)

## Policy Decision (per RPC)

Per the spec's `policy_decision_process`, the investigation step inspected the param shapes at the cited call sites:

| RPC | Param shape (call site) | Client-token slot? | Probe surface | Decision |
|---|---|---|---|---|
| `START_FAST_RESEARCH` | `[[query, source_type], None, 1, notebook_id]` (`_research.py:316`) | No | `ResearchAPI.poll` by `(notebook_id, query)` is ambiguous when multiple peer tasks exist | **NON_IDEMPOTENT_NO_RETRY** |
| `START_DEEP_RESEARCH` | `[None, [1], [query, source_type], 5, notebook_id]` (`_research.py:319`) | No | Same as fast-research; query is not a unique key | **NON_IDEMPOTENT_NO_RETRY** |
| `IMPORT_RESEARCH` | `[None, [1], task_id, notebook_id, source_array]` (`_research.py:615`) | No (task_id is correlation, not dedupe) | `SourcesAPI.list` post-commit-lost cannot bind URL-matched rows to "this specific import batch" — collides with prior workflows | **NON_IDEMPOTENT_NO_RETRY** |
| `CREATE_NOTE` (plain) | `[notebook_id, "", [1], None, title]` (`_mind_map.py:187`) | No | `GET_NOTES_AND_MIND_MAPS` returns no client-visible `note_id` post-commit-lost (CREATE_NOTE failed before returning the row id); content is empty (set by follow-up `UPDATE_NOTE`) | **NON_IDEMPOTENT_NO_RETRY** |
| `CREATE_NOTE` (saved_from_chat) | 7-element params from `build_save_chat_as_note_params` (`_mind_map.py:569`) | No | Title-based probe breaks under server-side smart-title generation; chat-answer fingerprints are not unique | **NON_IDEMPOTENT_NO_RETRY** |

None of the five payload shapes reserves a `None` / empty positional slot for a caller-supplied token, so `CLIENT_TOKEN_DEDUPE` was rejected. The available probe surfaces cannot reliably disambiguate a commit-lost retry from a pre-existing peer resource, so `PROBE_THEN_CREATE` was rejected. The fallback is `NON_IDEMPOTENT_NO_RETRY`: surface the first 5xx and let the caller poll/list to resolve manually. This mirrors the `sources.add_text(idempotent=True)` precedent established in audit item #2.

`CREATE_NOTE` is registered with two explicit operation variants (`"plain"` for the 5-element default path, `"saved_from_chat"` for the 7-element issue #660 variant). Today they share the same policy; the variant table documents the two distinct param shapes so a future change can differentiate them via the existing `operation_variant` plumbing in `RpcExecutor` without further registry churn. The `(CREATE_NOTE, None)` default mirrors the same policy so runtime call sites (which do not pass `operation_variant`) still get the correct classification.

## Acceptance Coverage

- 5 mock-transport commit-lost-response tests (one per RPC family + saved-from-chat variant) assert exactly one POST fires on the 5xx failure path.
- 2 happy-path tests assert exactly one POST on the 200 path (no regression of the success contract).
- 6 classification tests assert the registry returns `NON_IDEMPOTENT_NO_RETRY` with a non-empty `notes` field for each entry, including the two explicit variants.
- All 5317 unit + integration tests stay green.

## Test plan

- [x] `uv run ruff format .` clean
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run pytest tests/unit tests/integration` all pass (5317 passed, 20 skipped)
- [x] New tests at `tests/integration/test_research_idempotency.py` (7 tests) + `tests/integration/test_notes_idempotency.py` (6 tests) all pass

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary automatic retries for research operations (Fast, Deep, Import) and note creation, reducing duplicate requests and clearer error propagation.

* **Tests**
  * Added integration tests validating idempotency and single-request behavior for research starts and note creation, ensuring reliable failure and success handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->