### PR TITLE
feat(core): per-sub-client narrow Protocols + _chat_transport.py (D2 PR-1 scaffolding)

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -10,13 +10,19 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from . import _artifact_formatters, _artifact_polling, _mind_map
 from ._artifact_downloads import ArtifactDownloadService, DownloadResult
 from ._artifact_generation import ArtifactGenerationService
 from ._artifact_listing import ArtifactListingService
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import (
+    AuthRouteProvider,
+    ClientCoreCapabilities,
+    CoreRPCProvider,
+    PollRegistryProvider,
+    TransportOperationProvider,
+)
 from .auth import load_httpx_cookies
 from .rpc import (
     ArtifactTypeCode,
@@ -48,6 +54,30 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _ArtifactsCore(
+    CoreRPCProvider,
+    AuthRouteProvider,
+    PollRegistryProvider,
+    TransportOperationProvider,
+    Protocol,
+):
+    """Narrow per-sub-client view of the core required by :class:`ArtifactsAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Inherits
+    only the capabilities ArtifactsAPI actually uses: ``rpc_call`` (from
+    :class:`CoreRPCProvider`), authuser routing (from
+    :class:`AuthRouteProvider`), the shared artifact poll registry (from
+    :class:`PollRegistryProvider`), and transport-operation bookkeeping for
+    long-running download streams (from :class:`TransportOperationProvider`).
+    The cutover to swap :class:`ArtifactsAPI.__init__` annotation from
+    :class:`ClientCoreCapabilities` to ``_ArtifactsCore`` lives in
+    ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    pass
+
 
 if TYPE_CHECKING:
     from ._notes import NotesAPI  # retained for backward-compatible type hints

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -8,9 +8,15 @@ import asyncio
 import contextlib
 import logging
 import weakref
-from typing import Any
+from typing import Any, Protocol
 
-from ._capabilities import ClientCoreCapabilities
+import httpx
+
+from ._capabilities import (
+    ClientCoreCapabilities,
+    CoreReqIdProvider,
+    TransportOperationProvider,
+)
 from ._chat_protocol import (
     build_streaming_chat_request,
     collect_texts_from_nested,
@@ -24,6 +30,7 @@ from ._chat_protocol import (
 )
 from ._core import _AuthSnapshot
 from ._core_cache import ConversationCache
+from ._core_transport import _BuildRequest
 from ._logging import get_request_id, reset_request_id, set_request_id
 from ._loop_affinity import assert_bound_loop
 from .exceptions import ChatError, NetworkError, ValidationError
@@ -36,6 +43,55 @@ from .rpc import (
 from .types import AskResult, ChatMode, ChatReference, ConversationTurn
 
 logger = logging.getLogger(__name__)
+
+
+class _ChatCore(TransportOperationProvider, CoreReqIdProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`ChatAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Chat
+    uses transport primitives directly rather than ``rpc_call``: the
+    streaming-chat path issues an authed POST against ``batchexecute``
+    and parses the streamed response inline, so :class:`CoreRPCProvider`
+    is intentionally absent.
+
+    Inherits the transport-operation bookkeeping (from
+    :class:`TransportOperationProvider`) and the shared request-id
+    counter (from :class:`CoreReqIdProvider`). The three underscore-
+    private members declared below are exposed under their native
+    :class:`ClientCore` names because :func:`_chat_transport.chat_aware_authed_post`
+    calls them by those names; they are the same transport capabilities the
+    inherited :class:`TransportOperationProvider` describes, just under the
+    underlying core's private names rather than the adapter's public ones
+    (the adapter is removed in ``arch-d2-cutover``).
+
+    Cutover note (for ``arch-d2-cutover``): until then, this Protocol is
+    intentionally over-constrained — a concrete class must expose both the
+    public ``begin_transport_post`` (from ``TransportOperationProvider``)
+    AND the underscore-private ``_begin_transport_post`` declared here. The
+    real ``ClientCore`` only has the underscore form; the public form lives
+    on the ``ClientCoreCapabilities`` adapter. D2 PR-2 reshapes
+    ``TransportOperationProvider`` so ``ClientCore`` becomes the canonical
+    implementer of the narrow Protocols (i.e. the no-underscore facade is
+    retired with ``ClientCoreCapabilities``).
+
+    The cutover to swap :class:`ChatAPI.__init__` annotation from
+    :class:`ClientCoreCapabilities` to ``_ChatCore`` and flip the
+    ``self._core.query_post`` call site to
+    :func:`_chat_transport.chat_aware_authed_post` lives in
+    ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    async def _begin_transport_post(self, log_label: str) -> Any: ...
+
+    async def _finish_transport_post(self, token: Any) -> None: ...
+
+    async def _perform_authed_post(
+        self,
+        *,
+        build_request: _BuildRequest,
+        log_label: str,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response: ...
 
 
 def _extract_next_turn_content(next_turn: Any) -> str | None:

--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -1,0 +1,124 @@
+"""Chat-domain consumer-side error-mapping seam over generic transport.
+
+This module owns the chat-flavored exception mapping that wraps a
+single authed POST attempt against the NotebookLM batchexecute
+endpoint. It is the chat-domain consumer-side seam: transport-layer
+exceptions (``_TransportAuthExpired``, ``_TransportRateLimited``,
+``_TransportServerError``, raw ``httpx.HTTPStatusError``) raised by
+``ClientCore._perform_authed_post`` are translated into ``ChatError``
+or ``NetworkError`` so callers (currently only :class:`ChatAPI.ask`)
+stay free of HTTP-status branching.
+
+Body is the function-level extraction of the pre-existing
+``_RpcExecutor.query_post`` at ``_core_rpc.py:222-306`` — preserved
+verbatim modulo the rename of ``self._owner`` to ``core``. The cutover
+that flips :meth:`ChatAPI.ask` to call :func:`chat_aware_authed_post`
+directly and deletes the old ``query_post`` chain lives in
+``arch-d2-cutover`` (D2 PR-2); this file is additive scaffolding.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ._core_transport import (
+    _TransportAuthExpired,
+    _TransportRateLimited,
+    _TransportServerError,
+)
+from .exceptions import ChatError, NetworkError
+
+if TYPE_CHECKING:
+    from ._chat import _ChatCore
+    from ._core_transport import _BuildRequest
+
+
+async def chat_aware_authed_post(
+    core: _ChatCore,
+    *,
+    build_request: _BuildRequest,
+    parse_label: str,
+) -> httpx.Response:
+    """Chat-side semantic owner around :meth:`_perform_authed_post`.
+
+    Wraps the shared transport pipeline with chat-flavored exception
+    mapping: transport-layer auth failures become
+    :class:`~notebooklm.exceptions.ChatError`, and transport-layer
+    network/rate-limit failures become
+    :class:`~notebooklm.exceptions.NetworkError` /
+    :class:`~notebooklm.exceptions.ChatError` respectively. This keeps
+    ChatAPI free of HTTP-status branching and matches the historical
+    contract of ``ChatAPI.ask`` (a planned follow-up will migrate that caller).
+
+    Args:
+        core: The chat-side narrow core view (declares the underscore-
+            private transport primitives + reqid counter).
+        build_request: See :meth:`_perform_authed_post`.
+        parse_label: Caller-friendly label used in log lines and error
+            messages (e.g. ``"chat.ask"``).
+    """
+    operation_token = await core._begin_transport_post(parse_label)
+    try:
+        try:
+            return await core._perform_authed_post(
+                build_request=build_request,
+                log_label=parse_label,
+            )
+        except _TransportAuthExpired as exc:
+            raise ChatError(
+                f"{parse_label} failed: authentication expired and refresh did not recover"
+            ) from exc
+        except _TransportRateLimited as exc:
+            raise ChatError(
+                f"{parse_label} rate-limited (HTTP 429)."
+                + (
+                    f" Retry after {exc.retry_after} seconds."
+                    if exc.retry_after is not None
+                    else ""
+                )
+            ) from exc
+        except _TransportServerError as exc:
+            if isinstance(exc.original, httpx.HTTPStatusError):
+                raise ChatError(
+                    f"{parse_label} failed with HTTP {exc.original.response.status_code} "
+                    f"after retries: {exc.original}"
+                ) from exc
+            # Network-layer failure (RequestError / Timeout).
+            # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
+            # ``_TransportServerError`` on the network path; this guard keeps
+            # the contract enforced under ``python -O`` (where ``assert``
+            # would be stripped) and gives a clear diagnostic if the
+            # invariant ever drifts.
+            if not isinstance(exc.original, httpx.RequestError):
+                raise TypeError(
+                    f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                ) from exc
+            # Preserve the timeout-specific message: TimeoutException is a
+            # subclass of RequestError, so without this branch read/connect
+            # timeouts would surface as a generic "network error after
+            # retries" line and lose the "timed out" signal callers rely on.
+            if isinstance(exc.original, httpx.TimeoutException):
+                raise NetworkError(
+                    f"{parse_label} timed out after retries: {exc.original}",
+                    original_error=exc.original,
+                ) from exc
+            raise NetworkError(
+                f"{parse_label} network error after retries: {exc.original}",
+                original_error=exc.original,
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            # Non-5xx / non-401 / non-429 status errors fall through
+            # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
+            # or unhandled 4xx).
+            raise ChatError(
+                f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
+            ) from exc
+    finally:
+        await core._finish_transport_post(operation_token)
+    # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
+    # handlers were removed here because ``_perform_authed_post`` always
+    # either retries those errors or wraps them in
+    # ``_TransportServerError`` (handled above), so they cannot reach
+    # this scope.

--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -93,7 +93,8 @@ async def chat_aware_authed_post(
             # invariant ever drifts.
             if not isinstance(exc.original, httpx.RequestError):
                 raise TypeError(
-                    f"Unexpected _TransportServerError.original type: {type(exc.original)}"
+                    f"Unexpected _TransportServerError.original type: {type(exc.original)}. "
+                    "Expected httpx.HTTPStatusError or httpx.RequestError."
                 ) from exc
             # Preserve the timeout-specific message: TimeoutException is a
             # subclass of RequestError, so without this branch read/connect

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -2,9 +2,9 @@
 
 import logging
 import warnings
-from typing import Any
+from typing import Any, Protocol
 
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import AuthRouteProvider, ClientCoreCapabilities, CoreRPCProvider
 from ._idempotency import idempotent_create
 from ._notebook_metadata import (
     NotebookMetadataService,
@@ -26,6 +26,22 @@ from .rpc import RPCMethod, safe_index
 from .types import AccountLimits, Notebook, NotebookDescription, NotebookMetadata, SuggestedTopic
 
 logger = logging.getLogger(__name__)
+
+
+class _NotebooksCore(CoreRPCProvider, AuthRouteProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`NotebooksAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002 §"narrow
+    Protocols, co-located"). Inherits only the capabilities NotebooksAPI
+    actually uses: ``rpc_call`` (from :class:`CoreRPCProvider`) and the
+    NotebookLM authuser routing surface (from :class:`AuthRouteProvider`).
+    The cutover to swap :class:`NotebooksAPI.__init__` annotation from
+    :class:`ClientCoreCapabilities` to ``_NotebooksCore`` lives in
+    ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    pass
+
 
 CREATE_NOTEBOOK_QUOTA_RPC_CODE = 3
 

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -11,13 +11,26 @@ historical ``NotesAPI`` method surface for backward compatibility.
 
 import builtins
 import logging
-from typing import Any
+from typing import Any, Protocol
 
 from . import _mind_map
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import ClientCoreCapabilities, CoreRPCProvider
 from .types import AskResult, Note
 
 logger = logging.getLogger(__name__)
+
+
+class _NotesCore(CoreRPCProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`NotesAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Inherits
+    only the single capability NotesAPI actually uses: ``rpc_call`` (from
+    :class:`CoreRPCProvider`). The cutover to swap :class:`NotesAPI.__init__`
+    annotation from :class:`ClientCoreCapabilities` to ``_NotesCore`` lives
+    in ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    pass
 
 
 class NotesAPI:

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -6,10 +6,10 @@ and importing discovered sources into notebooks.
 
 import logging
 import warnings
-from typing import Any
+from typing import Any, Protocol
 
 from . import research as _research_pub
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import ClientCoreCapabilities, CoreRPCProvider, PollRegistryProvider
 from .exceptions import ResearchTaskMismatchError, ValidationError
 from .rpc import RPCMethod, safe_index
 from .types import CitedSourceSelection
@@ -17,6 +17,22 @@ from .types import CitedSourceSelection
 __all__ = ["CitedSourceSelection", "ResearchAPI"]
 
 logger = logging.getLogger(__name__)
+
+
+class _ResearchCore(CoreRPCProvider, PollRegistryProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`ResearchAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Inherits
+    only the capabilities ResearchAPI actually uses: ``rpc_call`` (from
+    :class:`CoreRPCProvider`) and the shared artifact poll registry (from
+    :class:`PollRegistryProvider`). The cutover to swap
+    :class:`ResearchAPI.__init__` annotation from
+    :class:`ClientCoreCapabilities` to ``_ResearchCore`` lives in
+    ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    pass
+
 
 _RESEARCH_RESULT_TYPE_ALIASES = {
     "web": 1,

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -2,13 +2,28 @@
 
 import logging
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, Protocol
 
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import ClientCoreCapabilities, CoreRPCProvider
 from .rpc import RPCMethod
 from .types import AccountLimits, AccountTier
 
 logger = logging.getLogger(__name__)
+
+
+class _SettingsCore(CoreRPCProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`SettingsAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Inherits
+    only the single capability the settings RPCs use: ``rpc_call`` (from
+    :class:`CoreRPCProvider`). The cutover to swap the settings sub-client's
+    ``__init__`` annotation from :class:`ClientCoreCapabilities` to
+    ``_SettingsCore`` lives in ``arch-d2-cutover`` (D2 PR-2); this class is
+    additive scaffolding.
+    """
+
+    pass
+
 
 _ACCOUNT_LIMITS_PATH = (0, 1)
 _NOTEBOOK_LIMIT_INDEX = 1

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -1,13 +1,29 @@
 """Sharing operations API."""
 
 import logging
+from typing import Protocol
 
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import AuthRouteProvider, ClientCoreCapabilities, CoreRPCProvider
 from .rpc import RPCMethod
 from .rpc.types import ShareAccess, SharePermission, ShareViewLevel
 from .types import ShareStatus
 
 logger = logging.getLogger(__name__)
+
+
+class _SharingCore(CoreRPCProvider, AuthRouteProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`SharingAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Inherits
+    only the capabilities SharingAPI actually uses: ``rpc_call`` (from
+    :class:`CoreRPCProvider`) and authuser routing (from
+    :class:`AuthRouteProvider`). The cutover to swap
+    :class:`SharingAPI.__init__` annotation from
+    :class:`ClientCoreCapabilities` to ``_SharingCore`` lives in
+    ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    pass
 
 
 class SharingAPI:

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -6,13 +6,18 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 from time import monotonic
-from typing import IO, TYPE_CHECKING, Any, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal, Protocol
 from urllib.parse import urlparse
 
 import httpx
 
 from . import _source_upload
-from ._capabilities import ClientCoreCapabilities
+from ._capabilities import (
+    AuthRouteProvider,
+    ClientCoreCapabilities,
+    CoreRPCProvider,
+    UploadConcurrencyProvider,
+)
 from ._source_add import SourceAddService
 from ._source_content import SourceContentRenderer
 from ._source_listing import SourceLister
@@ -29,6 +34,23 @@ if TYPE_CHECKING:
     from ._core import ClientCore
 
 logger = logging.getLogger(__name__)
+
+
+class _SourcesCore(CoreRPCProvider, AuthRouteProvider, UploadConcurrencyProvider, Protocol):
+    """Narrow per-sub-client view of the core required by :class:`SourcesAPI`.
+
+    Co-located with the sub-client that consumes it (per ADR-002). Inherits
+    only the capabilities SourcesAPI actually uses: ``rpc_call`` (from
+    :class:`CoreRPCProvider`), the NotebookLM authuser routing surface
+    (from :class:`AuthRouteProvider`), and the upload-concurrency semaphore
+    + queue-wait recorder (from :class:`UploadConcurrencyProvider`). The
+    cutover to swap :class:`SourcesAPI.__init__` annotation from
+    :class:`ClientCoreCapabilities` to ``_SourcesCore`` lives in
+    ``arch-d2-cutover`` (D2 PR-2); this class is additive scaffolding.
+    """
+
+    pass
+
 
 _SOURCE_ID_UUID_PATTERN = _source_upload._SOURCE_ID_UUID_PATTERN
 _extract_register_file_source_id = _source_upload._extract_register_file_source_id

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -187,6 +187,7 @@ async def test_transport_rate_limited_without_retry_after_omits_retry_clause():
     assert "HTTP 429" in message
     assert "Retry after" not in message  # No "Retry after N seconds" clause.
     assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +217,7 @@ async def test_transport_server_error_with_http_status_error_maps_to_chat_error(
     assert "HTTP 503" in message
     assert "after retries" in message
     assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -236,6 +238,7 @@ async def test_transport_server_error_with_request_error_maps_to_network_error()
     assert "timed out" not in message
     assert excinfo.value.original_error is original
     assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -259,6 +262,7 @@ async def test_transport_server_error_with_timeout_exception_keeps_timeout_messa
     assert "network error after retries" not in message
     assert excinfo.value.original_error is original
     assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -284,6 +288,7 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
 
     assert "_TransportServerError.original" in str(excinfo.value)
     assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +316,7 @@ async def test_raw_http_status_error_maps_to_chat_error():
     assert "HTTP 404" in message
     assert "chat.ask" in message
     assert excinfo.value.__cause__ is raw_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -286,7 +286,12 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
             parse_label="chat.ask",
         )
 
-    assert "_TransportServerError.original" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "_TransportServerError.original" in message
+    # The diagnostic must include both the actual type and the expected
+    # types so a future invariant drift produces an actionable error
+    # (per gemini-code-assist review on PR #832).
+    assert "Expected httpx.HTTPStatusError or httpx.RequestError" in message
     assert excinfo.value.__cause__ is transport_exc
     core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -1,0 +1,338 @@
+"""Unit tests for :func:`notebooklm._chat_transport.chat_aware_authed_post`.
+
+Exercises the chat-domain error-mapping seam over the generic transport
+primitives. Each test injects a stub ``core`` whose ``_perform_authed_post``
+raises one of the transport-layer exceptions (or the raw ``httpx``
+status error) and asserts the function maps the failure to the expected
+``ChatError`` / ``NetworkError`` shape, message, and exception chain.
+The drain-tracking bookkeeping (``_begin_transport_post`` /
+``_finish_transport_post``) is verified by checking the begin/finish
+call counts and the operation-token round-trip.
+
+The stub ``core`` is a lightweight ``SimpleNamespace`` rather than a
+``MagicMock(spec=_ChatCore)`` so the tests stay independent of the
+protocol's exact member set — they only need the three transport
+primitives the function actually calls. After D2 cutover, the function
+will run against the real ``ClientCore``; this unit-test layer keeps
+the chat-side error mapping isolated from transport implementation
+details.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from notebooklm._chat_transport import chat_aware_authed_post
+from notebooklm._core_transport import (
+    _TransportAuthExpired,
+    _TransportRateLimited,
+    _TransportServerError,
+)
+from notebooklm.exceptions import ChatError, NetworkError
+
+# ---------------------------------------------------------------------------
+# Test scaffolding
+# ---------------------------------------------------------------------------
+
+
+_SENTINEL_TOKEN = object()
+
+
+def _make_request() -> httpx.Request:
+    return httpx.Request("POST", "https://example.test/x")
+
+
+def _make_status_error(code: int, *, retry_after: str | None = None) -> httpx.HTTPStatusError:
+    headers = {"retry-after": retry_after} if retry_after else {}
+    request = _make_request()
+    response = httpx.Response(code, request=request, headers=headers)
+    return httpx.HTTPStatusError(f"HTTP {code}", request=request, response=response)
+
+
+def _make_stub_core(
+    *,
+    perform_side_effect: Any = None,
+    perform_return_value: Any = None,
+) -> SimpleNamespace:
+    """Build a stub ``core`` matching the slice of ``_ChatCore`` we exercise.
+
+    Pass ``perform_side_effect`` to make ``_perform_authed_post`` raise
+    (exception instance) or invoke a callable; pass ``perform_return_value``
+    to make it return that response unchanged. Exactly one of the two
+    should be supplied per test — they are mutually exclusive.
+    """
+    return SimpleNamespace(
+        _begin_transport_post=AsyncMock(return_value=_SENTINEL_TOKEN),
+        _finish_transport_post=AsyncMock(return_value=None),
+        _perform_authed_post=AsyncMock(
+            side_effect=perform_side_effect,
+            return_value=perform_return_value,
+        ),
+    )
+
+
+def _noop_build_request(_snapshot: Any) -> tuple[str, str, dict[str, str]]:
+    """Build-request stub: the real transport invokes this, our stub does not."""
+    return "https://example.test/x", "payload", {}
+
+
+# ---------------------------------------------------------------------------
+# Happy path — bookkeeping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_aware_authed_post_returns_response_and_balances_bookkeeping():
+    """Success path: response forwarded; begin/finish tokens balanced."""
+    expected_response = httpx.Response(200, request=_make_request())
+    core = _make_stub_core(perform_return_value=expected_response)
+
+    result = await chat_aware_authed_post(
+        core,  # type: ignore[arg-type]
+        build_request=_noop_build_request,
+        parse_label="chat.ask",
+    )
+
+    assert result is expected_response
+    core._begin_transport_post.assert_awaited_once_with("chat.ask")
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
+    core._perform_authed_post.assert_awaited_once_with(
+        build_request=_noop_build_request,
+        log_label="chat.ask",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _TransportAuthExpired → ChatError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_auth_expired_maps_to_chat_error():
+    original = _make_status_error(401)
+    transport_exc = _TransportAuthExpired("auth refresh failed", original=original)
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(ChatError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    assert "authentication expired" in str(excinfo.value).lower()
+    assert "chat.ask" in str(excinfo.value)
+    assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
+
+
+# ---------------------------------------------------------------------------
+# _TransportRateLimited → ChatError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_rate_limited_with_retry_after_includes_retry_seconds():
+    original = _make_status_error(429, retry_after="42")
+    response = original.response
+    transport_exc = _TransportRateLimited(
+        "rate-limited",
+        retry_after=42,
+        response=response,
+        original=original,
+    )
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(ChatError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    message = str(excinfo.value)
+    assert "rate-limited" in message
+    assert "HTTP 429" in message
+    assert "Retry after 42 seconds" in message
+    assert excinfo.value.__cause__ is transport_exc
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
+
+
+@pytest.mark.asyncio
+async def test_transport_rate_limited_without_retry_after_omits_retry_clause():
+    original = _make_status_error(429)
+    response = original.response
+    transport_exc = _TransportRateLimited(
+        "rate-limited",
+        retry_after=None,
+        response=response,
+        original=original,
+    )
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(ChatError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    message = str(excinfo.value)
+    assert "rate-limited" in message
+    assert "HTTP 429" in message
+    assert "Retry after" not in message  # No "Retry after N seconds" clause.
+    assert excinfo.value.__cause__ is transport_exc
+
+
+# ---------------------------------------------------------------------------
+# _TransportServerError variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transport_server_error_with_http_status_error_maps_to_chat_error():
+    original = _make_status_error(503)
+    transport_exc = _TransportServerError(
+        "5xx after retries",
+        original=original,
+        response=original.response,
+        status_code=503,
+    )
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(ChatError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    message = str(excinfo.value)
+    assert "HTTP 503" in message
+    assert "after retries" in message
+    assert excinfo.value.__cause__ is transport_exc
+
+
+@pytest.mark.asyncio
+async def test_transport_server_error_with_request_error_maps_to_network_error():
+    original = httpx.RequestError("connect failed", request=_make_request())
+    transport_exc = _TransportServerError("network failure", original=original)
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(NetworkError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    message = str(excinfo.value)
+    assert "network error after retries" in message
+    assert "timed out" not in message
+    assert excinfo.value.original_error is original
+    assert excinfo.value.__cause__ is transport_exc
+
+
+@pytest.mark.asyncio
+async def test_transport_server_error_with_timeout_exception_keeps_timeout_message():
+    """Regression: ``httpx.TimeoutException`` is a subclass of
+    ``httpx.RequestError``; without the explicit timeout branch the message
+    would collapse to the generic "network error after retries" line."""
+    original = httpx.ReadTimeout("read timed out", request=_make_request())
+    transport_exc = _TransportServerError("timeout", original=original)
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(NetworkError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    message = str(excinfo.value)
+    assert "timed out after retries" in message
+    assert "network error after retries" not in message
+    assert excinfo.value.original_error is original
+    assert excinfo.value.__cause__ is transport_exc
+
+
+@pytest.mark.asyncio
+async def test_transport_server_error_with_unexpected_original_type_raises_type_error():
+    """Defensive: ``_perform_authed_post`` should only wrap
+    ``HTTPStatusError`` / ``RequestError`` into ``_TransportServerError``.
+    Anything else surfaces as ``TypeError`` so an invariant drift is loud
+    rather than silently mis-mapped."""
+
+    class _UnexpectedException(Exception):
+        pass
+
+    original = _UnexpectedException("not http, not request")
+    transport_exc = _TransportServerError("bogus original", original=original)
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(TypeError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    assert "_TransportServerError.original" in str(excinfo.value)
+    assert excinfo.value.__cause__ is transport_exc
+
+
+# ---------------------------------------------------------------------------
+# Raw httpx.HTTPStatusError fall-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_raw_http_status_error_maps_to_chat_error():
+    """Non-401 / non-429 / non-5xx status errors that fall through
+    ``_perform_authed_post`` reach this layer as raw
+    ``httpx.HTTPStatusError`` and get wrapped in a ``ChatError`` that
+    surfaces the status code."""
+    raw_exc = _make_status_error(404)
+    core = _make_stub_core(perform_side_effect=raw_exc)
+
+    with pytest.raises(ChatError) as excinfo:
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    message = str(excinfo.value)
+    assert "HTTP 404" in message
+    assert "chat.ask" in message
+    assert excinfo.value.__cause__ is raw_exc
+
+
+# ---------------------------------------------------------------------------
+# Finalization invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finish_transport_post_runs_even_when_perform_raises():
+    """The drain-tracking ``finish`` must always run in the ``finally``
+    clause; otherwise a chat-error path could leak in-flight counters."""
+    transport_exc = _TransportAuthExpired(
+        "auth expired",
+        original=_make_status_error(401),
+    )
+    core = _make_stub_core(perform_side_effect=transport_exc)
+
+    with pytest.raises(ChatError):
+        await chat_aware_authed_post(
+            core,  # type: ignore[arg-type]
+            build_request=_noop_build_request,
+            parse_label="chat.ask",
+        )
+
+    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)


### PR DESCRIPTION
## Summary

Wave 2 of the architecture-disease-remediation arc — D2 PR-1: **additive scaffolding** that lays the groundwork for the D2 cutover (D2 PR-2 / `arch-d2-cutover`) without flipping any call sites.

- Adds 8 new private per-sub-client `_<Name>Core` Protocol classes, each co-located in the sub-client file that consumes it (per ADR-002's per-sub-client narrow-Protocol pattern).
- Adds `src/notebooklm/_chat_transport.py` exposing `chat_aware_authed_post()` — the ~85-line block from `_core_rpc.py:222-306` (the existing `_RpcExecutor.query_post`), preserved verbatim modulo the `self._owner` → `core` rename.
- Adds `tests/unit/test_chat_transport.py` with 10 unit tests for each transport-failure variant + bookkeeping invariants. Coverage on the new module: **100%**.

**Additive scaffolding only — no sub-client annotation flip, no deletions. Cutover happens in `arch-d2-cutover` (D2 PR-2).** Specifically:
- No sub-client `__init__` annotation is changed; sub-clients still take `core: ClientCoreCapabilities`.
- `_capabilities.py` is untouched (`ClientCoreCapabilities`, `ChatStreamingProvider` remain).
- `_core.query_post`, `_RpcExecutor.query_post`, and the `_core.py` property-bridge zoo all remain.
- `_chat.py:284`'s call to `self._core.query_post(...)` is NOT yet flipped to `chat_aware_authed_post(...)`.

## New Protocol classes

Each is co-located with the sub-client that consumes it; each inherits only from the narrow Protocols its sub-client actually uses (a strict subset of `ClientCoreCapabilities`).

| Sub-client file | New Protocol | Parents |
|---|---|---|
| `_notebooks.py` | `_NotebooksCore` | `CoreRPCProvider, AuthRouteProvider` |
| `_sources.py`   | `_SourcesCore`   | `CoreRPCProvider, AuthRouteProvider, UploadConcurrencyProvider` |
| `_artifacts.py` | `_ArtifactsCore` | `CoreRPCProvider, AuthRouteProvider, PollRegistryProvider, TransportOperationProvider` |
| `_chat.py`      | `_ChatCore`     | `TransportOperationProvider, CoreReqIdProvider` (no `CoreRPCProvider` — chat uses transport primitives) |
| `_research.py`  | `_ResearchCore`  | `CoreRPCProvider, PollRegistryProvider` |
| `_notes.py`     | `_NotesCore`     | `CoreRPCProvider` |
| `_settings.py`  | `_SettingsCore`  | `CoreRPCProvider` |
| `_sharing.py`   | `_SharingCore`   | `CoreRPCProvider, AuthRouteProvider` |

`_ChatCore` additionally declares the three underscore-private members (`_begin_transport_post`, `_finish_transport_post`, `_perform_authed_post`) that `chat_aware_authed_post()` calls by their `ClientCore`-native names. The docstring includes a cutover note for D2 PR-2 implementers about the temporarily over-constrained state.

## Phase plan reference

[`.sisyphus/phases/arch-disease-remediation/phase-1.md#arch-d2-narrow-protocols-scaffolding`](.sisyphus/phases/arch-disease-remediation/phase-1.md)

## Coverage

- D3 PR (#831, post-merge) baseline: **93.52%** (unit + integration).
- This PR: **93.55%** (unit + integration). Delta: **+0.03%** (gate `≥ -0.5%`).
- New module `_chat_transport.py`: 100% line + branch coverage.

## Verification

- `uv run ruff format .` → 413 files unchanged.
- `uv run ruff check .` → All checks passed.
- `uv run mypy src/notebooklm --ignore-missing-imports` → 0 errors in 125 source files.
- `uv run pytest tests/unit tests/integration` → **5409 passed**, 20 skipped (10 new chat_transport tests added).

## Test plan

- [x] `uv run pytest tests/unit tests/integration` — full unit + integration pass (5409 passed)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 errors
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `_chat_transport.py` body is verbatim from `_core_rpc.py:222-306` (modulo `self._owner` → `core`)
- [x] Each Protocol's parent set is a strict subset of what `ClientCoreCapabilities` provides today
- [x] No sub-client `__init__` annotation changed
- [x] No deletions of `query_post`, `ClientCoreCapabilities`, `ChatStreamingProvider`, or property bridges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer, more accurate chat transport error messages for auth expiry, rate limits, server errors, and timeouts.

* **New Features**
  * Chat-aware authenticated POST operation that balances transport lifecycle and surfaces upstream responses consistently.

* **Refactor**
  * Modularized internal client core surface into narrower per-component interfaces to ease future cutovers.

* **Tests**
  * Added comprehensive tests validating chat transport behavior, error mappings, and lifecycle balancing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->