### PR TITLE
docs(claude): refresh Repository Structure for tier-10 foundation seams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,13 @@ RPC Layer (rpc/)
    - `decoder.py`: Response parsing
 
 2. **Core Layer** (`src/notebooklm/_core.py` + `_core_*.py` seam modules):
-   - `_core.py`: `NotebookLMClient` orchestration (will shrink further as Phase 2 lands)
+   - `_core.py`: `NotebookLMClient` orchestration
    - `_core_transport.py`, `_core_rpc.py`: HTTP client + RPC call abstraction
    - `_core_auth.py`, `_core_cookie_persistence.py`: Auth refresh + cookie storage
    - `_core_metrics.py`, `_core_drain.py`, `_core_reqid.py`: Telemetry, drain coordination, request-counter handling
    - `_core_cache.py`, `_core_polling.py`: Conversation cache + artifact polling helpers
+   - `_core_constants.py`, `_core_helpers.py`, `_core_error_injection.py`: Module-level constants, helper utilities, synthetic-error transport
+   - `_core_lifecycle.py`: Open/close lifecycle (loop-affinity guard + keepalive task)
    - `_capabilities.py`: Capability adapters for feature APIs
 
 3. **Client Layer** (`src/notebooklm/client.py`, `_*.py`):
@@ -81,12 +83,15 @@ RPC Layer (rpc/)
 | File | Purpose |
 |------|---------|
 | `client.py` | Main `NotebookLMClient` class |
-| `_core.py` | `ClientCore` orchestrator; HTTP client lifecycle; module-level constants and re-exports |
+| `_core.py` | `ClientCore` orchestrator; HTTP client lifecycle; late-binding wrappers |
+| `_core_constants.py` | `DEFAULT_*` knobs and module-level constants |
+| `_core_helpers.py` | `is_auth_error`, `AUTH_ERROR_PATTERNS`, `_resolve_keepalive_interval` |
+| `_core_error_injection.py` | `_SyntheticErrorTransport` + env-var guard for fault injection |
 | `_core_metrics.py` | `ClientMetrics` — `ClientMetricsSnapshot` counters + `on_rpc_event` callback |
 | `_core_drain.py` | `TransportDrainTracker` — in-flight transport counters + `_TransportOperationToken` |
 | `_core_reqid.py` | `ReqidCounter` — monotonic `_reqid` for the chat backend |
-| `_core_auth.py` | `AuthRefreshCoordinator` (Phase 2 in progress) — refresh task + auth-snapshot lock |
-| `_core_lifecycle.py` | `ClientLifecycle` (Phase 2 in progress) — loop-affinity guard + keepalive task |
+| `_core_auth.py` | `AuthRefreshCoordinator` — refresh task + auth-snapshot lock |
+| `_core_lifecycle.py` | `ClientLifecycle` — loop-affinity guard + keepalive task |
 | `_core_rpc.py` | RPC dispatch executor with `DecodeResponse` + `RpcOwner` Protocols |
 | `_core_transport.py` | Authed POST path, retry loops, `_AuthedTransportHost` Protocol |
 | `_core_cache.py` | Per-instance LRU conversation cache for `ChatAPI` |
@@ -98,7 +103,17 @@ RPC Layer (rpc/)
 | `_artifacts.py` | `client.artifacts` API |
 | `_chat.py` | `client.chat` API |
 | `rpc/types.py` | RPC method IDs (source of truth) |
-| `auth.py` | Authentication handling |
+| `auth.py` | Authentication facade — re-exports + `_AuthFacadeModule` shim that forwards monkeypatches to `_auth/*` seams |
+| `_auth/paths.py` | Storage paths and filesystem helpers |
+| `_auth/extraction.py` | Cookie/token extraction from browser sessions |
+| `_auth/headers.py` | HTTP header construction |
+| `_auth/cookies.py` | Cookie map manipulation + `_update_cookie_input` |
+| `_auth/cookie_policy.py` | Cookie-domain allowlist and policy decisions |
+| `_auth/account.py` | Account profile + multi-account switching |
+| `_auth/session.py` | Session-level dataclasses |
+| `_auth/storage.py` | Profile/state persistence on disk |
+| `_auth/keepalive.py` | Cookie keepalive + `__Secure-1PSIDTS` rotation loop |
+| `_auth/refresh.py` | Token refresh: external `notebooklm login` driver + coalesced runs + redaction |
 | `cli/` | CLI command modules |
 
 ### Repository Structure
@@ -107,9 +122,12 @@ RPC Layer (rpc/)
 src/notebooklm/
 ├── __init__.py                  # Public exports
 ├── client.py                    # NotebookLMClient
-├── auth.py                      # Authentication
+├── auth.py                      # Authentication facade — re-exports + _AuthFacadeModule shim
 ├── types.py                     # Dataclasses
 ├── _core.py                     # Core orchestration (NotebookLMClient internals)
+├── _core_constants.py           # DEFAULT_* knobs + module-level constants
+├── _core_helpers.py             # is_auth_error / AUTH_ERROR_PATTERNS / keepalive helpers
+├── _core_error_injection.py     # _SyntheticErrorTransport + fault-injection env-var guard
 ├── _core_transport.py           # HTTP client + transport-layer concerns
 ├── _core_rpc.py                 # RPC call abstraction
 ├── _core_auth.py                # Auth refresh seam
@@ -119,8 +137,20 @@ src/notebooklm/
 ├── _core_reqid.py               # Request-counter / request-id helpers
 ├── _core_cache.py               # Conversation cache seam
 ├── _core_polling.py             # Artifact polling helpers
-│                                # (Phase 2 in progress: _core_lifecycle.py — open/close lifecycle seam)
+├── _core_lifecycle.py           # Open/close lifecycle seam (loop affinity + keepalive task)
 ├── _capabilities.py             # Capability adapters for feature APIs
+├── _auth/                       # Auth subpackage (forwarded through auth.py facade)
+│   ├── __init__.py
+│   ├── paths.py                 # Storage paths and filesystem helpers
+│   ├── extraction.py            # Cookie/token extraction from browser sessions
+│   ├── headers.py               # HTTP header construction
+│   ├── cookies.py               # Cookie maps + _update_cookie_input
+│   ├── cookie_policy.py         # Domain allowlist and cookie policy
+│   ├── account.py               # Account profile + multi-account switching
+│   ├── session.py               # Session-level dataclasses
+│   ├── storage.py               # Profile/state persistence on disk
+│   ├── keepalive.py             # Cookie keepalive + __Secure-1PSIDTS rotation
+│   └── refresh.py               # Token refresh driver (external login cmd, coalesced runs, redaction)
 ├── _notebooks.py                # NotebooksAPI
 ├── _sources.py                  # SourcesAPI
 ├── _artifacts.py                # ArtifactsAPI


### PR DESCRIPTION
## Summary
- Bring CLAUDE.md in sync with the tier-10 foundation decomposition merges (#810, #811, #812, #814)
- Add core seam entries: `_core_constants.py`, `_core_helpers.py`, `_core_error_injection.py`
- Add `_auth/` subpackage entries (paths/extraction/headers/cookies/cookie_policy/account/session/storage/keepalive/refresh)
- Drop "Phase 2 in progress" markers on `_core_auth.py` and `_core_lifecycle.py` (both landed)
- Clarify `auth.py` is a facade module with `_AuthFacadeModule` shim forwarding monkeypatches to `_auth/*` seams

Docs-only — no code changes.

## Test plan
- [x] Visual diff review of `CLAUDE.md`
- [x] Entries match actual `src/notebooklm/_auth/*.py` files on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architecture documentation to reflect repository structure reorganization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->