### PR TITLE
fix(ci): scope nightly retry to tests/e2e + drop broken new-conversation e2e

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -217,4 +217,9 @@ jobs:
         fi
         echo "Initial E2E run failed. Sleeping 600s before retrying failed tests."
         sleep 600
-        uv run pytest --last-failed -s -v --tb=short
+        # Pin ``tests/e2e`` so pyproject's ``addopts = --ignore=tests/e2e``
+        # doesn't drop every lastfailed entry; otherwise pytest's default
+        # ``--last-failed-no-failures=all`` would expand to the full non-e2e
+        # suite under NOTEBOOKLM_AUTH_JSON. ``=none`` makes a missing cache
+        # fail fast instead.
+        uv run pytest tests/e2e --last-failed --last-failed-no-failures=none -s -v --tb=short

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -95,26 +95,6 @@ class TestChatE2E:
         assert result2.turn_number > result1.turn_number
 
     @pytest.mark.asyncio
-    async def test_ask_new_conversation_flag(self, client, multi_source_notebook_id):
-        """Test that --new flag starts a fresh conversation."""
-        # Ask first question
-        result1 = await client.chat.ask(
-            multi_source_notebook_id,
-            "What is covered in these sources?",
-        )
-
-        # Ask with new conversation (no conversation_id)
-        result2 = await client.chat.ask(
-            multi_source_notebook_id,
-            "Start fresh - what are the main themes?",
-        )
-
-        # Should be a new conversation
-        assert result2.conversation_id != result1.conversation_id
-        assert result2.is_follow_up is False
-        assert result2.turn_number == 1
-
-    @pytest.mark.asyncio
     async def test_ask_specific_sources(self, client, multi_source_notebook_id):
         """Test asking questions about specific sources."""
         # Get sources


### PR DESCRIPTION
## Summary

Fixes two issues uncovered while triaging a nightly E2E job that reported 84 failures: https://github.com/teng-lin/notebooklm-py/actions/runs/26019127504

- **`.github/workflows/nightly.yml` retry step** — was running `pytest --last-failed -s -v --tb=short` with no path. pyproject's `addopts = --ignore=tests/e2e` drops every e2e entry from collection, the cached e2e lastfailed entry can't match, and pytest's default `--last-failed-no-failures=all` then expands to the entire non-e2e suite under `NOTEBOOKLM_AUTH_JSON` — which causes ~80 spurious login unit-test failures (the CLI refuses to run with that env set). Pin to `tests/e2e` and use `=none` so missing/empty cache fails loudly instead of silently broadening.
- **`tests/e2e/test_chat.py::test_ask_new_conversation_flag`** — asserted two consecutive `chat.ask()` calls with no `conversation_id` return *different* conversation_ids, but `_chat.py:204-209` documents the opposite (all such calls extend the most-recent conversation). Per issue #659 the "fresh conversation" RPC has not been reverse-engineered. The test was asserting documented-impossible behavior — deleted.

## Evidence

Nightly run summary:
- First e2e step: `1 failed, 126 passed, 4 skipped, 25 deselected, 1 xpassed, 10 warnings, 1 rerun` (just e2e)
- Retry step: `84 failed, 5297 passed, 20 skipped` ← the whole non-e2e suite ran

Windows was green because it runs `-m "readonly and not variants"`, never failed, so the retry never fired and the scope bug stayed hidden.

## Follow-ups (out of scope for this PR)

- The CLI `--new` flag (`cli/chat.py:86-91`, help text "Start a fresh conversation") is genuinely misleading per the same `_chat.py:204-209` contract — `--new` just skips local-cache resume, the server still extends the most-recent conversation. Pre-existing; should be either a help-text fix or proper implementation pending issue #659.

## Test plan

- [ ] CI green on this branch (unit + integration + verify-package + rpc-health)
- [ ] Next nightly run exercises the new retry path naturally if any e2e fails
- [ ] If no nightly failure occurs, a `workflow_dispatch` with a known-failing `test_filter` will validate the retry scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an end-to-end test case related to conversation functionality.

* **Chores**
  * Updated the nightly CI workflow's end-to-end test retry mechanism to improve failure detection accuracy and provide faster feedback when tests encounter issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->