### PR TITLE
ci(workflow): tolerate Playwright cache backend flakes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,11 @@ jobs:
 
     - name: Cache Playwright browsers
       uses: actions/cache@v5
+      # Tolerate transient cache-backend failures: a miss already falls
+      # through to the install step below, and a backend hiccup should be
+      # treated the same. Without this, a 29s backend flake on a single
+      # matrix entry hard-fails the job and skips the entire test run.
+      continue-on-error: true
       with:
         path: ${{ github.workspace }}/.playwright-browsers
         # ``-ws`` suffix invalidates archives keyed to the prior dual-path


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the `Cache Playwright browsers` step in `.github/workflows/test.yml`.
- A transient `actions/cache@v5` backend failure currently hard-fails the entire matrix job and skips every downstream step — including the test run itself.
- A cache miss already falls through to the unconditional `Install Playwright browsers` step; a backend hiccup is now treated the same.
- Per GitHub Actions docs + `actions/cache@v5` action.yml, step-level `continue-on-error` covers both the restore (action main) and save (post-step) phases, so a flaky save half is also tolerated.

## Why

Two recent matrix jobs hard-failed on Windows × Python 3.13 ~29s into the run, before any test executed:

- PR #808 — Windows-3.13
- PR #813 — Windows-3.13 (job 76453070311)

Failure shape (from #813):

```
✅ Set up job
✅ Install dependencies
✅ Get Playwright version
❌ Cache Playwright browsers     <- transient backend failure (29s)
⏭️  Install Playwright browsers
⏭️  Run tests with coverage
⏭️  Assert per-file coverage floors
```

The cache step succeeded materially (the install step would have re-installed on a miss), but a backend hiccup gated everything downstream.

## Tradeoff

A permanently broken cache backend will go green — every matrix entry will silently re-install Playwright (~10–30s extra) and the only signal is a yellow annotation on the run. This matches the existing tolerance pattern on the Linux system-deps step (`.github/workflows/test.yml` lines 134–141, which emits `::warning::` on `playwright install-deps` timeout). The functional fallback is sound: `uv run playwright install chromium` runs unconditionally and validates the real requirement (browsers present before tests).

## Alternatives considered

- **Split `actions/cache/restore` + `actions/cache/save`** — more granular, but adds two steps and config surface for a transient-flake problem; still needs `continue-on-error` on each half.
- **`restore-keys`** — only helps cache misses, not backend failures.
- **`fail-on-cache-miss: true`** — opposite of the desired behavior.
- **Retry wrappers** — don't work cleanly around a `uses:` step.

The simple knob matches the issue scope.

## Polish notes (deferred, non-blocking)

The polish pipeline (code-simplifier + claude/codex/gemini triple review + ultrathink) returned **0 critical, 0 important**. Three nits were noted and deferred as informational:

- N1 (claude): comment frames the failure recovery as restore-phase only; `continue-on-error` also covers the save post-step (codex confirmed via docs).
- N2 (claude): no automated detection path for permanent cache backend breakage — surfaces only as a workflow annotation. Matches house style (Linux deps step has the same property).
- (codex): comment is incident-specific with "29s"; intentional intent-capture, codex opted to keep.

## Closes

Closes #815.

## Test plan

- [ ] CI green across `ubuntu-latest`, `macos-latest`, `windows-latest` × Python `3.10`, `3.11`, `3.12`, `3.13`, `3.14`.
- [ ] If a cache-backend flake recurs, it surfaces as a workflow annotation on the run and the `Install Playwright browsers` step re-installs cleanly without skipping downstream steps.
- [ ] No new failure modes introduced on the happy path (cache hit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI test reliability by making the browser cache step more resilient to transient backend failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->