### PR TITLE
refactor(core): add __all__ to tier-10 PR-A seam modules + identity pins

### DIFF
--- a/src/notebooklm/_core_constants.py
+++ b/src/notebooklm/_core_constants.py
@@ -11,6 +11,14 @@ below for guidance on when an operator would want to override them via the
 
 from __future__ import annotations
 
+__all__ = [
+    "DEFAULT_CONNECT_TIMEOUT",
+    "DEFAULT_KEEPALIVE_MIN_INTERVAL",
+    "DEFAULT_MAX_CONCURRENT_RPCS",
+    "DEFAULT_MAX_CONCURRENT_UPLOADS",
+    "DEFAULT_TIMEOUT",
+]
+
 # Default HTTP timeouts in seconds
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_CONNECT_TIMEOUT = 10.0  # Connection establishment timeout

--- a/src/notebooklm/_core_error_injection.py
+++ b/src/notebooklm/_core_error_injection.py
@@ -29,6 +29,13 @@ at call time so the monkeypatch surface remains hot.
 
 from __future__ import annotations
 
+__all__ = [
+    "ERROR_INJECT_ENV_VAR",
+    "_SyntheticErrorTransport",
+    "_get_error_injection_mode",
+    "_refuse_synthetic_error_outside_test_context",
+]
+
 import importlib.util
 import logging
 import os

--- a/src/notebooklm/_core_helpers.py
+++ b/src/notebooklm/_core_helpers.py
@@ -11,6 +11,12 @@ data-only.
 
 from __future__ import annotations
 
+__all__ = [
+    "AUTH_ERROR_PATTERNS",
+    "_resolve_keepalive_interval",
+    "is_auth_error",
+]
+
 import math
 
 import httpx

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1259,11 +1259,5 @@ def test_error_injection_symbols_resolve_through_core():
     from notebooklm import _core_error_injection
 
     assert _core.ERROR_INJECT_ENV_VAR is _core_error_injection.ERROR_INJECT_ENV_VAR
-    assert (
-        _core._get_error_injection_mode
-        is _core_error_injection._get_error_injection_mode
-    )
-    assert (
-        _core._SyntheticErrorTransport
-        is _core_error_injection._SyntheticErrorTransport
-    )
+    assert _core._get_error_injection_mode is _core_error_injection._get_error_injection_mode
+    assert _core._SyntheticErrorTransport is _core_error_injection._SyntheticErrorTransport

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1242,3 +1242,28 @@ def test_is_auth_error_resolves_through_module():
     from notebooklm import _core_helpers
 
     assert _core.is_auth_error is _core_helpers.is_auth_error
+
+
+def test_error_injection_symbols_resolve_through_core():
+    """Pin re-export identity for the highest-risk monkeypatch surfaces.
+
+    ``test_core_lifecycle.py`` monkeypatches ``_get_error_injection_mode``
+    through ``notebooklm._core``, and ``tests/conftest.py`` /
+    ``tests/unit/test_vcr_config.py`` import ``ERROR_INJECT_ENV_VAR`` and
+    ``_SyntheticErrorTransport`` from ``notebooklm._core``. A future refactor
+    that accidentally shadows the re-export (e.g. by reassigning the alias
+    at module scope) would silently break those monkeypatches before any
+    behavior test catches it — these identity pins surface that drift here.
+    """
+    import notebooklm._core as _core
+    from notebooklm import _core_error_injection
+
+    assert _core.ERROR_INJECT_ENV_VAR is _core_error_injection.ERROR_INJECT_ENV_VAR
+    assert (
+        _core._get_error_injection_mode
+        is _core_error_injection._get_error_injection_mode
+    )
+    assert (
+        _core._SyntheticErrorTransport
+        is _core_error_injection._SyntheticErrorTransport
+    )


### PR DESCRIPTION
## Summary

Follow-up to #811 addressing both polish items from the claude bot review (which landed after PR #811 was already merged):

1. **`__all__` added to all three new modules** — matches the established pattern in `_core_metrics.py` / `_core_drain.py` / `_core_lifecycle.py`:
   - `_core_constants.py`: 5 `DEFAULT_*` constants
   - `_core_helpers.py`: `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval`, `is_auth_error`
   - `_core_error_injection.py`: `ERROR_INJECT_ENV_VAR`, `_SyntheticErrorTransport`, `_get_error_injection_mode`, `_refuse_synthetic_error_outside_test_context`

2. **Identity-pin test added** — `test_error_injection_symbols_resolve_through_core` in `tests/unit/test_public_shims.py` pins the three highest-risk monkeypatch surfaces (`ERROR_INJECT_ENV_VAR`, `_get_error_injection_mode`, `_SyntheticErrorTransport`) so a future shadowing rebind surfaces here rather than at a downstream `monkeypatch.setattr` call site (e.g. `test_core_lifecycle.py`, `tests/conftest.py`, `test_vcr_config.py`).

Pure cleanup follow-up — no production behavior change. 4 files, +46 LOC.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 119 files, no issues
- [x] `uv run pytest tests/unit tests/integration` — 5306 passed, 20 skipped (one more than #811: the new identity pin)
- [x] Rebased onto current `origin/main` (HEAD `6ac449c`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized module export declarations to tighten public interfaces and improve maintainability across core modules
* **Tests**
  * Added unit coverage to verify exported symbol consistency and legacy surface re-exports remain intact

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->