### PR TITLE
test(conftest): isolate NOTEBOOKLM_HOME per test to match CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,26 @@ _PLAYWRIGHT_INSTALLED = importlib.util.find_spec("playwright") is not None
 
 
 @pytest.fixture(autouse=True)
+def _isolate_notebooklm_home(request, tmp_path, monkeypatch):
+    """Pin ``NOTEBOOKLM_HOME`` at a per-test tmp dir.
+
+    Without this, tests that route through the real CLI auth path read the
+    developer's actual ``~/.notebooklm/`` state. An empty or partial
+    ``storage_state.json`` there fails ``_validate_required_cookies`` inside
+    ``build_cookie_jar`` and produces hundreds of ``exit_code=2`` failures
+    locally while CI (with a clean ``HOME``) passes. Pinning
+    ``NOTEBOOKLM_HOME`` at a tmp dir gives every test the same empty-storage
+    view CI sees, so the suite is reproducible across machines.
+
+    E2E tests opt out: they need the real ``~/.notebooklm/`` profile to mint
+    live tokens, so the marker bypasses this fixture.
+    """
+    if request.node.get_closest_marker("e2e"):
+        return
+    monkeypatch.setenv("NOTEBOOKLM_HOME", str(tmp_path / "notebooklm-home"))
+
+
+@pytest.fixture(autouse=True)
 def _reset_poke_state():
     """Reset module-level rotation guards between tests.
 


### PR DESCRIPTION
## Summary
- Adds an autouse fixture in `tests/conftest.py` that pins `NOTEBOOKLM_HOME` at a per-test `tmp_path`, so the suite stops reading the developer's real `~/.notebooklm/` profile state.
- Without this, an empty or partial `storage_state.json` in the user's `default` profile fails `_validate_required_cookies` inside `build_cookie_jar`, producing hundreds of `exit_code=2` CLI-test failures locally while CI (no `~/.notebooklm/`) stays green.
- E2E tests (`@pytest.mark.e2e`) opt out because they need real on-disk tokens to mint live sessions.

## Why
Repro on `origin/main` HEAD `933cd85` with an empty `~/.notebooklm/profiles/default/storage_state.json`:
- Before fix: 442 failed, 4972 passed.
- After fix: 5414 passed, 20 skipped.

CI on the same SHA reported `5415 passed` because it has no `~/.notebooklm/` at all and the `build_cookie_jar` branch falls through to the in-memory mock cookies. The fixture closes that local-vs-CI gap.

## Test plan
- [x] `uv run pytest tests/unit tests/integration -n auto` — green with polluted local profile (5414 passed).
- [x] `HOME=/tmp/clean uv run pytest tests/unit tests/integration -n auto` — green on a clean HOME (5414 passed).
- [x] `uv run pre-commit run --files tests/conftest.py` — passes ruff/format.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- [ ] CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation to prevent interference from local authentication state during test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->