### PR TITLE
ci(publish): split build/test from publish job to minimize id-token:write scope (#820)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,16 @@ on:
       - "v*"
 
 jobs:
-  build-and-publish:
-    name: Build and publish to PyPI
+  build-and-test:
+    name: Build wheel and run release smoke
     runs-on: ubuntu-latest
-    environment: release
+    # Smoke install pulls `[browser,dev,markdown]` extras (pytest, playwright,
+    # mypy, ruff, markdownify, transitive deps). A compromised dep here is a
+    # supply-chain concern but cannot mint a Trusted Publishing OIDC token,
+    # because this job is not granted `id-token: write`. The publish job
+    # below carries that scope and runs nothing except the trusted PyPA
+    # action. See issue #820 for the threat model.
     permissions:
-      id-token: write
       contents: read
 
     steps:
@@ -41,6 +45,23 @@ jobs:
       run: |
         python -m build
 
+    - name: Upload distribution artifacts
+      # Capture pristine wheel + sdist BEFORE any third-party code (smoke
+      # install, playwright, pytest) runs against `dist/`. If we uploaded
+      # after the smoke install, a compromised dev/test dep could mutate
+      # `dist/` post-build, and the publish job would upload tampered bytes
+      # — attested with the project's trusted OIDC identity. Uploading here
+      # snapshots the build output before any attacker-controlled code has
+      # touched the runner. Smoke install/test below still runs against
+      # `dist/` for behavior validation but can no longer influence what
+      # the publish job receives.
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-distribution
+        path: dist/
+        if-no-files-found: error
+        retention-days: 1
+
     - name: Install built wheel + canonical contributor extras in a clean venv
       # Canonical contributor extras (`[browser,dev,markdown]`, equivalent to
       # `[all]`) match the install path documented in `docs/installation.md`,
@@ -63,6 +84,26 @@ jobs:
 
     - name: Run unit tests against wheel
       run: smoke-venv/bin/pytest tests/unit -q --no-cov -x
+
+  publish:
+    name: Publish to PyPI
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    environment: release
+    # Minimum-scope publish job: only the trusted PyPA action runs here. No
+    # `actions/checkout`, no Python install, no third-party dependencies in
+    # the runner environment — so the OIDC token request that `id-token:
+    # write` enables has no co-tenant code that could exfiltrate it.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: python-distribution
+        path: dist/
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -4,12 +4,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
-    name: Build and publish to TestPyPI
+  build-and-test:
+    name: Build wheel and run release smoke
     runs-on: ubuntu-latest
+    # Smoke install pulls `[browser,dev,markdown]` extras (pytest, playwright,
+    # mypy, ruff, markdownify, transitive deps). A compromised dep here is a
+    # supply-chain concern but cannot mint a Trusted Publishing OIDC token,
+    # because this job is not granted `id-token: write`. The publish job
+    # below carries that scope and runs nothing except the trusted PyPA
+    # action. See issue #820 for the threat model.
     permissions:
-      id-token: write
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
     - uses: actions/checkout@v6
@@ -34,6 +41,23 @@ jobs:
     - name: Build package
       run: python -m build
 
+    - name: Upload distribution artifacts
+      # Capture pristine wheel + sdist BEFORE any third-party code (smoke
+      # install, playwright, pytest) runs against `dist/`. If we uploaded
+      # after the smoke install, a compromised dev/test dep could mutate
+      # `dist/` post-build, and the publish job would upload tampered bytes
+      # — attested with the project's trusted OIDC identity. Uploading here
+      # snapshots the build output before any attacker-controlled code has
+      # touched the runner. Smoke install/test below still runs against
+      # `dist/` for behavior validation but can no longer influence what
+      # the publish job receives.
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-distribution
+        path: dist/
+        if-no-files-found: error
+        retention-days: 1
+
     - name: Install built wheel + canonical contributor extras in a clean venv
       # Canonical contributor extras (`[browser,dev,markdown]`, equivalent to
       # `[all]`) match the install path documented in `docs/installation.md`,
@@ -57,6 +81,25 @@ jobs:
     - name: Run unit tests against wheel
       run: smoke-venv/bin/pytest tests/unit -q --no-cov -x
 
+  publish:
+    name: Publish to TestPyPI
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    # Minimum-scope publish job: only the trusted PyPA action runs here. No
+    # `actions/checkout`, no Python install, no third-party dependencies in
+    # the runner environment — so the OIDC token request that `id-token:
+    # write` enables has no co-tenant code that could exfiltrate it.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: python-distribution
+        path: dist/
+
     - name: Upload to TestPyPI
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # @ v1.14.0
       with:
@@ -66,8 +109,8 @@ jobs:
       run: |
         echo "## Published to TestPyPI" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Version:** ${{ needs.build-and-test.outputs.version }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Package:** https://test.pypi.org/project/notebooklm-py/${{ steps.version.outputs.version }}/" >> $GITHUB_STEP_SUMMARY
+        echo "**Package:** https://test.pypi.org/project/notebooklm-py/${{ needs.build-and-test.outputs.version }}/" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Next Step:** Run the **Verify Package** workflow with source=testpypi" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Splits `publish.yml` and `testpypi-publish.yml` into two jobs each so `permissions: id-token: write` is scoped to a job that runs **only** the trusted PyPA action (no third-party Python deps in the OIDC-token-minting context). Fixes #820.

- **`build-and-test`** (`permissions: contents: read`) — builds the wheel/sdist, uploads `dist/` as an artifact, then runs the release smoke (install with `[browser,dev,markdown]` extras, Playwright Chromium, unit tests).
- **`publish`** (`permissions: id-token: write, contents: read`, `needs: build-and-test`) — downloads the `dist/` artifact and runs only `pypa/gh-action-pypi-publish`. No `actions/checkout`, no Python install, no third-party deps.

## Threat model

Before this PR, `id-token: write` was at job scope while the same job installed `[browser,dev,markdown]` extras (pytest, playwright, mypy, ruff, markdownify, transitive deps). A compromised dev/test dep could read `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` from the environment and exchange them for a PyPI Trusted Publishing token. After the split, the OIDC-enabled job hosts zero attacker-influenceable code.

### Subtle fix during review (Codex Critical)

The artifact upload step runs **immediately after `Build package` and before** the smoke install. If `Upload distribution artifacts` ran after the smoke install (the original draft), a compromised dep could mutate `dist/` between the venv install and the upload — the smoke tests would still pass against the venv copy (bytes A) while the publish job uploaded tampered bytes (bytes B), now attested with the project's trusted OIDC identity. Uploading first captures pristine bytes; smoke tests still validate behavior against `dist/` but cannot influence what the publish job receives. Comment block at `Upload distribution artifacts` documents this invariant inline.

## What stays the same

- `pypa/gh-action-pypi-publish@cef221092...  # @ v1.14.0` SHA-pin and `attestations: true` on PyPI (PEP 740 in-toto attestations via Trusted Publishing).
- `environment: release` on PyPI publish job — protection rules + Trusted Publisher matching key off the environment attached to the OIDC-minting job.
- TestPyPI's `Summary` step still renders version; version flows through `needs.build-and-test.outputs.version` since the publish job no longer has the source checked out.
- First-party `actions/*` use version tags (`@v6`, `@v7`); third-party actions SHA-pinned with version comment — repo convention preserved.

## Verification

- [x] `actionlint .github/workflows/publish.yml` — clean (exit 0)
- [x] `actionlint .github/workflows/testpypi-publish.yml` — only pre-existing SC2086/SC2129 info findings on (unchanged) version-emit + Summary shell content; no new findings introduced by this PR
- [x] Codex review: critical (artifact ordering) found and fixed during polish; re-review verdict **ship**
- [x] Gemini + Claude reviews: **ship**
- [x] Ultrathink: **ship**, non-blocking notes captured below
- [ ] Confirm on a TestPyPI release that the new flow still attests correctly (per issue acceptance criteria; needs a workflow_dispatch trigger after merge)

## Deferred / follow-up (out of scope for #820, but surfaced for follow-up)

These are pre-existing absences on `origin/main`; the issue explicitly scopes this PR to the build/publish job split. None block this merge, but worth tracking:

1. **TestPyPI lacks `environment:` protection.** Adding `environment: testpypi` would gate the OIDC trust on a repo-configured environment (matching how PyPI uses `environment: release`). Requires out-of-band repo settings + TestPyPI Trusted Publisher config to align — separate hardening task.
2. **TestPyPI lacks `attestations: true`.** Adds rehearsal value: the first prod release currently exercises an unrehearsed attestation path. Coupled with item 1.
3. **`actions/upload-artifact@v7` / `actions/download-artifact@v7` are version-tagged, not SHA-pinned.** Repo convention is to version-tag first-party `actions/*` and SHA-pin third-party. Since the artifact handoff is now the critical trust boundary between jobs, SHA-pinning these two would close symmetry with `pypa/gh-action-pypi-publish`.
4. **`pip install build` is unpinned.** One rung up the supply chain from anything this PR addresses. Pre-existing.
5. **`retention-days: 1`** is sensible (publish runs within minutes of upload) but means a transient PyPI 5xx >24h later requires a fresh tag/dispatch rather than re-running just the publish job.
6. **Artifact name `python-distribution`** is generic; per-run artifact scope makes this benign today, but a project-scoped name (`notebooklm-py-dist`) would future-proof against cross-workflow collisions in shared runs.
7. **No `concurrency:` group on either workflow.** Tag-push is naturally serialized; `workflow_dispatch` is manual. No regression vs. `origin/main`.

## Test plan

- [ ] After merge: manually `workflow_dispatch` `Publish to TestPyPI` and confirm the artifact handoff + TestPyPI upload still succeeds.
- [ ] Verify the next prod tag triggers the new two-job flow and that `attestations: true` still publishes a PEP 740 in-toto attestation.
- [ ] Check the Actions UI for any new "permission denied" failures (would surface if `actions/checkout` was secretly needed in publish job — it isn't, by design).

## Refs

- Issue: #820
- Original audit finding: P2-14 (Codex Important #3 on PR #819 review)
- Adjacent: PR #819 (release-smoke hardening that prompted this), #815 (Playwright cache flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI/CD build and publish workflows to improve release process reliability and security
  * Enhanced automation with refined job permissions and optimized artifact handling for safer package distribution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->