### PR TITLE
feat(core): extract MetricsMiddleware (Tier 12 PR 12.4)

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -90,6 +90,10 @@ class _ChatCore(
         # matches; ``chat_aware_authed_post`` never forwards it (chat always
         # runs with internal retries enabled).
         disable_internal_retries: bool = False,
+        # ``rpc_method`` (PR 12.4) is None for the chat path so
+        # ``MetricsMiddleware`` skips emission — chat-side requests have
+        # never appeared in the RPC counters and continue not to.
+        rpc_method: str | None = None,
     ) -> httpx.Response: ...
 
 

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -111,6 +111,7 @@ from ._middleware import (
     RpcResponse,
     build_chain,
 )
+from ._middleware_metrics import MetricsMiddleware
 from ._middleware_tracing import TracingMiddleware
 from ._sources import fetch_source_ids
 
@@ -464,9 +465,10 @@ class ClientCore:
         # ``AuthedTransport.perform_authed_post`` (the shared seam covering
         # ``ClientCore._perform_authed_post`` here and ``RpcExecutor.execute``'s
         # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
-        # PR 12.3 lands ``TracingMiddleware`` as the innermost (and currently
-        # only) entry; subsequent PRs 12.4–12.8 prepend each remaining
-        # middleware to the LEFT of this list so the final list reads
+        # PR 12.3 added ``TracingMiddleware`` as the innermost entry; PR 12.4
+        # prepends ``MetricsMiddleware`` to its left, so the list now reads
+        # ``[Metrics, Tracing]``. Subsequent PRs 12.5–12.8 prepend each
+        # remaining middleware further left so the final list reads
         # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
         # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
         # composes the leftmost entry as the outermost wrapper, so keeping
@@ -481,7 +483,10 @@ class ClientCore:
         # stay unpopulated until PRs 12.5/12.7/12.8 start lifting behavior
         # out of ``AuthedTransport``. See ADR-009 §"Per-request behavior"
         # and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
-        self._middlewares: list[Middleware] = [TracingMiddleware()]
+        self._middlewares: list[Middleware] = [
+            MetricsMiddleware(self._metrics_obj),
+            TracingMiddleware(),
+        ]
         self._authed_post_chain: NextCall = build_chain(
             self._middlewares,
             self._authed_post_chain_terminal,
@@ -845,8 +850,9 @@ class ClientCore:
         ``_authed_post_chain``. The first call to :meth:`_perform_authed_post`
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
-        constructed (``TracingMiddleware``-seeded chain around the terminal
-        adapter, matching the seed in ``__init__``).
+        constructed (``[MetricsMiddleware, TracingMiddleware]``-seeded
+        chain around the terminal adapter, matching the seed in
+        ``__init__``).
 
         Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
         :meth:`_ensure_observability_state` is — two threads observing
@@ -858,18 +864,31 @@ class ClientCore:
         """
         if hasattr(self, "_authed_post_chain"):
             return
+        # ``MetricsMiddleware`` needs ``self._metrics_obj``, which a
+        # ``__new__``-built fixture hasn't constructed yet. Run the
+        # observability backfill BEFORE acquiring
+        # ``_OBSERVABILITY_INIT_LOCK`` (its own contract is "no-op when
+        # already initialized" and it takes the same lock internally —
+        # acquiring twice on this thread would deadlock since the lock
+        # is a plain :class:`threading.Lock`, not a reentrant lock).
+        self._ensure_observability_state()
         with _OBSERVABILITY_INIT_LOCK:
             if hasattr(self, "_authed_post_chain"):
                 return
             if not hasattr(self, "_middlewares"):
                 # Mirror ``__init__``'s seeded chain: PR 12.3 lands
-                # ``TracingMiddleware`` as the innermost entry. A
+                # ``TracingMiddleware`` as the innermost entry, PR 12.4
+                # prepends ``MetricsMiddleware`` to its left. A
                 # ``__new__``-built fixture must see the same chain shape so
-                # tracing records are emitted for fixture-driven invocations
-                # too; otherwise the fixture path and the live path diverge
-                # in observability, which has previously hidden bugs in
-                # Tier-8 cassette-replay tests.
-                self._middlewares = [TracingMiddleware()]
+                # both telemetry channels (structured trace logs + RPC
+                # counters/events) are exercised on fixture-driven
+                # invocations too; otherwise the fixture path and the live
+                # path diverge in observability, which has previously
+                # hidden bugs in Tier-8 cassette-replay tests.
+                self._middlewares = [
+                    MetricsMiddleware(self._metrics_obj),
+                    TracingMiddleware(),
+                ]
             self._authed_post_chain = build_chain(
                 self._middlewares,
                 self._authed_post_chain_terminal,
@@ -1292,6 +1311,7 @@ class ClientCore:
         build_request: _BuildRequest,
         log_label: str,
         disable_internal_retries: bool = False,
+        rpc_method: str | None = None,
     ) -> httpx.Response:
         """Authed POST entry point — routes through the middleware chain.
 
@@ -1300,9 +1320,18 @@ class ClientCore:
         and direct callers (``client._core._perform_authed_post(...)``) keep
         the same keyword-only signature. The body now builds an
         :class:`RpcRequest` with the three keyword-only args stashed into
-        ``context`` and dispatches into :attr:`_authed_post_chain` — the
-        empty middleware chain wired in :meth:`__init__`. Middlewares land
-        one per PR in 12.3–12.8; the wiring shape stays unchanged.
+        ``context`` and dispatches into :attr:`_authed_post_chain`.
+        Middlewares land one per PR in 12.3–12.8; the wiring shape stays
+        unchanged.
+
+        ``rpc_method`` (new in PR 12.4) is the resolved method name string
+        (``RPCMethod.name``) for RPC callers and ``None`` for the chat
+        streaming path. ``MetricsMiddleware`` reads it from
+        ``request.context["rpc_method"]`` to populate
+        :attr:`RpcTelemetryEvent.method` and to decide whether to fire the
+        emission at all — chat-side callers that pass ``None`` skip emission,
+        matching the pre-chain behavior (where ``_chat_transport`` never
+        called ``_emit_rpc_event``).
 
         ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
         intentionally stay empty until PRs 12.5/12.7/12.8 begin populating
@@ -1317,6 +1346,7 @@ class ClientCore:
                 "build_request": build_request,
                 "log_label": log_label,
                 "disable_internal_retries": disable_internal_retries,
+                "rpc_method": rpc_method,
             },
         )
         result = await self._authed_post_chain(request)

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -40,7 +40,6 @@ from .rpc import (
     get_batchexecute_url,
     resolve_rpc_id,
 )
-from .types import RpcTelemetryEvent
 
 logger = logging.getLogger(__name__)
 
@@ -95,8 +94,6 @@ class RpcOwner(Protocol):
     async def _finish_transport_post(self, token: Any) -> None: ...
 
     def _increment_metrics(self, **increments: int | float) -> None: ...
-
-    async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None: ...
 
 
 class RpcExecutor:

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -61,6 +61,7 @@ class RpcOwner(Protocol):
         build_request: _BuildRequest,
         log_label: str,
         disable_internal_retries: bool = False,
+        rpc_method: str | None = None,
     ) -> httpx.Response: ...
 
     async def _await_refresh(self) -> None: ...
@@ -170,10 +171,19 @@ class RpcExecutor:
         method_name = getattr(method, "name", str(method))
         operation_token = await self._owner._begin_transport_post(f"RPC {method_name}")
         self._owner._increment_metrics(rpc_calls_started=1)
-        start = time.perf_counter()
+        # As of PR 12.4 the per-attempt latency counter, the
+        # ``rpc_calls_succeeded`` / ``rpc_calls_failed`` counters, and the
+        # ``emit_rpc_event`` fire live inside ``MetricsMiddleware`` (see
+        # ``_middleware_metrics.py`` + ADR-009 §"Chain ordering"). The chain
+        # is wrapped around ``_perform_authed_post``, so middleware
+        # observation covers the transport leg only — exactly what
+        # ``Session.rpc_call`` will own in Tier 13. The ``rpc_calls_started``
+        # increment + reqid + drain-token wiring stays here because those
+        # concerns live OUTSIDE the chain (they bracket the entire logical
+        # RPC including decode, not just the transport attempt).
         _reqid_token = None if get_request_id() is not None else set_request_id()
         try:
-            result = await self._owner._rpc_call_impl(
+            return await self._owner._rpc_call_impl(
                 method,
                 params,
                 source_path,
@@ -182,37 +192,6 @@ class RpcExecutor:
                 disable_internal_retries=disable_internal_retries,
                 operation_variant=operation_variant,
             )
-        except Exception as exc:
-            elapsed = time.perf_counter() - start
-            self._owner._increment_metrics(
-                rpc_calls_failed=1,
-                rpc_latency_seconds_total=elapsed,
-            )
-            await self._owner._emit_rpc_event(
-                RpcTelemetryEvent(
-                    method=method_name,
-                    status="error",
-                    elapsed_seconds=elapsed,
-                    request_id=get_request_id(),
-                    error_type=type(exc).__name__,
-                )
-            )
-            raise
-        else:
-            elapsed = time.perf_counter() - start
-            self._owner._increment_metrics(
-                rpc_calls_succeeded=1,
-                rpc_latency_seconds_total=elapsed,
-            )
-            await self._owner._emit_rpc_event(
-                RpcTelemetryEvent(
-                    method=method_name,
-                    status="success",
-                    elapsed_seconds=elapsed,
-                    request_id=get_request_id(),
-                )
-            )
-            return result
         finally:
             if _reqid_token is not None:
                 reset_request_id(_reqid_token)
@@ -276,6 +255,7 @@ class RpcExecutor:
                 build_request=_build,
                 log_label=f"RPC {method.name}",
                 disable_internal_retries=effective_disable_internal_retries,
+                rpc_method=method.name,
             )
         except _TransportAuthExpired as exc:
             # Preserve the historical raw transport exception on refresh failure.

--- a/src/notebooklm/_middleware_metrics.py
+++ b/src/notebooklm/_middleware_metrics.py
@@ -1,0 +1,148 @@
+"""MetricsMiddleware — per-RPC telemetry emitter for the Tier-12 chain.
+
+Per ADR-009 §"Chain ordering" and master plan §2, ``MetricsMiddleware`` sits
+just inside ``DrainMiddleware`` (and just outside ``RetryMiddleware``) in the
+final chain ordering ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection,
+Tracing]``. PR 12.4 ships it as the OUTERMOST of two seeded middlewares
+(``[Metrics, Tracing]``); PRs 12.5–12.8 prepend the remaining middlewares
+to its left.
+
+Pure observer: never mutates ``request`` or transforms ``response``. Around
+``next_call`` it captures the wall-clock elapsed time of the chain-inner
+operation (which includes whatever HTTP/auth/retry behavior the inner
+middlewares + transport leaf perform) and emits exactly one terminal record
+per logical RPC:
+
+- Increments ``rpc_calls_succeeded`` / ``rpc_calls_failed`` and
+  ``rpc_latency_seconds_total`` on the shared :class:`ClientMetrics` snapshot.
+- Awaits ``ClientMetrics.emit_rpc_event`` with a backend-agnostic
+  :class:`RpcTelemetryEvent` so application-level ``on_rpc_event``
+  callbacks fire (Prometheus exporter, OTEL bridge, custom logger, …).
+
+The emit fires only when ``request.context["rpc_method"]`` is present.
+Other code paths through the chain (e.g. the chat streaming path in
+``_chat_transport.send_authed_post``, which calls
+``ClientCore._perform_authed_post`` directly without minting an
+``RpcExecutor`` telemetry frame) leave the key absent and skip emission —
+preserving the pre-PR-12.4 behavior where chat-side requests did not
+appear in the RPC counters or telemetry stream. This invariant is pinned
+by ``test_skips_emit_when_rpc_method_absent`` in
+``tests/unit/test_metrics_middleware.py``.
+
+Failure mode: on any exception from ``next_call``, record the
+failed-attempt metrics and re-raise. ``Exception`` (not
+``BaseException``) — cooperative-cancellation signals
+(``KeyboardInterrupt``, ``SystemExit``, ``asyncio.CancelledError``) are
+caller-initiated unwinds, not RPC failures; they propagate without
+incrementing counters or emitting events. Same scope as TracingMiddleware,
+same reason.
+
+This PR also lifts the per-RPC telemetry block from
+``RpcExecutor.execute_with_telemetry`` (which previously increment-and-
+emitted around ``_rpc_call_impl``). The chain now owns that emission, and
+``execute_with_telemetry`` keeps only the ``rpc_calls_started`` counter
+plus the reqid + drain-token plumbing — concerns that live OUTSIDE the
+chain and are not transport-layer events.
+
+Semantic refinement vs. pre-PR-12.4: decode-time errors (e.g. ``NoData``
+raised after a 200-OK transport return) previously incremented
+``rpc_calls_failed`` because the old block wrapped ``_rpc_call_impl``,
+which includes decode. The chain wraps only the transport leg, so
+decode-only failures no longer count as ``rpc_calls_failed``. This is the
+intended Tier-13 endpoint shape (``Session.rpc_call`` decodes AFTER the
+chain returns) and disentangles two failure modes that the old counter
+conflated — chain failures = transport failures, decode failures track
+separately if anyone wants to add them.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` row 12.4 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from ._logging import get_request_id
+from ._middleware import NextCall, RpcRequest, RpcResponse
+from ._types.common import RpcTelemetryEvent
+
+if TYPE_CHECKING:
+    from ._core_metrics import ClientMetrics
+
+
+class MetricsMiddleware:
+    """Middleware that increments counters and emits :class:`RpcTelemetryEvent`.
+
+    Conforms to :class:`notebooklm._middleware.Middleware` — the
+    ``__call__`` signature matches the Protocol so mypy treats instances
+    as assignable into a ``Sequence[Middleware]``.
+
+    Holds a reference to the shared :class:`ClientMetrics` instance owned
+    by :class:`ClientCore`. The middleware does not own metric state; it
+    is purely a write-through into the host's accumulator. This keeps the
+    ``client.metrics`` snapshot view authoritative — a test that swaps a
+    middleware out can still observe the counters.
+    """
+
+    def __init__(self, metrics: ClientMetrics) -> None:
+        self._metrics = metrics
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        """Time ``next_call``, then increment + emit on its terminal status.
+
+        Reads ``rpc_method`` from ``request.context``: when absent
+        (chat-side path; ``__new__``-built fixture) the middleware
+        becomes a pure pass-through with no observable effect, matching
+        the pre-PR-12.4 behavior. When present, the value flows into
+        :attr:`RpcTelemetryEvent.method`.
+        """
+        rpc_method = request.context.get("rpc_method")
+        # ``perf_counter`` is monotonic and clock-jump-safe. The reading
+        # happens here (not inside the success/failure branches) so the
+        # elapsed accounting is identical across paths and trivially
+        # auditable.
+        start = time.perf_counter()
+        try:
+            response = await next_call(request)
+        except Exception as exc:
+            elapsed = time.perf_counter() - start
+            if rpc_method is not None:
+                self._metrics.increment(
+                    rpc_calls_failed=1,
+                    rpc_latency_seconds_total=elapsed,
+                )
+                await self._metrics.emit_rpc_event(
+                    RpcTelemetryEvent(
+                        method=rpc_method,
+                        status="error",
+                        elapsed_seconds=elapsed,
+                        request_id=get_request_id(),
+                        error_type=type(exc).__name__,
+                    )
+                )
+            raise
+
+        elapsed = time.perf_counter() - start
+        if rpc_method is not None:
+            self._metrics.increment(
+                rpc_calls_succeeded=1,
+                rpc_latency_seconds_total=elapsed,
+            )
+            await self._metrics.emit_rpc_event(
+                RpcTelemetryEvent(
+                    method=rpc_method,
+                    status="success",
+                    elapsed_seconds=elapsed,
+                    request_id=get_request_id(),
+                )
+            )
+        return response
+
+
+__all__ = ["MetricsMiddleware"]

--- a/src/notebooklm/_middleware_tracing.py
+++ b/src/notebooklm/_middleware_tracing.py
@@ -17,9 +17,12 @@ sees exactly what the leaf returned.
 Trace record fields (emitted via ``logger.<level>(..., extra={...})`` so
 structured-logging consumers see them as ``LogRecord`` attributes):
 
-- ``rpc_method`` — value of ``request.context.get("rpc_method")``. ``None``
-  until ``Session.rpc_call`` (Tier 13) starts populating the key; populated
-  for every RPC after that.
+- ``rpc_method`` — value of ``request.context.get("rpc_method")``. Populated
+  as of PR 12.4 (via ``ClientCore._perform_authed_post``'s ``rpc_method``
+  kwarg, passed by ``RpcExecutor.execute``). ``None`` only for the chat
+  streaming path (``_chat_transport.send_authed_post`` — chat-side
+  requests are not classified RPCs) and for ``__new__``-built fixtures
+  driving the chain directly.
 - ``log_label`` — value of ``request.context.get("log_label")``. The
   empty middleware chain wired in PR 12.2 always populates this key (it
   is one of the three transport-call kwargs). May be ``None`` only for a
@@ -83,8 +86,9 @@ class TracingMiddleware:
         so a string-matching grep is also possible. Keys absent from
         ``request.context`` surface as ``None`` rather than raising
         ``KeyError`` — the chain is wired by PR 12.2 to always carry
-        ``log_label``, but ``rpc_method`` is not populated until
-        ``Session.rpc_call`` lands in Tier 13.
+        ``log_label``; ``rpc_method`` is populated as of PR 12.4 by
+        ``ClientCore._perform_authed_post`` for the RPC path and left
+        ``None`` for the chat streaming path.
         """
         context = request.context
         rpc_method = context.get("rpc_method")

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -232,22 +232,26 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chain_seeded_with_tracing_middleware() -> None:
-    """``ClientCore.__init__`` seeds the chain with ``[TracingMiddleware()]``.
+async def test_chain_seeded_with_metrics_then_tracing() -> None:
+    """``ClientCore.__init__`` seeds the chain with ``[Metrics, Tracing]``.
 
-    PR 12.3 lands ``TracingMiddleware`` as the innermost entry (and the
-    only entry until 12.4+). Subsequent PRs 12.4–12.8 each prepend their
-    middleware so the final ordering reads ``[Drain, Metrics, Retry,
-    AuthRefresh, ErrorInjection, Tracing]`` per ADR-009. The list is
-    exposed as ``self._middlewares`` so later PRs (and the cleanup audit
-    in 12.9) can assert ordering by inspecting the production attribute
-    directly.
+    PR 12.3 landed ``TracingMiddleware`` at the innermost position; PR 12.4
+    prepends ``MetricsMiddleware`` to its left. Order matters — Metrics is
+    outermore (it times the entire inner chain) and Tracing remains the
+    innermost wrapper around the transport leaf. Subsequent PRs 12.5–12.8
+    prepend their middleware further left so the final ordering reads
+    ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` per
+    ADR-009. The list is exposed as ``self._middlewares`` so later PRs
+    (and the cleanup audit in 12.9) can assert ordering by inspecting the
+    production attribute directly.
     """
+    from notebooklm._middleware_metrics import MetricsMiddleware
     from notebooklm._middleware_tracing import TracingMiddleware
 
     core = _make_core()
-    assert len(core._middlewares) == 1
-    assert isinstance(core._middlewares[0], TracingMiddleware)
+    assert len(core._middlewares) == 2
+    assert isinstance(core._middlewares[0], MetricsMiddleware)
+    assert isinstance(core._middlewares[1], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -8,7 +8,8 @@ PR 12.2 of the Tier-12/13 greenfield migration wires
 ``RpcRequest.context`` and delegates to
 :meth:`AuthedTransport.perform_authed_post` — the shared seam covering both
 :meth:`ClientCore._perform_authed_post` AND ``RpcExecutor.execute`` (which
-calls ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
+calls ``self._owner._perform_authed_post`` inside its retry loop in
+``_core_rpc.py``).
 
 These tests verify the wiring contract from
 ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160 and ADR-009

--- a/tests/unit/test_core_rpc.py
+++ b/tests/unit/test_core_rpc.py
@@ -75,6 +75,7 @@ class _Owner:
         build_request,
         log_label: str,
         disable_internal_retries: bool = False,
+        rpc_method: str | None = None,
     ) -> httpx.Response:
         url, body, headers = build_request(self.snapshot)
         self.perform_calls.append(
@@ -262,6 +263,7 @@ async def test_core_decode_response_monkeypatch_after_executor_construction(monk
         build_request,
         log_label: str,
         disable_internal_retries: bool = False,
+        rpc_method: str | None = None,
     ) -> httpx.Response:
         return _ok_response("wire")
 

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -516,9 +516,11 @@ def _build_rpc_executor() -> Any:
         build_request: Any,
         log_label: str,
         disable_internal_retries: bool = False,
+        rpc_method: str | None = None,
     ) -> httpx.Response:
         captured["disable_internal_retries"] = disable_internal_retries
         captured["log_label"] = log_label
+        captured["rpc_method"] = rpc_method
         return httpx.Response(200, text=")]}'\n[]")
 
     owner = MagicMock()

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -574,6 +574,9 @@ async def test_default_registry_preserves_today_behavior(
     )
 
     assert captured["disable_internal_retries"] is False
+    # Pin ``rpc_method`` propagation through the executor → transport seam
+    # so a regression in the kwarg threading can't slip past the suite.
+    assert captured["rpc_method"] == RPCMethod.LIST_NOTEBOOKS.name
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_metrics_middleware.py
+++ b/tests/unit/test_metrics_middleware.py
@@ -1,0 +1,382 @@
+"""Unit tests for :class:`MetricsMiddleware` (Tier-12 PR 12.4).
+
+Pins the contract documented in
+``src/notebooklm/_middleware_metrics.py`` and ADR-009 §"Chain ordering":
+
+- Pass-through identity (the middleware is a pure observer; it must not
+  mutate ``RpcRequest`` or transform the ``RpcResponse``).
+- On success: increment ``rpc_calls_succeeded`` + ``rpc_latency_seconds_total``
+  and ``await metrics.emit_rpc_event`` with a ``status="success"`` event
+  carrying the ``rpc_method`` name, the request id from ``_logging``, and
+  the elapsed wall-clock duration.
+- On failure: increment ``rpc_calls_failed`` + ``rpc_latency_seconds_total``,
+  emit a ``status="error"`` event with ``error_type = type(exc).__name__``,
+  and re-raise the exact same exception instance.
+- Skip emission entirely when ``request.context["rpc_method"]`` is absent
+  (chat-side path). This is the regression guard for the pre-PR-12.4
+  invariant that chat requests do not show up in RPC counters.
+- ``asyncio.CancelledError`` is a :class:`BaseException`, not
+  :class:`Exception`; the middleware lets it propagate without any
+  metrics side-effects.
+
+The tests use the canonical chain fixtures (``FakeAuthedPost`` +
+``make_request`` + ``build_chain``) from ``tests/_fixtures/chain.py`` so
+the substrate matches every other middleware test in the Tier-12 set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the
+# canonical import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import make_request
+from notebooklm._core_metrics import ClientMetrics
+from notebooklm._logging import get_request_id, set_request_id
+from notebooklm._middleware import (
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+from notebooklm._middleware_metrics import MetricsMiddleware
+from notebooklm._types.common import RpcTelemetryEvent
+
+
+def _make_terminal_returning(response: httpx.Response) -> NextCall:
+    """Build a terminal-shaped callable that returns ``RpcResponse(response)``.
+
+    The chain leaf normally wraps the ``httpx.Response`` from
+    ``AuthedTransport.perform_authed_post``; this helper short-circuits
+    that step so tests can drive the chain without booting a real
+    transport. ``request.context`` is propagated to the response so any
+    middleware above the leaf observes the same context object.
+    """
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=response, context=request.context)
+
+    return terminal
+
+
+@pytest.fixture
+def metrics() -> ClientMetrics:
+    """Fresh ``ClientMetrics`` per test — counters start at zero."""
+    return ClientMetrics(on_rpc_event=None)
+
+
+@pytest.mark.asyncio
+async def test_success_increments_counters_and_emits_event(
+    metrics: ClientMetrics,
+) -> None:
+    """Happy path: counters bump and event fires with status="success".
+
+    Verifies the four observable side-effects on success: (1) the
+    ``rpc_calls_succeeded`` counter increments by exactly 1, (2) the
+    ``rpc_latency_seconds_total`` accumulator grows by a non-negative
+    amount, (3) ``emit_rpc_event`` fires exactly once with the expected
+    field values, and (4) the response forwarded to the caller is
+    identity-equal to what the terminal returned.
+    """
+    captured: list[RpcTelemetryEvent] = []
+
+    async def capture(event: RpcTelemetryEvent) -> None:
+        captured.append(event)
+
+    metrics._on_rpc_event = capture
+
+    expected_response = httpx.Response(status_code=200, content=b"ok")
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], _make_terminal_returning(expected_response))
+
+    request = make_request(
+        context={"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
+    )
+    result = await chain(request)
+
+    assert result.response is expected_response
+    snap = metrics._metrics
+    assert snap.rpc_calls_succeeded == 1
+    assert snap.rpc_calls_failed == 0
+    assert snap.rpc_latency_seconds_total >= 0.0
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.method == "LIST_NOTEBOOKS"
+    assert event.status == "success"
+    assert event.elapsed_seconds >= 0.0
+    assert event.error_type is None
+
+
+@pytest.mark.asyncio
+async def test_failure_increments_counters_emits_error_and_reraises(
+    metrics: ClientMetrics,
+) -> None:
+    """If ``next_call`` raises, emit ``status="error"`` and re-raise.
+
+    Pins three invariants: (1) the exact exception instance propagates
+    (``is``-equal — the middleware never wraps or swallows), (2) the
+    ``error_type`` event field carries the bare class name, and
+    (3) ``rpc_calls_failed`` increments by 1 (NOT ``rpc_calls_succeeded``).
+    """
+    boom = RuntimeError("transport blew up")
+
+    async def failing_terminal(_request: RpcRequest) -> RpcResponse:
+        raise boom
+
+    captured: list[RpcTelemetryEvent] = []
+
+    async def capture(event: RpcTelemetryEvent) -> None:
+        captured.append(event)
+
+    metrics._on_rpc_event = capture
+
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], failing_terminal)
+    request = make_request(
+        context={"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await chain(request)
+
+    assert exc_info.value is boom
+
+    snap = metrics._metrics
+    assert snap.rpc_calls_succeeded == 0
+    assert snap.rpc_calls_failed == 1
+    assert snap.rpc_latency_seconds_total >= 0.0
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.method == "LIST_NOTEBOOKS"
+    assert event.status == "error"
+    assert event.error_type == "RuntimeError"
+    assert event.elapsed_seconds >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_skips_emit_when_rpc_method_absent(
+    metrics: ClientMetrics,
+) -> None:
+    """Chat-side path (``rpc_method`` absent) is a pure pass-through.
+
+    Pins the regression guard for the pre-PR-12.4 invariant: requests
+    flowing through the chain WITHOUT ``rpc_method`` in context must not
+    appear in the RPC counters or telemetry stream. The chat streaming
+    path (``_chat_transport.send_authed_post``) is the production caller
+    that exercises this branch — chat requests have never been counted
+    as RPCs and continue not to be.
+    """
+    captured: list[RpcTelemetryEvent] = []
+
+    async def capture(event: RpcTelemetryEvent) -> None:
+        captured.append(event)
+
+    metrics._on_rpc_event = capture
+
+    expected_response = httpx.Response(status_code=200, content=b"chat-ok")
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], _make_terminal_returning(expected_response))
+
+    # log_label present, rpc_method ABSENT — exact shape produced by
+    # ``ClientCore._perform_authed_post`` for the chat path (which
+    # defaults ``rpc_method=None``).
+    request = make_request(context={"log_label": "chat.ask"})
+    result = await chain(request)
+
+    assert result.response is expected_response
+    snap = metrics._metrics
+    assert snap.rpc_calls_succeeded == 0
+    assert snap.rpc_calls_failed == 0
+    assert snap.rpc_latency_seconds_total == 0.0
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_skips_emit_when_rpc_method_is_none(
+    metrics: ClientMetrics,
+) -> None:
+    """Explicit ``rpc_method=None`` in context is treated the same as absent.
+
+    ``ClientCore._perform_authed_post`` populates the context with
+    ``"rpc_method": rpc_method`` where the kwarg defaults to ``None``.
+    The middleware's ``context.get("rpc_method")`` returns ``None`` in
+    both cases, but pin the explicit-None case in a separate test so a
+    future refactor that changes the population logic (e.g. omitting the
+    key entirely when ``None``) doesn't silently change semantics.
+    """
+    captured: list[RpcTelemetryEvent] = []
+
+    async def capture(event: RpcTelemetryEvent) -> None:
+        captured.append(event)
+
+    metrics._on_rpc_event = capture
+
+    expected_response = httpx.Response(status_code=200, content=b"ok")
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], _make_terminal_returning(expected_response))
+
+    request = make_request(context={"log_label": "chat.ask", "rpc_method": None})
+    await chain(request)
+
+    assert metrics._metrics.rpc_calls_succeeded == 0
+    assert metrics._metrics.rpc_calls_failed == 0
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_error_bypasses_all_metrics(
+    metrics: ClientMetrics,
+) -> None:
+    """``asyncio.CancelledError`` propagates without touching metrics state.
+
+    ``CancelledError`` is a :class:`BaseException`, not
+    :class:`Exception`; the middleware's ``except Exception`` clause is
+    deliberately narrow so cooperative-cancellation signals (also
+    ``KeyboardInterrupt``, ``SystemExit``) skip the metrics path
+    entirely. Pinning this in a test guards against a future
+    widening-to-``BaseException`` regression that would inflate the
+    failed-call counter on every benign task cancellation.
+    """
+    captured: list[RpcTelemetryEvent] = []
+
+    async def capture(event: RpcTelemetryEvent) -> None:
+        captured.append(event)
+
+    metrics._on_rpc_event = capture
+
+    async def cancelling_terminal(_request: RpcRequest) -> RpcResponse:
+        raise asyncio.CancelledError()
+
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], cancelling_terminal)
+    request = make_request(
+        context={"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await chain(request)
+
+    snap = metrics._metrics
+    assert snap.rpc_calls_failed == 0
+    assert snap.rpc_calls_succeeded == 0
+    assert snap.rpc_latency_seconds_total == 0.0
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_event_carries_current_request_id(
+    metrics: ClientMetrics,
+) -> None:
+    """Event ``request_id`` reflects the active ``contextvar`` at emit time.
+
+    ``RpcExecutor.execute_with_telemetry`` mints (or inherits) a request
+    id via ``set_request_id()`` BEFORE invoking the chain, and the
+    middleware's call to ``get_request_id()`` reads that contextvar. Pin
+    the propagation by setting the id explicitly in test scope and
+    asserting it appears on the event.
+    """
+    captured: list[RpcTelemetryEvent] = []
+
+    async def capture(event: RpcTelemetryEvent) -> None:
+        captured.append(event)
+
+    metrics._on_rpc_event = capture
+
+    expected_response = httpx.Response(status_code=200, content=b"ok")
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], _make_terminal_returning(expected_response))
+
+    request = make_request(
+        context={"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
+    )
+    token = set_request_id("test-req-id-7f2a")
+    try:
+        assert get_request_id() == "test-req-id-7f2a"
+        await chain(request)
+    finally:
+        # Best-effort reset to keep test isolation tight. The reqid
+        # contextvar is process-scoped but pytest gives each test a
+        # fresh frame, so leaking here would not affect other tests in
+        # practice; resetting anyway is the disciplined choice.
+        import contextvars
+
+        contextvars.copy_context()  # no-op; the token cleanup happens
+        # automatically when the test function frame exits.
+        del token
+
+    assert len(captured) == 1
+    assert captured[0].request_id == "test-req-id-7f2a"
+
+
+@pytest.mark.asyncio
+async def test_no_callback_still_increments_counters(
+    metrics: ClientMetrics,
+) -> None:
+    """When ``on_rpc_event`` is ``None``, counters still increment.
+
+    Pins the contract that the counter side of the middleware is
+    independent of the callback side — applications that opt out of the
+    ``on_rpc_event`` channel still see ``metrics_snapshot()`` track
+    RPC volume. ``ClientMetrics.emit_rpc_event`` no-ops when
+    ``_on_rpc_event is None``; the increment runs unconditionally.
+    """
+    # No on_rpc_event registered; the fixture default is None.
+    assert metrics._on_rpc_event is None
+
+    expected_response = httpx.Response(status_code=200, content=b"ok")
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], _make_terminal_returning(expected_response))
+
+    request = make_request(
+        context={"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
+    )
+    await chain(request)
+
+    snap = metrics._metrics
+    assert snap.rpc_calls_succeeded == 1
+    assert snap.rpc_latency_seconds_total >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_pass_through_does_not_mutate_request(
+    metrics: ClientMetrics,
+) -> None:
+    """Middleware does not mutate the ``RpcRequest`` instance it receives.
+
+    ``RpcRequest`` is a frozen dataclass so attribute mutation raises
+    ``FrozenInstanceError``, but the ``context`` dict is mutable by
+    reference. The middleware reads ``context.get("rpc_method")`` and
+    must not write back. Pin this by snapshotting context keys before
+    the call and asserting equality after.
+    """
+    observed_request: dict[str, Any] = {}
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        observed_request["instance"] = request
+        observed_request["context_keys"] = set(request.context)
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b""),
+            context=request.context,
+        )
+
+    middleware = MetricsMiddleware(metrics)
+    chain = build_chain([middleware], terminal)
+
+    context_before = {
+        "log_label": "RPC LIST_NOTEBOOKS",
+        "rpc_method": "LIST_NOTEBOOKS",
+        "disable_internal_retries": False,
+    }
+    request = make_request(context=dict(context_before))  # defensive copy
+    await chain(request)
+
+    assert observed_request["instance"] is request
+    assert observed_request["context_keys"] == set(context_before)
+    # No new keys leaked back into the request context.
+    assert set(request.context) == set(context_before)

--- a/tests/unit/test_metrics_middleware.py
+++ b/tests/unit/test_metrics_middleware.py
@@ -36,7 +36,7 @@ import pytest
 # canonical import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
 from notebooklm._core_metrics import ClientMetrics
-from notebooklm._logging import get_request_id, set_request_id
+from notebooklm._logging import get_request_id, reset_request_id, set_request_id
 from notebooklm._middleware import (
     NextCall,
     RpcRequest,
@@ -300,15 +300,13 @@ async def test_event_carries_current_request_id(
         assert get_request_id() == "test-req-id-7f2a"
         await chain(request)
     finally:
-        # Best-effort reset to keep test isolation tight. The reqid
-        # contextvar is process-scoped but pytest gives each test a
-        # fresh frame, so leaking here would not affect other tests in
-        # practice; resetting anyway is the disciplined choice.
-        import contextvars
-
-        contextvars.copy_context()  # no-op; the token cleanup happens
-        # automatically when the test function frame exits.
-        del token
+        # Restore the prior reqid context. ``ContextVar`` tokens are not
+        # cleared when the function frame exits — they must be explicitly
+        # ``reset()``-ed (see ``ContextVar.reset`` docs). pytest-asyncio
+        # gives each async test its own task + ``copy_context()`` snapshot,
+        # so a leak here usually doesn't affect sibling tests in practice,
+        # but the disciplined cleanup is to reset the token we minted.
+        reset_request_id(token)
 
     assert len(captured) == 1
     assert captured[0].request_id == "test-req-id-7f2a"

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -23,18 +23,64 @@ from notebooklm.types import GenerationStatus
 
 @pytest.mark.asyncio
 async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) -> None:
+    """Public contract: ``rpc_call`` bumps counters + emits ``RpcTelemetryEvent``.
+
+    As of Tier-12 PR 12.4 the per-RPC success/failure counters and the
+    ``on_rpc_event`` fire live inside ``MetricsMiddleware`` (which sits
+    in the chain around ``_perform_authed_post``), not inside
+    ``RpcExecutor.execute_with_telemetry``. The seam the test mocks
+    therefore has to live below the chain — mocking ``_rpc_call_impl``
+    (the historical swap point) now bypasses the chain entirely and
+    would silence both the counter and the event. We mock
+    ``_perform_authed_post`` instead so the chain runs end-to-end, and
+    we return a wire-format payload that the real decoder accepts.
+
+    The test still asserts the same five public-contract invariants it
+    always has: result value, correlation-id propagation INTO the chain,
+    contextvar cleanup AFTER the chain, counter increments, and one
+    event with the expected fields.
+    """
     events: list[RpcTelemetryEvent] = []
     core = ClientCore(auth_tokens, on_rpc_event=events.append)
     core._http_client = AsyncMock(spec=httpx.AsyncClient)
     seen_request_ids: list[str | None] = []
 
-    async def fake_impl(*args: object, **kwargs: object) -> dict[str, bool]:
+    # Mock the chain LEAF (innermost wrapper around
+    # ``AuthedTransport.perform_authed_post``) so the real chain runs
+    # end-to-end and ``MetricsMiddleware`` sees the call. Mocking
+    # ``_perform_authed_post`` itself would bypass the chain entirely
+    # and silence the counters this test exists to assert. Mocking
+    # ``_rpc_call_impl`` (the historical swap point) would do the same.
+    from notebooklm._middleware import RpcResponse
+
+    async def fake_terminal(request: object) -> RpcResponse:
+        # Read the correlation id INSIDE the chain so the assertion
+        # below verifies the contextvar survived chain entry.
         seen_request_ids.append(get_request_id())
+        return RpcResponse(
+            response=httpx.Response(200, text=")]}'\n[]"),
+            context=request.context,  # type: ignore[attr-defined]
+        )
+
+    core._authed_post_chain_terminal = fake_terminal  # type: ignore[method-assign]
+    # Rebuild the chain so it wraps the new terminal (the original chain
+    # was built in ``__init__`` against the original bound method).
+    from notebooklm._middleware import build_chain
+
+    core._authed_post_chain = build_chain(core._middlewares, fake_terminal)
+
+    # Patch the decoder to a no-network stub. The real decoder requires a
+    # wire payload that matches the method's RPC ID; constructing one
+    # makes the test brittle to RPC-ID changes. Stubbing keeps the test
+    # focused on observability semantics (counters + events + correlation)
+    # rather than wire-format details.
+    def fake_decode(raw: str, rpc_id: str, *, allow_null: bool = False) -> dict:
         return {"ok": True}
 
-    core._rpc_call_impl = fake_impl  # type: ignore[method-assign]
-
-    with correlation_id("batch-42"):
+    with (
+        patch("notebooklm._core.decode_response", fake_decode),
+        correlation_id("batch-42"),
+    ):
         result = await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb_123"])
 
     assert result == {"ok": True}


### PR DESCRIPTION
## Summary

Lands `MetricsMiddleware` as the second concrete middleware in the Tier-12 chain. Sits **outside** TracingMiddleware (`[MetricsMiddleware, TracingMiddleware]`) — Metrics times the entire inner chain, Tracing remains the innermost wrapper around the transport leaf. Subsequent PRs 12.5–12.8 prepend their middleware to the left, ending at the ADR-009 final order `[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`.

**Replaces** the `_increment_metrics(rpc_calls_succeeded/failed, rpc_latency_seconds_total)` + `_emit_rpc_event(...)` block in `RpcExecutor.execute_with_telemetry`. The `rpc_calls_started=1` increment + reqid + drain-token plumbing stays — those concerns live OUTSIDE the chain (they bracket the entire logical RPC including decode).

## Files changed

- **NEW** `src/notebooklm/_middleware_metrics.py` (148 lines) — `MetricsMiddleware` class, takes a `ClientMetrics` reference, around-style `__call__`, emits on success/failure when `rpc_method` is present, pure pass-through otherwise.
- `src/notebooklm/_core.py` — seed `[Metrics, Tracing]` in `__init__` and `_ensure_chain_state`; thread `rpc_method` kwarg through `_perform_authed_post` into `RpcRequest.context["rpc_method"]`.
- `src/notebooklm/_core_rpc.py` — remove the duplicate emission block; pass `rpc_method=method.name` from `RpcExecutor.execute`.
- `src/notebooklm/_chat.py` — Protocol signature includes `rpc_method: str | None = None` so structural typing matches; chat path leaves it `None`.
- `src/notebooklm/_middleware_tracing.py` — docstring update: `rpc_method` is now populated as of PR 12.4.
- **NEW** `tests/unit/test_metrics_middleware.py` (382 lines, 8 tests).
- `tests/unit/test_chain_wiring.py` — assert new two-middleware ordering.
- `tests/unit/test_observability.py` — `test_rpc_metrics_event_and_correlation_scope` mocks chain LEAF instead of `_rpc_call_impl` (which now bypasses the chain entirely).
- `tests/unit/test_core_rpc.py`, `tests/unit/test_idempotency_registry.py` — fake `_perform_authed_post` signatures grow `rpc_method` kwarg.

## Semantic refinements

1. **Decode-error semantics disentangled.** Previously, decode failures (e.g. `NoData` after a 200 OK) incremented `rpc_calls_failed` because the old block wrapped `_rpc_call_impl` (transport + decode). The chain wraps only the transport leg, so decode-only failures no longer count as `rpc_calls_failed`. This is the intended Tier-13 endpoint shape (`Session.rpc_call` decodes AFTER the chain returns).
2. **`CancelledError` / `KeyboardInterrupt` / `SystemExit` bypass.** The middleware's `except Exception` clause is deliberately narrow — `BaseException` subclasses are caller-initiated unwinds, not RPC failures. Matches TracingMiddleware's policy.
3. **Chat-side requests skip emission.** `rpc_method=None` from `_chat_transport` → middleware short-circuits with no counter/event side-effects, matching pre-PR behavior.

## Test plan

- [x] 54/54 targeted middleware + chain tests pass
- [x] Full unit sweep matches pre-12.4 baseline (402 failed, 4335 passed — same 402 pre-existing failures from the CLI test suite, no net new regressions)
- [x] mypy clean (129 source files, 0 issues)
- [x] pre-commit clean (ruff + ruff-format pass)
- [ ] Full CI matrix (Linux/macOS/Windows × Python 3.10-3.14)
- [ ] CodeRabbit / gemini-code-assist / claude bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Observability**
  * Adds per-RPC telemetry middleware for latency, success/failure counters and events; telemetry is automatically skipped for streaming/chat calls.
  * Middleware seeding adjusted so metrics are collected earlier in the request pipeline, improving observability and correlation of request IDs.

* **Tests**
  * Expanded and updated unit tests to cover metrics middleware behavior, telemetry emission, and middleware wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->