### PR TITLE
fix(auth): gate refresh-gen bump on current-attempt inflight (#816)

### DIFF
--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -456,11 +456,14 @@ async def _fetch_tokens_with_refresh(
         refresh_token = _REFRESH_ATTEMPTED_CONTEXT.set(True)
         try:
             async with _get_refresh_lock(refresh_storage_path):
-                # Bump generation ONLY after the subprocess succeeds AND
-                # storage is reloaded. An earlier implementation bumped the
-                # generation eagerly BEFORE ``_run_refresh_cmd`` — when the
+                # Bump generation ONLY after the current-attempt subprocess
+                # succeeds — never eagerly. An earlier implementation bumped
+                # the generation BEFORE ``_run_refresh_cmd``; when the
                 # subprocess failed, the phantom bump made concurrent waiters
-                # short-circuit and proceed with stale storage.
+                # short-circuit and proceed with stale storage. The bump
+                # itself happens just below, immediately before
+                # ``build_httpx_cookies_from_storage`` reloads the freshly-
+                # written disk state.
                 #
                 # Re-check under the sync state lock so the read is atomic
                 # ACROSS event loops. The per-loop asyncio lock only
@@ -483,38 +486,95 @@ async def _fetch_tokens_with_refresh(
                     # caller could spawn a duplicate concurrent refresh by
                     # observing the mid-flight lock release.
                     caller_cancelled = False
+                    # ``observed_inflight`` distinguishes "current-attempt
+                    # subprocess actually ran" from "cancellation arrived
+                    # before any subprocess registered for THIS attempt"
+                    # (issue #816). Only when we have proof of the current
+                    # attempt do we have license to bump the generation.
+                    observed_inflight = False
                     subprocess_exc: BaseException | None = None
+                    # Snapshot the inflight registry slot BEFORE entering
+                    # the await. The ``_settle`` callback intentionally
+                    # leaves done futures in the registry so the
+                    # cancel/settle race fix from CodeRabbit PR #621 can
+                    # still inspect ``inflight.exception()``; that
+                    # retention also means the registry may still hold a
+                    # STALE done future from a previous refresh cycle when
+                    # our await starts. We distinguish that stale slot
+                    # from a current-attempt future so the
+                    # cancel-before-register narrow window (issue #816)
+                    # does not attribute a prior cycle's success to this
+                    # caller's no-op attempt.
+                    registry = _get_inflight_registry()
+                    with _REFRESH_STATE_LOCK:
+                        prior_inflight = registry.get(refresh_key)
+                    # A pre-existing registry entry that was already done
+                    # at capture time is stale leftover from a prior cycle.
+                    # A pre-existing entry that was still active is a
+                    # sibling leader's current-cycle future — same-loop
+                    # coalescing means we legitimately follow it.
+                    prior_was_active = prior_inflight is not None and not prior_inflight.done()
                     while True:
                         try:
                             await _coalesced_run_refresh_cmd(
                                 refresh_key, refresh_storage_path, profile
                             )
+                            # Normal return only happens when the shielded
+                            # future resolved with success — i.e. a
+                            # current-attempt subprocess ran to completion.
+                            observed_inflight = True
                             break
                         except asyncio.CancelledError:
                             # Caller-side cancellation. Re-enter the await
                             # so the shielded subprocess can settle while we
                             # still hold the asyncio lock.
                             caller_cancelled = True
-                            registry = _get_inflight_registry()
                             with _REFRESH_STATE_LOCK:
                                 inflight = registry.get(refresh_key)
-                            if inflight is None or inflight.done():
-                                # Subprocess already settled; we absorbed the
-                                # cancellation. Inspect its terminal state.
-                                # Per the CodeRabbit finding on PR #621, the
-                                # ``_settle`` callback intentionally leaves
-                                # the done future in the registry so this
-                                # branch can still observe ``inflight.
-                                # exception()`` after a cancel/settle race.
-                                if inflight is not None:
-                                    if inflight.cancelled():
-                                        # Subprocess itself was cancelled —
-                                        # treat as failure (do not bump gen).
-                                        subprocess_exc = asyncio.CancelledError()
-                                    else:
-                                        subprocess_exc = inflight.exception()
+                            # Determine whether the registry slot belongs
+                            # to the CURRENT refresh attempt. Two cases
+                            # mean "yes":
+                            #   (a) the slot was overwritten during our
+                            #       await (``inflight is not prior_inflight``
+                            #       — a new leader inserted a fresh future);
+                            #   (b) the slot already held an actively-
+                            #       running sibling leader at capture time
+                            #       (``prior_was_active``) — same-loop
+                            #       coalescing means we legitimately follow
+                            #       its subprocess.
+                            # Otherwise the slot is either empty or a
+                            # stale done future that ``_settle``
+                            # intentionally left behind from a prior cycle
+                            # (PR #621 cancel/settle race retention).
+                            # Treating that stale entry as proof of our
+                            # attempt would re-bump generation against an
+                            # outdated result — the warm-registry variant
+                            # of #816.
+                            if inflight is None or (
+                                inflight is prior_inflight and not prior_was_active
+                            ):
+                                # No current-attempt future to wait on
+                                # (issue #816 narrow window: cancellation
+                                # arrived before the registry insert).
                                 break
-                            # Otherwise loop — re-await the shielded future.
+                            observed_inflight = True
+                            if inflight.done():
+                                # Current attempt already settled and we
+                                # absorbed the cancellation. ``_settle``
+                                # left the done future in the registry so
+                                # this branch can inspect its terminal
+                                # state (PR #621 cancel/settle race).
+                                if inflight.cancelled():
+                                    # Subprocess itself was cancelled —
+                                    # treat as failure (do not bump gen).
+                                    subprocess_exc = asyncio.CancelledError()
+                                else:
+                                    subprocess_exc = inflight.exception()
+                                break
+                            # Otherwise (current-attempt future still in
+                            # flight) loop and re-await the shielded
+                            # future so the asyncio lock is not released
+                            # until the subprocess settles.
                         except BaseException as exc:  # noqa: BLE001
                             subprocess_exc = exc
                             break
@@ -530,23 +590,34 @@ async def _fetch_tokens_with_refresh(
                             raise asyncio.CancelledError() from subprocess_exc
                         raise subprocess_exc
 
-                    # Subprocess succeeded AND we're about to reload
-                    # storage. Bump the generation now so other callers
-                    # (any loop) see the success and skip their own
-                    # subprocess. The bump is atomic across loops via
-                    # ``_REFRESH_STATE_LOCK``.
-                    with _REFRESH_STATE_LOCK:
-                        # ``max(...)`` defends against the rare interleaving
-                        # where another loop's pre-lock capture was AFTER
-                        # ours and bumped past us.
-                        existing = _REFRESH_GENERATIONS.get(refresh_key, 0)
-                        _REFRESH_GENERATIONS[refresh_key] = max(existing, refresh_generation + 1)
+                    if observed_inflight:
+                        # Subprocess succeeded AND we're about to reload
+                        # storage. Bump the generation now so other callers
+                        # (any loop) see the success and skip their own
+                        # subprocess. The bump is atomic across loops via
+                        # ``_REFRESH_STATE_LOCK``.
+                        with _REFRESH_STATE_LOCK:
+                            # ``max(...)`` defends against the rare
+                            # interleaving where another loop's pre-lock
+                            # capture was AFTER ours and bumped past us.
+                            existing = _REFRESH_GENERATIONS.get(refresh_key, 0)
+                            _REFRESH_GENERATIONS[refresh_key] = max(
+                                existing, refresh_generation + 1
+                            )
 
                     if caller_cancelled:
-                        # Subprocess succeeded; generation bump persists for
-                        # other callers' benefit. THIS caller still
-                        # propagates cancellation rather than completing the
-                        # retry.
+                        # Generation handling depends on whether a subprocess
+                        # actually ran:
+                        # * observed_inflight=True: subprocess succeeded (the
+                        #   failure branch already raised above); the bump
+                        #   above persists for other callers' benefit.
+                        # * observed_inflight=False: no subprocess ever
+                        #   registered, so generation stays at the pre-fetch
+                        #   baseline (issue #816) — concurrent / subsequent
+                        #   waiters re-attempt the refresh instead of
+                        #   short-circuiting on a phantom bump.
+                        # Either way THIS caller propagates cancellation
+                        # rather than completing the retry.
                         raise asyncio.CancelledError()
                 fresh_jar = build_httpx_cookies_from_storage(refresh_storage_path)
                 _replace_cookie_jar(cookie_jar, fresh_jar)

--- a/tests/integration/concurrency/test_refresh_cmd_race.py
+++ b/tests/integration/concurrency/test_refresh_cmd_race.py
@@ -527,3 +527,199 @@ async def test_cancel_settle_race_does_not_bump_on_failure(monkeypatch, tmp_path
         f"_REFRESH_GENERATIONS[{refresh_key!r}] = "
         f"{auth_mod._REFRESH_GENERATIONS.get(refresh_key, 0)} — phantom bump regression."
     )
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_subprocess_registers_no_phantom_bump(monkeypatch, tmp_path):
+    """Cancel-before-registration must not phantom-bump generation (issue #816).
+
+    Narrow race: ``_coalesced_run_refresh_cmd`` exits via ``CancelledError``
+    BEFORE the inflight future is registered in
+    ``_REFRESH_INFLIGHT_BY_LOOP[loop][refresh_key]``. The caller's
+    ``CancelledError`` handler then sees ``inflight is None``, the
+    ``if inflight is None or inflight.done():`` branch is taken,
+    ``subprocess_exc`` stays ``None``, and pre-fix the code falls through to
+    the generation bump even though no subprocess ever ran.
+
+    A concurrent waiter on a different event loop sharing the same
+    ``refresh_key`` would observe the phantom generation bump on its
+    lock-re-acquire path, treat the storage as freshly-refreshed, skip its
+    own ``_run_refresh_cmd``, and proceed with STALE on-disk state.
+
+    We model the race deterministically by patching
+    ``_coalesced_run_refresh_cmd`` itself to raise ``CancelledError``
+    without touching the registry — equivalent to cancellation landing in
+    the sync prefix before the registry insert.
+
+    Post-fix: the cancel-recovery loop tracks ``observed_inflight``;
+    ``inflight is None`` keeps it ``False``; the generation bump is gated
+    on ``observed_inflight``, so the bump is skipped.
+    """
+    storage = tmp_path / "storage_state.json"
+    storage.write_text('{"cookies": [], "origins": []}')
+    monkeypatch.setenv(auth_mod.NOTEBOOKLM_REFRESH_CMD_ENV, "dummy")
+
+    coalesced_calls = 0
+
+    async def fake_coalesced_run_refresh_cmd(refresh_key, storage_path, profile):
+        # Simulate the narrow window where cancellation arrives before the
+        # inflight future is registered: raise CancelledError without ever
+        # populating the registry, so the caller's recovery path observes
+        # ``inflight is None``.
+        nonlocal coalesced_calls
+        coalesced_calls += 1
+        raise asyncio.CancelledError()
+
+    async def fake_fetch_tokens_with_jar(cookie_jar, storage_path, **kwargs):
+        if not getattr(cookie_jar, "_first_fetch_done", False):
+            cookie_jar._first_fetch_done = True
+            raise ValueError("Authentication expired. Run 'notebooklm login'.")
+        return "csrf-token", "session-id"
+
+    def fake_build(_p):
+        return httpx.Cookies()
+
+    def fake_snapshot(_j):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_coalesced_run_refresh_cmd", fake_coalesced_run_refresh_cmd)
+    monkeypatch.setattr(auth_mod, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(auth_mod, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(auth_mod, "snapshot_cookie_jar", fake_snapshot)
+
+    # Pre-condition: registry is empty for this refresh_key on this loop.
+    refresh_key = str(storage.expanduser().resolve())
+    registry = auth_mod._get_inflight_registry()
+    assert registry.get(refresh_key) is None, "Pre-condition: no inflight future for refresh_key"
+
+    jar = httpx.Cookies()
+    result = await asyncio.gather(
+        auth_mod._fetch_tokens_with_refresh(jar, storage_path=storage),
+        return_exceptions=True,
+    )
+
+    # The caller's cancellation must propagate as CancelledError.
+    assert isinstance(result[0], asyncio.CancelledError), (
+        f"Expected CancelledError to propagate when _coalesced_run_refresh_cmd "
+        f"raised it before registering inflight, got {result[0]!r}"
+    )
+
+    # The patched _coalesced_run_refresh_cmd must have been invoked exactly
+    # once — this confirms the race window we are modelling actually fired.
+    assert coalesced_calls == 1, (
+        f"Expected 1 _coalesced_run_refresh_cmd invocation, saw {coalesced_calls}. "
+        "Test scaffolding mismatch."
+    )
+
+    # Post-condition: registry is STILL empty — confirms the fake faithfully
+    # modelled the cancel-before-registration race (no future was ever
+    # inserted, mirroring the production narrow window).
+    assert registry.get(refresh_key) is None, (
+        "Test scaffolding: fake_coalesced_run_refresh_cmd must not register an inflight future."
+    )
+
+    # The load-bearing assertion: generation must NOT have advanced.
+    # Pre-fix, the caller falls through to ``_REFRESH_GENERATIONS[refresh_key]
+    # = max(existing, refresh_generation + 1)`` even though no subprocess
+    # ran. A concurrent waiter on a sibling loop would then short-circuit
+    # on this phantom bump and reload stale storage.
+    assert auth_mod._REFRESH_GENERATIONS.get(refresh_key, 0) == 0, (
+        "Generation must not advance when cancellation arrived before any "
+        "subprocess registered an inflight future. "
+        f"_REFRESH_GENERATIONS[{refresh_key!r}] = "
+        f"{auth_mod._REFRESH_GENERATIONS.get(refresh_key, 0)} — issue #816 regression."
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_register_with_warm_registry_no_phantom_bump(monkeypatch, tmp_path):
+    """Cancel-before-registration with a STALE done future in the registry.
+
+    Warm-registry variant of issue #816. ``_settle`` intentionally leaves
+    done futures in the registry (PR #621 cancel/settle race), so after a
+    prior successful refresh the registry slot still holds that done
+    success future and ``_REFRESH_GENERATIONS[refresh_key] = 1``. If
+    cancellation arrives before ``_coalesced_run_refresh_cmd`` overwrites
+    the slot with a current-attempt future, the caller's ``CancelledError``
+    handler reads the registry and finds a NON-NONE entry — but that
+    entry is the OLD success future from a previous cycle, not proof of
+    the current attempt.
+
+    Pre-fix, ``observed_inflight`` was set to True for any non-None
+    registry entry; the cancel-before-register path then attributed the
+    prior cycle's success to this caller's no-op attempt and bumped
+    ``_REFRESH_GENERATIONS`` from 1 → 2. A concurrent waiter on a sibling
+    event loop would observe the phantom bump and skip its own refresh.
+
+    Post-fix, the cancel-recovery loop snapshots ``prior_inflight``
+    BEFORE the await and only treats the registry entry as a current
+    attempt when either the slot was overwritten (``inflight is not
+    prior_inflight``) or the pre-existing entry was active at capture
+    (``prior_was_active``). A stale done future fails both predicates,
+    so the bump is correctly skipped and generation stays at 1.
+    """
+    storage = tmp_path / "storage_state.json"
+    storage.write_text('{"cookies": [], "origins": []}')
+    monkeypatch.setenv(auth_mod.NOTEBOOKLM_REFRESH_CMD_ENV, "dummy")
+
+    refresh_key = str(storage.expanduser().resolve())
+
+    # Seed the warm-registry state: a prior successful refresh on this
+    # loop left a done success future in the registry and generation=1.
+    registry = auth_mod._get_inflight_registry()
+    stale_done_future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    stale_done_future.set_result(None)
+    registry[refresh_key] = stale_done_future
+    auth_mod._REFRESH_GENERATIONS[refresh_key] = 1
+
+    async def fake_coalesced_run_refresh_cmd(refresh_key_arg, storage_path, profile):
+        # Model the narrow race: cancellation in the sync prefix before
+        # the registry insert. The stale done future stays in place.
+        raise asyncio.CancelledError()
+
+    async def fake_fetch_tokens_with_jar(cookie_jar, storage_path, **kwargs):
+        if not getattr(cookie_jar, "_first_fetch_done", False):
+            cookie_jar._first_fetch_done = True
+            raise ValueError("Authentication expired. Run 'notebooklm login'.")
+        return "csrf-token", "session-id"
+
+    def fake_build(_p):
+        return httpx.Cookies()
+
+    def fake_snapshot(_j):
+        return None
+
+    monkeypatch.setattr(auth_mod, "_coalesced_run_refresh_cmd", fake_coalesced_run_refresh_cmd)
+    monkeypatch.setattr(auth_mod, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(auth_mod, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(auth_mod, "snapshot_cookie_jar", fake_snapshot)
+
+    jar = httpx.Cookies()
+    result = await asyncio.gather(
+        auth_mod._fetch_tokens_with_refresh(jar, storage_path=storage),
+        return_exceptions=True,
+    )
+
+    # Caller cancellation propagates.
+    assert isinstance(result[0], asyncio.CancelledError), (
+        f"Expected CancelledError to propagate, got {result[0]!r}"
+    )
+
+    # The stale done future must still be the registry entry — the fake
+    # _coalesced_run_refresh_cmd did not overwrite it.
+    assert registry.get(refresh_key) is stale_done_future, (
+        "Test scaffolding: stale done future should remain in the registry "
+        "(fake never replaced it)."
+    )
+
+    # The load-bearing assertion: generation must stay at 1. Pre-fix it
+    # bumped to 2 because the stale done success future was mistaken for
+    # the current attempt.
+    assert auth_mod._REFRESH_GENERATIONS.get(refresh_key, 0) == 1, (
+        "Generation must not advance against a STALE done future from a "
+        "prior cycle. Cancellation arrived before the current attempt "
+        "registered, so the registry slot's pre-existing entry must not "
+        "count as proof of the current attempt. "
+        f"_REFRESH_GENERATIONS[{refresh_key!r}] = "
+        f"{auth_mod._REFRESH_GENERATIONS.get(refresh_key, 0)} — warm-registry #816 regression."
+    )


### PR DESCRIPTION
## Summary

Closes #816.

`_fetch_tokens_with_refresh` could phantom-bump `_REFRESH_GENERATIONS` in two narrow cancel races where no current-attempt subprocess ran:

1. **Cold registry** (issue #816 original): cancellation arrived before `_coalesced_run_refresh_cmd` registered its inflight future. The cancel handler saw `inflight is None`; the code fell through to the generation bump anyway.
2. **Warm registry** (surfaced by Codex during polish): `_settle` intentionally leaves done futures in the registry (PR #621 cancel/settle race retention). After a prior successful refresh, the registry still holds that done success future. If cancellation arrives before our `_coalesced_run_refresh_cmd` overwrites the slot, treating the leftover as proof of our attempt re-bumps the generation against an outdated result.

In both cases a concurrent waiter on a sibling event loop would observe the phantom bump on its lock-re-acquire path, treat storage as freshly refreshed, skip its own `_run_refresh_cmd`, and proceed with STALE on-disk state.

## Fix

Capture `prior_inflight` BEFORE the await and `prior_was_active` (was it not-done at capture). In the cancel handler, the registry slot counts as the current refresh attempt only when either:
- it was overwritten during our await (`inflight is not prior_inflight` — a new leader inserted a fresh future), OR
- it already held an actively-running sibling leader at capture (`prior_was_active`).

A stale-done future identical to `prior_inflight` fails both predicates, so the generation bump is correctly skipped.

Also realigned the line-459 comment (the bump happens immediately *before* `build_httpx_cookies_from_storage` reloads, not after) per a Codex Optional review nit.

## Test plan

- [x] `test_cancel_before_subprocess_registers_no_phantom_bump` — cold registry; red-gate verified by stashing the fix (pre-fix bumped 0 → 1)
- [x] `test_cancel_before_register_with_warm_registry_no_phantom_bump` — seeds stale done future + `_REFRESH_GENERATIONS=1`; red-gate verified (pre-fix bumped 1 → 2)
- [x] All 6 refresh-race tests pass
- [x] Full 5383-test unit + integration suite stays green
- [x] mypy clean (124 files), ruff format + lint clean

## Polish receipts (`/polish` pipeline from `/execute-task` Step 4)

- Stage 1 (code-simplifier): comment refinement on the post-cancel propagation block (enumerates both `observed_inflight` branches)
- Stage 2 (triple review: claude + codex + gemini in parallel):
  - **claude** — no critical/important, walk-through verified
  - **gemini** — "Verification Status: Passed"
  - **codex** — found a CRITICAL bug in the v1 fix (warm-registry case) + Important test gap + Optional stale comment. All three fixed before opening this PR.
- Stage 3 (ultrathink): no additional findings; reasoned through 9 edge-case scenarios for the new discriminator and confirmed type narrowing, thread safety, and re-entry correctness.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Improved robustness of authentication token refresh logic to prevent generation counter issues during concurrent refresh attempts
  - Enhanced cancellation handling to properly manage active and stale refresh operations
  - Added regression test coverage for edge cases in refresh coalescing scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->