### PR TITLE
feat(core): extract ErrorInjectionMiddleware into chain (Tier-12 PR 12.6)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -112,6 +112,7 @@ from ._middleware import (
     build_chain,
 )
 from ._middleware_drain import DrainMiddleware
+from ._middleware_error_injection import ErrorInjectionMiddleware
 from ._middleware_metrics import MetricsMiddleware
 from ._middleware_tracing import TracingMiddleware
 from ._sources import fetch_source_ids
@@ -467,27 +468,35 @@ class ClientCore:
         # ``ClientCore._perform_authed_post`` here and ``RpcExecutor.execute``'s
         # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
         # PR 12.3 added ``TracingMiddleware`` (innermost), PR 12.4 prepended
-        # ``MetricsMiddleware``, and PR 12.5 prepends ``DrainMiddleware`` to
-        # the left of both, so the list now reads
-        # ``[Drain, Metrics, Tracing]``. Subsequent PRs 12.6–12.8 insert each
-        # remaining middleware BETWEEN ``Drain`` and ``Metrics`` so the
+        # ``MetricsMiddleware``, PR 12.5 prepended ``DrainMiddleware``
+        # outermost, and PR 12.6 inserts ``ErrorInjectionMiddleware`` between
+        # ``MetricsMiddleware`` and ``TracingMiddleware`` so the list now
+        # reads ``[Drain, Metrics, ErrorInjection, Tracing]``. PRs 12.7–12.8
+        # insert ``RetryMiddleware`` and ``AuthRefreshMiddleware`` BETWEEN
+        # ``MetricsMiddleware`` and ``ErrorInjectionMiddleware`` so the
         # final list reads
         # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
         # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
         # composes the leftmost entry as the outermost wrapper, so keeping
         # ``TracingMiddleware`` at the RIGHT end of the list preserves
-        # Tracing as the innermost wrapper as later PRs grow the list.
+        # Tracing as the innermost wrapper as later PRs grow the list, and
+        # keeping ``ErrorInjectionMiddleware`` adjacent to ``TracingMiddleware``
+        # matches the rationale "synthetic transient failures trigger retry"
+        # (ADR-009 §"Chain ordering rationale"): once ``RetryMiddleware``
+        # lands, it sits outside ``ErrorInjection`` and sees the synthetic
+        # error on each attempt.
         #
         # The terminal adapter reads ``build_request`` / ``log_label`` /
         # ``disable_internal_retries`` from ``RpcRequest.context`` and
         # delegates to ``self._get_authed_transport().perform_authed_post``.
         # ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
-        # stay unpopulated until PRs 12.5/12.7/12.8 start lifting behavior
+        # stay unpopulated until PRs 12.7/12.8 start lifting behavior
         # out of ``AuthedTransport``. See ADR-009 §"Per-request behavior"
         # and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
         self._middlewares: list[Middleware] = [
             DrainMiddleware(self._drain_tracker),
             MetricsMiddleware(self._metrics_obj),
+            ErrorInjectionMiddleware(),
             TracingMiddleware(),
         ]
         self._authed_post_chain: NextCall = build_chain(
@@ -854,8 +863,8 @@ class ClientCore:
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
         constructed (``[DrainMiddleware, MetricsMiddleware,
-        TracingMiddleware]``-seeded chain around the terminal adapter,
-        matching the seed in ``__init__``).
+        ErrorInjectionMiddleware, TracingMiddleware]``-seeded chain around
+        the terminal adapter, matching the seed in ``__init__``).
 
         Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
         :meth:`_ensure_observability_state` is — two threads observing
@@ -881,17 +890,22 @@ class ClientCore:
             if not hasattr(self, "_middlewares"):
                 # Mirror ``__init__``'s seeded chain: PR 12.3 lands
                 # ``TracingMiddleware`` as the innermost entry, PR 12.4
-                # prepends ``MetricsMiddleware``, and PR 12.5 prepends
-                # ``DrainMiddleware`` outermost. A ``__new__``-built fixture
-                # must see the same chain shape so all three observability
-                # channels (drain admission, structured trace logs, RPC
-                # counters/events) are exercised on fixture-driven
-                # invocations too; otherwise the fixture path and the live
-                # path diverge in observability, which has previously
-                # hidden bugs in Tier-8 cassette-replay tests.
+                # prepends ``MetricsMiddleware``, PR 12.5 prepends
+                # ``DrainMiddleware`` outermost, and PR 12.6 inserts
+                # ``ErrorInjectionMiddleware`` just outside
+                # ``TracingMiddleware``. A ``__new__``-built fixture must
+                # see the same chain shape so the three observability
+                # channels (drain admission, RPC counters/events,
+                # structured trace logs) AND the fault-injection
+                # short-circuit (active only when
+                # ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set) are exercised on
+                # fixture-driven invocations too; otherwise the fixture path
+                # and the live path diverge, which has previously hidden
+                # bugs in Tier-8 cassette-replay tests.
                 self._middlewares = [
                     DrainMiddleware(self._drain_tracker),
                     MetricsMiddleware(self._metrics_obj),
+                    ErrorInjectionMiddleware(),
                     TracingMiddleware(),
                 ]
             self._authed_post_chain = build_chain(

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -36,13 +36,13 @@ Design constraints (load-bearing — see ``tests/unit/test_client_keepalive.py``
   The shielded ``aclose()`` is critical: without it, a ``CancelledError``
   arriving mid-close leaks the underlying httpx transport.
 
-* :meth:`open` wraps the inner transport in
-  :class:`notebooklm._core._SyntheticErrorTransport` IFF
-  :func:`notebooklm._core._get_error_injection_mode` returns a non-``None``
-  value. Both symbols are resolved from ``notebooklm._core`` at call time
-  (not imported at module load) so the opt-in env-var path stays test-only
-  and ``test_vcr_config.py``'s ``from notebooklm._core import …`` imports
-  keep working unchanged.
+* :meth:`open` no longer wraps the inner transport for synthetic-error
+  injection — Tier-12 PR 12.6 lifted that path into the chain
+  (:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`,
+  wired by :class:`ClientCore.__init__`). When
+  ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set, the chain middleware
+  short-circuits before the chain leaf reaches httpx, so the httpx-layer
+  transport stays a real, unwrapped transport at all times.
 
 * :meth:`save_cookies` resolves ``save_cookies_to_storage`` from
   ``notebooklm._core`` at call time so the
@@ -187,22 +187,14 @@ class ClientLifecycle:
         intentionally replaces the binding — ``open()`` is the only binding
         moment.
 
-        Wraps the inner transport in
-        :class:`notebooklm._core._SyntheticErrorTransport` IFF
-        :func:`notebooklm._core._get_error_injection_mode` returns a
-        non-``None`` value. Both symbols are resolved from ``notebooklm._core``
-        at call time so the opt-in env-var path stays test-only and the
-        ``test_vcr_config.py`` import surface is unaffected.
+        Synthetic-error injection moved from this layer to the chain in
+        Tier-12 PR 12.6 — see
+        :class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`
+        for the new substitution point. The httpx transport built here is
+        always a real, unwrapped transport.
         """
         if self._http_client is not None:
             return
-
-        # Resolve through the parent module at call time so production paths
-        # never import the test-only synthetic-transport plumbing eagerly and
-        # so monkeypatches of ``_get_error_injection_mode`` (if any) keep
-        # working. ``_core`` import-cycles back into us only via TYPE_CHECKING
-        # so this runtime import is safe and cheap (cached after first call).
-        from . import _core as _core_module
 
         # Capture event-loop affinity before any awaitable resource is built
         # so the binding is consistent with the loop that owns every primitive
@@ -244,29 +236,6 @@ class ClientLifecycle:
             storage_path=host.auth.storage_path,
         )
 
-        # Opt-in synthetic-error transport wrapper. When the env var is unset
-        # (the default) this is a no-op and the AsyncClient is constructed
-        # exactly as before. See ``_SyntheticErrorTransport`` docstring in
-        # :mod:`notebooklm._core_error_injection` (re-exported on
-        # ``notebooklm._core`` for the legacy import surface).
-        error_mode = _core_module._get_error_injection_mode()
-        synthetic_transport: httpx.AsyncBaseTransport | None = None
-        if error_mode is not None:
-            # When we supply a custom ``transport=`` to ``AsyncClient``, httpx
-            # no longer constructs its own internal transport from the
-            # ``limits=`` kwarg below — those limits are consumed by the inner
-            # transport here instead, so connection-pool sizing remains
-            # identical to the no-injection path.
-            inner_transport = httpx.AsyncHTTPTransport(
-                limits=self._limits.to_httpx_limits(),
-            )
-            synthetic_transport = _core_module._SyntheticErrorTransport(error_mode, inner_transport)
-            logger.info(
-                "synthetic-error injection enabled (mode=%s) — "
-                "production paths will see substituted responses",
-                error_mode,
-            )
-
         self._http_client = httpx.AsyncClient(
             headers={
                 "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -274,14 +243,7 @@ class ClientLifecycle:
             cookies=cookies,
             timeout=timeout,
             follow_redirects=True,
-            # ``limits=`` is honored when ``transport=None`` (default) —
-            # httpx builds its own default transport with these limits.
-            # When ``transport=synthetic_transport`` (error-injection record
-            # mode) this kwarg is ignored by httpx and the inner_transport
-            # above carries the limits instead. The redundant pass is
-            # harmless and avoids a branch on the AsyncClient construction.
             limits=self._limits.to_httpx_limits(),
-            transport=synthetic_transport,
         )
 
         # Capture the open-time snapshot AFTER the AsyncClient is built (httpx

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -1,0 +1,198 @@
+"""ErrorInjectionMiddleware — synthetic-error short-circuit for the Tier-12 chain.
+
+Per ADR-009 §"Chain ordering", ``ErrorInjectionMiddleware`` sits just *inside*
+``RetryMiddleware`` / ``AuthRefreshMiddleware`` (which extract in PRs 12.7–12.8)
+and just *outside* ``TracingMiddleware``. The final Tier-12 chain is
+``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``. PR 12.6 ships
+the interim 4-middleware chain ``[Drain, Metrics, ErrorInjection, Tracing]``;
+PRs 12.7–12.8 insert ``Retry`` and ``AuthRefresh`` BETWEEN ``Metrics`` and
+``ErrorInjection`` so the ordering rationale holds at every step.
+
+Test-only path. Production behavior is unchanged when ``NOTEBOOKLM_VCR_RECORD_ERRORS``
+is unset — the middleware delegates straight to ``next_call``. When the env var
+resolves to ``"429"`` / ``"5xx"`` / ``"expired_csrf"`` (via
+:func:`_core_error_injection._get_error_injection_mode`), every chain invocation
+short-circuits with a synthetic :class:`httpx.Response` built by
+``tests/cassette_patterns.build_synthetic_error_response`` — the chain leaf
+(``_perform_authed_post``) is NOT called. The same env-var startup guard
+(:func:`_core_error_injection._refuse_synthetic_error_outside_test_context`)
+still fires at ``ClientCore`` construction so a leaked deploy env never reaches
+this code path in production.
+
+This PR lifts the substitution from the httpx transport
+(:class:`_core_error_injection._SyntheticErrorTransport`, which previously
+wrapped ``httpx.AsyncClient`` in ``ClientLifecycle``) into the middleware
+chain. After this PR the lifecycle no longer wraps the transport, so the
+class is unused production code; PR 12.9 cleanup deletes it. Direct
+instantiation tests in ``tests/unit/test_vcr_config.py`` still pass because
+the class itself is untouched.
+
+Behavior contract:
+
+- Env var unset → ``await next_call(request)`` unchanged (pass-through).
+- Env var set → build the synthetic ``(status_code, body, headers)`` triple,
+  wrap as :class:`httpx.Response` anchored to ``request.url`` / ``request.body``
+  so callers that inspect ``response.request`` still see a sane request, and
+  return :class:`RpcResponse` carrying the synthetic response with
+  ``request.context`` propagated unchanged.
+
+Note on retry semantics: the pre-PR-12.6 httpx-layer
+:class:`_SyntheticErrorTransport` fired on *every* batchexecute POST, including
+the ones that ``AuthedTransport.perform_authed_post`` re-issued from its
+internal retry-on-5xx/429 loop. After this PR the middleware short-circuits
+*before* the leaf, so that internal retry loop never sees synthetic errors.
+PR 12.7 (``RetryMiddleware``) inserts a retry loop OUTSIDE this middleware
+and restores the "every retry re-fires the synthetic error" behavior.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract,
+``src/notebooklm/_core_error_injection.py`` for the env-var / startup-guard
+helpers, and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` row 12.6
+for the PR sequence.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+import httpx
+
+from . import _core_error_injection
+from ._core_error_injection import ERROR_INJECT_ENV_VAR
+from ._middleware import NextCall, RpcRequest, RpcResponse
+
+# Logger name pinned to ``notebooklm._core`` (not the literal module name) so
+# log filters in tests — e.g. ``caplog.at_level(..., logger="notebooklm._core")``
+# — keep matching the synthetic-error log line the lifecycle previously emitted.
+logger = logging.getLogger("notebooklm._core")
+
+_SyntheticBuilder = Callable[[str], tuple[int, bytes, dict[str, str]]]
+
+
+class ErrorInjectionMiddleware:
+    """Short-circuit chain middleware that returns synthetic error responses.
+
+    Conforms to :class:`notebooklm._middleware.Middleware` — ``__call__``
+    matches the Protocol so instances are assignable into a
+    ``Sequence[Middleware]``.
+
+    Holds no shared state. The lazily-loaded synthetic-response builder is
+    cached on the instance after first activation so a long-running test
+    suite doesn't pay the ``importlib`` cost per chain call.
+    """
+
+    def __init__(self) -> None:
+        # Cached after first ``_load_builder`` call; ``None`` means "not yet loaded".
+        self._builder: _SyntheticBuilder | None = None
+        # Gates the one-shot "injection enabled" log line — preserves the
+        # pre-PR-12.6 ``_core_lifecycle`` log signal that operators running
+        # cassette-recording flows rely on to confirm their env var was picked up.
+        self._logged_activation = False
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        """Substitute a synthetic error response when the env var is set.
+
+        Reads the env var via
+        :func:`_core_error_injection._get_error_injection_mode` at call
+        time (not construction time) so tests that flip the var
+        per-test — via :func:`monkeypatch.setenv` or by monkeypatching the
+        function itself on :mod:`notebooklm._core_error_injection` —
+        see the change without rebuilding the chain. Resolving through the
+        module (rather than a value-imported binding) keeps the
+        :func:`monkeypatch.setattr` seam live: a value-import would freeze
+        the binding at module-load time and silently dead-letter any
+        function swap.
+        """
+        mode = _core_error_injection._get_error_injection_mode()
+        if mode is None:
+            return await next_call(request)
+
+        if not self._logged_activation:
+            logger.info(
+                "synthetic-error injection enabled (mode=%s) — "
+                "chain will return substituted responses until %s is unset",
+                mode,
+                ERROR_INJECT_ENV_VAR,
+            )
+            self._logged_activation = True
+
+        status_code, body, headers = self._load_builder()(mode)
+        # Anchor the synthetic response to the original method/URL/body/headers
+        # so callers that inspect ``response.request`` see what the leaf would
+        # have sent.
+        synthetic_request = httpx.Request(
+            method="POST",
+            url=request.url,
+            headers=dict(request.headers),
+            content=request.body,
+        )
+        response = httpx.Response(
+            status_code=status_code,
+            headers=headers,
+            content=body,
+            request=synthetic_request,
+        )
+        return RpcResponse(response=response, context=request.context)
+
+    def _load_builder(self) -> _SyntheticBuilder:
+        """Lazy importlib-load of ``tests.cassette_patterns.build_synthetic_error_response``.
+
+        Production code must not import from ``tests/`` at module load —
+        installed-package layouts don't ship ``tests/``. The env var that
+        gates this whole path is test-only, so this import only ever runs
+        in recording / unit-test contexts where ``tests/`` is on disk
+        relative to ``src/notebooklm/``.
+
+        Mirrors the same lazy-load logic in
+        :class:`_core_error_injection._SyntheticErrorTransport._load_builder`
+        so the synthetic-response shape stays identical between the
+        legacy transport path and the chain path. PR 12.9 removes the
+        legacy path and this duplication along with it.
+        """
+        if self._builder is not None:
+            return self._builder
+        # Walk up from src/notebooklm/_middleware_error_injection.py to the
+        # repo root, then dive into tests/cassette_patterns.py.
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        target = repo_root / "tests" / "cassette_patterns.py"
+        if not target.exists():
+            raise RuntimeError(
+                f"{ERROR_INJECT_ENV_VAR} is set but "
+                f"tests/cassette_patterns.py is not available at {target}. "
+                f"This plumbing is test-only — unset {ERROR_INJECT_ENV_VAR} "
+                f"to restore normal behavior."
+            )
+        spec = importlib.util.spec_from_file_location("_notebooklm_cassette_patterns", target)
+        # NOT ``assert`` — runtime invariant must survive ``python -O``.
+        if spec is None or spec.loader is None:
+            raise RuntimeError(
+                f"Failed to load module spec for {target}. "
+                f"Unset {ERROR_INJECT_ENV_VAR} to restore normal behavior."
+            )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        builder = getattr(mod, "build_synthetic_error_response", None)
+        if builder is None:
+            # Explicit guard so a renamed/removed symbol in
+            # tests/cassette_patterns.py surfaces with the same actionable
+            # remediation as the missing-file path above — without this,
+            # ``cast`` is type-only and the failure would be a bare
+            # ``AttributeError`` on the next call to ``builder(mode)``.
+            raise RuntimeError(
+                f"tests/cassette_patterns.py at {target} does not export "
+                f"``build_synthetic_error_response`` — the synthetic-error "
+                f"plumbing is misaligned. Unset {ERROR_INJECT_ENV_VAR} to "
+                f"restore normal behavior."
+            )
+        self._builder = cast(_SyntheticBuilder, builder)
+        return self._builder
+
+
+__all__ = ["ErrorInjectionMiddleware"]

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -31,21 +31,24 @@ a real-world error shape (e.g. a quota-exhaustion 429 with a real
 
 Recording note (maintainers)
 ----------------------------
-The synthetic-error transport wrapper in ``_core.py`` substitutes the response BEFORE
-httpcore is reached — and VCR's record hook patches ``httpcore.
-AsyncConnectionPool.handle_async_request``, so the wrapper ALSO bypasses the
-record hook. As a consequence these cassettes are hand-written from the
-canonical synthetic shapes in ``tests/cassette_patterns.py`` rather than
-captured by running the tests under ``NOTEBOOKLM_VCR_RECORD=1``. The replay
-path is unaffected — VCR returns the cassette's synthetic response to the
-client's httpx pipeline normally, and the exception-mapping branches fire as
-they would for a real upstream error.
+As of Tier-12 PR 12.6, synthetic-error substitution lives in
+:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`
+at the chain layer — well above the ``httpx`` transport. VCR's record
+hook patches ``httpcore.AsyncConnectionPool.handle_async_request`` (below
+httpx), so the chain short-circuit happens before VCR ever sees the
+request: the wrapper bypasses the record hook entirely. As a consequence
+these cassettes are hand-written from the canonical synthetic shapes in
+``tests/cassette_patterns.py`` rather than captured by running the tests
+under ``NOTEBOOKLM_VCR_RECORD=1``. The replay path is unaffected — VCR
+returns the cassette's synthetic response to the client's httpx pipeline
+normally, and the exception-mapping branches fire as they would for a
+real upstream error.
 
 The ``@pytest.mark.synthetic_error("<mode>")`` marker is intentionally NOT
-used here: it would activate the transport wrapper during replay too,
-short-circuiting VCR and making the cassette decorative. Leaving the env var
-unset lets VCR's cassette drive the response, which is the behavior we want
-the replay tests to exercise.
+used here: it would activate the chain middleware during replay too,
+short-circuiting VCR and making the cassette decorative. Leaving the env
+var unset lets VCR's cassette drive the response, which is the behavior
+we want the replay tests to exercise.
 
 See ``docs/development.md`` (section "Synthetic error cassettes") and
 ``tests/cassette_patterns.py:build_synthetic_error_response`` for the canonical

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -232,29 +232,34 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chain_seeded_with_drain_metrics_tracing() -> None:
-    """``ClientCore.__init__`` seeds the chain with ``[Drain, Metrics, Tracing]``.
+async def test_chain_seeded_with_drain_metrics_error_injection_tracing() -> None:
+    """``ClientCore.__init__`` seeds the chain with ``[Drain, Metrics, ErrorInjection, Tracing]``.
 
     PR 12.3 landed ``TracingMiddleware`` at the innermost position; PR 12.4
-    prepended ``MetricsMiddleware``; PR 12.5 prepends ``DrainMiddleware``
-    outermost. Order matters — Drain admits/finalizes the operation outside
-    all observability, Metrics times the inner chain, Tracing remains the
-    innermost wrapper around the transport leaf. PRs 12.6–12.8 insert their
-    middleware BETWEEN Drain and Metrics so the final ordering reads
+    prepended ``MetricsMiddleware``; PR 12.5 prepended ``DrainMiddleware``
+    outermost; PR 12.6 inserts ``ErrorInjectionMiddleware`` between Metrics
+    and Tracing. Order matters — Drain admits/finalizes the operation outside
+    all observability, Metrics times the inner chain, ErrorInjection
+    short-circuits with synthetic responses when activated, and Tracing
+    remains the innermost wrapper around the transport leaf. PRs 12.7–12.8
+    insert ``RetryMiddleware`` and ``AuthRefreshMiddleware`` BETWEEN Metrics
+    and ErrorInjection so the final ordering reads
     ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` per
-    ADR-009. The list is exposed as ``self._middlewares`` so later PRs
-    (and the cleanup audit in 12.9) can assert ordering by inspecting the
+    ADR-009. The list is exposed as ``self._middlewares`` so later PRs (and
+    the cleanup audit in 12.9) can assert ordering by inspecting the
     production attribute directly.
     """
     from notebooklm._middleware_drain import DrainMiddleware
+    from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
     from notebooklm._middleware_metrics import MetricsMiddleware
     from notebooklm._middleware_tracing import TracingMiddleware
 
     core = _make_core()
-    assert len(core._middlewares) == 3
+    assert len(core._middlewares) == 4
     assert isinstance(core._middlewares[0], DrainMiddleware)
     assert isinstance(core._middlewares[1], MetricsMiddleware)
-    assert isinstance(core._middlewares[2], TracingMiddleware)
+    assert isinstance(core._middlewares[2], ErrorInjectionMiddleware)
+    assert isinstance(core._middlewares[3], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -21,9 +21,12 @@ Specifically pinned here:
   ``path`` arguments AND with the ``save_cookies_to_storage`` value resolved
   from ``notebooklm._core`` at call time (so the monkeypatch surface keeps
   working).
-* :class:`_SyntheticErrorTransport` **wrap activates only when**
-  :func:`_get_error_injection_mode` returns a non-``None`` value — the
-  default path constructs the ``AsyncClient`` with ``transport=None``.
+* The httpx ``AsyncClient`` **is never wrapped in
+  ``_SyntheticErrorTransport``** — Tier-12 PR 12.6 lifted synthetic-error
+  injection into the chain
+  (:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`),
+  so the lifecycle constructs a plain transport regardless of
+  ``NOTEBOOKLM_VCR_RECORD_ERRORS``.
 * :meth:`ClientLifecycle._keepalive_loop` **respects the min-interval
   clamp** — ``_resolve_keepalive_interval`` floors the configured interval
   at ``keepalive_min_interval`` so a sub-floor user value gets bumped up.
@@ -207,7 +210,7 @@ async def test_open_captures_cookie_snapshot() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Synthetic-error transport — only wraps on opt-in
+# Synthetic-error injection — lifted to the chain in PR 12.6
 # ---------------------------------------------------------------------------
 
 
@@ -225,19 +228,28 @@ async def test_open_does_not_wrap_synthetic_transport_by_default(
     try:
         client = lifecycle._http_client
         assert client is not None
-        # When ``transport=None`` is passed to ``AsyncClient``, httpx builds
-        # its own default transport — never a ``_SyntheticErrorTransport``.
+        # When no custom ``transport=`` is passed to ``AsyncClient``, httpx
+        # builds its own default transport — never a ``_SyntheticErrorTransport``.
         assert not isinstance(client._transport, _core_module._SyntheticErrorTransport)
     finally:
         await lifecycle.close(host)
 
 
 @pytest.mark.asyncio
-async def test_open_wraps_synthetic_transport_when_env_var_set(
+async def test_open_uses_default_httpx_transport_when_env_var_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Opt-in: ``_get_error_injection_mode`` returns a mode → the AsyncClient's
-    transport is a ``_SyntheticErrorTransport`` wrapping the inner transport."""
+    """PR 12.6: ``AsyncClient`` uses httpx's default transport even with env var set.
+
+    Pre-PR-12.6 the lifecycle wrapped the inner transport in
+    ``_SyntheticErrorTransport`` whenever ``_get_error_injection_mode`` was
+    non-``None``. After PR 12.6 that substitution lives in the chain
+    (``ErrorInjectionMiddleware``), and the lifecycle constructs a plain
+    transport regardless of the env var. Asserted positively (httpx's
+    default ``AsyncHTTPTransport``) rather than as a negative against
+    ``_SyntheticErrorTransport`` so the test stays load-bearing after PR
+    12.9 deletes that class.
+    """
     monkeypatch.setattr(_core_module, "_get_error_injection_mode", lambda: "429")
     lifecycle = _make_lifecycle()
     host = _StubHost()
@@ -246,7 +258,7 @@ async def test_open_wraps_synthetic_transport_when_env_var_set(
     try:
         client = lifecycle._http_client
         assert client is not None
-        assert isinstance(client._transport, _core_module._SyntheticErrorTransport)
+        assert isinstance(client._transport, httpx.AsyncHTTPTransport)
     finally:
         await lifecycle.close(host)
 

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -1,0 +1,455 @@
+"""Unit tests for :class:`ErrorInjectionMiddleware` (Tier-12 PR 12.6).
+
+Pins the contract documented in ``src/notebooklm/_middleware_error_injection.py``
+and ADR-009 §"Chain ordering":
+
+- **Pass-through when env var is unset.** The middleware delegates straight
+  to ``next_call``; production behavior is byte-for-byte unchanged.
+- **Short-circuit when env var is set.** Every chain invocation returns a
+  synthetic :class:`httpx.Response` built by
+  ``tests.cassette_patterns.build_synthetic_error_response``; the leaf is
+  NOT called.
+- **All three synthetic modes** (``"429"`` / ``"5xx"`` / ``"expired_csrf"``)
+  produce the documented status code + body + headers shape.
+- **Request shape preserved on the synthetic response.** The wrapped
+  :class:`httpx.Response` has a ``response.request`` attached whose
+  ``method`` / ``url`` / ``body`` mirror the incoming
+  :class:`RpcRequest`, so callers that inspect the request after the fact
+  still see what they would have sent.
+- **Context propagated.** ``RpcResponse.context`` is the same dict object
+  as ``RpcRequest.context`` (no copying); middlewares above can see any
+  annotations a deeper middleware would have added had the leaf been
+  reached.
+- **Builder cached on the instance** so a long-running test suite pays
+  the ``importlib`` cost exactly once per middleware.
+
+The tests use a real :class:`ErrorInjectionMiddleware` instance plus the
+canonical chain fixtures (``make_request`` and a one-shot terminal stub)
+rather than mocking the substitution logic. Activation is flipped via
+:func:`monkeypatch.setenv` against ``NOTEBOOKLM_VCR_RECORD_ERRORS`` so the
+production env-var resolution code path
+(:func:`notebooklm._core_error_injection._get_error_injection_mode`) is
+exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
+# import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import make_request
+from notebooklm._core_error_injection import ERROR_INJECT_ENV_VAR
+from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
+from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
+
+
+def _static_terminal(response: httpx.Response) -> NextCall:
+    """Build a chain-terminal coroutine that wraps ``response``.
+
+    The terminal records nothing — tests that want to know whether the
+    leaf was reached should use ``_recording_terminal`` instead.
+    """
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        return RpcResponse(response=response, context=request.context)
+
+    return terminal
+
+
+def _recording_terminal() -> tuple[NextCall, list[RpcRequest]]:
+    """Build a terminal that records every request it sees.
+
+    Returns ``(terminal, calls)`` — append the request to ``calls`` before
+    returning a default 200 OK. Tests assert on ``len(calls)`` to detect
+    whether the leaf was reached.
+    """
+    calls: list[RpcRequest] = []
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        calls.append(request)
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b"leaf-reached"),
+            context=request.context,
+        )
+
+    return terminal, calls
+
+
+# ---------------------------------------------------------------------------
+# Pass-through when env var is unset
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_env_var_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default path: env var unset → middleware delegates to ``next_call``."""
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(calls) == 1
+    assert response.response.status_code == 200
+    assert response.response.content == b"leaf-reached"
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_env_var_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty-string env var also resolves to ``None`` → pass-through.
+
+    ``_get_error_injection_mode`` strips whitespace; ``""`` and ``"   "``
+    both resolve to ``None`` so the middleware must not short-circuit on
+    those values. Defends against an operator who set the var via a
+    half-baked shell snippet (e.g. ``export NOTEBOOKLM_VCR_RECORD_ERRORS=``).
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "   ")
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_env_var_unknown_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unrecognized mode → ``_get_error_injection_mode`` returns ``None``."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "418")  # not in VALID_ERROR_MODES
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Short-circuit + synthetic response shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_status"),
+    [("429", 429), ("5xx", 500), ("expired_csrf", 400)],
+)
+@pytest.mark.asyncio
+async def test_short_circuits_with_synthetic_response_for_each_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    mode: str,
+    expected_status: int,
+) -> None:
+    """Each valid mode → short-circuit + status code from
+    ``build_synthetic_error_response``.
+
+    The middleware must NOT call ``next_call`` (the leaf), and the returned
+    ``httpx.Response`` must carry the status the builder produces.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # Leaf NEVER reached.
+    assert calls == []
+    assert response.response.status_code == expected_status
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_response_carries_retry_after_for_429(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``429`` mode → synthetic ``Retry-After`` header is forwarded.
+
+    ``build_synthetic_error_response`` sets ``Retry-After: 1`` for the
+    rate-limited shape so the eventual ``RetryMiddleware`` (PR 12.7,
+    outside this middleware in the final chain) honors it.
+    ErrorInjectionMiddleware must forward that header verbatim onto the
+    wrapped ``httpx.Response``.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
+    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert response.response.status_code == 429
+    assert response.response.headers.get("retry-after") == "1"
+
+
+@pytest.mark.asyncio
+async def test_short_circuit_response_carries_json_content_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Synthetic bodies are JSON-shaped → ``Content-Type`` is propagated."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
+    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert "application/json" in response.response.headers.get("content-type", "")
+    assert b'"error"' in response.response.content
+
+
+# ---------------------------------------------------------------------------
+# Request-on-synthetic-response shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthetic_response_carries_request_with_original_url_and_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The synthetic ``httpx.Response.request`` mirrors the chain request.
+
+    Anchors the synthetic response to the would-have-been-sent request so
+    callers that read ``response.request.url`` / ``response.request.method``
+    (e.g. when constructing an ``httpx.HTTPStatusError`` for diagnostic
+    messages) still see the URL and body the leaf would have used.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
+    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    custom_url = "https://example.test/_/LabsTailwindUi/data/batchexecute?authuser=0"
+    request = make_request(url=custom_url, body=b"chain-body")
+    response = await chain(request)
+
+    assert response.response.request is not None
+    assert response.response.request.method == "POST"
+    assert str(response.response.request.url) == custom_url
+    # ``httpx.Request.content`` is bytes; we passed ``body=b"chain-body"`` so the
+    # synthetic request mirrors that exact payload.
+    assert response.response.request.content == b"chain-body"
+
+
+# ---------------------------------------------------------------------------
+# Context propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthetic_response_propagates_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``RpcResponse.context`` is the same dict as ``RpcRequest.context``.
+
+    The middleware must NOT copy the context — a deeper middleware (had the
+    leaf been reached) might have annotated it; an outer middleware reads
+    those annotations. The synthetic path can't add annotations the deeper
+    middlewares would have added, but it must still propagate the dict
+    instance so outer middlewares see a consistent shape.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
+    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    request_context = {"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
+    request = make_request(context=request_context)
+    response = await chain(request)
+
+    assert response.context is request.context
+    assert response.context["log_label"] == "RPC LIST_NOTEBOOKS"
+
+
+# ---------------------------------------------------------------------------
+# Builder caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_builder_loaded_once_across_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_load_builder`` caches its result on the instance.
+
+    Importing ``tests.cassette_patterns`` via importlib is non-trivial; pin
+    that the second call reuses the cached builder rather than re-importing.
+    Asserted via direct attribute inspection (``middleware._builder``) so
+    we don't have to stub importlib itself.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
+    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    assert middleware._builder is None
+    await chain(make_request())
+    first = middleware._builder
+    assert first is not None
+
+    await chain(make_request())
+    assert middleware._builder is first  # same object — no re-load
+
+
+# ---------------------------------------------------------------------------
+# Activation flip mid-chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_activation_flip_between_calls_is_observed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A test that flips the env var between two chain calls observes both modes.
+
+    Pins that the middleware reads the env var at ``__call__`` time, not
+    at construction time. The fixture flow that supports this is:
+
+    1. Construct the middleware + chain with env var unset.
+    2. First chain call → passes through, leaf reached.
+    3. Set the env var.
+    4. Second chain call → short-circuits, leaf NOT reached again.
+
+    Catches a regression where someone "optimizes" the env-var read into
+    the ``__init__`` (forfeiting per-call activation flips that tests rely on).
+    """
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    # Call 1: pass-through, leaf reached.
+    await chain(make_request())
+    assert len(calls) == 1
+
+    # Flip on.
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
+
+    # Call 2: short-circuit, leaf NOT reached again.
+    response = await chain(make_request())
+    assert len(calls) == 1  # still 1 — leaf was bypassed on second call
+    assert response.response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Type hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_satisfies_protocol() -> None:
+    """``ErrorInjectionMiddleware`` instance is assignable to ``Middleware``.
+
+    The :class:`notebooklm._middleware.Middleware` Protocol is the only
+    thing :func:`build_chain` accepts. mypy would catch a Protocol drift
+    at static-analysis time; this runtime check is the regression guard
+    that survives a "mypy not run in CI" misconfiguration.
+    """
+    from notebooklm._middleware import Middleware
+
+    middleware: Middleware = ErrorInjectionMiddleware()
+    assert callable(middleware)
+
+
+# ---------------------------------------------------------------------------
+# Monkeypatch seam + activation log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_monkeypatch_setattr_on_get_error_injection_mode_is_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The middleware resolves ``_get_error_injection_mode`` through the
+    module at call time, so ``monkeypatch.setattr(_core_error_injection,
+    "_get_error_injection_mode", …)`` reaches the chain.
+
+    Regression guard: a value-import (``from ._core_error_injection import
+    _get_error_injection_mode``) would freeze the binding at module-load
+    time, silently dead-lettering this monkeypatch surface.
+    ``tests/unit/test_core_lifecycle.py`` relies on the same seam (via the
+    ``_core`` re-export) — keeping it live in the middleware too keeps the
+    project's test idiom consistent.
+    """
+    from notebooklm import _core_error_injection as _eim_module
+
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    # Replace the function itself — env var stays unset, so any reader that
+    # cached the function by value would return ``None`` and pass through.
+    monkeypatch.setattr(_eim_module, "_get_error_injection_mode", lambda: "5xx")
+
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert calls == []
+    assert response.response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_activation_log_fires_once_per_instance(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The "synthetic-error injection enabled" log line fires exactly once.
+
+    Pre-PR-12.6 the lifecycle emitted this at ``open()``; the middleware
+    now emits it at first activation. Pinning "once per instance" guards
+    against a refactor that drops the ``_logged_activation`` flag and
+    spams the log every chain call.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"x")))
+
+    with caplog.at_level("INFO", logger="notebooklm._core"):
+        await chain(make_request())
+        await chain(make_request())
+        await chain(make_request())
+
+    activations = [r for r in caplog.records if "synthetic-error injection enabled" in r.message]
+    assert len(activations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Function-call signature
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_receives_next_call_and_invokes_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the env var is unset, ``__call__`` invokes ``next_call(request)``.
+
+    Direct ``__call__`` test (not via ``build_chain``) so the contract is
+    exercised at the Protocol seam — what every other middleware PR
+    relies on.
+    """
+    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+    seen: list[RpcRequest] = []
+
+    async def next_call(request: RpcRequest) -> RpcResponse:
+        seen.append(request)
+        return RpcResponse(
+            response=httpx.Response(status_code=200, content=b"next-called"),
+            context=request.context,
+        )
+
+    middleware = ErrorInjectionMiddleware()
+    request = make_request()
+
+    response = await middleware(request, next_call)
+
+    assert seen == [request]
+    assert response.response.content == b"next-called"

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -677,12 +677,16 @@ async def test_synthetic_transport_no_op_when_env_var_unset_in_clientcore(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mode", ["429", "5xx", "expired_csrf"])
-async def test_synthetic_transport_wired_when_env_var_set_in_clientcore(monkeypatch, mode):
-    """End-to-end: when the env var resolves to a valid mode,
-    ``ClientCore.open()`` builds the AsyncClient with the synthetic wrapper
-    in place. The transport's ``_mode`` attribute reflects the env var."""
+async def test_error_injection_middleware_present_when_env_var_set_in_clientcore(monkeypatch, mode):
+    """End-to-end: Tier-12 PR 12.6 lifted synthetic-error injection from the
+    httpx transport into the chain. With the env var set, ``ClientCore``'s
+    middleware list contains an :class:`ErrorInjectionMiddleware` AND the
+    httpx ``AsyncClient`` transport is unwrapped (no
+    ``_SyntheticErrorTransport``) — the substitution happens above the
+    transport now."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
     from notebooklm._core import ClientCore
+    from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
     from notebooklm.auth import AuthTokens
 
     auth = AuthTokens(cookies={"SID": "t"}, csrf_token="c", session_id="s")
@@ -690,9 +694,16 @@ async def test_synthetic_transport_wired_when_env_var_set_in_clientcore(monkeypa
     try:
         await core.open()
         assert core._http_client is not None
+        # PR 12.6: httpx transport is unwrapped regardless of env var.
         transport = core._http_client._transport
-        assert isinstance(transport, _SyntheticErrorTransport)
-        assert transport._mode == mode
+        assert not isinstance(transport, _SyntheticErrorTransport)
+        # PR 12.6: chain seed contains an ``ErrorInjectionMiddleware`` that
+        # short-circuits at chain-invocation time when the env var resolves
+        # to a valid mode. The middleware itself doesn't expose the
+        # active mode (it reads the env var per call); env-var-to-mode
+        # resolution is covered by the dedicated middleware tests in
+        # ``test_error_injection_middleware.py``.
+        assert any(isinstance(mw, ErrorInjectionMiddleware) for mw in core._middlewares)
     finally:
         if core._http_client is not None:
             await core._http_client.aclose()


### PR DESCRIPTION
## Summary

- Adds `ErrorInjectionMiddleware` to the middleware chain (4th of 6 per ADR-009). Interim chain after this PR: `[Drain, Metrics, ErrorInjection, Tracing]`. PRs 12.7/12.8 will insert Retry + AuthRefresh between Metrics and ErrorInjection.
- The middleware short-circuits with a synthetic `httpx.Response` (built by `tests/cassette_patterns.build_synthetic_error_response`) when `NOTEBOOKLM_VCR_RECORD_ERRORS` resolves to `"429"`/`"5xx"`/`"expired_csrf"`. Env-var unset → pass-through to `next_call` (production behavior unchanged).
- Unwires the legacy `_SyntheticErrorTransport` from `ClientLifecycle.open()`. The class + its `tests/unit/test_vcr_config.py` direct-instantiation tests stay until PR 12.9 cleanup.

**Stacked on**: #843 (Tier-12 PR 12.5 DrainMiddleware). GitHub auto-updates the base to `main` when #843 merges.

## Behavioral changes

- **Internal retry loop bypass (interim)**: Pre-PR-12.6 the httpx-transport wrapper fired on every batchexecute POST, including ones `AuthedTransport`'s internal retry-on-5xx/429 loop re-issued. After PR 12.6 the chain middleware short-circuits before the leaf, so that internal loop never sees synthetic errors. PR 12.7 (RetryMiddleware) restores per-attempt firing by inserting a retry loop OUTSIDE this middleware.
- **Cassette recording**: synthetic-error VCR recording relied on the httpx-layer substitution sitting below VCR's record hook. After PR 12.6 the chain short-circuits above VCR — recording for synthetic errors is no longer supported. Existing cassettes are hand-written; replay is unaffected. Plan line 174 only requires playback green.

## Polish receipts (per /execute-task SKILL.md)

| Stage | Result |
|---|---|
| 4.1 simplifier | Renamed `_terminal_returning`→`_static_terminal`; trimmed verbose `__init__` comments |
| 4.2 gemini | LGTM. 2 [Important] noted by-design (cassette-recording / tracing bypass) |
| 4.2 claude | 0 [Critical], 3 [Important], 5 [Nit]. 3 importants addressed inline |
| 4.2 codex | 0 [Critical], 2 [Important], 1 [Nit]. Both importants addressed: (a) frozen-binding bug for `_get_error_injection_mode` would have dead-lettered the `monkeypatch.setattr` seam — fixed by resolving through the module at call time; (b) added monkeypatch-seam regression test + activation-log-once test |
| 4.3 ultrathink | Triple-review convergence caught codex's load-bearing bug; 5 nits deferred to PR 12.9 |

## Test plan

- [x] ruff format/check: clean
- [x] mypy `src/notebooklm --ignore-missing-imports`: 131 source files, 0 errors
- [x] `pytest -n auto tests/unit`: 4725 passed, 50 skipped (+2 new tests)
- [x] `pytest -n auto tests/integration`: 674 passed, 7 skipped
- [ ] CI green
- [ ] Bot reviews addressed
- [ ] `mergeStateStatus` CLEAN

## Follow-ups (deferred to PR 12.9 cleanup)

- Delete `_SyntheticErrorTransport` class + its direct-instantiation tests
- De-duplicate `_load_builder` between middleware and legacy transport
- De-duplicate the `logging.getLogger("notebooklm._core")` pin
- Cassette-recording mode for synthetic errors (if needed; plan says playback-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling architecture to improve consistency and reliability across test and recording scenarios.

* **Tests**
  * Expanded test coverage for error injection behavior validation.

* **Documentation**
  * Updated documentation to clarify how error injection functions during test recording and replay modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->