### PR TITLE
chore(d2-followup): address Claude bot nits on merged #835

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -85,6 +85,10 @@ class _ChatCore(
         *,
         build_request: _BuildRequest,
         log_label: str,
+        # ``disable_internal_retries`` mirrors the concrete
+        # ``ClientCore._perform_authed_post`` signature so structural typing
+        # matches; ``chat_aware_authed_post`` never forwards it (chat always
+        # runs with internal retries enabled).
         disable_internal_retries: bool = False,
     ) -> httpx.Response: ...
 

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -91,9 +91,11 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         # TransportOperationProvider — fresh token object per call so drain tracking
         # gets unique identities (return_value=object() would share one instance).
         # The Protocol declares the underscore-private names that ClientCore
-        # exposes directly; the no-underscore aliases below are preserved as
-        # forward-compat shims so any legacy callers that still reach for the
-        # adapter-era names land on benign mocks rather than AttributeError.
+        # exposes directly. The no-underscore aliases below are purely defensive
+        # safety-net defaults — no test site currently calls them on a
+        # FakeClientCore instance (all no-underscore callers in the test tree
+        # invoke these on TransportDrainTracker, not FakeClientCore). Kept so a
+        # stray legacy reference lands on a benign mock rather than AttributeError.
         "_begin_transport_post": AsyncMock(side_effect=lambda *a, **kw: object()),
         "_begin_transport_task": AsyncMock(side_effect=lambda *a, **kw: object()),
         "_finish_transport_post": AsyncMock(return_value=None),

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -107,7 +107,7 @@ _PATTERN_OBJECT_ATTR = re.compile(r"monkeypatch\.setattr\(\s*notebooklm\.")
 # start position.
 _PATTERN_ASYNCMOCK_ASSIGN = re.compile(
     r"(?<![\w.])[\w.]+\."
-    r"(rpc_call|_perform_authed_post|_begin_transport_post|_finish_transport_post|query_post)"
+    r"(rpc_call|_perform_authed_post|_begin_transport_post|_finish_transport_post)"
     r"\s*=\s*(?:[\w]+\.)*AsyncMock"
 )
 

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -107,7 +107,7 @@ _PATTERN_OBJECT_ATTR = re.compile(r"monkeypatch\.setattr\(\s*notebooklm\.")
 # start position.
 _PATTERN_ASYNCMOCK_ASSIGN = re.compile(
     r"(?<![\w.])[\w.]+\."
-    r"(rpc_call|_perform_authed_post|_begin_transport_post|_finish_transport_post)"
+    r"(rpc_call|_perform_authed_post|_begin_transport_post|_begin_transport_task|_finish_transport_post)"
     r"\s*=\s*(?:[\w]+\.)*AsyncMock"
 )
 


### PR DESCRIPTION
## Summary

Three cosmetic / dead-code clean-ups flagged by the Claude bot on #835's final review pass after that PR had already merged. None are correctness fixes; all three reduce maintenance noise.

- **\`tests/_lint/test_no_forbidden_monkeypatches.py:110\`** — remove \`|query_post\` from the \`_PATTERN_ASYNCMOCK_ASSIGN\` alternation. \`ClientCore.query_post\` was deleted in #835, so this alternative can never match again. Dead regex branches mislead future readers who wonder whether the method still exists somewhere.
- **\`tests/_fixtures/fake_core.py:91-96\`** — rewrite the no-underscore transport-shim comment. The old comment implied \`~273\` legacy test sites still call \`begin_transport_post\` / \`finish_transport_post\` on \`FakeClientCore\` instances — \`grep\` confirms the only no-underscore callers in the test tree invoke these on \`TransportDrainTracker\`, not \`FakeClientCore\`. New comment clarifies the shims are purely defensive safety-net defaults.
- **\`src/notebooklm/_chat.py:88\`** — add an inline comment on \`_ChatCore._perform_authed_post\`'s \`disable_internal_retries\` kwarg explaining it exists for structural-typing parity with \`ClientCore._perform_authed_post\` and is never forwarded by \`chat_aware_authed_post\`. Pre-empts the obvious "how do I disable retries on the chat path?" question.

## Test plan

- [x] \`uv run ruff format . && uv run ruff check .\` clean
- [x] \`uv run mypy src/notebooklm --ignore-missing-imports\` clean (untouched src behaviour)
- [x] \`uv run pytest -n auto tests/_lint tests/unit/test_chat_transport.py tests/unit/test_core_rpc.py\` — 35 passed
- [x] \`uv run pre-commit run --files <changed>\` — Passed (ruff legacy alias + ruff format)
- [ ] CI matrix on the PR

Refs #835 (post-merge follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added clarifying inline comments describing internal retry behavior and defensive test fixture defaults.

* **Tests**
  * Updated linting rules to refine detection of forbidden attribute assignments in test mocks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->