### PR TITLE
feat(core): extract DrainMiddleware (Tier 12 PR 12.5)

### DIFF
--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -75,11 +75,7 @@ async def chat_aware_authed_post(
     except _TransportRateLimited as exc:
         raise ChatError(
             f"{parse_label} rate-limited (HTTP 429)."
-            + (
-                f" Retry after {exc.retry_after} seconds."
-                if exc.retry_after is not None
-                else ""
-            )
+            + (f" Retry after {exc.retry_after} seconds." if exc.retry_after is not None else "")
         ) from exc
     except _TransportServerError as exc:
         if isinstance(exc.original, httpx.HTTPStatusError):

--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -58,65 +58,66 @@ async def chat_aware_authed_post(
         parse_label: Caller-friendly label used in log lines and error
             messages (e.g. ``"chat.ask"``).
     """
-    operation_token = await core._begin_transport_post(parse_label)
+    # Drain admission lives in ``DrainMiddleware`` at the outermost chain
+    # position around ``_perform_authed_post`` — it reads ``log_label``
+    # from ``RpcRequest.context`` (passed below as ``parse_label``), so a
+    # drained client still surfaces ``RuntimeError`` with the chat-friendly
+    # label without explicit bracketing here.
     try:
-        try:
-            return await core._perform_authed_post(
-                build_request=build_request,
-                log_label=parse_label,
+        return await core._perform_authed_post(
+            build_request=build_request,
+            log_label=parse_label,
+        )
+    except _TransportAuthExpired as exc:
+        raise ChatError(
+            f"{parse_label} failed: authentication expired and refresh did not recover"
+        ) from exc
+    except _TransportRateLimited as exc:
+        raise ChatError(
+            f"{parse_label} rate-limited (HTTP 429)."
+            + (
+                f" Retry after {exc.retry_after} seconds."
+                if exc.retry_after is not None
+                else ""
             )
-        except _TransportAuthExpired as exc:
+        ) from exc
+    except _TransportServerError as exc:
+        if isinstance(exc.original, httpx.HTTPStatusError):
             raise ChatError(
-                f"{parse_label} failed: authentication expired and refresh did not recover"
+                f"{parse_label} failed with HTTP {exc.original.response.status_code} "
+                f"after retries: {exc.original}"
             ) from exc
-        except _TransportRateLimited as exc:
-            raise ChatError(
-                f"{parse_label} rate-limited (HTTP 429)."
-                + (
-                    f" Retry after {exc.retry_after} seconds."
-                    if exc.retry_after is not None
-                    else ""
-                )
+        # Network-layer failure (RequestError / Timeout).
+        # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
+        # ``_TransportServerError`` on the network path; this guard keeps
+        # the contract enforced under ``python -O`` (where ``assert``
+        # would be stripped) and gives a clear diagnostic if the
+        # invariant ever drifts.
+        if not isinstance(exc.original, httpx.RequestError):
+            raise TypeError(
+                f"Unexpected _TransportServerError.original type: {type(exc.original)}. "
+                "Expected httpx.HTTPStatusError or httpx.RequestError."
             ) from exc
-        except _TransportServerError as exc:
-            if isinstance(exc.original, httpx.HTTPStatusError):
-                raise ChatError(
-                    f"{parse_label} failed with HTTP {exc.original.response.status_code} "
-                    f"after retries: {exc.original}"
-                ) from exc
-            # Network-layer failure (RequestError / Timeout).
-            # ``_perform_authed_post`` only wraps ``httpx.RequestError`` into
-            # ``_TransportServerError`` on the network path; this guard keeps
-            # the contract enforced under ``python -O`` (where ``assert``
-            # would be stripped) and gives a clear diagnostic if the
-            # invariant ever drifts.
-            if not isinstance(exc.original, httpx.RequestError):
-                raise TypeError(
-                    f"Unexpected _TransportServerError.original type: {type(exc.original)}. "
-                    "Expected httpx.HTTPStatusError or httpx.RequestError."
-                ) from exc
-            # Preserve the timeout-specific message: TimeoutException is a
-            # subclass of RequestError, so without this branch read/connect
-            # timeouts would surface as a generic "network error after
-            # retries" line and lose the "timed out" signal callers rely on.
-            if isinstance(exc.original, httpx.TimeoutException):
-                raise NetworkError(
-                    f"{parse_label} timed out after retries: {exc.original}",
-                    original_error=exc.original,
-                ) from exc
+        # Preserve the timeout-specific message: TimeoutException is a
+        # subclass of RequestError, so without this branch read/connect
+        # timeouts would surface as a generic "network error after
+        # retries" line and lose the "timed out" signal callers rely on.
+        if isinstance(exc.original, httpx.TimeoutException):
             raise NetworkError(
-                f"{parse_label} network error after retries: {exc.original}",
+                f"{parse_label} timed out after retries: {exc.original}",
                 original_error=exc.original,
             ) from exc
-        except httpx.HTTPStatusError as exc:
-            # Non-5xx / non-401 / non-429 status errors fall through
-            # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
-            # or unhandled 4xx).
-            raise ChatError(
-                f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
-            ) from exc
-    finally:
-        await core._finish_transport_post(operation_token)
+        raise NetworkError(
+            f"{parse_label} network error after retries: {exc.original}",
+            original_error=exc.original,
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        # Non-5xx / non-401 / non-429 status errors fall through
+        # ``_perform_authed_post``'s "Anything else" branch (e.g. a 404
+        # or unhandled 4xx).
+        raise ChatError(
+            f"{parse_label} failed with HTTP {exc.response.status_code}: {exc}"
+        ) from exc
     # NOTE: bare ``httpx.TimeoutException`` / ``httpx.RequestError``
     # handlers were removed here because ``_perform_authed_post`` always
     # either retries those errors or wraps them in

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -111,6 +111,7 @@ from ._middleware import (
     RpcResponse,
     build_chain,
 )
+from ._middleware_drain import DrainMiddleware
 from ._middleware_metrics import MetricsMiddleware
 from ._middleware_tracing import TracingMiddleware
 from ._sources import fetch_source_ids
@@ -465,16 +466,17 @@ class ClientCore:
         # ``AuthedTransport.perform_authed_post`` (the shared seam covering
         # ``ClientCore._perform_authed_post`` here and ``RpcExecutor.execute``'s
         # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
-        # PR 12.3 added ``TracingMiddleware`` as the innermost entry; PR 12.4
-        # prepends ``MetricsMiddleware`` to its left, so the list now reads
-        # ``[Metrics, Tracing]``. Subsequent PRs 12.5–12.8 prepend each
-        # remaining middleware further left so the final list reads
+        # PR 12.3 added ``TracingMiddleware`` (innermost), PR 12.4 prepended
+        # ``MetricsMiddleware``, and PR 12.5 prepends ``DrainMiddleware`` to
+        # the left of both, so the list now reads
+        # ``[Drain, Metrics, Tracing]``. Subsequent PRs 12.6–12.8 insert each
+        # remaining middleware BETWEEN ``Drain`` and ``Metrics`` so the
+        # final list reads
         # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
         # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
         # composes the leftmost entry as the outermost wrapper, so keeping
-        # ``TracingMiddleware`` at the RIGHT end of the list (and prepending
-        # new entries to the left) preserves Tracing as the innermost wrapper
-        # as later PRs grow the list.
+        # ``TracingMiddleware`` at the RIGHT end of the list preserves
+        # Tracing as the innermost wrapper as later PRs grow the list.
         #
         # The terminal adapter reads ``build_request`` / ``log_label`` /
         # ``disable_internal_retries`` from ``RpcRequest.context`` and
@@ -484,6 +486,7 @@ class ClientCore:
         # out of ``AuthedTransport``. See ADR-009 §"Per-request behavior"
         # and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
         self._middlewares: list[Middleware] = [
+            DrainMiddleware(self._drain_tracker),
             MetricsMiddleware(self._metrics_obj),
             TracingMiddleware(),
         ]
@@ -850,9 +853,9 @@ class ClientCore:
         ``_authed_post_chain``. The first call to :meth:`_perform_authed_post`
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
-        constructed (``[MetricsMiddleware, TracingMiddleware]``-seeded
-        chain around the terminal adapter, matching the seed in
-        ``__init__``).
+        constructed (``[DrainMiddleware, MetricsMiddleware,
+        TracingMiddleware]``-seeded chain around the terminal adapter,
+        matching the seed in ``__init__``).
 
         Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
         :meth:`_ensure_observability_state` is — two threads observing
@@ -878,14 +881,16 @@ class ClientCore:
             if not hasattr(self, "_middlewares"):
                 # Mirror ``__init__``'s seeded chain: PR 12.3 lands
                 # ``TracingMiddleware`` as the innermost entry, PR 12.4
-                # prepends ``MetricsMiddleware`` to its left. A
-                # ``__new__``-built fixture must see the same chain shape so
-                # both telemetry channels (structured trace logs + RPC
+                # prepends ``MetricsMiddleware``, and PR 12.5 prepends
+                # ``DrainMiddleware`` outermost. A ``__new__``-built fixture
+                # must see the same chain shape so all three observability
+                # channels (drain admission, structured trace logs, RPC
                 # counters/events) are exercised on fixture-driven
                 # invocations too; otherwise the fixture path and the live
                 # path diverge in observability, which has previously
                 # hidden bugs in Tier-8 cassette-replay tests.
                 self._middlewares = [
+                    DrainMiddleware(self._drain_tracker),
                     MetricsMiddleware(self._metrics_obj),
                     TracingMiddleware(),
                 ]

--- a/src/notebooklm/_core_rpc.py
+++ b/src/notebooklm/_core_rpc.py
@@ -40,6 +40,7 @@ from .rpc import (
     get_batchexecute_url,
     resolve_rpc_id,
 )
+from .types import RpcTelemetryEvent
 
 logger = logging.getLogger(__name__)
 
@@ -89,11 +90,9 @@ class RpcOwner(Protocol):
         operation_variant: str | None = None,
     ) -> Any: ...
 
-    async def _begin_transport_post(self, log_label: str) -> Any: ...
-
-    async def _finish_transport_post(self, token: Any) -> None: ...
-
     def _increment_metrics(self, **increments: int | float) -> None: ...
+
+    async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None: ...
 
 
 class RpcExecutor:
@@ -165,19 +164,13 @@ class RpcExecutor:
                 operation_variant=operation_variant,
             )
 
-        method_name = getattr(method, "name", str(method))
-        operation_token = await self._owner._begin_transport_post(f"RPC {method_name}")
         self._owner._increment_metrics(rpc_calls_started=1)
-        # As of PR 12.4 the per-attempt latency counter, the
-        # ``rpc_calls_succeeded`` / ``rpc_calls_failed`` counters, and the
-        # ``emit_rpc_event`` fire live inside ``MetricsMiddleware`` (see
-        # ``_middleware_metrics.py`` + ADR-009 §"Chain ordering"). The chain
-        # is wrapped around ``_perform_authed_post``, so middleware
-        # observation covers the transport leg only — exactly what
-        # ``Session.rpc_call`` will own in Tier 13. The ``rpc_calls_started``
-        # increment + reqid + drain-token wiring stays here because those
-        # concerns live OUTSIDE the chain (they bracket the entire logical
-        # RPC including decode, not just the transport attempt).
+        # ``rpc_calls_started`` and reqid stay HERE (outside the chain)
+        # because they bracket the entire logical RPC including decode —
+        # the chain wraps only the transport leg. Per-attempt latency,
+        # ``rpc_calls_succeeded`` / ``rpc_calls_failed``, and
+        # ``emit_rpc_event`` live in ``MetricsMiddleware``; drain
+        # admission lives in ``DrainMiddleware``.
         _reqid_token = None if get_request_id() is not None else set_request_id()
         try:
             return await self._owner._rpc_call_impl(
@@ -192,7 +185,6 @@ class RpcExecutor:
         finally:
             if _reqid_token is not None:
                 reset_request_id(_reqid_token)
-            await self._owner._finish_transport_post(operation_token)
 
     async def execute(
         self,

--- a/src/notebooklm/_middleware_drain.py
+++ b/src/notebooklm/_middleware_drain.py
@@ -1,0 +1,117 @@
+"""DrainMiddleware — in-flight transport-operation tracker for the Tier-12 chain.
+
+Per ADR-009 §"Chain ordering" and master plan §2, ``DrainMiddleware`` sits at
+the OUTERMOST position of the final Tier-12 chain ``[Drain, Metrics, Retry,
+AuthRefresh, ErrorInjection, Tracing]``. PR 12.5 ships it as the first entry
+of the three-middleware chain ``[Drain, Metrics, Tracing]``; PRs 12.6–12.8
+insert the remaining middlewares BETWEEN ``Drain`` and ``Metrics`` (Retry,
+AuthRefresh, ErrorInjection) so Drain stays outermost.
+
+Pure observer of the transport leg with bookkeeping side-effects: brackets
+``next_call`` with calls to :meth:`TransportDrainTracker.begin_transport_post`
+and :meth:`TransportDrainTracker.finish_transport_post`, propagating the
+``log_label`` from ``request.context`` as the tracker label. The chain
+caller (``ClientCore._perform_authed_post``) always populates ``log_label``,
+so the middleware reads it via ``context["log_label"]`` and falls back to
+a synthetic ``"<unknown-chain-call>"`` only for malformed requests.
+
+This PR lifts the drain bookkeeping from
+``RpcExecutor.execute_with_telemetry`` (which previously bracketed
+``_rpc_call_impl`` with ``_begin_transport_post`` / ``_finish_transport_post``)
+and from ``_chat_transport.send_authed_post`` (the chat-streaming entry).
+After PR 12.5, drain admission is owned by the chain — the explicit
+bookkeeping calls in those two call sites are gone.
+
+Drain admission semantics preserved:
+- ``begin_transport_post`` STILL rejects new top-level work once
+  ``TransportDrainTracker._draining`` is set, raising ``RuntimeError``.
+  This propagates out of ``next_call`` as it always did — the chain
+  doesn't swallow it.
+- Nested operations (e.g. an RPC issued from inside a source upload
+  whose token was admitted before drain started) STILL pass through
+  because ``TransportDrainTracker`` looks at ``asyncio.current_task()``'s
+  depth, not the chain seam.
+- Source-upload and artifact-polling paths (``_source_upload.py``,
+  ``_artifact_polling.py``) keep their explicit ``_begin_transport_post`` /
+  ``_finish_transport_post`` calls — they bracket logical operations that
+  span multiple chain invocations (the upload spans an authed-POST per
+  chunk, the poll spans multiple GET attempts), so the chain seam is the
+  wrong scope. Those call sites are unchanged.
+
+Failure mode: if ``next_call`` raises, the ``finally`` clause still calls
+``finish_transport_post`` so the in-flight counter never orphans a token —
+matching the structure of every previous explicit ``begin/finish`` pair
+the codebase had before this PR. Same scope (``Exception``-aware via
+``try/finally``, not via narrow ``except``) and same reason.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract,
+``src/notebooklm/_core_drain.py`` for the underlying tracker, and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` row 12.5 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._middleware import NextCall, RpcRequest, RpcResponse
+
+if TYPE_CHECKING:
+    from ._core_drain import TransportDrainTracker
+
+
+class DrainMiddleware:
+    """Middleware that brackets the chain inner call with drain bookkeeping.
+
+    Conforms to :class:`notebooklm._middleware.Middleware` — the
+    ``__call__`` signature matches the Protocol so mypy treats instances
+    as assignable into a ``Sequence[Middleware]``.
+
+    Holds a reference to the shared :class:`TransportDrainTracker` owned
+    by :class:`ClientCore`. The middleware does not own drain state; it
+    is a write-through into the host's counters. This keeps
+    ``drain()``'s view of in-flight work authoritative even when tests
+    swap a middleware out (the explicit ``_begin/_finish_transport_post``
+    calls in the upload + polling paths still feed the same tracker).
+    """
+
+    def __init__(self, drain_tracker: TransportDrainTracker) -> None:
+        self._drain_tracker = drain_tracker
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        """Admit + finalize one transport operation around ``next_call``.
+
+        Reads ``log_label`` from ``request.context``: the value is the
+        same string callers used to pass directly to
+        ``_begin_transport_post`` (e.g. ``"RPC LIST_NOTEBOOKS"`` from the
+        RPC path, ``"chat.ask"`` from the chat path). A missing key
+        surfaces as a defensive sentinel rather than a ``KeyError`` —
+        ``__new__``-built fixtures driving the chain raw might omit it,
+        and the operation should still admit + count.
+
+        ``await begin_transport_post`` may raise ``RuntimeError`` when
+        the tracker is in draining mode and the current task has no
+        prior operation depth. The exception propagates out of the
+        chain unchanged — that's exactly the pre-PR-12.5 behavior;
+        ``RpcExecutor.execute_with_telemetry`` and
+        ``_chat_transport.send_authed_post`` both let
+        ``_begin_transport_post`` errors propagate without catching.
+        """
+        log_label = request.context.get("log_label", "<unknown-chain-call>")
+        token = await self._drain_tracker.begin_transport_post(log_label)
+        try:
+            return await next_call(request)
+        finally:
+            # ``finish_transport_post`` is the load-bearing notify path for
+            # ``drain()``. The ``finally`` ensures the counter is decremented
+            # even when ``next_call`` raises — orphaning a token would stall
+            # ``drain`` forever. Matches the structure of every previous
+            # explicit begin/finish pair in the codebase.
+            await self._drain_tracker.finish_transport_post(token)
+
+
+__all__ = ["DrainMiddleware"]

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -8,8 +8,7 @@ PR 12.2 of the Tier-12/13 greenfield migration wires
 ``RpcRequest.context`` and delegates to
 :meth:`AuthedTransport.perform_authed_post` — the shared seam covering both
 :meth:`ClientCore._perform_authed_post` AND ``RpcExecutor.execute`` (which
-calls ``self._owner._perform_authed_post`` inside its retry loop in
-``_core_rpc.py``).
+calls ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
 
 These tests verify the wiring contract from
 ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160 and ADR-009
@@ -233,26 +232,29 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chain_seeded_with_metrics_then_tracing() -> None:
-    """``ClientCore.__init__`` seeds the chain with ``[Metrics, Tracing]``.
+async def test_chain_seeded_with_drain_metrics_tracing() -> None:
+    """``ClientCore.__init__`` seeds the chain with ``[Drain, Metrics, Tracing]``.
 
     PR 12.3 landed ``TracingMiddleware`` at the innermost position; PR 12.4
-    prepends ``MetricsMiddleware`` to its left. Order matters — Metrics is
-    outermore (it times the entire inner chain) and Tracing remains the
-    innermost wrapper around the transport leaf. Subsequent PRs 12.5–12.8
-    prepend their middleware further left so the final ordering reads
+    prepended ``MetricsMiddleware``; PR 12.5 prepends ``DrainMiddleware``
+    outermost. Order matters — Drain admits/finalizes the operation outside
+    all observability, Metrics times the inner chain, Tracing remains the
+    innermost wrapper around the transport leaf. PRs 12.6–12.8 insert their
+    middleware BETWEEN Drain and Metrics so the final ordering reads
     ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` per
     ADR-009. The list is exposed as ``self._middlewares`` so later PRs
     (and the cleanup audit in 12.9) can assert ordering by inspecting the
     production attribute directly.
     """
+    from notebooklm._middleware_drain import DrainMiddleware
     from notebooklm._middleware_metrics import MetricsMiddleware
     from notebooklm._middleware_tracing import TracingMiddleware
 
     core = _make_core()
-    assert len(core._middlewares) == 2
-    assert isinstance(core._middlewares[0], MetricsMiddleware)
-    assert isinstance(core._middlewares[1], TracingMiddleware)
+    assert len(core._middlewares) == 3
+    assert isinstance(core._middlewares[0], DrainMiddleware)
+    assert isinstance(core._middlewares[1], MetricsMiddleware)
+    assert isinstance(core._middlewares[2], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -5,17 +5,21 @@ primitives. Each test injects a stub ``core`` whose ``_perform_authed_post``
 raises one of the transport-layer exceptions (or the raw ``httpx``
 status error) and asserts the function maps the failure to the expected
 ``ChatError`` / ``NetworkError`` shape, message, and exception chain.
-The drain-tracking bookkeeping (``_begin_transport_post`` /
-``_finish_transport_post``) is verified by checking the begin/finish
-call counts and the operation-token round-trip.
+
+As of Tier-12 PR 12.5 the drain-tracking bookkeeping
+(``_begin_transport_post`` / ``_finish_transport_post``) has moved into
+``DrainMiddleware`` at the outermost chain position around
+``_perform_authed_post``. ``chat_aware_authed_post`` no longer brackets
+its own ``_perform_authed_post`` call with explicit drain calls —
+admission and finalization are middleware concerns now. The tests
+correspondingly stub only ``_perform_authed_post`` on the core.
 
 The stub ``core`` is a lightweight ``SimpleNamespace`` rather than a
 ``MagicMock(spec=_ChatCore)`` so the tests stay independent of the
-protocol's exact member set — they only need the three transport
-primitives the function actually calls. After D2 cutover, the function
-will run against the real ``ClientCore``; this unit-test layer keeps
-the chat-side error mapping isolated from transport implementation
-details.
+protocol's exact member set — they only need the one transport
+primitive the function actually calls. The drain-fires-on-exception
+invariant is now covered by
+``tests/unit/test_drain_middleware.py::test_finish_fires_on_exception``.
 """
 
 from __future__ import annotations
@@ -40,9 +44,6 @@ from notebooklm.exceptions import ChatError, NetworkError
 # ---------------------------------------------------------------------------
 
 
-_SENTINEL_TOKEN = object()
-
-
 def _make_request() -> httpx.Request:
     return httpx.Request("POST", "https://example.test/x")
 
@@ -65,10 +66,12 @@ def _make_stub_core(
     (exception instance) or invoke a callable; pass ``perform_return_value``
     to make it return that response unchanged. Exactly one of the two
     should be supplied per test — they are mutually exclusive.
+
+    PR 12.5 lifted ``_begin_transport_post`` / ``_finish_transport_post``
+    into DrainMiddleware, so the stub no longer needs to mock them —
+    ``chat_aware_authed_post`` does not call them.
     """
     return SimpleNamespace(
-        _begin_transport_post=AsyncMock(return_value=_SENTINEL_TOKEN),
-        _finish_transport_post=AsyncMock(return_value=None),
         _perform_authed_post=AsyncMock(
             side_effect=perform_side_effect,
             return_value=perform_return_value,
@@ -99,8 +102,6 @@ async def test_chat_aware_authed_post_returns_response_and_balances_bookkeeping(
     )
 
     assert result is expected_response
-    core._begin_transport_post.assert_awaited_once_with("chat.ask")
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
     core._perform_authed_post.assert_awaited_once_with(
         build_request=_noop_build_request,
         log_label="chat.ask",
@@ -128,7 +129,6 @@ async def test_transport_auth_expired_maps_to_chat_error():
     assert "authentication expired" in str(excinfo.value).lower()
     assert "chat.ask" in str(excinfo.value)
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,6 @@ async def test_transport_rate_limited_with_retry_after_includes_retry_seconds():
     assert "HTTP 429" in message
     assert "Retry after 42 seconds" in message
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -187,7 +186,6 @@ async def test_transport_rate_limited_without_retry_after_omits_retry_clause():
     assert "HTTP 429" in message
     assert "Retry after" not in message  # No "Retry after N seconds" clause.
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +215,6 @@ async def test_transport_server_error_with_http_status_error_maps_to_chat_error(
     assert "HTTP 503" in message
     assert "after retries" in message
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -238,7 +235,6 @@ async def test_transport_server_error_with_request_error_maps_to_network_error()
     assert "timed out" not in message
     assert excinfo.value.original_error is original
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -262,7 +258,6 @@ async def test_transport_server_error_with_timeout_exception_keeps_timeout_messa
     assert "network error after retries" not in message
     assert excinfo.value.original_error is original
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 @pytest.mark.asyncio
@@ -293,7 +288,6 @@ async def test_transport_server_error_with_unexpected_original_type_raises_type_
     # (per gemini-code-assist review on PR #832).
     assert "Expected httpx.HTTPStatusError or httpx.RequestError" in message
     assert excinfo.value.__cause__ is transport_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------
@@ -321,29 +315,24 @@ async def test_raw_http_status_error_maps_to_chat_error():
     assert "HTTP 404" in message
     assert "chat.ask" in message
     assert excinfo.value.__cause__ is raw_exc
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)
 
 
 # ---------------------------------------------------------------------------
-# Finalization invariant
+# Finalization invariant (PR 12.5: moved into DrainMiddleware)
 # ---------------------------------------------------------------------------
+#
+# The pre-PR-12.5 contract that ``chat_aware_authed_post`` ran
+# ``_finish_transport_post`` in its own ``finally`` is no longer this
+# function's responsibility — drain admission/finalization moved into
+# ``DrainMiddleware`` at the outermost chain position. The exception-
+# path finalization invariant is now pinned by
+# ``tests/unit/test_drain_middleware.py::test_finish_fires_on_exception``,
+# which exercises a real ``TransportDrainTracker`` end-to-end rather
+# than mocking the bookkeeping.
+#
+# What remains here as a chat-specific invariant: the error-mapping
+# still raises ``ChatError`` even when the underlying transport raises.
+# The error-mapping tests above already cover that path
+# (`test_transport_auth_expired_maps_to_chat_error` exercises the same
+# transport exception used by the deleted finalization test).
 
-
-@pytest.mark.asyncio
-async def test_finish_transport_post_runs_even_when_perform_raises():
-    """The drain-tracking ``finish`` must always run in the ``finally``
-    clause; otherwise a chat-error path could leak in-flight counters."""
-    transport_exc = _TransportAuthExpired(
-        "auth expired",
-        original=_make_status_error(401),
-    )
-    core = _make_stub_core(perform_side_effect=transport_exc)
-
-    with pytest.raises(ChatError):
-        await chat_aware_authed_post(
-            core,  # type: ignore[arg-type]
-            build_request=_noop_build_request,
-            parse_label="chat.ask",
-        )
-
-    core._finish_transport_post.assert_awaited_once_with(_SENTINEL_TOKEN)

--- a/tests/unit/test_chat_transport.py
+++ b/tests/unit/test_chat_transport.py
@@ -335,4 +335,3 @@ async def test_raw_http_status_error_maps_to_chat_error():
 # The error-mapping tests above already cover that path
 # (`test_transport_auth_expired_maps_to_chat_error` exercises the same
 # transport exception used by the deleted finalization test).
-

--- a/tests/unit/test_drain_middleware.py
+++ b/tests/unit/test_drain_middleware.py
@@ -1,0 +1,297 @@
+"""Unit tests for :class:`DrainMiddleware` (Tier-12 PR 12.5).
+
+Pins the contract documented in ``src/notebooklm/_middleware_drain.py``
+and ADR-009 §"Chain ordering":
+
+- Pass-through identity: the middleware brackets ``next_call`` but does
+  not transform request or response.
+- Counter accounting: ``begin_transport_post`` increments the
+  ``TransportDrainTracker`` in-flight counter before ``next_call``;
+  ``finish_transport_post`` decrements it after. Net effect at steady
+  state is zero, but the counter rises by 1 during ``next_call``.
+- Failure path: if ``next_call`` raises, ``finish_transport_post``
+  STILL fires (via ``try/finally``) so the counter never orphans.
+- Drain admission: with the tracker in draining mode and the current
+  task at depth 0, ``begin_transport_post`` raises ``RuntimeError``
+  carrying the ``log_label``. The exception propagates out of the
+  middleware (no swallow).
+- ``log_label`` propagation: the value comes from
+  ``request.context["log_label"]``; a missing key falls back to a
+  defensive sentinel.
+
+The tests use the canonical chain fixtures + a real
+``TransportDrainTracker`` instance (not a mock) so the begin/finish
+condition-variable + per-task depth bookkeeping is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the
+# canonical import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import make_request
+from notebooklm._core_drain import TransportDrainTracker
+from notebooklm._middleware import (
+    NextCall,
+    RpcRequest,
+    RpcResponse,
+    build_chain,
+)
+from notebooklm._middleware_drain import DrainMiddleware
+
+
+def _terminal_returning(response: httpx.Response) -> NextCall:
+    """Build a chain-terminal coroutine that wraps ``response``.
+
+    The chain leaf normally adapts to
+    ``AuthedTransport.perform_authed_post``; this helper short-circuits
+    that adaptation so tests can exercise the middleware without booting
+    a real transport. ``request.context`` is propagated to the
+    ``RpcResponse`` so any outer middleware (or test assertion) sees the
+    same context object.
+    """
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=response, context=request.context)
+
+    return terminal
+
+
+@pytest.fixture
+def tracker() -> TransportDrainTracker:
+    """Fresh tracker per test — counters start at zero, not draining."""
+    return TransportDrainTracker()
+
+
+@pytest.mark.asyncio
+async def test_brackets_next_call_with_begin_finish(
+    tracker: TransportDrainTracker,
+) -> None:
+    """Counter rises during ``next_call`` and returns to zero after.
+
+    Verifies the in-flight bookkeeping covers exactly the chain inner
+    leg: the count is 0 before chain entry, 1 while the terminal is
+    awaiting, and 0 after the chain returns. Capturing inside the
+    terminal makes the during-call value observable.
+    """
+    seen_in_flight: list[int] = []
+
+    async def observing_terminal(request: RpcRequest) -> RpcResponse:
+        seen_in_flight.append(tracker._in_flight_posts)
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b"ok"),
+            context=request.context,
+        )
+
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], observing_terminal)
+    request = make_request(context={"log_label": "RPC LIST_NOTEBOOKS"})
+
+    assert tracker._in_flight_posts == 0
+    await chain(request)
+    assert seen_in_flight == [1]
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_finish_fires_on_exception(
+    tracker: TransportDrainTracker,
+) -> None:
+    """If ``next_call`` raises, the counter still decrements via ``finally``.
+
+    Pins the load-bearing invariant that orphaning a token would stall
+    ``drain()`` forever — the ``try/finally`` in DrainMiddleware exists
+    precisely to make ``finish_transport_post`` fire on the failure
+    path. The exception itself propagates unchanged (not swallowed).
+    """
+    boom = RuntimeError("transport blew up")
+
+    async def failing_terminal(_request: RpcRequest) -> RpcResponse:
+        raise boom
+
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], failing_terminal)
+    request = make_request(context={"log_label": "RPC LIST_NOTEBOOKS"})
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await chain(request)
+
+    assert exc_info.value is boom
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_draining_top_level_request_is_rejected(
+    tracker: TransportDrainTracker,
+) -> None:
+    """A drained tracker raises ``RuntimeError`` on top-level admission.
+
+    Flips ``tracker._draining`` via the public ``drain()`` API (with a
+    zero-in-flight short-circuit so the call returns immediately) and
+    asserts that the next chain invocation surfaces the standard
+    "client is draining" ``RuntimeError`` from
+    ``begin_transport_post``. The terminal must NOT be reached.
+    """
+    terminal_ran = False
+
+    async def must_not_run(_request: RpcRequest) -> RpcResponse:
+        nonlocal terminal_ran
+        terminal_ran = True
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b""),
+            context={},
+        )
+
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], must_not_run)
+
+    # ``drain(timeout=0)`` with no in-flight posts short-circuits the
+    # condition wait and just flips ``_draining = True``. (The
+    # ``assert_bound_loop`` short-circuit is a no-op when bound_loop is
+    # None, which it is for a bare-constructed tracker.)
+    await tracker.drain(timeout=0)
+
+    request = make_request(context={"log_label": "RPC LIST_NOTEBOOKS"})
+    with pytest.raises(RuntimeError, match="draining") as exc_info:
+        await chain(request)
+
+    assert "RPC LIST_NOTEBOOKS" in str(exc_info.value)
+    assert terminal_ran is False
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_nested_call_admitted_after_drain_starts(
+    tracker: TransportDrainTracker,
+) -> None:
+    """An admitted operation's nested chain call passes through after drain.
+
+    The drain-admission semantic — load-bearing because source-upload
+    operations issue inner RPCs from within their admitted outer scope
+    — keys on ``asyncio.current_task()``'s depth, not on a new-call
+    sentinel. If the task already has depth > 0 from an admitted outer
+    begin, a NEW chain invocation issued by that task DURING drain
+    must still admit. Tests this path by:
+
+    1. Manually admitting one operation (depth=1 on the current task).
+    2. Flipping the tracker into draining mode.
+    3. Driving the chain — which calls ``begin_transport_post`` again,
+       lifting depth to 2 — and asserting the terminal runs.
+    4. Decrementing back to depth=0 to leave the tracker clean.
+    """
+    terminal_ran = False
+
+    async def inner_terminal(request: RpcRequest) -> RpcResponse:
+        nonlocal terminal_ran
+        terminal_ran = True
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b"ok"),
+            context=request.context,
+        )
+
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], inner_terminal)
+
+    # Outer admission lifts the current task's depth to 1.
+    outer_token = await tracker.begin_transport_post("outer.upload")
+
+    # Flip into draining mode without releasing the outer slot.
+    async with tracker.get_drain_condition():
+        tracker._draining = True
+
+    try:
+        await chain(make_request(context={"log_label": "RPC GET_NOTEBOOK"}))
+    finally:
+        # Restore the outer slot regardless of test outcome.
+        await tracker.finish_transport_post(outer_token)
+
+    assert terminal_ran is True
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_log_label_falls_back_to_sentinel(
+    tracker: TransportDrainTracker,
+) -> None:
+    """A request with no ``log_label`` in context admits with a sentinel label.
+
+    ``ClientCore._perform_authed_post`` always populates ``log_label``,
+    so this case only arises for ``__new__``-built fixtures driving the
+    chain raw. The middleware should still admit + count rather than
+    raising ``KeyError`` — pinning this guards against a regression
+    that would surface as a flaky test-fixture failure under a
+    seemingly-unrelated refactor.
+    """
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], _terminal_returning(httpx.Response(200, content=b"")))
+
+    request = make_request(context={})  # explicitly no log_label
+    await chain(request)
+
+    assert tracker._in_flight_posts == 0
+
+
+@pytest.mark.asyncio
+async def test_pass_through_does_not_mutate_request(
+    tracker: TransportDrainTracker,
+) -> None:
+    """Middleware does not mutate the ``RpcRequest`` instance.
+
+    ``RpcRequest`` is a frozen dataclass so attribute mutation raises
+    ``FrozenInstanceError``, but ``context`` is mutable by reference.
+    DrainMiddleware reads ``context["log_label"]`` and must not write
+    back. Pin by snapshotting context keys before the call and asserting
+    equality after.
+    """
+    observed: dict[str, object] = {}
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        observed["instance"] = request
+        observed["context_keys"] = set(request.context)
+        return RpcResponse(
+            response=httpx.Response(200, content=b""),
+            context=request.context,
+        )
+
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], terminal)
+
+    context_before = {
+        "log_label": "RPC LIST_NOTEBOOKS",
+        "rpc_method": "LIST_NOTEBOOKS",
+        "disable_internal_retries": False,
+    }
+    request = make_request(context=dict(context_before))  # defensive copy
+    await chain(request)
+
+    assert observed["instance"] is request
+    assert observed["context_keys"] == set(context_before)
+    # No new keys leaked back into the request context.
+    assert set(request.context) == set(context_before)
+
+
+@pytest.mark.asyncio
+async def test_drain_after_chain_finishes_does_not_block(
+    tracker: TransportDrainTracker,
+) -> None:
+    """Once the chain returns, ``drain()`` resolves immediately.
+
+    End-to-end smoke: run a chain call, then call ``drain()`` with a
+    finite timeout. If the middleware correctly fires
+    ``finish_transport_post`` after the terminal returns, the counter
+    is back at zero and drain's ``wait_for(in_flight==0)`` short-
+    circuits without blocking. A timeout here would indicate the
+    counter was orphaned.
+    """
+    middleware = DrainMiddleware(tracker)
+    chain = build_chain([middleware], _terminal_returning(httpx.Response(200, content=b"")))
+
+    await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # If the counter is orphaned, this ``wait_for`` raises TimeoutError.
+    await asyncio.wait_for(tracker.drain(timeout=1.0), timeout=1.5)
+    assert tracker._in_flight_posts == 0


### PR DESCRIPTION
## Summary

Lands `DrainMiddleware` as the third concrete middleware in the Tier-12 chain. Sits at the **outermost** position (`[DrainMiddleware, MetricsMiddleware, TracingMiddleware]`) — Drain admits/finalizes the operation outside all observability, Metrics times the inner chain, Tracing remains innermost. Subsequent PRs 12.6-12.8 insert their middleware BETWEEN Drain and Metrics so the final order reads `[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`.

**Replaces** the explicit `_begin_transport_post` / `_finish_transport_post` bracketing in two call sites:
- `RpcExecutor.execute_with_telemetry` (`_core_rpc.py`)
- `_chat_transport.chat_aware_authed_post`

Both now rely on the chain providing drain admission via `DrainMiddleware`, which reads `log_label` from `RpcRequest.context` and uses it as the tracker label.

**Intentionally NOT lifted:** `_source_upload.py` and `_artifact_polling.py` keep their explicit drain bracketing because they span MULTIPLE chain invocations (upload spans register + start + per-chunk POSTs). Lifting would let drain admit half-finished operations. Nested chain invocations from those scopes bump task depth and pass through drain admission as before.

## Files changed

- **NEW** `src/notebooklm/_middleware_drain.py` (~145 lines): `DrainMiddleware` class, holds shared `TransportDrainTracker` reference, around-style `__call__` with `try/finally` finalization.
- `src/notebooklm/_core.py`: chain seed updated to `[Drain, Metrics, Tracing]` in both `__init__` and `_ensure_chain_state`; import added. Lazy backfill now calls `_ensure_observability_state()` BEFORE acquiring `_OBSERVABILITY_INIT_LOCK` (non-reentrant lock — back-to-back acquisition on same thread would deadlock).
- `src/notebooklm/_core_rpc.py`: removed `_begin_transport_post` / `_finish_transport_post` calls from `execute_with_telemetry`; removed corresponding dead Protocol members from `RpcOwner`. Kept `rpc_calls_started` + reqid plumbing (OUTSIDE chain scope — they bracket the entire logical RPC including decode).
- `src/notebooklm/_chat_transport.py`: removed `try/_begin/_finally/_finish` bracketing around `_perform_authed_post`; kept the error-mapping `try/except` structure.
- **NEW** `tests/unit/test_drain_middleware.py` (~265 lines, 7 tests): counter brackets, finally-fires-on-exception, drain-rejection, nested-admission, missing-log-label fallback, request immutability, drain-after-chain end-to-end.
- `tests/unit/test_chain_wiring.py`: assert new three-middleware ordering.
- `tests/unit/test_chat_transport.py`: stub no longer mocks `_begin/_finish_transport_post`; deleted finalization test (moved to drain_middleware tests).

## Test plan

- [x] 78/78 targeted tests pass (`test_drain_middleware.py` + `test_chain_wiring.py` + `test_metrics_middleware.py` + `test_tracing_middleware.py` + `test_middleware_types.py` + `test_chain_fixtures.py` + `test_chat_transport.py`)
- [x] mypy clean (130 source files, 0 issues)
- [x] pre-commit clean (ruff + ruff-format)
- [x] Full unit sweep: 4341 passed, 402 failed (= pre-PR baseline; zero net new regressions). The 402 are pre-existing CLI/auth-fixture failures unrelated to Tier 12 (see follow-up note below).
- [ ] Full CI matrix (Linux/macOS/Windows × Python 3.10-3.14)
- [ ] CodeRabbit / gemini-code-assist / claude bot review

## Polish receipts

- Step 4.1 — code-simplifier: 1 finding applied (dead Protocol members), 0 deferred
- Step 4.2 — code-reviewer: 0 critical, 0 important, 3 nits + 1 optional missing-edge-case (all deferred to PR 12.6+/12.9 per reviewer recommendation)
- Step 4.3 — ultrathink: no concerns (deadlock avoidance verified, try/finally semantics verified, chain ordering verified, backwards-compat intentional)

## Follow-up note

The 402 pre-existing test failures in `tests/unit/cli/`, `tests/unit/test_json_stdout_purity.py`, and `tests/integration/cli_vcr/` all bottom out at `"Missing required cookies: SID, __Secure-1PSIDTS"`. Root cause: PR #650 added `__Secure-1PSIDTS` to `MINIMUM_REQUIRED_COOKIES` and PR #834 reshaped `_AuthFacadeModule` write-through — the test fixtures (`tests/unit/test_json_stdout_purity.py:48`, `tests/unit/cli/conftest.py:52`) patch `notebooklm.cli.helpers.load_auth_from_storage` only, but a secondary validation path now runs that the patch doesn't intercept. Documented as a separate fixture-infrastructure defect for a focused follow-up PR (NOT bundled here because it's orthogonal to Tier 12 middleware extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized transport operation lifecycle management for improved error handling and exception mapping
  * Enhanced draining mechanism to better coordinate concurrent operation admission
  
* **Tests**
  * Expanded test coverage for transport draining and middleware orchestration
  * Updated tests to reflect middleware layer restructuring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->