### PR TITLE
feat(middleware): type-only scaffolding for middleware chain + ADR-009 (Tier 12 PR 12.1)

### DIFF
--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -112,7 +112,7 @@ chain operates on already-encoded HTTP requests; encoding/decoding lives
 
 The chain is composed in this exact order (outermost → innermost):
 
-```
+```text
 Drain → Metrics → Retry → AuthRefresh → ErrorInjection → Tracing → terminal
 ```
 

--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -1,0 +1,348 @@
+# ADR-009: Middleware chain for cross-cutting transport concerns
+
+## Status
+
+Accepted (Tier 12 PR 12.1).
+
+This ADR ships in PR 12.1 of the Tier-12/13 greenfield migration as
+type-only scaffolding. The Protocol, dataclasses, and `build_chain` helper
+land; no production code wires the chain. PR 12.2 wires an empty chain into
+`ClientCore`. PRs 12.3 through 12.8 each extract one cross-cutting concern
+into a dedicated middleware. PR 12.9 closes the tier — removes the
+underscore-prefixed compatibility aliases, confirms the chain ordering, and
+re-statuses this ADR (it stays `Accepted`; the load-bearing contract here
+does not change).
+
+The signatures pinned in this ADR (especially the `AuthRefreshMiddleware`
+constructor, §"AuthRefreshMiddleware constructor signature") are
+load-bearing: PR 12.8's implementation has zero degrees of freedom on
+shape. PRs 12.2–12.7 also depend on the chain ordering and the
+`RpcRequest.context` keys defined below.
+
+Forward reference: ADR-002 ("Capability Protocol pattern,
+`ClientCoreCapabilities` fat union") will be superseded by ADR-010 in
+Tier 13. That supersession is *not* performed by this ADR; ADR-002 remains
+`Accepted (Sunset = D2 cutover)` until ADR-010 lands.
+
+## Context
+
+The post-remediation `ClientCore` orchestrates six cross-cutting concerns
+across every authenticated POST:
+
+| Concern | Today | Module |
+|---|---|---|
+| In-flight drain tracking | `TransportDrainTracker.begin/end` around the call | `_core_drain.py` |
+| Metrics emission | `ClientMetrics.on_rpc_event` callbacks woven through `AuthedTransport` | `_core_metrics.py` |
+| Retry on 5xx / 429 | inline loops inside `AuthedTransport.perform_authed_post` | `_core_transport.py:243` |
+| Auth refresh on 401 | inline branch inside `AuthedTransport.perform_authed_post` | `_core_transport.py:243`, `_core_auth.py` |
+| Synthetic error injection (tests) | `_SyntheticErrorTransport` wraps the httpx client | `_core_error_injection.py` |
+| Per-attempt tracing/logging | scattered `logger.debug` calls inside the retry loop | `_core_transport.py:243` |
+
+Adding a seventh concern (e.g. an idempotency-routing wrapper for retry
+safety, ADR-005) requires touching `AuthedTransport.perform_authed_post`
+directly. Each concern's state holder
+(`TransportDrainTracker` / `ClientMetrics` / etc.) is also threaded into
+`AuthedTransport` as constructor arguments or `_AuthedTransportHost`
+attributes, which means: (a) a new concern grows the host Protocol, and
+(b) every change to one concern risks regressing the others because they
+share a function body.
+
+The greenfield design in `docs/architecture-evolution.md` §3.4 proposes
+lifting each concern into a composable middleware, leaving
+`AuthedTransport.perform_authed_post` (and, post-PR 13.2, `Kernel.post`)
+as a pure-transport function. The chain is the composition substrate.
+
+Five details that shaped this ADR (the others are in the master plan):
+
+1. **HTTP-level, not RPC-level.** The chain wraps the transport, not the
+   encoder. Middlewares see already-encoded bytes; encoding and decoding
+   live in `Session.rpc_call` (Tier 13). This keeps every middleware
+   agnostic of `batchexecute` framing and makes test fixtures small.
+2. **Around-style, not before/after pairs.** Each middleware receives a
+   `next_call` and decides whether (and how) to invoke it. The
+   `AuthRefreshMiddleware` needs to *transform the request and retry once*
+   on 401 — that idiom is awkward to express as separate before/after
+   hooks and natural as an around handler.
+3. **One global chain at Session init, not per-call.** The chain is
+   stateless; per-call metadata travels through `RpcRequest.context`.
+   Tests override the middleware list via constructor injection
+   (`Session(kernel, middlewares=[FakeMetrics(), real_drain])`) — never
+   by monkeypatching (ADR-007).
+4. **Idempotency resolution happens *above* the chain.**
+   `Session.rpc_call` calls
+   `_idempotency.resolve_effective_disable_internal_retries(...)` and
+   stuffs the resolved bool into `RpcRequest.context["disable_internal_retries"]`
+   before chain entry. The `RetryMiddleware` (PR 12.7) reads the bool; it
+   does not see the `IdempotencyPolicy` enum or know about
+   `operation_variant` routing. Keeps the chain ignorant of the
+   mutating-RPC idempotency registry while preserving its semantics.
+5. **`AuthRefreshMiddleware` callbacks are pinned here, not in PR 12.8.**
+   The constructor's `rebuild_headers` and `build_request_factory`
+   callable signatures (§"AuthRefreshMiddleware constructor signature")
+   are part of *this* ADR so PR 12.8's implementation has zero degrees of
+   freedom on shape. PRs 12.2–12.7 also depend on those signatures
+   because they shape `RpcRequest.context` and the chain's interaction
+   with `AuthSnapshot`.
+
+## Decision
+
+A single around-style middleware chain wraps the authenticated POST
+transport. The chain is built once at Session init and invoked per
+request.
+
+### Middleware Protocol
+
+```python
+class Middleware(Protocol):
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse: ...
+
+NextCall = Callable[[RpcRequest], Awaitable[RpcResponse]]
+```
+
+`RpcRequest` and `RpcResponse` are HTTP-shape dataclasses (`url: str`,
+`headers: dict[str, str]`, `body: bytes`, `context: dict[str, Any]`). The
+chain operates on already-encoded HTTP requests; encoding/decoding lives
+*above* the chain in `Session.rpc_call`.
+
+### Chain ordering (load-bearing)
+
+The chain is composed in this exact order (outermost → innermost):
+
+```
+Drain → Metrics → Retry → AuthRefresh → ErrorInjection → Tracing → terminal
+```
+
+Where `terminal` is `Kernel.post` after PR 13.2, and
+`AuthedTransport.perform_authed_post` until then.
+
+The leftmost middleware in the sequence becomes the outermost wrapper.
+`build_chain` enforces this ordering by composing in reverse (last
+middleware is wrapped first around `terminal`).
+
+Per-position rationale:
+
+- **Drain outermost.** Every in-flight call — including ones that haven't
+  reached the transport yet because Retry / AuthRefresh / ErrorInjection
+  haven't released them — must count toward shutdown drain. Putting Drain
+  inside any of those would let a stuck retry escape the drain accounting.
+- **Metrics outside Retry.** Metrics measure end-to-end timing, not
+  per-attempt timing. (`ClientMetrics` already separates the two with
+  `record_rpc_queue_wait` for queue time and the outer span for total.)
+  Placing Metrics inside Retry would emit one metric per attempt, which
+  the existing observers don't expect.
+- **Retry outside AuthRefresh.** These are orthogonal failure modes — 5xx
+  / 429 / network errors trigger `RetryMiddleware`; 401 triggers
+  `AuthRefreshMiddleware`. Nesting prevents infinite-loop duplication
+  (each layer has its own guard). Putting them in the other order would
+  let an auth-refresh-then-success-then-5xx sequence cause a retry that
+  re-triggers the refresh, which is a bug the current `AuthedTransport`
+  also guards against with a per-attempt flag.
+- **AuthRefresh outside ErrorInjection.** Test-injected 401s exercise the
+  refresh path realistically — a test that injects a 401 expects the
+  refresh middleware to run, not for the injection to short-circuit
+  before refresh sees it. Putting AuthRefresh inside ErrorInjection would
+  invert that.
+- **ErrorInjection inside Retry.** Synthetic transient failures
+  (`_SyntheticErrorTransport`-style) should look like network errors to
+  `RetryMiddleware`. Putting ErrorInjection outside Retry would make the
+  retry path invisible to the test, defeating the purpose.
+- **Tracing innermost.** Tracing logs every actual HTTP attempt, including
+  retried ones. Putting Tracing outside Retry would log only one entry
+  per logical call regardless of retries, losing the per-attempt visibility
+  the current `_core_transport.py:243` debug logging provides.
+
+### `RpcRequest.context` keys (the chain's metadata vocabulary)
+
+| Key | Type | Set by | Read by |
+|---|---|---|---|
+| `rpc_method` | `RPCMethod \| None` | `Session.rpc_call` | metrics, tracing |
+| `operation_variant` | `str \| None` | `Session.rpc_call` | `AuthRefreshMiddleware` (passes back to `resolve_effective_disable_internal_retries` on retry) |
+| `disable_internal_retries` | `bool` | `Session.rpc_call` (post-resolution from `_idempotency.resolve_effective_disable_internal_retries`) | `RetryMiddleware` |
+| `build_request` | `BuildRequest` | `Session.rpc_call` / `Session.transport_post` | chain leaf (adapter into `AuthedTransport.perform_authed_post`) |
+| `log_label` | `str` | `Session.rpc_call` / `Session.transport_post` | chain leaf, `DrainMiddleware`, `TracingMiddleware` |
+
+Middlewares are forbidden from inventing new keys without an ADR update.
+The dict is mutable by reference (deliberately, per master plan
+§"Per-request behavior") but read-mostly in practice.
+
+### AuthRefreshMiddleware constructor signature
+
+This is the load-bearing pin. PR 12.8 implements *exactly* this shape:
+
+```python
+class AuthRefreshMiddleware:
+    def __init__(
+        self,
+        coordinator: AuthRefreshCoordinator,
+        rebuild_headers: Callable[[AuthSnapshot], Mapping[str, str]],
+        build_request_factory: Callable[[AuthSnapshot], BuildRequestResult],
+    ) -> None: ...
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        try:
+            return await next_call(request)
+        except (HTTP401, _TransportAuthExpired):
+            # Refresh tokens (coalesced, may raise).
+            await self.coordinator.refresh()
+            # Re-snapshot auth state, rebuild headers + url + body for the retry.
+            # ``build_request_factory`` is called exactly ONCE so the rebuilt
+            # url and body stay consistent (a side-effecting factory must not
+            # produce a torn pair).
+            snapshot: AuthSnapshot = await self.coordinator.snapshot()
+            rebuilt = self.build_request_factory(snapshot)
+            new_headers = dict(self.rebuild_headers(snapshot))
+            if rebuilt.headers is not None:
+                # Per the headers-merge policy below, ``BuildRequestResult.headers``
+                # overlays ``rebuild_headers`` so per-request extras (e.g. an
+                # explicit ``Content-Type`` for an upload variant) win over the
+                # snapshot-derived auth headers.
+                new_headers.update(rebuilt.headers)
+            new_request = dataclasses.replace(
+                request,
+                headers=new_headers,
+                url=rebuilt.url,
+                body=rebuilt.body,
+            )
+            return await next_call(new_request)
+```
+
+Pinned details:
+
+- `coordinator: AuthRefreshCoordinator` — the existing seam from
+  `_core_auth.py:53` (`AuthRefreshCoordinator`). PR 12.8 reuses it.
+- `rebuild_headers: Callable[[AuthSnapshot], Mapping[str, str]]` — **sync**
+  (no I/O; pure header construction from snapshot). Returns the *full*
+  base header dict for the retry, not a delta. The middleware copies the
+  result into a fresh `dict` via `dict(self.rebuild_headers(snapshot))` so
+  the callback's return is not shared with `RpcRequest.headers`.
+- `build_request_factory: Callable[[AuthSnapshot], BuildRequestResult]` —
+  **sync**. Returns a `BuildRequestResult` dataclass (`url: str`,
+  `body: bytes`, `headers: Mapping[str, str] | None`) — equivalent to
+  today's `_BuildRequest` tuple return, but as a named dataclass for the
+  new code path. Called **exactly once per retry attempt**: a single
+  invocation produces the rebuilt `url`, `body`, and per-request headers
+  overlay so a side-effecting factory cannot emit a torn `url`/`body`
+  pair.
+- Headers-merge policy: `rebuild_headers` provides the *base* headers
+  (snapshot-derived auth: CSRF token, session id, X-Goog-AuthUser, etc.).
+  `BuildRequestResult.headers` is an *overlay*: when non-`None`, the
+  middleware merges it on top of the base via `dict.update`. This mirrors
+  today's `_core_transport.py:282` semantics where the `headers` slot in
+  the `_BuildRequest` tuple represents per-request extras (e.g. an
+  explicit `Content-Type` for an upload variant) that win over the
+  snapshot defaults. Most call sites today pass `None` here, in which
+  case the base headers from `rebuild_headers` are used unchanged.
+- Retry semantics: **exactly one** retry per `next_call` invocation. If
+  the retry also raises 401, the exception propagates — no second retry,
+  no recursion. `RetryMiddleware` (outside `AuthRefresh` per the chain
+  ordering) handles non-auth retries.
+- `AuthSnapshot` and `BuildRequestResult` are promoted from private to
+  public-ish in `_request_types.py` (PR 12.1, alongside `BuildRequest`).
+  The current `_AuthSnapshot` and the tuple-return shape become these
+  named types; the underscore-prefixed originals remain as
+  `__all__`-excluded re-exports for one cycle, then delete in PR 12.9.
+
+PR 12.8 writes the implementation; everything else (the `Session` wiring
+of the two callbacks, the retry semantics, the types) is fixed here.
+
+## Consequences
+
+**Wanted:**
+
+- `AuthedTransport.perform_authed_post` shrinks to a pure POST after
+  PRs 12.4 (metrics out), 12.5 (drain out), 12.7 (retry out), 12.8 (auth
+  refresh out). PR 12.9 verifies the post-extraction leaf has no
+  middleware concerns left.
+- Each cross-cutting concern becomes independently testable: build a
+  chain with just `[FakeRetry()]` around a `FakeAuthedPost`, drive a
+  failing request, assert the retry happened. No more "the metrics
+  callback fires on the third nested call inside `AuthedTransport` if
+  the 429 branch …" tests.
+- Adding a new concern is a new middleware class plus an entry in the
+  chain ordering — no `AuthedTransport` surgery, no growth of
+  `_AuthedTransportHost`.
+- The chain ordering becomes a single line of code (`[Drain, Metrics,
+  Retry, AuthRefresh, ErrorInjection, Tracing]`) instead of an implicit
+  invariant scattered across `_core_transport.py:243`-`379`.
+
+**Unwanted:**
+
+- A typed dataclass per request is more allocation than the existing
+  three-tuple from `_BuildRequest`. The cost is in microseconds per RPC;
+  the chain itself does not run in a hot loop (one chain dispatch per
+  authed POST, of which there are at most a few hundred per session).
+  Benchmarks in PR 12.2 will quantify; expected overhead is <1% of
+  per-RPC wall time and dominated by the existing `httpx` POST.
+- The chain's `context: dict[str, Any]` is dynamically typed and
+  trades static-type-checking strictness for forward compatibility
+  across middleware PRs. The `RpcRequest.context` keys table above is
+  the policy that bounds drift; the meta-lint planned for PR 12.9 will
+  enforce it.
+- Around-style middlewares can short-circuit (return without calling
+  `next_call`). No production middleware in the Tier-12 set does this,
+  but the protocol allows it; test middlewares that need to (e.g. a
+  "deny all requests" canary) get the capability for free. The lint
+  policy is to grep the production middleware modules for "without
+  calling `next_call`" patterns at review time.
+- Six small middleware files replace six branches in one large
+  `AuthedTransport` function. Total LOC roughly equal; navigation
+  improves (one concern per file) but the call path becomes longer in
+  the stack trace.
+
+## Alternatives considered
+
+**Before/after hook pairs (the Flask / Express middleware shape).** Rejected.
+The `AuthRefreshMiddleware` transforms the request and *retries once*; a
+before-hook returns the transformed request and an after-hook can observe
+the response, but neither can re-invoke the chain mid-call. Modelling
+auth refresh as before/after would require a separate "retry once on
+401" mechanism inside the transport, defeating the extraction.
+
+**Single `transport_wrapper: Callable[[NextCall], NextCall]` factory list.**
+Rejected. The factory shape works for around-style behavior but obscures
+the request/response types at every wrap site, since each factory has to
+re-declare its own `async def wrapper(request, /): …` body. The
+`Middleware: Protocol` shape with `RpcRequest` and `RpcResponse`
+dataclasses gives type checkers full visibility into the chain at every
+wrap point.
+
+**`contextvars.ContextVar` for per-request metadata instead of
+`RpcRequest.context: dict`.** Rejected. The `dict` is shared by reference
+across the chain (intentional), is trivially mockable in tests, and shows
+up plainly in `repr(request)`. `contextvars` would: (a) require every
+middleware to import the var; (b) be invisible in the request repr; (c)
+leak state across tests if not cleared. The audit work that goes into
+`tests/_lint/` to enforce `RpcRequest.context` key discipline is cheaper
+than the audit work to enforce `ContextVar` reset discipline.
+
+**Build the chain per-call instead of once at Session init.** Rejected.
+Per-call chain construction would allow per-call middleware lists, which
+breaks the "the chain is the transport contract" invariant — every call
+must traverse the same chain, otherwise the chain isn't doing the
+cross-cutting work it's supposed to. Tests that want different middleware
+lists construct different `Session` instances.
+
+**Inline the dataclass definitions in `_middleware.py` and skip
+`_request_types.py`.** Rejected. The `AuthSnapshot` and `BuildRequest`
+aliases are not chain-specific — they describe types that already live in
+`_core_transport.py` and are read by `_chat.py`, `_chat_transport.py`, and
+`_core_rpc.py`. Promoting them into a sibling module (`_request_types.py`)
+keeps `_middleware.py` focused on the chain envelope shape and gives
+non-chain callers a stable import path that survives PR 12.9's underscore
+removal.
+
+**Use `httpx.Request` / `httpx.Response` directly instead of
+`RpcRequest` / `RpcResponse` dataclasses.** Rejected for the request side;
+accepted for the response side. The request dataclass needs to carry
+`context: dict[str, Any]` for chain metadata, and `httpx.Request` has no
+extension point for that. The response side just carries
+`httpx.Response` (the field name `RpcResponse.response`) plus context, so
+the dataclass is a thin wrapper there.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ Pure bug fixes, additive RPC method IDs, and CLI ergonomics changes do not requi
 | [0006](0006-vcr-scrubber-strategy.md) | VCR cassette scrubber strategy | Accepted (retroactive) |
 | [0007](0007-test-monkeypatch-policy.md) | Test monkeypatch policy | Accepted |
 | [0008](0008-cli-services-extraction-pattern.md) | `cli/services/` extraction pattern | Accepted (retroactive) |
+| [0009](0009-middleware-chain.md) | Middleware chain for cross-cutting transport concerns | Accepted (Tier 12 PR 12.1) |
 
 ADR-007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -1,0 +1,220 @@
+"""Type-only scaffolding for the Tier-12 middleware chain.
+
+This module ships in PR 12.1 of the Tier-12/13 greenfield migration. It
+defines:
+
+- :class:`RpcRequest` / :class:`RpcResponse` — the HTTP-shape envelopes the
+  chain passes around (NOT RPC-shape; encoding/decoding lives above the
+  chain in ``Session.rpc_call``).
+- :data:`NextCall` — the call-the-next-link type alias used by middlewares
+  and by the chain builder.
+- :class:`Middleware` — the ``Protocol`` every middleware satisfies. Around-
+  style: each middleware receives the request and a ``next_call`` callable;
+  it decides whether (and how) to invoke ``next_call(request)``, optionally
+  observing or transforming the response.
+- :func:`build_chain` — composes a ``Sequence[Middleware]`` around a terminal
+  ``NextCall`` so the leftmost middleware in the sequence becomes the
+  *outermost* wrapper (matches the ordering documented in ADR-009).
+
+No middleware is implemented in this PR. No production code wires the
+chain in this PR. PR 12.2 wires an empty chain into ``ClientCore``; PRs
+12.3–12.8 extract one middleware at a time. See
+``docs/adr/0009-middleware-chain.md`` for the load-bearing decisions and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` section 2 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Chain envelope types.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RpcRequest:
+    """HTTP-shape request envelope passed through the middleware chain.
+
+    The chain wraps ``Kernel.post`` (or, until PR 13.2 renames the seam,
+    ``AuthedTransport.perform_authed_post``). Every middleware sees an
+    already-encoded HTTP request — encoding lives *above* the chain in
+    ``Session.rpc_call``. RPC-level metadata that middlewares need (rpc
+    method id, idempotency, operation variant, log labels, build-request
+    callback, etc.) travels through :attr:`context`.
+
+    Frozen: middlewares that want to alter the request build a new
+    :class:`RpcRequest` via :func:`dataclasses.replace`. The
+    :class:`AuthRefreshMiddleware` (PR 12.8) does exactly this when
+    rebuilding headers and URL after an auth refresh.
+
+    :attr:`context` is mutable by reference (it's a plain :class:`dict`) and
+    is shared across the chain by design — see ADR-009 §"Per-request
+    behavior". Middlewares that want isolation should make a shallow copy
+    before mutating.
+    """
+
+    url: str
+    """Fully-built ``batchexecute`` URL with ``authuser`` and ``_reqid`` set."""
+
+    headers: dict[str, str]
+    """HTTP headers for this attempt (auth headers, ``X-Goog-AuthUser``, …)."""
+
+    body: bytes
+    """Encoded ``batchexecute`` body bytes for this attempt."""
+
+    context: dict[str, Any] = field(default_factory=dict)
+    """RPC-level metadata the chain reads (e.g. ``rpc_method``,
+    ``operation_variant``, ``disable_internal_retries``, ``build_request``,
+    ``log_label``). Read by middlewares; populated by the caller of the
+    chain (typically ``Session.rpc_call`` after PR 13.x lands).
+
+    Until PR 12.2 wires the chain in, no production code reads or writes
+    this dict; the contract is fixed here so middleware PRs 12.3–12.8 do
+    not re-spec it per extraction.
+    """
+
+
+@dataclass(frozen=True)
+class RpcResponse:
+    """HTTP-shape response envelope returned by the middleware chain.
+
+    Carries the same :class:`httpx.Response` ``Kernel.post`` returns today,
+    plus a propagated ``context`` so middlewares above the chain can read
+    additions a deeper middleware made (e.g. a tracing middleware annotating
+    the attempt with a trace id).
+
+    Frozen for the same reason as :class:`RpcRequest`: middlewares that
+    transform the response build a new instance via
+    :func:`dataclasses.replace`.
+    """
+
+    response: httpx.Response
+    """The buffered :class:`httpx.Response` from the transport leaf.
+
+    Identical in shape to what ``AuthedTransport.perform_authed_post``
+    returns today (see ``_core_transport._stream_post_with_size_cap``):
+    fully-buffered body, headers stripped of ``content-encoding`` /
+    ``content-length`` so ``.text`` / ``.content`` work synchronously.
+    """
+
+    context: dict[str, Any] = field(default_factory=dict)
+    """Propagated metadata. Typically the same dict as
+    :attr:`RpcRequest.context` (so a tracing middleware that wrote
+    ``request.context['trace_id']`` can read it back here) plus any
+    response-side additions a middleware made.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Chain-call callable type and the middleware Protocol.
+# ---------------------------------------------------------------------------
+
+#: Callable shape of the "call the next link" function passed to each
+#: middleware. Implementations invoke ``await next_call(request)`` (or a
+#: replaced ``await next_call(new_request)`` after transforming the
+#: request via :func:`dataclasses.replace` — what
+#: :class:`AuthRefreshMiddleware` does on its retry leg) to continue the
+#: chain. A middleware may also short-circuit by returning a response
+#: without invoking ``next_call`` at all; no production middleware in the
+#: Tier-12 set does this, but test middlewares (e.g. a "deny all" canary)
+#: are free to.
+NextCall = Callable[[RpcRequest], Awaitable[RpcResponse]]
+
+
+class Middleware(Protocol):
+    """Around-style middleware Protocol.
+
+    Each middleware is an *async callable*: it receives the
+    :class:`RpcRequest` plus a :data:`NextCall` and returns an
+    :class:`RpcResponse`. Implementations may:
+
+    - Observe the request before calling ``next_call`` (logging, metrics).
+    - Transform the request via :func:`dataclasses.replace` and pass the new
+      one to ``next_call`` (auth refresh).
+    - Wrap ``next_call`` in a try/except to handle specific exceptions
+      (retry, auth refresh).
+    - Observe or transform the response after ``next_call`` returns
+      (metrics, tracing).
+    - Short-circuit (return without calling ``next_call``). Used only by
+      error-injection middlewares in tests; not by any production
+      middleware in the Tier-12 set.
+
+    The constructor of a middleware is not constrained by this Protocol —
+    each middleware takes whatever collaborators it needs (the
+    :class:`AuthRefreshMiddleware` constructor signature is pinned in
+    ADR-009 §"AuthRefreshMiddleware constructor signature").
+    """
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse: ...
+
+
+# ---------------------------------------------------------------------------
+# Chain composition helper.
+# ---------------------------------------------------------------------------
+
+
+def build_chain(
+    middlewares: Sequence[Middleware],
+    terminal: NextCall,
+) -> NextCall:
+    """Compose ``middlewares`` around ``terminal`` and return the outer call.
+
+    Ordering contract: the **first** middleware in the sequence becomes the
+    **outermost** wrapper around ``terminal``. With
+    ``middlewares = [A, B, C]`` and ``terminal = T``, the returned callable
+    invokes ``A.__call__(request, →B)`` where ``→B`` invokes
+    ``B.__call__(request, →C)`` where ``→C`` invokes
+    ``C.__call__(request, →T)``.
+
+    This matches the chain ordering documented in ADR-009: ``[Drain,
+    Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` — Drain at
+    index 0 is the outermost wrapper, Tracing at index 5 is the innermost
+    wrapper around the terminal.
+
+    Implementation: wrap in reverse, so the last middleware in the sequence
+    is composed first (it becomes the innermost wrapper, with ``terminal``
+    as its ``next_call``), then each earlier middleware wraps the chain
+    built so far. ``make_wrapper`` is a defensive idiom that captures
+    ``mw`` and ``next_call`` in its own function scope (one set of
+    bindings per call) rather than letting the inner ``wrapped`` close
+    over the loop variable — without it, every wrapper in a Python loop
+    would close over the *final* value of the loop variable.
+
+    The returned :data:`NextCall` is safe to invoke concurrently from
+    multiple tasks: the chain itself is stateless, and each middleware's
+    state (if any) is its own concern. Returning a fresh chain per
+    ``build_chain`` call also means tests can build per-test chains
+    without leaking state across tests.
+
+    An empty ``middlewares`` sequence returns ``terminal`` unchanged.
+    """
+
+    def make_wrapper(mw: Middleware, next_call: NextCall) -> NextCall:
+        async def wrapped(request: RpcRequest) -> RpcResponse:
+            return await mw(request, next_call)
+
+        return wrapped
+
+    chain: NextCall = terminal
+    for mw in reversed(middlewares):
+        chain = make_wrapper(mw, chain)
+    return chain
+
+
+__all__ = [
+    "Middleware",
+    "NextCall",
+    "RpcRequest",
+    "RpcResponse",
+    "build_chain",
+]

--- a/src/notebooklm/_middleware.py
+++ b/src/notebooklm/_middleware.py
@@ -26,7 +26,7 @@ PR sequence.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -62,8 +62,18 @@ class RpcRequest:
     url: str
     """Fully-built ``batchexecute`` URL with ``authuser`` and ``_reqid`` set."""
 
-    headers: dict[str, str]
-    """HTTP headers for this attempt (auth headers, ``X-Goog-AuthUser``, …)."""
+    headers: Mapping[str, str]
+    """HTTP headers for this attempt (auth headers, ``X-Goog-AuthUser``, …).
+
+    Typed as :class:`~collections.abc.Mapping` (read-only protocol) rather
+    than :class:`dict` so the frozen-dataclass contract extends to the
+    header values: middlewares that want to add or alter headers build a
+    new :class:`RpcRequest` via :func:`dataclasses.replace` with a freshly
+    constructed dict (e.g.
+    ``dataclasses.replace(request, headers={**request.headers, "X-Foo": "1"})``).
+    Concrete :class:`dict` instances satisfy this annotation, so callers
+    that pass a literal ``{...}`` need no special treatment.
+    """
 
     body: bytes
     """Encoded ``batchexecute`` body bytes for this attempt."""

--- a/src/notebooklm/_request_types.py
+++ b/src/notebooklm/_request_types.py
@@ -1,0 +1,106 @@
+"""Public-ish request-shape aliases for the Tier-12 middleware chain.
+
+This module promotes a small set of types that were previously private to
+``_core_transport.py`` so the Tier-12 middleware chain (introduced in PRs
+12.1–12.9) can refer to them without reaching across underscore-prefixed
+seams. The originals (``_AuthSnapshot`` and ``_BuildRequest`` in
+``_core_transport.py``) remain in place; this module simply exposes them
+under names without a leading underscore. PR 12.9 collapses the aliases by
+relocating the definitions into this module and deleting the underscore
+originals.
+
+Three names live here:
+
+- :data:`AuthSnapshot` — point-in-time view of auth headers used to build
+  one HTTP attempt; alias for :class:`notebooklm._core_transport._AuthSnapshot`.
+  ADR-009 pins this as the public input type of the
+  ``AuthRefreshMiddleware`` callbacks.
+- :data:`BuildRequest` — sync callable that maps an ``AuthSnapshot`` to a
+  ``(url, body, headers)`` tuple ready for the transport. Alias for the
+  existing ``_BuildRequest`` callable type. The chain leaf in PR 12.2 reads
+  the callable from ``RpcRequest.context["build_request"]`` and invokes it
+  inside ``AuthedTransport.perform_authed_post``.
+- :class:`BuildRequestResult` — the *named* dataclass form of the same
+  ``(url, body, headers)`` triple, introduced for PR 12.8's
+  ``AuthRefreshMiddleware.build_request_factory`` callback. The dataclass
+  shape is preferred for new code (named fields, immutable, type-checked
+  at construction) over the legacy tuple return. Existing callers continue
+  to use the tuple shape until they migrate.
+
+The underscore-prefixed originals (``_AuthSnapshot``, ``_BuildRequest``)
+are imported here too so callers that want the private name during the
+one-cycle transition can write ``from notebooklm._request_types import
+_AuthSnapshot``. They are deliberately excluded from ``__all__`` so
+star-imports do not propagate the private names.
+
+See ``docs/adr/0009-middleware-chain.md`` for the full chain contract and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` section 2 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+# Re-exported under public names below. The underscore originals are also
+# kept importable from this module (see ``__all__`` note above).
+from ._core_transport import _AuthSnapshot, _BuildRequest
+
+#: Point-in-time view of auth headers used to build one HTTP attempt.
+#:
+#: Alias for :class:`notebooklm._core_transport._AuthSnapshot`. The underscore
+#: original remains the canonical definition site for one cycle; PR 12.9
+#: collapses the alias by relocating the dataclass definition here.
+AuthSnapshot = _AuthSnapshot
+
+#: Build-request factory callable type used by the transport and chain leaf.
+#:
+#: Receives a fresh ``AuthSnapshot`` and returns a ``(url, body, headers)``
+#: tuple for one HTTP attempt. Alias for the existing
+#: :data:`notebooklm._core_transport._BuildRequest` type. Carried in
+#: :attr:`notebooklm._middleware.RpcRequest.context` under the
+#: ``"build_request"`` key (PR 12.2 wires the chain leaf).
+BuildRequest = _BuildRequest
+
+
+@dataclass(frozen=True)
+class BuildRequestResult:
+    """Named dataclass form of the ``(url, body, headers)`` request triple.
+
+    Introduced for the Tier-12 ``AuthRefreshMiddleware`` (ADR-009, PR 12.8):
+    the middleware's ``build_request_factory`` callback returns this dataclass
+    instead of the legacy ``(url, body, headers)`` tuple so the constructor
+    signature reads as a single named value rather than positional unpacking.
+
+    The fields mirror the tuple's positional order:
+
+    - ``url`` — fully-built ``batchexecute`` URL (including ``authuser`` and
+      ``_reqid`` query params).
+    - ``body`` — encoded ``batchexecute`` body. Pinned to :class:`bytes` in
+      ADR-009; the legacy ``_BuildRequest`` tuple accepts ``str | bytes`` for
+      backward compatibility with existing call sites that build the body as
+      a UTF-8 string.
+    - ``headers`` — extra headers to merge for this request, or ``None`` when
+      the snapshot's headers are sufficient.
+
+    Frozen so a middleware cannot accidentally mutate a callback's return
+    value before passing it back to the chain. Equality is value-based so
+    tests can assert against expected results without identity tracking.
+    """
+
+    url: str
+    body: bytes
+    headers: Mapping[str, str] | None
+
+
+# Only the public-named symbols are part of the module's documented API.
+# ``_AuthSnapshot`` and ``_BuildRequest`` remain importable from this module
+# (because they are bound at module scope by the ``from ._core_transport ...``
+# line above) but are excluded from ``__all__`` so ``from notebooklm._request_types
+# import *`` does not propagate the private names.
+__all__ = [
+    "AuthSnapshot",
+    "BuildRequest",
+    "BuildRequestResult",
+]

--- a/tests/_fixtures/chain.py
+++ b/tests/_fixtures/chain.py
@@ -30,7 +30,7 @@ PR sequence.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import httpx
@@ -41,7 +41,7 @@ from notebooklm._middleware import (
     RpcResponse,
     build_chain,
 )
-from notebooklm._request_types import BuildRequest
+from notebooklm._request_types import AuthSnapshot, BuildRequest
 
 
 class FakeAuthedPost:
@@ -112,6 +112,10 @@ class FakeAuthedPost:
             }
         )
 
+        # Resolution priority: ``raises`` (highest — exception preempts everything
+        # else, but the call is *already recorded above* so tests can still
+        # assert ``call_count == 1``) → ``response_factory`` (per-call dynamic)
+        # → ``response`` (single canned value) → built-in 200/empty default.
         if self.raises is not None:
             raise self.raises
 
@@ -164,7 +168,7 @@ def make_request(**overrides: Any) -> RpcRequest:
 
 def chain_calls_through_to_authed_post(
     transport: FakeAuthedPost,
-    middlewares: list[Middleware],
+    middlewares: Sequence[Middleware],
 ) -> bool:
     """Return ``True`` iff invoking the chain reaches the transport leaf.
 
@@ -197,7 +201,7 @@ def chain_calls_through_to_authed_post(
     # ``request.context["build_request"]``; this fallback keeps the helper
     # usable with a bare ``make_request()``.
     def _default_build_request(
-        snapshot: object,
+        snapshot: AuthSnapshot,
     ) -> tuple[str, bytes, dict[str, str] | None]:
         return ("https://fake/build-request-fallback", b"", None)
 

--- a/tests/_fixtures/chain.py
+++ b/tests/_fixtures/chain.py
@@ -1,0 +1,233 @@
+"""Test fixtures for the Tier-12 middleware chain.
+
+These fixtures land in PR 12.1 so every subsequent middleware PR (12.3–12.8)
+has a uniform test substrate. Each new middleware extraction can express its
+unit tests as "build a chain with [..., FakeMiddleware(), ...], call it, assert
+behaviour" without re-inventing the chain plumbing per PR.
+
+Three helpers live here:
+
+- :class:`FakeAuthedPost` — programmable stub matching the shape of
+  :meth:`notebooklm._core_transport.AuthedTransport.perform_authed_post`. This
+  is **not** ``FakeKernel`` — the ``Kernel`` Protocol doesn't exist until
+  PR 13.2, and renaming to ``FakeKernel`` is part of PR 13.2's scope. Until
+  then, the terminal call still goes through ``AuthedTransport``.
+- :func:`make_request` — factory for :class:`notebooklm._middleware.RpcRequest`
+  instances with benign defaults. Tests override only the fields they care
+  about via keyword arguments.
+- :func:`chain_calls_through_to_authed_post` — assertion helper that builds
+  a chain over a :class:`FakeAuthedPost` terminal, invokes it once, and
+  returns whether the underlying ``perform_authed_post`` was called. The
+  helper is the canonical answer to "did this set of middlewares actually
+  wire up so the request reaches the transport?" and is used by every
+  middleware PR's wire-up smoke test.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` section 2 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+from notebooklm._middleware import (
+    Middleware,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+from notebooklm._request_types import BuildRequest
+
+
+class FakeAuthedPost:
+    """Programmable stub for ``AuthedTransport.perform_authed_post``.
+
+    Matches the production callable's keyword-only signature (``build_request``,
+    ``log_label``, ``disable_internal_retries``) so a terminal that adapts
+    :class:`RpcRequest` into a transport call can target this fake without
+    branching on "is this a real transport or a fake."
+
+    Records every call into :attr:`calls` (a list of ``dict`` snapshots) so
+    tests can assert both *that* the transport was reached and *what*
+    arguments arrived. The default return is a minimal
+    :class:`httpx.Response` with status 200 and an empty body (no attached
+    ``.request``, unlike the production buffered response from
+    ``_stream_post_with_size_cap``) — enough for middlewares that just
+    observe and pass through.
+
+    Override the return value by setting :attr:`response` (single fixed
+    response) or :attr:`response_factory` (callable producing per-call
+    responses). If :attr:`raises` is set, the call raises that exception
+    instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        response: httpx.Response | None = None,
+        response_factory: Callable[[], httpx.Response] | None = None,
+        raises: BaseException | None = None,
+    ) -> None:
+        self.response: httpx.Response | None = response
+        self.response_factory: Callable[[], httpx.Response] | None = response_factory
+        self.raises: BaseException | None = raises
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def was_called(self) -> bool:
+        """``True`` if :meth:`perform_authed_post` was called at least once."""
+        return bool(self.calls)
+
+    @property
+    def call_count(self) -> int:
+        """Number of times :meth:`perform_authed_post` was called."""
+        return len(self.calls)
+
+    async def perform_authed_post(
+        self,
+        *,
+        build_request: BuildRequest,
+        log_label: str,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response:
+        """Record the call and return the configured response.
+
+        Signature mirrors
+        :meth:`notebooklm._core_transport.AuthedTransport.perform_authed_post`
+        verbatim (keyword-only ``build_request`` / ``log_label`` /
+        ``disable_internal_retries``). ``build_request`` is typed as
+        :data:`BuildRequest` so a signature drift in the real transport
+        surfaces as a mypy error on the fake too.
+        """
+        self.calls.append(
+            {
+                "build_request": build_request,
+                "log_label": log_label,
+                "disable_internal_retries": disable_internal_retries,
+            }
+        )
+
+        if self.raises is not None:
+            raise self.raises
+
+        if self.response_factory is not None:
+            return self.response_factory()
+
+        if self.response is not None:
+            return self.response
+
+        # Default: a benign 200 OK with an empty body. Constructed lazily so
+        # tests that supply their own ``response`` / ``response_factory``
+        # never pay the construction cost, and so the default Response is
+        # a fresh instance per call rather than a shared one.
+        return httpx.Response(status_code=200, content=b"")
+
+
+def make_request(**overrides: Any) -> RpcRequest:
+    """Build an :class:`RpcRequest` with benign defaults plus overrides.
+
+    Default-shape fields:
+
+    - ``url`` — a placeholder ``batchexecute`` URL (no live network call —
+      this is a chain-input fixture, never reaches the wire).
+    - ``headers`` — a minimal headers dict.
+    - ``body`` — empty bytes.
+    - ``context`` — an empty dict (each call returns a fresh dict so tests
+      don't share mutable state).
+
+    Passing an unknown keyword raises ``TypeError`` early so test typos
+    don't silently no-op.
+    """
+    defaults: dict[str, Any] = {
+        "url": "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute?authuser=0&_reqid=100000",
+        "headers": {"X-Goog-AuthUser": "0"},
+        "body": b"",
+        # Fresh dict per call so independent invocations don't share state.
+        "context": {},
+    }
+
+    unknown = set(overrides) - set(defaults)
+    if unknown:
+        raise TypeError(
+            "make_request() got unexpected keyword(s): "
+            f"{sorted(unknown)!r}. Known fields: {sorted(defaults)!r}"
+        )
+
+    defaults.update(overrides)
+    return RpcRequest(**defaults)
+
+
+def chain_calls_through_to_authed_post(
+    transport: FakeAuthedPost,
+    middlewares: list[Middleware],
+) -> bool:
+    """Return ``True`` iff invoking the chain reaches the transport leaf.
+
+    Builds a chain with ``middlewares`` wrapped around a terminal that
+    adapts :class:`RpcRequest` into a
+    :meth:`FakeAuthedPost.perform_authed_post` call (reading
+    ``build_request`` / ``log_label`` / ``disable_internal_retries`` from
+    ``request.context``), invokes the chain with a default
+    :func:`make_request`, and reports whether the transport recorded any
+    call.
+
+    This is the canonical wire-up smoke test for every middleware PR
+    12.3–12.8: extracts a middleware, asserts
+    ``chain_calls_through_to_authed_post(fake_transport, [new_middleware])
+    is True``. A short-circuiting middleware (one that returns without
+    calling ``next_call``) is the only legitimate way for this to return
+    ``False``; in the Tier-12 set, no production middleware does that.
+
+    The helper synchronously drives the chain with :func:`asyncio.run` so
+    callers don't need to mark their test as ``async`` just to use the
+    helper. Tests that need finer control over the event loop or that want
+    to assert on the chain's return value can drop the helper and call
+    :func:`build_chain` directly — that's exactly what the
+    :mod:`test_chain_fixtures` and per-middleware tests do.
+    """
+
+    # Default ``build_request`` returns the same triple every call (consistent
+    # url/body across retry attempts). Production callers (PR 12.2's chain
+    # leaf) will pass a real ``BuildRequest`` via
+    # ``request.context["build_request"]``; this fallback keeps the helper
+    # usable with a bare ``make_request()``.
+    def _default_build_request(
+        snapshot: object,
+    ) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/build-request-fallback", b"", None)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        ctx = request.context
+        build_request = ctx.get("build_request", _default_build_request)
+        log_label = ctx.get("log_label", "fake-log-label")
+        disable_internal_retries = bool(ctx.get("disable_internal_retries", False))
+        response = await transport.perform_authed_post(
+            build_request=build_request,
+            log_label=log_label,
+            disable_internal_retries=disable_internal_retries,
+        )
+        return RpcResponse(response=response, context=ctx)
+
+    chain = build_chain(middlewares, terminal)
+
+    async def driver() -> RpcResponse:
+        return await chain(make_request())
+
+    # ``asyncio.run`` raises if there's already a running loop. The fixture
+    # is meant to be called from synchronous test bodies; tests that need
+    # to invoke the chain from an async context should compose
+    # ``build_chain`` + ``make_request`` directly.
+    asyncio.run(driver())
+    return transport.was_called
+
+
+__all__ = [
+    "FakeAuthedPost",
+    "chain_calls_through_to_authed_post",
+    "make_request",
+]

--- a/tests/unit/test_chain_fixtures.py
+++ b/tests/unit/test_chain_fixtures.py
@@ -1,0 +1,265 @@
+"""Unit tests for the ``tests/_fixtures/chain.py`` test substrate.
+
+Exercises the three helpers that PR 12.1 lands so every subsequent
+middleware PR (12.3–12.8) has a uniform test substrate:
+
+- ``FakeAuthedPost`` — programmable stub matching
+  ``AuthedTransport.perform_authed_post``.
+- ``make_request`` — factory for ``RpcRequest`` with benign defaults.
+- ``chain_calls_through_to_authed_post`` — assertion helper that builds a
+  chain over a ``FakeAuthedPost`` terminal and reports whether the
+  transport was reached.
+
+These tests verify the fixtures themselves so middleware-extraction PRs
+can trust the substrate without re-discovering its shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+# Match the import idiom documented in ``tests/_fixtures/__init__.py``:
+# pytest puts ``tests/`` on ``sys.path``, so ``_fixtures.chain`` is the
+# canonical import path for these helpers.
+from _fixtures.chain import (
+    FakeAuthedPost,
+    chain_calls_through_to_authed_post,
+    make_request,
+)
+from notebooklm._middleware import (
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+
+# ---------------------------------------------------------------------------
+# make_request
+# ---------------------------------------------------------------------------
+
+
+def test_make_request_defaults_are_benign() -> None:
+    req = make_request()
+    assert req.url.startswith("https://notebooklm.google.com/")
+    assert "X-Goog-AuthUser" in req.headers
+    assert req.body == b""
+    assert req.context == {}
+
+
+def test_make_request_overrides_replace_defaults() -> None:
+    req = make_request(url="https://x", body=b"payload", context={"rpc_method": "ListNotebooks"})
+    assert req.url == "https://x"
+    assert req.body == b"payload"
+    assert req.context == {"rpc_method": "ListNotebooks"}
+
+
+def test_make_request_unknown_kwarg_raises_type_error() -> None:
+    """Typo guard — unknown overrides raise eagerly rather than silently no-op."""
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        make_request(rpc_method="ListNotebooks")  # should be in context
+
+
+def test_make_request_context_is_independent_per_call() -> None:
+    """Each call returns a fresh ``context`` dict — no shared mutable state."""
+    a = make_request()
+    b = make_request()
+    a.context["leak"] = "value"
+    assert "leak" not in b.context
+
+
+# ---------------------------------------------------------------------------
+# FakeAuthedPost
+# ---------------------------------------------------------------------------
+
+
+def test_fake_authed_post_records_calls() -> None:
+    transport = FakeAuthedPost()
+
+    async def driver() -> httpx.Response:
+        return await transport.perform_authed_post(
+            build_request=lambda snap: ("https://x", b"", None),
+            log_label="my-label",
+            disable_internal_retries=True,
+        )
+
+    resp = asyncio.run(driver())
+    assert resp.status_code == 200
+    assert transport.was_called is True
+    assert transport.call_count == 1
+    assert transport.calls[0]["log_label"] == "my-label"
+    assert transport.calls[0]["disable_internal_retries"] is True
+
+
+def test_fake_authed_post_default_response_is_fresh_each_call() -> None:
+    """Default 200/empty response is constructed per call (not shared)."""
+    transport = FakeAuthedPost()
+
+    async def driver() -> tuple[httpx.Response, httpx.Response]:
+        a = await transport.perform_authed_post(
+            build_request=lambda s: ("https://x", b"", None),
+            log_label="a",
+        )
+        b = await transport.perform_authed_post(
+            build_request=lambda s: ("https://x", b"", None),
+            log_label="b",
+        )
+        return a, b
+
+    a, b = asyncio.run(driver())
+    assert a is not b  # fresh instances per call
+    assert a.status_code == 200
+    assert b.status_code == 200
+
+
+def test_fake_authed_post_explicit_response_is_returned() -> None:
+    canned = httpx.Response(status_code=204, content=b"")
+    transport = FakeAuthedPost(response=canned)
+
+    async def driver() -> httpx.Response:
+        return await transport.perform_authed_post(
+            build_request=lambda s: ("https://x", b"", None),
+            log_label="lbl",
+        )
+
+    result = asyncio.run(driver())
+    assert result is canned
+
+
+def test_fake_authed_post_response_factory_produces_per_call_responses() -> None:
+    counter = {"n": 0}
+
+    def factory() -> httpx.Response:
+        counter["n"] += 1
+        return httpx.Response(status_code=200 + counter["n"], content=b"")
+
+    transport = FakeAuthedPost(response_factory=factory)
+
+    async def driver() -> list[int]:
+        results: list[int] = []
+        for _ in range(3):
+            resp = await transport.perform_authed_post(
+                build_request=lambda s: ("https://x", b"", None),
+                log_label="lbl",
+            )
+            results.append(resp.status_code)
+        return results
+
+    statuses = asyncio.run(driver())
+    assert statuses == [201, 202, 203]
+
+
+def test_fake_authed_post_raises_when_configured() -> None:
+    transport = FakeAuthedPost(raises=httpx.RequestError("boom"))
+
+    async def driver() -> None:
+        await transport.perform_authed_post(
+            build_request=lambda s: ("https://x", b"", None),
+            log_label="lbl",
+        )
+
+    with pytest.raises(httpx.RequestError, match="boom"):
+        asyncio.run(driver())
+    # The call is still recorded — the fake records first, then raises.
+    assert transport.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# chain_calls_through_to_authed_post
+# ---------------------------------------------------------------------------
+
+
+def test_chain_calls_through_with_no_middlewares() -> None:
+    """Empty chain still reaches the transport (terminal call)."""
+    transport = FakeAuthedPost()
+    assert chain_calls_through_to_authed_post(transport, []) is True
+    assert transport.call_count == 1
+
+
+def test_chain_calls_through_with_passthrough_middleware() -> None:
+    """A passthrough middleware doesn't block the chain from reaching transport."""
+    transport = FakeAuthedPost()
+
+    async def passthrough(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        return await next_call(request)
+
+    assert chain_calls_through_to_authed_post(transport, [passthrough]) is True
+    assert transport.call_count == 1
+
+
+def test_chain_calls_through_with_short_circuit_middleware_returns_false() -> None:
+    """A short-circuiting middleware prevents the chain from reaching transport.
+
+    No production middleware in the Tier-12 set does this, but the helper
+    correctly reports it so tests that *expect* short-circuit behavior can
+    assert against it.
+    """
+    transport = FakeAuthedPost()
+
+    async def short_circuit(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        return RpcResponse(response=httpx.Response(status_code=418, content=b""))
+
+    assert chain_calls_through_to_authed_post(transport, [short_circuit]) is False
+    assert transport.call_count == 0
+
+
+def test_chain_calls_through_with_multiple_middlewares_runs_all_in_order() -> None:
+    """All middlewares get a chance to observe the request before transport."""
+    transport = FakeAuthedPost()
+    call_order: list[str] = []
+
+    def make_recorder(label: str):
+        async def mw(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+            call_order.append(label)
+            return await next_call(request)
+
+        return mw
+
+    middlewares = [make_recorder("A"), make_recorder("B"), make_recorder("C")]
+    assert chain_calls_through_to_authed_post(transport, middlewares) is True
+    assert call_order == ["A", "B", "C"]
+    assert transport.call_count == 1
+
+
+def test_chain_terminal_reads_context_keys_for_transport_call() -> None:
+    """The terminal forwards ``build_request`` / ``log_label`` from request.context.
+
+    PR 12.2's chain leaf will do exactly this on real production data.
+    The fixture mirrors the contract so middleware PRs can assert against
+    a realistic chain shape.
+    """
+    transport = FakeAuthedPost()
+
+    sentinel_build_request = object()
+
+    async def stuff_context(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        # Middleware populates the keys the terminal expects.
+        request.context["build_request"] = sentinel_build_request
+        request.context["log_label"] = "test-label"
+        request.context["disable_internal_retries"] = True
+        return await next_call(request)
+
+    async def driver() -> None:
+        # We can't use ``chain_calls_through_to_authed_post`` here because
+        # we want to assert on the *content* of the recorded call, not
+        # just whether it happened.
+        async def terminal(req: RpcRequest) -> RpcResponse:
+            ctx = req.context
+            resp = await transport.perform_authed_post(
+                build_request=ctx["build_request"],
+                log_label=ctx["log_label"],
+                disable_internal_retries=ctx["disable_internal_retries"],
+            )
+            return RpcResponse(response=resp, context=ctx)
+
+        chain = build_chain([stuff_context], terminal)
+        await chain(make_request())
+
+    asyncio.run(driver())
+    assert transport.call_count == 1
+    call = transport.calls[0]
+    assert call["build_request"] is sentinel_build_request
+    assert call["log_label"] == "test-label"
+    assert call["disable_internal_retries"] is True

--- a/tests/unit/test_middleware_types.py
+++ b/tests/unit/test_middleware_types.py
@@ -1,0 +1,392 @@
+"""Unit tests for the Tier-12 middleware-chain type scaffolding.
+
+Exercises the shapes defined in ``src/notebooklm/_middleware.py`` and the
+public-ish aliases in ``src/notebooklm/_request_types.py``:
+
+- ``RpcRequest`` / ``RpcResponse`` dataclass round-trip (construction,
+  ``dataclasses.replace`` equivalence, frozen-mutation guard).
+- ``Middleware: Protocol`` structural typing — a plain async callable
+  satisfies the Protocol without inheriting from it.
+- ``build_chain`` composition order — leftmost middleware in the sequence
+  becomes the outermost wrapper (matches ADR-009 chain ordering).
+- ``BuildRequestResult`` value semantics.
+
+These tests target the type-only scaffolding from PR 12.1. No production
+chain is wired (PR 12.2 does that), so the tests build chains over fake
+terminals and observe behavior directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import httpx
+import pytest
+
+from notebooklm._middleware import (
+    Middleware,
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+from notebooklm._request_types import (
+    AuthSnapshot,
+    BuildRequest,
+    BuildRequestResult,
+)
+
+# ---------------------------------------------------------------------------
+# RpcRequest / RpcResponse dataclass shape
+# ---------------------------------------------------------------------------
+
+
+def _make_response(status: int = 200) -> httpx.Response:
+    """Fully-buffered ``httpx.Response`` for tests — no live network call."""
+    return httpx.Response(status_code=status, content=b"")
+
+
+def test_rpc_request_construction_with_defaults_and_overrides() -> None:
+    req = RpcRequest(
+        url="https://example/batchexecute?authuser=0&_reqid=100000",
+        headers={"X-Goog-AuthUser": "0"},
+        body=b"f.req=...",
+    )
+    assert req.url == "https://example/batchexecute?authuser=0&_reqid=100000"
+    assert req.headers == {"X-Goog-AuthUser": "0"}
+    assert req.body == b"f.req=..."
+    # ``context`` defaults to an empty dict, fresh per instance.
+    assert req.context == {}
+    other = RpcRequest(url="https://x", headers={}, body=b"")
+    assert other.context is not req.context  # independent dict instances
+
+
+def test_rpc_request_is_frozen() -> None:
+    req = RpcRequest(url="https://x", headers={}, body=b"")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        req.url = "https://y"
+
+
+def test_rpc_request_replace_returns_new_instance() -> None:
+    req = RpcRequest(url="https://x", headers={"a": "1"}, body=b"", context={"k": "v"})
+    new = dataclasses.replace(req, url="https://y")
+    assert new.url == "https://y"
+    assert req.url == "https://x"  # original untouched
+    # ``replace`` keeps the same context dict by reference (intentional —
+    # ADR-009 §"Per-request behavior"). Mutating ``new.context`` is visible
+    # on ``req.context`` because they are the same object.
+    assert new.context is req.context
+
+
+def test_rpc_response_construction() -> None:
+    resp = _make_response()
+    rpc_resp = RpcResponse(response=resp, context={"trace_id": "abc"})
+    assert rpc_resp.response is resp
+    assert rpc_resp.context == {"trace_id": "abc"}
+
+
+def test_rpc_response_is_frozen() -> None:
+    rpc_resp = RpcResponse(response=_make_response())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        rpc_resp.context = {"x": 1}
+
+
+# ---------------------------------------------------------------------------
+# Middleware Protocol — structural typing check
+# ---------------------------------------------------------------------------
+
+
+async def _passthrough_middleware(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+    return await next_call(request)
+
+
+def test_async_callable_satisfies_middleware_protocol() -> None:
+    """A bare async function with the right shape *is* a ``Middleware``.
+
+    ``Middleware`` is a ``Protocol`` with a single ``__call__``; structural
+    typing accepts any async callable whose parameters and return type
+    match.
+    """
+    mw: Middleware = _passthrough_middleware  # mypy will fail if wrong shape
+    assert callable(mw)
+
+
+class _ClassMiddleware:
+    """Class-based middleware — also satisfies the Protocol structurally."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        self.calls += 1
+        return await next_call(request)
+
+
+def test_class_with_async_call_satisfies_middleware_protocol() -> None:
+    mw: Middleware = _ClassMiddleware()
+    assert callable(mw)
+
+
+# ---------------------------------------------------------------------------
+# build_chain ordering — leftmost-is-outermost (the ADR-009 contract)
+# ---------------------------------------------------------------------------
+
+
+def _ordering_recorder(label: str, order_log: list[str]) -> Middleware:
+    """Make a middleware that records its label before *and* after recursing.
+
+    Used by the composition-order tests below: a chain ``[A, B, C]`` over
+    terminal ``T`` should produce the log
+    ``['A-pre', 'B-pre', 'C-pre', 'T', 'C-post', 'B-post', 'A-post']``.
+    """
+
+    async def _middleware(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        order_log.append(f"{label}-pre")
+        response = await next_call(request)
+        order_log.append(f"{label}-post")
+        return response
+
+    return _middleware
+
+
+def test_build_chain_empty_middlewares_returns_terminal_unchanged() -> None:
+    terminal_calls = 0
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        nonlocal terminal_calls
+        terminal_calls += 1
+        return RpcResponse(response=_make_response())
+
+    chain = build_chain([], terminal)
+    asyncio.run(chain(RpcRequest(url="https://x", headers={}, body=b"")))
+    assert terminal_calls == 1
+    # And ``build_chain([], t)`` should literally return ``t`` — the
+    # implementation skips the wrapper loop entirely.
+    assert chain is terminal
+
+
+def test_build_chain_three_middleware_call_order() -> None:
+    """First in list is outermost; last in list is innermost.
+
+    Matches ADR-009 chain ordering: ``[Drain, Metrics, Retry, AuthRefresh,
+    ErrorInjection, Tracing]`` → Drain (index 0) is the outermost wrapper,
+    Tracing (index 5) wraps the terminal directly.
+    """
+    log: list[str] = []
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        log.append("T")
+        return RpcResponse(response=_make_response())
+
+    chain = build_chain(
+        [
+            _ordering_recorder("A", log),
+            _ordering_recorder("B", log),
+            _ordering_recorder("C", log),
+        ],
+        terminal,
+    )
+    asyncio.run(chain(RpcRequest(url="https://x", headers={}, body=b"")))
+
+    assert log == [
+        "A-pre",  # outermost middleware enters
+        "B-pre",
+        "C-pre",  # innermost middleware enters
+        "T",  # terminal runs
+        "C-post",  # unwinds inside-out
+        "B-post",
+        "A-post",
+    ]
+
+
+def test_build_chain_preserves_class_middleware_state_across_calls() -> None:
+    """Class-based middlewares keep their own state across chain invocations."""
+    mw = _ClassMiddleware()
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=_make_response())
+
+    chain = build_chain([mw], terminal)
+    asyncio.run(chain(RpcRequest(url="https://x", headers={}, body=b"")))
+    asyncio.run(chain(RpcRequest(url="https://y", headers={}, body=b"")))
+    assert mw.calls == 2
+
+
+def test_build_chain_middleware_can_transform_request() -> None:
+    """A middleware that uses ``dataclasses.replace`` propagates the new request."""
+    seen_urls: list[str] = []
+
+    async def rewrite(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        new_request = dataclasses.replace(request, url=request.url + "?rewritten")
+        return await next_call(new_request)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        seen_urls.append(request.url)
+        return RpcResponse(response=_make_response())
+
+    chain = build_chain([rewrite], terminal)
+    asyncio.run(chain(RpcRequest(url="https://x", headers={}, body=b"")))
+    assert seen_urls == ["https://x?rewritten"]
+
+
+def test_build_chain_short_circuit_middleware_can_skip_terminal() -> None:
+    """A middleware may return without calling ``next_call``.
+
+    No production middleware in the Tier-12 set does this, but the protocol
+    permits it (and certain test middlewares need it — e.g. a "deny all
+    requests" canary).
+    """
+    terminal_calls = 0
+    short_circuit_response = _make_response(status=418)
+
+    async def short_circuit(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        return RpcResponse(response=short_circuit_response)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        nonlocal terminal_calls
+        terminal_calls += 1
+        return RpcResponse(response=_make_response())
+
+    chain = build_chain([short_circuit], terminal)
+    result = asyncio.run(chain(RpcRequest(url="https://x", headers={}, body=b"")))
+    assert terminal_calls == 0
+    assert result.response is short_circuit_response
+
+
+def test_build_chain_each_call_gets_independent_closures() -> None:
+    """Defensive guard against the late-binding closure bug in loops.
+
+    Without the ``make_wrapper`` helper in ``build_chain``, every wrapped
+    middleware would close over the *final* loop variable. This test would
+    pick that up — each middleware would see the same (last) ``mw``.
+    """
+    log: list[str] = []
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=_make_response())
+
+    chain = build_chain(
+        [
+            _ordering_recorder("first", log),
+            _ordering_recorder("second", log),
+            _ordering_recorder("third", log),
+        ],
+        terminal,
+    )
+    asyncio.run(chain(RpcRequest(url="https://x", headers={}, body=b"")))
+    # If the closure bug were present, we'd see "third-pre" three times in
+    # a row (every wrapped middleware closed over the same final label).
+    assert log == [
+        "first-pre",
+        "second-pre",
+        "third-pre",
+        "third-post",
+        "second-post",
+        "first-post",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _request_types.py — public aliases for AuthSnapshot / BuildRequest / BuildRequestResult
+# ---------------------------------------------------------------------------
+
+
+def test_auth_snapshot_alias_round_trip() -> None:
+    """``AuthSnapshot`` is a value-equivalent alias for ``_AuthSnapshot``."""
+    snap = AuthSnapshot(
+        csrf_token="csrf-1",
+        session_id="sid-1",
+        authuser=0,
+        account_email=None,
+    )
+    assert snap.csrf_token == "csrf-1"
+    assert snap.session_id == "sid-1"
+    assert snap.authuser == 0
+    assert snap.account_email is None
+    # Equality is value-based (frozen dataclass).
+    assert snap == AuthSnapshot(
+        csrf_token="csrf-1",
+        session_id="sid-1",
+        authuser=0,
+        account_email=None,
+    )
+
+
+def test_auth_snapshot_alias_is_same_object_as_underscore_original() -> None:
+    """The public alias and the private original refer to the same class.
+
+    PR 12.9 will collapse the alias by relocating the definition into
+    ``_request_types.py``; until then, the two names point at the same class.
+    """
+    from notebooklm._core_transport import _AuthSnapshot
+
+    assert AuthSnapshot is _AuthSnapshot
+
+
+def test_build_request_alias_is_callable_type() -> None:
+    """``BuildRequest`` is a callable type alias.
+
+    Runtime check: a function with the right shape can be assigned to a
+    ``BuildRequest``-annotated variable without mypy complaint, and the
+    function is callable as documented.
+    """
+    snap = AuthSnapshot(csrf_token="csrf", session_id="sid", authuser=0, account_email=None)
+
+    def factory(s: AuthSnapshot) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://x", b"body", {"X-Goog-AuthUser": str(s.authuser)})
+
+    callable_factory: BuildRequest = factory
+    url, body, headers = callable_factory(snap)
+    assert url == "https://x"
+    assert body == b"body"
+    assert headers == {"X-Goog-AuthUser": "0"}
+
+
+def test_build_request_alias_is_same_object_as_underscore_original() -> None:
+    """``BuildRequest`` is the same type alias as ``_BuildRequest``."""
+    from notebooklm._core_transport import _BuildRequest
+
+    assert BuildRequest is _BuildRequest
+
+
+def test_build_request_result_value_semantics() -> None:
+    """``BuildRequestResult`` is frozen + value-equal."""
+    r1 = BuildRequestResult(url="https://x", body=b"body", headers={"a": "1"})
+    r2 = BuildRequestResult(url="https://x", body=b"body", headers={"a": "1"})
+    assert r1 == r2
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r1.url = "https://y"
+
+
+def test_build_request_result_accepts_none_headers() -> None:
+    r = BuildRequestResult(url="https://x", body=b"", headers=None)
+    assert r.headers is None
+
+
+# ---------------------------------------------------------------------------
+# _request_types underscore re-exports are still importable
+# ---------------------------------------------------------------------------
+
+
+def test_underscore_originals_remain_importable_from_request_types() -> None:
+    """The underscore-prefixed originals are importable from ``_request_types``.
+
+    They're excluded from ``__all__`` so star-imports don't propagate them,
+    but explicit import works for one cycle. PR 12.9 collapses the shim.
+    """
+    from notebooklm._request_types import _AuthSnapshot, _BuildRequest
+
+    assert _AuthSnapshot is AuthSnapshot
+    assert _BuildRequest is BuildRequest
+
+
+def test_request_types_all_excludes_underscore_names() -> None:
+    """``__all__`` is the canonical export list and excludes underscore names."""
+    from notebooklm import _request_types
+
+    assert "AuthSnapshot" in _request_types.__all__
+    assert "BuildRequest" in _request_types.__all__
+    assert "BuildRequestResult" in _request_types.__all__
+    assert "_AuthSnapshot" not in _request_types.__all__
+    assert "_BuildRequest" not in _request_types.__all__


### PR DESCRIPTION
## Summary

Lands the Tier-12 greenfield migration scaffolding: a `Middleware` Protocol, `RpcRequest`/`RpcResponse` dataclasses, a `NextCall` type alias, a `build_chain` composition helper, the public-ish `AuthSnapshot`/`BuildRequest`/`BuildRequestResult` aliases, plus the `tests/_fixtures/chain.py` test substrate. ADR-009 pins the chain ordering and the `AuthRefreshMiddleware` constructor signature verbatim so PR 12.8's implementation has zero degrees of freedom on shape.

**Type-only scaffolding. No transport code modified. Cassettes untouched. Coverage neutral.**

## Task

- Master plan: `.sisyphus/plans/tier-12-13-greenfield-migration.md` §2 — Tier 12 middleware extraction (9 PRs).
- ADR: [`docs/adr/0009-middleware-chain.md`](docs/adr/0009-middleware-chain.md) — committed in this PR.
- Phase: `.sisyphus/phases/tier-12-13-greenfield-migration/phase-1.md`.

**Forcing function:** ADR-009's pinned callback signatures (§"AuthRefreshMiddleware constructor signature") give PR 12.8 (`AuthRefreshMiddleware`) zero design freedom on chain shape.

## Files added

- `src/notebooklm/_middleware.py` — `Middleware: Protocol`, `RpcRequest`/`RpcResponse` frozen dataclasses, `NextCall` alias, `build_chain()` helper.
- `src/notebooklm/_request_types.py` — public `AuthSnapshot` + `BuildRequest` aliases (one-cycle `__all__`-excluded underscore re-exports kept) + `BuildRequestResult` dataclass.
- `tests/_fixtures/chain.py` — `FakeAuthedPost` (NOT `FakeKernel` — `Kernel` doesn't exist until PR 13.2), `make_request(**overrides)`, `chain_calls_through_to_authed_post(transport, middlewares)`.
- `docs/adr/0009-middleware-chain.md` — full ADR with pinned chain ordering, `RpcRequest.context` key table, and verbatim `AuthRefreshMiddleware` constructor signature. Status: `Accepted (Tier 12 PR 12.1)`. Forward references ADR-002 supersession by ADR-010 in Tier 13.
- `tests/unit/test_middleware_types.py` — 23 unit tests covering dataclasses (round-trip + frozen guard), `Middleware: Protocol` structural typing, `build_chain` ordering + closure-bug guard + short-circuit, alias identity tests.
- `tests/unit/test_chain_fixtures.py` — 12 unit tests for the three helpers in `tests/_fixtures/chain.py`.
- `docs/adr/README.md` — ADR-009 added to index.

## Chain ordering (ADR-009)

```
Drain → Metrics → Retry → AuthRefresh → ErrorInjection → Tracing → Kernel.post
(outermost)                                                       (innermost)
```

Implementation contract: leftmost middleware in the `Sequence` passed to `build_chain` becomes the outermost wrapper. Verified by `test_build_chain_three_middleware_call_order`.

## Test plan

- [x] `uv run pre-commit run --all-files` — pass.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — pass (127 source files, 0 errors).
- [x] `uv run mypy tests/unit/test_middleware_types.py tests/unit/test_chain_fixtures.py tests/_fixtures/chain.py --ignore-missing-imports` — pass (0 errors).
- [x] `uv run pytest tests/unit/test_middleware_types.py tests/unit/test_chain_fixtures.py` — 35/35 pass.
- [x] `git diff main -- tests/cassettes/` — byte-identical (1 byte = trailing newline of empty diff).
- [x] Full suite: 442 pre-existing failures on `main` unchanged; zero new failures introduced.
- [ ] Bot reviewers (gemini-code-assist, coderabbitai, claude@github) — to be invoked.

## Deferred polish findings

None. Triple review (claude + codex + gemini) produced 0 critical, 2 important, 5 nits — all 7 addressed before opening this PR. See commit body for the polish summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an ADR documenting the middleware chain design for cross-cutting HTTP transport concerns.

* **New Features**
  * Introduced an async middleware chain for layered HTTP transport handling and public types to support it.

* **Tests**
  * Added comprehensive tests and fixtures validating middleware composition, ordering, short-circuiting, and type/behavior guarantees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->