### PR TITLE
fix(sources): address coderabbit review on PR #813 — baseline-unavailable sentinel + probe-before-fail

### DIFF
--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -348,22 +348,71 @@ class SourceUploadPipeline:
 
         # Capture baseline source IDs before the first create attempt so the
         # probe can distinguish "this upload landed" from "a same-named source
-        # already existed." Mirrors the pattern in NotebooksAPI.create. A
-        # transport failure during the baseline fetch falls back to an empty
-        # set, which makes the probe maximally permissive (any same-named
-        # source is treated as a potential match, including pre-existing
-        # ones). This is a doubly-exceptional scenario — baseline list failure
-        # AND a same-name collision — and is accepted as a known limitation
-        # mirroring the parallel note in NotebooksAPI.create. The baseline
-        # fetch is best-effort and never blocks the primary create path.
+        # already existed." Mirrors the pattern in NotebooksAPI.create.
+        #
+        # ``None`` is the "baseline unavailable" sentinel — used when the
+        # baseline fetch failed (e.g. transient 5xx). The probe treats this
+        # as "we cannot safely distinguish new sources from pre-existing
+        # ones" and raises ``SourceAddError`` on any same-titled match,
+        # rather than risk returning a pre-existing source as if it were the
+        # just-created one. This protects against the silent
+        # data-corruption mode where a failed create + pre-existing
+        # same-name source would otherwise direct the subsequent upload
+        # stream to the wrong source.
+        baseline_ids: set[str] | None
         try:
             baseline_ids = {source.id for source in await list_sources(notebook_id)}
         except Exception:
             logger.debug(
-                "register_file_source: baseline list() failed; falling back to empty baseline",
+                "register_file_source: baseline list() failed; baseline unavailable",
                 exc_info=True,
             )
-            baseline_ids = set()
+            baseline_ids = None
+
+        async def _probe() -> str | None:
+            try:
+                sources = await list_sources(notebook_id)
+            except (AuthError, RateLimitError, ServerError, NetworkError):
+                # Transport- and auth-level probe failures must propagate
+                # (P1-2) — otherwise idempotent_create would retry the
+                # register on top of a broken probe.
+                raise
+            except Exception:
+                logger.debug(
+                    "register_file_source: probe list() failed with "
+                    "non-transport error; treating as no match",
+                    exc_info=True,
+                )
+                return None
+            matches = [source for source in sources if source.title == filename]
+            if baseline_ids is not None:
+                matches = [source for source in matches if source.id not in baseline_ids]
+            elif matches:
+                # Baseline was unavailable so we cannot safely tell a new
+                # source apart from a pre-existing one with the same name.
+                # Surface this as an ambiguity rather than guessing — see
+                # the ``baseline_ids`` comment above for the failure mode
+                # this guards against.
+                raise SourceAddError(
+                    filename,
+                    message=(
+                        f"Cannot disambiguate file source with title {filename!r}: "
+                        "baseline snapshot was unavailable, so a matching title may "
+                        "predate this upload. Resolve manually before retrying."
+                    ),
+                )
+            if len(matches) == 1:
+                return matches[0].id
+            if len(matches) > 1:
+                raise SourceAddError(
+                    filename,
+                    message=(
+                        f"Cannot disambiguate file source with title {filename!r}: "
+                        f"probe found {len(matches)} new sources with this title "
+                        "after a transport failure. Resolve manually before retrying."
+                    ),
+                )
+            return None
 
         async def _create() -> str:
             try:
@@ -389,6 +438,21 @@ class SourceUploadPipeline:
             if source_id:
                 return source_id
 
+            # The RPC returned successfully but the response shape did not
+            # contain a parseable SOURCE_ID. Before raising, run the probe
+            # to see if the source landed server-side anyway — the
+            # extraction can fail for schema-drift reasons (#474) while the
+            # create has actually committed. This converts a recoverable
+            # success into the same probe-recovery path that 5xx uses.
+            probed_source_id = await _probe()
+            if probed_source_id is not None:
+                logger.info(
+                    "register_file_source[%s]: response missing SOURCE_ID but "
+                    "probe found a freshly committed source",
+                    filename,
+                )
+                return probed_source_id
+
             if isinstance(result, str):
                 preview = repr(result[:200])
                 if len(result) > 200:
@@ -403,39 +467,6 @@ class SourceUploadPipeline:
                     f"Failed to get SOURCE_ID from registration response. Response shape: {preview}"
                 ),
             )
-
-        async def _probe() -> str | None:
-            try:
-                sources = await list_sources(notebook_id)
-            except (AuthError, RateLimitError, ServerError, NetworkError):
-                # Transport- and auth-level probe failures must propagate
-                # (P1-2) — otherwise idempotent_create would retry the
-                # register on top of a broken probe.
-                raise
-            except Exception:
-                logger.debug(
-                    "register_file_source: probe list() failed with "
-                    "non-transport error; treating as no match",
-                    exc_info=True,
-                )
-                return None
-            matches = [
-                source
-                for source in sources
-                if source.id not in baseline_ids and source.title == filename
-            ]
-            if len(matches) == 1:
-                return matches[0].id
-            if len(matches) > 1:
-                raise SourceAddError(
-                    filename,
-                    message=(
-                        f"Cannot disambiguate file source with title {filename!r}: "
-                        f"probe found {len(matches)} new sources with this title "
-                        "after a transport failure. Resolve manually before retrying."
-                    ),
-                )
-            return None
 
         return await idempotent_create(
             _create,

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -503,6 +503,81 @@ async def test_register_file_source_does_not_match_pre_existing_filename(
     assert get_count >= 1, f"expected ≥1 GET_NOTEBOOK, got {get_count}"
 
 
+async def test_register_file_source_baseline_unavailable_raises_on_ambiguity(
+    auth_tokens, tmp_path: Path
+) -> None:
+    """Baseline fetch failure + same-name match → raise ``SourceAddError``.
+
+    When the baseline GET_NOTEBOOK fails (e.g. transient 5xx) AND the probe
+    later finds a same-named source, the wrapper cannot safely distinguish
+    "this upload landed" from "a pre-existing source has the same filename."
+    Surfacing this as an ambiguity is the correct behavior — silently
+    returning the existing source would direct the subsequent upload stream
+    to the wrong source (the original CodeRabbit critical concern).
+
+    Scenario:
+      - baseline list raises (server 503)
+      - create gets 503
+      - probe lists notebook → finds same-named source
+      - baseline_ids is None (sentinel) → wrapper raises SourceAddError
+        rather than returning the existing source's id
+    """
+    notebook_id = "nb_test"
+    filename = "report.pdf"
+    pre_existing_src_id = "src_OLD_report"
+
+    test_file = tmp_path / filename
+    test_file.write_bytes(b"%PDF-1.4 minimal pdf")
+
+    register_count = 0
+    get_count = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal register_count, get_count
+        rpc_id = _rpc_id_in_request(request)
+        if rpc_id == RPCMethod.ADD_SOURCE_FILE.value:
+            register_count += 1
+            return httpx.Response(503, text="service unavailable")
+        if rpc_id == RPCMethod.GET_NOTEBOOK.value:
+            get_count += 1
+            # First call (baseline) — 503 to simulate transport failure.
+            # Subsequent calls (probe) — return the pre-existing source.
+            if get_count == 1:
+                return httpx.Response(503, text="service unavailable")
+            return httpx.Response(
+                200,
+                text=_get_notebook_with_sources_response(
+                    notebook_id, [(pre_existing_src_id, filename, None)]
+                ),
+            )
+        return httpx.Response(404, text=f"unexpected rpc_id={rpc_id}")
+
+    transport = httpx.MockTransport(handler)
+    client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=0)
+    try:
+        with (
+            patch.object(
+                client.sources,
+                "_start_resumable_upload",
+                AsyncMock(return_value="https://upload.example/scotty"),
+            ),
+            patch.object(
+                client.sources,
+                "_upload_file_streaming",
+                AsyncMock(return_value=None),
+            ),
+            pytest.raises(NotebookLMError, match="baseline snapshot was unavailable"),
+        ):
+            await client.sources.add_file(notebook_id, test_file)
+    finally:
+        await client._core._http_client.aclose()
+
+    # Pre-existing source's id was NOT silently returned — instead the
+    # baseline-unavailable ambiguity guard fired.
+    assert register_count >= 1
+    assert get_count >= 2  # baseline + at least one probe
+
+
 # ---------------------------------------------------------------------------
 # add_text — NON_IDEMPOTENT_NO_RETRY enforcement
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -2564,6 +2564,10 @@ class TestRegisterFileSourceError:
             url=re.compile(r".*batchexecute.*"),
             content=rpc_response.encode(),
         )
+        # register_file_source now runs the probe BEFORE raising on a
+        # source-less response (CodeRabbit fix), so a second baseline-shape
+        # response is needed for the probe lookup.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
 
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(SourceAddError, match="Failed to get SOURCE_ID"):
@@ -2592,6 +2596,10 @@ class TestRegisterFileSourceError:
             url=re.compile(r".*batchexecute.*"),
             content=rpc_response.encode(),
         )
+        # register_file_source now runs the probe BEFORE raising on a
+        # source-less response (CodeRabbit fix), so a second baseline-shape
+        # response is needed for the probe lookup.
+        _add_register_file_source_baseline_mock(httpx_mock, build_rpc_response)
 
         async with NotebookLMClient(auth_tokens) as client:
             with pytest.raises(SourceAddError):


### PR DESCRIPTION
## Summary

Follow-up to PR #813 (b-sources). PR #813 merged at \`01849df\` before the CodeRabbit review fully posted; this PR ships the two CR critical/major findings that landed after the merge.

## Changes

1. **Baseline-unavailable sentinel** (\`_source_upload.py:register_file_source\`). The previous \`baseline_ids = set()\` on baseline-fetch failure made the probe maximally permissive — a single pre-existing same-name source could be silently returned as if it were the just-created upload, directing the subsequent streaming POST onto the wrong source. Replaced with \`baseline_ids: set[str] | None = None\` sentinel; the probe raises \`SourceAddError\` ("baseline snapshot was unavailable") when any same-titled match is found in this state rather than guessing.

2. **Probe-before-fail on source-less success** (\`_source_upload.py:register_file_source._create\`). If the ADD_SOURCE_FILE RPC returns 200 but \`_extract_register_file_source_id\` can't find a SOURCE_ID (e.g. schema drift per #474), the previous code raised \`SourceAddError\` immediately. Now \`_create\` calls \`_probe()\` first — the create may have actually committed server-side and the probe can recover the new source's id. Only raises if the probe also fails.

## Test plan

New test \`test_register_file_source_baseline_unavailable_raises_on_ambiguity\` covers the sentinel path. Existing \`TestRegisterFileSourceError\` tests updated for the extra probe call now made before raising on source-less success responses.

All checks green:
- \`ruff format\` + \`ruff check\` clean
- \`mypy src/notebooklm --ignore-missing-imports\` clean
- \`pytest tests/unit tests/integration\` — 5369 passed / 20 skipped

## Context: why a follow-up?

PR #813 was merged at \`01849df\` before CodeRabbit's review fully posted. The CR review included three findings:
- **Critical (Drive URL boundary)**: already addressed in \`01849df\` via the Claude-bot fix (same issue both bots flagged).
- **Major (baseline-unavailable sentinel)**: shipped here.
- **Major (probe-before-fail)**: shipped here.

The CR review threads on PR #813 have replies pointing at this follow-up's SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced file source registration to handle unavailable baseline snapshots without misidentifying existing sources.
  * Improved error handling for source ID extraction failures with better fallback recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->