### PR TITLE
feat(core): wire empty middleware chain into ClientCore (Tier 12 PR 12.2)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -104,6 +104,13 @@ from ._core_transport import (
 from ._core_transport import (
     _TransportServerError as _TransportServerError,
 )
+from ._middleware import (
+    Middleware,
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
 from ._sources import fetch_source_ids
 
 # ``save_cookies_to_storage`` is re-exported as ``notebooklm._core.save_cookies_to_storage``
@@ -452,6 +459,26 @@ class ClientCore:
         self.poll_registry: PollRegistry = PollRegistry()
         self._authed_transport: AuthedTransport | None = None
         self._rpc_executor: RpcExecutor | None = None
+        # Tier-12 PR 12.2: empty middleware chain wired around
+        # ``AuthedTransport.perform_authed_post`` (the shared seam covering
+        # ``ClientCore._perform_authed_post`` here and ``RpcExecutor.execute``'s
+        # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
+        # Middlewares land one per PR in 12.3–12.8 (Tracing, Metrics, Drain,
+        # ErrorInjection, Retry, AuthRefresh) and are inserted into the empty
+        # list below; the wiring shape stays unchanged.
+        #
+        # The terminal adapter reads ``build_request`` / ``log_label`` /
+        # ``disable_internal_retries`` from ``RpcRequest.context`` and
+        # delegates to ``self._get_authed_transport().perform_authed_post``.
+        # ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
+        # stay unpopulated until PRs 12.5/12.7/12.8 start lifting behavior
+        # out of ``AuthedTransport``. See ADR-009 §"Per-request behavior"
+        # and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
+        self._middlewares: list[Middleware] = []
+        self._authed_post_chain: NextCall = build_chain(
+            self._middlewares,
+            self._authed_post_chain_terminal,
+        )
 
     @property
     def _save_lock(self) -> threading.Lock:
@@ -802,6 +829,36 @@ class ClientCore:
                 self._metrics_obj = ClientMetrics(on_rpc_event=None)
             if not hasattr(self, "_drain_tracker"):
                 self._drain_tracker = TransportDrainTracker()
+
+    def _ensure_authed_post_chain(self) -> None:
+        """Backfill the middleware chain for tests that construct via ``__new__``.
+
+        Mirrors :meth:`_ensure_observability_state` — a ``__new__``-built
+        fixture skips ``__init__`` and so misses both ``_middlewares`` and
+        ``_authed_post_chain``. The first call to :meth:`_perform_authed_post`
+        on such a fixture would raise ``AttributeError``; this helper
+        backfills both slots with the same shape ``__init__`` would have
+        constructed (empty middleware list around the terminal adapter).
+
+        Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
+        :meth:`_ensure_observability_state` is — two threads observing
+        ``hasattr is False`` simultaneously must not both construct a
+        chain (one would clobber the other and break the
+        ``self._middlewares`` ↔ ``self._authed_post_chain`` linkage that
+        later middleware PRs rely on). The lock is uncontested on the
+        happy ``__init__`` path because the chain is already populated.
+        """
+        if hasattr(self, "_authed_post_chain"):
+            return
+        with _OBSERVABILITY_INIT_LOCK:
+            if hasattr(self, "_authed_post_chain"):
+                return
+            if not hasattr(self, "_middlewares"):
+                self._middlewares = []
+            self._authed_post_chain = build_chain(
+                self._middlewares,
+                self._authed_post_chain_terminal,
+            )
 
     def _increment_metrics(self, **increments: int | float) -> None:
         self._ensure_observability_state()
@@ -1182,6 +1239,38 @@ class ClientCore:
             rpc_id_override=rpc_id_override,
         )
 
+    async def _authed_post_chain_terminal(self, request: RpcRequest) -> RpcResponse:
+        """Chain leaf — adapts ``RpcRequest`` into ``AuthedTransport`` call shape.
+
+        Reads ``build_request`` / ``log_label`` / ``disable_internal_retries``
+        from ``request.context`` and delegates to
+        :meth:`AuthedTransport.perform_authed_post` — the shared seam that
+        covers both :meth:`ClientCore._perform_authed_post` and
+        ``RpcExecutor.execute`` (which calls ``_perform_authed_post`` at
+        ``_core_rpc.py:275``). Wraps the returned :class:`httpx.Response` in
+        an :class:`RpcResponse` so middlewares above the leaf see the chain
+        contract from ``_middleware.py``.
+
+        ``self._get_authed_transport()`` is resolved on every invocation so
+        late-bound monkeypatches of ``_get_authed_transport`` (e.g. fixtures
+        that swap the transport mid-test) still affect live behavior. The
+        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
+        dataclass fields stay unpopulated for the empty chain — PRs
+        12.5/12.7/12.8 begin populating them as middlewares strip behavior
+        out of :class:`AuthedTransport`. See ADR-009 §"RpcRequest.context
+        keys" for the metadata vocabulary.
+        """
+        context = request.context
+        build_request = context["build_request"]
+        log_label = context["log_label"]
+        disable_internal_retries = context.get("disable_internal_retries", False)
+        response = await self._get_authed_transport().perform_authed_post(
+            build_request=build_request,
+            log_label=log_label,
+            disable_internal_retries=disable_internal_retries,
+        )
+        return RpcResponse(response=response, context=context)
+
     async def _perform_authed_post(
         self,
         *,
@@ -1189,12 +1278,34 @@ class ClientCore:
         log_label: str,
         disable_internal_retries: bool = False,
     ) -> httpx.Response:
-        """Compatibility wrapper around :class:`AuthedTransport`."""
-        return await self._get_authed_transport().perform_authed_post(
-            build_request=build_request,
-            log_label=log_label,
-            disable_internal_retries=disable_internal_retries,
+        """Authed POST entry point — routes through the middleware chain.
+
+        Compatibility surface preserved so ``RpcExecutor.execute``
+        (``_core_rpc.py:275``), ``_chat_transport`` (``_chat_transport.py:64``),
+        and direct callers (``client._core._perform_authed_post(...)``) keep
+        the same keyword-only signature. The body now builds an
+        :class:`RpcRequest` with the three keyword-only args stashed into
+        ``context`` and dispatches into :attr:`_authed_post_chain` — the
+        empty middleware chain wired in :meth:`__init__`. Middlewares land
+        one per PR in 12.3–12.8; the wiring shape stays unchanged.
+
+        ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
+        intentionally stay empty until PRs 12.5/12.7/12.8 begin populating
+        them as middlewares strip behavior out of :class:`AuthedTransport`.
+        """
+        self._ensure_authed_post_chain()
+        request = RpcRequest(
+            url="",
+            headers={},
+            body=b"",
+            context={
+                "build_request": build_request,
+                "log_label": log_label,
+                "disable_internal_retries": disable_internal_retries,
+            },
         )
+        result = await self._authed_post_chain(request)
+        return result.response
 
     async def _await_refresh(self) -> None:
         """Run / join the shared refresh task.

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -1,0 +1,380 @@
+"""Integration tests for the empty middleware chain wired into ``ClientCore``.
+
+PR 12.2 of the Tier-12/13 greenfield migration wires
+:func:`notebooklm._middleware.build_chain` into
+:meth:`ClientCore.__init__` with an empty middleware list. The chain leaf
+(:meth:`ClientCore._authed_post_chain_terminal`) reads
+``build_request`` / ``log_label`` / ``disable_internal_retries`` from
+``RpcRequest.context`` and delegates to
+:meth:`AuthedTransport.perform_authed_post` — the shared seam covering both
+:meth:`ClientCore._perform_authed_post` AND ``RpcExecutor.execute`` (which
+calls ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
+
+These tests verify the wiring contract from
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160 and ADR-009
+§"RpcRequest.context keys":
+
+1. Both call paths (``ClientCore._perform_authed_post`` directly and
+   ``RpcExecutor.execute`` indirectly) flow through the empty chain to the
+   transport.
+2. ``RpcRequest.context`` carries ``build_request`` / ``log_label`` /
+   ``disable_internal_retries`` exactly as the leaf expects them.
+3. The leaf returns an :class:`RpcResponse` wrapping the
+   :class:`httpx.Response` from the transport.
+
+The terminal adapter resolves ``self._get_authed_transport()`` per
+invocation so swapping the transport mid-test (the idiom used here) still
+affects live behavior — a property the existing
+``test_core_transport.py`` test suite already relies on for its
+monkeypatch surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the
+# canonical import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import FakeAuthedPost
+from notebooklm._core import ClientCore
+from notebooklm._middleware import (
+    Middleware,
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+
+
+def _make_core() -> ClientCore:
+    """Build a ``ClientCore`` instance without opening an HTTP client.
+
+    ``ClientCore.__init__`` is event-loop-agnostic, so we can construct an
+    instance in synchronous test setup. The transport is then swapped in
+    each test for a :class:`FakeAuthedPost` so no real HTTP call fires.
+    """
+    auth = MagicMock()
+    auth.storage_path = None
+    auth.authuser = 0
+    auth.account_email = None
+    auth.csrf_token = "csrf-token"
+    auth.session_id = "session-id"
+    return ClientCore(auth=auth)
+
+
+def _swap_transport(core: ClientCore, fake: FakeAuthedPost) -> None:
+    """Replace ``core._get_authed_transport`` with a callable returning ``fake``.
+
+    The chain terminal calls ``self._get_authed_transport()`` per
+    invocation; overriding the bound method on the instance is sufficient
+    because Python's attribute lookup finds the instance attribute before
+    the class method. This keeps the swap local to the test (no shared
+    module-level monkeypatch).
+    """
+    core._get_authed_transport = lambda: fake  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_empty_chain_routes_perform_authed_post_to_transport() -> None:
+    """``ClientCore._perform_authed_post`` flows through the empty chain to transport.
+
+    Covers the first of the two call paths from master plan line 160:
+    direct callers of ``ClientCore._perform_authed_post`` (the chat path
+    in ``_chat_transport.py:64`` and any first-party caller via
+    ``client._core._perform_authed_post``).
+    """
+    expected_response = httpx.Response(status_code=200, content=b"chain-routed")
+    fake = FakeAuthedPost(response=expected_response)
+    core = _make_core()
+    _swap_transport(core, fake)
+
+    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/url", b"body", None)
+
+    response = await core._perform_authed_post(
+        build_request=build_request,
+        log_label="test-log-label",
+        disable_internal_retries=False,
+    )
+
+    assert response is expected_response
+    assert fake.call_count == 1
+    call = fake.calls[0]
+    assert call["build_request"] is build_request
+    assert call["log_label"] == "test-log-label"
+    assert call["disable_internal_retries"] is False
+
+
+@pytest.mark.asyncio
+async def test_empty_chain_routes_rpc_executor_path_to_transport() -> None:
+    """``RpcExecutor.execute`` → ``_perform_authed_post`` flows through the chain too.
+
+    Covers the second of the two call paths from master plan line 160:
+    ``RpcExecutor.execute`` (``_core_rpc.py:275``) calls
+    ``self._owner._perform_authed_post(...)`` which is precisely
+    :meth:`ClientCore._perform_authed_post`. Routing both paths through
+    one seam is the whole point of wiring at ``_perform_authed_post``
+    rather than at each call site.
+
+    We exercise the route by calling ``_perform_authed_post`` with the
+    keyword shape ``RpcExecutor.execute`` uses (the
+    ``log_label=f"RPC {method.name}"`` template at ``_core_rpc.py:277``)
+    and asserting the chain leaf hands those exact kwargs to the
+    transport. We do NOT spin up a full ``RpcExecutor`` here because that
+    pulls in the idempotency registry and encoder fixtures; the seam
+    invariant is "the chain receives whatever ``_perform_authed_post``
+    receives," which a direct call validates without the extra surface.
+    """
+    expected_response = httpx.Response(status_code=200, content=b"rpc-path")
+    fake = FakeAuthedPost(response=expected_response)
+    core = _make_core()
+    _swap_transport(core, fake)
+
+    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/rpc", b"rpc-body", {"X-Goog-AuthUser": "0"})
+
+    response = await core._perform_authed_post(
+        build_request=build_request,
+        log_label="RPC LIST_NOTEBOOKS",
+        disable_internal_retries=True,
+    )
+
+    assert response is expected_response
+    assert fake.call_count == 1
+    call = fake.calls[0]
+    assert call["build_request"] is build_request
+    assert call["log_label"] == "RPC LIST_NOTEBOOKS"
+    # The ``disable_internal_retries`` bool resolved by
+    # ``_idempotency.resolve_effective_disable_internal_retries`` upstream
+    # propagates through the chain unchanged.
+    assert call["disable_internal_retries"] is True
+
+
+@pytest.mark.asyncio
+async def test_chain_terminal_reads_context_keys() -> None:
+    """``RpcRequest.context`` carries the three keys the terminal reads.
+
+    Drives the terminal adapter directly with a hand-built ``RpcRequest``
+    so we can assert the contract independently of
+    :meth:`ClientCore._perform_authed_post`'s context-construction code.
+    This is what every middleware PR 12.3–12.8 will rely on when it
+    builds a chain over ``[*middlewares, ...]`` and lets the leaf adapt
+    the request into a transport call.
+    """
+    expected_response = httpx.Response(status_code=204, content=b"")
+    fake = FakeAuthedPost(response=expected_response)
+    core = _make_core()
+    _swap_transport(core, fake)
+
+    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/ctx", b"ctx-body", None)
+
+    request = RpcRequest(
+        url="",
+        headers={},
+        body=b"",
+        context={
+            "build_request": build_request,
+            "log_label": "context-test",
+            "disable_internal_retries": False,
+        },
+    )
+
+    result = await core._authed_post_chain_terminal(request)
+
+    assert isinstance(result, RpcResponse)
+    assert result.response is expected_response
+    # The ``RpcResponse.context`` propagates the same dict the request
+    # carried, so middlewares above the leaf can read additions a deeper
+    # link made. The empty chain leaves the dict unchanged.
+    assert result.context is request.context
+    assert fake.call_count == 1
+    assert fake.calls[0]["build_request"] is build_request
+    assert fake.calls[0]["log_label"] == "context-test"
+    assert fake.calls[0]["disable_internal_retries"] is False
+
+
+@pytest.mark.asyncio
+async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
+    """When ``context`` omits ``disable_internal_retries`` the leaf reads ``False``.
+
+    ``_perform_authed_post`` always populates the key, but the leaf
+    defends against a missing entry so middlewares that build a request
+    without the key (e.g. a future ``Session.transport_post`` raw-POST
+    seam, master plan section 3) cannot trip the leaf with a
+    ``KeyError``.
+    """
+    fake = FakeAuthedPost()
+    core = _make_core()
+    _swap_transport(core, fake)
+
+    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/no-retry-flag", b"", None)
+
+    request = RpcRequest(
+        url="",
+        headers={},
+        body=b"",
+        context={
+            "build_request": build_request,
+            "log_label": "default-flag",
+        },
+    )
+
+    await core._authed_post_chain_terminal(request)
+
+    assert fake.call_count == 1
+    assert fake.calls[0]["disable_internal_retries"] is False
+
+
+@pytest.mark.asyncio
+async def test_chain_is_empty_by_default() -> None:
+    """``ClientCore.__init__`` constructs the chain with an empty middleware list.
+
+    PRs 12.3–12.8 each prepend one middleware; PR 12.2 ships only the
+    wiring shape. The list must be exposed as ``self._middlewares`` so
+    later PRs (and the cleanup audit in 12.9) can assert ordering by
+    inspecting the production attribute directly.
+    """
+    core = _make_core()
+    assert core._middlewares == []
+    # The chain itself is the terminal (``build_chain`` returns the
+    # terminal unchanged when given an empty middleware list — see
+    # ``_middleware.build_chain``'s "empty middlewares" branch). Bound
+    # methods are equal (by ``__func__`` + ``__self__``) but not
+    # identity-equal across attribute accesses, so compare with ``==``.
+    assert core._authed_post_chain == core._authed_post_chain_terminal
+
+
+@pytest.mark.asyncio
+async def test_chain_with_test_middleware_observes_request_and_response() -> None:
+    """A test middleware can observe the request and response around the leaf.
+
+    Demonstrates the contract every middleware PR 12.3–12.8 will rely on:
+    insert a middleware into the chain, drive a request through, and
+    assert the middleware saw both the inbound request and the outbound
+    response. This is the wire-up smoke test for middleware extractions.
+
+    Builds the chain locally (rather than mutating ``core._middlewares``
+    in-place) because production code does not yet support hot-swapping
+    the chain — that's a PR 12.3 concern when ``TracingMiddleware`` lands.
+    """
+    observed: dict[str, Any] = {}
+
+    async def observer(request: RpcRequest, next_call: NextCall) -> RpcResponse:
+        observed["request"] = request
+        response = await next_call(request)
+        observed["response"] = response
+        return response
+
+    expected_response = httpx.Response(status_code=200, content=b"observed")
+    fake = FakeAuthedPost(response=expected_response)
+    core = _make_core()
+    _swap_transport(core, fake)
+
+    # Build a chain with one observer middleware around the production
+    # terminal. The production chain stays empty; this is a per-test
+    # composition that validates the leaf's contract against
+    # ``build_chain`` rather than ``ClientCore.__init__``.
+    chain: NextCall = build_chain([observer], core._authed_post_chain_terminal)
+
+    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/observe", b"", None)
+
+    request = RpcRequest(
+        url="",
+        headers={},
+        body=b"",
+        context={
+            "build_request": build_request,
+            "log_label": "observer-test",
+            "disable_internal_retries": False,
+        },
+    )
+
+    result = await chain(request)
+
+    assert observed["request"] is request
+    assert isinstance(observed["response"], RpcResponse)
+    assert observed["response"].response is expected_response
+    assert result.response is expected_response
+    assert fake.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_perform_authed_post_works_on_new_built_fixture() -> None:
+    """A ``__new__``-built fixture can still call ``_perform_authed_post``.
+
+    Mirrors the ``_ensure_observability_state`` /
+    ``_ensure_auth_coord`` / ``_ensure_lifecycle`` backfill pattern: a
+    test that constructs ``ClientCore.__new__(ClientCore)`` (skipping
+    ``__init__``) must still be able to drive the authed-POST path.
+    The :meth:`ClientCore._ensure_authed_post_chain` helper backfills
+    ``_middlewares`` and ``_authed_post_chain`` lazily so the first call
+    succeeds. This regression guard catches the path before any
+    middleware PR (12.3+) inadvertently moves the chain build out of
+    the backfill.
+    """
+    core = ClientCore.__new__(ClientCore)
+    fake = FakeAuthedPost(response=httpx.Response(status_code=200, content=b"new"))
+    _swap_transport(core, fake)
+
+    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
+        return ("https://fake/new", b"", None)
+
+    response = await core._perform_authed_post(
+        build_request=build_request,
+        log_label="new-fixture",
+        disable_internal_retries=False,
+    )
+
+    assert response.status_code == 200
+    assert fake.call_count == 1
+
+
+def test_build_chain_empty_returns_terminal_unchanged() -> None:
+    """:func:`build_chain` returns the terminal unchanged when ``middlewares`` is empty.
+
+    Pins the contract that ``_middleware.build_chain([], terminal) is terminal``
+    so :meth:`ClientCore.__init__`'s ``self._authed_post_chain is
+    self._authed_post_chain_terminal`` invariant from
+    :func:`test_chain_is_empty_by_default` does not silently flip if
+    ``build_chain``'s identity behavior changes. Synchronous test —
+    no event-loop overhead.
+    """
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b""),
+            context=request.context,
+        )
+
+    middlewares: list[Middleware] = []
+    chain = build_chain(middlewares, terminal)
+    assert chain is terminal
+
+
+def test_perform_authed_post_signature_unchanged() -> None:
+    """The keyword-only signature of ``_perform_authed_post`` is unchanged.
+
+    Many call sites pass the three kwargs by name
+    (``_core_rpc.py:275``, ``_chat_transport.py:64``, integration tests).
+    The chain wiring inside the body must NOT change the public-ish
+    signature; this guard catches an accidental rename.
+    """
+    import inspect
+
+    sig = inspect.signature(ClientCore._perform_authed_post)
+    params = sig.parameters
+    assert "build_request" in params
+    assert "log_label" in params
+    assert "disable_internal_retries" in params
+    # All three are keyword-only — the ``*`` separator in the production
+    # signature is what makes this true.
+    assert params["build_request"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params["log_label"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params["disable_internal_retries"].kind is inspect.Parameter.KEYWORD_ONLY


### PR DESCRIPTION
## Summary

Wires an empty middleware chain (`build_chain([], terminal)`) into `ClientCore` around `AuthedTransport.perform_authed_post` — the shared seam covering both `ClientCore._perform_authed_post` AND `RpcExecutor.execute`'s call to `_owner._perform_authed_post` at `_core_rpc.py:275`. Middlewares land one per PR in 12.3-12.8; the wiring shape stays unchanged.

**Stacked on #839** (PR 12.1 — type-only scaffolding). Base will auto-update to `main` when #839 merges. Before merging this PR, rebase onto `origin/main` for a clean fast-forward.

## Implementation

- `ClientCore.__init__` (`_core.py:459-479`): instantiates `self._middlewares: list[Middleware]` empty + builds `self._authed_post_chain` via `build_chain([], self._authed_post_chain_terminal)`.
- `_authed_post_chain_terminal` (`_core.py:1239`): chain leaf reads `build_request` / `log_label` / `disable_internal_retries` from `RpcRequest.context` and delegates to `self._get_authed_transport().perform_authed_post`. Wraps the `httpx.Response` in an `RpcResponse`.
- `_perform_authed_post` (`_core.py:1277`): keyword-only signature preserved; body builds an `RpcRequest` and dispatches into the chain. `url` / `headers` / `body` dataclass fields stay empty — PRs 12.5/12.7/12.8 populate them as middlewares strip behavior out of `AuthedTransport`.
- `_ensure_authed_post_chain` (`_core.py:833`): backfills chain for `__new__`-built fixtures, mirroring the existing `_ensure_observability_state` pattern (same `_OBSERVABILITY_INIT_LOCK` guard).

## Test plan

- [x] `tests/unit/test_chain_wiring.py` — 9 integration tests covering both call paths through the empty chain, `RpcRequest.context` contract, `RpcResponse` envelope, `build_chain([], _)` identity, `__new__`-fixture backfill.
- [x] `uv run pre-commit run --all-files` green (ruff format + check pass).
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean (0 errors, 127 source files).
- [x] `uv run pytest tests/unit/test_chain_wiring.py tests/unit/test_middleware_types.py tests/unit/test_chain_fixtures.py -n auto` — 44/44 pass.
- [x] Pre-existing baseline auth-cookie test failures verified to also occur on `t12-1-scaffolding` (not introduced by this PR).
- [ ] CI run on this commit verifies the same in the proper environment.

## Cassettes

Cassette suite untouched: this PR adds chain-leaf indirection but doesn't change wire behavior or the `AuthedTransport.perform_authed_post` HTTP path. The empty chain is identity beyond one `RpcRequest` allocation per call. VCR playback bytes should be unchanged.

## References

- Master plan: `.sisyphus/plans/tier-12-13-greenfield-migration.md` section 2 (line 160)
- ADR-009: `docs/adr/0009-middleware-chain.md` (merged in #839)
- Per master plan: this PR deserves an `/argus` audit before merge — load-bearing first wiring step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced middleware chain architecture for authenticated HTTP request handling to support future extensibility.

* **Tests**
  * Added comprehensive test coverage validating middleware chain wiring and request routing through the core system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->