### PR TITLE
refactor(auth): extract keepalive + refresh into _auth subpackage with facade-forwarding (tier-10 PR-B-high) — HIGH-RISK

### DIFF
--- a/src/notebooklm/_auth/__init__.py
+++ b/src/notebooklm/_auth/__init__.py
@@ -1,5 +1,5 @@
 """Private authentication implementation package."""
 
-from . import extraction, headers, paths
+from . import extraction, headers, keepalive, paths, refresh
 
-__all__ = ["extraction", "headers", "paths"]
+__all__ = ["extraction", "headers", "keepalive", "paths", "refresh"]

--- a/src/notebooklm/_auth/cookies.py
+++ b/src/notebooklm/_auth/cookies.py
@@ -587,3 +587,32 @@ def _cookie_map_from_jar(cookie_jar: httpx.Cookies) -> DomainCookieMap:
         and cookie.value is not None
         and _is_allowed_auth_domain(cookie.domain)
     }
+
+
+def _update_cookie_input(target: CookieInput, fresh: DomainCookieMap) -> None:
+    """Update caller-provided cookies in place while preserving key style.
+
+    The caller's ``target`` may use any of the three accepted shapes (flat
+    ``name -> value``, legacy ``(name, domain) -> value``, or path-aware
+    ``(name, domain, path) -> value``). The freshly-fetched delta is always the
+    path-aware shape; we collapse it back to the caller's original shape so
+    they don't observe an in-place type change.
+    """
+    if any(isinstance(key, tuple) and len(key) == 2 for key in target):
+        # Legacy 2-tuple caller. Collapse the path dimension by keeping the
+        # first occurrence per (name, domain); for cookies that share name and
+        # domain at distinct paths this is lossy, but legacy callers had no
+        # way to express path either, so this matches their original contract.
+        legacy: dict[tuple[str, str], str] = {}
+        for (name, domain, _path), value in fresh.items():
+            legacy.setdefault((name, domain), value)
+        target.clear()
+        target.update(legacy)  # type: ignore[arg-type]
+        return
+
+    use_domain_keys = any(isinstance(key, tuple) for key in target)
+    target.clear()
+    if use_domain_keys:
+        target.update(fresh)  # type: ignore[arg-type]
+    else:
+        target.update(flatten_cookie_map(fresh))  # type: ignore[arg-type]

--- a/src/notebooklm/_auth/keepalive.py
+++ b/src/notebooklm/_auth/keepalive.py
@@ -1,0 +1,355 @@
+"""Keepalive ``RotateCookies`` poke helpers for authentication.
+
+This private module hosts the rotation throttle + POST that
+``notebooklm.auth`` previously owned at module level. ``notebooklm.auth`` keeps
+re-exporting every name listed here (and the facade write-through in
+``_AuthFacadeModule`` mirrors any monkeypatched values back to this module so
+white-box tests keep working when they patch ``notebooklm.auth.X``).
+
+Logger name is pinned to ``"notebooklm.auth"`` (NOT ``__name__``) so existing
+``caplog`` assertions targeting ``notebooklm.auth`` keep matching the records
+emitted from the moved bodies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import threading
+import time
+import weakref
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from . import paths as _auth_paths
+from . import storage as _auth_storage
+
+logger = logging.getLogger("notebooklm.auth")
+
+
+# --- Keepalive constants -----------------------------------------------------
+# Google's __Secure-1PSIDTS / __Secure-3PSIDTS cookies are the rotating freshness
+# partners of __Secure-1PSID / __Secure-3PSID. Their server-side validity window
+# is short (minutes-to-hours scale) and Google only emits a rotated value when
+# the client asks the identity surface to rotate. Pure RPC traffic against
+# notebooklm.google.com never triggers rotation, so a long-lived storage_state
+# silently stales out and every subsequent call fails with the
+# "Authentication expired or invalid" redirect (see issue #312).
+#
+# We POST to ``accounts.google.com/RotateCookies`` — the dedicated rotation
+# endpoint Chrome itself calls for legacy cookie rotation. Empirically validated
+# against both DBSC-bound (Playwright-minted) and unbound (Firefox-imported)
+# profiles in #345: a single POST returns 200 and sets fresh
+# ``__Secure-1PSIDTS`` / ``__Secure-3PSIDTS`` for either session type. The
+# response body declares the next-rotation interval (`["identity.hfcr",600]` —
+# 10 minutes), which sets the floor for how often this is worth firing.
+KEEPALIVE_ROTATE_URL = "https://accounts.google.com/RotateCookies"
+_KEEPALIVE_ROTATE_HEADERS = {
+    "Content-Type": "application/json",
+    "Origin": "https://accounts.google.com",
+}
+# Observed unbound RotateCookies request body — a placeholder pair Chrome sends
+# when there is no DBSC binding token to attest. Validated across Gemini-API and
+# the in-house experiments referenced in #345; kept in one place so it can be
+# changed if Google ever changes the contract.
+_KEEPALIVE_ROTATE_BODY = '[000,"-0000000000000000000"]'
+_KEEPALIVE_POKE_TIMEOUT = 15.0
+# Skip the poke if storage_state.json was rewritten within this window — protects
+# accounts.google.com from rapid CLI loops (e.g. 10 sequential `notebooklm`
+# invocations) that would each fire their own rotation. Google's own declared
+# rotation cadence is 600 s, so 60 s is well under the useful interval.
+_KEEPALIVE_RATE_LIMIT_SECONDS = 60.0
+# Sub-second drift between ``time.time()`` and filesystem mtime can land a
+# freshly-written file fractionally in the future on some platforms (notably
+# Windows + older Python where the clock is coarser than NTFS mtime). Tolerate
+# that without re-opening the "future mtime wedges the guard" bug.
+_KEEPALIVE_PRECISION_TOLERANCE = 2.0
+
+# Env-var name lives in ``notebooklm._auth.paths``; aliased here so the
+# keepalive bodies can reference it without an extra module hop.
+NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV = _auth_paths.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV
+
+# In-process state for rotation throttling, keyed per-profile and per-loop.
+#
+# - Per-profile (``storage_path``) so a rotation against profile A doesn't
+#   suppress profile B for the rate-limit window. A ``None`` key represents
+#   env-var auth.
+# - Per event loop because ``asyncio.Lock`` is loop-bound: a lock created in
+#   loop X cannot be safely awaited from loop Y. Multiple ``asyncio.run()``
+#   invocations in the same process, or worker threads each running their
+#   own loop, would otherwise trip ``RuntimeError`` or leave waiters in
+#   inconsistent state.
+#
+# The outer registry is a ``WeakKeyDictionary`` keyed on the loop *object* (not
+# its ``id()``): when a loop is garbage-collected, its inner dict is reclaimed
+# automatically. This bounds the lock cache for hosts that repeatedly create
+# short-lived loops, and avoids the ``id()``-reuse hazard where a closed loop's
+# stale lock could be returned to a new loop that happens to allocate at the
+# same address.
+#
+# ``_POKE_STATE_LOCK`` (sync ``threading.Lock``) protects two module-level
+# operations that must be atomic across threads:
+#   1. ``_get_poke_lock``: get-or-create the per-(loop, profile) async lock
+#      so two threads with their own loops don't race on dict insertion.
+#   2. ``_try_claim_rotation``: atomic check-and-stamp of the per-profile
+#      timestamp. Without this, two direct ``_rotate_cookies`` callers (e.g.
+#      two layer-2 keepalive loops on the same profile, or a layer-1 +
+#      layer-2 pair on different event loops) can each read a stale 0.0
+#      and both fire the POST.
+# It is held briefly, never across an ``await``, so it cannot deadlock against
+# any asyncio primitive.
+_POKE_STATE_LOCK = threading.Lock()
+_POKE_LOCKS_BY_LOOP: weakref.WeakKeyDictionary[Any, dict[Path | None, asyncio.Lock]] = (
+    weakref.WeakKeyDictionary()
+)
+# Monotonic timestamp of the last in-process poke *attempt* (success or
+# failure), keyed by storage_path. Stamped under ``_POKE_STATE_LOCK`` inside
+# ``_try_claim_rotation`` so the check-and-set is atomic across event loops
+# and across direct ``_rotate_cookies`` callers. Failure-stampede protection
+# comes for free: even a POST that times out has already claimed the slot,
+# so 10 fanned-out callers don't each wait 15 s on a hung server.
+_LAST_POKE_ATTEMPT_MONOTONIC: dict[Path | None, float] = {}
+
+# Rotation sentinel path lives in ``notebooklm._auth.paths``; aliased here for
+# white-box callers that reach ``notebooklm.auth._rotation_lock_path``.
+_rotation_lock_path = _auth_paths._rotation_lock_path
+
+# Cross-process file-lock primitives live in ``_auth.storage``. Aliased into
+# this module's namespace so the keepalive bodies resolve them locally — this
+# also lets tests that monkeypatch ``notebooklm.auth._file_lock`` propagate
+# through the facade write-through.
+_file_lock = _auth_storage._file_lock
+
+
+def _get_poke_lock(storage_path: Path | None) -> asyncio.Lock:
+    """Return the ``asyncio.Lock`` for ``(running event loop, storage_path)``.
+
+    Lazily created on first call from each loop/profile pair so the lock binds
+    to the current loop. The dict mutation runs under the sync state lock so
+    concurrent threads with their own loops don't tear the registry.
+    """
+    loop = asyncio.get_running_loop()
+    with _POKE_STATE_LOCK:
+        per_loop = _POKE_LOCKS_BY_LOOP.get(loop)
+        if per_loop is None:
+            per_loop = {}
+            _POKE_LOCKS_BY_LOOP[loop] = per_loop
+        lock = per_loop.get(storage_path)
+        if lock is None:
+            lock = asyncio.Lock()
+            per_loop[storage_path] = lock
+        return lock
+
+
+def _try_claim_rotation(storage_path: Path | None) -> bool:
+    """Atomic check-and-claim of the per-profile rotation slot.
+
+    Returns ``True`` if the caller may proceed with the POST, ``False`` if
+    another in-process call has claimed the slot within the rate-limit
+    window. The claim and the timestamp update happen under one sync lock,
+    so this is safe across event loops and across direct
+    ``_rotate_cookies`` callers (layer-2 keepalive loops, etc.) — neither
+    of which holds the per-loop async lock used by layer-1 ``_poke_session``.
+    """
+    with _POKE_STATE_LOCK:
+        last = _LAST_POKE_ATTEMPT_MONOTONIC.get(storage_path, 0.0)
+        now = time.monotonic()
+        if last > 0 and (now - last) < _KEEPALIVE_RATE_LIMIT_SECONDS:
+            return False
+        _LAST_POKE_ATTEMPT_MONOTONIC[storage_path] = now
+        return True
+
+
+@contextlib.contextmanager
+def _file_lock_try_exclusive(lock_path: Path) -> Iterator[bool]:
+    """Non-blocking exclusive flock. Yields ``True`` if caller should proceed.
+
+    Mirrors :func:`_file_lock_exclusive` but with ``LOCK_NB`` semantics:
+      - genuine contention (another process holds the lock) → yield ``False``,
+        caller skips its work (the holder is rotating; we don't need to)
+      - lock infrastructure unavailable (read-only dir, NFS without flock,
+        permission denied) → yield ``True``, caller **fails open** and
+        proceeds without coordination, since waiting forever for an
+        unworkable lock would permanently suppress rotation.
+    """
+    with _file_lock(lock_path, blocking=False, log_prefix="rotate lock") as state:
+        # "held" → True (proceed, we own it); "unavailable" → True (fail open);
+        # "contended" → False (someone else is rotating, skip).
+        yield state != "contended"
+
+
+def _is_recently_rotated(storage_path: Path | None) -> bool:
+    """Return True if ``storage_path`` was modified within the rate-limit window.
+
+    A meaningfully-future mtime (clock skew, NTP step, restored file, NFS drift)
+    is treated as **not recent**: we'd rather fire one extra rotation than wedge
+    the guard until wall time catches up. The lower bound is a small negative
+    tolerance to absorb sub-second drift between ``time.time()`` and filesystem
+    mtime resolution (notably Windows NTFS at lower clock granularity), which
+    can otherwise classify a freshly-written file as future-dated. A
+    missing/unreadable file falls through to the not-recent default.
+    """
+    if storage_path is None:
+        return False
+    try:
+        mtime = storage_path.stat().st_mtime
+    except OSError:
+        return False
+    age = time.time() - mtime
+    return -_KEEPALIVE_PRECISION_TOLERANCE <= age <= _KEEPALIVE_RATE_LIMIT_SECONDS
+
+
+async def _poke_session(client: httpx.AsyncClient, storage_path: Path | None = None) -> None:
+    """Best-effort POST to ``accounts.google.com/RotateCookies`` to rotate SIDTS.
+
+    Failures are logged at DEBUG and swallowed: this is purely a freshness
+    optimisation. The caller's request to notebooklm.google.com is the
+    authoritative health check.
+
+    Three layered guards keep the POST from stampeding ``accounts.google.com``:
+
+    1. **Disk mtime fast path.** If ``storage_state.json`` was rewritten within
+       the rate-limit window, skip without any locking. Covers the common
+       sequential-CLI case at zero cost.
+    2. **In-process ``asyncio.Lock``.** Inside the lock, re-check the disk
+       mtime (a sibling task may have rotated and saved during the wait) and
+       a monotonic in-memory timestamp (a sibling may have rotated but not
+       yet saved). Together these dedupe an ``asyncio.gather`` fan-out so
+       only one POST fires per process per rate-limit window.
+    3. **Cross-process non-blocking flock.** When ``storage_path`` is set, try
+       to acquire ``.storage_state.json.rotate.lock`` with ``LOCK_NB``. If
+       another process holds it, skip — they're rotating right now. This
+       handles ``xargs -P``, parallel MCP workers, and similar parallel
+       launches without queueing.
+
+       Known gap: the flock is released as soon as the POST returns, but the
+       caller's storage-state save happens *after* this function returns. A
+       second process that starts in that narrow window observes the still-
+       stale on-disk mtime and an unheld flock, and will fire its own POST.
+       Worst case is two pokes back-to-back across processes — bounded, not
+       a stampede. Closing this fully would require holding the flock past
+       ``_poke_session`` until the save completes, which would entangle this
+       throttle with the caller's lifecycle. Not worth the complexity here.
+
+    Args:
+        client: Live ``httpx.AsyncClient`` whose cookie jar should receive the
+            rotated ``Set-Cookie``.
+        storage_path: Optional path to the on-disk ``storage_state.json``. When
+            provided, gates the poke via the disk mtime and the cross-process
+            flock; when ``None`` (env-var auth) only the in-process serializer
+            applies.
+
+    Set ``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` to disable (e.g., environments
+    that block ``accounts.google.com``).
+    """
+    if os.environ.get(NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV) == "1":
+        return
+    if _is_recently_rotated(storage_path):
+        logger.debug(
+            "Keepalive RotateCookies skipped: %s rotated within %.0fs",
+            storage_path,
+            _KEEPALIVE_RATE_LIMIT_SECONDS,
+        )
+        return
+
+    async with _get_poke_lock(storage_path):
+        # Re-check after acquiring the per-(loop, profile) async lock — another
+        # task in this loop may have rotated and persisted while we were waiting.
+        if _is_recently_rotated(storage_path):
+            logger.debug(
+                "Keepalive RotateCookies skipped: storage refreshed while waiting for lock"
+            )
+            return
+
+        rotate_lock_path = _rotation_lock_path(storage_path)
+        if rotate_lock_path is None:
+            # No on-disk path → cross-process flock has no anchor. The
+            # atomic claim inside ``_rotate_cookies`` is the only gate.
+            await _rotate_cookies(client, storage_path)
+            return
+
+        with _file_lock_try_exclusive(rotate_lock_path) as acquired:
+            if not acquired:
+                logger.debug(
+                    "Keepalive RotateCookies skipped: %s held by another process",
+                    rotate_lock_path,
+                )
+                return
+            # One last disk recheck: another process may have completed its
+            # rotation + save between our top-of-function check and acquiring
+            # this flock.
+            if _is_recently_rotated(storage_path):
+                logger.debug(
+                    "Keepalive RotateCookies skipped: storage refreshed before flock acquired"
+                )
+                return
+            # ``_rotate_cookies`` does its own atomic claim — if another
+            # in-process caller (e.g. a sibling layer-2 keepalive loop on a
+            # different event loop) just claimed this profile, the POST is
+            # skipped here too.
+            await _rotate_cookies(client, storage_path)
+
+
+async def _rotate_cookies(client: httpx.AsyncClient, storage_path: Path | None = None) -> None:
+    """Fire the ``RotateCookies`` POST. Bare operation; no guards.
+
+    Used directly by the layer-2 keepalive loop, which is already self-paced
+    via ``keepalive_min_interval`` and does not need the layer-1 dedup
+    serialization. ``_poke_session`` calls this through its guard stack.
+
+    Honours ``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` so a single env-var disables
+    every rotation path (the layer-1 wrapper *and* the layer-2 loop).
+
+    Stamps the per-profile attempt timestamp **before** the network await so
+    that concurrent layer-1 callers (and concurrent layer-2 keepalive loops on
+    other ``NotebookLMClient`` instances watching the same profile) see "this
+    profile is rotating right now" and skip the POST. Stamping early covers:
+      - the layer-1/layer-2 overlap where one is mid-flight and another arrives
+      - failure stampedes — a 15 s timeout against a hung accounts.google.com
+        does not let 10 fanned-out callers each wait the full timeout
+
+    Does not propagate ``httpx.HTTPError``: this is a best-effort freshness
+    call, not a health check.
+
+    Args:
+        client: Live ``httpx.AsyncClient`` whose cookie jar should receive the
+            rotated ``Set-Cookie``.
+        storage_path: Optional storage_state.json path used to key the
+            in-process attempt timestamp by profile. ``None`` = env-var auth.
+    """
+    if os.environ.get(NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV) == "1":
+        return
+    # Atomic check-and-claim: another caller (a sibling layer-2 keepalive
+    # loop, a layer-1 ``_poke_session`` on a different event loop, etc.) may
+    # have already taken the slot for this profile within the rate-limit
+    # window. ``_try_claim_rotation`` is the *only* authoritative gate;
+    # everything above it in ``_poke_session`` is a fast-path optimisation.
+    if not _try_claim_rotation(storage_path):
+        logger.debug(
+            "Keepalive RotateCookies skipped: %s claimed by another in-process caller",
+            storage_path,
+        )
+        return
+    try:
+        # ``follow_redirects=True`` is defensive: empirically RotateCookies
+        # answers 200 directly with the rotated Set-Cookie, but if Google ever
+        # routes a 30x through an identity hop we still pick up cookies from
+        # the terminal response.
+        response = await client.post(
+            KEEPALIVE_ROTATE_URL,
+            headers=_KEEPALIVE_ROTATE_HEADERS,
+            content=_KEEPALIVE_ROTATE_BODY,
+            follow_redirects=True,
+            timeout=_KEEPALIVE_POKE_TIMEOUT,
+        )
+        # httpx does not auto-raise on 4xx/5xx; without this, a 429 or 5xx from
+        # Google would log nothing and the caller would proceed assuming the
+        # rotation happened.
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.debug("Keepalive RotateCookies POST failed (non-fatal): %s", exc)

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -115,6 +115,12 @@ _REFRESH_GENERATIONS: dict[str, int] = {}
 _REFRESH_INFLIGHT_BY_LOOP: weakref.WeakKeyDictionary[Any, dict[str, asyncio.Future[None]]] = (
     weakref.WeakKeyDictionary()
 )
+# Strong-ref set keyed by task identity. ``set.add`` / ``set.discard`` are
+# atomic under CPython's GIL (individual bytecode mutations on the underlying
+# hash table cannot interleave), so concurrent ``add`` / ``discard`` calls
+# from different event-loop threads are safe without an explicit lock. This is
+# implementation-specific to CPython; non-CPython runtimes would need a
+# ``threading.Lock`` here.
 _REFRESH_INFLIGHT_TASKS: set[asyncio.Task[None]] = set()
 
 

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -646,10 +646,11 @@ async def fetch_tokens(
 
     Prefer AuthTokens.from_storage() which preserves cookie domains. If
     ``NOTEBOOKLM_REFRESH_CMD`` is set and auth has expired, the command is run
-    through the platform shell, cookies are reloaded from ``storage_path`` or
-    the active profile storage path, and token fetch is retried once. Refresh
-    commands receive ``NOTEBOOKLM_REFRESH_STORAGE_PATH`` and
-    ``NOTEBOOKLM_REFRESH_PROFILE`` in their environment.
+    with ``shell=False`` by default (or via the platform shell when
+    ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1``), cookies are reloaded from
+    ``storage_path`` or the active profile storage path, and token fetch is
+    retried once. Refresh commands receive ``NOTEBOOKLM_REFRESH_STORAGE_PATH``
+    and ``NOTEBOOKLM_REFRESH_PROFILE`` in their environment.
 
     Args:
         cookies: Google auth cookies. Mutated in place on refresh.

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -1,0 +1,737 @@
+"""Refresh-cmd coordination + token-fetch entry points for authentication.
+
+This private module owns the ``NOTEBOOKLM_REFRESH_CMD`` subprocess flow, the
+per-loop coalescing of refresh attempts, and the public ``fetch_tokens`` /
+``fetch_tokens_with_domains`` entry points. ``notebooklm.auth`` re-exports
+every name listed here; the facade write-through in ``_AuthFacadeModule``
+mirrors any monkeypatched values back to this module so the existing white-box
+tests (``monkeypatch.setattr(auth_mod, "_run_refresh_cmd", ...)``,
+``..., "snapshot_cookie_jar"``, etc.) keep working after the move.
+
+Logger name is pinned to ``"notebooklm.auth"`` (NOT ``__name__``) so existing
+``caplog`` assertions targeting ``notebooklm.auth`` keep matching the records
+emitted from the moved bodies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shlex
+import subprocess
+import threading
+import weakref
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from .._env import get_base_url
+from .._url_utils import is_google_auth_redirect
+from ..paths import get_storage_path, resolve_profile
+from . import cookies as _auth_cookies
+from . import extraction as _auth_extraction
+from . import headers as _auth_headers
+from . import keepalive as _keepalive
+from . import paths as _auth_paths
+from . import storage as _auth_storage
+from .account import authuser_query
+
+logger = logging.getLogger("notebooklm.auth")
+
+# --- Names aliased from sibling modules --------------------------------------
+# The moved bodies historically resolved these names against ``notebooklm.auth``
+# (where they were direct-assigned). Re-aliasing them here gives each one a
+# rebindable bare name local to this module; the ``notebooklm.auth`` facade
+# write-through (``_AuthFacadeModule._REFRESH_DEP_MIRROR_NAMES``) mirrors any
+# monkeypatched value back to this module so the bare-name lookups inside the
+# moved bodies still observe the patch.
+build_httpx_cookies_from_storage = _auth_cookies.build_httpx_cookies_from_storage
+_replace_cookie_jar = _auth_cookies._replace_cookie_jar
+_cookie_map_from_jar = _auth_cookies._cookie_map_from_jar
+build_cookie_jar = _auth_cookies.build_cookie_jar
+flatten_cookie_map = _auth_cookies.flatten_cookie_map
+_update_cookie_input = _auth_cookies._update_cookie_input
+snapshot_cookie_jar = _auth_storage.snapshot_cookie_jar
+save_cookies_to_storage = _auth_storage.save_cookies_to_storage
+extract_csrf_from_html = _auth_extraction.extract_csrf_from_html
+extract_session_id_from_html = _auth_extraction.extract_session_id_from_html
+_safe_url = _auth_extraction._safe_url
+_resolve_token_route_kwargs = _auth_headers._resolve_token_route_kwargs
+
+# Env-var names live in ``_auth.paths``; aliased so the refresh bodies can
+# reference them without an extra hop.
+NOTEBOOKLM_REFRESH_CMD_ENV = _auth_paths.NOTEBOOKLM_REFRESH_CMD_ENV
+NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV = _auth_paths.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV
+_REFRESH_ATTEMPTED_ENV = _auth_paths._REFRESH_ATTEMPTED_ENV
+
+# ``_poke_session`` lives in ``_auth.keepalive``; aliased here as a rebindable
+# bare name so monkeypatches to ``notebooklm.auth._poke_session`` flow through
+# the facade write-through into this module's slot.
+_poke_session = _keepalive._poke_session
+
+
+# --- Refresh-coalescing state ------------------------------------------------
+# The ContextVar prevents same-task retry loops in the parent process. The env
+# flag is passed only to child refresh commands so recursive CLI calls skip refresh.
+_REFRESH_ATTEMPTED_CONTEXT: ContextVar[bool] = ContextVar(
+    "_REFRESH_ATTEMPTED_CONTEXT", default=False
+)
+# In-process state for refresh coordination, keyed per resolved storage path.
+#
+# Two layers of protection are required:
+#
+# - ``_REFRESH_STATE_LOCK`` (sync ``threading.Lock``) makes the
+#   ``_REFRESH_GENERATIONS`` check-and-update atomic ACROSS event loops.
+#   Two loops sharing a storage path each hold their own ``asyncio.Lock``
+#   (see below), so the asyncio lock alone cannot serialize the generation
+#   bump.
+#
+# - ``_REFRESH_LOCKS_BY_LOOP`` mirrors the keepalive ``_POKE_LOCKS_BY_LOOP``
+#   pattern: ``asyncio.Lock`` is loop-bound, so a per-loop / per-resolved-
+#   storage-path registry avoids the cross-loop / cross-thread hazard of a
+#   module-global ``asyncio.Lock`` that binds to the first event loop that
+#   uses it. The outer ``WeakKeyDictionary`` is keyed on the loop object so
+#   the inner dict is reclaimed when the loop is garbage-collected.
+_REFRESH_STATE_LOCK = threading.Lock()
+_REFRESH_LOCKS_BY_LOOP: weakref.WeakKeyDictionary[Any, dict[Path | None, asyncio.Lock]] = (
+    weakref.WeakKeyDictionary()
+)
+_REFRESH_GENERATIONS: dict[str, int] = {}
+
+# In-flight ``asyncio.Future`` registry for refresh-cmd coalescing.
+#
+# Same-loop concurrent callers that both encounter auth-expiry coalesce on a
+# single in-flight subprocess by sharing a per-resolved-storage-path
+# ``asyncio.Future``. The future is keyed per-loop because ``asyncio.Future``
+# is loop-bound; cross-loop coordination falls back to the
+# ``_REFRESH_GENERATIONS`` counter guarded by ``_REFRESH_STATE_LOCK``.
+#
+# The strong-ref ``_REFRESH_INFLIGHT_TASKS`` set keeps the shielded subprocess
+# Tasks alive so the asyncio GC does not collect them. The task self-removes
+# via ``add_done_callback(set.discard)`` once settled.
+_REFRESH_INFLIGHT_BY_LOOP: weakref.WeakKeyDictionary[Any, dict[str, asyncio.Future[None]]] = (
+    weakref.WeakKeyDictionary()
+)
+_REFRESH_INFLIGHT_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _get_inflight_registry() -> dict[str, asyncio.Future[None]]:
+    """Return the per-loop in-flight refresh-cmd future registry.
+
+    Mirrors ``_get_refresh_lock``: ``asyncio.Future`` is loop-bound, so we
+    need a per-loop registry. ``_REFRESH_STATE_LOCK`` makes the lookup /
+    insert atomic across threads (different loops on different threads can
+    each populate their own per-loop dict concurrently).
+    """
+    loop = asyncio.get_running_loop()
+    with _REFRESH_STATE_LOCK:
+        per_loop = _REFRESH_INFLIGHT_BY_LOOP.get(loop)
+        if per_loop is None:
+            per_loop = {}
+            _REFRESH_INFLIGHT_BY_LOOP[loop] = per_loop
+        return per_loop
+
+
+async def _coalesced_run_refresh_cmd(
+    refresh_key: str,
+    resolved_storage_path: Path,
+    profile: str | None,
+) -> None:
+    """Run ``_run_refresh_cmd`` once per ``refresh_key`` on this event loop.
+
+    Same-loop concurrent callers that hit this function while a refresh is
+    in flight will await the same underlying ``asyncio.Future`` rather than
+    spawning their own subprocess.
+
+    Cancel-safety design:
+
+    - The subprocess is driven by a strongly-referenced background
+      ``asyncio.Task`` (registered in ``_REFRESH_INFLIGHT_TASKS``) so it
+      survives cancellation of any individual awaiter.
+    - Each awaiter wraps the future in ``asyncio.shield`` so local
+      cancellation of the awaiter does NOT cancel the shared subprocess —
+      mirrors the ``ClientCore._await_refresh`` pattern used for the RPC
+      refresh path.
+    - The caller in ``_fetch_tokens_with_refresh`` keeps re-awaiting the
+      shielded future under the per-loop asyncio lock so the lock is not
+      released until the subprocess settles. This prevents a duplicate
+      subprocess from being spawned if the lock is released mid-refresh
+      and a second caller observes a partially-completed state.
+    """
+    loop = asyncio.get_running_loop()
+    registry = _get_inflight_registry()
+    with _REFRESH_STATE_LOCK:
+        existing = registry.get(refresh_key)
+        leader = existing is None or existing.done()
+        if leader:
+            future: asyncio.Future[None] = loop.create_future()
+            registry[refresh_key] = future
+        else:
+            future = existing  # type: ignore[assignment]
+
+    if leader:
+        task = asyncio.create_task(_run_refresh_cmd(resolved_storage_path, profile))
+        # Strong-ref pattern: without ``add_done_callback`` the task can be
+        # collected by the asyncio GC before completion if no awaiter is
+        # holding a reference.
+        _REFRESH_INFLIGHT_TASKS.add(task)
+        task.add_done_callback(_REFRESH_INFLIGHT_TASKS.discard)
+
+        def _settle(t: asyncio.Task[None]) -> None:
+            # ``Future.set_*`` is loop-affine; the callback runs on the owning
+            # loop (same loop that created the future and the task), so direct
+            # ``set_result`` / ``set_exception`` is safe.
+            if not future.done():
+                if t.cancelled():
+                    future.cancel()
+                else:
+                    exc = t.exception()
+                    if exc is not None:
+                        future.set_exception(exc)
+                    else:
+                        future.set_result(None)
+            # Intentionally LEAVE the (now-done) future in the registry so the
+            # caller's CancelledError handler in ``_fetch_tokens_with_refresh``
+            # can still inspect ``inflight.exception()`` after a cancel/settle
+            # race (CodeRabbit PR #621 finding). The leader-check at the
+            # get-or-create site (``existing is None or existing.done()``)
+            # treats a done future as overwritable, so the next refresh
+            # cycle's leader replaces this slot — no accumulation.
+
+        task.add_done_callback(_settle)
+
+    # All callers (leader + followers) await the shared future under shield.
+    # Re-raises subprocess exception to every awaiter.
+    await asyncio.shield(future)
+
+
+def _get_refresh_lock(resolved_storage_path: Path | None) -> asyncio.Lock:
+    """Return the ``asyncio.Lock`` for ``(running event loop, resolved storage path)``.
+
+    Mirrors ``_get_poke_lock``. Keyed on the RESOLVED storage path so callers
+    passing ``(None, profile="foo")`` share the lock with callers passing the
+    explicit profile-resolved path.
+    """
+    loop = asyncio.get_running_loop()
+    with _REFRESH_STATE_LOCK:
+        per_loop = _REFRESH_LOCKS_BY_LOOP.get(loop)
+        if per_loop is None:
+            per_loop = {}
+            _REFRESH_LOCKS_BY_LOOP[loop] = per_loop
+        lock = per_loop.get(resolved_storage_path)
+        if lock is None:
+            lock = asyncio.Lock()
+            per_loop[resolved_storage_path] = lock
+        return lock
+
+
+_AUTH_ERROR_SIGNALS = (
+    "authentication expired",
+    "redirected to",
+    "run 'notebooklm login'",
+)
+
+
+def _should_try_refresh(err: Exception) -> bool:
+    """True when an auth failure should trigger NOTEBOOKLM_REFRESH_CMD."""
+    if _REFRESH_ATTEMPTED_CONTEXT.get() or os.environ.get(_REFRESH_ATTEMPTED_ENV) == "1":
+        return False
+    if not os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV):
+        return False
+    msg = str(err).lower()
+    return any(sig in msg for sig in _AUTH_ERROR_SIGNALS)
+
+
+def _split_refresh_cmd(cmd: str) -> list[str]:
+    """Parse ``NOTEBOOKLM_REFRESH_CMD`` into an argv for ``shell=False`` exec.
+
+    On POSIX systems, defers to :func:`shlex.split`. On Windows, uses
+    ``CommandLineToArgvW`` so quoted paths like
+    ``"C:\\Program Files\\Python\\python.exe"`` produce a properly unquoted
+    argv that ``subprocess.run(argv, shell=False)`` can locate. ``shlex``
+    in non-POSIX mode preserves the literal quote characters and would
+    leave the OS unable to find the executable.
+
+    Raises:
+        ValueError: If the command is malformed (e.g., unterminated quote).
+    """
+    if os.name != "nt":
+        return shlex.split(cmd)
+
+    import ctypes
+    from ctypes import wintypes
+
+    CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW  # type: ignore[attr-defined]
+    CommandLineToArgvW.argtypes = [wintypes.LPCWSTR, ctypes.POINTER(ctypes.c_int)]
+    CommandLineToArgvW.restype = ctypes.POINTER(wintypes.LPWSTR)
+    LocalFree = ctypes.windll.kernel32.LocalFree  # type: ignore[attr-defined]
+    LocalFree.argtypes = [wintypes.HLOCAL]
+    LocalFree.restype = wintypes.HLOCAL
+
+    argc = ctypes.c_int(0)
+    argv_ptr = CommandLineToArgvW(cmd, ctypes.byref(argc))
+    if not argv_ptr:
+        # CommandLineToArgvW returns NULL for some empty-input edge cases.
+        # Mirror shlex.split's behavior and return an empty list; the caller
+        # surfaces this as ``RuntimeError("...parsed to empty argv")``.
+        return []
+    try:
+        # On Windows, ``CommandLineToArgvW`` is documented to return a single
+        # empty-string entry (argc=1, argv[0]="") for whitespace-only input,
+        # rather than NULL. Filter out empty entries so the caller's
+        # ``if not argv`` empty-argv guard catches this case the same way
+        # ``shlex.split("   ") == []`` does on POSIX.
+        return [argv_ptr[i] for i in range(argc.value) if argv_ptr[i]]
+    finally:
+        LocalFree(ctypes.cast(argv_ptr, wintypes.HLOCAL))
+
+
+async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None = None) -> None:
+    """Run ``NOTEBOOKLM_REFRESH_CMD`` to refresh stored cookies.
+
+    By default, the command string is parsed with :func:`shlex.split` and
+    executed with ``shell=False`` to avoid shell-injection footguns when the
+    env var is sourced from CI configs or container env files. Set
+    ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1`` to opt back into the legacy
+    ``shell=True`` behavior (e.g., when the command relies on shell features
+    like pipes, redirection, or env-var expansion).
+
+    Raises:
+        RuntimeError: If the refresh command is missing, parses to an empty
+            argv, is malformed (unterminated quote), times out, or exits
+            non-zero.
+    """
+    cmd = os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV)
+    if not cmd:
+        raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} is not set; cannot refresh cookies.")
+    refresh_env = os.environ.copy()
+    refresh_env[_REFRESH_ATTEMPTED_ENV] = "1"
+    refresh_env["NOTEBOOKLM_REFRESH_PROFILE"] = resolve_profile(profile)
+    refresh_env["NOTEBOOKLM_REFRESH_STORAGE_PATH"] = str(
+        storage_path or get_storage_path(profile=profile)
+    )
+
+    use_shell = os.environ.get(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV) == "1"
+    run_target: str | list[str]
+    run_shell: bool
+    if use_shell:
+        logger.warning("Using shell-mode for %s (opt-in)", NOTEBOOKLM_REFRESH_CMD_ENV)
+        # Deliberately do NOT log a basename/preview of ``cmd`` here: in
+        # shell-mode the entire string is forwarded to ``/bin/sh -c`` and
+        # may contain pipes, redirection, ``$VAR`` expansion, or inline
+        # tokens. We can't extract a single "first token" without risking
+        # leaking the rest, so we stay silent past the opt-in warning.
+        run_target = cmd
+        run_shell = True
+    else:
+        try:
+            # POSIX → shlex.split. Windows → CommandLineToArgvW so quoted
+            # paths like ``"C:\\Program Files\\..."`` arrive unquoted.
+            argv = _split_refresh_cmd(cmd)
+        except ValueError as split_err:
+            raise RuntimeError(
+                f"{NOTEBOOKLM_REFRESH_CMD_ENV} could not be parsed: {split_err}"
+            ) from split_err
+        if not argv:
+            raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} parsed to empty argv")
+        # Log basename only — full argv may carry tokens and absolute paths
+        # can leak secrets-directory layouts.
+        logger.info("Running refresh command: %s ...", os.path.basename(argv[0]))
+        run_target = argv
+        run_shell = False
+
+    try:
+        result = await asyncio.to_thread(
+            subprocess.run,
+            run_target,
+            shell=run_shell,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=refresh_env,
+        )
+    except (subprocess.TimeoutExpired, OSError) as refresh_err:
+        raise RuntimeError(
+            f"{NOTEBOOKLM_REFRESH_CMD_ENV} failed to execute: {refresh_err}"
+        ) from refresh_err
+    if result.returncode != 0:
+        # P1-18: do NOT interpolate stdout/stderr into the user-facing raise.
+        # Subprocesses commonly print bearer tokens, cookies, and absolute
+        # paths into a user's credentials directory. ``RuntimeError`` bubbles
+        # up through ``cli.error_handler`` and lands on stderr (or a JSON
+        # envelope), which is the wrong audience for that material.
+        #
+        # Two-channel disclosure: the user sees only exit code + executable
+        # basename; developers running with ``-vv`` get the full output
+        # through the package's redacting DEBUG logger.
+        # Claude bot review feedback: in shell-mode ``run_target`` is the raw
+        # command STRING, not a list. Extract the basename of its first token
+        # so users still see a useful script name (the string is user-supplied
+        # and not a secret — its argv[0] equivalent is safe to surface).
+        if isinstance(run_target, list) and run_target:
+            executable_basename = os.path.basename(run_target[0])
+        elif isinstance(run_target, str) and run_target.strip():
+            executable_basename = os.path.basename(run_target.split()[0])
+        else:
+            executable_basename = "shell"
+        logger.debug(
+            "%s exited %d. stdout=%r stderr=%r",
+            NOTEBOOKLM_REFRESH_CMD_ENV,
+            result.returncode,
+            result.stdout,
+            result.stderr,
+        )
+        raise RuntimeError(
+            f"{NOTEBOOKLM_REFRESH_CMD_ENV} exited {result.returncode} "
+            f"(executable: {executable_basename}). "
+            f"Run with --verbose to see captured stdout/stderr in the debug log."
+        )
+    logger.info("NotebookLM cookies refreshed via %s", NOTEBOOKLM_REFRESH_CMD_ENV)
+
+
+async def _fetch_tokens_with_refresh(
+    cookie_jar: httpx.Cookies,
+    storage_path: Path | None = None,
+    profile: str | None = None,
+    *,
+    authuser: int = 0,
+    account_email: str | None = None,
+    force_authuser_query: bool = False,
+) -> tuple[str, str, bool, _auth_storage.CookieSnapshot | None]:
+    """Fetch tokens, optionally running NOTEBOOKLM_REFRESH_CMD on auth expiry.
+
+    Returns ``(csrf, session_id, refreshed, post_refresh_snapshot)``.
+
+    When ``refreshed`` is ``True``, ``post_refresh_snapshot`` is a snapshot
+    captured **immediately after** ``_replace_cookie_jar`` swaps in the
+    refresh-cmd output and **before** the retry token fetch can mutate the
+    jar with redirect Set-Cookies. Callers must use that snapshot as the
+    save baseline; re-snapshotting the jar after this function returns
+    would include the retry's rotations in the baseline (so they would
+    never reach disk on the subsequent save).
+
+    When ``refreshed`` is ``False`` the snapshot is ``None`` (no refresh
+    happened; caller's pre-fetch snapshot is still the right baseline).
+    """
+    try:
+        route_kwargs: dict[str, Any] = {"authuser": authuser}
+        if account_email is not None:
+            route_kwargs["account_email"] = account_email
+        if force_authuser_query:
+            route_kwargs["force_authuser_query"] = True
+        csrf, session_id = await _fetch_tokens_with_jar(cookie_jar, storage_path, **route_kwargs)
+        return csrf, session_id, False, None
+    except ValueError as err:
+        if not _should_try_refresh(err):
+            raise
+        logger.warning(
+            "NotebookLM auth failed (%s). Running %s to refresh cookies.",
+            err,
+            NOTEBOOKLM_REFRESH_CMD_ENV,
+        )
+        # Canonicalize the storage path so different representations of the
+        # same physical file (relative vs absolute, with or without symlinks,
+        # ``~`` shorthand) hash to the same lock-registry / generation key.
+        # ``get_storage_path`` already returns a resolved path, but a
+        # caller-supplied ``storage_path`` may be relative or a symlink.
+        refresh_storage_path = (
+            (storage_path or get_storage_path(profile=profile)).expanduser().resolve()
+        )
+        refresh_key = str(refresh_storage_path)
+        # Snapshot the generation BEFORE acquiring the async lock so we can
+        # detect whether a concurrent refresh (potentially on a different
+        # event loop) bumped it while we were waiting. ``_REFRESH_STATE_LOCK``
+        # makes this read atomic with the later check-and-update below.
+        with _REFRESH_STATE_LOCK:
+            refresh_generation = _REFRESH_GENERATIONS.get(refresh_key, 0)
+        refresh_token = _REFRESH_ATTEMPTED_CONTEXT.set(True)
+        try:
+            async with _get_refresh_lock(refresh_storage_path):
+                # Bump generation ONLY after the subprocess succeeds AND
+                # storage is reloaded. An earlier implementation bumped the
+                # generation eagerly BEFORE ``_run_refresh_cmd`` — when the
+                # subprocess failed, the phantom bump made concurrent waiters
+                # short-circuit and proceed with stale storage.
+                #
+                # Re-check under the sync state lock so the read is atomic
+                # ACROSS event loops. The per-loop asyncio lock only
+                # serializes within a single loop; a second loop sharing this
+                # storage path holds its own asyncio.Lock.
+                with _REFRESH_STATE_LOCK:
+                    current_generation = _REFRESH_GENERATIONS.get(refresh_key, 0)
+                    # ``current > refresh_generation`` means another caller
+                    # (any loop) has SUCCESSFULLY refreshed since we observed
+                    # auth-expiry — we can skip ``_run_refresh_cmd`` and just
+                    # reload the freshly-written storage.
+                    should_run_refresh = current_generation <= refresh_generation
+                if should_run_refresh:
+                    # Cancel-safety: drive the subprocess through the shared
+                    # in-flight future. Same-loop concurrent callers coalesce
+                    # on the same subprocess. If THIS caller is cancelled
+                    # while the subprocess is in flight, we keep awaiting the
+                    # shielded future so the asyncio lock is NOT released
+                    # until the subprocess settles — otherwise a second
+                    # caller could spawn a duplicate concurrent refresh by
+                    # observing the mid-flight lock release.
+                    caller_cancelled = False
+                    subprocess_exc: BaseException | None = None
+                    while True:
+                        try:
+                            await _coalesced_run_refresh_cmd(
+                                refresh_key, refresh_storage_path, profile
+                            )
+                            break
+                        except asyncio.CancelledError:
+                            # Caller-side cancellation. Re-enter the await
+                            # so the shielded subprocess can settle while we
+                            # still hold the asyncio lock.
+                            caller_cancelled = True
+                            registry = _get_inflight_registry()
+                            with _REFRESH_STATE_LOCK:
+                                inflight = registry.get(refresh_key)
+                            if inflight is None or inflight.done():
+                                # Subprocess already settled; we absorbed the
+                                # cancellation. Inspect its terminal state.
+                                # Per the CodeRabbit finding on PR #621, the
+                                # ``_settle`` callback intentionally leaves
+                                # the done future in the registry so this
+                                # branch can still observe ``inflight.
+                                # exception()`` after a cancel/settle race.
+                                if inflight is not None:
+                                    if inflight.cancelled():
+                                        # Subprocess itself was cancelled —
+                                        # treat as failure (do not bump gen).
+                                        subprocess_exc = asyncio.CancelledError()
+                                    else:
+                                        subprocess_exc = inflight.exception()
+                                break
+                            # Otherwise loop — re-await the shielded future.
+                        except BaseException as exc:  # noqa: BLE001
+                            subprocess_exc = exc
+                            break
+
+                    if subprocess_exc is not None:
+                        # Subprocess failed — DO NOT bump generation.
+                        # Concurrent / subsequent waiters re-attempt the
+                        # refresh instead of short-circuiting on a phantom
+                        # bump.
+                        if caller_cancelled:
+                            # Caller cancellation takes priority for THIS
+                            # caller.
+                            raise asyncio.CancelledError() from subprocess_exc
+                        raise subprocess_exc
+
+                    # Subprocess succeeded AND we're about to reload
+                    # storage. Bump the generation now so other callers
+                    # (any loop) see the success and skip their own
+                    # subprocess. The bump is atomic across loops via
+                    # ``_REFRESH_STATE_LOCK``.
+                    with _REFRESH_STATE_LOCK:
+                        # ``max(...)`` defends against the rare interleaving
+                        # where another loop's pre-lock capture was AFTER
+                        # ours and bumped past us.
+                        existing = _REFRESH_GENERATIONS.get(refresh_key, 0)
+                        _REFRESH_GENERATIONS[refresh_key] = max(existing, refresh_generation + 1)
+
+                    if caller_cancelled:
+                        # Subprocess succeeded; generation bump persists for
+                        # other callers' benefit. THIS caller still
+                        # propagates cancellation rather than completing the
+                        # retry.
+                        raise asyncio.CancelledError()
+                fresh_jar = build_httpx_cookies_from_storage(refresh_storage_path)
+                _replace_cookie_jar(cookie_jar, fresh_jar)
+                # Capture the baseline NOW — after the wholesale replacement
+                # but before the retry fetch can mutate the jar.
+                post_refresh_snapshot = snapshot_cookie_jar(cookie_jar)
+            route_kwargs = {"authuser": authuser}
+            if account_email is not None:
+                route_kwargs["account_email"] = account_email
+            if force_authuser_query:
+                route_kwargs["force_authuser_query"] = True
+            csrf, session_id = await _fetch_tokens_with_jar(
+                cookie_jar, refresh_storage_path, **route_kwargs
+            )
+            return csrf, session_id, True, post_refresh_snapshot
+        finally:
+            _REFRESH_ATTEMPTED_CONTEXT.reset(refresh_token)
+
+
+async def _fetch_tokens_with_jar(
+    cookie_jar: httpx.Cookies,
+    storage_path: Path | None = None,
+    *,
+    authuser: int = 0,
+    account_email: str | None = None,
+    force_authuser_query: bool = False,
+) -> tuple[str, str]:
+    """Internal: fetch CSRF and session tokens using a pre-built cookie jar.
+
+    This is the single implementation for all token-fetch paths. All public
+    functions (fetch_tokens, fetch_tokens_with_domains) delegate to this.
+
+    Before fetching tokens, makes a best-effort POST to accounts.google.com to
+    rotate __Secure-1PSIDTS; see ``_poke_session``. The poke may be skipped if
+    ``storage_path`` was modified within the rate-limit window — that path
+    relies on the existing on-disk cookies still being fresh.
+
+    Args:
+        cookie_jar: httpx.Cookies jar with auth cookies (domain-preserving or fallback).
+        storage_path: Optional storage_state.json path, forwarded to
+            ``_poke_session`` to gate the rotation poke.
+        authuser: Google account index to authenticate as. ``0`` is the
+            default account.
+        account_email: Stable account email to use instead of the integer
+            index when known.
+        force_authuser_query: Append ``?authuser=0`` when callers explicitly
+            requested account index 0. Implicit default-account calls leave the
+            URL byte-identical to pre-multi-account behavior.
+
+    Returns:
+        Tuple of (csrf_token, session_id)
+
+    Raises:
+        httpx.HTTPError: If request fails
+        ValueError: If tokens cannot be extracted from response
+    """
+    logger.debug("Fetching CSRF and session tokens from NotebookLM")
+
+    async with httpx.AsyncClient(cookies=cookie_jar) as client:
+        await _poke_session(client, storage_path)
+
+        url = f"{get_base_url()}/"
+        if account_email or authuser or force_authuser_query:
+            url = f"{url}?{authuser_query(authuser, account_email)}"
+        response = await client.get(
+            url,
+            follow_redirects=True,
+            timeout=30.0,
+        )
+        response.raise_for_status()
+
+        final_url = str(response.url)
+
+        # Check if we were redirected to login
+        if is_google_auth_redirect(final_url):
+            raise ValueError(
+                "Authentication expired or invalid. "
+                "Redirected to: " + _safe_url(final_url) + "\n"
+                "Run 'notebooklm login' to re-authenticate."
+            )
+
+        csrf = extract_csrf_from_html(response.text, final_url)
+        session_id = extract_session_id_from_html(response.text, final_url)
+
+        # httpx copies the input Cookies object into the client. Copy any
+        # redirect Set-Cookie updates back to the caller's jar before it is
+        # persisted.
+        _replace_cookie_jar(cookie_jar, client.cookies)
+
+        logger.debug("Authentication tokens obtained successfully")
+        return csrf, session_id
+
+
+async def fetch_tokens(
+    cookies: _auth_cookies.CookieInput,
+    storage_path: Path | None = None,
+    profile: str | None = None,
+    *,
+    authuser: int | None = None,
+    account_email: str | None = None,
+) -> tuple[str, str]:
+    """Fetch tokens from a cookie mapping. For backward compatibility.
+
+    Prefer AuthTokens.from_storage() which preserves cookie domains. If
+    ``NOTEBOOKLM_REFRESH_CMD`` is set and auth has expired, the command is run
+    through the platform shell, cookies are reloaded from ``storage_path`` or
+    the active profile storage path, and token fetch is retried once. Refresh
+    commands receive ``NOTEBOOKLM_REFRESH_STORAGE_PATH`` and
+    ``NOTEBOOKLM_REFRESH_PROFILE`` in their environment.
+
+    Args:
+        cookies: Google auth cookies. Mutated in place on refresh.
+        storage_path: Optional storage_state.json path to reload after refresh.
+        profile: Optional profile name exposed to the refresh command.
+        authuser: Optional explicit Google account index. Defaults to the
+            persisted profile value, or 0 when none exists.
+        account_email: Optional explicit Google account email. When provided,
+            it is used as the auth routing value instead of the integer index.
+
+    Returns:
+        Tuple of (csrf_token, session_id)
+
+    Raises:
+        httpx.HTTPError: If request fails
+        ValueError: If tokens cannot be extracted from response
+        RuntimeError: If ``NOTEBOOKLM_REFRESH_CMD`` is set but fails
+    """
+    jar = build_cookie_jar(cookies=cookies, storage_path=storage_path)
+    route_kwargs = _resolve_token_route_kwargs(
+        storage_path,
+        authuser=authuser,
+        account_email=account_email,
+    )
+    csrf, session_id, refreshed, _post_refresh_snapshot = await _fetch_tokens_with_refresh(
+        jar, storage_path, profile, **route_kwargs
+    )
+    if refreshed:
+        fresh = _cookie_map_from_jar(jar)
+        _update_cookie_input(cookies, fresh)
+    return csrf, session_id
+
+
+async def fetch_tokens_with_domains(
+    path: Path | None = None,
+    profile: str | None = None,
+    *,
+    authuser: int | None = None,
+    account_email: str | None = None,
+) -> tuple[str, str]:
+    """Fetch tokens with domain-preserving cookies from storage.
+
+    Used by CLI helpers. Loads storage, builds jar, fetches tokens, optionally
+    runs NOTEBOOKLM_REFRESH_CMD on auth expiry, and persists any refreshed
+    cookies back.
+
+    Args:
+        path: Path to storage_state.json. If provided, takes precedence over env vars.
+        profile: Optional profile name exposed to the refresh command.
+        authuser: Optional explicit Google account index. Defaults to the
+            persisted profile value, or 0 when none exists.
+        account_email: Optional explicit Google account email. When provided,
+            it is used as the auth routing value instead of the integer index.
+
+    Returns:
+        Tuple of (csrf_token, session_id)
+
+    Raises:
+        FileNotFoundError: If storage file doesn't exist.
+        httpx.HTTPError: If request fails.
+        ValueError: If tokens cannot be extracted from response.
+        RuntimeError: If ``NOTEBOOKLM_REFRESH_CMD`` is set but fails.
+    """
+    if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
+        path = get_storage_path(profile=profile)
+    jar = build_httpx_cookies_from_storage(path)
+    route_kwargs = _resolve_token_route_kwargs(path, authuser=authuser, account_email=account_email)
+    # Capture the open-time snapshot before any rotation could fire. The
+    # snapshot is the input to the dirty-flag/delta merge that closes the
+    # stale-overwrite-fresh race (docs/auth-keepalive.md §3.4.1).
+    snapshot = snapshot_cookie_jar(jar)
+    csrf, session_id, refreshed, post_refresh_snapshot = await _fetch_tokens_with_refresh(
+        jar, path, profile, **route_kwargs
+    )
+    if refreshed and post_refresh_snapshot is not None:
+        # NOTEBOOKLM_REFRESH_CMD replaced the jar wholesale. Use the snapshot
+        # captured immediately after the replacement (before the retry fetch
+        # added redirect Set-Cookies); re-snapshotting here would let those
+        # retry rotations be absorbed into the baseline and never reach disk.
+        snapshot = post_refresh_snapshot
+    # Offload the blocking storage save to a worker thread so the
+    # atomic-replace + fsync + flock can't stall the event loop on
+    # slow filesystems.
+    await asyncio.to_thread(save_cookies_to_storage, jar, path, original_snapshot=snapshot)
+    return csrf, session_id

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -28,17 +28,10 @@ Security Notes:
 """
 
 import asyncio
-import contextlib
 import logging
 import os
-import shlex
-import subprocess
+import subprocess  # noqa: F401  # re-exported for tests that patch ``auth.subprocess.run``
 import sys
-import threading
-import time
-import weakref
-from collections.abc import Iterator
-from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
@@ -51,11 +44,11 @@ from ._auth import cookie_policy as _cookie_policy
 from ._auth import cookies as _auth_cookies
 from ._auth import extraction as _auth_extraction
 from ._auth import headers as _auth_headers
+from ._auth import keepalive as _auth_keepalive
 from ._auth import paths as _auth_paths
+from ._auth import refresh as _auth_refresh
 from ._auth import storage as _auth_storage
-from ._env import get_base_url
-from ._url_utils import is_google_auth_redirect
-from .paths import get_storage_path, resolve_profile
+from .paths import get_storage_path
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +66,7 @@ _find_cookie_for_storage = _auth_cookies._find_cookie_for_storage
 _load_storage_state = _auth_cookies._load_storage_state
 _replace_cookie_jar = _auth_cookies._replace_cookie_jar
 _storage_entry_to_cookie = _auth_cookies._storage_entry_to_cookie
+_update_cookie_input = _auth_cookies._update_cookie_input
 build_cookie_jar = _auth_cookies.build_cookie_jar
 build_httpx_cookies_from_storage = _auth_cookies.build_httpx_cookies_from_storage
 convert_rookiepy_cookies_to_storage_state = _auth_cookies.convert_rookiepy_cookies_to_storage_state
@@ -208,6 +202,88 @@ _AUTH_ACCOUNT_FACADE_NAMES = {
     "clear_account_metadata",
 }
 
+# Keepalive bodies moved into ``_auth.keepalive``. The facade write-through
+# below mirrors any monkeypatched value (e.g. ``auth._poke_session = fake``)
+# into the moved module so the bodies that reference these bare names still
+# observe the patch when they execute.
+_AUTH_KEEPALIVE_FACADE_NAMES = {
+    "KEEPALIVE_ROTATE_URL",
+    "_KEEPALIVE_ROTATE_HEADERS",
+    "_KEEPALIVE_ROTATE_BODY",
+    "_KEEPALIVE_POKE_TIMEOUT",
+    "_KEEPALIVE_RATE_LIMIT_SECONDS",
+    "_KEEPALIVE_PRECISION_TOLERANCE",
+    "_POKE_STATE_LOCK",
+    "_POKE_LOCKS_BY_LOOP",
+    "_LAST_POKE_ATTEMPT_MONOTONIC",
+    "_get_poke_lock",
+    "_try_claim_rotation",
+    "_file_lock_try_exclusive",
+    "_is_recently_rotated",
+    "_poke_session",
+    "_rotate_cookies",
+}
+
+# Refresh bodies moved into ``_auth.refresh``. ``_run_refresh_cmd`` carries the
+# tier-9 E redaction logic (P1-18) — see the moved body for the two-channel
+# disclosure pattern. Names listed here include the public token-fetch entry
+# points (``fetch_tokens`` / ``fetch_tokens_with_domains``) as well as every
+# white-box affordance currently exercised by the test suite.
+_AUTH_REFRESH_FACADE_NAMES = {
+    "fetch_tokens",
+    "fetch_tokens_with_domains",
+    "_should_try_refresh",
+    "_split_refresh_cmd",
+    "_run_refresh_cmd",
+    "_fetch_tokens_with_refresh",
+    "_fetch_tokens_with_jar",
+    "_coalesced_run_refresh_cmd",
+    "_get_refresh_lock",
+    "_get_inflight_registry",
+    "_REFRESH_ATTEMPTED_CONTEXT",
+    "_REFRESH_STATE_LOCK",
+    "_REFRESH_LOCKS_BY_LOOP",
+    "_REFRESH_GENERATIONS",
+    "_REFRESH_INFLIGHT_BY_LOOP",
+    "_REFRESH_INFLIGHT_TASKS",
+    "_AUTH_ERROR_SIGNALS",
+}
+
+# Names that the refresh module aliases from sibling modules at import time.
+# When a test does ``monkeypatch.setattr(auth, "snapshot_cookie_jar", fake)``,
+# the facade fires the storage-name mirror (which patches ``_auth.storage``)
+# AND mirrors into ``_auth.refresh`` so the bare-name lookups inside the moved
+# bodies (``snapshot_cookie_jar(...)``) observe the patch. The same pattern
+# applies to cookie helpers patched via ``auth_mod`` and consumed by refresh.
+#
+# ``get_storage_path`` is also mirrored so the existing
+# ``monkeypatch.setattr("notebooklm.auth.get_storage_path", ...)`` pattern keeps
+# working — the refresh path calls ``get_storage_path`` to canonicalize a
+# caller-supplied storage path before keying the lock/generation registries.
+_REFRESH_DEP_MIRROR_NAMES = {
+    "snapshot_cookie_jar",
+    "save_cookies_to_storage",
+    "build_httpx_cookies_from_storage",
+    "build_cookie_jar",
+    "_replace_cookie_jar",
+    "_cookie_map_from_jar",
+    "flatten_cookie_map",
+    "_update_cookie_input",
+    "extract_csrf_from_html",
+    "extract_session_id_from_html",
+    "_safe_url",
+    "_resolve_token_route_kwargs",
+    "get_storage_path",
+}
+
+# Names that the keepalive module aliases from sibling modules at import time;
+# kept in sync via the facade's write-through. ``_file_lock`` is patched by
+# ``tests/unit/test_warning_dedupe.py`` via ``auth_module._file_lock``.
+_KEEPALIVE_DEP_MIRROR_NAMES = {
+    "_file_lock",
+    "_rotation_lock_path",
+}
+
 
 class _AuthFacadeModule(ModuleType):
     """Keep compatibility assignments to auth globals meaningful after moves."""
@@ -217,6 +293,10 @@ class _AuthFacadeModule(ModuleType):
             return getattr(_auth_storage, name)
         if name in _AUTH_ACCOUNT_FACADE_NAMES:
             return getattr(_auth_account, name)
+        if name in _AUTH_KEEPALIVE_FACADE_NAMES:
+            return getattr(_auth_keepalive, name)
+        if name in _AUTH_REFRESH_FACADE_NAMES:
+            return getattr(_auth_refresh, name)
         return super().__getattribute__(name)
 
     def __setattr__(self, name: str, value: Any) -> None:
@@ -225,6 +305,24 @@ class _AuthFacadeModule(ModuleType):
             setattr(_auth_storage, name, value)
         if name in _AUTH_ACCOUNT_FACADE_NAMES:
             setattr(_auth_account, name, value)
+        if name in _AUTH_KEEPALIVE_FACADE_NAMES:
+            setattr(_auth_keepalive, name, value)
+        if name in _AUTH_REFRESH_FACADE_NAMES:
+            setattr(_auth_refresh, name, value)
+        # Cross-module monkeypatch targets — names that physically live in one
+        # sibling module but are aliased into ``_auth.refresh`` /
+        # ``_auth.keepalive`` so the moved bodies can resolve them locally.
+        # Mirror writes through to those alias slots so a test patching the
+        # name on ``notebooklm.auth`` affects every site that consumes it.
+        if name in _REFRESH_DEP_MIRROR_NAMES:
+            setattr(_auth_refresh, name, value)
+        if name in _KEEPALIVE_DEP_MIRROR_NAMES:
+            setattr(_auth_keepalive, name, value)
+        if name == "_poke_session":
+            # ``_auth.refresh`` aliases ``_poke_session`` from keepalive at
+            # import time; mirror writes so a patch on ``auth._poke_session``
+            # flows into both the keepalive owner AND the refresh consumer.
+            _auth_refresh._poke_session = value
         if name == "_SECONDARY_BINDING_WARNED":
             _cookie_policy._SECONDARY_BINDING_WARNED = bool(value)
         elif name in {
@@ -477,6 +575,12 @@ extract_csrf_from_html = _auth_extraction.extract_csrf_from_html
 extract_session_id_from_html = _auth_extraction.extract_session_id_from_html
 extract_wiz_field = _auth_extraction.extract_wiz_field
 
+# Token-route resolver lives in ``notebooklm._auth.headers``; re-exported so
+# internal callers (``fetch_tokens``, ``fetch_tokens_with_domains`` — now in
+# ``_auth.refresh``) and white-box tests keep resolving the helper against
+# ``notebooklm.auth``.
+_resolve_token_route_kwargs = _auth_headers._resolve_token_route_kwargs
+
 
 Account = _auth_account.Account
 MAX_AUTHUSER_PROBE = _auth_account.MAX_AUTHUSER_PROBE
@@ -548,1017 +652,71 @@ def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
 NOTEBOOKLM_REFRESH_CMD_ENV = _auth_paths.NOTEBOOKLM_REFRESH_CMD_ENV
 NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV = _auth_paths.NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV
 _REFRESH_ATTEMPTED_ENV = _auth_paths._REFRESH_ATTEMPTED_ENV
-# The ContextVar prevents same-task retry loops in the parent process. The env
-# flag is passed only to child refresh commands so recursive CLI calls skip refresh.
-_REFRESH_ATTEMPTED_CONTEXT: ContextVar[bool] = ContextVar(
-    "_REFRESH_ATTEMPTED_CONTEXT", default=False
-)
-# In-process state for refresh coordination, keyed per resolved storage path.
-#
-# Two layers of protection are required:
-#
-# - ``_REFRESH_STATE_LOCK`` (sync ``threading.Lock``) makes the
-#   ``_REFRESH_GENERATIONS`` check-and-update atomic ACROSS event loops.
-#   Two loops sharing a storage path each hold their own ``asyncio.Lock``
-#   (see below), so the asyncio lock alone cannot serialize the generation
-#   bump.
-#
-# - ``_REFRESH_LOCKS_BY_LOOP`` mirrors the keepalive ``_POKE_LOCKS_BY_LOOP``
-#   pattern: ``asyncio.Lock`` is loop-bound, so a per-loop / per-resolved-
-#   storage-path registry avoids the cross-loop / cross-thread hazard of a
-#   module-global ``asyncio.Lock`` that binds to the first event loop that
-#   uses it. The outer ``WeakKeyDictionary`` is keyed on the loop object so
-#   the inner dict is reclaimed when the loop is garbage-collected.
-_REFRESH_STATE_LOCK = threading.Lock()
-_REFRESH_LOCKS_BY_LOOP: "weakref.WeakKeyDictionary[Any, dict[Path | None, asyncio.Lock]]" = (
-    weakref.WeakKeyDictionary()
-)
-_REFRESH_GENERATIONS: dict[str, int] = {}
-
-# In-flight ``asyncio.Future`` registry for refresh-cmd coalescing.
-#
-# Same-loop concurrent callers that both encounter auth-expiry coalesce on a
-# single in-flight subprocess by sharing a per-resolved-storage-path
-# ``asyncio.Future``. The future is keyed per-loop because ``asyncio.Future``
-# is loop-bound; cross-loop coordination falls back to the
-# ``_REFRESH_GENERATIONS`` counter guarded by ``_REFRESH_STATE_LOCK``.
-#
-# The strong-ref ``_REFRESH_INFLIGHT_TASKS`` set keeps the shielded subprocess
-# Tasks alive so the asyncio GC does not collect them. The task self-removes
-# via ``add_done_callback(set.discard)`` once settled.
-_REFRESH_INFLIGHT_BY_LOOP: "weakref.WeakKeyDictionary[Any, dict[str, asyncio.Future[None]]]" = (
-    weakref.WeakKeyDictionary()
-)
-_REFRESH_INFLIGHT_TASKS: set[asyncio.Task[None]] = set()
-
-
-def _get_inflight_registry() -> dict[str, asyncio.Future[None]]:
-    """Return the per-loop in-flight refresh-cmd future registry.
-
-    Mirrors ``_get_refresh_lock``: ``asyncio.Future`` is loop-bound, so we
-    need a per-loop registry. ``_REFRESH_STATE_LOCK`` makes the lookup /
-    insert atomic across threads (different loops on different threads can
-    each populate their own per-loop dict concurrently).
-    """
-    loop = asyncio.get_running_loop()
-    with _REFRESH_STATE_LOCK:
-        per_loop = _REFRESH_INFLIGHT_BY_LOOP.get(loop)
-        if per_loop is None:
-            per_loop = {}
-            _REFRESH_INFLIGHT_BY_LOOP[loop] = per_loop
-        return per_loop
-
-
-async def _coalesced_run_refresh_cmd(
-    refresh_key: str,
-    resolved_storage_path: Path,
-    profile: str | None,
-) -> None:
-    """Run ``_run_refresh_cmd`` once per ``refresh_key`` on this event loop.
-
-    Same-loop concurrent callers that hit this function while a refresh is
-    in flight will await the same underlying ``asyncio.Future`` rather than
-    spawning their own subprocess.
-
-    Cancel-safety design:
-
-    - The subprocess is driven by a strongly-referenced background
-      ``asyncio.Task`` (registered in ``_REFRESH_INFLIGHT_TASKS``) so it
-      survives cancellation of any individual awaiter.
-    - Each awaiter wraps the future in ``asyncio.shield`` so local
-      cancellation of the awaiter does NOT cancel the shared subprocess —
-      mirrors the ``ClientCore._await_refresh`` pattern used for the RPC
-      refresh path.
-    - The caller in ``_fetch_tokens_with_refresh`` keeps re-awaiting the
-      shielded future under the per-loop asyncio lock so the lock is not
-      released until the subprocess settles. This prevents a duplicate
-      subprocess from being spawned if the lock is released mid-refresh
-      and a second caller observes a partially-completed state.
-    """
-    loop = asyncio.get_running_loop()
-    registry = _get_inflight_registry()
-    with _REFRESH_STATE_LOCK:
-        existing = registry.get(refresh_key)
-        leader = existing is None or existing.done()
-        if leader:
-            future: asyncio.Future[None] = loop.create_future()
-            registry[refresh_key] = future
-        else:
-            future = existing  # type: ignore[assignment]
-
-    if leader:
-        task = asyncio.create_task(_run_refresh_cmd(resolved_storage_path, profile))
-        # Strong-ref pattern: without ``add_done_callback`` the task can be
-        # collected by the asyncio GC before completion if no awaiter is
-        # holding a reference.
-        _REFRESH_INFLIGHT_TASKS.add(task)
-        task.add_done_callback(_REFRESH_INFLIGHT_TASKS.discard)
-
-        def _settle(t: asyncio.Task[None]) -> None:
-            # ``Future.set_*`` is loop-affine; the callback runs on the owning
-            # loop (same loop that created the future and the task), so direct
-            # ``set_result`` / ``set_exception`` is safe.
-            if not future.done():
-                if t.cancelled():
-                    future.cancel()
-                else:
-                    exc = t.exception()
-                    if exc is not None:
-                        future.set_exception(exc)
-                    else:
-                        future.set_result(None)
-            # Intentionally LEAVE the (now-done) future in the registry so the
-            # caller's CancelledError handler in ``_fetch_tokens_with_refresh``
-            # can still inspect ``inflight.exception()`` after a cancel/settle
-            # race (CodeRabbit PR #621 finding). The leader-check at the
-            # get-or-create site (``existing is None or existing.done()``)
-            # treats a done future as overwritable, so the next refresh
-            # cycle's leader replaces this slot — no accumulation.
-
-        task.add_done_callback(_settle)
-
-    # All callers (leader + followers) await the shared future under shield.
-    # Re-raises subprocess exception to every awaiter.
-    await asyncio.shield(future)
-
-
-def _get_refresh_lock(resolved_storage_path: Path | None) -> asyncio.Lock:
-    """Return the ``asyncio.Lock`` for ``(running event loop, resolved storage path)``.
-
-    Mirrors ``_get_poke_lock``. Keyed on the RESOLVED storage path so callers
-    passing ``(None, profile="foo")`` share the lock with callers passing the
-    explicit profile-resolved path.
-    """
-    loop = asyncio.get_running_loop()
-    with _REFRESH_STATE_LOCK:
-        per_loop = _REFRESH_LOCKS_BY_LOOP.get(loop)
-        if per_loop is None:
-            per_loop = {}
-            _REFRESH_LOCKS_BY_LOOP[loop] = per_loop
-        lock = per_loop.get(resolved_storage_path)
-        if lock is None:
-            lock = asyncio.Lock()
-            per_loop[resolved_storage_path] = lock
-        return lock
-
-
-_AUTH_ERROR_SIGNALS = (
-    "authentication expired",
-    "redirected to",
-    "run 'notebooklm login'",
-)
-
-
-def _should_try_refresh(err: Exception) -> bool:
-    """True when an auth failure should trigger NOTEBOOKLM_REFRESH_CMD."""
-    if _REFRESH_ATTEMPTED_CONTEXT.get() or os.environ.get(_REFRESH_ATTEMPTED_ENV) == "1":
-        return False
-    if not os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV):
-        return False
-    msg = str(err).lower()
-    return any(sig in msg for sig in _AUTH_ERROR_SIGNALS)
-
-
-def _split_refresh_cmd(cmd: str) -> list[str]:
-    """Parse ``NOTEBOOKLM_REFRESH_CMD`` into an argv for ``shell=False`` exec.
-
-    On POSIX systems, defers to :func:`shlex.split`. On Windows, uses
-    ``CommandLineToArgvW`` so quoted paths like
-    ``"C:\\Program Files\\Python\\python.exe"`` produce a properly unquoted
-    argv that ``subprocess.run(argv, shell=False)`` can locate. ``shlex``
-    in non-POSIX mode preserves the literal quote characters and would
-    leave the OS unable to find the executable.
-
-    Raises:
-        ValueError: If the command is malformed (e.g., unterminated quote).
-    """
-    if os.name != "nt":
-        return shlex.split(cmd)
-
-    import ctypes
-    from ctypes import wintypes
-
-    CommandLineToArgvW = ctypes.windll.shell32.CommandLineToArgvW  # type: ignore[attr-defined]
-    CommandLineToArgvW.argtypes = [wintypes.LPCWSTR, ctypes.POINTER(ctypes.c_int)]
-    CommandLineToArgvW.restype = ctypes.POINTER(wintypes.LPWSTR)
-    LocalFree = ctypes.windll.kernel32.LocalFree  # type: ignore[attr-defined]
-    LocalFree.argtypes = [wintypes.HLOCAL]
-    LocalFree.restype = wintypes.HLOCAL
-
-    argc = ctypes.c_int(0)
-    argv_ptr = CommandLineToArgvW(cmd, ctypes.byref(argc))
-    if not argv_ptr:
-        # CommandLineToArgvW returns NULL for some empty-input edge cases.
-        # Mirror shlex.split's behavior and return an empty list; the caller
-        # surfaces this as ``RuntimeError("...parsed to empty argv")``.
-        return []
-    try:
-        # On Windows, ``CommandLineToArgvW`` is documented to return a single
-        # empty-string entry (argc=1, argv[0]="") for whitespace-only input,
-        # rather than NULL. Filter out empty entries so the caller's
-        # ``if not argv`` empty-argv guard catches this case the same way
-        # ``shlex.split("   ") == []`` does on POSIX.
-        return [argv_ptr[i] for i in range(argc.value) if argv_ptr[i]]
-    finally:
-        LocalFree(ctypes.cast(argv_ptr, wintypes.HLOCAL))
-
-
-async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None = None) -> None:
-    """Run ``NOTEBOOKLM_REFRESH_CMD`` to refresh stored cookies.
-
-    By default, the command string is parsed with :func:`shlex.split` and
-    executed with ``shell=False`` to avoid shell-injection footguns when the
-    env var is sourced from CI configs or container env files. Set
-    ``NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1`` to opt back into the legacy
-    ``shell=True`` behavior (e.g., when the command relies on shell features
-    like pipes, redirection, or env-var expansion).
-
-    Raises:
-        RuntimeError: If the refresh command is missing, parses to an empty
-            argv, is malformed (unterminated quote), times out, or exits
-            non-zero.
-    """
-    cmd = os.environ.get(NOTEBOOKLM_REFRESH_CMD_ENV)
-    if not cmd:
-        raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} is not set; cannot refresh cookies.")
-    refresh_env = os.environ.copy()
-    refresh_env[_REFRESH_ATTEMPTED_ENV] = "1"
-    refresh_env["NOTEBOOKLM_REFRESH_PROFILE"] = resolve_profile(profile)
-    refresh_env["NOTEBOOKLM_REFRESH_STORAGE_PATH"] = str(
-        storage_path or get_storage_path(profile=profile)
-    )
-
-    use_shell = os.environ.get(NOTEBOOKLM_REFRESH_CMD_USE_SHELL_ENV) == "1"
-    run_target: str | list[str]
-    run_shell: bool
-    if use_shell:
-        logger.warning("Using shell-mode for %s (opt-in)", NOTEBOOKLM_REFRESH_CMD_ENV)
-        # Deliberately do NOT log a basename/preview of ``cmd`` here: in
-        # shell-mode the entire string is forwarded to ``/bin/sh -c`` and
-        # may contain pipes, redirection, ``$VAR`` expansion, or inline
-        # tokens. We can't extract a single "first token" without risking
-        # leaking the rest, so we stay silent past the opt-in warning.
-        run_target = cmd
-        run_shell = True
-    else:
-        try:
-            # POSIX → shlex.split. Windows → CommandLineToArgvW so quoted
-            # paths like ``"C:\\Program Files\\..."`` arrive unquoted.
-            argv = _split_refresh_cmd(cmd)
-        except ValueError as split_err:
-            raise RuntimeError(
-                f"{NOTEBOOKLM_REFRESH_CMD_ENV} could not be parsed: {split_err}"
-            ) from split_err
-        if not argv:
-            raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} parsed to empty argv")
-        # Log basename only — full argv may carry tokens and absolute paths
-        # can leak secrets-directory layouts.
-        logger.info("Running refresh command: %s ...", os.path.basename(argv[0]))
-        run_target = argv
-        run_shell = False
-
-    try:
-        result = await asyncio.to_thread(
-            subprocess.run,
-            run_target,
-            shell=run_shell,
-            capture_output=True,
-            text=True,
-            timeout=60,
-            env=refresh_env,
-        )
-    except (subprocess.TimeoutExpired, OSError) as refresh_err:
-        raise RuntimeError(
-            f"{NOTEBOOKLM_REFRESH_CMD_ENV} failed to execute: {refresh_err}"
-        ) from refresh_err
-    if result.returncode != 0:
-        # P1-18: do NOT interpolate stdout/stderr into the user-facing raise.
-        # Subprocesses commonly print bearer tokens, cookies, and absolute
-        # paths into a user's credentials directory. ``RuntimeError`` bubbles
-        # up through ``cli.error_handler`` and lands on stderr (or a JSON
-        # envelope), which is the wrong audience for that material.
-        #
-        # Two-channel disclosure: the user sees only exit code + executable
-        # basename; developers running with ``-vv`` get the full output
-        # through the package's redacting DEBUG logger.
-        # Claude bot review feedback: in shell-mode ``run_target`` is the raw
-        # command STRING, not a list. Extract the basename of its first token
-        # so users still see a useful script name (the string is user-supplied
-        # and not a secret — its argv[0] equivalent is safe to surface).
-        if isinstance(run_target, list) and run_target:
-            executable_basename = os.path.basename(run_target[0])
-        elif isinstance(run_target, str) and run_target.strip():
-            executable_basename = os.path.basename(run_target.split()[0])
-        else:
-            executable_basename = "shell"
-        logger.debug(
-            "%s exited %d. stdout=%r stderr=%r",
-            NOTEBOOKLM_REFRESH_CMD_ENV,
-            result.returncode,
-            result.stdout,
-            result.stderr,
-        )
-        raise RuntimeError(
-            f"{NOTEBOOKLM_REFRESH_CMD_ENV} exited {result.returncode} "
-            f"(executable: {executable_basename}). "
-            f"Run with --verbose to see captured stdout/stderr in the debug log."
-        )
-    logger.info("NotebookLM cookies refreshed via %s", NOTEBOOKLM_REFRESH_CMD_ENV)
-
-
-async def _fetch_tokens_with_refresh(
-    cookie_jar: httpx.Cookies,
-    storage_path: Path | None = None,
-    profile: str | None = None,
-    *,
-    authuser: int = 0,
-    account_email: str | None = None,
-    force_authuser_query: bool = False,
-) -> tuple[str, str, bool, CookieSnapshot | None]:
-    """Fetch tokens, optionally running NOTEBOOKLM_REFRESH_CMD on auth expiry.
-
-    Returns ``(csrf, session_id, refreshed, post_refresh_snapshot)``.
-
-    When ``refreshed`` is ``True``, ``post_refresh_snapshot`` is a snapshot
-    captured **immediately after** ``_replace_cookie_jar`` swaps in the
-    refresh-cmd output and **before** the retry token fetch can mutate the
-    jar with redirect Set-Cookies. Callers must use that snapshot as the
-    save baseline; re-snapshotting the jar after this function returns
-    would include the retry's rotations in the baseline (so they would
-    never reach disk on the subsequent save).
-
-    When ``refreshed`` is ``False`` the snapshot is ``None`` (no refresh
-    happened; caller's pre-fetch snapshot is still the right baseline).
-    """
-    try:
-        route_kwargs: dict[str, Any] = {"authuser": authuser}
-        if account_email is not None:
-            route_kwargs["account_email"] = account_email
-        if force_authuser_query:
-            route_kwargs["force_authuser_query"] = True
-        csrf, session_id = await _fetch_tokens_with_jar(cookie_jar, storage_path, **route_kwargs)
-        return csrf, session_id, False, None
-    except ValueError as err:
-        if not _should_try_refresh(err):
-            raise
-        logger.warning(
-            "NotebookLM auth failed (%s). Running %s to refresh cookies.",
-            err,
-            NOTEBOOKLM_REFRESH_CMD_ENV,
-        )
-        # Canonicalize the storage path so different representations of the
-        # same physical file (relative vs absolute, with or without symlinks,
-        # ``~`` shorthand) hash to the same lock-registry / generation key.
-        # ``get_storage_path`` already returns a resolved path, but a
-        # caller-supplied ``storage_path`` may be relative or a symlink.
-        refresh_storage_path = (
-            (storage_path or get_storage_path(profile=profile)).expanduser().resolve()
-        )
-        refresh_key = str(refresh_storage_path)
-        # Snapshot the generation BEFORE acquiring the async lock so we can
-        # detect whether a concurrent refresh (potentially on a different
-        # event loop) bumped it while we were waiting. ``_REFRESH_STATE_LOCK``
-        # makes this read atomic with the later check-and-update below.
-        with _REFRESH_STATE_LOCK:
-            refresh_generation = _REFRESH_GENERATIONS.get(refresh_key, 0)
-        refresh_token = _REFRESH_ATTEMPTED_CONTEXT.set(True)
-        try:
-            async with _get_refresh_lock(refresh_storage_path):
-                # Bump generation ONLY after the subprocess succeeds AND
-                # storage is reloaded. An earlier implementation bumped the
-                # generation eagerly BEFORE ``_run_refresh_cmd`` — when the
-                # subprocess failed, the phantom bump made concurrent waiters
-                # short-circuit and proceed with stale storage.
-                #
-                # Re-check under the sync state lock so the read is atomic
-                # ACROSS event loops. The per-loop asyncio lock only
-                # serializes within a single loop; a second loop sharing this
-                # storage path holds its own asyncio.Lock.
-                with _REFRESH_STATE_LOCK:
-                    current_generation = _REFRESH_GENERATIONS.get(refresh_key, 0)
-                    # ``current > refresh_generation`` means another caller
-                    # (any loop) has SUCCESSFULLY refreshed since we observed
-                    # auth-expiry — we can skip ``_run_refresh_cmd`` and just
-                    # reload the freshly-written storage.
-                    should_run_refresh = current_generation <= refresh_generation
-                if should_run_refresh:
-                    # Cancel-safety: drive the subprocess through the shared
-                    # in-flight future. Same-loop concurrent callers coalesce
-                    # on the same subprocess. If THIS caller is cancelled
-                    # while the subprocess is in flight, we keep awaiting the
-                    # shielded future so the asyncio lock is NOT released
-                    # until the subprocess settles — otherwise a second
-                    # caller could spawn a duplicate concurrent refresh by
-                    # observing the mid-flight lock release.
-                    caller_cancelled = False
-                    subprocess_exc: BaseException | None = None
-                    while True:
-                        try:
-                            await _coalesced_run_refresh_cmd(
-                                refresh_key, refresh_storage_path, profile
-                            )
-                            break
-                        except asyncio.CancelledError:
-                            # Caller-side cancellation. Re-enter the await
-                            # so the shielded subprocess can settle while we
-                            # still hold the asyncio lock.
-                            caller_cancelled = True
-                            registry = _get_inflight_registry()
-                            with _REFRESH_STATE_LOCK:
-                                inflight = registry.get(refresh_key)
-                            if inflight is None or inflight.done():
-                                # Subprocess already settled; we absorbed the
-                                # cancellation. Inspect its terminal state.
-                                # Per the CodeRabbit finding on PR #621, the
-                                # ``_settle`` callback intentionally leaves
-                                # the done future in the registry so this
-                                # branch can still observe ``inflight.
-                                # exception()`` after a cancel/settle race.
-                                if inflight is not None:
-                                    if inflight.cancelled():
-                                        # Subprocess itself was cancelled —
-                                        # treat as failure (do not bump gen).
-                                        subprocess_exc = asyncio.CancelledError()
-                                    else:
-                                        subprocess_exc = inflight.exception()
-                                break
-                            # Otherwise loop — re-await the shielded future.
-                        except BaseException as exc:  # noqa: BLE001
-                            subprocess_exc = exc
-                            break
-
-                    if subprocess_exc is not None:
-                        # Subprocess failed — DO NOT bump generation.
-                        # Concurrent / subsequent waiters re-attempt the
-                        # refresh instead of short-circuiting on a phantom
-                        # bump.
-                        if caller_cancelled:
-                            # Caller cancellation takes priority for THIS
-                            # caller.
-                            raise asyncio.CancelledError() from subprocess_exc
-                        raise subprocess_exc
-
-                    # Subprocess succeeded AND we're about to reload
-                    # storage. Bump the generation now so other callers
-                    # (any loop) see the success and skip their own
-                    # subprocess. The bump is atomic across loops via
-                    # ``_REFRESH_STATE_LOCK``.
-                    with _REFRESH_STATE_LOCK:
-                        # ``max(...)`` defends against the rare interleaving
-                        # where another loop's pre-lock capture was AFTER
-                        # ours and bumped past us.
-                        existing = _REFRESH_GENERATIONS.get(refresh_key, 0)
-                        _REFRESH_GENERATIONS[refresh_key] = max(existing, refresh_generation + 1)
-
-                    if caller_cancelled:
-                        # Subprocess succeeded; generation bump persists for
-                        # other callers' benefit. THIS caller still
-                        # propagates cancellation rather than completing the
-                        # retry.
-                        raise asyncio.CancelledError()
-                fresh_jar = build_httpx_cookies_from_storage(refresh_storage_path)
-                _replace_cookie_jar(cookie_jar, fresh_jar)
-                # Capture the baseline NOW — after the wholesale replacement
-                # but before the retry fetch can mutate the jar.
-                post_refresh_snapshot = snapshot_cookie_jar(cookie_jar)
-            route_kwargs = {"authuser": authuser}
-            if account_email is not None:
-                route_kwargs["account_email"] = account_email
-            if force_authuser_query:
-                route_kwargs["force_authuser_query"] = True
-            csrf, session_id = await _fetch_tokens_with_jar(
-                cookie_jar, refresh_storage_path, **route_kwargs
-            )
-            return csrf, session_id, True, post_refresh_snapshot
-        finally:
-            _REFRESH_ATTEMPTED_CONTEXT.reset(refresh_token)
-
-
-def _update_cookie_input(target: CookieInput, fresh: DomainCookieMap) -> None:
-    """Update caller-provided cookies in place while preserving key style.
-
-    The caller's ``target`` may use any of the three accepted shapes (flat
-    ``name -> value``, legacy ``(name, domain) -> value``, or path-aware
-    ``(name, domain, path) -> value``). The freshly-fetched delta is always the
-    path-aware shape; we collapse it back to the caller's original shape so
-    they don't observe an in-place type change.
-    """
-    if any(isinstance(key, tuple) and len(key) == 2 for key in target):
-        # Legacy 2-tuple caller. Collapse the path dimension by keeping the
-        # first occurrence per (name, domain); for cookies that share name and
-        # domain at distinct paths this is lossy, but legacy callers had no
-        # way to express path either, so this matches their original contract.
-        legacy: dict[tuple[str, str], str] = {}
-        for (name, domain, _path), value in fresh.items():
-            legacy.setdefault((name, domain), value)
-        target.clear()
-        target.update(legacy)  # type: ignore[arg-type]
-        return
-
-    use_domain_keys = any(isinstance(key, tuple) for key in target)
-    target.clear()
-    if use_domain_keys:
-        target.update(fresh)  # type: ignore[arg-type]
-    else:
-        target.update(flatten_cookie_map(fresh))  # type: ignore[arg-type]
 
 
 # --- Keepalive poke ----------------------------------------------------------
-# Google's __Secure-1PSIDTS / __Secure-3PSIDTS cookies are the rotating freshness
-# partners of __Secure-1PSID / __Secure-3PSID. Their server-side validity window
-# is short (minutes-to-hours scale) and Google only emits a rotated value when
-# the client asks the identity surface to rotate. Pure RPC traffic against
-# notebooklm.google.com never triggers rotation, so a long-lived storage_state
-# silently stales out and every subsequent call fails with the
-# "Authentication expired or invalid" redirect (see issue #312).
-#
-# We POST to ``accounts.google.com/RotateCookies`` — the dedicated rotation
-# endpoint Chrome itself calls for legacy cookie rotation. Empirically validated
-# against both DBSC-bound (Playwright-minted) and unbound (Firefox-imported)
-# profiles in #345: a single POST returns 200 and sets fresh
-# ``__Secure-1PSIDTS`` / ``__Secure-3PSIDTS`` for either session type. The
-# response body declares the next-rotation interval (`["identity.hfcr",600]` —
-# 10 minutes), which sets the floor for how often this is worth firing.
-KEEPALIVE_ROTATE_URL = "https://accounts.google.com/RotateCookies"
-_KEEPALIVE_ROTATE_HEADERS = {
-    "Content-Type": "application/json",
-    "Origin": "https://accounts.google.com",
-}
-# Observed unbound RotateCookies request body — a placeholder pair Chrome sends
-# when there is no DBSC binding token to attest. Validated across Gemini-API and
-# the in-house experiments referenced in #345; kept in one place so it can be
-# changed if Google ever changes the contract.
-_KEEPALIVE_ROTATE_BODY = '[000,"-0000000000000000000"]'
-# Env-var name lives in ``notebooklm._auth.paths``; re-exported to keep
-# ``notebooklm.auth.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV`` (a public-surface
-# name listed in ``__all__``) resolving against this module.
+# Rotation throttle + ``RotateCookies`` POST bodies live in
+# ``notebooklm._auth.keepalive``. Re-exported here so every name that was
+# previously module-level on ``notebooklm.auth`` (constants, the per-loop /
+# per-profile lock registry, the public ``KEEPALIVE_ROTATE_URL`` listed in
+# ``__all__``, and white-box helpers like ``_poke_session`` /
+# ``_rotate_cookies``) keeps resolving against this module. The
+# ``_AuthFacadeModule`` write-through above mirrors monkeypatched values back
+# to the moved module so the bare-name lookups inside the moved bodies still
+# observe the patch.
+KEEPALIVE_ROTATE_URL = _auth_keepalive.KEEPALIVE_ROTATE_URL
+_KEEPALIVE_ROTATE_HEADERS = _auth_keepalive._KEEPALIVE_ROTATE_HEADERS
+_KEEPALIVE_ROTATE_BODY = _auth_keepalive._KEEPALIVE_ROTATE_BODY
+_KEEPALIVE_POKE_TIMEOUT = _auth_keepalive._KEEPALIVE_POKE_TIMEOUT
+_KEEPALIVE_RATE_LIMIT_SECONDS = _auth_keepalive._KEEPALIVE_RATE_LIMIT_SECONDS
+_KEEPALIVE_PRECISION_TOLERANCE = _auth_keepalive._KEEPALIVE_PRECISION_TOLERANCE
 NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV = _auth_paths.NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV
-_KEEPALIVE_POKE_TIMEOUT = 15.0
-# Skip the poke if storage_state.json was rewritten within this window — protects
-# accounts.google.com from rapid CLI loops (e.g. 10 sequential `notebooklm`
-# invocations) that would each fire their own rotation. Google's own declared
-# rotation cadence is 600 s, so 60 s is well under the useful interval.
-_KEEPALIVE_RATE_LIMIT_SECONDS = 60.0
-# Sub-second drift between ``time.time()`` and filesystem mtime can land a
-# freshly-written file fractionally in the future on some platforms (notably
-# Windows + older Python where the clock is coarser than NTFS mtime). Tolerate
-# that without re-opening the "future mtime wedges the guard" bug.
-_KEEPALIVE_PRECISION_TOLERANCE = 2.0
-# In-process state for rotation throttling, keyed per-profile and per-loop.
-#
-# - Per-profile (``storage_path``) so a rotation against profile A doesn't
-#   suppress profile B for the rate-limit window. A ``None`` key represents
-#   env-var auth.
-# - Per event loop because ``asyncio.Lock`` is loop-bound: a lock created in
-#   loop X cannot be safely awaited from loop Y. Multiple ``asyncio.run()``
-#   invocations in the same process, or worker threads each running their
-#   own loop, would otherwise trip ``RuntimeError`` or leave waiters in
-#   inconsistent state.
-#
-# The outer registry is a ``WeakKeyDictionary`` keyed on the loop *object* (not
-# its ``id()``): when a loop is garbage-collected, its inner dict is reclaimed
-# automatically. This bounds the lock cache for hosts that repeatedly create
-# short-lived loops, and avoids the ``id()``-reuse hazard where a closed loop's
-# stale lock could be returned to a new loop that happens to allocate at the
-# same address.
-#
-# ``_POKE_STATE_LOCK`` (sync ``threading.Lock``) protects two module-level
-# operations that must be atomic across threads:
-#   1. ``_get_poke_lock``: get-or-create the per-(loop, profile) async lock
-#      so two threads with their own loops don't race on dict insertion.
-#   2. ``_try_claim_rotation``: atomic check-and-stamp of the per-profile
-#      timestamp. Without this, two direct ``_rotate_cookies`` callers (e.g.
-#      two layer-2 keepalive loops on the same profile, or a layer-1 +
-#      layer-2 pair on different event loops) can each read a stale 0.0
-#      and both fire the POST.
-# It is held briefly, never across an ``await``, so it cannot deadlock against
-# any asyncio primitive.
-_POKE_STATE_LOCK = threading.Lock()
-_POKE_LOCKS_BY_LOOP: "weakref.WeakKeyDictionary[Any, dict[Path | None, asyncio.Lock]]" = (
-    weakref.WeakKeyDictionary()
-)
-# Monotonic timestamp of the last in-process poke *attempt* (success or
-# failure), keyed by storage_path. Stamped under ``_POKE_STATE_LOCK`` inside
-# ``_try_claim_rotation`` so the check-and-set is atomic across event loops
-# and across direct ``_rotate_cookies`` callers. Failure-stampede protection
-# comes for free: even a POST that times out has already claimed the slot,
-# so 10 fanned-out callers don't each wait 15 s on a hung server.
-_LAST_POKE_ATTEMPT_MONOTONIC: dict[Path | None, float] = {}
-
-
-def _get_poke_lock(storage_path: Path | None) -> asyncio.Lock:
-    """Return the ``asyncio.Lock`` for ``(running event loop, storage_path)``.
-
-    Lazily created on first call from each loop/profile pair so the lock binds
-    to the current loop. The dict mutation runs under the sync state lock so
-    concurrent threads with their own loops don't tear the registry.
-    """
-    loop = asyncio.get_running_loop()
-    with _POKE_STATE_LOCK:
-        per_loop = _POKE_LOCKS_BY_LOOP.get(loop)
-        if per_loop is None:
-            per_loop = {}
-            _POKE_LOCKS_BY_LOOP[loop] = per_loop
-        lock = per_loop.get(storage_path)
-        if lock is None:
-            lock = asyncio.Lock()
-            per_loop[storage_path] = lock
-        return lock
-
-
-def _try_claim_rotation(storage_path: Path | None) -> bool:
-    """Atomic check-and-claim of the per-profile rotation slot.
-
-    Returns ``True`` if the caller may proceed with the POST, ``False`` if
-    another in-process call has claimed the slot within the rate-limit
-    window. The claim and the timestamp update happen under one sync lock,
-    so this is safe across event loops and across direct
-    ``_rotate_cookies`` callers (layer-2 keepalive loops, etc.) — neither
-    of which holds the per-loop async lock used by layer-1 ``_poke_session``.
-    """
-    with _POKE_STATE_LOCK:
-        last = _LAST_POKE_ATTEMPT_MONOTONIC.get(storage_path, 0.0)
-        now = time.monotonic()
-        if last > 0 and (now - last) < _KEEPALIVE_RATE_LIMIT_SECONDS:
-            return False
-        _LAST_POKE_ATTEMPT_MONOTONIC[storage_path] = now
-        return True
-
-
-# Rotation sentinel path lives in ``notebooklm._auth.paths``; re-exported so
-# tests and internal callers keep resolving the white-box affordance against
-# ``notebooklm.auth``.
+# The state dicts and locks are SHARED by identity with the moved module so
+# ``tests/conftest.py`` invariants — which clear these dicts on the
+# ``notebooklm.auth`` attribute — propagate into the keepalive module's own
+# bodies. (Direct assignment from the same object preserves identity.)
+_POKE_STATE_LOCK = _auth_keepalive._POKE_STATE_LOCK
+_POKE_LOCKS_BY_LOOP = _auth_keepalive._POKE_LOCKS_BY_LOOP
+_LAST_POKE_ATTEMPT_MONOTONIC = _auth_keepalive._LAST_POKE_ATTEMPT_MONOTONIC
+_get_poke_lock = _auth_keepalive._get_poke_lock
+_try_claim_rotation = _auth_keepalive._try_claim_rotation
+_file_lock_try_exclusive = _auth_keepalive._file_lock_try_exclusive
+_is_recently_rotated = _auth_keepalive._is_recently_rotated
+_poke_session = _auth_keepalive._poke_session
+_rotate_cookies = _auth_keepalive._rotate_cookies
+# Rotation sentinel path lives in ``_auth.paths``; the keepalive module also
+# aliases it locally. Re-exported here for white-box callers that resolve it
+# against ``notebooklm.auth``.
 _rotation_lock_path = _auth_paths._rotation_lock_path
 
 
-@contextlib.contextmanager
-def _file_lock_try_exclusive(lock_path: Path) -> Iterator[bool]:
-    """Non-blocking exclusive flock. Yields ``True`` if caller should proceed.
-
-    Mirrors :func:`_file_lock_exclusive` but with ``LOCK_NB`` semantics:
-      - genuine contention (another process holds the lock) → yield ``False``,
-        caller skips its work (the holder is rotating; we don't need to)
-      - lock infrastructure unavailable (read-only dir, NFS without flock,
-        permission denied) → yield ``True``, caller **fails open** and
-        proceeds without coordination, since waiting forever for an
-        unworkable lock would permanently suppress rotation.
-    """
-    with _file_lock(lock_path, blocking=False, log_prefix="rotate lock") as state:
-        # "held" → True (proceed, we own it); "unavailable" → True (fail open);
-        # "contended" → False (someone else is rotating, skip).
-        yield state != "contended"
-
-
-def _is_recently_rotated(storage_path: Path | None) -> bool:
-    """Return True if ``storage_path`` was modified within the rate-limit window.
-
-    A meaningfully-future mtime (clock skew, NTP step, restored file, NFS drift)
-    is treated as **not recent**: we'd rather fire one extra rotation than wedge
-    the guard until wall time catches up. The lower bound is a small negative
-    tolerance to absorb sub-second drift between ``time.time()`` and filesystem
-    mtime resolution (notably Windows NTFS at lower clock granularity), which
-    can otherwise classify a freshly-written file as future-dated. A
-    missing/unreadable file falls through to the not-recent default.
-    """
-    if storage_path is None:
-        return False
-    try:
-        mtime = storage_path.stat().st_mtime
-    except OSError:
-        return False
-    age = time.time() - mtime
-    return -_KEEPALIVE_PRECISION_TOLERANCE <= age <= _KEEPALIVE_RATE_LIMIT_SECONDS
-
-
-async def _poke_session(client: httpx.AsyncClient, storage_path: Path | None = None) -> None:
-    """Best-effort POST to ``accounts.google.com/RotateCookies`` to rotate SIDTS.
-
-    Failures are logged at DEBUG and swallowed: this is purely a freshness
-    optimisation. The caller's request to notebooklm.google.com is the
-    authoritative health check.
-
-    Three layered guards keep the POST from stampeding ``accounts.google.com``:
-
-    1. **Disk mtime fast path.** If ``storage_state.json`` was rewritten within
-       the rate-limit window, skip without any locking. Covers the common
-       sequential-CLI case at zero cost.
-    2. **In-process ``asyncio.Lock``.** Inside the lock, re-check the disk
-       mtime (a sibling task may have rotated and saved during the wait) and
-       a monotonic in-memory timestamp (a sibling may have rotated but not
-       yet saved). Together these dedupe an ``asyncio.gather`` fan-out so
-       only one POST fires per process per rate-limit window.
-    3. **Cross-process non-blocking flock.** When ``storage_path`` is set, try
-       to acquire ``.storage_state.json.rotate.lock`` with ``LOCK_NB``. If
-       another process holds it, skip — they're rotating right now. This
-       handles ``xargs -P``, parallel MCP workers, and similar parallel
-       launches without queueing.
-
-       Known gap: the flock is released as soon as the POST returns, but the
-       caller's storage-state save happens *after* this function returns. A
-       second process that starts in that narrow window observes the still-
-       stale on-disk mtime and an unheld flock, and will fire its own POST.
-       Worst case is two pokes back-to-back across processes — bounded, not
-       a stampede. Closing this fully would require holding the flock past
-       ``_poke_session`` until the save completes, which would entangle this
-       throttle with the caller's lifecycle. Not worth the complexity here.
-
-    Args:
-        client: Live ``httpx.AsyncClient`` whose cookie jar should receive the
-            rotated ``Set-Cookie``.
-        storage_path: Optional path to the on-disk ``storage_state.json``. When
-            provided, gates the poke via the disk mtime and the cross-process
-            flock; when ``None`` (env-var auth) only the in-process serializer
-            applies.
-
-    Set ``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` to disable (e.g., environments
-    that block ``accounts.google.com``).
-    """
-    if os.environ.get(NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV) == "1":
-        return
-    if _is_recently_rotated(storage_path):
-        logger.debug(
-            "Keepalive RotateCookies skipped: %s rotated within %.0fs",
-            storage_path,
-            _KEEPALIVE_RATE_LIMIT_SECONDS,
-        )
-        return
-
-    async with _get_poke_lock(storage_path):
-        # Re-check after acquiring the per-(loop, profile) async lock — another
-        # task in this loop may have rotated and persisted while we were waiting.
-        if _is_recently_rotated(storage_path):
-            logger.debug(
-                "Keepalive RotateCookies skipped: storage refreshed while waiting for lock"
-            )
-            return
-
-        rotate_lock_path = _rotation_lock_path(storage_path)
-        if rotate_lock_path is None:
-            # No on-disk path → cross-process flock has no anchor. The
-            # atomic claim inside ``_rotate_cookies`` is the only gate.
-            await _rotate_cookies(client, storage_path)
-            return
-
-        with _file_lock_try_exclusive(rotate_lock_path) as acquired:
-            if not acquired:
-                logger.debug(
-                    "Keepalive RotateCookies skipped: %s held by another process",
-                    rotate_lock_path,
-                )
-                return
-            # One last disk recheck: another process may have completed its
-            # rotation + save between our top-of-function check and acquiring
-            # this flock.
-            if _is_recently_rotated(storage_path):
-                logger.debug(
-                    "Keepalive RotateCookies skipped: storage refreshed before flock acquired"
-                )
-                return
-            # ``_rotate_cookies`` does its own atomic claim — if another
-            # in-process caller (e.g. a sibling layer-2 keepalive loop on a
-            # different event loop) just claimed this profile, the POST is
-            # skipped here too.
-            await _rotate_cookies(client, storage_path)
-
-
-async def _rotate_cookies(client: httpx.AsyncClient, storage_path: Path | None = None) -> None:
-    """Fire the ``RotateCookies`` POST. Bare operation; no guards.
-
-    Used directly by the layer-2 keepalive loop, which is already self-paced
-    via ``keepalive_min_interval`` and does not need the layer-1 dedup
-    serialization. ``_poke_session`` calls this through its guard stack.
-
-    Honours ``NOTEBOOKLM_DISABLE_KEEPALIVE_POKE=1`` so a single env-var disables
-    every rotation path (the layer-1 wrapper *and* the layer-2 loop).
-
-    Stamps the per-profile attempt timestamp **before** the network await so
-    that concurrent layer-1 callers (and concurrent layer-2 keepalive loops on
-    other ``NotebookLMClient`` instances watching the same profile) see "this
-    profile is rotating right now" and skip the POST. Stamping early covers:
-      - the layer-1/layer-2 overlap where one is mid-flight and another arrives
-      - failure stampedes — a 15 s timeout against a hung accounts.google.com
-        does not let 10 fanned-out callers each wait the full timeout
-
-    Does not propagate ``httpx.HTTPError``: this is a best-effort freshness
-    call, not a health check.
-
-    Args:
-        client: Live ``httpx.AsyncClient`` whose cookie jar should receive the
-            rotated ``Set-Cookie``.
-        storage_path: Optional storage_state.json path used to key the
-            in-process attempt timestamp by profile. ``None`` = env-var auth.
-    """
-    if os.environ.get(NOTEBOOKLM_DISABLE_KEEPALIVE_POKE_ENV) == "1":
-        return
-    # Atomic check-and-claim: another caller (a sibling layer-2 keepalive
-    # loop, a layer-1 ``_poke_session`` on a different event loop, etc.) may
-    # have already taken the slot for this profile within the rate-limit
-    # window. ``_try_claim_rotation`` is the *only* authoritative gate;
-    # everything above it in ``_poke_session`` is a fast-path optimisation.
-    if not _try_claim_rotation(storage_path):
-        logger.debug(
-            "Keepalive RotateCookies skipped: %s claimed by another in-process caller",
-            storage_path,
-        )
-        return
-    try:
-        # ``follow_redirects=True`` is defensive: empirically RotateCookies
-        # answers 200 directly with the rotated Set-Cookie, but if Google ever
-        # routes a 30x through an identity hop we still pick up cookies from
-        # the terminal response.
-        response = await client.post(
-            KEEPALIVE_ROTATE_URL,
-            headers=_KEEPALIVE_ROTATE_HEADERS,
-            content=_KEEPALIVE_ROTATE_BODY,
-            follow_redirects=True,
-            timeout=_KEEPALIVE_POKE_TIMEOUT,
-        )
-        # httpx does not auto-raise on 4xx/5xx; without this, a 429 or 5xx from
-        # Google would log nothing and the caller would proceed assuming the
-        # rotation happened.
-        response.raise_for_status()
-    except httpx.HTTPError as exc:
-        logger.debug("Keepalive RotateCookies POST failed (non-fatal): %s", exc)
-
-
-async def _fetch_tokens_with_jar(
-    cookie_jar: httpx.Cookies,
-    storage_path: Path | None = None,
-    *,
-    authuser: int = 0,
-    account_email: str | None = None,
-    force_authuser_query: bool = False,
-) -> tuple[str, str]:
-    """Internal: fetch CSRF and session tokens using a pre-built cookie jar.
-
-    This is the single implementation for all token-fetch paths. All public
-    functions (fetch_tokens, fetch_tokens_with_domains) delegate to this.
-
-    Before fetching tokens, makes a best-effort POST to accounts.google.com to
-    rotate __Secure-1PSIDTS; see ``_poke_session``. The poke may be skipped if
-    ``storage_path`` was modified within the rate-limit window — that path
-    relies on the existing on-disk cookies still being fresh.
-
-    Args:
-        cookie_jar: httpx.Cookies jar with auth cookies (domain-preserving or fallback).
-        storage_path: Optional storage_state.json path, forwarded to
-            ``_poke_session`` to gate the rotation poke.
-        authuser: Google account index to authenticate as. ``0`` is the
-            default account.
-        account_email: Stable account email to use instead of the integer
-            index when known.
-        force_authuser_query: Append ``?authuser=0`` when callers explicitly
-            requested account index 0. Implicit default-account calls leave the
-            URL byte-identical to pre-multi-account behavior.
-
-    Returns:
-        Tuple of (csrf_token, session_id)
-
-    Raises:
-        httpx.HTTPError: If request fails
-        ValueError: If tokens cannot be extracted from response
-    """
-    logger.debug("Fetching CSRF and session tokens from NotebookLM")
-
-    async with httpx.AsyncClient(cookies=cookie_jar) as client:
-        await _poke_session(client, storage_path)
-
-        url = f"{get_base_url()}/"
-        if account_email or authuser or force_authuser_query:
-            url = f"{url}?{authuser_query(authuser, account_email)}"
-        response = await client.get(
-            url,
-            follow_redirects=True,
-            timeout=30.0,
-        )
-        response.raise_for_status()
-
-        final_url = str(response.url)
-
-        # Check if we were redirected to login
-        if is_google_auth_redirect(final_url):
-            raise ValueError(
-                "Authentication expired or invalid. "
-                "Redirected to: " + _safe_url(final_url) + "\n"
-                "Run 'notebooklm login' to re-authenticate."
-            )
-
-        csrf = extract_csrf_from_html(response.text, final_url)
-        session_id = extract_session_id_from_html(response.text, final_url)
-
-        # httpx copies the input Cookies object into the client. Copy any
-        # redirect Set-Cookie updates back to the caller's jar before it is
-        # persisted.
-        _replace_cookie_jar(cookie_jar, client.cookies)
-
-        logger.debug("Authentication tokens obtained successfully")
-        return csrf, session_id
-
-
-# Token-route resolver lives in ``notebooklm._auth.headers``; re-exported so
-# internal callers (``fetch_tokens``, ``fetch_tokens_with_domains``) and any
-# white-box tests keep resolving the helper against ``notebooklm.auth``.
-_resolve_token_route_kwargs = _auth_headers._resolve_token_route_kwargs
-
-
-async def fetch_tokens(
-    cookies: CookieInput,
-    storage_path: Path | None = None,
-    profile: str | None = None,
-    *,
-    authuser: int | None = None,
-    account_email: str | None = None,
-) -> tuple[str, str]:
-    """Fetch tokens from a cookie mapping. For backward compatibility.
-
-    Prefer AuthTokens.from_storage() which preserves cookie domains. If
-    ``NOTEBOOKLM_REFRESH_CMD`` is set and auth has expired, the command is run
-    through the platform shell, cookies are reloaded from ``storage_path`` or
-    the active profile storage path, and token fetch is retried once. Refresh
-    commands receive ``NOTEBOOKLM_REFRESH_STORAGE_PATH`` and
-    ``NOTEBOOKLM_REFRESH_PROFILE`` in their environment.
-
-    Args:
-        cookies: Google auth cookies. Mutated in place on refresh.
-        storage_path: Optional storage_state.json path to reload after refresh.
-        profile: Optional profile name exposed to the refresh command.
-        authuser: Optional explicit Google account index. Defaults to the
-            persisted profile value, or 0 when none exists.
-        account_email: Optional explicit Google account email. When provided,
-            it is used as the auth routing value instead of the integer index.
-
-    Returns:
-        Tuple of (csrf_token, session_id)
-
-    Raises:
-        httpx.HTTPError: If request fails
-        ValueError: If tokens cannot be extracted from response
-        RuntimeError: If ``NOTEBOOKLM_REFRESH_CMD`` is set but fails
-    """
-    jar = build_cookie_jar(cookies=cookies, storage_path=storage_path)
-    route_kwargs = _resolve_token_route_kwargs(
-        storage_path,
-        authuser=authuser,
-        account_email=account_email,
-    )
-    csrf, session_id, refreshed, _post_refresh_snapshot = await _fetch_tokens_with_refresh(
-        jar, storage_path, profile, **route_kwargs
-    )
-    if refreshed:
-        fresh = _cookie_map_from_jar(jar)
-        _update_cookie_input(cookies, fresh)
-    return csrf, session_id
-
-
-async def fetch_tokens_with_domains(
-    path: Path | None = None,
-    profile: str | None = None,
-    *,
-    authuser: int | None = None,
-    account_email: str | None = None,
-) -> tuple[str, str]:
-    """Fetch tokens with domain-preserving cookies from storage.
-
-    Used by CLI helpers. Loads storage, builds jar, fetches tokens, optionally
-    runs NOTEBOOKLM_REFRESH_CMD on auth expiry, and persists any refreshed
-    cookies back.
-
-    Args:
-        path: Path to storage_state.json. If provided, takes precedence over env vars.
-        profile: Optional profile name exposed to the refresh command.
-        authuser: Optional explicit Google account index. Defaults to the
-            persisted profile value, or 0 when none exists.
-        account_email: Optional explicit Google account email. When provided,
-            it is used as the auth routing value instead of the integer index.
-
-    Returns:
-        Tuple of (csrf_token, session_id)
-
-    Raises:
-        FileNotFoundError: If storage file doesn't exist.
-        httpx.HTTPError: If request fails.
-        ValueError: If tokens cannot be extracted from response.
-        RuntimeError: If ``NOTEBOOKLM_REFRESH_CMD`` is set but fails.
-    """
-    if path is None and (profile is not None or "NOTEBOOKLM_AUTH_JSON" not in os.environ):
-        path = get_storage_path(profile=profile)
-    jar = build_httpx_cookies_from_storage(path)
-    route_kwargs = _resolve_token_route_kwargs(path, authuser=authuser, account_email=account_email)
-    # Capture the open-time snapshot before any rotation could fire. The
-    # snapshot is the input to the dirty-flag/delta merge that closes the
-    # stale-overwrite-fresh race (docs/auth-keepalive.md §3.4.1).
-    snapshot = snapshot_cookie_jar(jar)
-    csrf, session_id, refreshed, post_refresh_snapshot = await _fetch_tokens_with_refresh(
-        jar, path, profile, **route_kwargs
-    )
-    if refreshed and post_refresh_snapshot is not None:
-        # NOTEBOOKLM_REFRESH_CMD replaced the jar wholesale. Use the snapshot
-        # captured immediately after the replacement (before the retry fetch
-        # added redirect Set-Cookies); re-snapshotting here would let those
-        # retry rotations be absorbed into the baseline and never reach disk.
-        snapshot = post_refresh_snapshot
-    # Offload the blocking storage save to a worker thread so the
-    # atomic-replace + fsync + flock can't stall the event loop on
-    # slow filesystems.
-    await asyncio.to_thread(save_cookies_to_storage, jar, path, original_snapshot=snapshot)
-    return csrf, session_id
+# --- Refresh-cmd + token-fetch entry points ---------------------------------
+# All refresh coordination and the public ``fetch_tokens`` /
+# ``fetch_tokens_with_domains`` entry points live in
+# ``notebooklm._auth.refresh``. Re-exported so the public surface
+# (``fetch_tokens`` + ``fetch_tokens_with_domains`` listed in ``__all__``) and
+# the white-box surface (lock registries, ContextVar, ``_run_refresh_cmd``
+# carrying the tier-9 E (P1-18) redaction logic, etc.) keep resolving against
+# ``notebooklm.auth``. The ``_AuthFacadeModule`` write-through above mirrors
+# monkeypatched values back to the moved module so existing test patterns
+# (``monkeypatch.setattr(auth_mod, "_run_refresh_cmd", fake)``,
+# ``..., "_fetch_tokens_with_jar"``, ``..., "_get_refresh_lock"``,
+# ``..., "snapshot_cookie_jar"``, ``..., "build_httpx_cookies_from_storage"``)
+# keep working.
+_REFRESH_ATTEMPTED_CONTEXT = _auth_refresh._REFRESH_ATTEMPTED_CONTEXT
+_REFRESH_STATE_LOCK = _auth_refresh._REFRESH_STATE_LOCK
+_REFRESH_LOCKS_BY_LOOP = _auth_refresh._REFRESH_LOCKS_BY_LOOP
+_REFRESH_GENERATIONS = _auth_refresh._REFRESH_GENERATIONS
+_REFRESH_INFLIGHT_BY_LOOP = _auth_refresh._REFRESH_INFLIGHT_BY_LOOP
+_REFRESH_INFLIGHT_TASKS = _auth_refresh._REFRESH_INFLIGHT_TASKS
+_AUTH_ERROR_SIGNALS = _auth_refresh._AUTH_ERROR_SIGNALS
+_get_inflight_registry = _auth_refresh._get_inflight_registry
+_coalesced_run_refresh_cmd = _auth_refresh._coalesced_run_refresh_cmd
+_get_refresh_lock = _auth_refresh._get_refresh_lock
+_should_try_refresh = _auth_refresh._should_try_refresh
+_split_refresh_cmd = _auth_refresh._split_refresh_cmd
+_run_refresh_cmd = _auth_refresh._run_refresh_cmd
+_fetch_tokens_with_refresh = _auth_refresh._fetch_tokens_with_refresh
+_fetch_tokens_with_jar = _auth_refresh._fetch_tokens_with_jar
+fetch_tokens = _auth_refresh.fetch_tokens
+fetch_tokens_with_domains = _auth_refresh.fetch_tokens_with_domains

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1261,3 +1261,227 @@ def test_error_injection_symbols_resolve_through_core():
     assert _core.ERROR_INJECT_ENV_VAR is _core_error_injection.ERROR_INJECT_ENV_VAR
     assert _core._get_error_injection_mode is _core_error_injection._get_error_injection_mode
     assert _core._SyntheticErrorTransport is _core_error_injection._SyntheticErrorTransport
+
+
+# ---------------------------------------------------------------------------
+# Tier-10 PR-B-high: semantic patch-and-execute tests for the keepalive +
+# refresh extraction.
+#
+# These do NOT just smoke-check that ``hasattr(notebooklm.auth, X)`` resolves —
+# they patch via ``auth_mod.X = fake`` and then EXECUTE the moved caller to
+# prove the patch actually rebinds the call site inside the moved module.
+# Without the facade write-through wiring this would silently regress when a
+# caller resolves the name from its own module's namespace.
+#
+# The five names covered match the high-risk signoff list:
+#   _run_refresh_cmd, _fetch_tokens_with_jar, _get_refresh_lock,
+#   _poke_session, _rotate_cookies.
+# ---------------------------------------------------------------------------
+
+
+def test_auth_keepalive_facade_module_wires_keepalive_names() -> None:
+    """``_AuthFacadeModule`` exposes every name in ``_AUTH_KEEPALIVE_FACADE_NAMES``."""
+    import notebooklm.auth as auth
+    from notebooklm._auth import keepalive
+
+    for name in auth._AUTH_KEEPALIVE_FACADE_NAMES:
+        assert hasattr(keepalive, name), f"_auth.keepalive missing {name}"
+        assert getattr(auth, name) is getattr(keepalive, name), f"identity drift for {name}"
+
+
+def test_auth_refresh_facade_module_wires_refresh_names() -> None:
+    """``_AuthFacadeModule`` exposes every name in ``_AUTH_REFRESH_FACADE_NAMES``."""
+    import notebooklm.auth as auth
+    from notebooklm._auth import refresh
+
+    for name in auth._AUTH_REFRESH_FACADE_NAMES:
+        assert hasattr(refresh, name), f"_auth.refresh missing {name}"
+        assert getattr(auth, name) is getattr(refresh, name), f"identity drift for {name}"
+
+
+def test_auth_keepalive_state_dicts_share_identity_with_seam() -> None:
+    """``tests/conftest.py`` clears ``_LAST_POKE_ATTEMPT_MONOTONIC`` and
+    ``_POKE_LOCKS_BY_LOOP`` on ``notebooklm.auth``. The dicts MUST be the same
+    objects in the keepalive seam so mutations through the facade flow into
+    the moved bodies that consume the dicts.
+    """
+    import notebooklm.auth as auth
+    from notebooklm._auth import keepalive
+
+    assert auth._LAST_POKE_ATTEMPT_MONOTONIC is keepalive._LAST_POKE_ATTEMPT_MONOTONIC
+    assert auth._POKE_LOCKS_BY_LOOP is keepalive._POKE_LOCKS_BY_LOOP
+
+
+def test_auth_subprocess_reexport_lets_tests_patch_run() -> None:
+    """White-box tests patch ``auth_mod.subprocess.run`` to intercept the
+    refresh-cmd subprocess. The re-exported ``subprocess`` module must be the
+    standard library module shared with ``_auth.refresh``.
+    """
+    import subprocess
+
+    import notebooklm.auth as auth
+    from notebooklm._auth import refresh
+
+    assert auth.subprocess is subprocess
+    assert refresh.subprocess is subprocess
+
+
+def test_auth_facade_propagates_run_refresh_cmd_patch_to_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEMANTIC: patching ``auth_mod._run_refresh_cmd = fake`` must rebind the
+    name inside ``_auth.refresh`` so ``_coalesced_run_refresh_cmd`` resolves
+    the fake instead of the original.
+    """
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import refresh
+
+    sentinel = object()
+
+    async def fake(*args: object, **kwargs: object) -> object:
+        return sentinel
+
+    monkeypatch.setattr(auth_mod, "_run_refresh_cmd", fake)
+    assert refresh._run_refresh_cmd is fake
+    # ``_coalesced_run_refresh_cmd`` spawns ``_run_refresh_cmd`` through a bare
+    # name lookup in ``refresh.py``; the facade write-through must have
+    # rebound that name for the patch to take effect.
+
+
+@pytest.mark.asyncio
+async def test_auth_facade_propagates_fetch_tokens_with_jar_patch_to_seam(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """SEMANTIC: patching ``auth_mod._fetch_tokens_with_jar = fake`` must rebind
+    the name inside ``_auth.refresh`` so ``_fetch_tokens_with_refresh`` calls
+    the fake when no refresh is needed.
+    """
+    import httpx
+
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import refresh
+
+    calls: list[str] = []
+
+    async def fake_jar(jar, storage_path, **kwargs):
+        calls.append("called")
+        return "csrf-fake", "session-fake"
+
+    monkeypatch.setattr(auth_mod, "_fetch_tokens_with_jar", fake_jar)
+    assert refresh._fetch_tokens_with_jar is fake_jar
+
+    csrf, sid, refreshed, snapshot = await auth_mod._fetch_tokens_with_refresh(
+        httpx.Cookies(), tmp_path / "missing.json"
+    )
+    assert calls == ["called"]
+    assert csrf == "csrf-fake"
+    assert sid == "session-fake"
+    assert refreshed is False
+    assert snapshot is None
+
+
+def test_auth_facade_propagates_get_refresh_lock_patch_to_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEMANTIC: patching ``auth_mod._get_refresh_lock = fake`` must rebind the
+    name inside ``_auth.refresh`` so ``_fetch_tokens_with_refresh`` picks up
+    the fake when it acquires the per-loop lock.
+    """
+    import asyncio
+
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import refresh
+
+    def fake_lock(_p):
+        return asyncio.Lock()
+
+    monkeypatch.setattr(auth_mod, "_get_refresh_lock", fake_lock)
+    assert refresh._get_refresh_lock is fake_lock
+
+
+def test_auth_facade_propagates_poke_session_patch_to_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEMANTIC: patching ``auth_mod._poke_session = fake`` must rebind the
+    name in BOTH ``_auth.keepalive`` (the owner) AND ``_auth.refresh`` (which
+    aliased ``_poke_session`` from keepalive at import time). The refresh
+    module's ``_fetch_tokens_with_jar`` resolves ``_poke_session`` as a bare
+    name; without the cross-module mirror the patch would only land in the
+    keepalive owner.
+    """
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import keepalive, refresh
+
+    async def fake_poke(client, sp=None):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_poke_session", fake_poke)
+    assert keepalive._poke_session is fake_poke
+    assert refresh._poke_session is fake_poke
+
+
+def test_auth_facade_propagates_rotate_cookies_patch_to_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEMANTIC: patching ``auth_mod._rotate_cookies = fake`` must rebind the
+    name inside ``_auth.keepalive`` so ``_poke_session`` calls the fake.
+    """
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import keepalive
+
+    async def fake_rot(client, sp=None):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_rotate_cookies", fake_rot)
+    assert keepalive._rotate_cookies is fake_rot
+
+
+def test_auth_facade_propagates_snapshot_cookie_jar_to_refresh_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEMANTIC: ``snapshot_cookie_jar`` physically lives in ``_auth.storage``
+    but ``_auth.refresh`` aliased it at import time as a rebindable bare
+    name. Patching it on ``auth_mod`` must mirror into BOTH ``_auth.storage``
+    (via ``_AUTH_STORAGE_FACADE_NAMES``) AND ``_auth.refresh`` (via the
+    cross-module mirror) so the moved ``_fetch_tokens_with_refresh`` /
+    ``fetch_tokens_with_domains`` bodies observe the patch.
+    """
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import refresh, storage
+
+    def fake_snap(_jar):
+        return None
+
+    monkeypatch.setattr(auth_mod, "snapshot_cookie_jar", fake_snap)
+    assert storage.snapshot_cookie_jar is fake_snap
+    assert refresh.snapshot_cookie_jar is fake_snap
+
+
+def test_auth_facade_propagates_build_httpx_cookies_to_refresh_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SEMANTIC: ``build_httpx_cookies_from_storage`` physically lives in
+    ``_auth.cookies`` but the refresh path calls it as a bare name. Patching
+    on ``auth_mod`` must mirror into ``_auth.refresh``.
+    """
+    import httpx
+
+    import notebooklm.auth as auth_mod
+    from notebooklm._auth import refresh
+
+    def fake_build(_p):
+        return httpx.Cookies()
+
+    monkeypatch.setattr(auth_mod, "build_httpx_cookies_from_storage", fake_build)
+    assert refresh.build_httpx_cookies_from_storage is fake_build
+
+
+def test_auth_update_cookie_input_lives_in_cookies_module() -> None:
+    """``_update_cookie_input`` was moved into ``_auth.cookies`` (cohesive
+    with ``flatten_cookie_map`` which it consumes); the public facade keeps
+    re-exporting it for the ``_AUTH_FIRST_PARTY_COMPATIBILITY_NAMES`` manifest.
+    """
+    import notebooklm.auth as auth
+    from notebooklm._auth import cookies
+
+    assert auth._update_cookie_input is cookies._update_cookie_input

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -988,6 +988,9 @@ def test_auth_subpackage_init_wires_new_seam_modules() -> None:
     assert hasattr(_auth, "paths")
     assert hasattr(_auth, "extraction")
     assert hasattr(_auth, "headers")
+    # Tier-10 PR-B-high additions:
+    assert hasattr(_auth, "keepalive")
+    assert hasattr(_auth, "refresh")
 
 
 def test_auth_secondary_binding_reset_syncs_to_cookie_policy(


### PR DESCRIPTION
## Summary

Final tier-10 auth-decomposition PR, shrinking `src/notebooklm/auth.py` from **1564 → 722 LOC** by extracting the keepalive + refresh-cmd flows into two new private modules (`_auth/keepalive.py`, `_auth/refresh.py`), with the `_AuthFacadeModule` write-through extended so every existing white-box monkeypatch site keeps working unchanged.

**HIGH-RISK** because the moved bodies are the cross-loop / cross-process lock-ordering hot spots in the auth surface (the rotation throttle, the per-loop refresh-cmd coalescing, the subprocess driver), and roughly two dozen unit + integration tests reach into them via `monkeypatch.setattr(auth_mod, ...)`.

## Changes

### LOC accounting

| File | Before | After | Net |
|------|-------:|------:|----:|
| `src/notebooklm/auth.py` | 1564 | 722 | -842 |
| `src/notebooklm/_auth/keepalive.py` | (new) | 355 | +355 |
| `src/notebooklm/_auth/refresh.py` | (new) | 737 | +737 |
| `src/notebooklm/_auth/cookies.py` | (existing) | +24 | +24 |
| `src/notebooklm/_auth/__init__.py` | (existing) | +2 | +2 |
| `tests/unit/test_public_shims.py` | (existing) | +225 | +225 |

### New modules

- **`_auth/keepalive.py`** owns `KEEPALIVE_ROTATE_URL`, the `_POKE_LOCKS_BY_LOOP` / `_LAST_POKE_ATTEMPT_MONOTONIC` state, the layered guards (`_get_poke_lock` / `_try_claim_rotation` / `_file_lock_try_exclusive` / `_is_recently_rotated`), and `_poke_session` / `_rotate_cookies`. Logger pinned to `"notebooklm.auth"` (NOT `__name__`) so existing `caplog` assertions keep matching.
- **`_auth/refresh.py`** owns the `_REFRESH_LOCKS_BY_LOOP` / `_REFRESH_INFLIGHT_BY_LOOP` registries, `_coalesced_run_refresh_cmd`, `_run_refresh_cmd` (carrying the tier-9 E P1-18 two-channel disclosure redaction verbatim), `_fetch_tokens_with_refresh`, `_fetch_tokens_with_jar`, and the public `fetch_tokens` / `fetch_tokens_with_domains` entry points.
- **`_auth/cookies.py`** gains `_update_cookie_input` (option a per plan — cohesive with `flatten_cookie_map`, its only dependency).

### `_AuthFacadeModule` extension

Two new name-sets route reads (via `__getattribute__`) and mirror writes (via `__setattr__`) to the moved modules:

- `_AUTH_KEEPALIVE_FACADE_NAMES` (15 names) → `_auth.keepalive`
- `_AUTH_REFRESH_FACADE_NAMES` (17 names) → `_auth.refresh`

Plus two **cross-module dependency mirror sets** for names that physically live in one seam but are aliased into another as rebindable bare-name slots (so the moved bodies' bare-name lookups still see the patched value):

- `_REFRESH_DEP_MIRROR_NAMES`: 13 names including `snapshot_cookie_jar`, `save_cookies_to_storage`, `build_httpx_cookies_from_storage`, `get_storage_path`, the cookie helpers used by the refresh path
- `_KEEPALIVE_DEP_MIRROR_NAMES`: `_file_lock`, `_rotation_lock_path`

The `_poke_session` slot is mirrored explicitly from `auth` → `_auth.refresh` so `_fetch_tokens_with_jar` (now in refresh.py) observes any monkeypatch on `notebooklm.auth._poke_session`.

## Invariants preserved

- **`tests/conftest.py:34` invariants**: `_LAST_POKE_ATTEMPT_MONOTONIC` and `_POKE_LOCKS_BY_LOOP` are shared by **identity** (direct-assignment) between `notebooklm.auth` and `_auth.keepalive`, so `.clear()` mutations through the facade propagate into the moved bodies. Verified by `test_auth_keepalive_state_dicts_share_identity_with_seam`.
- **`auth.subprocess` re-export** preserved (white-box tests patch `auth_mod.subprocess.run` per `test_refresh_cmd_shlex.py:73`). Verified by `test_auth_subprocess_reexport_lets_tests_patch_run`.
- **Tier-9 E (P1-18) `_run_refresh_cmd` redaction** carried verbatim — Codex confirmed byte-level identity against `origin/main:src/notebooklm/auth.py`. User-facing `RuntimeError` surfaces only exit code + executable basename; full stdout/stderr only reach the DEBUG logger.
- **`_settle` callback in `_coalesced_run_refresh_cmd`** intentionally leaves the done future in the registry (CodeRabbit PR #621 finding) so the `except CancelledError` branch can still inspect `inflight.exception()`.
- **All 17 `monkeypatch.setattr(auth_mod, "X", ...)` test targets** verified to land in an existing facade or dependency mirror.

## Signoff (all 8 items verified)

- [x] (a) `tests/unit/test_auth_cookie_save_race.py` (1775 LOC) passes
- [x] (b) `tests/unit/concurrency/test_auth_load_blocks_loop.py` passes
- [x] (c) `tests/integration/test_auth_refresh_vcr.py` passes
- [x] (d) every moved global has its lock also moved AND its re-export AND its facade-name-set entry
- [x] (e) every moved white-box-monkeypatch target resolvable via `getattr(notebooklm.auth, ...)`
- [x] (f) SEMANTIC patch-and-execute tests (NOT just `getattr` smoke) for `_run_refresh_cmd`, `_fetch_tokens_with_jar`, `_get_refresh_lock`, `_poke_session`, `_rotate_cookies`
- [x] (g) `auth.subprocess` re-export preserved
- [x] (h) `tests/conftest.py:34` invariants preserved

## Test plan

- [x] `uv run pre-commit run --files <touched>` — ruff lint + format clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (124 files)
- [x] `uv run pytest tests/unit tests/integration` — **5370 passed, 20 skipped** (5358 baseline + 12 new semantic tests)
- [x] All 17 unique `monkeypatch.setattr(auth_mod, "X", ...)` targets in tests audited and confirmed mirrored or covered by a facade name-set

## Deferred polish findings

None — the only minor note from triple review is that `_REFRESH_DEP_MIRROR_NAMES` and `_KEEPALIVE_DEP_MIRROR_NAMES` could share a single mirror set with target dispatching, but the current split makes the consumer-module intent clearer at the cost of one extra set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session keepalive to rotate auth cookies (disable via env) and async token-refresh orchestration with subprocess support, coalescing, and retry on expiry.
  * Cookie reconciliation that preserves the caller’s original cookie key/shape after refresh.

* **Refactor**
  * Authentication logic split into dedicated submodules with a compatibility/facade layer preserving public API.

* **Tests**
  * Added unit tests for facade wiring, symbol identity, refresh/keepalive interactions, and cookie-update behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->