### PR TITLE
feat(core): extract TracingMiddleware (Tier 12 PR 12.3)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -466,12 +466,13 @@ class ClientCore:
         # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
         # PR 12.3 lands ``TracingMiddleware`` as the innermost (and currently
         # only) entry; subsequent PRs 12.4–12.8 prepend each remaining
-        # middleware in chain-order so the final list reads
+        # middleware to the LEFT of this list so the final list reads
         # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
         # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
-        # composes the leftmost entry as the outermost wrapper, so appending
-        # to the right of ``TracingMiddleware`` keeps Tracing innermost as
-        # later PRs grow the list.
+        # composes the leftmost entry as the outermost wrapper, so keeping
+        # ``TracingMiddleware`` at the RIGHT end of the list (and prepending
+        # new entries to the left) preserves Tracing as the innermost wrapper
+        # as later PRs grow the list.
         #
         # The terminal adapter reads ``build_request`` / ``log_label`` /
         # ``disable_internal_retries`` from ``RpcRequest.context`` and

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -111,6 +111,7 @@ from ._middleware import (
     RpcResponse,
     build_chain,
 )
+from ._middleware_tracing import TracingMiddleware
 from ._sources import fetch_source_ids
 
 # ``save_cookies_to_storage`` is re-exported as ``notebooklm._core.save_cookies_to_storage``
@@ -463,9 +464,14 @@ class ClientCore:
         # ``AuthedTransport.perform_authed_post`` (the shared seam covering
         # ``ClientCore._perform_authed_post`` here and ``RpcExecutor.execute``'s
         # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
-        # Middlewares land one per PR in 12.3–12.8 (Tracing, Metrics, Drain,
-        # ErrorInjection, Retry, AuthRefresh) and are inserted into the empty
-        # list below; the wiring shape stays unchanged.
+        # PR 12.3 lands ``TracingMiddleware`` as the innermost (and currently
+        # only) entry; subsequent PRs 12.4–12.8 prepend each remaining
+        # middleware in chain-order so the final list reads
+        # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
+        # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
+        # composes the leftmost entry as the outermost wrapper, so appending
+        # to the right of ``TracingMiddleware`` keeps Tracing innermost as
+        # later PRs grow the list.
         #
         # The terminal adapter reads ``build_request`` / ``log_label`` /
         # ``disable_internal_retries`` from ``RpcRequest.context`` and
@@ -474,7 +480,7 @@ class ClientCore:
         # stay unpopulated until PRs 12.5/12.7/12.8 start lifting behavior
         # out of ``AuthedTransport``. See ADR-009 §"Per-request behavior"
         # and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
-        self._middlewares: list[Middleware] = []
+        self._middlewares: list[Middleware] = [TracingMiddleware()]
         self._authed_post_chain: NextCall = build_chain(
             self._middlewares,
             self._authed_post_chain_terminal,
@@ -854,7 +860,14 @@ class ClientCore:
             if hasattr(self, "_authed_post_chain"):
                 return
             if not hasattr(self, "_middlewares"):
-                self._middlewares = []
+                # Mirror ``__init__``'s seeded chain: PR 12.3 lands
+                # ``TracingMiddleware`` as the innermost entry. A
+                # ``__new__``-built fixture must see the same chain shape so
+                # tracing records are emitted for fixture-driven invocations
+                # too; otherwise the fixture path and the live path diverge
+                # in observability, which has previously hidden bugs in
+                # Tier-8 cassette-replay tests.
+                self._middlewares = [TracingMiddleware()]
             self._authed_post_chain = build_chain(
                 self._middlewares,
                 self._authed_post_chain_terminal,

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -844,7 +844,8 @@ class ClientCore:
         ``_authed_post_chain``. The first call to :meth:`_perform_authed_post`
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
-        constructed (empty middleware list around the terminal adapter).
+        constructed (``TracingMiddleware``-seeded chain around the terminal
+        adapter, matching the seed in ``__init__``).
 
         Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
         :meth:`_ensure_observability_state` is — two threads observing

--- a/src/notebooklm/_middleware_tracing.py
+++ b/src/notebooklm/_middleware_tracing.py
@@ -1,0 +1,143 @@
+"""TracingMiddleware — innermost middleware in the Tier-12 chain.
+
+Per ADR-009 §"Chain ordering" and master plan §2, ``TracingMiddleware`` is
+the **innermost** wrapper around the transport leaf (``Kernel.post`` after
+PR 13.2, ``AuthedTransport.perform_authed_post`` until then). It logs one
+"starting" record before invoking ``next_call`` and one "completed"
+(success) or "failed" (exception) record after, capturing per-attempt
+HTTP-level visibility — including retry attempts, which is why it sits
+inside ``RetryMiddleware``.
+
+Pure observer: the middleware never mutates ``request`` or transforms
+``response``. The frozen ``RpcRequest`` dataclass enforces request
+immutability at the type level; the response is forwarded unchanged
+(same :class:`RpcResponse` instance) so any middleware above the leaf
+sees exactly what the leaf returned.
+
+Trace record fields (emitted via ``logger.<level>(..., extra={...})`` so
+structured-logging consumers see them as ``LogRecord`` attributes):
+
+- ``rpc_method`` — value of ``request.context.get("rpc_method")``. ``None``
+  until ``Session.rpc_call`` (Tier 13) starts populating the key; populated
+  for every RPC after that.
+- ``log_label`` — value of ``request.context.get("log_label")``. The
+  empty middleware chain wired in PR 12.2 always populates this key (it
+  is one of the three transport-call kwargs). May be ``None`` only for a
+  ``__new__``-built fixture exercising a malformed request.
+- ``status_code`` — ``response.response.status_code`` on the success
+  record (omitted from "starting" and "failed" records).
+- ``duration_ms`` — wall-clock duration of the ``next_call`` invocation
+  in milliseconds (via :func:`time.perf_counter`). Omitted from the
+  "starting" record; included on success and failure.
+- ``exception_type`` — only on the "failed" record; the qualified name of
+  the exception class that propagated out of ``next_call``.
+
+Failure mode: if ``next_call`` raises, emit a "failed" trace record at
+``logging.WARNING`` and re-raise the original exception unchanged. The
+middleware never swallows.
+
+This is a small class on purpose — the contract is "log before, log
+after, never touch the payload." More elaborate tracing (span IDs,
+``contextvars`` propagation, OpenTelemetry export) is a future concern;
+the structured ``extra=`` fields here give downstream observers enough
+hooks to attach.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` row 12.3 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from ._middleware import NextCall, RpcRequest, RpcResponse
+
+logger = logging.getLogger("notebooklm.middleware.tracing")
+
+
+class TracingMiddleware:
+    """Innermost middleware — emits a per-attempt trace record around ``next_call``.
+
+    Stateless and constructor-arg-free: the only collaborator is the
+    module-level :data:`logger`. Tests that need to capture emitted
+    records use stdlib :mod:`logging` machinery (``caplog`` fixture in
+    pytest, or :class:`logging.handlers.MemoryHandler` directly).
+
+    Conforms to :class:`notebooklm._middleware.Middleware` — the
+    ``__call__`` signature matches the Protocol so mypy treats the
+    instance as assignable into a ``Sequence[Middleware]``.
+    """
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        """Log one "starting" record, invoke ``next_call``, log one terminal record.
+
+        The ``extra=`` mapping turns each key into a ``LogRecord``
+        attribute (e.g. ``record.rpc_method``) for structured-logging
+        consumers. The message strings themselves stay short and stable
+        so a string-matching grep is also possible. Keys absent from
+        ``request.context`` surface as ``None`` rather than raising
+        ``KeyError`` — the chain is wired by PR 12.2 to always carry
+        ``log_label``, but ``rpc_method`` is not populated until
+        ``Session.rpc_call`` lands in Tier 13.
+        """
+        context = request.context
+        rpc_method = context.get("rpc_method")
+        log_label = context.get("log_label")
+        # ``base_extra`` is the per-attempt structured-logging keyset shared
+        # across the three records this middleware emits. Each terminal
+        # record (completed / failed) augments it with record-specific
+        # fields (status_code or exception_type, plus duration_ms).
+        base_extra: dict[str, object] = {
+            "rpc_method": rpc_method,
+            "log_label": log_label,
+        }
+
+        logger.debug("rpc starting: %s", log_label, extra=base_extra)
+
+        # ``perf_counter`` is monotonic and not affected by system-clock
+        # adjustments, so the resulting ``duration_ms`` is safe to use
+        # for both per-attempt latency stats and ordering invariants in
+        # tests. ``Exception`` (not ``BaseException``) — we want to skip
+        # tracing for cooperative-cancellation signals (``KeyboardInterrupt``,
+        # ``SystemExit``, ``asyncio.CancelledError``); those are not "RPC
+        # failed" events, they are caller-initiated unwinds.
+        start = time.perf_counter()
+        try:
+            response = await next_call(request)
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            exc_type = type(exc).__qualname__
+            logger.warning(
+                "rpc failed: %s (%s)",
+                log_label,
+                exc_type,
+                extra={
+                    **base_extra,
+                    "duration_ms": duration_ms,
+                    "exception_type": exc_type,
+                },
+            )
+            raise
+
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        status_code = response.response.status_code
+        logger.debug(
+            "rpc completed: %s -> %d",
+            log_label,
+            status_code,
+            extra={
+                **base_extra,
+                "status_code": status_code,
+                "duration_ms": duration_ms,
+            },
+        )
+        return response
+
+
+__all__ = ["TracingMiddleware"]

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -232,22 +232,22 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chain_is_empty_by_default() -> None:
-    """``ClientCore.__init__`` constructs the chain with an empty middleware list.
+async def test_chain_seeded_with_tracing_middleware() -> None:
+    """``ClientCore.__init__`` seeds the chain with ``[TracingMiddleware()]``.
 
-    PRs 12.3–12.8 each prepend one middleware; PR 12.2 ships only the
-    wiring shape. The list must be exposed as ``self._middlewares`` so
-    later PRs (and the cleanup audit in 12.9) can assert ordering by
-    inspecting the production attribute directly.
+    PR 12.3 lands ``TracingMiddleware`` as the innermost entry (and the
+    only entry until 12.4+). Subsequent PRs 12.4–12.8 each prepend their
+    middleware so the final ordering reads ``[Drain, Metrics, Retry,
+    AuthRefresh, ErrorInjection, Tracing]`` per ADR-009. The list is
+    exposed as ``self._middlewares`` so later PRs (and the cleanup audit
+    in 12.9) can assert ordering by inspecting the production attribute
+    directly.
     """
+    from notebooklm._middleware_tracing import TracingMiddleware
+
     core = _make_core()
-    assert core._middlewares == []
-    # The chain itself is the terminal (``build_chain`` returns the
-    # terminal unchanged when given an empty middleware list — see
-    # ``_middleware.build_chain``'s "empty middlewares" branch). Bound
-    # methods are equal (by ``__func__`` + ``__self__``) but not
-    # identity-equal across attribute accesses, so compare with ``==``.
-    assert core._authed_post_chain == core._authed_post_chain_terminal
+    assert len(core._middlewares) == 1
+    assert isinstance(core._middlewares[0], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_tracing_middleware.py
+++ b/tests/unit/test_tracing_middleware.py
@@ -38,6 +38,7 @@ full client.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 import httpx
@@ -316,3 +317,39 @@ async def test_failure_emits_failed_record_and_reraises(
     assert failed.exception_type == "RuntimeError"
     assert isinstance(failed.duration_ms, float)
     assert failed.duration_ms >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_bypasses_failed_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``asyncio.CancelledError`` propagates without emitting a "failed" record.
+
+    ``CancelledError`` is a :class:`BaseException` subclass (Python 3.8+), and
+    the ``except Exception`` clause in :class:`TracingMiddleware` is
+    deliberately narrow: cooperative-cancellation signals
+    (``CancelledError`` / ``KeyboardInterrupt`` / ``SystemExit``) are caller-
+    initiated unwinds, not RPC failures, so they bypass the failure-trace
+    path entirely. Only the "starting" record lands.
+
+    Pinning this in a test guards against a future maintainer widening the
+    ``except`` to ``BaseException`` (or adding a bare ``except``), which
+    would silently turn benign cancellations into noisy "failed" warnings
+    and inflate the duration_ms latency histogram.
+    """
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        raise asyncio.CancelledError()
+
+    chain = build_chain([TracingMiddleware()], terminal)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=_TRACE_LOGGER),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await chain(make_request(context={"log_label": "cancel-test"}))
+
+    records = [r for r in caplog.records if r.name == _TRACE_LOGGER]
+    assert len(records) == 1
+    assert "rpc starting" in records[0].getMessage()
+    assert records[0].log_label == "cancel-test"

--- a/tests/unit/test_tracing_middleware.py
+++ b/tests/unit/test_tracing_middleware.py
@@ -1,0 +1,318 @@
+"""Unit tests for :class:`notebooklm._middleware_tracing.TracingMiddleware`.
+
+PR 12.3 of the Tier-12/13 greenfield migration lands ``TracingMiddleware``
+as the innermost middleware in the chain (ADR-009 §"Chain ordering"). The
+middleware is a pure observer: it logs one "starting" record before
+``next_call`` and one "completed"/"failed" record after, without
+transforming the request or response.
+
+These tests verify:
+
+1. The middleware satisfies the :class:`Middleware` Protocol shape and
+   wires through the chain (smoke test via the shared
+   :func:`chain_calls_through_to_authed_post` fixture).
+2. Two log records are emitted around a successful call: one BEFORE
+   ``next_call`` ("starting"), one AFTER ("completed" with
+   ``status_code`` and ``duration_ms``).
+3. ``rpc_method`` / ``log_label`` are propagated from
+   ``request.context`` into the log record's ``extra`` mapping (so
+   structured-logging consumers see them as ``LogRecord`` attributes).
+4. The response returned by the middleware is the exact instance
+   returned by ``next_call`` (identity-equal, no rewrap).
+5. The request is unchanged after the middleware runs (frozen dataclass
+   enforces this at the type level; this test asserts it at runtime to
+   guard against a future maintainer relaxing the frozen invariant).
+6. On exception from ``next_call``, the middleware emits a "failed"
+   record (with ``duration_ms`` and ``exception_type``) and re-raises
+   the original exception unchanged.
+7. The middleware does NOT raise ``KeyError`` when ``rpc_method`` is
+   absent from ``request.context`` (``Session.rpc_call`` populates it
+   in Tier 13; PR 12.2's wiring does not).
+
+The tests use stdlib :func:`caplog` to capture log records — no
+production logger reconfiguration leaks across tests. The chain is
+driven directly via :func:`build_chain` rather than going through
+``ClientCore`` so the unit boundary is the middleware itself, not the
+full client.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
+# import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import (
+    FakeAuthedPost,
+    chain_calls_through_to_authed_post,
+    make_request,
+)
+from notebooklm._middleware import (
+    Middleware,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+from notebooklm._middleware_tracing import TracingMiddleware
+
+_TRACE_LOGGER = "notebooklm.middleware.tracing"
+
+
+# ---------------------------------------------------------------------------
+# Protocol / wire-up.
+# ---------------------------------------------------------------------------
+
+
+def test_tracing_middleware_satisfies_protocol() -> None:
+    """``TracingMiddleware`` is assignable into ``Middleware`` (Protocol check).
+
+    Static check at runtime: assignment to a ``Middleware``-typed variable
+    is the mypy-visible equivalent of "satisfies the Protocol." If a
+    future change adds a positional arg to ``__call__``, this assignment
+    fails type-check; the runtime assertion guards against the runtime
+    invariant too.
+    """
+    middleware: Middleware = TracingMiddleware()
+    assert middleware is not None
+
+
+def test_tracing_middleware_calls_through_to_transport() -> None:
+    """Chain of ``[TracingMiddleware()]`` reaches ``FakeAuthedPost`` exactly once.
+
+    Uses the shared :func:`chain_calls_through_to_authed_post` fixture from
+    ``tests/_fixtures/chain.py`` — the canonical wire-up smoke test for
+    every middleware PR per ADR-009 §"Per-position rationale" and master
+    plan line 105.
+    """
+    transport = FakeAuthedPost()
+    assert chain_calls_through_to_authed_post(transport, [TracingMiddleware()])
+    assert transport.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Logging behaviour.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emits_starting_and_completed_records_on_success(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two records around a successful call: one "starting", one "completed".
+
+    Verifies the per-attempt visibility requirement from ADR-009 §"Chain
+    ordering" (Tracing innermost — "logs every actual HTTP attempt").
+    """
+    expected_response = httpx.Response(status_code=200, content=b"ok")
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=expected_response, context={})
+
+    chain = build_chain([TracingMiddleware()], terminal)
+
+    with caplog.at_level(logging.DEBUG, logger=_TRACE_LOGGER):
+        result = await chain(
+            make_request(
+                context={"rpc_method": "LIST_NOTEBOOKS", "log_label": "RPC LIST_NOTEBOOKS"}
+            )
+        )
+
+    assert result.response is expected_response
+
+    records = [r for r in caplog.records if r.name == _TRACE_LOGGER]
+    assert len(records) == 2
+
+    starting, completed = records
+    assert starting.getMessage() == "rpc starting: RPC LIST_NOTEBOOKS"
+    assert starting.rpc_method == "LIST_NOTEBOOKS"
+    assert starting.log_label == "RPC LIST_NOTEBOOKS"
+    # ``starting`` is emitted BEFORE the call returns, so no status_code /
+    # duration_ms yet (LogRecord lacks those attributes — accessing them
+    # would raise ``AttributeError`` rather than return ``None``).
+    assert not hasattr(starting, "status_code")
+    assert not hasattr(starting, "duration_ms")
+
+    assert completed.getMessage() == "rpc completed: RPC LIST_NOTEBOOKS -> 200"
+    assert completed.rpc_method == "LIST_NOTEBOOKS"
+    assert completed.log_label == "RPC LIST_NOTEBOOKS"
+    assert completed.status_code == 200
+    assert isinstance(completed.duration_ms, float)
+    assert completed.duration_ms >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_starting_record_is_emitted_before_next_call(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The "starting" record is emitted *before* the terminal runs.
+
+    Validated by recording the log count inside the terminal: at that
+    point exactly one record has been emitted (the "starting" one); the
+    "completed" record cannot land until ``next_call`` returns.
+    """
+    log_count_during_terminal: list[int] = []
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        log_count_during_terminal.append(sum(1 for r in caplog.records if r.name == _TRACE_LOGGER))
+        return RpcResponse(response=httpx.Response(status_code=200, content=b""), context={})
+
+    chain = build_chain([TracingMiddleware()], terminal)
+
+    with caplog.at_level(logging.DEBUG, logger=_TRACE_LOGGER):
+        await chain(make_request(context={"log_label": "ordering-check"}))
+
+    assert log_count_during_terminal == [1]
+
+
+@pytest.mark.asyncio
+async def test_rpc_method_absent_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``rpc_method`` missing from context is fine — middleware logs ``None``.
+
+    ``Session.rpc_call`` (Tier 13) populates ``context["rpc_method"]``;
+    PR 12.2's wiring does not, so the empty-chain path through
+    ``ClientCore._perform_authed_post`` only carries ``log_label`` /
+    ``build_request`` / ``disable_internal_retries``. The middleware
+    must handle this gracefully (``.get()`` returns ``None``, no
+    ``KeyError``).
+    """
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=httpx.Response(status_code=204, content=b""), context={})
+
+    chain = build_chain([TracingMiddleware()], terminal)
+
+    with caplog.at_level(logging.DEBUG, logger=_TRACE_LOGGER):
+        # Context has ``log_label`` but no ``rpc_method``.
+        await chain(make_request(context={"log_label": "no-rpc-method"}))
+
+    records = [r for r in caplog.records if r.name == _TRACE_LOGGER]
+    assert len(records) == 2
+    assert records[0].rpc_method is None
+    assert records[1].rpc_method is None
+    assert records[1].log_label == "no-rpc-method"
+    assert records[1].status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_empty_context_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Even with a fully-empty ``context`` dict, both records emit with ``None`` fields.
+
+    Edge case: ``make_request()`` defaults ``context`` to ``{}``. The
+    middleware should not require any specific key.
+    """
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=httpx.Response(status_code=200, content=b""), context={})
+
+    chain = build_chain([TracingMiddleware()], terminal)
+
+    with caplog.at_level(logging.DEBUG, logger=_TRACE_LOGGER):
+        await chain(make_request())
+
+    records = [r for r in caplog.records if r.name == _TRACE_LOGGER]
+    assert len(records) == 2
+    for record in records:
+        assert record.rpc_method is None
+        assert record.log_label is None
+
+
+# ---------------------------------------------------------------------------
+# Pass-through invariants.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_passthrough_identity() -> None:
+    """The middleware returns the exact ``RpcResponse`` produced by ``next_call``.
+
+    Pure observer contract: no rewrap, no replace. Identity equality
+    (``is``) catches a future maintainer who accidentally wraps the
+    response in a new dataclass; value equality would not.
+    """
+    sentinel_response = RpcResponse(
+        response=httpx.Response(status_code=201, content=b"made"),
+        context={"trace_id": "abc-123"},
+    )
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        return sentinel_response
+
+    chain = build_chain([TracingMiddleware()], terminal)
+    result = await chain(make_request())
+
+    assert result is sentinel_response
+
+
+@pytest.mark.asyncio
+async def test_request_is_not_mutated() -> None:
+    """The middleware does not mutate ``request`` — frozen dataclass + identity.
+
+    The frozen ``RpcRequest`` dataclass enforces immutability at the
+    type level (assigning to a field raises ``FrozenInstanceError``).
+    This test asserts at runtime that the terminal receives the *same*
+    ``RpcRequest`` instance the middleware was given — no
+    ``dataclasses.replace`` happened in between.
+    """
+    received_requests: list[RpcRequest] = []
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        received_requests.append(request)
+        return RpcResponse(response=httpx.Response(status_code=200, content=b""), context={})
+
+    chain = build_chain([TracingMiddleware()], terminal)
+    sent = make_request(context={"log_label": "no-mutation"})
+    await chain(sent)
+
+    assert len(received_requests) == 1
+    assert received_requests[0] is sent
+
+
+# ---------------------------------------------------------------------------
+# Failure path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failure_emits_failed_record_and_reraises(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If ``next_call`` raises, emit a "failed" record and re-raise unchanged.
+
+    Verifies the never-swallow contract: the propagated exception is the
+    exact instance raised by the terminal (``is``-equal), and a
+    ``WARNING``-level record with ``exception_type`` and ``duration_ms``
+    is emitted before the re-raise.
+    """
+    boom = RuntimeError("transport-failed")
+
+    async def terminal(_request: RpcRequest) -> RpcResponse:
+        raise boom
+
+    chain = build_chain([TracingMiddleware()], terminal)
+
+    with (
+        caplog.at_level(logging.DEBUG, logger=_TRACE_LOGGER),
+        pytest.raises(RuntimeError) as exc_info,
+    ):
+        await chain(make_request(context={"log_label": "boom-label"}))
+
+    assert exc_info.value is boom
+
+    records = [r for r in caplog.records if r.name == _TRACE_LOGGER]
+    # "starting" + "failed".
+    assert len(records) == 2
+
+    failed = records[1]
+    assert failed.levelno == logging.WARNING
+    assert "rpc failed: boom-label" in failed.getMessage()
+    assert failed.log_label == "boom-label"
+    assert failed.exception_type == "RuntimeError"
+    assert isinstance(failed.duration_ms, float)
+    assert failed.duration_ms >= 0.0


### PR DESCRIPTION
## Summary

Lands the first concrete middleware in the Tier-12/13 greenfield migration chain (ADR-009). `TracingMiddleware` is the **innermost** chain entry — it sees every actual HTTP attempt (including retries).

- `src/notebooklm/_middleware_tracing.py` (new, ~145 lines): `TracingMiddleware` class — pure observer, around-style; logs `rpc starting`, then `rpc completed: <status>` or `rpc failed: <exc_type>`; structured-logging fields include `rpc_method`, `log_label`, `duration_ms`, `status_code` / `exception_type`.
- `src/notebooklm/_core.py`: `ClientCore.__init__` and `_ensure_authed_post_chain` both seed `self._middlewares = [TracingMiddleware()]`. PRs 12.4-12.8 will prepend each remaining middleware.
- `tests/unit/test_tracing_middleware.py` (new, 9 tests): pass-through identity, success/failure record shape, missing-context-key tolerance.
- `tests/unit/test_chain_wiring.py`: updated `test_chain_is_empty_by_default` → `test_chain_seeded_with_tracing_middleware` (the empty-chain invariant only held in PR 12.2; PRs 12.3+ each prepend).

## Design notes

- **`Exception` not `BaseException`**: `KeyboardInterrupt` / `SystemExit` / `asyncio.CancelledError` are caller-initiated unwinds, not RPC failures, so they bypass the failed-trace path.
- **`base_extra` dict** consolidates the per-attempt structured-logging keyset shared across the three records.
- **Pure observer** — no request/response mutation.

## Stacking history

Originally stacked on `t12-2-wire-empty-chain` (PR #840). After #840 squash-merged to main (`23ea456`), this branch was rebased directly onto current `origin/main` (which also picked up `#836`, `#837`, `#839` in the interim). The diff this PR introduces is now exactly the 12.3 changes — no inherited 12.2 noise.

## Test plan

- [x] `uv run pytest tests/unit/test_tracing_middleware.py tests/unit/test_chain_wiring.py tests/unit/test_middleware_types.py tests/unit/test_chain_fixtures.py -n auto` — 53/53 pass
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — 0 issues, 128 files
- [x] `uv run pre-commit run --files <changed files>` — clean (ruff legacy + ruff-format pass)
- [ ] Full CI matrix (Linux/macOS/Windows × Python 3.10-3.14)
- [ ] CodeRabbit / gemini-code-assist review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic RPC tracing enabled by default: logs when requests start and complete, captures duration (ms) and status codes.
* **Bug Fixes**
  * Cancelled operations no longer emit a failure log; only the start trace is recorded.
* **Tests**
  * Added/updated tests to verify default tracing is seeded and cancelled-error behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->