### PR TITLE
test(playwright): make playwright dependency optional for unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures."""
 
+import importlib.util
 import json
 import os
 import re
@@ -8,6 +9,8 @@ import pytest
 
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
+
+_PLAYWRIGHT_INSTALLED = importlib.util.find_spec("playwright") is not None
 
 
 @pytest.fixture(autouse=True)
@@ -126,12 +129,39 @@ def pytest_configure(config):
         "Used by error-cassette recording to produce cassettes with "
         "synthetic error shapes. Mode must be one of: 429, 5xx, expired_csrf.",
     )
+    config.addinivalue_line(
+        "markers",
+        "requires_playwright: skip the test unless the ``playwright`` Python "
+        "package is importable. Install with ``uv sync --extra browser``. "
+        "Apply to tests that import from ``playwright.sync_api`` at runtime; "
+        "leave OFF tests that intentionally exercise the playwright-missing "
+        "code path via ``patch.dict('sys.modules', {'playwright': None})``. "
+        "CI always installs the browser extra so marked tests run there.",
+    )
     # Disable Rich/Click formatting in tests to avoid ANSI escape codes in output
     # This ensures consistent test assertions regardless of -s flag
     # NO_COLOR disables colors, TERM=dumb disables all formatting (bold, etc.)
     # Force these values to ensure consistent behavior across all environments
     os.environ["NO_COLOR"] = "1"
     os.environ["TERM"] = "dumb"
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip ``@pytest.mark.requires_playwright`` items when playwright is missing.
+
+    Resolves the marker at collection time so local runs without the ``browser``
+    extra (``uv sync`` without ``--extra browser``) skip cleanly instead of
+    raising ``ImportError`` at runtime. CI installs the extra, so this is a
+    no-op there.
+    """
+    if _PLAYWRIGHT_INSTALLED:
+        return
+    skip_marker = pytest.mark.skip(
+        reason="playwright not installed; install with: uv sync --extra browser"
+    )
+    for item in items:
+        if "requires_playwright" in item.keywords:
+            item.add_marker(skip_marker)
 
 
 @pytest.fixture

--- a/tests/unit/cli/test_session.py
+++ b/tests/unit/cli/test_session.py
@@ -196,6 +196,13 @@ class TestLoginCommand:
         block. Yields (mock_ensure, mock_launch) for assertions on chromium
         install check and launch_persistent_context kwargs.
         """
+        # patch() below resolves the target module at setup time and raises
+        # ModuleNotFoundError if playwright is not installed. Skip cleanly
+        # so local runs without ``uv sync --extra browser`` don't crash.
+        pytest.importorskip(
+            "playwright.sync_api",
+            reason="playwright not installed; install with: uv sync --extra browser",
+        )
         with (
             patch("notebooklm.cli.session._ensure_chromium_installed") as mock_ensure,
             patch("playwright.sync_api.sync_playwright") as mock_pw,
@@ -249,6 +256,7 @@ class TestLoginCommand:
             ("chrome", "Google Chrome", "google.com/chrome"),
         ],
     )
+    @pytest.mark.requires_playwright
     def test_login_channel_browser_not_installed_shows_helpful_error(
         self, runner, tmp_path, browser, expected_label, expected_install_url_fragment
     ):
@@ -286,6 +294,11 @@ class TestLoginCommand:
         reports it is already on the NotebookLM host, so the auto-detect
         fast-path is taken.
         """
+        # See ``mock_login_browser`` above — same playwright-missing skip path.
+        pytest.importorskip(
+            "playwright.sync_api",
+            reason="playwright not installed; install with: uv sync --extra browser",
+        )
         storage_file = tmp_path / "storage.json"
         with (
             patch("notebooklm.cli.session._ensure_chromium_installed"),
@@ -320,6 +333,7 @@ class TestLoginCommand:
             ),
         ],
     )
+    @pytest.mark.requires_playwright
     def test_login_handles_navigation_interrupted_error(
         self, runner, mock_login_browser_with_storage, error_message
     ):
@@ -346,6 +360,7 @@ class TestLoginCommand:
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_reraises_non_navigation_playwright_errors(
         self, runner, mock_login_browser_with_storage
     ):
@@ -415,6 +430,7 @@ class TestLoginCommand:
         assert mock_page.wait_for_url.call_args.kwargs.get("timeout") == 300_000
         assert "Login detected" in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_auto_detect_timeout_exits_with_helpful_message(
         self, runner, mock_login_browser_with_storage
     ):
@@ -430,6 +446,7 @@ class TestLoginCommand:
         assert result.exit_code == 1
         assert "Login not detected within 5 minutes" in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_auto_detect_browser_closed_during_wait_shows_help(
         self, runner, mock_login_browser_with_storage
     ):
@@ -472,6 +489,7 @@ class TestLoginCommand:
         assert "Unexpected URL after login" in result.output
         assert "Authentication saved" not in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_retries_on_connection_closed_error(
         self, runner, mock_login_browser_with_storage
     ):
@@ -501,6 +519,7 @@ class TestLoginCommand:
         # Verify that goto was called more than once (retried)
         assert mock_page.goto.call_count >= 2
 
+    @pytest.mark.requires_playwright
     def test_login_retries_on_connection_reset_error(self, runner, mock_login_browser_with_storage):
         """Test login retries when initial navigation fails with ERR_CONNECTION_RESET (#243)."""
         mock_page = mock_login_browser_with_storage
@@ -526,6 +545,7 @@ class TestLoginCommand:
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_exits_after_max_retries(self, runner, mock_login_browser_with_storage):
         """Test login exits with error message after 3 failed connection attempts (#243)."""
         mock_page = mock_login_browser_with_storage
@@ -547,6 +567,7 @@ class TestLoginCommand:
         # Verify retry attempts were made
         assert mock_page.goto.call_count == 3
 
+    @pytest.mark.requires_playwright
     def test_login_fails_fast_on_non_retryable_errors(
         self, runner, mock_login_browser_with_storage
     ):
@@ -569,6 +590,7 @@ class TestLoginCommand:
         # Should fail immediately without retrying (only 1 call)
         assert mock_page.goto.call_count == 1
 
+    @pytest.mark.requires_playwright
     def test_login_displays_help_text_after_exhausting_retries(
         self, runner, mock_login_browser_with_storage
     ):
@@ -596,6 +618,7 @@ class TestLoginCommand:
         # Verify exactly 3 retry attempts
         assert mock_page.goto.call_count == 3
 
+    @pytest.mark.requires_playwright
     def test_login_fresh_deletes_browser_profile(self, runner, tmp_path):
         """Test --fresh deletes existing browser_profile directory before login."""
         browser_dir = tmp_path / "profile"
@@ -634,6 +657,7 @@ class TestLoginCommand:
         assert not (browser_dir / "Default" / "Cookies").exists()
         assert "Cleared cached browser session" in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_fresh_works_when_no_profile_exists(self, runner, tmp_path):
         """Test --fresh works when browser_profile doesn't exist yet (first login)."""
         browser_dir = tmp_path / "profile"
@@ -666,6 +690,7 @@ class TestLoginCommand:
         assert result.exit_code == 0
         assert "Authentication saved" in result.output
 
+    @pytest.mark.requires_playwright
     def test_playwright_login_clears_stale_account_metadata(self, runner, tmp_path):
         """Interactive login targets the visible account, so stale browser-cookie
         account routing metadata must not survive the new storage state."""
@@ -741,6 +766,7 @@ class TestLoginCommand:
         assert result.exit_code == 1
         assert "Cannot clear browser profile" in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_recovers_from_target_closed_on_initial_navigation(self, runner, tmp_path):
         """Test login retries with fresh page when initial goto gets TargetClosedError (#246)."""
         storage_file = tmp_path / "storage.json"
@@ -787,6 +813,7 @@ class TestLoginCommand:
         # Verify new_page was called to recover from the stale page
         mock_context.new_page.assert_called()
 
+    @pytest.mark.requires_playwright
     def test_login_recovers_from_target_closed_in_cookie_forcing(self, runner, tmp_path):
         """Test login recovers when cookie-forcing goto hits TargetClosedError (#246).
 
@@ -846,6 +873,7 @@ class TestLoginCommand:
         # Verify new_page was called to get a fresh page after the stale one died
         mock_context.new_page.assert_called()
 
+    @pytest.mark.requires_playwright
     def test_login_ignores_navigation_interrupted_after_recovering_page(self, runner, tmp_path):
         """Test recovered pages can also hit the Playwright navigation race (#317)."""
         storage_file = tmp_path / "storage.json"
@@ -899,6 +927,7 @@ class TestLoginCommand:
         assert "Authentication saved" in result.output
         mock_context.new_page.assert_called()
 
+    @pytest.mark.requires_playwright
     def test_login_shows_browser_closed_message_after_exhausting_retries(self, runner, tmp_path):
         """Test login shows browser-specific error (not network error) when TargetClosedError exhausts retries."""
         storage_file = tmp_path / "storage.json"
@@ -940,6 +969,7 @@ class TestLoginCommand:
         assert "browser" in result.output.lower() and "closed" in result.output.lower()
         assert "Network connectivity" not in result.output
 
+    @pytest.mark.requires_playwright
     def test_login_cookie_forcing_double_failure_shows_browser_closed(self, runner, tmp_path):
         """Test cookie-forcing shows BROWSER_CLOSED_HELP when recovered page also raises TargetClosedError (#246).
 
@@ -1020,6 +1050,11 @@ class TestLoginNoTraceback:
         Hermetic: ``NOTEBOOKLM_HOME=tmp_path`` so the test never touches the
         real ``~/.notebooklm/`` (would fail with PermissionError in sandboxes).
         """
+        # See ``mock_login_browser`` above — same playwright-missing skip path.
+        pytest.importorskip(
+            "playwright.sync_api",
+            reason="playwright not installed; install with: uv sync --extra browser",
+        )
         monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path))
         with (
             patch("notebooklm.cli.session._ensure_chromium_installed"),

--- a/tests/unit/test_playwright_marker_hook.py
+++ b/tests/unit/test_playwright_marker_hook.py
@@ -81,12 +81,10 @@ UNMARKED_TEST = textwrap.dedent(
 
 
 def _scaffold(pytester: pytest.Pytester, *, test_body: str) -> None:
-    pytester.makepyfile(
-        **{
-            "conftest.py": HOOK_SOURCE,
-            "test_under_test.py": test_body,
-        }
-    )
+    # ``pytester.makepyfile`` appends ``.py`` internally via
+    # ``Path.with_suffix(".py")``, so keys are passed *without* the
+    # extension (idiomatic per the pytest docs).
+    pytester.makepyfile(conftest=HOOK_SOURCE, test_under_test=test_body)
 
 
 def test_marker_is_noop_when_playwright_installed(

--- a/tests/unit/test_playwright_marker_hook.py
+++ b/tests/unit/test_playwright_marker_hook.py
@@ -1,0 +1,128 @@
+"""pytester regression test for the ``requires_playwright`` marker hook.
+
+``tests/conftest.py`` registers a ``pytest_collection_modifyitems`` hook that
+auto-skips items carrying ``@pytest.mark.requires_playwright`` when the
+``playwright`` Python package is not installed. This file pins that behavior
+end-to-end via ``pytester`` so the hook does not silently regress.
+
+Three scenarios:
+
+1. **Playwright installed** — a marked test runs normally (no skip).
+2. **Playwright missing** — the same marked test is skipped with the
+   install-hint reason.
+3. **Playwright missing + unmarked test** — the hook leaves it alone.
+
+Each scenario builds a self-contained synthetic project via ``pytester`` and
+inlines a faithful copy of the hook so the regression test does NOT depend on
+importing the real conftest. The inlined hook is kept in lockstep with the
+real one — if the production hook's detection logic changes, update
+``HOOK_SOURCE`` here too.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+pytest_plugins = ["pytester"]
+
+
+# Faithful copy of the hook + the ``_PLAYWRIGHT_INSTALLED`` constant from
+# ``tests/conftest.py``. The constant is parameterized via an env var so the
+# scenarios below can flip it without mutating the real module. The
+# production constant uses ``importlib.util.find_spec("playwright")`` — a
+# pure boolean, equivalently shaped by the env var here.
+HOOK_SOURCE = textwrap.dedent(
+    """
+    import os
+    import pytest
+
+    _PLAYWRIGHT_INSTALLED = os.environ.get("FAKE_PLAYWRIGHT_INSTALLED") == "1"
+
+
+    def pytest_configure(config):
+        config.addinivalue_line(
+            "markers", "requires_playwright: skip when playwright is missing"
+        )
+
+
+    def pytest_collection_modifyitems(config, items):
+        if _PLAYWRIGHT_INSTALLED:
+            return
+        skip_marker = pytest.mark.skip(
+            reason="playwright not installed; install with: uv sync --extra browser"
+        )
+        for item in items:
+            if "requires_playwright" in item.keywords:
+                item.add_marker(skip_marker)
+    """
+).strip()
+
+
+MARKED_TEST = textwrap.dedent(
+    """
+    import pytest
+
+
+    @pytest.mark.requires_playwright
+    def test_marked():
+        assert True
+    """
+).strip()
+
+
+UNMARKED_TEST = textwrap.dedent(
+    """
+    def test_unmarked():
+        assert True
+    """
+).strip()
+
+
+def _scaffold(pytester: pytest.Pytester, *, test_body: str) -> None:
+    pytester.makepyfile(
+        **{
+            "conftest.py": HOOK_SOURCE,
+            "test_under_test.py": test_body,
+        }
+    )
+
+
+def test_marker_is_noop_when_playwright_installed(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_PLAYWRIGHT_INSTALLED = True`` → marked test runs normally."""
+    monkeypatch.setenv("FAKE_PLAYWRIGHT_INSTALLED", "1")
+    _scaffold(pytester, test_body=MARKED_TEST)
+    result = pytester.runpytest("-v")
+    assert result.ret == 0
+    result.assert_outcomes(passed=1)
+
+
+def test_marker_skips_when_playwright_missing(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_PLAYWRIGHT_INSTALLED = False`` → marked test is skipped with the install hint."""
+    monkeypatch.setenv("FAKE_PLAYWRIGHT_INSTALLED", "0")
+    _scaffold(pytester, test_body=MARKED_TEST)
+    result = pytester.runpytest("-v", "-rs")
+    assert result.ret == 0
+    result.assert_outcomes(skipped=1)
+    # Skip reason must surface the install hint so users know how to enable.
+    assert "uv sync --extra browser" in result.stdout.str()
+
+
+def test_unmarked_test_unaffected_when_playwright_missing(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hook only touches marked items — unmarked tests run regardless.
+
+    Guards against the hook accidentally over-reaching to every test in the
+    suite when playwright is missing.
+    """
+    monkeypatch.setenv("FAKE_PLAYWRIGHT_INSTALLED", "0")
+    _scaffold(pytester, test_body=UNMARKED_TEST)
+    result = pytester.runpytest("-v")
+    assert result.ret == 0
+    result.assert_outcomes(passed=1)

--- a/tests/unit/test_windows_compatibility.py
+++ b/tests/unit/test_windows_compatibility.py
@@ -20,6 +20,7 @@ import pytest
 from notebooklm.cli.session import _windows_playwright_event_loop
 
 
+@pytest.mark.requires_playwright
 class TestPlaywrightSmokeTest:
     """Smoke tests that actually invoke Playwright to catch real integration issues.
 


### PR DESCRIPTION
## Summary

`pytest tests/unit` previously crashed with `ModuleNotFoundError: No module named 'playwright'` when developers ran it without `uv sync --extra browser`. The crash came from two paths:

1. Test methods doing `from playwright.sync_api import Error/TimeoutError as ...` at runtime.
2. Shared login fixtures (`mock_login_browser`, `mock_login_browser_with_storage`, `mock_login_crash`) doing `patch("playwright.sync_api.sync_playwright")`, which resolves the target module at patch construction.

This PR makes the playwright dependency optional locally while keeping full coverage on CI (CI installs `--extra browser`).

## How it gates

Two complementary mechanisms:

- **`requires_playwright` pytest marker** (registered in `tests/conftest.py`). A `pytest_collection_modifyitems` hook auto-applies `pytest.mark.skip(reason="playwright not installed; install with: uv sync --extra browser")` to any item carrying the marker when `importlib.util.find_spec("playwright") is None`.

- **`pytest.importorskip("playwright.sync_api", reason=...)`** at the top of each shared login fixture, so any consumer test skips cleanly without needing an explicit marker.

## Audit map

| File | Change |
|---|---|
| `tests/conftest.py` | `_PLAYWRIGHT_INSTALLED` constant + `requires_playwright` marker registration + `pytest_collection_modifyitems` hook |
| `tests/unit/test_windows_compatibility.py` | `@pytest.mark.requires_playwright` class-level on `TestPlaywrightSmokeTest` (2 tests inside) |
| `tests/unit/cli/test_session.py` | `pytest.importorskip(...)` at top of `mock_login_browser`, `mock_login_browser_with_storage`, `mock_login_crash` fixtures; `@pytest.mark.requires_playwright` on 14 + 4 = 18 individual methods (14 from the first pass that import `from playwright.sync_api` directly, 4 with inline `patch(...)` that do not consume a fixture) |

## Intentional non-changes

The 5 sibling methods that exercise the playwright-missing path via `patch.dict("sys.modules", {"playwright": None, "playwright.sync_api": None})` are **NOT decorated** — they need to run regardless of install state:

- `tests/unit/test_cookie_domain_split.py::test_login_include_domains_on_playwright_path_no_longer_warns`
- `tests/unit/cli/test_session.py::test_login_playwright_import_error_handling`
- `tests/unit/cli/test_session.py::test_login_install_hint_includes_browser_extra`
- `tests/unit/cli/test_session.py::test_windows_login_skips_mode_and_chmod`
- `tests/unit/cli/test_session.py::test_unix_login_sets_mode_and_chmod`

`tests/integration/` was audited — no test imports playwright at runtime. `tests/integration/cli_vcr/test_login_browser_cookies.py` only references playwright in a docstring comment; it uses `rookiepy`, not playwright.

## Polish nits (deferred, non-blocking)

The polish pipeline (code-simplifier + claude/codex/gemini triple review + ultrathink) returned **1 Critical (the fixture-patch gap, addressed in this PR before opening), 0 Important, 1 nit**:

- (codex): adding a tier-style unit test for the `pytest_collection_modifyitems` hook itself (precedent: `tests/unit/test_tier_enforcement_hook.py`). Deferred — the hook is small and the simulation below is sufficient verification for an `ImportError` safeguard.

## Why this matters

Before this PR, a contributor cloning the repo and running `uv sync` (without optional extras) followed by `pytest tests/unit` would see a wall of red. They'd think the suite was broken; the actual fix (install the browser extra) was nowhere in the error message.

After this PR, the skip reason itself contains the install instruction: `"playwright not installed; install with: uv sync --extra browser"`.

## Verification

**With playwright installed (CI parity):**
```
$ uv run pytest tests/unit -q
4719 passed, 16 skipped, 10 warnings in 29.28s
```
Same as before the PR — no new skips, no behavior change.

**With playwright simulated missing** (via `sys.modules["playwright"] = None` + `__import__` block + `find_spec` patch, all before pytest startup), running the affected files only:
```
140 passed, 37 skipped, 0 errors
```
Previously, those 37 would have been `ERROR at setup: ModuleNotFoundError`.

## Test plan

- [ ] CI runs green across Linux/macOS/Windows × Python 3.10-3.14 matrix.
- [ ] Locally: `uv sync --extra dev` (no `--extra browser`) followed by `uv run pytest tests/unit/cli/test_session.py tests/unit/test_windows_compatibility.py` skips the 37 affected items cleanly with the install-hint reason instead of erroring.
- [ ] No new test skips appear when running the full suite with `--extra browser` installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test marker to gate Playwright-dependent tests; such tests are automatically skipped when the browser automation package is not available, preventing import errors.
  * Updated existing test suites to mark Playwright-reliant cases so they fail cleanly on environments without the optional dependency.
  * Added regression tests validating marker behavior in both installed and missing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->