### PR TITLE
fix(sources): variant-keyed idempotency for ADD_SOURCE + ADD_SOURCE_FILE; propagate probe failures (P0-3, P1-2)

### DIFF
--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -395,11 +395,12 @@ class IdempotencyRegistry:
 # Module-level production registry. Wave 2 classifies individual RPCs in
 # two passes:
 #
-#   * Some entries (research/notes from b-research-notes) are registered
-#     *before* the default-fill seeding pass so ``_seed_defaults`` skips
-#     them (it only populates ``(method, None)`` entries that are
-#     absent). Variant entries (``variant != None``) sit alongside the
-#     ``None`` default; the seeder leaves them alone.
+#   * Some entries (research/notes from b-research-notes, sources/
+#     ADD_SOURCE variants from b-sources) are registered *before* the
+#     default-fill seeding pass so ``_seed_defaults`` skips them (it only
+#     populates ``(method, None)`` entries that are absent). Variant
+#     entries (``variant != None``) sit alongside the ``None`` default;
+#     the seeder leaves them alone.
 #   * Other entries (delete/refresh/share from b-generation) are
 #     registered *after* the seeding pass and overwrite the
 #     UNCLASSIFIED placeholders that the seeder populated.
@@ -641,6 +642,67 @@ IDEMPOTENCY_REGISTRY.register(
         "mutates ACL; blind retry can re-send invite emails or double-flip access. "
         "GET_SHARE_STATUS exposes the server-side ACL for a future probe-then-create "
         "wrapper; today's classification suppresses the inner retry loop."
+    ),
+)
+
+
+# ----------------------------------------------------------------------------
+# Wave 2 classifications — ADD_SOURCE + ADD_SOURCE_FILE (P0-3, P1-2)
+# ----------------------------------------------------------------------------
+#
+# ADD_SOURCE is variant-shaped: the call site distinguishes ``"url"`` (web /
+# YouTube), ``"drive"`` (Google Drive document), and ``"text"`` (pasted
+# content). Each variant has a different retry-safety profile because the
+# server-side dedupe key differs:
+#
+# * ``"url"`` — probe by ``source.url == url`` on a notebook list. The probe
+#   is a single GET_NOTEBOOK; the wrapper retries the create once if the
+#   probe finds nothing. PROBE_THEN_CREATE.
+# * ``"drive"`` — probe by ``file_id in source.url`` (Drive URLs embed the
+#   file_id). Same wrapper as ``"url"``. PROBE_THEN_CREATE.
+# * ``"text"`` — no reliable dedupe key (titles non-unique, body not
+#   exposed in the source list). NON_IDEMPOTENT_NO_RETRY: force-disable the
+#   inner transport retries and let the first failure surface so the caller
+#   can decide. See the ``add_text`` rationale in
+#   ``tests/integration/concurrency/test_idempotency_create.py:17-19``.
+#
+# ADD_SOURCE_FILE is single-shape: it registers a file source by name.
+# Filenames are NOT identity-bearing (two uploads of ``report.pdf`` are
+# legitimately two distinct sources), so the per-API wrapper captures a
+# baseline of source IDs *before* the create attempt and filters probe
+# matches to "new since the create started" sources only. Ambiguous
+# matches (>1 new source with the same filename) raise rather than guess.
+# PROBE_THEN_CREATE.
+#
+# These four entries flip the executor onto the probe-then-create path
+# via ``resolve_effective_disable_internal_retries`` — the per-API call
+# sites in ``_source_add.py`` / ``_source_upload.py`` own the probe loop.
+
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.ADD_SOURCE,
+    IdempotencyPolicy.PROBE_THEN_CREATE,
+    variant="url",
+    notes="probe by source.url == url on notebook list (web + YouTube)",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.ADD_SOURCE,
+    IdempotencyPolicy.PROBE_THEN_CREATE,
+    variant="drive",
+    notes="probe by /d/<file_id> URL segment marker on notebook list",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.ADD_SOURCE,
+    IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY,
+    variant="text",
+    notes="no reliable dedupe key — titles non-unique, body not exposed",
+)
+IDEMPOTENCY_REGISTRY.register(
+    RPCMethod.ADD_SOURCE_FILE,
+    IdempotencyPolicy.PROBE_THEN_CREATE,
+    notes=(
+        "baseline-diff probe by source.title == filename — filenames are not "
+        "identity-bearing, so the wrapper captures source-id baseline before "
+        "the create and filters probe matches to new sources only"
     ),
 )
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -13,7 +13,15 @@ from ._notebook_metadata import (
 )
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._sharing_manager import ShareManager
-from .exceptions import NetworkError, NotebookLimitError, NotebookNotFoundError, RPCError
+from .exceptions import (
+    AuthError,
+    NetworkError,
+    NotebookLimitError,
+    NotebookNotFoundError,
+    RateLimitError,
+    RPCError,
+    ServerError,
+)
 from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, NotebookMetadata, SuggestedTopic
 
@@ -257,14 +265,14 @@ class NotebooksAPI:
             return notebook
 
         async def _probe() -> Notebook | None:
-            # NetworkError during the probe MUST propagate (P1-2): the
-            # original create may have committed server-side and we have
-            # no way to confirm. Silently returning None would let
-            # ``idempotent_create`` re-issue the create on the next
-            # attempt and duplicate the notebook. Surfacing the network
-            # error keeps the caller in control — they can decide whether
-            # to re-probe later (e.g. once connectivity recovers) before
-            # retrying the create.
+            # Transport- and auth-level errors during the probe MUST
+            # propagate (P1-2): the original create may have committed
+            # server-side and we have no way to confirm. Silently
+            # returning None would let ``idempotent_create`` re-issue the
+            # create on the next attempt and duplicate the notebook.
+            # Surfacing the transport error keeps the caller in control —
+            # they can decide whether to re-probe later (e.g. once
+            # connectivity recovers) before retrying the create.
             #
             # Other exception types (decoding errors, unexpected RPC
             # failures, programming bugs) are still treated as "probe
@@ -274,15 +282,20 @@ class NotebooksAPI:
             # contract of "best-effort probe".
             try:
                 current = await self.list()
-            except NetworkError:
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                # Transport- and auth-level probe failures must propagate.
+                # Silently returning None here lets ``idempotent_create``
+                # re-issue the create on top of a broken probe, which is
+                # exactly the duplicate-resource bug we are guarding against
+                # (P1-2).
                 logger.warning(
-                    "create: probe list() failed with NetworkError; propagating "
-                    "so the caller can avoid a duplicate-resource retry"
+                    "create: probe list() failed with transport/auth error; "
+                    "propagating so the caller can avoid a duplicate-resource retry"
                 )
                 raise
             except Exception:
                 logger.debug(
-                    "create: probe list() failed; treating as no match",
+                    "create: probe list() failed with non-transport error; treating as no match",
                     exc_info=True,
                 )
                 return None

--- a/src/notebooklm/_source_add.py
+++ b/src/notebooklm/_source_add.py
@@ -238,11 +238,15 @@ class SourceAddService:
             return Source.from_api_response(result)
 
         # Drive URLs canonically embed the file_id as a path segment, e.g.
-        # ``https://docs.google.com/document/d/<file_id>/edit``. Matching the
-        # ``/d/<file_id>`` segment (with separators on both sides) avoids
-        # false-positive substring matches against other file_ids that
-        # happen to contain ``<file_id>`` as an interior substring.
-        drive_url_marker = f"/d/{file_id}"
+        # ``https://docs.google.com/document/d/<file_id>/edit``. Match the
+        # ``/d/<file_id>`` slug with a trailing segment boundary (either a
+        # ``/`` or end-of-string) so neither an interior substring nor a
+        # prefix-collision (e.g. ``/d/abc`` matching ``/d/abcdef/edit``)
+        # produces a false-positive. Real-world Drive IDs are 33–44-char
+        # Base64URL strings making prefix collisions astronomically unlikely
+        # in practice, but the boundary check costs nothing.
+        drive_url_marker = f"/d/{file_id}/"
+        drive_url_tail = f"/d/{file_id}"
 
         async def _probe() -> Source | None:
             try:
@@ -258,7 +262,9 @@ class SourceAddService:
                 )
                 return None
             for source in sources:
-                if source.url and drive_url_marker in source.url:
+                if source.url and (
+                    drive_url_marker in source.url or source.url.endswith(drive_url_tail)
+                ):
                     return source
             return None
 

--- a/src/notebooklm/_source_add.py
+++ b/src/notebooklm/_source_add.py
@@ -84,9 +84,16 @@ class SourceAddService:
         async def _probe() -> Source | None:
             try:
                 sources = await list_sources(notebook_id)
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                # Transport- and auth-level probe failures must propagate.
+                # Silently returning None here lets ``idempotent_create``
+                # re-issue the create on top of a broken probe, which is
+                # exactly the duplicate-source bug we are guarding against
+                # (P1-2).
+                raise
             except Exception:
                 logger.debug(
-                    "add_url: probe list() failed; treating as no match",
+                    "add_url: probe list() failed with non-transport error; treating as no match",
                     exc_info=True,
                 )
                 return None
@@ -141,6 +148,7 @@ class SourceAddService:
                 RPCMethod.ADD_SOURCE,
                 params,
                 source_path=f"/notebook/{notebook_id}",
+                operation_variant="text",
             )
         except RPCError as e:
             raise SourceAddError(
@@ -169,10 +177,19 @@ class SourceAddService:
         wait: bool = False,
         wait_timeout: float = 120.0,
         rpc_call: RpcCall,
+        list_sources: ListSources,
         wait_until_ready: WaitUntilReady,
         logger: logging.Logger,
     ) -> Source:
-        """Add a Google Drive document as a source."""
+        """Add a Google Drive document as a source.
+
+        Drive sources go through the same probe-then-create idempotency
+        pattern as ``add_url`` (P0-3-sources): a 5xx / network failure
+        between server-side commit and client-side response could
+        otherwise duplicate the source on a naive retry. The probe matches
+        by ``file_id`` substring against ``source.url`` (Drive URLs embed
+        the file_id, e.g. ``https://docs.google.com/document/d/<id>/edit``).
+        """
         logger.debug("Adding Drive source to notebook %s: %s", notebook_id, title)
         source_data = [
             [file_id, mime_type, 1, title],
@@ -193,15 +210,63 @@ class SourceAddService:
             [2],
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
-        result = await rpc_call(
-            RPCMethod.ADD_SOURCE,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-            allow_null=True,
+
+        async def _create() -> Source:
+            # Preserve transport-level signals so callers can act on the
+            # specific type (AuthError -> re-login, RateLimitError -> back-off,
+            # ServerError -> transient retry). The retryable transport
+            # exceptions must propagate so idempotent_create can catch them
+            # and run the probe.
+            try:
+                result = await rpc_call(
+                    RPCMethod.ADD_SOURCE,
+                    params,
+                    source_path=f"/notebook/{notebook_id}",
+                    allow_null=True,
+                    disable_internal_retries=True,
+                    operation_variant="drive",
+                )
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                raise
+            except RPCError as e:
+                raise SourceAddError(title, cause=e) from e
+
+            if result is None:
+                raise SourceAddError(
+                    title, message=f"API returned no data for Drive source: {title}"
+                )
+            return Source.from_api_response(result)
+
+        # Drive URLs canonically embed the file_id as a path segment, e.g.
+        # ``https://docs.google.com/document/d/<file_id>/edit``. Matching the
+        # ``/d/<file_id>`` segment (with separators on both sides) avoids
+        # false-positive substring matches against other file_ids that
+        # happen to contain ``<file_id>`` as an interior substring.
+        drive_url_marker = f"/d/{file_id}"
+
+        async def _probe() -> Source | None:
+            try:
+                sources = await list_sources(notebook_id)
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                # Transport- and auth-level probe failures must propagate
+                # — see the rationale in ``add_url._probe`` (P1-2).
+                raise
+            except Exception:
+                logger.debug(
+                    "add_drive: probe list() failed with non-transport error; treating as no match",
+                    exc_info=True,
+                )
+                return None
+            for source in sources:
+                if source.url and drive_url_marker in source.url:
+                    return source
+            return None
+
+        source = await idempotent_create(
+            _create,
+            _probe,
+            label=f"sources.add_drive[{file_id}]",
         )
-        if result is None:
-            raise SourceAddError(title, message=f"API returned no data for Drive source: {title}")
-        source = Source.from_api_response(result)
 
         if wait:
             return await wait_until_ready(notebook_id, source.id, timeout=wait_timeout)
@@ -290,6 +355,7 @@ class SourceAddService:
             source_path=f"/notebook/{notebook_id}",
             allow_null=False,
             disable_internal_retries=True,
+            operation_variant="url",
         )
 
     async def add_url_source(
@@ -312,6 +378,7 @@ class SourceAddService:
             params,
             source_path=f"/notebook/{notebook_id}",
             disable_internal_retries=True,
+            operation_variant="url",
         )
 
 

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -350,10 +350,12 @@ class SourceUploadPipeline:
         # probe can distinguish "this upload landed" from "a same-named source
         # already existed." Mirrors the pattern in NotebooksAPI.create. A
         # transport failure during the baseline fetch falls back to an empty
-        # set, which makes the probe maximally conservative (any pre-existing
-        # filename match is treated as ambiguous) rather than maximally
-        # permissive. The baseline list is best-effort and never blocks the
-        # primary create path.
+        # set, which makes the probe maximally permissive (any same-named
+        # source is treated as a potential match, including pre-existing
+        # ones). This is a doubly-exceptional scenario — baseline list failure
+        # AND a same-name collision — and is accepted as a known limitation
+        # mirroring the parallel note in NotebooksAPI.create. The baseline
+        # fetch is best-effort and never blocks the primary create path.
         try:
             baseline_ids = {source.id for source in await list_sources(notebook_id)}
         except Exception:

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import warnings
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from pathlib import Path
 from time import monotonic
@@ -23,6 +23,7 @@ from ._capabilities import (
     UploadConcurrencyProvider,
 )
 from ._env import get_base_url
+from ._idempotency import idempotent_create
 from .exceptions import (
     AuthError,
     NetworkError,
@@ -141,6 +142,9 @@ class CancelUploadSession(Protocol):
     """Late-bound facade hook for best-effort upload cancellation."""
 
     async def __call__(self, upload_url: str, base_url: str, auth_route: str) -> None: ...
+
+
+ListSources = Callable[[str], Awaitable[list[Source]]]
 
 
 _BACKGROUND_CANCEL_TASKS: set[asyncio.Task[None]] = set()
@@ -313,8 +317,28 @@ class SourceUploadPipeline:
         filename: str,
         *,
         rpc_call: RpcCaller,
+        list_sources: ListSources,
+        logger: Any,
     ) -> str:
-        """Register a file source intent and get SOURCE_ID."""
+        """Register a file source intent and get SOURCE_ID.
+
+        Uses the same probe-then-create idempotency pattern as ``add_url`` /
+        ``add_drive`` (P0-3-sources). The ADD_SOURCE_FILE RPC is mutating: a
+        5xx / network failure between server-side commit and client-side
+        response could otherwise duplicate the source on a naive retry.
+
+        Probe semantics: unlike ``add_url`` (where URL equality is a stable
+        dedupe key) or ``add_drive`` (where the Drive file_id is unique
+        server-side), filenames are NOT identity-bearing — two distinct
+        uploads of ``report.pdf`` are legitimately two separate sources.
+        To avoid mis-matching a pre-existing source from an earlier upload,
+        the probe captures a baseline of source IDs *before* the first
+        create attempt and filters probe matches to IDs that are NOT in
+        the baseline (the "new since the create started" set). An
+        ambiguous match (>1 new source with the same filename, e.g. a
+        concurrent uploader added one) raises ``SourceAddError`` rather
+        than guessing.
+        """
         params = [
             [[filename]],
             notebook_id,
@@ -322,39 +346,99 @@ class SourceUploadPipeline:
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
 
+        # Capture baseline source IDs before the first create attempt so the
+        # probe can distinguish "this upload landed" from "a same-named source
+        # already existed." Mirrors the pattern in NotebooksAPI.create. A
+        # transport failure during the baseline fetch falls back to an empty
+        # set, which makes the probe maximally conservative (any pre-existing
+        # filename match is treated as ambiguous) rather than maximally
+        # permissive. The baseline list is best-effort and never blocks the
+        # primary create path.
         try:
-            result = await rpc_call(
-                RPCMethod.ADD_SOURCE_FILE,
-                params,
-                source_path=f"/notebook/{notebook_id}",
-                allow_null=False,
+            baseline_ids = {source.id for source in await list_sources(notebook_id)}
+        except Exception:
+            logger.debug(
+                "register_file_source: baseline list() failed; falling back to empty baseline",
+                exc_info=True,
             )
-        except (AuthError, RateLimitError, ServerError):
-            raise
-        except RPCError as exc:
+            baseline_ids = set()
+
+        async def _create() -> str:
+            try:
+                result = await rpc_call(
+                    RPCMethod.ADD_SOURCE_FILE,
+                    params,
+                    source_path=f"/notebook/{notebook_id}",
+                    allow_null=False,
+                    disable_internal_retries=True,
+                )
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                # Transport-level signals must propagate so idempotent_create
+                # can catch them and run the probe before retrying.
+                raise
+            except RPCError as exc:
+                raise SourceAddError(
+                    filename,
+                    cause=exc,
+                    message=f"Failed to register file source for {filename}: {exc}",
+                ) from exc
+
+            source_id = _extract_register_file_source_id(result, filename)
+            if source_id:
+                return source_id
+
+            if isinstance(result, str):
+                preview = repr(result[:200])
+                if len(result) > 200:
+                    preview += "..."
+            else:
+                preview = repr(result)
+                if len(preview) > 200:
+                    preview = preview[:200] + "..."
             raise SourceAddError(
                 filename,
-                cause=exc,
-                message=f"Failed to register file source for {filename}: {exc}",
-            ) from exc
+                message=(
+                    f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
+                ),
+            )
 
-        source_id = _extract_register_file_source_id(result, filename)
-        if source_id:
-            return source_id
+        async def _probe() -> str | None:
+            try:
+                sources = await list_sources(notebook_id)
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                # Transport- and auth-level probe failures must propagate
+                # (P1-2) — otherwise idempotent_create would retry the
+                # register on top of a broken probe.
+                raise
+            except Exception:
+                logger.debug(
+                    "register_file_source: probe list() failed with "
+                    "non-transport error; treating as no match",
+                    exc_info=True,
+                )
+                return None
+            matches = [
+                source
+                for source in sources
+                if source.id not in baseline_ids and source.title == filename
+            ]
+            if len(matches) == 1:
+                return matches[0].id
+            if len(matches) > 1:
+                raise SourceAddError(
+                    filename,
+                    message=(
+                        f"Cannot disambiguate file source with title {filename!r}: "
+                        f"probe found {len(matches)} new sources with this title "
+                        "after a transport failure. Resolve manually before retrying."
+                    ),
+                )
+            return None
 
-        if isinstance(result, str):
-            preview = repr(result[:200])
-            if len(result) > 200:
-                preview += "..."
-        else:
-            preview = repr(result)
-            if len(preview) > 200:
-                preview = preview[:200] + "..."
-        raise SourceAddError(
-            filename,
-            message=(
-                f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
-            ),
+        return await idempotent_create(
+            _create,
+            _probe,
+            label=f"sources.register_file_source[{filename}]",
         )
 
     async def start_resumable_upload(

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -418,11 +418,14 @@ class SourcesAPI:
                 probe-then-retry pattern used by ``add_url`` cannot be
                 applied here. When True, raises
                 :class:`NonIdempotentRetryError` immediately. Default
-                ``False`` preserves historical behavior (the underlying
-                ``_perform_authed_post`` 5xx / 429 / network retry loop
-                still runs and can duplicate the resource on a retry that
-                follows a server-side commit). For idempotent text imports,
-                embed a UUID in the title and dedupe client-side. See
+                ``False`` no longer relies on the inner transport retry
+                loop — as of the variant-keyed idempotency rollout, the
+                ``(ADD_SOURCE, "text")`` registry entry classifies this
+                call as ``NON_IDEMPOTENT_NO_RETRY``, which force-disables
+                the inner 5xx / 429 / network retry loop so the first
+                failure surfaces immediately instead of risking a
+                duplicate on retry. For idempotent text imports, embed a
+                UUID in the title and dedupe client-side. See
                 ``docs/python-api.md#idempotency``.
 
         Returns:
@@ -590,6 +593,7 @@ class SourcesAPI:
             wait=wait,
             wait_timeout=wait_timeout,
             rpc_call=self._rpc_call,
+            list_sources=self.list,
             wait_until_ready=self.wait_until_ready,
             logger=logger,
         )
@@ -851,6 +855,8 @@ class SourcesAPI:
             notebook_id,
             filename,
             rpc_call=self._rpc_call,
+            list_sources=self.list,
+            logger=logger,
         )
 
     async def _start_resumable_upload(

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -17,8 +17,13 @@ sources when the server already committed the write before returning the
    the second attempt. The probe is variant-specific:
 
      - ``add_url`` probes by ``source.url == url``
-     - ``add_drive`` probes by ``file_id in source.url``
-     - ``register_file_source`` probes by ``source.title == filename``
+     - ``add_drive`` probes by ``/d/<file_id>`` URL-segment marker with a
+       trailing boundary (avoids interior-substring + prefix-collision
+       false-positives)
+     - ``register_file_source`` probes by baseline-diff + ``source.title ==
+       filename`` (filenames are not identity-bearing, so the wrapper
+       captures source-ids before the create and filters probe matches to
+       sources that appeared after the create started)
 
    The "commit-lost-response" test sequence is: first call returns 200
    (server commits + returns success), second call returns 503 (lost
@@ -179,12 +184,13 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
 
 
 async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_tokens) -> None:
-    """Drive sources: 503 + probe-by-file_id-substring returns existing source.
+    """Drive sources: 503 + ``/d/<file_id>`` segment probe returns existing source.
 
-    Drive sources surface their file_id as a substring of the URL stored
-    server-side (typical shape: ``https://docs.google.com/document/d/<file_id>/edit``).
-    The probe matches by substring containment, so any URL that embeds the
-    file_id counts as a hit.
+    Drive sources canonically embed the file_id as a path segment of
+    ``source.url`` (typical shape: ``https://docs.google.com/document/d/<file_id>/edit``).
+    The probe matches by ``/d/<file_id>/`` segment marker (with trailing
+    boundary) so neither interior-substring nor prefix collisions can
+    spuriously match — see the dedicated false-positive tests below.
     """
     notebook_id = "nb_test"
     file_id = "drive_file_abc123xyz"
@@ -222,30 +228,84 @@ async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_toke
     assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
 
 
+async def test_add_drive_probe_matches_segment_at_end_of_url(auth_tokens) -> None:
+    """Drive probe correctly handles ``/d/<file_id>`` at the very end of the URL.
+
+    Some Drive URLs are stored without a trailing ``/edit`` or other path
+    suffix (e.g. ``https://docs.google.com/document/d/<file_id>``). The
+    end-of-string branch of the probe ensures these still match.
+    """
+    notebook_id = "nb_test"
+    file_id = "drive_file_xyz123"
+    title = "Untrailing Drive Doc"
+    src_id = "src_drive_no_trailing"
+    drive_url = f"https://docs.google.com/document/d/{file_id}"  # no trailing /
+
+    add_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(notebook_id, [(src_id, title, drive_url)]),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_drive(notebook_id, file_id, title)
+    finally:
+        await client._core._http_client.aclose()
+
+    assert source.id == src_id
+    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
+    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+
+
+@pytest.mark.parametrize(
+    "other_drive_url",
+    [
+        # Interior substring: contains ``abc`` but not as a ``/d/abc/`` segment.
+        "https://docs.google.com/document/d/xabcy/edit",
+        # Prefix collision: another file_id begins with the target file_id.
+        # ``/d/abc`` IS a substring of ``/d/abcdef/edit`` but the trailing
+        # boundary check rejects it.
+        "https://docs.google.com/document/d/abcdef/edit",
+    ],
+    ids=["interior_substring", "prefix_collision"],
+)
 async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
-    auth_tokens,
+    auth_tokens, other_drive_url: str
 ) -> None:
-    """Drive probe uses ``/d/<file_id>`` segment match, not naked substring.
+    """Drive probe uses ``/d/<file_id>/`` segment match with trailing boundary.
 
-    Regression guard: if the probe used ``file_id in source.url`` directly,
-    a file_id like ``abc`` could spuriously match a URL containing the
-    substring ``xabcy``. Using the ``/d/<file_id>`` path-segment marker
-    constrains the match to the canonical Drive URL shape.
+    Regression guard against two false-positive shapes the probe must reject:
 
-    Scenario: notebook contains a Drive source whose URL embeds a DIFFERENT
-    file_id that happens to contain our target file_id as an interior
-    substring. The probe must NOT match it.
+    * **Interior substring**: ``/d/xabcy/`` contains ``abc`` as a naked
+      substring, so the original ``file_id in source.url`` check would
+      spuriously match.
+    * **Prefix collision**: ``/d/abc`` is also a substring of ``/d/abcdef/``,
+      so the simpler ``/d/<file_id>`` segment marker (without a trailing
+      boundary) would still false-positive. Real-world Drive IDs are 33–44
+      character Base64URL strings making prefix collisions astronomically
+      unlikely, but the boundary check is essentially free.
+
+    In both cases the probe must return ``None`` so ``idempotent_create``
+    retries the create rather than returning the unrelated source.
     """
     from notebooklm.exceptions import ServerError
 
     notebook_id = "nb_test"
     target_file_id = "abc"  # short file_id chosen to maximize collision chance
     title = "My Drive Doc"
-    other_drive_url = (
-        # URL embeds "xabcy" — contains "abc" as a substring but NOT as a
-        # ``/d/abc`` segment.
-        "https://docs.google.com/document/d/xabcy/edit"
-    )
 
     add_count = 0
     get_count = 0

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -1,0 +1,584 @@
+"""Variant-keyed idempotency tests for ADD_SOURCE + ADD_SOURCE_FILE.
+
+Tier 9 Wave 2 (P0-3-sources, P1-2-sources): the previous behavior in
+``_source_add.py``/``_source_upload.py`` relied on the inner transport
+retry loop to handle 5xx for mutating create RPCs, which could duplicate
+sources when the server already committed the write before returning the
+5xx. The fix is two-fold:
+
+1. Variant-keyed registry entries — ``(ADD_SOURCE, "url"|"drive")`` and
+   ``(ADD_SOURCE_FILE, None)`` flip to ``PROBE_THEN_CREATE``;
+   ``(ADD_SOURCE, "text")`` flips to ``NON_IDEMPOTENT_NO_RETRY``. The
+   registry forces ``disable_internal_retries=True`` at the executor.
+
+2. Probe-then-create wrappers — for the three PROBE_THEN_CREATE variants,
+   ``idempotent_create`` issues a single create attempt, and on a
+   retryable transport error (5xx / 429 / network) runs a probe before
+   the second attempt. The probe is variant-specific:
+
+     - ``add_url`` probes by ``source.url == url``
+     - ``add_drive`` probes by ``file_id in source.url``
+     - ``register_file_source`` probes by ``source.title == filename``
+
+   The "commit-lost-response" test sequence is: first call returns 200
+   (server commits + returns success), second call returns 503 (lost
+   response from a third-party retry); the probe short-circuits and the
+   wrapper returns the existing source without re-issuing the create.
+
+3. Probe-failure propagation — a probe that raises ``NetworkError``
+   (transport-layer) must propagate so the caller sees the original
+   failure mode, not a silent retry on top of a broken probe.
+
+These tests use mock ``httpx.MockTransport`` (NOT VCR cassettes) per the
+Codex iter-1 critique: cassette-based replay can't model the "first call
+returns 200, second call returns 503" sequence because each route is
+flatly keyed by request shape, not call order.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from notebooklm import NotebookLMClient
+from notebooklm._idempotency import IDEMPOTENCY_REGISTRY, IdempotencyPolicy
+from notebooklm.exceptions import NetworkError, NotebookLMError
+from notebooklm.rpc import RPCMethod
+
+# Mock-transport idempotency tests; no HTTP, no cassette. Opt out of the
+# tier-enforcement hook in tests/integration/conftest.py.
+pytestmark = pytest.mark.allow_no_vcr
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror tests/integration/concurrency/test_idempotency_create.py)
+# ---------------------------------------------------------------------------
+
+
+def _wrb_response(rpc_id: str, payload) -> str:
+    """Build a single-RPC batchexecute response body."""
+    inner = json.dumps(payload)
+    chunk = json.dumps([["wrb.fr", rpc_id, inner, None, None]])
+    return f")]}}'\n{len(chunk)}\n{chunk}\n"
+
+
+def _get_notebook_with_sources_response(
+    notebook_id: str,
+    sources: list[tuple[str, str, str | None]],
+) -> str:
+    """Build a GET_NOTEBOOK response that ``SourcesAPI.list`` parses.
+
+    ``sources`` is ``[(source_id, title, url_or_None), ...]``. The metadata
+    layout matches the parsing path in ``Source.from_api_response``: ``url``
+    at index ``[7]`` when present (matches ``_extract_source_url`` precedence
+    with ``allow_bare_http=False``).
+    """
+    src_rows: list = []
+    for src_id, title, url in sources:
+        metadata: list = [None] * 8
+        if url is not None:
+            metadata[7] = [url]
+        status_block = [None, 2]  # READY
+        src_rows.append([[src_id], title, metadata, status_block])
+    nb_info = ["Test Notebook", src_rows]
+    return _wrb_response(RPCMethod.GET_NOTEBOOK.value, [nb_info])
+
+
+def _make_client_with_transport(
+    transport: httpx.AsyncBaseTransport,
+    auth_tokens,
+    *,
+    server_error_max_retries: int = 3,
+) -> NotebookLMClient:
+    """Construct a NotebookLMClient backed by a mock transport.
+
+    Mirrors the helper used in tests/integration/concurrency/
+    test_idempotency_create.py: stub in a pre-built httpx.AsyncClient
+    wired to the supplied mock transport, bypassing the full
+    ClientCore.open() path that would otherwise build a real connection
+    pool.
+    """
+    client = NotebookLMClient(
+        auth_tokens,
+        server_error_max_retries=server_error_max_retries,
+    )
+    client._core._http_client = httpx.AsyncClient(
+        transport=transport,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        },
+    )
+    return client
+
+
+def _rpc_id_in_request(request: httpx.Request) -> str | None:
+    for key, value in request.url.params.multi_items():
+        if key == "rpcids":
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# add_url — commit-lost-response (PROBE_THEN_CREATE, variant="url")
+# ---------------------------------------------------------------------------
+
+
+async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens) -> None:
+    """First ADD_SOURCE call commits server-side but client sees 503; probe wins.
+
+    Models the commit-lost-response failure mode: the server processed the
+    create successfully, but the response was lost (e.g. proxy timeout
+    returned 503 to the caller). The probe finds the new source already
+    landed and returns it; only ONE ADD_SOURCE actually fires.
+    """
+    notebook_id = "nb_test"
+    url = "https://example.com/article"
+    src_id = "src_lost_response"
+
+    add_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            # First call (the server committed but the response was lost)
+            # — the client sees a 503.
+            return httpx.Response(503, text="service unavailable")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(notebook_id, [(src_id, "Article", url)]),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_url(notebook_id, url)
+    finally:
+        await client._core._http_client.aclose()
+
+    assert source.id == src_id
+    assert source.url == url
+    # Exactly ONE ADD_SOURCE (no naive re-POST after the 503)
+    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
+    # Exactly ONE GET_NOTEBOOK (the probe)
+    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+
+
+# ---------------------------------------------------------------------------
+# add_drive — commit-lost-response (PROBE_THEN_CREATE, variant="drive")
+# ---------------------------------------------------------------------------
+
+
+async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_tokens) -> None:
+    """Drive sources: 503 + probe-by-file_id-substring returns existing source.
+
+    Drive sources surface their file_id as a substring of the URL stored
+    server-side (typical shape: ``https://docs.google.com/document/d/<file_id>/edit``).
+    The probe matches by substring containment, so any URL that embeds the
+    file_id counts as a hit.
+    """
+    notebook_id = "nb_test"
+    file_id = "drive_file_abc123xyz"
+    title = "My Drive Doc"
+    src_id = "src_drive_lost"
+    drive_url = f"https://docs.google.com/document/d/{file_id}/edit"
+
+    add_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(notebook_id, [(src_id, title, drive_url)]),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        source = await client.sources.add_drive(notebook_id, file_id, title)
+    finally:
+        await client._core._http_client.aclose()
+
+    assert source.id == src_id
+    assert file_id in (source.url or "")
+    assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
+    assert get_count == 1, f"expected 1 GET_NOTEBOOK probe, got {get_count}"
+
+
+async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
+    auth_tokens,
+) -> None:
+    """Drive probe uses ``/d/<file_id>`` segment match, not naked substring.
+
+    Regression guard: if the probe used ``file_id in source.url`` directly,
+    a file_id like ``abc`` could spuriously match a URL containing the
+    substring ``xabcy``. Using the ``/d/<file_id>`` path-segment marker
+    constrains the match to the canonical Drive URL shape.
+
+    Scenario: notebook contains a Drive source whose URL embeds a DIFFERENT
+    file_id that happens to contain our target file_id as an interior
+    substring. The probe must NOT match it.
+    """
+    from notebooklm.exceptions import ServerError
+
+    notebook_id = "nb_test"
+    target_file_id = "abc"  # short file_id chosen to maximize collision chance
+    title = "My Drive Doc"
+    other_drive_url = (
+        # URL embeds "xabcy" — contains "abc" as a substring but NOT as a
+        # ``/d/abc`` segment.
+        "https://docs.google.com/document/d/xabcy/edit"
+    )
+
+    add_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(
+                    notebook_id, [("src_other", title, other_drive_url)]
+                ),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(ServerError):
+            await client.sources.add_drive(notebook_id, target_file_id, title)
+    finally:
+        await client._core._http_client.aclose()
+
+    # The probe must NOT have spuriously matched the unrelated Drive
+    # source — instead the wrapper retried, exhausted, and re-raised.
+    assert add_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# register_file_source (ADD_SOURCE_FILE) — commit-lost-response
+# (PROBE_THEN_CREATE, variant=None)
+# ---------------------------------------------------------------------------
+
+
+async def test_register_file_source_probe_short_circuits_when_first_response_lost(
+    auth_tokens, tmp_path: Path
+) -> None:
+    """File uploads: 503 on ADD_SOURCE_FILE + baseline-diff probe returns new source.
+
+    The full add_file flow is three steps (register → start_resumable → finalize).
+    Here we exercise only the register step's idempotency: the test patches
+    the upload stages to no-op so the probe-then-retry behavior of
+    ``register_file_source`` is observable in isolation.
+
+    Because filenames are not identity-bearing (two uploads of ``report.pdf``
+    are legitimately two distinct sources), the probe uses a baseline-diff
+    pattern: it captures source IDs BEFORE the create attempt and only
+    counts sources that appear AFTER the create as "the upload landed."
+    This test exercises the typical case: baseline returns no matching
+    sources, the create gets 503, the probe finds the new source, and the
+    wrapper short-circuits with exactly 1 ADD_SOURCE_FILE call.
+    """
+    notebook_id = "nb_test"
+    filename = "my_document.pdf"
+    src_id = "src_file_lost"
+
+    test_file = tmp_path / filename
+    test_file.write_bytes(b"%PDF-1.4 minimal pdf")
+
+    register_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal register_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE_FILE.value:
+            register_count += 1
+            return httpx.Response(503, text="service unavailable")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            # Call 1: baseline — empty notebook (no pre-existing file).
+            # Call 2: probe after the 503 — the new source has landed
+            # server-side; the wrapper should return its id without retrying.
+            if get_count == 1:
+                return httpx.Response(
+                    200,
+                    text=_get_notebook_with_sources_response(notebook_id, []),
+                )
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(notebook_id, [(src_id, filename, None)]),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        # Stub start_resumable_upload + upload_file_streaming so this test
+        # exercises only the ADD_SOURCE_FILE register step's idempotency.
+        with (
+            patch.object(
+                client.sources,
+                "_start_resumable_upload",
+                AsyncMock(return_value="https://upload.example/scotty"),
+            ),
+            patch.object(
+                client.sources,
+                "_upload_file_streaming",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            source = await client.sources.add_file(notebook_id, test_file)
+    finally:
+        await client._core._http_client.aclose()
+
+    assert source.id == src_id
+    # Exactly ONE ADD_SOURCE_FILE register request (no naive re-POST)
+    assert register_count == 1, f"expected 1 ADD_SOURCE_FILE, got {register_count}"
+    # TWO GET_NOTEBOOK calls: baseline + probe-after-failure
+    assert get_count == 2, f"expected 2 GET_NOTEBOOK calls (baseline + probe), got {get_count}"
+
+
+async def test_register_file_source_does_not_match_pre_existing_filename(
+    auth_tokens, tmp_path: Path
+) -> None:
+    """File uploads: baseline-diff prevents matching a pre-existing same-named source.
+
+    Regression guard for the original Codex critical finding: filenames are
+    NOT identity-bearing. If the notebook already has ``report.pdf`` from a
+    previous upload and the user calls ``add_file(notebook_id, report.pdf)``
+    again, a transport failure during the second register must NOT cause
+    the wrapper to return the OLD source's id — that would silently
+    redirect the new upload onto the existing source.
+
+    Scenario:
+      - baseline list returns the pre-existing ``report.pdf`` source
+      - create gets 503 (no second source landed server-side either)
+      - probe list returns the SAME pre-existing source
+      - filtered by baseline_ids, the probe finds zero "new" matches
+      - the wrapper retries the create, which 503s again, and exhausts
+        attempts → original ServerError surfaces
+
+    The load-bearing assertion is that the wrapper does NOT return the
+    pre-existing source's id under any failure mode.
+    """
+    from notebooklm.exceptions import ServerError
+
+    notebook_id = "nb_test"
+    filename = "report.pdf"
+    pre_existing_src_id = "src_OLD_report"
+
+    test_file = tmp_path / filename
+    test_file.write_bytes(b"%PDF-1.4 minimal pdf")
+
+    register_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal register_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE_FILE.value:
+            register_count += 1
+            return httpx.Response(503, text="service unavailable")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            # Both baseline and probe return the SAME pre-existing source.
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(
+                    notebook_id, [(pre_existing_src_id, filename, None)]
+                ),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with (
+            patch.object(
+                client.sources,
+                "_start_resumable_upload",
+                AsyncMock(return_value="https://upload.example/scotty"),
+            ),
+            patch.object(
+                client.sources,
+                "_upload_file_streaming",
+                AsyncMock(return_value=None),
+            ),
+            pytest.raises(ServerError),
+        ):
+            await client.sources.add_file(notebook_id, test_file)
+    finally:
+        await client._core._http_client.aclose()
+
+    # The pre-existing source's id was never returned — instead, the
+    # original transport error propagated after retries were exhausted.
+    # The exact register_count is implementation-defined (idempotent_create
+    # default is 2 attempts), but it must be at least 1.
+    assert register_count >= 1, f"expected ≥1 ADD_SOURCE_FILE, got {register_count}"
+    assert get_count >= 1, f"expected ≥1 GET_NOTEBOOK, got {get_count}"
+
+
+# ---------------------------------------------------------------------------
+# add_text — NON_IDEMPOTENT_NO_RETRY enforcement
+# ---------------------------------------------------------------------------
+
+
+async def test_add_text_no_probe_no_retry_under_5xx(
+    auth_tokens, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """add_text under 5xx must surface the failure immediately.
+
+    No probe (no reliable dedupe key) and no retry — the registry
+    classifies (ADD_SOURCE, "text") as NON_IDEMPOTENT_NO_RETRY, which
+    force-disables the inner transport retry loop. The caller sees the
+    503 on the first attempt and exactly one ADD_SOURCE request fires.
+
+    asyncio.sleep is patched to a no-op so a regression that re-enables
+    retries doesn't pay backoff wall time before the test catches it. The
+    assertion on the surfaced exception type tolerates either
+    ``ServerError`` or ``SourceAddError`` because ``add_text`` historically
+    wraps ``RPCError`` subclasses (including ``ServerError``) in
+    ``SourceAddError`` — the load-bearing assertion is the request count.
+    """
+    notebook_id = "nb_test"
+    title = "Some Note"
+    content = "some content"
+    add_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            return httpx.Response(503, text="service unavailable")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            # Should NEVER be called for add_text.
+            get_count += 1
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(notebook_id, []),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens)
+    try:
+        with pytest.raises(NotebookLMError):
+            await client.sources.add_text(notebook_id, title, content)
+    finally:
+        await client._core._http_client.aclose()
+
+    # Exactly ONE ADD_SOURCE attempt: no retry loop, no probe.
+    assert add_count == 1, (
+        f"add_text must fire exactly 1 ADD_SOURCE under NON_IDEMPOTENT_NO_RETRY; got {add_count}"
+    )
+    assert get_count == 0, f"add_text must not probe; got {get_count} GET_NOTEBOOK"
+
+
+# ---------------------------------------------------------------------------
+# Probe-failure propagation (P1-2)
+# ---------------------------------------------------------------------------
+
+
+async def test_add_url_probe_network_error_propagates(auth_tokens) -> None:
+    """When the probe itself fails with NetworkError, propagate the failure.
+
+    Previously the probe wrapper caught any Exception and returned ``None``,
+    which made ``idempotent_create`` re-issue the create on top of a broken
+    probe — duplicating the resource on the very next attempt. The fix
+    surfaces transport-layer probe failures directly so the caller can act
+    on them (refresh auth, back off, etc.) instead of silently retrying.
+
+    Triggered by:
+      - first ADD_SOURCE returns 502 → enters probe branch
+      - GET_NOTEBOOK raises a transport-level failure (httpx.ConnectError),
+        which ``rpc_call`` translates into NetworkError
+      - probe propagates NetworkError → idempotent_create surfaces it
+        to the caller
+    """
+    notebook_id = "nb_test"
+    url = "https://example.com/article"
+
+    add_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal add_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE.value:
+            add_count += 1
+            return httpx.Response(502, text="bad gateway")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            # Synthesize a transport-layer connect failure for the probe.
+            raise httpx.ConnectError("probe synthetic connection error")
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with pytest.raises(NetworkError, match="probe synthetic connection error"):
+            await client.sources.add_url(notebook_id, url)
+    finally:
+        await client._core._http_client.aclose()
+
+    # Probe was attempted (the original create failed with 502, then the
+    # probe was issued and raised).
+    assert add_count == 1, f"expected 1 ADD_SOURCE before probe, got {add_count}"
+    assert get_count >= 1, f"probe must run; got {get_count}"
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity check: variant-keyed entries are present and classified
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_variant_entries_for_add_source_and_add_source_file() -> None:
+    """Smoke-test that the four required registry entries exist and have the
+    right policy classification.
+
+    This guards against accidental regressions where a refactor drops the
+    registry registration in ``_idempotency.py`` but leaves the per-variant
+    plumbing intact — the executor would silently fall back to UNCLASSIFIED
+    (today's retries) and the duplicate-source bug would resurrect.
+    """
+    url_entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.ADD_SOURCE, operation_variant="url")
+    drive_entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.ADD_SOURCE, operation_variant="drive")
+    text_entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.ADD_SOURCE, operation_variant="text")
+    file_entry = IDEMPOTENCY_REGISTRY.get_entry(RPCMethod.ADD_SOURCE_FILE, operation_variant=None)
+
+    assert url_entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
+    assert drive_entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE
+    assert text_entry.policy is IdempotencyPolicy.NON_IDEMPOTENT_NO_RETRY
+    assert file_entry.policy is IdempotencyPolicy.PROBE_THEN_CREATE

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -24,6 +24,25 @@ from notebooklm.types import SourceAddError, SourceNotFoundError
 pytestmark = pytest.mark.allow_no_vcr
 
 
+def _add_register_file_source_baseline_mock(httpx_mock: HTTPXMock, build_rpc_response) -> None:
+    """Register an empty GET_NOTEBOOK baseline response for ``add_file`` paths.
+
+    The ``register_file_source`` wrapper captures a baseline of source IDs
+    before the create attempt (see ``_source_upload.py:register_file_source``
+    for the rationale — pre-existing same-named sources must NOT match a
+    retry probe). For tests that exercise ``add_file`` with a single
+    ``ADD_SOURCE_FILE`` batchexecute mock, this helper adds the baseline
+    GET_NOTEBOOK response (empty notebook) that the new code path requires.
+
+    Place this BEFORE the test's ``ADD_SOURCE_FILE`` mock so the registered
+    responses match the actual request order.
+    """
+    httpx_mock.add_response(
+        url=re.compile(r".*batchexecute.*rpcids=" + RPCMethod.GET_NOTEBOOK.value + r".*"),
+        content=build_rpc_response(RPCMethod.GET_NOTEBOOK, [["", []]]).encode(),
+    )
+
+
 class TestAddSource:
     @pytest.mark.asyncio
     async def test_add_source_url(
@@ -688,6 +707,9 @@ class TestAddFileSource:
         test_file = tmp_path / "test_document.txt"
         test_file.write_text("This is test content for upload.")
 
+        # Step 0: register_file_source captures a baseline GET_NOTEBOOK
+        # before the create — see the helper docstring for the rationale.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         # Step 1: Mock RPC registration response (o4cbdc)
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
@@ -722,20 +744,24 @@ class TestAddFileSource:
         assert source.title == "test_document.txt"
         assert source.kind == "unknown"
 
-        # Verify all 3 requests were made
+        # Verify all 4 requests were made: baseline GET_NOTEBOOK + 3-step
+        # upload protocol (register + start + finalize).
         requests = httpx_mock.get_requests()
-        assert len(requests) == 3
+        assert len(requests) == 4
+
+        # Verify Step 0: baseline GET_NOTEBOOK
+        assert RPCMethod.GET_NOTEBOOK in str(requests[0].url)
 
         # Verify Step 1: RPC call
-        assert RPCMethod.ADD_SOURCE_FILE in str(requests[0].url)
+        assert RPCMethod.ADD_SOURCE_FILE in str(requests[1].url)
 
         # Verify Step 2: Upload start
-        assert "x-goog-upload-command" in requests[1].headers
-        assert requests[1].headers["x-goog-upload-command"] == "start"
-
-        # Verify Step 3: Upload finalize
         assert "x-goog-upload-command" in requests[2].headers
-        assert requests[2].headers["x-goog-upload-command"] == "upload, finalize"
+        assert requests[2].headers["x-goog-upload-command"] == "start"
+
+        # Verify Step 3: Upload finalize (now requests[3] after baseline)
+        assert "x-goog-upload-command" in requests[3].headers
+        assert requests[3].headers["x-goog-upload-command"] == "upload, finalize"
 
     @pytest.mark.asyncio
     async def test_add_file_rpc_params_format(
@@ -749,6 +775,8 @@ class TestAddFileSource:
         test_file = tmp_path / "my_file.pdf"
         test_file.write_bytes(b"%PDF-1.4 fake pdf content")
 
+        # Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         # Mock all 3 responses
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
@@ -768,7 +796,9 @@ class TestAddFileSource:
         # params[0] should be [[filename]] (double-nested within the param)
         # In the full params array JSON: [[[filename]], nb_id, ...] (3 brackets total)
         # NOT [[[[filename]]], ...] (4 brackets - the old bug)
-        rpc_request = httpx_mock.get_requests()[0]
+        # Index [1] is the ADD_SOURCE_FILE request (index [0] is the
+        # baseline GET_NOTEBOOK from the probe-then-create wrapper).
+        rpc_request = httpx_mock.get_requests()[1]
         body = urllib.parse.unquote(rpc_request.content.decode())
         # The params are JSON-encoded inside the RPC wrapper, so quotes are escaped
         # Verify 3 brackets (correct) not 4 brackets (bug)
@@ -801,6 +831,8 @@ class TestAddFileSource:
         content = "Test content " * 100
         test_file.write_text(content)
 
+        # Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
             [[[["src_abc"], "document.txt", [None, None, None, None, 0]]]],
@@ -815,8 +847,10 @@ class TestAddFileSource:
         async with NotebookLMClient(auth_tokens) as client:
             await client.sources.add_file("nb_123", test_file)
 
-        # Check upload start request (Step 2)
-        start_request = httpx_mock.get_requests()[1]
+        # Check upload start request (Step 2). Request indices: [0]
+        # baseline GET_NOTEBOOK, [1] ADD_SOURCE_FILE register, [2] upload
+        # start, [3] upload finalize.
+        start_request = httpx_mock.get_requests()[2]
 
         # Verify headers
         assert start_request.headers["x-goog-upload-protocol"] == "resumable"
@@ -843,6 +877,8 @@ class TestAddFileSource:
         binary_content = b"\x00\x01\x02\x03\xff\xfe\xfd"
         test_file.write_bytes(binary_content)
 
+        # Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
             [[[["src_bin"], "binary_file.bin", [None, None, None, None, 0]]]],
@@ -857,8 +893,10 @@ class TestAddFileSource:
         async with NotebookLMClient(auth_tokens) as client:
             await client.sources.add_file("nb_123", test_file)
 
-        # Check upload content request (Step 3)
-        upload_request = httpx_mock.get_requests()[2]
+        # Check upload content request (Step 3 — finalize POST). Request
+        # indices: [0] baseline GET_NOTEBOOK, [1] ADD_SOURCE_FILE register,
+        # [2] upload start, [3] upload finalize.
+        upload_request = httpx_mock.get_requests()[3]
 
         # Verify the actual content was sent
         assert upload_request.content == binary_content
@@ -886,6 +924,8 @@ class TestAddEpubFileSource:
             zf.writestr("OEBPS/chapter1.xhtml", "<html><body><p>Test</p></body></html>")
         test_epub.write_bytes(buffer.getvalue())
 
+        # Step 0: Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         # Step 1: Mock RPC registration
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
@@ -925,12 +965,14 @@ class TestAddEpubFileSource:
         assert source.id == "epub_source_123"
         assert source.title == "test_book.epub"
 
-        # Verify all 3 requests were made
+        # Verify all 4 requests were made: baseline GET_NOTEBOOK +
+        # 3-step upload protocol (register + start + finalize).
         requests = httpx_mock.get_requests()
-        assert len(requests) == 3
+        assert len(requests) == 4
 
-        # Verify uploaded content is the EPUB ZIP bytes
-        upload_request = requests[2]
+        # Verify uploaded content is the EPUB ZIP bytes (now requests[3]
+        # after the baseline shifted indices).
+        upload_request = requests[3]
         assert upload_request.content == test_epub.read_bytes()
 
 
@@ -2510,6 +2552,8 @@ class TestRegisterFileSourceError:
         test_file = tmp_path / "test.pdf"
         test_file.write_bytes(b"%PDF-1.4 fake")
 
+        # Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         # Return a response where extract_id returns None - nested empty list
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
@@ -2537,6 +2581,8 @@ class TestRegisterFileSourceError:
         test_file = tmp_path / "empty_nested.pdf"
         test_file.write_bytes(b"%PDF-1.4 content")
 
+        # Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         # Result is [[[]]] - extract_id([[]]) -> extract_id([]) -> returns None
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,
@@ -2567,6 +2613,8 @@ class TestStartResumableUploadError:
         test_file = tmp_path / "no_url.pdf"
         test_file.write_bytes(b"%PDF-1.4 content")
 
+        # Step 0: Baseline GET_NOTEBOOK for the register_file_source probe wrapper.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
         # Step 1: Successful RPC registration
         rpc_response = build_rpc_response(
             RPCMethod.ADD_SOURCE_FILE,

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -30,6 +30,7 @@ class RecordingRpc:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
         self.calls.append(
             {
@@ -38,6 +39,7 @@ class RecordingRpc:
                 "source_path": source_path,
                 "allow_null": allow_null,
                 "disable_internal_retries": disable_internal_retries,
+                "operation_variant": operation_variant,
             }
         )
         return self.response
@@ -164,6 +166,7 @@ async def test_add_text_uses_exact_rpc_shape_and_wait_hook(
             "source_path": "/notebook/nb_1",
             "allow_null": False,
             "disable_internal_retries": False,
+            "operation_variant": "text",
         }
     ]
     wait_until_ready.assert_awaited_once_with("nb_1", "src_text", timeout=9.0)
@@ -203,11 +206,16 @@ async def test_add_drive_uses_exact_rpc_shape_and_wait_hook(
         wait=True,
         wait_timeout=7.0,
         rpc_call=rpc,
+        list_sources=AsyncMock(return_value=[]),
         wait_until_ready=wait_until_ready,
         logger=logger,
     )
 
     assert result is ready
+    # add_drive now wraps with idempotent_create, which requires
+    # disable_internal_retries=True at the RPC layer (the wrapper owns
+    # probe-then-retry recovery). operation_variant="drive" routes the
+    # call through the registry's PROBE_THEN_CREATE entry.
     assert rpc.calls == [
         {
             "method": RPCMethod.ADD_SOURCE,
@@ -233,7 +241,8 @@ async def test_add_drive_uses_exact_rpc_shape_and_wait_hook(
             ],
             "source_path": "/notebook/nb_1",
             "allow_null": True,
-            "disable_internal_retries": False,
+            "disable_internal_retries": True,
+            "operation_variant": "drive",
         }
     ]
     wait_until_ready.assert_awaited_once_with("nb_1", "src_drive", timeout=7.0)
@@ -250,6 +259,7 @@ async def test_add_drive_raises_source_add_error_on_null_result(
             "drive_file",
             "Drive Doc",
             rpc_call=RecordingRpc(None),
+            list_sources=AsyncMock(return_value=[]),
             wait_until_ready=AsyncMock(),
             logger=logger,
         )
@@ -263,19 +273,23 @@ async def test_add_drive_preserves_rpc_error_propagation(
     service: SourceAddService,
     logger: logging.Logger,
 ) -> None:
+    # A non-transport RPCError (e.g. validation) must propagate through
+    # idempotent_create as a SourceAddError, just like add_url does. The
+    # cause chain preserves the original RPCError for callers that need it.
     rpc_error = RPCError("drive add failed")
 
-    with pytest.raises(RPCError) as exc_info:
+    with pytest.raises(SourceAddError) as exc_info:
         await service.add_drive(
             "nb_1",
             "drive_file",
             "Drive Doc",
             rpc_call=AsyncMock(side_effect=rpc_error),
+            list_sources=AsyncMock(return_value=[]),
             wait_until_ready=AsyncMock(),
             logger=logger,
         )
 
-    assert exc_info.value is rpc_error
+    assert exc_info.value.cause is rpc_error
 
 
 def test_extract_youtube_video_id_uses_injected_parser_and_helpers(

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -187,11 +187,21 @@ async def test_add_file_custom_title_waits_for_registration_before_rename(
 async def test_register_file_source_uses_rpc_shape_and_wraps_rpc_error(
     service: SourceUploadPipeline,
 ) -> None:
+    # A non-transport RPCError must propagate as SourceAddError (the
+    # wrapper preserves the original cause). The RPC layer is invoked with
+    # ``disable_internal_retries=True`` because register_file_source now
+    # owns probe-then-retry recovery via ``idempotent_create``.
     rpc_error = RPCError("bad response")
     rpc = RecordingRpc(rpc_error)
 
     with pytest.raises(SourceAddError) as exc_info:
-        await service.register_file_source("nb_123", "report.pdf", rpc_call=rpc)
+        await service.register_file_source(
+            "nb_123",
+            "report.pdf",
+            rpc_call=rpc,
+            list_sources=AsyncMock(return_value=[]),
+            logger=MagicMock(),
+        )
 
     assert exc_info.value.cause is rpc_error
     assert rpc.calls == [
@@ -205,7 +215,7 @@ async def test_register_file_source_uses_rpc_shape_and_wraps_rpc_error(
             ],
             "source_path": "/notebook/nb_123",
             "allow_null": False,
-            "disable_internal_retries": False,
+            "disable_internal_retries": True,
         }
     ]
 
@@ -217,7 +227,13 @@ async def test_register_file_source_truncates_large_string_response_preview(
     rpc = RecordingRpc("x" * 5000)
 
     with pytest.raises(SourceAddError) as exc_info:
-        await service.register_file_source("nb_123", "report.pdf", rpc_call=rpc)
+        await service.register_file_source(
+            "nb_123",
+            "report.pdf",
+            rpc_call=rpc,
+            list_sources=AsyncMock(return_value=[]),
+            logger=MagicMock(),
+        )
 
     message = str(exc_info.value)
     assert "..." in message

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -13,6 +13,7 @@ from notebooklm._capabilities import ClientCoreCapabilities
 from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
 from notebooklm.exceptions import NetworkError, RPCError, ValidationError
+from notebooklm.rpc import RPCMethod
 from notebooklm.rpc.types import SourceStatus
 from notebooklm.types import Source
 
@@ -177,14 +178,23 @@ class TestRegisterFileSource:
 
     @pytest.mark.asyncio
     async def test_register_file_source_success(self, sources_api, mock_core):
-        """Test successful file source registration."""
+        """Test successful file source registration.
+
+        The wrapper now captures a baseline source-list before the create,
+        so the happy path issues two RPCs: GET_NOTEBOOK (baseline) + the
+        ADD_SOURCE_FILE register. The baseline-diff is what prevents
+        mis-matching a pre-existing same-named source on a retry probe.
+        """
         # Response structure: [[[["source_id_123"]]]] - 4 levels with string at deepest
         mock_core.rpc_call.return_value = [[[["source_id_abc"]]]]
 
         result = await sources_api._register_file_source("nb_123", "test.pdf")
 
         assert result == "source_id_abc"
-        mock_core.rpc_call.assert_called_once()
+        # 2 calls: baseline GET_NOTEBOOK + ADD_SOURCE_FILE register.
+        assert mock_core.rpc_call.call_count == 2
+        methods_called = [call.args[0] for call in mock_core.rpc_call.await_args_list]
+        assert RPCMethod.ADD_SOURCE_FILE in methods_called
 
     @pytest.mark.asyncio
     async def test_register_file_source_parses_deeply_nested(self, sources_api, mock_core):
@@ -773,7 +783,8 @@ class TestAddFile:
         assert result.id == "src_new_123"
         assert result.title == "test.pdf"
         assert result.kind == "unknown"
-        assert mock_core.rpc_call.call_count == 1
+        # 2 RPCs: GET_NOTEBOOK baseline + ADD_SOURCE_FILE register.
+        assert mock_core.rpc_call.call_count == 2
 
     @pytest.mark.asyncio
     async def test_add_file_raises_file_not_found(self, sources_api, mock_core):
@@ -916,8 +927,12 @@ class TestAddFile:
         test_file = tmp_path / "boring-filename.md"
         test_file.write_bytes(b"# content\n")
 
-        # First rpc_call serves the file registration; the second serves rename().
+        # 3 rpc_call invocations in order:
+        #   [0] baseline GET_NOTEBOOK for the probe-then-create wrapper
+        #   [1] ADD_SOURCE_FILE register
+        #   [2] UPDATE_SOURCE rename
         mock_core.rpc_call.side_effect = [
+            None,  # baseline returns no useful list — empty notebook
             [[[["src_md"]]]],
             [[[["src_md"], "Real Intended Title", [None, None, None, None, 8]]]],
         ]
@@ -946,9 +961,9 @@ class TestAddFile:
 
         assert result.id == "src_md"
         assert result.title == "Real Intended Title"
-        # 1 register + 1 rename
-        assert mock_core.rpc_call.call_count == 2
-        rename_params = mock_core.rpc_call.call_args_list[1].args[1]
+        # 1 baseline GET_NOTEBOOK + 1 register + 1 rename
+        assert mock_core.rpc_call.call_count == 3
+        rename_params = mock_core.rpc_call.call_args_list[2].args[1]
         assert rename_params == [None, ["src_md"], [[["Real Intended Title"]]]]
         # Narrow wait uses the caller's wait_timeout (default 120s) — not the
         # full wait_until_ready. wait_until_registered returns on first
@@ -969,7 +984,10 @@ class TestAddFile:
         test_file = tmp_path / "boring-filename.md"
         test_file.write_bytes(b"# content\n")
 
+        # 3 rpc_call invocations: baseline + register + rename (see the
+        # earlier test for the same pattern).
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_md"]]]],
             [[[["src_md"], "Real Intended Title"]]],
         ]
@@ -979,8 +997,10 @@ class TestAddFile:
             assert source_id == "src_md"
             assert timeout == 120.0
             # Wait must happen BEFORE the rename: at this point only the
-            # registration RPC has been issued.
-            assert mock_core.rpc_call.call_count == 1
+            # baseline GET_NOTEBOOK + ADD_SOURCE_FILE register RPCs have
+            # fired (2 total — see register_file_source's probe-then-create
+            # design for why the baseline call is required).
+            assert mock_core.rpc_call.call_count == 2
             return Source(id=source_id, title="boring-filename.md", _type_code=8)
 
         sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)
@@ -1005,8 +1025,8 @@ class TestAddFile:
 
         assert result.title == "Real Intended Title"
         sources_api.wait_until_ready.assert_awaited_once_with("nb_123", "src_md", timeout=120.0)
-        # After the wait, the rename RPC fires — so the final RPC count is 2.
-        assert mock_core.rpc_call.call_count == 2
+        # 3 RPCs in total: baseline + register + rename.
+        assert mock_core.rpc_call.call_count == 3
 
     @pytest.mark.asyncio
     async def test_add_file_with_title_forces_wait_when_wait_false(
@@ -1018,7 +1038,9 @@ class TestAddFile:
         test_file = tmp_path / "boring-filename.md"
         test_file.write_bytes(b"# content\n")
 
+        # 3 RPCs: baseline + register + rename.
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_md"]]]],
             [[[["src_md"], "Real Intended Title", [None, None, None, None, 8]]]],
         ]
@@ -1028,9 +1050,10 @@ class TestAddFile:
             # verbatim. wait_until_registered returns on the first non-PREPARING
             # status, so the bound stays cheap.
             assert timeout == 120.0
-            # Wait runs BEFORE the rename: at this point only the register
-            # RPC has been issued.
-            assert mock_core.rpc_call.call_count == 1
+            # Wait runs BEFORE the rename: at this point only the baseline
+            # GET_NOTEBOOK + ADD_SOURCE_FILE register RPCs have fired (2
+            # total).
+            assert mock_core.rpc_call.call_count == 2
             return Source(id=source_id, title="boring-filename.md", _type_code=8)
 
         sources_api.wait_until_registered = AsyncMock(side_effect=wait_side_effect)
@@ -1072,7 +1095,9 @@ class TestAddFile:
         test_file = tmp_path / "podcast.mp3"
         test_file.write_bytes(b"fake audio")
 
+        # 3 RPCs: baseline + register + rename.
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_audio"]]]],
             [[[["src_audio"], "Episode 1", [None, None, None, None, 10]]]],
         ]
@@ -1208,8 +1233,9 @@ class TestAddFile:
 
         assert result.id == "src_pdf"
         assert result.title == "report.pdf"
-        # Only the registration call — no rename.
-        assert mock_core.rpc_call.call_count == 1
+        # No rename happened (title matches filename) — but registration is
+        # still 2 RPCs: baseline GET_NOTEBOOK + ADD_SOURCE_FILE.
+        assert mock_core.rpc_call.call_count == 2
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -1234,7 +1260,9 @@ class TestAddFile:
         # Registration succeeds; rename raises a library-level expected error
         # (representative of what `self.rename` actually raises in the wild).
         # The forced wait between register and rename is mocked separately.
+        # 3 RPCs: baseline + register + rename (the rename raises).
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_doc"]]]],
             rename_error,
         ]
@@ -1287,7 +1315,10 @@ class TestAddFile:
         # First rpc_call serves file registration. Second serves rename() —
         # which returns a sparse Source (only id + new title) so we can verify
         # the merge preserves type_code/url/created_at from the waited source.
+        # 3 RPCs: baseline + register + rename (rename returns None to
+        # trigger the fallback).
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_audio"]]]],
             None,  # Triggers rename()'s Source(id=source_id, title=new_title) fallback
         ]
@@ -1334,7 +1365,9 @@ class TestAddFile:
         test_file = tmp_path / "long-audio.mp3"
         test_file.write_bytes(b"fake audio")
 
+        # 3 RPCs: baseline + register + rename.
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_audio"]]]],
             [[[["src_audio"], "My Title", [None, None, None, None, 10]]]],
         ]
@@ -1376,7 +1409,9 @@ class TestAddFile:
         test_file = tmp_path / "doc.txt"
         test_file.write_bytes(b"content")
 
+        # 3 RPCs: baseline + register + rename (rename raises).
         mock_core.rpc_call.side_effect = [
+            None,
             [[[["src_doc"]]]],
             RPCError("rename rpc blew up"),
         ]
@@ -1385,8 +1420,9 @@ class TestAddFile:
             assert notebook_id == "nb_123"
             assert source_id == "src_doc"
             assert timeout == 120.0
-            # Wait runs BEFORE rename — only the register RPC has fired.
-            assert mock_core.rpc_call.call_count == 1
+            # Wait runs BEFORE rename — baseline GET_NOTEBOOK + register
+            # RPCs have fired (2 total), no rename yet.
+            assert mock_core.rpc_call.call_count == 2
             return Source(id=source_id, title="doc.txt", _type_code=4)
 
         sources_api.wait_until_ready = AsyncMock(side_effect=wait_side_effect)


### PR DESCRIPTION
## Summary

Tier 9 Wave 2 — task **b-sources** (P0-3-sources, P1-2-sources).

- Classifies all four variant-shaped source-creation RPCs in `IDEMPOTENCY_REGISTRY`:
  - `(ADD_SOURCE, "url")` / `(ADD_SOURCE, "drive")` / `(ADD_SOURCE_FILE, None)` → `PROBE_THEN_CREATE`
  - `(ADD_SOURCE, "text")` → `NON_IDEMPOTENT_NO_RETRY`
- Wraps `add_drive` and `register_file_source` with the existing `idempotent_create` probe-then-create wrapper (matching the pre-existing `add_url` pattern).
- Probe-failure propagation (P1-2): the four probe sites (`add_url`, `add_drive`, `register_file_source`, `notebooks.create`) now propagate `(AuthError, RateLimitError, ServerError, NetworkError)` instead of swallowing all exceptions. Silently returning `None` on a broken probe lets `idempotent_create` re-issue the create on top of a broken probe — exactly the duplicate-resource bug the layer guards against.

## Probe semantics

| Call site | Probe key | Notes |
|-----------|-----------|-------|
| `add_url` | `source.url == url` | URL is identity-bearing; re-adding the same URL is semantically idempotent |
| `add_drive` | `/d/<file_id>` segment in `source.url` | Path-segment marker avoids substring false-positives (`abc` vs `xabcy`) |
| `register_file_source` | `source.title == filename` + **baseline-diff** | Filenames are NOT identity-bearing — captures source-id baseline before create, filters probe matches to "new" sources only, raises on ambiguous >1 matches (mirrors `notebooks.create`) |
| `add_text` | (no probe) | NON_IDEMPOTENT_NO_RETRY — no reliable dedupe key, first failure surfaces immediately |

## Test plan

New file `tests/integration/test_sources_idempotency.py` (8 mock-transport scenarios, per Codex iter-1 critique — VCR cassettes cannot model the "first call returns 200, second call returns 503" sequence):

- [x] `test_add_url_probe_short_circuits_when_first_response_lost`
- [x] `test_add_drive_probe_short_circuits_when_first_response_lost`
- [x] `test_add_drive_probe_does_not_substring_match_unrelated_file_id` (segment-marker guard)
- [x] `test_register_file_source_probe_short_circuits_when_first_response_lost`
- [x] `test_register_file_source_does_not_match_pre_existing_filename` (baseline-diff guard)
- [x] `test_add_text_no_probe_no_retry_under_5xx`
- [x] `test_add_url_probe_network_error_propagates`
- [x] `test_registry_has_variant_entries_for_add_source_and_add_source_file`

Plus updates to existing unit/integration tests for the new signatures (`list_sources` param on `add_drive` + `register_file_source`; extra GET_NOTEBOOK baseline call on `add_file` happy path).

All checks green:
- `ruff format` + `ruff check` clean
- `mypy src/notebooklm --ignore-missing-imports` clean
- `pytest tests/unit tests/integration` — 5365 passed / 20 skipped

## Polish stage

- **Code-simplifier**: hoisted inline imports in the new test file to module-top.
- **Triple review** (claude direct + codex CLI + gemini CLI):
  - Critical (Codex): `register_file_source` could mis-match pre-existing same-name source on retry → **applied** (baseline-diff pattern, mirrors `notebooks.create`).
  - Important (Codex/Gemini): `AuthError` probe propagation → **applied** to all 4 probe sites (forward-compatible).
  - Suggestion (Codex): Drive probe `/d/<file_id>` segment marker → **applied**.
  - Suggestion (Codex): `_sources.py:add_text` docstring referenced the pre-Wave-2 retry behavior → **applied**.
- **Ultrathink**: 1 latent observation (RPCError-shaped 401s still swallow at probe — matches existing `notebooks.create` pattern; not introduced by this PR; documented as known limitation).

## Deferred polish findings

- _none — all critical/important findings applied._

## Files changed

- `src/notebooklm/_idempotency.py` — 4 new registry entries (variant-keyed)
- `src/notebooklm/_source_add.py` — `add_drive` wraps `idempotent_create`; `add_url._probe` propagates transport errors; `operation_variant` plumbed everywhere
- `src/notebooklm/_source_upload.py` — `register_file_source` wraps `idempotent_create` with baseline-diff
- `src/notebooklm/_sources.py` — wired `list_sources` + `logger` into the new signatures; docstring update on `add_text`
- `src/notebooklm/_notebooks.py` — sibling probe-failure propagation fix
- `tests/integration/test_sources_idempotency.py` — NEW (8 tests)
- `tests/integration/test_sources_integration.py` — added baseline GET_NOTEBOOK mocks to file-upload tests
- `tests/unit/test_source_add_service.py` — updated for new signatures
- `tests/unit/test_source_upload_pipeline.py` — updated for new signatures
- `tests/unit/test_sources_upload.py` — updated call-count assertions for baseline call

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened source-creation flows: probe-then-create for URL/Drive and resilient file-upload registration with baseline probing; transport/auth failures now propagate correctly.
  * Text-source additions now disable internal retries so failures surface immediately (no silent retries or duplicate creates).

* **Tests**
  * Added integration and unit tests covering variant-keyed idempotency, probe-then-create semantics, baseline probing for uploads, and error-propagation scenarios.

* **Documentation**
  * Clarified idempotency seeding and variant behaviors in inline docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->