### PR TITLE
feat(core): extract RetryMiddleware into chain (Tier-12 PR 12.7)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -114,6 +114,7 @@ from ._middleware import (
 from ._middleware_drain import DrainMiddleware
 from ._middleware_error_injection import ErrorInjectionMiddleware
 from ._middleware_metrics import MetricsMiddleware
+from ._middleware_retry import RetryMiddleware
 from ._middleware_tracing import TracingMiddleware
 from ._sources import fetch_source_ids
 
@@ -469,33 +470,48 @@ class ClientCore:
         # call to ``self._owner._perform_authed_post`` at ``_core_rpc.py:275``).
         # PR 12.3 added ``TracingMiddleware`` (innermost), PR 12.4 prepended
         # ``MetricsMiddleware``, PR 12.5 prepended ``DrainMiddleware``
-        # outermost, and PR 12.6 inserts ``ErrorInjectionMiddleware`` between
-        # ``MetricsMiddleware`` and ``TracingMiddleware`` so the list now
-        # reads ``[Drain, Metrics, ErrorInjection, Tracing]``. PRs 12.7–12.8
-        # insert ``RetryMiddleware`` and ``AuthRefreshMiddleware`` BETWEEN
-        # ``MetricsMiddleware`` and ``ErrorInjectionMiddleware`` so the
-        # final list reads
+        # outermost, PR 12.6 inserted ``ErrorInjectionMiddleware`` between
+        # ``MetricsMiddleware`` and ``TracingMiddleware``, and PR 12.7
+        # inserts ``RetryMiddleware`` between ``MetricsMiddleware`` and
+        # ``ErrorInjectionMiddleware`` so the list now reads
+        # ``[Drain, Metrics, Retry, ErrorInjection, Tracing]``. PR 12.8
+        # inserts ``AuthRefreshMiddleware`` BETWEEN ``RetryMiddleware`` and
+        # ``ErrorInjectionMiddleware`` so the final list reads
         # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
         # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
         # composes the leftmost entry as the outermost wrapper, so keeping
         # ``TracingMiddleware`` at the RIGHT end of the list preserves
-        # Tracing as the innermost wrapper as later PRs grow the list, and
-        # keeping ``ErrorInjectionMiddleware`` adjacent to ``TracingMiddleware``
-        # matches the rationale "synthetic transient failures trigger retry"
-        # (ADR-009 §"Chain ordering rationale"): once ``RetryMiddleware``
-        # lands, it sits outside ``ErrorInjection`` and sees the synthetic
-        # error on each attempt.
+        # Tracing as the innermost wrapper as later PRs grow the list.
+        #
+        # PR 12.7 also LIFTS the 429 / 5xx retry loops out of
+        # ``AuthedTransport.perform_authed_post`` (the chain leaf) and into
+        # ``RetryMiddleware``. The leaf now raises
+        # ``_TransportRateLimited`` / ``_TransportServerError`` immediately
+        # on the first 429 / 5xx, and ``RetryMiddleware`` catches those
+        # exceptions and re-invokes the chain. Auth-refresh stays in the
+        # leaf as a localized loop until PR 12.8 lifts it.
         #
         # The terminal adapter reads ``build_request`` / ``log_label`` /
         # ``disable_internal_retries`` from ``RpcRequest.context`` and
         # delegates to ``self._get_authed_transport().perform_authed_post``.
-        # ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
-        # stay unpopulated until PRs 12.7/12.8 start lifting behavior
-        # out of ``AuthedTransport``. See ADR-009 §"Per-request behavior"
-        # and ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
+        # ``RetryMiddleware`` reads ``log_label`` /
+        # ``disable_internal_retries`` from the same ``context`` dict. See
+        # ADR-009 §"Per-request behavior" and
+        # ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
         self._middlewares: list[Middleware] = [
             DrainMiddleware(self._drain_tracker),
             MetricsMiddleware(self._metrics_obj),
+            # Pass callable budgets so post-construction mutation of
+            # ``self._rate_limit_max_retries`` / ``self._server_error_max_retries``
+            # (an integration-test idiom; production never mutates these)
+            # still takes effect — bit-for-bit preserving the pre-PR-12.7
+            # live-binding contract where ``AuthedTransport`` read these
+            # attrs LIVE inside its retry loop.
+            RetryMiddleware(
+                rate_limit_max_retries=lambda: self._rate_limit_max_retries,
+                server_error_max_retries=lambda: self._server_error_max_retries,
+                metrics=self._metrics_obj,
+            ),
             ErrorInjectionMiddleware(),
             TracingMiddleware(),
         ]
@@ -862,7 +878,7 @@ class ClientCore:
         ``_authed_post_chain``. The first call to :meth:`_perform_authed_post`
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
-        constructed (``[DrainMiddleware, MetricsMiddleware,
+        constructed (``[DrainMiddleware, MetricsMiddleware, RetryMiddleware,
         ErrorInjectionMiddleware, TracingMiddleware]``-seeded chain around
         the terminal adapter, matching the seed in ``__init__``).
 
@@ -891,20 +907,39 @@ class ClientCore:
                 # Mirror ``__init__``'s seeded chain: PR 12.3 lands
                 # ``TracingMiddleware`` as the innermost entry, PR 12.4
                 # prepends ``MetricsMiddleware``, PR 12.5 prepends
-                # ``DrainMiddleware`` outermost, and PR 12.6 inserts
+                # ``DrainMiddleware`` outermost, PR 12.6 inserts
                 # ``ErrorInjectionMiddleware`` just outside
-                # ``TracingMiddleware``. A ``__new__``-built fixture must
-                # see the same chain shape so the three observability
+                # ``TracingMiddleware``, and PR 12.7 inserts
+                # ``RetryMiddleware`` between ``MetricsMiddleware`` and
+                # ``ErrorInjectionMiddleware``. A ``__new__``-built fixture
+                # must see the same chain shape so the three observability
                 # channels (drain admission, RPC counters/events,
-                # structured trace logs) AND the fault-injection
-                # short-circuit (active only when
-                # ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set) are exercised on
-                # fixture-driven invocations too; otherwise the fixture path
-                # and the live path diverge, which has previously hidden
-                # bugs in Tier-8 cassette-replay tests.
+                # structured trace logs), the retry-on-429/5xx loop, and
+                # the fault-injection short-circuit (active only when
+                # ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set) are all
+                # exercised on fixture-driven invocations too; otherwise
+                # the fixture path and the live path diverge, which has
+                # previously hidden bugs in Tier-8 cassette-replay tests.
+                #
+                # ``getattr`` defaults for the retry budgets match
+                # ``__init__``'s default values so a ``__new__``-built
+                # fixture that didn't set them still gets a sane
+                # ``RetryMiddleware``.
                 self._middlewares = [
                     DrainMiddleware(self._drain_tracker),
                     MetricsMiddleware(self._metrics_obj),
+                    # Callable budgets preserve live-binding (see ``__init__``
+                    # for the rationale). ``getattr`` defaults match
+                    # ``__init__``'s argument defaults so a ``__new__``-built
+                    # fixture that never set the attrs still gets a sane
+                    # ``RetryMiddleware``.
+                    RetryMiddleware(
+                        rate_limit_max_retries=lambda: getattr(self, "_rate_limit_max_retries", 3),
+                        server_error_max_retries=lambda: getattr(
+                            self, "_server_error_max_retries", 3
+                        ),
+                        metrics=self._metrics_obj,
+                    ),
                     ErrorInjectionMiddleware(),
                     TracingMiddleware(),
                 ]

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -10,11 +10,10 @@ from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 import httpx
 
-from ._backoff import compute_backoff_delay
 from .exceptions import RPCResponseTooLargeError
 
 # Upper bound on Retry-After wait. Caps both integer-seconds and HTTP-date forms
@@ -262,21 +261,49 @@ class AuthedTransport:
             )
 
         refreshed_this_call = False
-        rate_limit_retries = 0
-        server_error_retries = 0
         start = time.perf_counter()
 
         # ---------------------------------------------------------------
         # Semaphore placement contract — DO NOT MOVE.
         #
-        # The semaphore wraps the entire retry loop. Releasing during backoff
-        # would let new callers burst in just as the current cohort wakes up,
-        # undoing the smoothing the semaphore exists to provide.
+        # The semaphore wraps the entire auth-refresh-and-retry loop (and
+        # in turn sits INSIDE the chain's ``RetryMiddleware`` retry loop,
+        # because the chain entered before this leaf was called).
+        # Releasing during backoff would let new callers burst in just as
+        # the current cohort wakes up, undoing the smoothing the semaphore
+        # exists to provide.
+        #
+        # **Backpressure-scope regression (PR 12.7 → 12.8 follow-up).**
+        # Before PR 12.7, this semaphore wrapped the FULL retry budget
+        # (initial attempt + all 429 / 5xx retries). After PR 12.7, the
+        # 429 / 5xx retry loop lives in ``RetryMiddleware`` OUTSIDE this
+        # semaphore — each retry re-enters the chain, releases the slot
+        # during ``RetryMiddleware``'s backoff sleep, and re-acquires on
+        # the next attempt. Under bursty rate-limit fan-out this means the
+        # smoothing the semaphore previously provided across the full
+        # retry budget is now coarser (per-attempt, not per-call). The
+        # auth-refresh-once loop here still benefits from the old
+        # whole-loop scope.
+        #
+        # The plan acknowledges this as an interim consequence of the
+        # chain ordering ``[Drain, Metrics, Retry, AuthRefresh,
+        # ErrorInjection, Tracing]``. A chain-level semaphore primitive
+        # (or moving the gate above ``RetryMiddleware``) is a viable
+        # follow-up; PR 12.7 ships the regression so the load-bearing
+        # lift can land. ADR-009 §"Chain ordering rationale" should
+        # eventually reflect this trade-off.
         # ---------------------------------------------------------------
         semaphore = host._get_rpc_semaphore()
         queue_wait_start = time.perf_counter()
         async with semaphore:
             host._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
+            # PR 12.7: the only retry this loop now drives is the
+            # auth-refresh-once retry. 429 and 5xx/network failures raise
+            # ``_TransportRateLimited`` / ``_TransportServerError``
+            # immediately so :class:`RetryMiddleware` (chain-level, sitting
+            # OUTSIDE this leaf) can decide whether to retry. ``raise from
+            # exc`` preserves the chained transport exception for
+            # diagnostic display.
             while True:
                 snapshot = await host._snapshot()
                 url, body, headers = build_request(snapshot)
@@ -285,10 +312,10 @@ class AuthedTransport:
                     # Streaming POST with a running size cap. The size guard
                     # lives inside the stream-read loop in
                     # ``_stream_post_with_size_cap``; ``raise_for_status()`` is
-                    # invoked before any body chunk is read so the existing
-                    # auth-refresh / 429 / 5xx branches below still fire with
-                    # the same :class:`httpx.HTTPStatusError` they did when
-                    # this used ``client.post``.
+                    # invoked before any body chunk is read so the
+                    # auth-refresh branch below + the 429 / 5xx exception
+                    # raisers fire with the same :class:`httpx.HTTPStatusError`
+                    # they did when this used ``client.post``.
                     response = await _stream_post_with_size_cap(
                         client,
                         url,
@@ -296,7 +323,7 @@ class AuthedTransport:
                         headers=headers,
                     )
                 except (httpx.HTTPStatusError, httpx.RequestError) as exc:
-                    # --- Auth refresh path ---------------------------------
+                    # --- Auth refresh path (stays here until PR 12.8) -------
                     if (
                         not refreshed_this_call
                         and host._refresh_callback is not None
@@ -321,38 +348,9 @@ class AuthedTransport:
                         host._increment_metrics(rpc_auth_retries=1)
                         continue
 
-                    # --- 429 rate-limit path --------------------------------
+                    # --- 429: raise for the chain RetryMiddleware to catch --
                     if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
                         retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
-                        if (
-                            not disable_internal_retries
-                            and rate_limit_retries < host._rate_limit_max_retries
-                        ):
-                            if retry_after is not None:
-                                sleep_seconds: float = retry_after
-                                sleep_source = f"Retry-After={retry_after}s"
-                            else:
-                                # rng=None → module random.uniform is honored
-                                # by tests that monkeypatch the shared module.
-                                backoff = compute_backoff_delay(
-                                    rate_limit_retries,
-                                    base=1.0,
-                                    cap=30.0,
-                                    jitter_ratio=0.2,
-                                )
-                                sleep_seconds = max(0.1, backoff)
-                                sleep_source = f"exp-backoff={sleep_seconds:.1f}s"
-                            self._logger.warning(
-                                "%s rate-limited (HTTP 429); sleeping (%s) then retrying (%d/%d)",
-                                log_label,
-                                sleep_source,
-                                rate_limit_retries + 1,
-                                host._rate_limit_max_retries,
-                            )
-                            await self._sleep(sleep_seconds)
-                            rate_limit_retries += 1
-                            host._increment_metrics(rpc_rate_limit_retries=1)
-                            continue
                         raise _TransportRateLimited(
                             f"{log_label} rate-limited (HTTP 429)",
                             retry_after=retry_after,
@@ -360,57 +358,20 @@ class AuthedTransport:
                             original=exc,
                         ) from exc
 
-                    # --- 5xx / network retry path ---------------------------
-                    is_server_error = (
+                    # --- 5xx / network: raise for RetryMiddleware to catch --
+                    if (
                         isinstance(exc, httpx.HTTPStatusError)
                         and 500 <= exc.response.status_code < 600
-                    )
-                    is_network_error = isinstance(exc, httpx.RequestError)
-                    if is_server_error or is_network_error:
-                        if (
-                            not disable_internal_retries
-                            and server_error_retries < host._server_error_max_retries
-                        ):
-                            # rng=None → module random.uniform is honored
-                            # by tests that monkeypatch the shared module.
-                            backoff = max(
-                                0.1,
-                                compute_backoff_delay(
-                                    server_error_retries,
-                                    base=1.0,
-                                    cap=30.0,
-                                    jitter_ratio=0.2,
-                                ),
-                            )
-                            status_label = (
-                                f"HTTP {exc.response.status_code}"  # type: ignore[union-attr]
-                                if is_server_error
-                                else type(exc).__name__
-                            )
-                            self._logger.warning(
-                                "%s server/network error (%s); backing off %.1fs then retrying (%d/%d)",
-                                log_label,
-                                status_label,
-                                backoff,
-                                server_error_retries + 1,
-                                host._server_error_max_retries,
-                            )
-                            await self._sleep(backoff)
-                            server_error_retries += 1
-                            host._increment_metrics(rpc_server_error_retries=1)
-                            continue
-                        if is_server_error:
-                            status_error = cast(httpx.HTTPStatusError, exc)
-                            raise _TransportServerError(
-                                f"{log_label} server error "
-                                f"(HTTP {status_error.response.status_code}) after "
-                                f"{server_error_retries} retries",
-                                original=status_error,
-                                response=status_error.response,
-                                status_code=status_error.response.status_code,
-                            ) from exc
+                    ):
                         raise _TransportServerError(
-                            f"{log_label} network error after {server_error_retries} retries: {exc}",
+                            f"{log_label} server error (HTTP {exc.response.status_code})",
+                            original=exc,
+                            response=exc.response,
+                            status_code=exc.response.status_code,
+                        ) from exc
+                    if isinstance(exc, httpx.RequestError):
+                        raise _TransportServerError(
+                            f"{log_label} network error: {exc}",
                             original=exc,
                         ) from exc
 

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -246,7 +246,15 @@ class AuthedTransport:
         log_label: str,
         disable_internal_retries: bool = False,
     ) -> httpx.Response:
-        """Run an authed POST through the shared retry/refresh pipeline."""
+        """Run an authed POST through the auth-refresh-and-retry pipeline.
+
+        Since PR 12.7 this leaf only drives the auth-refresh-once retry;
+        429 / 5xx / network retries live in :class:`RetryMiddleware` above
+        this leaf in the chain. ``disable_internal_retries`` is accepted
+        for signature stability but no longer read here — the middleware
+        reads the flag from ``request.context`` directly. PR 12.9 removes
+        the parameter once the legacy non-chain code path is retired.
+        """
         host = self._host
         if host._http_client is None:
             raise RuntimeError("Client not initialized. Use 'async with' context.")

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -30,19 +30,33 @@ the class itself is untouched.
 Behavior contract:
 
 - Env var unset → ``await next_call(request)`` unchanged (pass-through).
-- Env var set → build the synthetic ``(status_code, body, headers)`` triple,
-  wrap as :class:`httpx.Response` anchored to ``request.url`` / ``request.body``
-  so callers that inspect ``response.request`` still see a sane request, and
-  return :class:`RpcResponse` carrying the synthetic response with
-  ``request.context`` propagated unchanged.
+- Env var set, mode ``"429"`` → raise :class:`_TransportRateLimited` so the
+  OUTER ``RetryMiddleware`` retries (restoring ADR-009 §"ErrorInjection
+  inside Retry — synthetic transient failures trigger retry"; codex iter-1
+  catch on PR 12.7). The raised exception carries the synthetic
+  ``Retry-After`` header so the retry honors the rate-limit timing.
+- Env var set, mode ``"5xx"`` → raise :class:`_TransportServerError` so
+  ``RetryMiddleware`` retries with exponential backoff.
+- Env var set, mode ``"expired_csrf"`` (HTTP 400) → return the synthetic
+  response unchanged. ``RetryMiddleware`` does not retry on 400; PR 12.8
+  ``AuthRefreshMiddleware`` will intercept and drive the refresh-then-retry
+  flow that the legacy leaf used to handle inline. Until 12.8 lands, the
+  400 propagates as a returned response and chat-domain mapping surfaces
+  it as a generic error (matches the PR-12.6 interim behavior).
 
-Note on retry semantics: the pre-PR-12.6 httpx-layer
-:class:`_SyntheticErrorTransport` fired on *every* batchexecute POST, including
-the ones that ``AuthedTransport.perform_authed_post`` re-issued from its
-internal retry-on-5xx/429 loop. After this PR the middleware short-circuits
-*before* the leaf, so that internal retry loop never sees synthetic errors.
-PR 12.7 (``RetryMiddleware``) inserts a retry loop OUTSIDE this middleware
-and restores the "every retry re-fires the synthetic error" behavior.
+All raised exceptions wrap a synthetic :class:`httpx.Response` anchored to
+``request.url`` / ``request.headers`` / ``request.body`` so callers
+inspecting ``response.request`` see what the leaf would have sent.
+
+Restored retry semantics: pre-PR-12.6 the httpx-layer
+:class:`_SyntheticErrorTransport` fired on *every* batchexecute POST,
+including the ones ``AuthedTransport.perform_authed_post`` re-issued from
+its internal retry loop. PR 12.6 lifted the middleware above the leaf,
+which broke that. PR 12.7 added ``RetryMiddleware`` OUTSIDE this
+middleware AND has this middleware raise the proper transport exceptions
+for 429/5xx so the outer retry actually fires. Each retry re-enters this
+middleware, which re-raises — matching the pre-PR-12.6 "every retry
+re-fires the synthetic error" behavior bit-for-bit.
 
 See ``docs/adr/0009-middleware-chain.md`` for the chain contract,
 ``src/notebooklm/_core_error_injection.py`` for the env-var / startup-guard
@@ -62,6 +76,11 @@ import httpx
 
 from . import _core_error_injection
 from ._core_error_injection import ERROR_INJECT_ENV_VAR
+from ._core_transport import (
+    _parse_retry_after,
+    _TransportRateLimited,
+    _TransportServerError,
+)
 from ._middleware import NextCall, RpcRequest, RpcResponse
 
 # Logger name pinned to ``notebooklm._core`` (not the literal module name) so
@@ -139,6 +158,44 @@ class ErrorInjectionMiddleware:
             content=body,
             request=synthetic_request,
         )
+        # PR 12.7: raise the proper transport exception for 429 / 5xx so the
+        # OUTER ``RetryMiddleware`` actually retries — restoring ADR-009
+        # §"ErrorInjection inside Retry — synthetic transient failures trigger
+        # retry". Pre-PR-12.6 this happened naturally because the legacy
+        # ``_SyntheticErrorTransport`` returned the synthetic response below
+        # httpx and ``AuthedTransport``'s ``raise_for_status()`` lifted it
+        # into an ``HTTPStatusError`` that the leaf's 429 / 5xx branches
+        # mapped to these same transport exceptions. Returning a plain
+        # ``RpcResponse`` here would skip retry entirely (codex iter-1 catch).
+        #
+        # For the ``expired_csrf`` (400) mode we still return the synthetic
+        # response — PR 12.8 (AuthRefreshMiddleware) will intercept it and
+        # drive the refresh-then-retry flow that the legacy leaf used to
+        # handle inline. Until 12.8 lands, the 400 propagates as a returned
+        # response and the chat-domain mapping surfaces it as a generic
+        # error (matches the PR-12.6 interim behavior for that mode).
+        log_label = request.context.get("log_label", "<unknown-chain-call>")
+        original = httpx.HTTPStatusError(
+            f"HTTP {status_code}",
+            request=synthetic_request,
+            response=response,
+        )
+        if status_code == 429:
+            retry_after = _parse_retry_after(response.headers.get("retry-after"))
+            raise _TransportRateLimited(
+                f"{log_label} rate-limited (HTTP 429)",
+                retry_after=retry_after,
+                response=response,
+                original=original,
+            ) from original
+        if 500 <= status_code < 600:
+            raise _TransportServerError(
+                f"{log_label} server error (HTTP {status_code})",
+                original=original,
+                response=response,
+                status_code=status_code,
+            ) from original
+        # 400 / expired_csrf / any other status: return as-is.
         return RpcResponse(response=response, context=request.context)
 
     def _load_builder(self) -> _SyntheticBuilder:

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -1,0 +1,292 @@
+"""RetryMiddleware — 429/5xx retry loop for the Tier-12 chain.
+
+Per ADR-009 §"Chain ordering", ``RetryMiddleware`` sits just *inside*
+``MetricsMiddleware`` and just *outside* ``AuthRefreshMiddleware`` (which
+extracts in PR 12.8). The final Tier-12 chain is
+``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``. PR 12.7
+ships the interim 5-middleware chain
+``[Drain, Metrics, Retry, ErrorInjection, Tracing]``; PR 12.8 inserts
+``AuthRefresh`` BETWEEN ``Retry`` and ``ErrorInjection``.
+
+This PR lifts the **retry-on-429** and **retry-on-5xx/network** loops out
+of ``AuthedTransport.perform_authed_post`` (the chain leaf). After PR
+12.7 the leaf is a single POST attempt that raises
+:class:`_TransportRateLimited` on HTTP 429 or
+:class:`_TransportServerError` on HTTP 5xx / network failures —
+**immediately**, without internal retry. The middleware catches those
+exceptions and decides whether to retry by re-invoking the chain.
+Auth-refresh-and-retry stays in the leaf as a localized loop until PR
+12.8 lifts it.
+
+Behavior preservation (vs. pre-PR-12.7):
+
+- **Same retry counts** — ``rate_limit_max_retries`` /
+  ``server_error_max_retries`` are propagated from ``ClientCore`` so the
+  budget matches the legacy ``AuthedTransport`` loop.
+- **Same backoff timing** — :func:`_backoff.compute_backoff_delay` is
+  invoked with the same ``base=1.0`` / ``cap=30.0`` / ``jitter_ratio=0.2``
+  parameters; ``Retry-After`` is honored before falling back to
+  exponential backoff.
+- **Same log lines** — "rate-limited (HTTP 429); sleeping (…); retrying
+  (n/N)" and "server/network error (…); backing off …; retrying (n/N)"
+  match the pre-PR-12.7 message shape so log-grep alerts keep matching.
+- **Same metrics** — ``rpc_rate_limit_retries`` and
+  ``rpc_server_error_retries`` are incremented per retry attempt, same as
+  the legacy code.
+- **Same disable_internal_retries gate** — read from
+  ``request.context["disable_internal_retries"]`` (post-resolution bool
+  produced by ``_idempotency.resolve_effective_disable_internal_retries``
+  before chain entry; see ADR-009 §"Per-request behavior").
+- **Same exception types on exhaustion** —
+  :class:`_TransportRateLimited` /
+  :class:`_TransportServerError` re-raised verbatim so
+  ``_chat_transport.chat_aware_authed_post`` (which catches both) sees
+  the same shape it always did.
+
+Subtle behavioral note (interim until PR 12.8 lands): pre-PR-12.7 the
+auth-refresh-and-retry counter (``refreshed_this_call``) sat inside the
+same ``while True`` as the 429/5xx counters, so a single call could
+auth-refresh at most once across ALL its retries. Post-PR-12.7, each
+``RetryMiddleware`` retry is a fresh chain invocation which means a fresh
+leaf invocation with its OWN ``refreshed_this_call``. In theory the same
+call could now auth-refresh once per retry. In practice auth refreshes
+are idempotent (they get fresh tokens), and ``RetryMiddleware``'s own
+budget bounds the total work — no infinite loop is possible. PR 12.8
+collapses this back into a single coordinated refresh path by lifting
+auth-refresh into a chain middleware outside this one.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract,
+``src/notebooklm/_core_transport.py`` for the (slimmed) leaf and the
+exception types this middleware catches, and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` row 12.7 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from ._backoff import compute_backoff_delay
+from ._core_transport import _parse_retry_after, _TransportRateLimited, _TransportServerError
+from ._middleware import NextCall, RpcRequest, RpcResponse
+
+if TYPE_CHECKING:
+    from ._core_metrics import ClientMetrics
+
+
+# Backoff parameters lifted verbatim from the pre-PR-12.7 retry loop in
+# ``AuthedTransport.perform_authed_post`` so end-to-end retry timing is
+# preserved bit-for-bit.
+_BACKOFF_BASE_SECONDS = 1.0
+_BACKOFF_CAP_SECONDS = 30.0
+_BACKOFF_JITTER_RATIO = 0.2
+# Floor on the actual sleep so a jitter-pulled-to-zero backoff still yields a
+# tiny sleep; mirrors the ``max(0.1, …)`` on both legacy retry paths.
+_BACKOFF_MIN_SECONDS = 0.1
+
+
+class RetryMiddleware:
+    """Chain middleware that retries on HTTP 429 / 5xx / network failures.
+
+    Conforms to :class:`notebooklm._middleware.Middleware` —
+    ``__call__`` matches the Protocol so instances are assignable into a
+    ``Sequence[Middleware]``.
+
+    Constructor inputs (all wired by ``ClientCore.__init__``):
+
+    - ``rate_limit_max_retries`` / ``server_error_max_retries``: the same
+      budgets ``ClientCore`` previously passed to ``AuthedTransport`` via
+      the host attributes ``_rate_limit_max_retries`` /
+      ``_server_error_max_retries``.
+    - ``sleep``: the awaitable sleep function. Defaults to
+      :func:`asyncio.sleep`; tests inject a stub to make backoff
+      deterministic and to assert on sleep durations.
+    - ``logger``: structured logger for the "rate-limited" / "server
+      error" retry-info lines. Defaults to the project-canonical
+      ``notebooklm._core`` logger so log filters in tests
+      (``caplog.at_level(..., logger="notebooklm._core")``) keep
+      matching.
+    - ``metrics``: a :class:`ClientMetrics` whose ``.increment(...)``
+      method we call per retry. ``None`` skips emission (useful for
+      tests that don't care about metrics).
+    """
+
+    def __init__(
+        self,
+        *,
+        rate_limit_max_retries: int | Callable[[], int],
+        server_error_max_retries: int | Callable[[], int],
+        sleep: Callable[[float], Awaitable[object]] | None = None,
+        logger: logging.Logger | None = None,
+        metrics: ClientMetrics | None = None,
+    ) -> None:
+        # Budgets accept either a static int OR a zero-arg callable. The
+        # callable form preserves the pre-PR-12.7 contract where
+        # ``AuthedTransport`` read ``host._rate_limit_max_retries`` /
+        # ``host._server_error_max_retries`` LIVE inside the retry loop, so
+        # tests (and any production tweaks) that mutate those attrs on the
+        # core after ``open()`` still take effect. ``ClientCore.__init__``
+        # wires the callable form via a ``lambda: self._rate_limit_max_retries``
+        # closure; tests that build a middleware in isolation typically pass
+        # the int form.
+        self._rate_limit_max = rate_limit_max_retries
+        self._server_error_max = server_error_max_retries
+        # ``None`` defers resolution to call time so a test that
+        # ``monkeypatch.setattr("asyncio.sleep", ...)`` (or anywhere
+        # asyncio.sleep is exposed) observes the fake. Capturing
+        # ``asyncio.sleep`` at construction would freeze the binding to
+        # whatever was imported when the middleware was instantiated,
+        # silently bypassing later monkeypatches.
+        self._sleep = sleep
+        self._logger = logger or logging.getLogger("notebooklm._core")
+        self._metrics = metrics
+
+    def _resolve_sleep(self) -> Callable[[float], Awaitable[object]]:
+        """Return the call-time sleep function — fake-or-real."""
+        return self._sleep if self._sleep is not None else asyncio.sleep
+
+    def _resolve_rate_limit_max(self) -> int:
+        v = self._rate_limit_max
+        return v() if callable(v) else v
+
+    def _resolve_server_error_max(self) -> int:
+        v = self._server_error_max
+        return v() if callable(v) else v
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        """Retry inner chain calls on 429 / 5xx / network failures.
+
+        Reads ``log_label`` and ``disable_internal_retries`` from
+        ``request.context``. A missing ``log_label`` falls back to a
+        defensive sentinel so a ``__new__``-built fixture driving the
+        chain raw doesn't trip on a ``KeyError`` (matches DrainMiddleware's
+        same fallback). ``disable_internal_retries`` defaults to ``False``
+        — the production path always populates it from
+        :func:`_idempotency.resolve_effective_disable_internal_retries`.
+        """
+        log_label = request.context.get("log_label", "<unknown-chain-call>")
+        # Post-resolution bool — see ADR-009 §"Per-request behavior".
+        disable_internal_retries = bool(request.context.get("disable_internal_retries", False))
+
+        rate_limit_retries = 0
+        server_error_retries = 0
+
+        while True:
+            try:
+                return await next_call(request)
+            except _TransportRateLimited as exc:
+                rate_limit_max = self._resolve_rate_limit_max()
+                if disable_internal_retries or rate_limit_retries >= rate_limit_max:
+                    raise
+                await self._wait_for_rate_limit(
+                    exc=exc,
+                    attempt=rate_limit_retries,
+                    log_label=log_label,
+                    rate_limit_max=rate_limit_max,
+                )
+                rate_limit_retries += 1
+                if self._metrics is not None:
+                    self._metrics.increment(rpc_rate_limit_retries=1)
+                continue
+            except _TransportServerError as exc:
+                server_error_max = self._resolve_server_error_max()
+                if disable_internal_retries or server_error_retries >= server_error_max:
+                    raise
+                await self._wait_for_server_error(
+                    exc=exc,
+                    attempt=server_error_retries,
+                    log_label=log_label,
+                    server_error_max=server_error_max,
+                )
+                server_error_retries += 1
+                if self._metrics is not None:
+                    self._metrics.increment(rpc_server_error_retries=1)
+                continue
+
+    async def _wait_for_rate_limit(
+        self,
+        *,
+        exc: _TransportRateLimited,
+        attempt: int,
+        log_label: str,
+        rate_limit_max: int,
+    ) -> None:
+        """Honor ``Retry-After`` if present; otherwise exponential backoff.
+
+        ``Retry-After`` is read from ``exc.retry_after`` — the leaf already
+        parsed it via :func:`_parse_retry_after` when it raised. We accept
+        either the parsed integer (preferred) or fall back to re-parsing
+        the header off ``exc.response`` if the parsed value is missing
+        (defensive — production always populates ``retry_after``).
+        """
+        retry_after = exc.retry_after
+        if retry_after is None and exc.response is not None:
+            retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+
+        if retry_after is not None:
+            sleep_seconds: float = float(retry_after)
+            sleep_source = f"Retry-After={retry_after}s"
+        else:
+            backoff = compute_backoff_delay(
+                attempt,
+                base=_BACKOFF_BASE_SECONDS,
+                cap=_BACKOFF_CAP_SECONDS,
+                jitter_ratio=_BACKOFF_JITTER_RATIO,
+            )
+            sleep_seconds = max(_BACKOFF_MIN_SECONDS, backoff)
+            sleep_source = f"exp-backoff={sleep_seconds:.1f}s"
+
+        self._logger.warning(
+            "%s rate-limited (HTTP 429); sleeping (%s) then retrying (%d/%d)",
+            log_label,
+            sleep_source,
+            attempt + 1,
+            rate_limit_max,
+        )
+        await self._resolve_sleep()(sleep_seconds)
+
+    async def _wait_for_server_error(
+        self,
+        *,
+        exc: _TransportServerError,
+        attempt: int,
+        log_label: str,
+        server_error_max: int,
+    ) -> None:
+        """Exponential backoff with the same parameters as the legacy loop."""
+        backoff = max(
+            _BACKOFF_MIN_SECONDS,
+            compute_backoff_delay(
+                attempt,
+                base=_BACKOFF_BASE_SECONDS,
+                cap=_BACKOFF_CAP_SECONDS,
+                jitter_ratio=_BACKOFF_JITTER_RATIO,
+            ),
+        )
+        # ``status_code`` is set on 5xx; the network-error branch sets
+        # ``response`` / ``status_code`` to ``None``, so fall back to the
+        # type name of the original exception (RequestError / TimeoutException
+        # subclasses, etc.) so the log line stays diagnostic.
+        if exc.status_code is not None:
+            status_label = f"HTTP {exc.status_code}"
+        else:
+            status_label = type(exc.original).__name__
+        self._logger.warning(
+            "%s server/network error (%s); backing off %.1fs then retrying (%d/%d)",
+            log_label,
+            status_label,
+            backoff,
+            attempt + 1,
+            server_error_max,
+        )
+        await self._resolve_sleep()(backoff)
+
+
+__all__ = ["RetryMiddleware"]

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -232,34 +232,39 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chain_seeded_with_drain_metrics_error_injection_tracing() -> None:
-    """``ClientCore.__init__`` seeds the chain with ``[Drain, Metrics, ErrorInjection, Tracing]``.
+async def test_chain_seeded_with_drain_metrics_retry_error_injection_tracing() -> None:
+    """``ClientCore.__init__`` seeds the chain with ``[Drain, Metrics, Retry, ErrorInjection, Tracing]``.
 
     PR 12.3 landed ``TracingMiddleware`` at the innermost position; PR 12.4
     prepended ``MetricsMiddleware``; PR 12.5 prepended ``DrainMiddleware``
-    outermost; PR 12.6 inserts ``ErrorInjectionMiddleware`` between Metrics
-    and Tracing. Order matters — Drain admits/finalizes the operation outside
-    all observability, Metrics times the inner chain, ErrorInjection
-    short-circuits with synthetic responses when activated, and Tracing
-    remains the innermost wrapper around the transport leaf. PRs 12.7–12.8
-    insert ``RetryMiddleware`` and ``AuthRefreshMiddleware`` BETWEEN Metrics
-    and ErrorInjection so the final ordering reads
+    outermost; PR 12.6 inserted ``ErrorInjectionMiddleware`` between
+    Metrics and Tracing; PR 12.7 inserts ``RetryMiddleware`` between
+    Metrics and ErrorInjection. Order matters — Drain admits/finalizes
+    the operation outside all observability, Metrics times the
+    end-to-end chain, Retry handles 429/5xx retries (with synthetic
+    errors that ErrorInjection produces visible to Retry on each
+    attempt), ErrorInjection short-circuits with synthetic responses
+    when activated, and Tracing remains the innermost wrapper around the
+    transport leaf. PR 12.8 inserts ``AuthRefreshMiddleware`` BETWEEN
+    Retry and ErrorInjection so the final ordering reads
     ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` per
-    ADR-009. The list is exposed as ``self._middlewares`` so later PRs (and
-    the cleanup audit in 12.9) can assert ordering by inspecting the
-    production attribute directly.
+    ADR-009. The list is exposed as ``self._middlewares`` so later PRs
+    (and the cleanup audit in 12.9) can assert ordering by inspecting
+    the production attribute directly.
     """
     from notebooklm._middleware_drain import DrainMiddleware
     from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
     from notebooklm._middleware_metrics import MetricsMiddleware
+    from notebooklm._middleware_retry import RetryMiddleware
     from notebooklm._middleware_tracing import TracingMiddleware
 
     core = _make_core()
-    assert len(core._middlewares) == 4
+    assert len(core._middlewares) == 5
     assert isinstance(core._middlewares[0], DrainMiddleware)
     assert isinstance(core._middlewares[1], MetricsMiddleware)
-    assert isinstance(core._middlewares[2], ErrorInjectionMiddleware)
-    assert isinstance(core._middlewares[3], TracingMiddleware)
+    assert isinstance(core._middlewares[2], RetryMiddleware)
+    assert isinstance(core._middlewares[3], ErrorInjectionMiddleware)
+    assert isinstance(core._middlewares[4], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -161,18 +161,33 @@ def test_core_transport_has_no_runtime_core_imports():
 
 
 @pytest.mark.asyncio
-async def test_authed_transport_reads_live_retry_budget(monkeypatch):
+async def test_chain_reads_live_retry_budget(monkeypatch):
+    """Tier-12 PR 12.7 lifted the 429 / 5xx retry loop into ``RetryMiddleware``.
+
+    The middleware reads ``self._rate_limit_max_retries`` on the host LIVE
+    (via the callable factory the chain seed installs) so a test that
+    mutates the budget AFTER ``open()`` still takes effect — preserving
+    the pre-PR-12.7 contract where ``AuthedTransport`` read the same
+    attr live inside its loop. Drives the chain via
+    ``core._perform_authed_post`` so the assertion exercises the
+    production seam ``RpcExecutor.execute`` uses.
+    """
     core = _make_core(rate_limit_max_retries=0)
     await core.open()
     try:
-        transport = core._get_authed_transport()
-        assert isinstance(transport, AuthedTransport)
+        # Confirm the leaf is still AuthedTransport (sanity).
+        assert isinstance(core._get_authed_transport(), AuthedTransport)
+        # Mutate AFTER open() — middleware reads via lambda closure so this
+        # bump from 0 → 1 grants a single retry on the next chain call.
         core._rate_limit_max_retries = 1
         sleeps: list[float] = []
 
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
+        # ``RetryMiddleware`` defaults to ``asyncio.sleep`` resolved at call
+        # time, so patching the asyncio module's ``sleep`` reaches it
+        # through Python's module identity.
         monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
@@ -188,7 +203,7 @@ async def test_authed_transport_reads_live_retry_budget(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._http_client, fake_post)
 
-        response = await transport.perform_authed_post(build_request=build, log_label="test")
+        response = await core._perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert call_count["n"] == 2
@@ -246,11 +261,16 @@ async def test_authed_transport_uses_late_bound_is_auth_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_authed_transport_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch):
+async def test_chain_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch):
+    """``RetryMiddleware`` resolves ``asyncio.sleep`` at call time and uses
+    the shared ``random`` module for jitter, so tests can monkey-patch both
+    surfaces post-construction. Pre-PR-12.7 this contract sat on
+    ``AuthedTransport``; PR 12.7 lifted retry into the chain but the
+    same late-bound seam is preserved end-to-end.
+    """
     core = _make_core(server_error_max_retries=1)
     await core.open()
     try:
-        transport = core._get_authed_transport()
         sleeps: list[float] = []
 
         async def fake_sleep(seconds: float) -> None:
@@ -272,7 +292,7 @@ async def test_authed_transport_uses_late_bound_sleep_and_shared_random_uniform(
 
         install_post_as_stream(monkeypatch, core._http_client, fake_post)
 
-        response = await transport.perform_authed_post(build_request=build, log_label="test")
+        response = await core._perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert call_count["n"] == 2

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -1,25 +1,25 @@
-"""Unit tests for :class:`ErrorInjectionMiddleware` (Tier-12 PR 12.6).
+"""Unit tests for :class:`ErrorInjectionMiddleware` (Tier-12 PR 12.6 / PR 12.7).
 
 Pins the contract documented in ``src/notebooklm/_middleware_error_injection.py``
 and ADR-009 §"Chain ordering":
 
 - **Pass-through when env var is unset.** The middleware delegates straight
   to ``next_call``; production behavior is byte-for-byte unchanged.
-- **Short-circuit when env var is set.** Every chain invocation returns a
-  synthetic :class:`httpx.Response` built by
-  ``tests.cassette_patterns.build_synthetic_error_response``; the leaf is
-  NOT called.
-- **All three synthetic modes** (``"429"`` / ``"5xx"`` / ``"expired_csrf"``)
-  produce the documented status code + body + headers shape.
-- **Request shape preserved on the synthetic response.** The wrapped
-  :class:`httpx.Response` has a ``response.request`` attached whose
+- **Raise transport exceptions for 429 / 5xx (PR 12.7).** When the env var
+  resolves to ``"429"`` the middleware raises
+  :class:`_TransportRateLimited` (carrying the synthetic ``Retry-After``);
+  ``"5xx"`` raises :class:`_TransportServerError`. This is the contract
+  that lets the OUTER ``RetryMiddleware`` retry, restoring ADR-009
+  §"ErrorInjection inside Retry — synthetic transient failures trigger
+  retry" (codex iter-1 catch on PR 12.7).
+- **Return synthetic response for expired_csrf (HTTP 400).** That mode
+  surfaces as a returned :class:`RpcResponse` until PR 12.8's
+  ``AuthRefreshMiddleware`` intercepts and drives refresh-then-retry.
+- **Request shape preserved on the wrapped response.** The wrapped
+  :class:`httpx.Response` (whether returned or carried in a raised
+  exception) has a ``response.request`` attached whose
   ``method`` / ``url`` / ``body`` mirror the incoming
-  :class:`RpcRequest`, so callers that inspect the request after the fact
-  still see what they would have sent.
-- **Context propagated.** ``RpcResponse.context`` is the same dict object
-  as ``RpcRequest.context`` (no copying); middlewares above can see any
-  annotations a deeper middleware would have added had the leaf been
-  reached.
+  :class:`RpcRequest`.
 - **Builder cached on the instance** so a long-running test suite pays
   the ``importlib`` cost exactly once per middleware.
 
@@ -41,16 +41,13 @@ import pytest
 # import path documented in ``tests/_fixtures/__init__.py``.
 from _fixtures.chain import make_request
 from notebooklm._core_error_injection import ERROR_INJECT_ENV_VAR
+from notebooklm._core_transport import _TransportRateLimited, _TransportServerError
 from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
 from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
 
 
 def _static_terminal(response: httpx.Response) -> NextCall:
-    """Build a chain-terminal coroutine that wraps ``response``.
-
-    The terminal records nothing — tests that want to know whether the
-    leaf was reached should use ``_recording_terminal`` instead.
-    """
+    """Build a chain-terminal coroutine that wraps ``response``."""
 
     async def terminal(request: RpcRequest) -> RpcResponse:
         return RpcResponse(response=response, context=request.context)
@@ -59,12 +56,7 @@ def _static_terminal(response: httpx.Response) -> NextCall:
 
 
 def _recording_terminal() -> tuple[NextCall, list[RpcRequest]]:
-    """Build a terminal that records every request it sees.
-
-    Returns ``(terminal, calls)`` — append the request to ``calls`` before
-    returning a default 200 OK. Tests assert on ``len(calls)`` to detect
-    whether the leaf was reached.
-    """
+    """Build a terminal that records every request it sees."""
     calls: list[RpcRequest] = []
 
     async def terminal(request: RpcRequest) -> RpcResponse:
@@ -103,13 +95,7 @@ async def test_passes_through_when_env_var_unset(
 async def test_passes_through_when_env_var_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An empty-string env var also resolves to ``None`` → pass-through.
-
-    ``_get_error_injection_mode`` strips whitespace; ``""`` and ``"   "``
-    both resolve to ``None`` so the middleware must not short-circuit on
-    those values. Defends against an operator who set the var via a
-    half-baked shell snippet (e.g. ``export NOTEBOOKLM_VCR_RECORD_ERRORS=``).
-    """
+    """An empty-string env var also resolves to ``None`` → pass-through."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "   ")
     terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
@@ -136,138 +122,196 @@ async def test_passes_through_when_env_var_unknown_mode(
 
 
 # ---------------------------------------------------------------------------
-# Short-circuit + synthetic response shape
+# 429 → raise _TransportRateLimited
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    ("mode", "expected_status"),
-    [("429", 429), ("5xx", 500), ("expired_csrf", 400)],
-)
 @pytest.mark.asyncio
-async def test_short_circuits_with_synthetic_response_for_each_mode(
+async def test_429_mode_raises_transport_rate_limited(
     monkeypatch: pytest.MonkeyPatch,
-    mode: str,
-    expected_status: int,
 ) -> None:
-    """Each valid mode → short-circuit + status code from
-    ``build_synthetic_error_response``.
+    """``429`` mode raises :class:`_TransportRateLimited` for ``RetryMiddleware``.
 
-    The middleware must NOT call ``next_call`` (the leaf), and the returned
-    ``httpx.Response`` must carry the status the builder produces.
+    Restores ADR-009 §"ErrorInjection inside Retry — synthetic transient
+    failures trigger retry" (codex iter-1 catch on PR 12.7). The raised
+    exception carries the synthetic ``Retry-After`` so the outer retry
+    honors rate-limit timing.
     """
-    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
     terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
 
-    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+    with pytest.raises(_TransportRateLimited) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
 
-    # Leaf NEVER reached.
     assert calls == []
-    assert response.response.status_code == expected_status
+    exc = excinfo.value
+    assert exc.retry_after == 1
+    assert exc.response is not None
+    assert exc.response.status_code == 429
+    assert "RPC LIST_NOTEBOOKS" in str(exc)
 
 
 @pytest.mark.asyncio
-async def test_short_circuit_response_carries_retry_after_for_429(
+async def test_429_response_carries_synthetic_request_url_and_body(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``429`` mode → synthetic ``Retry-After`` header is forwarded.
-
-    ``build_synthetic_error_response`` sets ``Retry-After: 1`` for the
-    rate-limited shape so the eventual ``RetryMiddleware`` (PR 12.7,
-    outside this middleware in the final chain) honors it.
-    ErrorInjectionMiddleware must forward that header verbatim onto the
-    wrapped ``httpx.Response``.
-    """
+    """The synthetic ``httpx.Response.request`` mirrors the chain request."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
-    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
     middleware = ErrorInjectionMiddleware()
-    chain = build_chain([middleware], terminal)
-
-    response = await chain(make_request())
-
-    assert response.response.status_code == 429
-    assert response.response.headers.get("retry-after") == "1"
-
-
-@pytest.mark.asyncio
-async def test_short_circuit_response_carries_json_content_type(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Synthetic bodies are JSON-shaped → ``Content-Type`` is propagated."""
-    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
-    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
-    middleware = ErrorInjectionMiddleware()
-    chain = build_chain([middleware], terminal)
-
-    response = await chain(make_request())
-
-    assert "application/json" in response.response.headers.get("content-type", "")
-    assert b'"error"' in response.response.content
-
-
-# ---------------------------------------------------------------------------
-# Request-on-synthetic-response shape
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_synthetic_response_carries_request_with_original_url_and_body(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The synthetic ``httpx.Response.request`` mirrors the chain request.
-
-    Anchors the synthetic response to the would-have-been-sent request so
-    callers that read ``response.request.url`` / ``response.request.method``
-    (e.g. when constructing an ``httpx.HTTPStatusError`` for diagnostic
-    messages) still see the URL and body the leaf would have used.
-    """
-    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
-    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
-    middleware = ErrorInjectionMiddleware()
-    chain = build_chain([middleware], terminal)
+    chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     custom_url = "https://example.test/_/LabsTailwindUi/data/batchexecute?authuser=0"
-    request = make_request(url=custom_url, body=b"chain-body")
-    response = await chain(request)
+    with pytest.raises(_TransportRateLimited) as excinfo:
+        await chain(make_request(url=custom_url, body=b"chain-body"))
 
-    assert response.response.request is not None
-    assert response.response.request.method == "POST"
-    assert str(response.response.request.url) == custom_url
-    # ``httpx.Request.content`` is bytes; we passed ``body=b"chain-body"`` so the
-    # synthetic request mirrors that exact payload.
-    assert response.response.request.content == b"chain-body"
+    response = excinfo.value.response
+    assert response is not None
+    assert response.request is not None
+    assert response.request.method == "POST"
+    assert str(response.request.url) == custom_url
+    assert response.request.content == b"chain-body"
 
 
 # ---------------------------------------------------------------------------
-# Context propagation
+# 5xx → raise _TransportServerError
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_synthetic_response_propagates_request_context(
+async def test_5xx_mode_raises_transport_server_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``RpcResponse.context`` is the same dict as ``RpcRequest.context``.
-
-    The middleware must NOT copy the context — a deeper middleware (had the
-    leaf been reached) might have annotated it; an outer middleware reads
-    those annotations. The synthetic path can't add annotations the deeper
-    middlewares would have added, but it must still propagate the dict
-    instance so outer middlewares see a consistent shape.
-    """
+    """``5xx`` mode raises :class:`_TransportServerError` for ``RetryMiddleware``."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
-    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
+    terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportServerError) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert calls == []
+    exc = excinfo.value
+    assert exc.status_code == 500
+    assert exc.response is not None
+    assert "application/json" in exc.response.headers.get("content-type", "")
+    assert b'"error"' in exc.response.content
+
+
+# ---------------------------------------------------------------------------
+# expired_csrf → return RpcResponse (PR 12.8 will intercept in AuthRefresh)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expired_csrf_mode_returns_400_response_for_now(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``expired_csrf`` mode returns the 400 response as-is — pending PR 12.8.
+
+    PR 12.8's AuthRefreshMiddleware will intercept 400 responses and drive
+    the refresh-then-retry flow. Until then, the response propagates.
+    """
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
+    terminal, calls = _recording_terminal()
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert calls == []  # leaf NOT reached
+    assert response.response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_expired_csrf_response_propagates_request_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """For the returned-response path (400), context is propagated."""
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
+    middleware = ErrorInjectionMiddleware()
+    chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     request_context = {"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
     request = make_request(context=request_context)
     response = await chain(request)
 
     assert response.context is request.context
-    assert response.context["log_label"] == "RPC LIST_NOTEBOOKS"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: Retry + ErrorInjection actually retries (codex iter-1 finding)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_outside_error_injection_retries_synthetic_429(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: chain ``[Retry, ErrorInjection]`` retries synthetic 429s.
+
+    This is the codex iter-1 catch: without ErrorInjection raising
+    :class:`_TransportRateLimited`, the synthetic 429 flowed back as a
+    returned response and Retry never saw it. With the exception-raising
+    fix, Retry catches and retries N times before re-raising.
+    """
+    from notebooklm._middleware_retry import RetryMiddleware
+
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
+    slept: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    error_injection = ErrorInjectionMiddleware()
+    retry = RetryMiddleware(
+        rate_limit_max_retries=2,
+        server_error_max_retries=2,
+        sleep=fake_sleep,
+    )
+    chain = build_chain(
+        [retry, error_injection], _static_terminal(httpx.Response(200, content=b"x"))
+    )
+
+    with pytest.raises(_TransportRateLimited):
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # 1 initial + 2 retries → 2 sleeps observed.
+    assert len(slept) == 2
+    # Each sleep honors the synthetic Retry-After=1.
+    assert slept == [1.0, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_retry_outside_error_injection_retries_synthetic_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: chain ``[Retry, ErrorInjection]`` retries synthetic 5xx too."""
+    from notebooklm._middleware_retry import RetryMiddleware
+
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
+    slept: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    error_injection = ErrorInjectionMiddleware()
+    retry = RetryMiddleware(
+        rate_limit_max_retries=2,
+        server_error_max_retries=1,
+        sleep=fake_sleep,
+    )
+    chain = build_chain(
+        [retry, error_injection], _static_terminal(httpx.Response(200, content=b"x"))
+    )
+
+    with pytest.raises(_TransportServerError):
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # 1 initial + 1 retry → 1 sleep observed.
+    assert len(slept) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -279,24 +323,19 @@ async def test_synthetic_response_propagates_request_context(
 async def test_builder_loaded_once_across_calls(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``_load_builder`` caches its result on the instance.
-
-    Importing ``tests.cassette_patterns`` via importlib is non-trivial; pin
-    that the second call reuses the cached builder rather than re-importing.
-    Asserted via direct attribute inspection (``middleware._builder``) so
-    we don't have to stub importlib itself.
-    """
+    """``_load_builder`` caches its result on the instance."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "429")
-    terminal = _static_terminal(httpx.Response(200, content=b"unreached"))
     middleware = ErrorInjectionMiddleware()
-    chain = build_chain([middleware], terminal)
+    chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
     assert middleware._builder is None
-    await chain(make_request())
+    with pytest.raises(_TransportRateLimited):
+        await chain(make_request())
     first = middleware._builder
     assert first is not None
 
-    await chain(make_request())
+    with pytest.raises(_TransportRateLimited):
+        await chain(make_request())
     assert middleware._builder is first  # same object — no re-load
 
 
@@ -309,19 +348,7 @@ async def test_builder_loaded_once_across_calls(
 async def test_activation_flip_between_calls_is_observed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A test that flips the env var between two chain calls observes both modes.
-
-    Pins that the middleware reads the env var at ``__call__`` time, not
-    at construction time. The fixture flow that supports this is:
-
-    1. Construct the middleware + chain with env var unset.
-    2. First chain call → passes through, leaf reached.
-    3. Set the env var.
-    4. Second chain call → short-circuits, leaf NOT reached again.
-
-    Catches a regression where someone "optimizes" the env-var read into
-    the ``__init__`` (forfeiting per-call activation flips that tests rely on).
-    """
+    """Flipping the env var between two chain calls observes both modes."""
     monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
     terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
@@ -334,10 +361,10 @@ async def test_activation_flip_between_calls_is_observed(
     # Flip on.
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
 
-    # Call 2: short-circuit, leaf NOT reached again.
-    response = await chain(make_request())
+    # Call 2: short-circuit (now raises), leaf NOT reached again.
+    with pytest.raises(_TransportServerError):
+        await chain(make_request())
     assert len(calls) == 1  # still 1 — leaf was bypassed on second call
-    assert response.response.status_code == 500
 
 
 # ---------------------------------------------------------------------------
@@ -346,13 +373,7 @@ async def test_activation_flip_between_calls_is_observed(
 
 
 def test_middleware_satisfies_protocol() -> None:
-    """``ErrorInjectionMiddleware`` instance is assignable to ``Middleware``.
-
-    The :class:`notebooklm._middleware.Middleware` Protocol is the only
-    thing :func:`build_chain` accepts. mypy would catch a Protocol drift
-    at static-analysis time; this runtime check is the regression guard
-    that survives a "mypy not run in CI" misconfiguration.
-    """
+    """``ErrorInjectionMiddleware`` instance is assignable to ``Middleware``."""
     from notebooklm._middleware import Middleware
 
     middleware: Middleware = ErrorInjectionMiddleware()
@@ -371,29 +392,20 @@ async def test_monkeypatch_setattr_on_get_error_injection_mode_is_live(
     """The middleware resolves ``_get_error_injection_mode`` through the
     module at call time, so ``monkeypatch.setattr(_core_error_injection,
     "_get_error_injection_mode", …)`` reaches the chain.
-
-    Regression guard: a value-import (``from ._core_error_injection import
-    _get_error_injection_mode``) would freeze the binding at module-load
-    time, silently dead-lettering this monkeypatch surface.
-    ``tests/unit/test_core_lifecycle.py`` relies on the same seam (via the
-    ``_core`` re-export) — keeping it live in the middleware too keeps the
-    project's test idiom consistent.
     """
     from notebooklm import _core_error_injection as _eim_module
 
     monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
-    # Replace the function itself — env var stays unset, so any reader that
-    # cached the function by value would return ``None`` and pass through.
     monkeypatch.setattr(_eim_module, "_get_error_injection_mode", lambda: "5xx")
 
     terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
 
-    response = await chain(make_request())
+    with pytest.raises(_TransportServerError):
+        await chain(make_request())
 
     assert calls == []
-    assert response.response.status_code == 500
 
 
 @pytest.mark.asyncio
@@ -401,21 +413,20 @@ async def test_activation_log_fires_once_per_instance(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The "synthetic-error injection enabled" log line fires exactly once.
-
-    Pre-PR-12.6 the lifecycle emitted this at ``open()``; the middleware
-    now emits it at first activation. Pinning "once per instance" guards
-    against a refactor that drops the ``_logged_activation`` flag and
-    spams the log every chain call.
-    """
+    """The "synthetic-error injection enabled" log line fires exactly once."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "5xx")
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"x")))
 
     with caplog.at_level("INFO", logger="notebooklm._core"):
-        await chain(make_request())
-        await chain(make_request())
-        await chain(make_request())
+        # Each call raises; this verifies the log is emitted on the FIRST
+        # call's path and suppressed on subsequent calls.
+        with pytest.raises(_TransportServerError):
+            await chain(make_request())
+        with pytest.raises(_TransportServerError):
+            await chain(make_request())
+        with pytest.raises(_TransportServerError):
+            await chain(make_request())
 
     activations = [r for r in caplog.records if "synthetic-error injection enabled" in r.message]
     assert len(activations) == 1
@@ -430,12 +441,7 @@ async def test_activation_log_fires_once_per_instance(
 async def test_call_receives_next_call_and_invokes_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the env var is unset, ``__call__`` invokes ``next_call(request)``.
-
-    Direct ``__call__`` test (not via ``build_chain``) so the contract is
-    exercised at the Protocol seam — what every other middleware PR
-    relies on.
-    """
+    """When the env var is unset, ``__call__`` invokes ``next_call(request)``."""
     monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
     seen: list[RpcRequest] = []
 

--- a/tests/unit/test_retry_middleware.py
+++ b/tests/unit/test_retry_middleware.py
@@ -1,0 +1,603 @@
+"""Unit tests for :class:`RetryMiddleware` (Tier-12 PR 12.7).
+
+Pins the contract documented in ``src/notebooklm/_middleware_retry.py`` and
+ADR-009 §"Chain ordering":
+
+- **Pass-through on success.** Single ``next_call`` invocation; result
+  returned unchanged.
+- **Retry on ``_TransportRateLimited``** up to ``rate_limit_max_retries``;
+  honor ``Retry-After`` when present, otherwise exponential backoff.
+- **Retry on ``_TransportServerError``** up to ``server_error_max_retries``;
+  exponential backoff.
+- **Disable gate**: when ``context["disable_internal_retries"]`` is truthy,
+  the first failure propagates without retry.
+- **Exhaustion**: after the budget is spent, the last exception re-raises
+  unchanged so callers
+  (``_chat_transport.chat_aware_authed_post``) see the same shape they
+  always did.
+- **Metrics**: ``rpc_rate_limit_retries`` / ``rpc_server_error_retries``
+  increment per retry (NOT for the original failed attempt — same
+  semantics as the pre-PR-12.7 legacy loop in
+  ``AuthedTransport.perform_authed_post``).
+- **Log lines** match the legacy "rate-limited (HTTP 429); sleeping (…);
+  retrying (n/N)" / "server/network error (…); backing off …; retrying
+  (n/N)" shape so log-grep alerts keep matching.
+
+Tests inject a deterministic ``sleep`` stub so backoff is observed by
+duration call, not by wall-clock wait. The stub records every sleep
+duration so tests can assert on the timing model without flakiness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
+# import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import make_request
+from notebooklm._core_metrics import ClientMetrics
+from notebooklm._core_transport import _TransportRateLimited, _TransportServerError
+from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
+from notebooklm._middleware_retry import RetryMiddleware
+
+
+def _recording_sleep() -> tuple[Callable[[float], Awaitable[None]], list[float]]:
+    """Build an async sleep stub that records every duration it's asked to wait.
+
+    Returns ``(sleep, slept)``: tests pass ``sleep`` into ``RetryMiddleware``
+    via the ``sleep=`` kwarg and assert on ``slept`` to verify the backoff
+    timing without spending wall-clock time.
+    """
+    slept: list[float] = []
+
+    async def sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    return sleep, slept
+
+
+def _rate_limited(
+    *,
+    log_label: str = "RPC LIST_NOTEBOOKS",
+    retry_after: int | None = None,
+    status: int = 429,
+) -> _TransportRateLimited:
+    """Build a ``_TransportRateLimited`` instance shaped like the leaf would raise."""
+    request = httpx.Request("POST", "https://example.test/x")
+    headers = {"retry-after": str(retry_after)} if retry_after is not None else {}
+    response = httpx.Response(status, request=request, headers=headers)
+    original = httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+    return _TransportRateLimited(
+        f"{log_label} rate-limited (HTTP {status})",
+        retry_after=retry_after,
+        response=response,
+        original=original,
+    )
+
+
+def _server_error(
+    *,
+    log_label: str = "RPC LIST_NOTEBOOKS",
+    status: int = 503,
+) -> _TransportServerError:
+    """Build a ``_TransportServerError`` instance shaped like the leaf would raise."""
+    request = httpx.Request("POST", "https://example.test/x")
+    response = httpx.Response(status, request=request)
+    original = httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+    return _TransportServerError(
+        f"{log_label} server error (HTTP {status})",
+        original=original,
+        response=response,
+        status_code=status,
+    )
+
+
+def _network_error(*, log_label: str = "RPC LIST_NOTEBOOKS") -> _TransportServerError:
+    """Build a ``_TransportServerError`` wrapping an ``httpx.RequestError``."""
+    request = httpx.Request("POST", "https://example.test/x")
+    original = httpx.RequestError("connect failed", request=request)
+    return _TransportServerError(
+        f"{log_label} network error: {original}",
+        original=original,
+    )
+
+
+def _scripted_terminal(behaviors: list[Any]) -> tuple[NextCall, list[RpcRequest]]:
+    """Build a terminal that yields each entry from ``behaviors`` per call.
+
+    Each entry is either an exception (raised) or an ``httpx.Response`` (wrapped
+    in an ``RpcResponse`` and returned). The list of received ``RpcRequest``
+    instances is exposed so tests can assert call count + per-attempt context.
+    """
+    calls: list[RpcRequest] = []
+    iterator = iter(behaviors)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        calls.append(request)
+        nxt = next(iterator)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return RpcResponse(response=nxt, context=request.context)
+
+    return terminal, calls
+
+
+# ---------------------------------------------------------------------------
+# Pass-through on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_no_retryable_failure() -> None:
+    """No retry on a clean 200 — single ``next_call`` invocation."""
+    sleep, slept = _recording_sleep()
+    terminal, calls = _scripted_terminal([httpx.Response(200, content=b"ok")])
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(calls) == 1
+    assert slept == []
+    assert response.response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 429 retry path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retries_on_429_until_success() -> None:
+    """Two 429s then success → three total terminal calls, two sleeps."""
+    sleep, slept = _recording_sleep()
+    terminal, calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            _rate_limited(retry_after=2),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(calls) == 3
+    assert slept == [1.0, 2.0]  # Retry-After values honored verbatim
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_429_without_retry_after_uses_exponential_backoff() -> None:
+    """``Retry-After`` absent → exponential backoff with min-floor."""
+    sleep, slept = _recording_sleep()
+    terminal, _calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=None),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # ``compute_backoff_delay`` with attempt=0, base=1.0 → roughly ~1s with
+    # jitter. The exact value depends on random.uniform; floor is 0.1s.
+    assert len(slept) == 1
+    assert slept[0] >= 0.1
+
+
+@pytest.mark.asyncio
+async def test_429_budget_exhausted_reraises_last_exception() -> None:
+    """After ``rate_limit_max_retries`` exhausted, the last ``_TransportRateLimited`` propagates."""
+    sleep, slept = _recording_sleep()
+    last = _rate_limited(retry_after=1)
+    terminal, calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            _rate_limited(retry_after=1),
+            last,  # 3rd attempt — exhausts budget of 2
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=2,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportRateLimited) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert excinfo.value is last
+    assert len(calls) == 3  # initial + 2 retries
+    assert slept == [1.0, 1.0]
+
+
+# ---------------------------------------------------------------------------
+# 5xx / network retry path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retries_on_503_until_success() -> None:
+    """5xx server error → retried; second attempt succeeds."""
+    sleep, slept = _recording_sleep()
+    terminal, calls = _scripted_terminal(
+        [
+            _server_error(status=503),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(calls) == 2
+    assert len(slept) == 1
+    assert slept[0] >= 0.1
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_retries_on_network_error_until_success() -> None:
+    """``httpx.RequestError`` wrapped as ``_TransportServerError`` → retried."""
+    sleep, _slept = _recording_sleep()
+    terminal, calls = _scripted_terminal(
+        [
+            _network_error(),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert len(calls) == 2
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_5xx_budget_exhausted_reraises_last_exception() -> None:
+    """After ``server_error_max_retries`` exhausted, last ``_TransportServerError`` propagates."""
+    sleep, _slept = _recording_sleep()
+    last = _server_error(status=502)
+    terminal, calls = _scripted_terminal(
+        [
+            _server_error(status=502),
+            last,
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=1,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportServerError) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is last
+    assert len(calls) == 2  # initial + 1 retry
+
+
+# ---------------------------------------------------------------------------
+# disable_internal_retries gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disable_internal_retries_skips_429_retry() -> None:
+    """When ``context["disable_internal_retries"]`` is True, 429 propagates immediately."""
+    sleep, slept = _recording_sleep()
+    boom = _rate_limited(retry_after=1)
+    terminal, calls = _scripted_terminal([boom])
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportRateLimited) as excinfo:
+        await chain(make_request(context={"disable_internal_retries": True}))
+
+    assert excinfo.value is boom
+    assert len(calls) == 1  # no retry
+    assert slept == []  # no sleep
+
+
+@pytest.mark.asyncio
+async def test_disable_internal_retries_skips_5xx_retry() -> None:
+    """When ``context["disable_internal_retries"]`` is True, 5xx propagates immediately."""
+    sleep, slept = _recording_sleep()
+    boom = _server_error(status=503)
+    terminal, calls = _scripted_terminal([boom])
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportServerError) as excinfo:
+        await chain(make_request(context={"disable_internal_retries": True}))
+
+    assert excinfo.value is boom
+    assert len(calls) == 1
+    assert slept == []
+
+
+# ---------------------------------------------------------------------------
+# Metrics emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_increment_per_429_retry() -> None:
+    """Each 429 retry increments ``rpc_rate_limit_retries`` exactly once."""
+    sleep, _slept = _recording_sleep()
+    metrics = ClientMetrics()
+    terminal, _calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            _rate_limited(retry_after=1),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+        metrics=metrics,
+    )
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    # 2 retries observed → 2 increments. The original failed attempt is NOT a
+    # "retry" — pre-PR-12.7 behavior. The third call (success) is not counted.
+    snapshot = metrics.snapshot()
+    assert snapshot.rpc_rate_limit_retries == 2
+    # 5xx retries untouched.
+    assert snapshot.rpc_server_error_retries == 0
+
+
+@pytest.mark.asyncio
+async def test_metrics_increment_per_5xx_retry() -> None:
+    """Each 5xx retry increments ``rpc_server_error_retries`` exactly once."""
+    sleep, _slept = _recording_sleep()
+    metrics = ClientMetrics()
+    terminal, _calls = _scripted_terminal(
+        [
+            _server_error(status=503),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+        metrics=metrics,
+    )
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    snapshot = metrics.snapshot()
+    assert snapshot.rpc_server_error_retries == 1
+    assert snapshot.rpc_rate_limit_retries == 0
+
+
+# ---------------------------------------------------------------------------
+# Log shape preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_retry_log_message_shape(caplog: pytest.LogCaptureFixture) -> None:
+    """The retry-info log line preserves the pre-PR-12.7 message shape.
+
+    Log-grep alerts in operator dashboards match on
+    "rate-limited (HTTP 429); sleeping (…); retrying (n/N)" — drifting
+    the message format silently breaks those alerts.
+    """
+    sleep, _slept = _recording_sleep()
+    terminal, _calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with caplog.at_level("WARNING", logger="notebooklm._core"):
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    rate_lines = [r.message for r in caplog.records if "rate-limited" in r.message]
+    assert len(rate_lines) == 1
+    msg = rate_lines[0]
+    assert "RPC LIST_NOTEBOOKS rate-limited (HTTP 429)" in msg
+    assert "sleeping (Retry-After=1s)" in msg
+    assert "retrying (1/3)" in msg
+
+
+@pytest.mark.asyncio
+async def test_5xx_retry_log_message_shape(caplog: pytest.LogCaptureFixture) -> None:
+    """The 5xx retry log line preserves the pre-PR-12.7 message shape."""
+    sleep, _slept = _recording_sleep()
+    terminal, _calls = _scripted_terminal(
+        [
+            _server_error(status=502),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with caplog.at_level("WARNING", logger="notebooklm._core"):
+        await chain(make_request(context={"log_label": "RPC GET_NOTEBOOK"}))
+
+    server_lines = [r.message for r in caplog.records if "server/network error" in r.message]
+    assert len(server_lines) == 1
+    msg = server_lines[0]
+    assert "RPC GET_NOTEBOOK server/network error (HTTP 502)" in msg
+    assert "retrying (1/3)" in msg
+
+
+# ---------------------------------------------------------------------------
+# Log-label fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_log_label_falls_back_to_sentinel(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A request without ``log_label`` admits a retry with a sentinel label.
+
+    Defensive against ``__new__``-built fixtures driving the chain raw.
+    The middleware must not raise ``KeyError`` on a missing label —
+    matches DrainMiddleware's same fallback (pinned in
+    ``test_drain_middleware.py::test_missing_log_label_falls_back_to_sentinel``).
+    """
+    sleep, _slept = _recording_sleep()
+    terminal, _calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with caplog.at_level("WARNING", logger="notebooklm._core"):
+        # context={} — no log_label
+        await chain(make_request(context={}))
+
+    rate_lines = [r.message for r in caplog.records if "rate-limited" in r.message]
+    assert len(rate_lines) == 1
+    assert "<unknown-chain-call>" in rate_lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Mixed-failure budgets are independent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_429_and_5xx_budgets_are_independent() -> None:
+    """A 429 then a 5xx then success → both retries observed; both budgets ticked."""
+    sleep, _slept = _recording_sleep()
+    metrics = ClientMetrics()
+    terminal, calls = _scripted_terminal(
+        [
+            _rate_limited(retry_after=1),
+            _server_error(status=503),
+            httpx.Response(200, content=b"ok"),
+        ]
+    )
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=1,
+        server_error_max_retries=1,
+        sleep=sleep,
+        metrics=metrics,
+    )
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert len(calls) == 3
+    assert response.response.status_code == 200
+    snapshot = metrics.snapshot()
+    assert snapshot.rpc_rate_limit_retries == 1
+    assert snapshot.rpc_server_error_retries == 1
+
+
+# ---------------------------------------------------------------------------
+# Type hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_satisfies_protocol() -> None:
+    """``RetryMiddleware`` instance is assignable to ``Middleware``."""
+    from notebooklm._middleware import Middleware
+
+    middleware: Middleware = RetryMiddleware(rate_limit_max_retries=3, server_error_max_retries=3)
+    assert callable(middleware)
+
+
+# ---------------------------------------------------------------------------
+# Non-retryable exceptions pass through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_transport_exception_propagates_without_retry() -> None:
+    """``RetryMiddleware`` only catches transport exceptions; everything else flows up.
+
+    A generic ``RuntimeError`` from a deeper middleware (e.g. drain
+    rejection) must propagate without consuming the retry budget.
+    Pre-PR-12.7 the legacy ``AuthedTransport`` loop only caught
+    ``httpx.HTTPStatusError`` / ``httpx.RequestError``; the middleware
+    only catches the two named transport-exception types so
+    ``DrainMiddleware``'s ``RuntimeError("draining…")`` still propagates.
+    """
+    sleep, slept = _recording_sleep()
+    boom = RuntimeError("not a transport error")
+    terminal, calls = _scripted_terminal([boom])
+    middleware = RetryMiddleware(
+        rate_limit_max_retries=3,
+        server_error_max_retries=3,
+        sleep=sleep,
+    )
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is boom
+    assert len(calls) == 1
+    assert slept == []


### PR DESCRIPTION
## Summary

- Adds `RetryMiddleware` (3rd of 6 per ADR-009). Interim chain: `[Drain, Metrics, Retry, ErrorInjection, Tracing]`. PR 12.8 will insert AuthRefresh between Retry and ErrorInjection.
- LIFTS the 429/5xx/network retry loops out of `AuthedTransport.perform_authed_post`. The leaf now raises `_TransportRateLimited`/`_TransportServerError` immediately on first failure; RetryMiddleware catches and retries.
- **Codex iter-1 catch**: `ErrorInjectionMiddleware` now RAISES `_TransportRateLimited` / `_TransportServerError` for 429 / 5xx modes (previously returned `RpcResponse`, so Retry never saw them). Restores ADR-009 §"ErrorInjection inside Retry — synthetic transient failures trigger retry" — broken since PR 12.6.

## Behavior preservation
- Same retry budgets, backoff timing (`base=1.0, cap=30.0, jitter_ratio=0.2`), log shapes, metrics, and exception types on exhaustion.
- Live-budget binding preserved via `lambda: self._rate_limit_max_retries` in the chain seed.
- `Retry-After` honored before falling back to exponential backoff.

## Known interim regressions (documented in code + below)
1. **Semaphore scope**: pre-PR-12.7 the leaf's RPC semaphore wrapped the FULL retry budget. Now each retry releases the slot during backoff and re-acquires. Smoothing is now per-attempt, not per-call. Auth-refresh-once loop still benefits from whole-loop scope. ADR-009 trade-off; chain-level semaphore is a viable follow-up.
2. **Auth-refresh counter**: pre-PR-12.7 `refreshed_this_call` lived in the same loop as 429/5xx retries (one refresh max per call). Now each RetryMiddleware retry is a fresh leaf invocation with its own `refreshed_this_call`, so up to N refreshes per call (bounded by retry budget). PR 12.8 collapses this back by lifting auth-refresh into a chain middleware.

## Polish receipts (per /execute-task SKILL.md)

| Stage | Result |
|---|---|
| 4.1 simplifier | Dropped `cast` import + inlined `isinstance` narrowing in `_core_transport.py` |
| 4.2 gemini | LGTM. 2 [Important] both by-plan-design, 3 nits |
| 4.2 claude | 0 [Critical], 3 [Important] (semaphore + auth-refresh interim + exception-message drift), 6 nits. Addressed via leaf docstring expansion + log shape verified verbatim |
| 4.2 codex | 0 [Critical], 3 [Important] — caught the **load-bearing bug** that ErrorInjectionMiddleware returned synthetic 429/500 as response (Retry never saw them). Fixed by raising the proper transport exceptions for 429/5xx |
| 4.3 ultrathink | Triple-review convergence caught codex's load-bearing finding; 2 remaining interim regressions documented |

## Test plan

- [x] ruff format/check: clean
- [x] mypy `src/notebooklm`: 132 source files, 0 errors
- [x] `pytest -n auto tests/unit`: 4742 passed (+24 new tests)
- [x] `pytest -n auto tests/integration`: 674 passed
- [ ] CI green
- [ ] Bot reviews addressed
- [ ] `mergeStateStatus` CLEAN

## Follow-ups
- **PR 12.8** restores auth-refresh-once contract by lifting auth-refresh out of the leaf into AuthRefreshMiddleware
- **Post-Tier-12** chain-level semaphore primitive (or move gate above RetryMiddleware) to restore full-retry-budget backpressure smoothing
- **PR 12.9** cleanup pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry behavior added for rate-limited (429) and server/network errors with Retry-After and exponential backoff support.

* **Bug Fixes**
  * Error-injection now surfaces retryable failures so retries behave consistently; transport-level no longer performs hidden retry loops.

* **Tests**
  * Comprehensive tests added and updated to validate retry logic, ordering, and metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->