### PR TITLE
feat(core): extract AuthRefreshMiddleware — final ADR-009 chain ordering (Tier-12 PR 12.8)

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -111,6 +111,7 @@ from ._middleware import (
     RpcResponse,
     build_chain,
 )
+from ._middleware_auth_refresh import AuthRefreshMiddleware
 from ._middleware_drain import DrainMiddleware
 from ._middleware_error_injection import ErrorInjectionMiddleware
 from ._middleware_metrics import MetricsMiddleware
@@ -471,32 +472,35 @@ class ClientCore:
         # PR 12.3 added ``TracingMiddleware`` (innermost), PR 12.4 prepended
         # ``MetricsMiddleware``, PR 12.5 prepended ``DrainMiddleware``
         # outermost, PR 12.6 inserted ``ErrorInjectionMiddleware`` between
-        # ``MetricsMiddleware`` and ``TracingMiddleware``, and PR 12.7
-        # inserts ``RetryMiddleware`` between ``MetricsMiddleware`` and
-        # ``ErrorInjectionMiddleware`` so the list now reads
-        # ``[Drain, Metrics, Retry, ErrorInjection, Tracing]``. PR 12.8
-        # inserts ``AuthRefreshMiddleware`` BETWEEN ``RetryMiddleware`` and
-        # ``ErrorInjectionMiddleware`` so the final list reads
+        # ``MetricsMiddleware`` and ``TracingMiddleware``, PR 12.7
+        # inserted ``RetryMiddleware`` between ``MetricsMiddleware`` and
+        # ``ErrorInjectionMiddleware``, and PR 12.8 inserts
+        # ``AuthRefreshMiddleware`` BETWEEN ``RetryMiddleware`` and
+        # ``ErrorInjectionMiddleware`` so the list now reads the
+        # **final** ADR-009 ordering
         # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
-        # (outermost → innermost, per ADR-009 §"Chain ordering"). ``build_chain``
-        # composes the leftmost entry as the outermost wrapper, so keeping
-        # ``TracingMiddleware`` at the RIGHT end of the list preserves
-        # Tracing as the innermost wrapper as later PRs grow the list.
+        # (outermost → innermost). ``build_chain`` composes the leftmost
+        # entry as the outermost wrapper, so keeping ``TracingMiddleware``
+        # at the RIGHT end of the list preserves Tracing as the innermost
+        # wrapper.
         #
-        # PR 12.7 also LIFTS the 429 / 5xx retry loops out of
-        # ``AuthedTransport.perform_authed_post`` (the chain leaf) and into
-        # ``RetryMiddleware``. The leaf now raises
-        # ``_TransportRateLimited`` / ``_TransportServerError`` immediately
-        # on the first 429 / 5xx, and ``RetryMiddleware`` catches those
-        # exceptions and re-invokes the chain. Auth-refresh stays in the
-        # leaf as a localized loop until PR 12.8 lifts it.
+        # PR 12.7 lifted the 429 / 5xx retry loops out of the leaf into
+        # ``RetryMiddleware``; PR 12.8 lifts the auth-refresh-once retry
+        # too. After PR 12.8 the leaf is a *pure* POST — every retry
+        # decision happens in the chain. The leaf still raises
+        # ``_TransportRateLimited`` / ``_TransportServerError`` for
+        # 429 / 5xx so ``RetryMiddleware`` can catch; raw
+        # ``httpx.HTTPStatusError`` (400/401/403) propagates so
+        # ``AuthRefreshMiddleware`` can catch via ``is_auth_error`` and
+        # drive refresh-then-retry.
         #
         # The terminal adapter reads ``build_request`` / ``log_label`` /
         # ``disable_internal_retries`` from ``RpcRequest.context`` and
         # delegates to ``self._get_authed_transport().perform_authed_post``.
         # ``RetryMiddleware`` reads ``log_label`` /
-        # ``disable_internal_retries`` from the same ``context`` dict. See
-        # ADR-009 §"Per-request behavior" and
+        # ``disable_internal_retries`` from the same ``context`` dict.
+        # ``AuthRefreshMiddleware`` reads ``log_label``. See ADR-009
+        # §"Per-request behavior" and
         # ``.sisyphus/plans/tier-12-13-greenfield-migration.md`` line 160.
         self._middlewares: list[Middleware] = [
             DrainMiddleware(self._drain_tracker),
@@ -510,6 +514,31 @@ class ClientCore:
             RetryMiddleware(
                 rate_limit_max_retries=lambda: self._rate_limit_max_retries,
                 server_error_max_retries=lambda: self._server_error_max_retries,
+                metrics=self._metrics_obj,
+            ),
+            # AuthRefresh callbacks: refresh_callable invokes the same
+            # ``_await_refresh`` path the leaf used pre-PR-12.8, so the
+            # coalesced single-flight refresh contract from
+            # ``AuthRefreshCoordinator`` is preserved end-to-end.
+            # ``refresh_callback_enabled`` reads the coordinator's
+            # internal callback slot to skip refresh when no callback was
+            # configured (matches the legacy
+            # ``host._refresh_callback is not None`` gate in the leaf).
+            # ``refresh_retry_delay`` is callable for live-binding parity
+            # with retry budgets.
+            AuthRefreshMiddleware(
+                refresh_callable=self._await_refresh,
+                # Resolve through the live module name at call time so
+                # ``monkeypatch.setattr("notebooklm._core.is_auth_error",
+                # ...)`` reaches the chain. Python function-body name
+                # lookup hits the module dict on each call, so this
+                # lambda is already late-bound — a value-import would
+                # freeze the binding at chain-construction time, but this
+                # idiom doesn't (codex iter-1 nit on PR 12.8: simpler
+                # than the prior ``globals()["is_auth_error"]`` indirection).
+                is_auth_error=lambda exc: is_auth_error(exc),
+                refresh_callback_enabled=lambda: self._auth_coord._refresh_callback is not None,
+                refresh_retry_delay=lambda: self._refresh_retry_delay,
                 metrics=self._metrics_obj,
             ),
             ErrorInjectionMiddleware(),
@@ -879,8 +908,9 @@ class ClientCore:
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
         constructed (``[DrainMiddleware, MetricsMiddleware, RetryMiddleware,
-        ErrorInjectionMiddleware, TracingMiddleware]``-seeded chain around
-        the terminal adapter, matching the seed in ``__init__``).
+        AuthRefreshMiddleware, ErrorInjectionMiddleware, TracingMiddleware]``-seeded
+        chain around the terminal adapter, matching the seed in
+        ``__init__``).
 
         Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
         :meth:`_ensure_observability_state` is — two threads observing
@@ -904,40 +934,46 @@ class ClientCore:
             if hasattr(self, "_authed_post_chain"):
                 return
             if not hasattr(self, "_middlewares"):
-                # Mirror ``__init__``'s seeded chain: PR 12.3 lands
-                # ``TracingMiddleware`` as the innermost entry, PR 12.4
-                # prepends ``MetricsMiddleware``, PR 12.5 prepends
-                # ``DrainMiddleware`` outermost, PR 12.6 inserts
-                # ``ErrorInjectionMiddleware`` just outside
-                # ``TracingMiddleware``, and PR 12.7 inserts
-                # ``RetryMiddleware`` between ``MetricsMiddleware`` and
-                # ``ErrorInjectionMiddleware``. A ``__new__``-built fixture
-                # must see the same chain shape so the three observability
-                # channels (drain admission, RPC counters/events,
-                # structured trace logs), the retry-on-429/5xx loop, and
-                # the fault-injection short-circuit (active only when
-                # ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set) are all
-                # exercised on fixture-driven invocations too; otherwise
-                # the fixture path and the live path diverge, which has
-                # previously hidden bugs in Tier-8 cassette-replay tests.
+                # Mirror ``__init__``'s seeded chain. PR 12.8 lands the
+                # **final** ADR-009 ordering [Drain, Metrics, Retry,
+                # AuthRefresh, ErrorInjection, Tracing]. A ``__new__``-built
+                # fixture must see the same chain shape so all four chain
+                # behaviors (drain admission, retry on 429/5xx,
+                # refresh-and-retry on 4xx auth shapes, synthetic-error
+                # short-circuit) are exercised on fixture-driven
+                # invocations too — otherwise the fixture path and the
+                # live path diverge, which has previously hidden bugs in
+                # Tier-8 cassette-replay tests.
                 #
-                # ``getattr`` defaults for the retry budgets match
-                # ``__init__``'s default values so a ``__new__``-built
-                # fixture that didn't set them still gets a sane
-                # ``RetryMiddleware``.
+                # ``getattr`` defaults match ``__init__``'s argument
+                # defaults so a ``__new__``-built fixture that never set
+                # the attrs still gets sane middleware instances.
+                # ``_ensure_auth_coord`` initializes ``_auth_coord`` so the
+                # ``refresh_callback_enabled`` lambda can read it.
+                self._ensure_auth_coord()
                 self._middlewares = [
                     DrainMiddleware(self._drain_tracker),
                     MetricsMiddleware(self._metrics_obj),
-                    # Callable budgets preserve live-binding (see ``__init__``
-                    # for the rationale). ``getattr`` defaults match
-                    # ``__init__``'s argument defaults so a ``__new__``-built
-                    # fixture that never set the attrs still gets a sane
-                    # ``RetryMiddleware``.
                     RetryMiddleware(
                         rate_limit_max_retries=lambda: getattr(self, "_rate_limit_max_retries", 3),
                         server_error_max_retries=lambda: getattr(
                             self, "_server_error_max_retries", 3
                         ),
+                        metrics=self._metrics_obj,
+                    ),
+                    AuthRefreshMiddleware(
+                        refresh_callable=self._await_refresh,
+                        # Resolve through the module's globals at call time so a
+                        # ``monkeypatch.setattr("notebooklm._core.is_auth_error",
+                        # ...)`` reaches the chain. A value-import would freeze
+                        # the binding at chain-construction time. ``globals()``
+                        # reads the live module dict, so the patched value is
+                        # observed on each call.
+                        is_auth_error=lambda exc: globals()["is_auth_error"](exc),
+                        refresh_callback_enabled=lambda: (
+                            self._auth_coord._refresh_callback is not None
+                        ),
+                        refresh_retry_delay=lambda: getattr(self, "_refresh_retry_delay", 0.0),
                         metrics=self._metrics_obj,
                     ),
                     ErrorInjectionMiddleware(),

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -963,17 +963,24 @@ class ClientCore:
                     ),
                     AuthRefreshMiddleware(
                         refresh_callable=self._await_refresh,
-                        # Resolve through the module's globals at call time so a
+                        # Resolve through the live module name at call time so
                         # ``monkeypatch.setattr("notebooklm._core.is_auth_error",
-                        # ...)`` reaches the chain. A value-import would freeze
-                        # the binding at chain-construction time. ``globals()``
-                        # reads the live module dict, so the patched value is
-                        # observed on each call.
-                        is_auth_error=lambda exc: globals()["is_auth_error"](exc),
+                        # ...)`` reaches the chain. Python function-body name
+                        # lookup hits the module dict on each call, so this
+                        # lambda is already late-bound — a value-import would
+                        # freeze the binding at chain-construction time, but
+                        # this idiom doesn't. Kept identical to the ``__init__``
+                        # site (codex iter-1 nit on PR 12.8: simpler than the
+                        # prior ``globals()["is_auth_error"]`` indirection).
+                        is_auth_error=lambda exc: is_auth_error(exc),
                         refresh_callback_enabled=lambda: (
                             self._auth_coord._refresh_callback is not None
                         ),
-                        refresh_retry_delay=lambda: getattr(self, "_refresh_retry_delay", 0.0),
+                        # ``getattr`` default matches ``__init__``'s argument
+                        # default (``refresh_retry_delay: float = 0.2``) so a
+                        # ``__new__``-built fixture that never set this attr
+                        # sees the same post-refresh sleep as the normal path.
+                        refresh_retry_delay=lambda: getattr(self, "_refresh_retry_delay", 0.2),
                         metrics=self._metrics_obj,
                     ),
                     ErrorInjectionMiddleware(),

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -268,130 +268,100 @@ class AuthedTransport:
                 "Each client is per-loop; create a new client in the target loop."
             )
 
-        refreshed_this_call = False
         start = time.perf_counter()
 
         # ---------------------------------------------------------------
         # Semaphore placement contract — DO NOT MOVE.
         #
-        # The semaphore wraps the entire auth-refresh-and-retry loop (and
-        # in turn sits INSIDE the chain's ``RetryMiddleware`` retry loop,
-        # because the chain entered before this leaf was called).
-        # Releasing during backoff would let new callers burst in just as
-        # the current cohort wakes up, undoing the smoothing the semaphore
-        # exists to provide.
+        # The semaphore wraps the single POST attempt this leaf makes.
+        # ``RetryMiddleware`` (outside this leaf) re-invokes the chain on
+        # 429 / 5xx and ``AuthRefreshMiddleware`` (also outside this leaf,
+        # PR 12.8) re-invokes the chain after a successful refresh. Each
+        # retry re-enters here and re-acquires the semaphore — so one slot
+        # is held per *HTTP attempt*, not per *logical RPC*.
         #
-        # **Backpressure-scope regression (PR 12.7 → 12.8 follow-up).**
-        # Before PR 12.7, this semaphore wrapped the FULL retry budget
-        # (initial attempt + all 429 / 5xx retries). After PR 12.7, the
-        # 429 / 5xx retry loop lives in ``RetryMiddleware`` OUTSIDE this
-        # semaphore — each retry re-enters the chain, releases the slot
-        # during ``RetryMiddleware``'s backoff sleep, and re-acquires on
-        # the next attempt. Under bursty rate-limit fan-out this means the
-        # smoothing the semaphore previously provided across the full
-        # retry budget is now coarser (per-attempt, not per-call). The
-        # auth-refresh-once loop here still benefits from the old
-        # whole-loop scope.
-        #
-        # The plan acknowledges this as an interim consequence of the
-        # chain ordering ``[Drain, Metrics, Retry, AuthRefresh,
-        # ErrorInjection, Tracing]``. A chain-level semaphore primitive
-        # (or moving the gate above ``RetryMiddleware``) is a viable
-        # follow-up; PR 12.7 ships the regression so the load-bearing
-        # lift can land. ADR-009 §"Chain ordering rationale" should
-        # eventually reflect this trade-off.
+        # **Backpressure-scope regression (Tier-12 PRs 12.7 / 12.8 →
+        # follow-up).** Before PR 12.7, this semaphore wrapped the FULL
+        # retry budget (initial + all 429/5xx retries + the
+        # auth-refresh-once retry); PR 12.7 lifted 429/5xx retry into
+        # ``RetryMiddleware`` outside the semaphore; PR 12.8 lifts the
+        # auth-refresh retry too. So the smoothing the semaphore
+        # previously provided across the full retry budget is now
+        # coarser (per-attempt, not per-call). The plan acknowledges
+        # this as an interim consequence of the chain ordering
+        # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection,
+        # Tracing]``. A chain-level semaphore primitive (or moving the
+        # gate above ``RetryMiddleware``) is a viable follow-up;
+        # PR 12.8 ships the regression so the load-bearing lift can
+        # land. ADR-009 §"Chain ordering rationale" should eventually
+        # reflect this trade-off.
         # ---------------------------------------------------------------
         semaphore = host._get_rpc_semaphore()
         queue_wait_start = time.perf_counter()
         async with semaphore:
             host._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
-            # PR 12.7: the only retry this loop now drives is the
-            # auth-refresh-once retry. 429 and 5xx/network failures raise
-            # ``_TransportRateLimited`` / ``_TransportServerError``
-            # immediately so :class:`RetryMiddleware` (chain-level, sitting
-            # OUTSIDE this leaf) can decide whether to retry. ``raise from
-            # exc`` preserves the chained transport exception for
-            # diagnostic display.
-            while True:
-                snapshot = await host._snapshot()
-                url, body, headers = build_request(snapshot)
+            # PR 12.8: the leaf is now a pure POST. 429 and 5xx/network
+            # failures still raise ``_TransportRateLimited`` /
+            # ``_TransportServerError`` so :class:`RetryMiddleware`
+            # (outside this leaf) decides whether to retry; raw
+            # ``httpx.HTTPStatusError`` (e.g. 400 / 401 / 403)
+            # propagates so :class:`AuthRefreshMiddleware` (also outside
+            # this leaf) can catch it via ``is_auth_error`` and drive
+            # refresh-then-retry. ``raise from exc`` preserves the
+            # chained transport exception for diagnostic display.
+            snapshot = await host._snapshot()
+            url, body, headers = build_request(snapshot)
 
-                try:
-                    # Streaming POST with a running size cap. The size guard
-                    # lives inside the stream-read loop in
-                    # ``_stream_post_with_size_cap``; ``raise_for_status()`` is
-                    # invoked before any body chunk is read so the
-                    # auth-refresh branch below + the 429 / 5xx exception
-                    # raisers fire with the same :class:`httpx.HTTPStatusError`
-                    # they did when this used ``client.post``.
-                    response = await _stream_post_with_size_cap(
-                        client,
-                        url,
-                        body=body,
-                        headers=headers,
-                    )
-                except (httpx.HTTPStatusError, httpx.RequestError) as exc:
-                    # --- Auth refresh path (stays here until PR 12.8) -------
-                    if (
-                        not refreshed_this_call
-                        and host._refresh_callback is not None
-                        and self._is_auth_error(exc)
-                    ):
-                        self._logger.info(
-                            "%s auth error detected, attempting token refresh",
-                            log_label,
-                        )
-                        try:
-                            await host._await_refresh()
-                        except Exception as refresh_error:
-                            self._logger.warning("Token refresh failed: %s", refresh_error)
-                            raise _TransportAuthExpired(
-                                f"auth refresh failed for {log_label}",
-                                original=exc,
-                            ) from refresh_error
-                        if host._refresh_retry_delay > 0:
-                            await self._sleep(host._refresh_retry_delay)
-                        self._logger.info("Token refresh successful, retrying %s", log_label)
-                        refreshed_this_call = True
-                        host._increment_metrics(rpc_auth_retries=1)
-                        continue
+            try:
+                # Streaming POST with a running size cap. The size guard
+                # lives inside the stream-read loop in
+                # ``_stream_post_with_size_cap``; ``raise_for_status()``
+                # is invoked before any body chunk is read so the chain
+                # middlewares see the same :class:`httpx.HTTPStatusError`
+                # they did when this used ``client.post``.
+                response = await _stream_post_with_size_cap(
+                    client,
+                    url,
+                    body=body,
+                    headers=headers,
+                )
+            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+                # --- 429: raise for ``RetryMiddleware`` to catch --------
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
+                    retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+                    raise _TransportRateLimited(
+                        f"{log_label} rate-limited (HTTP 429)",
+                        retry_after=retry_after,
+                        response=exc.response,
+                        original=exc,
+                    ) from exc
 
-                    # --- 429: raise for the chain RetryMiddleware to catch --
-                    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
-                        retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
-                        raise _TransportRateLimited(
-                            f"{log_label} rate-limited (HTTP 429)",
-                            retry_after=retry_after,
-                            response=exc.response,
-                            original=exc,
-                        ) from exc
+                # --- 5xx / network: raise for ``RetryMiddleware`` -------
+                if isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600:
+                    raise _TransportServerError(
+                        f"{log_label} server error (HTTP {exc.response.status_code})",
+                        original=exc,
+                        response=exc.response,
+                        status_code=exc.response.status_code,
+                    ) from exc
+                if isinstance(exc, httpx.RequestError):
+                    raise _TransportServerError(
+                        f"{log_label} network error: {exc}",
+                        original=exc,
+                    ) from exc
 
-                    # --- 5xx / network: raise for RetryMiddleware to catch --
-                    if (
-                        isinstance(exc, httpx.HTTPStatusError)
-                        and 500 <= exc.response.status_code < 600
-                    ):
-                        raise _TransportServerError(
-                            f"{log_label} server error (HTTP {exc.response.status_code})",
-                            original=exc,
-                            response=exc.response,
-                            status_code=exc.response.status_code,
-                        ) from exc
-                    if isinstance(exc, httpx.RequestError):
-                        raise _TransportServerError(
-                            f"{log_label} network error: {exc}",
-                            original=exc,
-                        ) from exc
+                # --- 4xx auth shapes (400/401/403) and everything else:
+                # propagate the raw ``httpx.HTTPStatusError`` so
+                # ``AuthRefreshMiddleware`` outside this leaf decides
+                # whether to refresh-and-retry via ``is_auth_error``.
+                elapsed = time.perf_counter() - start
+                self._logger.debug(
+                    "%s transport error after %.3fs: %s",
+                    log_label,
+                    elapsed,
+                    exc,
+                )
+                raise
 
-                    # --- Anything else: propagate the raw transport error ----
-                    elapsed = time.perf_counter() - start
-                    self._logger.debug(
-                        "%s transport error after %.3fs: %s",
-                        log_label,
-                        elapsed,
-                        exc,
-                    )
-                    raise
-
-                # Success
-                return response
+            # Success
+            return response

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -1,0 +1,236 @@
+"""AuthRefreshMiddleware — 401/403/400-CSRF retry-with-refresh for the chain.
+
+Per ADR-009 §"Chain ordering", ``AuthRefreshMiddleware`` sits just *inside*
+``RetryMiddleware`` and just *outside* ``ErrorInjectionMiddleware``. The final
+Tier-12 chain is
+``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` — PR 12.8
+inserts ``AuthRefresh`` between ``Retry`` and ``ErrorInjection`` so this
+ordering is now realized end-to-end.
+
+This PR lifts the **auth-refresh-once retry** loop out of
+``AuthedTransport.perform_authed_post`` (the chain leaf). After PR 12.8 the
+leaf is a *pure* POST that lets ``httpx.HTTPStatusError`` /
+``httpx.RequestError`` propagate raw for auth errors (the 429 / 5xx
+exception-raisers stay since they feed ``RetryMiddleware``). The middleware
+catches the raw auth-error ``httpx.HTTPStatusError``, triggers a coalesced
+refresh via :class:`AuthRefreshCoordinator`, then re-invokes ``next_call``
+exactly once.
+
+Why "exactly once": ADR-009 §"Retry semantics" pins
+"**exactly one** retry per ``next_call`` invocation. If the retry also
+raises 401, the exception propagates — no second retry, no recursion."
+``RetryMiddleware`` outside this middleware does NOT retry on auth
+errors (it catches only ``_TransportRateLimited`` /
+``_TransportServerError``), so a persistent 401 surfaces cleanly to the
+caller without burning the rate-limit / server-error budget on auth
+loops.
+
+Refresh-failure path: if the refresh callback itself raises (network
+flake, login expired, etc.), the middleware wraps the original
+``httpx.HTTPStatusError`` in :class:`_TransportAuthExpired` so callers
+that key on the transport exception type still see a coherent shape.
+Matches the pre-PR-12.8 leaf-side ``_TransportAuthExpired`` raise.
+
+Pre-refresh sleep: when ``refresh_retry_delay > 0`` the middleware sleeps
+that duration AFTER the successful refresh and BEFORE the retry. Matches
+the legacy ``AuthedTransport`` behavior so a cassette that recorded the
+post-refresh delay replays the same timing.
+
+Why this PR does NOT use ADR-009's pinned ``rebuild_headers`` /
+``build_request_factory`` closure callbacks (yet): the chain envelope
+(``RpcRequest.url`` / ``.headers`` / ``.body``) is still empty in
+production — the chain leaf builds the HTTP request from
+``context["build_request"]`` on each invocation. So a simple
+``await next_call(request)`` on the unchanged ``RpcRequest`` envelope is
+sufficient: the leaf re-snapshots auth state via
+``AuthRefreshCoordinator.snapshot`` (which sees the refreshed tokens)
+and re-builds headers + body. The full closure-callback contract from
+ADR-009 §"AuthRefreshMiddleware constructor signature" activates in PR
+13.x when the chain envelope carries url/headers/body and the leaf
+shrinks to a pure ``Kernel.post``-shaped seam.
+
+This regression-fix from PR 12.7 also closes here: pre-PR-12.7 the leaf's
+``refreshed_this_call`` lived in the same loop as 429/5xx retries (one
+refresh max per logical call). PR 12.7 split the loops, leaving each
+``RetryMiddleware`` retry to spawn a fresh leaf invocation with its own
+``refreshed_this_call`` — up to N refreshes per call. PR 12.8 collapses
+this back: refresh is now a chain-level concern, ``RetryMiddleware`` is
+unaware of refreshes, and the once-per-call contract is restored by the
+fact that ``AuthRefreshMiddleware`` only retries ONCE per ``next_call``
+invocation.
+
+See ``docs/adr/0009-middleware-chain.md`` for the chain contract,
+``src/notebooklm/_core_auth.py`` for :class:`AuthRefreshCoordinator`
+(coalesced refresh + auth-snapshot lock), and
+``.sisyphus/plans/tier-12-13-greenfield-migration.md`` row 12.8 for the
+PR sequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+import httpx
+
+from ._core_transport import _TransportAuthExpired
+from ._middleware import NextCall, RpcRequest, RpcResponse
+
+if TYPE_CHECKING:
+    from ._core_metrics import ClientMetrics
+
+
+class AuthRefreshMiddleware:
+    """Chain middleware that retries authed POSTs once after refreshing tokens.
+
+    Conforms to :class:`notebooklm._middleware.Middleware` — ``__call__``
+    matches the Protocol so instances are assignable into a
+    ``Sequence[Middleware]``.
+
+    Constructor inputs (all wired by ``ClientCore.__init__``):
+
+    - ``refresh_callable``: a zero-arg async callable that drives one
+      coalesced auth refresh. Production wires
+      ``lambda: ClientCore._await_refresh(self)`` which delegates to
+      :meth:`AuthRefreshCoordinator.await_refresh`. The middleware never
+      reaches into the coordinator directly; this keeps the seam thin
+      and testable.
+    - ``is_auth_error``: predicate that decides whether an exception is
+      an auth failure (HTTP 400 / 401 / 403). Production wires
+      :func:`notebooklm._core_helpers.is_auth_error` through a lambda
+      that resolves it via ``notebooklm._core``'s module globals at
+      call time, so ``monkeypatch.setattr("notebooklm._core.is_auth_error",
+      ...)`` reaches the chain live; tests that build the middleware
+      directly typically pass the function itself.
+    - ``refresh_callback_enabled``: a zero-arg callable returning ``True``
+      iff a refresh callback is wired on the host. Production wires
+      ``lambda: self._auth_coord._refresh_callback is not None`` so a
+      client built without ``refresh_callback`` skips the refresh path
+      entirely (matches the legacy leaf gate on
+      ``host._refresh_callback is not None``).
+    - ``refresh_retry_delay``: zero-arg callable returning the
+      post-refresh sleep duration. Production wires
+      ``lambda: self._refresh_retry_delay`` so a test that mutates the
+      attr on the live client still takes effect (matches the live-binding
+      contract preserved for retry budgets in PR 12.7).
+    - ``sleep``: optional sleep injection (defaults to :func:`asyncio.sleep`
+      resolved at call time). Same lazy-resolve pattern as
+      :class:`RetryMiddleware`.
+    - ``logger``: structured logger for the "auth error detected" /
+      "refresh successful" / "refresh failed" info / warning lines.
+      Defaults to the project-canonical ``notebooklm._core`` logger so
+      ``caplog.at_level(..., logger="notebooklm._core")`` keeps matching.
+    - ``metrics``: a :class:`ClientMetrics` whose ``increment(...)`` is
+      called once per successful refresh (matches the legacy
+      ``host._increment_metrics(rpc_auth_retries=1)`` site).
+    """
+
+    def __init__(
+        self,
+        *,
+        refresh_callable: Callable[[], Awaitable[None]],
+        is_auth_error: Callable[[Exception], bool],
+        refresh_callback_enabled: Callable[[], bool],
+        refresh_retry_delay: Callable[[], float],
+        sleep: Callable[[float], Awaitable[object]] | None = None,
+        logger: logging.Logger | None = None,
+        metrics: ClientMetrics | None = None,
+    ) -> None:
+        self._refresh_callable = refresh_callable
+        self._is_auth_error = is_auth_error
+        self._refresh_callback_enabled = refresh_callback_enabled
+        self._refresh_retry_delay = refresh_retry_delay
+        # See ``RetryMiddleware._resolve_sleep`` for the lazy-binding rationale.
+        self._sleep = sleep
+        self._logger = logger or logging.getLogger("notebooklm._core")
+        self._metrics = metrics
+
+    def _resolve_sleep(self) -> Callable[[float], Awaitable[object]]:
+        return self._sleep if self._sleep is not None else asyncio.sleep
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        """Catch auth-error ``HTTPStatusError``, refresh, retry exactly once.
+
+        Reads ``log_label`` from ``request.context`` for log lines (defensive
+        sentinel fallback matches DrainMiddleware / RetryMiddleware /
+        ErrorInjectionMiddleware).
+
+        Tracks ``context["auth_refreshed"]`` to enforce **at most one
+        refresh per logical call** even when ``RetryMiddleware`` (outside
+        this middleware) re-invokes the chain on a 429/5xx that fires
+        after a successful refresh. Without this flag the sequence
+        ``401 → refresh → 429 → Retry retry → 401`` would refresh twice
+        (codex iter-1 catch on PR 12.8). With it, the second 401
+        propagates without a redundant refresh, matching the pre-PR-12.7
+        "one refresh max per logical call" contract.
+
+        Pass-through paths:
+        - No refresh callback configured → propagate any exception unchanged.
+        - Exception is not an auth error → propagate.
+        - Refresh already done for this logical call → propagate.
+        - First ``next_call`` raises something non-``HTTPStatusError`` → propagate.
+
+        Refresh-and-retry path:
+        1. ``next_call`` raises ``httpx.HTTPStatusError`` AND
+           ``is_auth_error(exc)`` returns True AND no prior refresh.
+        2. Call ``refresh_callable()`` (coalesced single-flight via
+           :class:`AuthRefreshCoordinator`).
+        3. Mark ``context["auth_refreshed"] = True`` on success.
+        4. If the refresh callable itself raises, wrap in
+           ``_TransportAuthExpired(original=exc)`` and propagate.
+        5. Optional post-refresh sleep (``refresh_retry_delay``).
+        6. Increment ``rpc_auth_retries`` metric.
+        7. Re-invoke ``next_call(request)`` — exactly once. If the retry
+           also raises, propagate unchanged (no second refresh,
+           no recursion).
+        """
+        log_label = request.context.get("log_label", "<unknown-chain-call>")
+        try:
+            return await next_call(request)
+        except httpx.HTTPStatusError as exc:
+            if (
+                not self._refresh_callback_enabled()
+                or not self._is_auth_error(exc)
+                or request.context.get("auth_refreshed")
+            ):
+                raise
+
+            self._logger.info(
+                "%s auth error detected, attempting token refresh",
+                log_label,
+            )
+            try:
+                await self._refresh_callable()
+            except Exception as refresh_error:
+                self._logger.warning("Token refresh failed: %s", refresh_error)
+                raise _TransportAuthExpired(
+                    f"auth refresh failed for {log_label}",
+                    original=exc,
+                ) from refresh_error
+
+            # Mark BEFORE the retry so a 429 thrown by the retry then
+            # caught by ``RetryMiddleware`` (outside us) doesn't trigger
+            # a second refresh when it re-enters our chain leg.
+            request.context["auth_refreshed"] = True
+
+            delay = self._refresh_retry_delay()
+            if delay > 0:
+                await self._resolve_sleep()(delay)
+            self._logger.info("Token refresh successful, retrying %s", log_label)
+            if self._metrics is not None:
+                self._metrics.increment(rpc_auth_retries=1)
+
+            # Exactly one retry. If this raises (auth or otherwise), the
+            # exception propagates — the outer caller decides what to do
+            # (chat error mapping, RetryMiddleware does NOT catch auth
+            # errors so a persistent 401 won't burn its budget).
+            return await next_call(request)
+
+
+__all__ = ["AuthRefreshMiddleware"]

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -37,12 +37,15 @@ Behavior contract:
   ``Retry-After`` header so the retry honors the rate-limit timing.
 - Env var set, mode ``"5xx"`` → raise :class:`_TransportServerError` so
   ``RetryMiddleware`` retries with exponential backoff.
-- Env var set, mode ``"expired_csrf"`` (HTTP 400) → return the synthetic
-  response unchanged. ``RetryMiddleware`` does not retry on 400; PR 12.8
-  ``AuthRefreshMiddleware`` will intercept and drive the refresh-then-retry
-  flow that the legacy leaf used to handle inline. Until 12.8 lands, the
-  400 propagates as a returned response and chat-domain mapping surfaces
-  it as a generic error (matches the PR-12.6 interim behavior).
+- Env var set, mode ``"expired_csrf"`` (HTTP 400) → raise the raw
+  :class:`httpx.HTTPStatusError` so ``AuthRefreshMiddleware`` (outside
+  this middleware in the final chain ordering) catches it via
+  ``is_auth_error`` and drives the refresh-then-retry flow. Pre-PR-12.6
+  this happened naturally because the legacy ``_SyntheticErrorTransport``
+  returned the synthetic 400 below httpx, the leaf's ``raise_for_status``
+  lifted it into an ``HTTPStatusError``, and the leaf's auth-refresh
+  branch handled it. PR 12.8 restores that end-to-end (codex iter-1
+  catch on PR 12.8).
 
 All raised exceptions wrap a synthetic :class:`httpx.Response` anchored to
 ``request.url`` / ``request.headers`` / ``request.body`` so callers
@@ -158,22 +161,23 @@ class ErrorInjectionMiddleware:
             content=body,
             request=synthetic_request,
         )
-        # PR 12.7: raise the proper transport exception for 429 / 5xx so the
-        # OUTER ``RetryMiddleware`` actually retries — restoring ADR-009
-        # §"ErrorInjection inside Retry — synthetic transient failures trigger
-        # retry". Pre-PR-12.6 this happened naturally because the legacy
-        # ``_SyntheticErrorTransport`` returned the synthetic response below
-        # httpx and ``AuthedTransport``'s ``raise_for_status()`` lifted it
-        # into an ``HTTPStatusError`` that the leaf's 429 / 5xx branches
-        # mapped to these same transport exceptions. Returning a plain
-        # ``RpcResponse`` here would skip retry entirely (codex iter-1 catch).
-        #
-        # For the ``expired_csrf`` (400) mode we still return the synthetic
-        # response — PR 12.8 (AuthRefreshMiddleware) will intercept it and
-        # drive the refresh-then-retry flow that the legacy leaf used to
-        # handle inline. Until 12.8 lands, the 400 propagates as a returned
-        # response and the chat-domain mapping surfaces it as a generic
-        # error (matches the PR-12.6 interim behavior for that mode).
+        # Raise the proper exception for each mode so the OUTER chain
+        # middlewares actually fire — restoring ADR-009 §"Chain ordering
+        # rationale" end-to-end:
+        # - 429 → ``_TransportRateLimited`` → ``RetryMiddleware`` retries
+        #   with Retry-After or exponential backoff
+        # - 5xx → ``_TransportServerError`` → ``RetryMiddleware`` retries
+        #   with exponential backoff
+        # - 400 / expired_csrf → raw ``httpx.HTTPStatusError`` →
+        #   ``AuthRefreshMiddleware`` catches via ``is_auth_error``,
+        #   refreshes, retries once (PR 12.8). Pre-PR-12.6 this happened
+        #   naturally because the legacy ``_SyntheticErrorTransport``
+        #   returned the synthetic response below httpx and
+        #   ``AuthedTransport``'s ``raise_for_status()`` lifted it into
+        #   an ``HTTPStatusError`` that the leaf's auth-refresh branch
+        #   then handled. Returning a plain ``RpcResponse`` here would
+        #   skip ``AuthRefreshMiddleware`` entirely (codex iter-1 catch
+        #   on PR 12.7 (429/5xx) + PR 12.8 (400)).
         log_label = request.context.get("log_label", "<unknown-chain-call>")
         original = httpx.HTTPStatusError(
             f"HTTP {status_code}",
@@ -195,8 +199,11 @@ class ErrorInjectionMiddleware:
                 response=response,
                 status_code=status_code,
             ) from original
-        # 400 / expired_csrf / any other status: return as-is.
-        return RpcResponse(response=response, context=request.context)
+        # Auth shapes (400 expired_csrf, and any other 4xx the synthetic
+        # builder grows in future) propagate as the raw
+        # ``HTTPStatusError`` so ``AuthRefreshMiddleware`` can drive the
+        # refresh-then-retry flow.
+        raise original
 
     def _load_builder(self) -> _SyntheticBuilder:
         """Lazy importlib-load of ``tests.cassette_patterns.build_synthetic_error_response``.

--- a/tests/unit/test_auth_refresh_middleware.py
+++ b/tests/unit/test_auth_refresh_middleware.py
@@ -1,0 +1,583 @@
+"""Unit tests for :class:`AuthRefreshMiddleware` (Tier-12 PR 12.8).
+
+Pins the contract documented in ``src/notebooklm/_middleware_auth_refresh.py``
+and ADR-009 §"Chain ordering":
+
+- **Pass-through on success.** Single ``next_call``; result returned.
+- **Pass-through on non-auth exception.** ``_TransportRateLimited`` /
+  ``_TransportServerError`` propagate to ``RetryMiddleware`` outside.
+- **Pass-through when no refresh callback configured.** The
+  ``refresh_callback_enabled`` gate matches the legacy
+  ``host._refresh_callback is not None`` check.
+- **Refresh-and-retry on auth error.** First ``next_call`` raises
+  ``httpx.HTTPStatusError`` recognized by ``is_auth_error`` → refresh
+  callable runs (coalesced single-flight) → optional post-refresh sleep
+  → metric increment → exactly one retry via ``next_call(request)``.
+- **Refresh failure** → wrap original ``HTTPStatusError`` in
+  ``_TransportAuthExpired`` and propagate.
+- **Exactly one retry.** Per ADR-009 §"Retry semantics", a second auth
+  error on the retry leg propagates — no second refresh, no recursion.
+- **Post-refresh sleep honored** when ``refresh_retry_delay > 0``.
+- **Live-bound `refresh_retry_delay`.** Callable getter so test mutation
+  on the host still takes effect (matches the RetryMiddleware idiom).
+- **Log shape preservation** — "auth error detected, attempting token
+  refresh" / "Token refresh failed: X" / "Token refresh successful,
+  retrying Y" match the legacy ``AuthedTransport`` messages bit-for-bit
+  so log-grep alerts keep matching.
+- **Metrics increment** — ``rpc_auth_retries`` incremented exactly once
+  per successful refresh.
+- **Log-label fallback** — missing ``log_label`` in context surfaces
+  ``"<unknown-chain-call>"`` rather than ``KeyError`` (defensive for
+  ``__new__``-built fixtures; matches Drain/Retry behavior).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+import pytest
+
+# pytest puts ``tests/`` on ``sys.path``; ``_fixtures.chain`` is the canonical
+# import path documented in ``tests/_fixtures/__init__.py``.
+from _fixtures.chain import make_request
+from notebooklm._core_helpers import is_auth_error
+from notebooklm._core_metrics import ClientMetrics
+from notebooklm._core_transport import (
+    _TransportAuthExpired,
+    _TransportRateLimited,
+    _TransportServerError,
+)
+from notebooklm._middleware import NextCall, RpcRequest, RpcResponse, build_chain
+from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
+
+
+def _recording_sleep() -> tuple[Callable[[float], Awaitable[None]], list[float]]:
+    slept: list[float] = []
+
+    async def sleep(seconds: float) -> None:
+        slept.append(seconds)
+
+    return sleep, slept
+
+
+def _auth_error(*, status: int = 401, url: str = "https://example.test/x") -> httpx.HTTPStatusError:
+    """Build an ``httpx.HTTPStatusError`` that ``is_auth_error`` recognizes."""
+    request = httpx.Request("POST", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+def _scripted_terminal(behaviors: list[Any]) -> tuple[NextCall, list[RpcRequest]]:
+    """Yield each ``behaviors`` entry per call. Exceptions raise; Responses wrap."""
+    calls: list[RpcRequest] = []
+    iterator = iter(behaviors)
+
+    async def terminal(request: RpcRequest) -> RpcResponse:
+        calls.append(request)
+        nxt = next(iterator)
+        if isinstance(nxt, BaseException):
+            raise nxt
+        return RpcResponse(response=nxt, context=request.context)
+
+    return terminal, calls
+
+
+def _make_middleware(
+    *,
+    refresh_callable: Callable[[], Awaitable[None]] | None = None,
+    refresh_enabled: bool = True,
+    refresh_retry_delay: float = 0.0,
+    sleep: Callable[[float], Awaitable[object]] | None = None,
+    metrics: ClientMetrics | None = None,
+    auth_error_predicate: Callable[[Exception], bool] = is_auth_error,
+) -> AuthRefreshMiddleware:
+    """Build an ``AuthRefreshMiddleware`` with sensible defaults for tests."""
+
+    async def _noop_refresh() -> None:
+        return None
+
+    return AuthRefreshMiddleware(
+        refresh_callable=refresh_callable or _noop_refresh,
+        is_auth_error=auth_error_predicate,
+        refresh_callback_enabled=lambda: refresh_enabled,
+        refresh_retry_delay=lambda: refresh_retry_delay,
+        sleep=sleep,
+        metrics=metrics,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pass-through paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_passes_through_on_success() -> None:
+    """No exception → single ``next_call`` invocation, response returned."""
+    terminal, calls = _scripted_terminal([httpx.Response(200, content=b"ok")])
+    middleware = _make_middleware()
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(calls) == 1
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_passes_through_on_rate_limited() -> None:
+    """``_TransportRateLimited`` propagates to ``RetryMiddleware`` outside."""
+    request = httpx.Request("POST", "https://example.test/x")
+    boom = _TransportRateLimited(
+        "rate limited",
+        retry_after=1,
+        response=httpx.Response(429, request=request),
+        original=httpx.HTTPStatusError("HTTP 429", request=request, response=httpx.Response(429)),
+    )
+    terminal, calls = _scripted_terminal([boom])
+    middleware = _make_middleware()
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportRateLimited) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is boom
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_passes_through_on_server_error() -> None:
+    """``_TransportServerError`` propagates."""
+    request = httpx.Request("POST", "https://example.test/x")
+    boom = _TransportServerError(
+        "server error",
+        original=httpx.HTTPStatusError("HTTP 503", request=request, response=httpx.Response(503)),
+    )
+    terminal, calls = _scripted_terminal([boom])
+    middleware = _make_middleware()
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportServerError) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is boom
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_refresh_callback_not_configured() -> None:
+    """No refresh callback → propagate auth error without refresh attempt.
+
+    Matches the legacy ``host._refresh_callback is not None`` gate in the
+    leaf — a client constructed without ``refresh_callback`` should not
+    silently swallow auth errors.
+    """
+    boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([boom])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh, refresh_enabled=False)
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is boom
+    assert len(calls) == 1
+    assert refresh_calls == []  # refresh NOT triggered
+
+
+@pytest.mark.asyncio
+async def test_passes_through_on_non_auth_http_error() -> None:
+    """A non-auth HTTPStatusError (e.g. 404) propagates without refresh."""
+    boom = _auth_error(status=404)  # 404 is NOT 400/401/403
+    terminal, calls = _scripted_terminal([boom])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is boom
+    assert refresh_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Refresh-and-retry path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refreshes_and_retries_on_auth_error() -> None:
+    """401 → refresh → retry → success."""
+    boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([boom, httpx.Response(200, content=b"retry-ok")])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert refresh_calls == [None]
+    assert len(calls) == 2  # initial + retry
+    assert response.response.status_code == 200
+    assert response.response.content == b"retry-ok"
+
+
+@pytest.mark.parametrize("status", [400, 401, 403])
+@pytest.mark.asyncio
+async def test_refreshes_on_all_auth_status_codes(status: int) -> None:
+    """Google returns 400 / 401 / 403 for auth errors — all trigger refresh."""
+    boom = _auth_error(status=status)
+    terminal, calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    response = await chain(make_request())
+
+    assert refresh_calls == [None]
+    assert len(calls) == 2
+    assert response.response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_refresh_retry_delay_honored() -> None:
+    """``refresh_retry_delay > 0`` → sleep that duration before retry."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+    sleep, slept = _recording_sleep()
+
+    middleware = _make_middleware(refresh_retry_delay=1.5, sleep=sleep)
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    assert slept == [1.5]
+
+
+@pytest.mark.asyncio
+async def test_refresh_retry_delay_zero_skips_sleep() -> None:
+    """``refresh_retry_delay == 0`` → no sleep call."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+    sleep, slept = _recording_sleep()
+
+    middleware = _make_middleware(refresh_retry_delay=0.0, sleep=sleep)
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    assert slept == []
+
+
+# ---------------------------------------------------------------------------
+# Refresh failure → _TransportAuthExpired
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_raises_transport_auth_expired() -> None:
+    """Refresh callable raises → wrap in ``_TransportAuthExpired``."""
+    boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([boom])  # only one attempt — refresh fails before retry
+    refresh_error = RuntimeError("refresh blew up")
+
+    async def refresh() -> None:
+        raise refresh_error
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportAuthExpired) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert excinfo.value.original is boom
+    assert excinfo.value.__cause__ is refresh_error
+    assert "RPC LIST_NOTEBOOKS" in str(excinfo.value)
+    assert len(calls) == 1  # NO retry attempted
+
+
+# ---------------------------------------------------------------------------
+# Once-per-logical-call contract (codex iter-1 catch on PR 12.8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_skipped_when_context_marks_already_refreshed() -> None:
+    """If ``context["auth_refreshed"]`` is set, a fresh 401 propagates.
+
+    Models the load-bearing scenario where ``RetryMiddleware`` (outside
+    this middleware in the final chain) re-invokes the chain after a 429
+    that fired post-refresh. The retry hits a 401 again; without the
+    per-request flag, AuthRefreshMiddleware would refresh a SECOND time.
+    With it, the 401 propagates — restoring the pre-PR-12.7
+    "one refresh max per logical call" contract.
+
+    Codex iter-1 PR 12.8 finding.
+    """
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    # Simulate a chain re-entry where a prior leg already refreshed.
+    request = make_request(context={"auth_refreshed": True})
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(request)
+
+    assert excinfo.value is boom
+    assert refresh_calls == []  # NO refresh — prior leg already did it
+
+
+@pytest.mark.asyncio
+async def test_context_auth_refreshed_flag_set_after_first_refresh() -> None:
+    """A successful refresh marks ``context["auth_refreshed"]`` so a later
+    chain re-entry through ``RetryMiddleware`` won't refresh again.
+    """
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+
+    async def refresh() -> None:
+        return None
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    request = make_request(context={"log_label": "RPC LIST_NOTEBOOKS"})
+    await chain(request)
+
+    assert request.context["auth_refreshed"] is True
+
+
+# ---------------------------------------------------------------------------
+# Exactly-one-retry contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_auth_error_on_retry_propagates_no_recursion() -> None:
+    """Per ADR-009: "exactly one retry per next_call invocation".
+
+    First call raises 401 → refresh → retry raises 401 again → propagate.
+    The middleware must NOT refresh a second time, NOT recurse.
+    """
+    first_boom = _auth_error(status=401)
+    second_boom = _auth_error(status=401)
+    terminal, calls = _scripted_terminal([first_boom, second_boom])
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(make_request())
+
+    assert excinfo.value is second_boom
+    assert len(refresh_calls) == 1  # exactly one refresh
+    assert len(calls) == 2  # initial + one retry
+
+
+# ---------------------------------------------------------------------------
+# Metrics emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_increment_on_successful_refresh() -> None:
+    """``rpc_auth_retries`` increments once per successful refresh."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+    metrics = ClientMetrics()
+
+    async def refresh() -> None:
+        return None
+
+    middleware = _make_middleware(refresh_callable=refresh, metrics=metrics)
+    chain = build_chain([middleware], terminal)
+
+    await chain(make_request())
+
+    assert metrics.snapshot().rpc_auth_retries == 1
+
+
+@pytest.mark.asyncio
+async def test_metrics_not_incremented_on_refresh_failure() -> None:
+    """Refresh failure → no auth-retry metric (no retry happened)."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom])
+    metrics = ClientMetrics()
+
+    async def refresh() -> None:
+        raise RuntimeError("refresh failed")
+
+    middleware = _make_middleware(refresh_callable=refresh, metrics=metrics)
+    chain = build_chain([middleware], terminal)
+
+    with pytest.raises(_TransportAuthExpired):
+        await chain(make_request())
+
+    assert metrics.snapshot().rpc_auth_retries == 0
+
+
+# ---------------------------------------------------------------------------
+# Log shape preservation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_shape_on_successful_refresh(caplog: pytest.LogCaptureFixture) -> None:
+    """Log messages match the legacy ``AuthedTransport`` shape verbatim."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+
+    async def refresh() -> None:
+        return None
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with caplog.at_level("INFO", logger="notebooklm._core"):
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    info_msgs = [r.message for r in caplog.records if r.levelname == "INFO"]
+    assert any(
+        "RPC LIST_NOTEBOOKS auth error detected, attempting token refresh" in m for m in info_msgs
+    )
+    assert any("Token refresh successful, retrying RPC LIST_NOTEBOOKS" in m for m in info_msgs)
+
+
+@pytest.mark.asyncio
+async def test_log_shape_on_refresh_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """Refresh failure log matches "Token refresh failed: X"."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom])
+
+    async def refresh() -> None:
+        raise RuntimeError("login expired")
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with (
+        caplog.at_level("WARNING", logger="notebooklm._core"),
+        pytest.raises(_TransportAuthExpired),
+    ):
+        await chain(make_request())
+
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert any("Token refresh failed: login expired" in m for m in warn_msgs)
+
+
+# ---------------------------------------------------------------------------
+# Log-label fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_log_label_falls_back_to_sentinel(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A request without ``log_label`` does not raise ``KeyError``."""
+    boom = _auth_error()
+    terminal, _calls = _scripted_terminal([boom, httpx.Response(200, content=b"ok")])
+
+    async def refresh() -> None:
+        return None
+
+    middleware = _make_middleware(refresh_callable=refresh)
+    chain = build_chain([middleware], terminal)
+
+    with caplog.at_level("INFO", logger="notebooklm._core"):
+        await chain(make_request(context={}))  # no log_label
+
+    info_msgs = [r.message for r in caplog.records if r.levelname == "INFO"]
+    assert any("<unknown-chain-call>" in m for m in info_msgs)
+
+
+# ---------------------------------------------------------------------------
+# Live-bound refresh_retry_delay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_retry_delay_is_live_bound() -> None:
+    """Mutating the delay between chain calls takes effect on the next call."""
+    delay = [0.0]
+
+    async def refresh() -> None:
+        return None
+
+    sleep, slept = _recording_sleep()
+    middleware = AuthRefreshMiddleware(
+        refresh_callable=refresh,
+        is_auth_error=is_auth_error,
+        refresh_callback_enabled=lambda: True,
+        refresh_retry_delay=lambda: delay[0],
+        sleep=sleep,
+    )
+    boom1 = _auth_error()
+    boom2 = _auth_error()
+    terminal, _calls = _scripted_terminal(
+        [boom1, httpx.Response(200, content=b"ok"), boom2, httpx.Response(200, content=b"ok")]
+    )
+    chain = build_chain([middleware], terminal)
+
+    # Call 1: delay=0 → no sleep.
+    await chain(make_request())
+    assert slept == []
+
+    # Mutate the delay.
+    delay[0] = 0.5
+
+    # Call 2: delay=0.5 → one sleep of 0.5.
+    await chain(make_request())
+    assert slept == [0.5]
+
+
+# ---------------------------------------------------------------------------
+# Type hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_satisfies_protocol() -> None:
+    """``AuthRefreshMiddleware`` instance is assignable to ``Middleware``."""
+    from notebooklm._middleware import Middleware
+
+    async def _noop() -> None:
+        return None
+
+    middleware: Middleware = AuthRefreshMiddleware(
+        refresh_callable=_noop,
+        is_auth_error=is_auth_error,
+        refresh_callback_enabled=lambda: True,
+        refresh_retry_delay=lambda: 0.0,
+    )
+    assert callable(middleware)

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -232,26 +232,32 @@ async def test_chain_terminal_disable_internal_retries_defaults_false() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chain_seeded_with_drain_metrics_retry_error_injection_tracing() -> None:
-    """``ClientCore.__init__`` seeds the chain with ``[Drain, Metrics, Retry, ErrorInjection, Tracing]``.
+async def test_chain_seeded_with_final_adr_009_ordering() -> None:
+    """``ClientCore.__init__`` seeds the chain with the FINAL ADR-009 ordering.
 
     PR 12.3 landed ``TracingMiddleware`` at the innermost position; PR 12.4
     prepended ``MetricsMiddleware``; PR 12.5 prepended ``DrainMiddleware``
     outermost; PR 12.6 inserted ``ErrorInjectionMiddleware`` between
-    Metrics and Tracing; PR 12.7 inserts ``RetryMiddleware`` between
-    Metrics and ErrorInjection. Order matters — Drain admits/finalizes
-    the operation outside all observability, Metrics times the
-    end-to-end chain, Retry handles 429/5xx retries (with synthetic
-    errors that ErrorInjection produces visible to Retry on each
-    attempt), ErrorInjection short-circuits with synthetic responses
-    when activated, and Tracing remains the innermost wrapper around the
-    transport leaf. PR 12.8 inserts ``AuthRefreshMiddleware`` BETWEEN
-    Retry and ErrorInjection so the final ordering reads
-    ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` per
-    ADR-009. The list is exposed as ``self._middlewares`` so later PRs
-    (and the cleanup audit in 12.9) can assert ordering by inspecting
-    the production attribute directly.
+    Metrics and Tracing; PR 12.7 inserted ``RetryMiddleware`` between
+    Metrics and ErrorInjection; PR 12.8 inserts ``AuthRefreshMiddleware``
+    between Retry and ErrorInjection. The list now reads the final
+    ADR-009 ordering
+    ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
+    (outermost → innermost).
+
+    Order rationale (per ADR-009):
+    - Drain outermost — every in-flight call counts toward shutdown wait
+    - Metrics outside Retry — end-to-end timing, not per-attempt
+    - Retry outside AuthRefresh — orthogonal failure modes
+    - AuthRefresh outside ErrorInjection — test-injected 401s exercise refresh
+    - ErrorInjection inside Retry — synthetic transient failures trigger retry
+    - Tracing innermost — logs actual HTTP attempts including retries
+
+    The list is exposed as ``self._middlewares`` so PR 12.9 (cleanup
+    audit) can verify ordering by inspecting the production attribute
+    directly.
     """
+    from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
     from notebooklm._middleware_drain import DrainMiddleware
     from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
     from notebooklm._middleware_metrics import MetricsMiddleware
@@ -259,12 +265,13 @@ async def test_chain_seeded_with_drain_metrics_retry_error_injection_tracing() -
     from notebooklm._middleware_tracing import TracingMiddleware
 
     core = _make_core()
-    assert len(core._middlewares) == 5
+    assert len(core._middlewares) == 6
     assert isinstance(core._middlewares[0], DrainMiddleware)
     assert isinstance(core._middlewares[1], MetricsMiddleware)
     assert isinstance(core._middlewares[2], RetryMiddleware)
-    assert isinstance(core._middlewares[3], ErrorInjectionMiddleware)
-    assert isinstance(core._middlewares[4], TracingMiddleware)
+    assert isinstance(core._middlewares[3], AuthRefreshMiddleware)
+    assert isinstance(core._middlewares[4], ErrorInjectionMiddleware)
+    assert isinstance(core._middlewares[5], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -84,53 +84,56 @@ EVENT_TIMEOUT_S = 5.0
 
 
 def test_perform_authed_post_has_no_await_before_post_per_iteration():
-    """Within a single retry iteration of ``_perform_authed_post``, no
-    ``await`` may sit lexically inside the ``try:`` block before the
-    ``client.post(...)`` call.
+    """No ``await`` may sit lexically inside the ``try:`` block before the
+    ``client.post(...)`` call in ``_perform_authed_post``.
 
-    Each retry iteration begins with ``snapshot = await self._snapshot()``
-    + a synchronous ``build_request(snapshot)`` — both immediately
-    *before* the try block. The try body's first statement is the actual
-    POST. If anyone introduces an ``await`` between ``build_request`` and
-    the POST (or any new await inside the try body's prologue), a
-    concurrent ``refresh_auth`` could update the httpx cookie jar
-    between the snapshot read and the wire, producing a mismatched-
-    generation request on the cookie axis (the ``_auth_snapshot_lock``
-    covers csrf/sid coherence; cookies still rely on this no-await rule).
+    The leaf begins with ``snapshot = await self._snapshot()`` + a
+    synchronous ``build_request(snapshot)`` — both immediately *before*
+    the try block. The try body's first statement is the actual POST. If
+    anyone introduces an ``await`` between ``build_request`` and the POST
+    (or any new await inside the try body's prologue), a concurrent
+    ``refresh_auth`` could update the httpx cookie jar between the
+    snapshot read and the wire, producing a mismatched-generation
+    request on the cookie axis (the ``_auth_snapshot_lock`` covers
+    csrf/sid coherence; cookies still rely on this no-await rule).
 
-    The check is per-iteration: awaits *between* iterations (e.g.
-    ``await self._await_refresh()`` followed by ``continue``) are fine
-    because each iteration takes a fresh snapshot.
-
-    Note: the lock acquisition inside ``_snapshot`` is the only
-    pre-POST ``await``, and it lives *before* the try block — so this
-    guard (which only walks the try body) remains valid.
+    Tier-12 PRs 12.7 / 12.8 lifted retry / auth-refresh out of the leaf
+    into ``RetryMiddleware`` and ``AuthRefreshMiddleware``. After PR
+    12.8 the leaf no longer has a ``while`` retry loop — it makes
+    exactly one attempt per chain invocation. Each chain-level retry
+    (driven by ``RetryMiddleware`` / ``AuthRefreshMiddleware``) re-enters
+    the leaf and re-runs ``_snapshot`` → ``build_request`` → POST.
+    The guard therefore walks the ``try`` block directly inside the
+    ``async with semaphore:`` body.
     """
     src = textwrap.dedent(inspect.getsource(AuthedTransport.perform_authed_post))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 
-    # Locate the retry loop (the outermost ``while`` in the body). The loop
-    # may sit directly under the function body OR one level deeper inside
-    # the RPC-semaphore ``async with self._get_rpc_semaphore():`` wrapper — both
-    # structures preserve the snapshot→POST invariant this guard checks
-    # (the semaphore acquire happens once per call, not per iteration).
-    def _find_first_while(parent: ast.AST) -> ast.While | None:
+    # Locate the ``try`` block guarding the POST. Post-PR-12.8 the leaf
+    # has no ``while`` retry loop; the try sits directly inside the
+    # ``async with self._get_rpc_semaphore():`` body (the semaphore
+    # acquire happens once per call, not per iteration).
+    def _find_first_try(parent: ast.AST) -> ast.Try | None:
         for child in ast.iter_child_nodes(parent):
-            if isinstance(child, ast.While):
+            if isinstance(child, ast.Try):
                 return child
             if isinstance(child, ast.AsyncWith | ast.With):
-                # Descend through context managers so the guard survives
-                # wrapping the loop in ``async with semaphore``.
-                found = _find_first_while(child)
+                found = _find_first_try(child)
+                if found is not None:
+                    return found
+            if isinstance(child, ast.While):
+                # Tolerate a re-introduced while (e.g. if a future PR
+                # adds a retry loop back to the leaf) — walk into it.
+                found = _find_first_try(child)
                 if found is not None:
                     return found
         return None
 
-    while_loop = _find_first_while(func)
-    assert while_loop is not None, (
-        "Could not locate the retry-loop ``while`` in AuthedTransport.perform_authed_post. "
-        "If the loop was restructured, update this guard to match."
+    found_try = _find_first_try(func)
+    assert found_try is not None, (
+        "Could not locate the ``try:`` block guarding the POST in "
+        "AuthedTransport.perform_authed_post. Update this guard to match."
     )
 
     def is_post_await(node):
@@ -169,20 +172,13 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
             yield child
             yield from _walk_outer(child)
 
-    # Walk only the ``try`` block at the top of the while body — that's the
-    # critical prologue → POST window. Awaits in ``except`` handlers are by
-    # definition AFTER the POST (post-error path) and don't violate the
-    # invariant. ``self._snapshot()`` and ``build_request(snapshot)`` are
-    # synchronous assignments inside the while body before the try, so
-    # they're irrelevant to this guard.
-    try_node = next(
-        (n for n in ast.iter_child_nodes(while_loop) if isinstance(n, ast.Try)),
-        None,
-    )
-    assert try_node is not None, (
-        "Could not locate the ``try:`` block guarding the POST in "
-        "AuthedTransport.perform_authed_post. Update this guard if the structure changed."
-    )
+    # Walk only the ``try`` body — that's the critical prologue → POST
+    # window. Awaits in ``except`` handlers are by definition AFTER the
+    # POST and don't violate the invariant. ``self._snapshot()`` and
+    # ``build_request(snapshot)`` are synchronous assignments inside the
+    # ``async with semaphore:`` body before the try, so they're
+    # irrelevant to this guard.
+    try_node = found_try
     # We only walk the try body, NOT its handlers.
     try_body_nodes: list[ast.AST] = []
     for stmt in try_node.body:

--- a/tests/unit/test_core_transport.py
+++ b/tests/unit/test_core_transport.py
@@ -225,7 +225,18 @@ async def test_authed_transport_requires_open_client():
 
 
 @pytest.mark.asyncio
-async def test_authed_transport_uses_late_bound_is_auth_error(monkeypatch):
+async def test_chain_uses_late_bound_is_auth_error(monkeypatch):
+    """Tier-12 PR 12.8 lifted auth-refresh into ``AuthRefreshMiddleware``.
+
+    The middleware reads ``is_auth_error`` LIVE through
+    ``notebooklm._core``'s module globals (via the lambda in the chain
+    seed) so a test that monkeypatches
+    ``notebooklm._core.is_auth_error`` still drives the refresh path —
+    preserving the pre-PR-12.8 contract where ``AuthedTransport`` read
+    the same module attr live. Drives the chain via
+    ``core._perform_authed_post`` since retry behavior moved out of the
+    leaf.
+    """
     refresh_calls: list[bool] = []
 
     async def refresh() -> AuthTokens:
@@ -235,7 +246,9 @@ async def test_authed_transport_uses_late_bound_is_auth_error(monkeypatch):
     core = _make_core(refresh_callback=refresh)
     await core.open()
     try:
-        transport = core._get_authed_transport()
+        # Force the middleware to treat ANY exception as an auth error.
+        # The chain reads ``is_auth_error`` through the module so this
+        # patch takes effect on the next call.
         monkeypatch.setattr("notebooklm._core.is_auth_error", lambda exc: True)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
@@ -251,7 +264,7 @@ async def test_authed_transport_uses_late_bound_is_auth_error(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._http_client, fake_post)
 
-        response = await transport.perform_authed_post(build_request=build, log_label="test")
+        response = await core._perform_authed_post(build_request=build, log_label="test")
 
         assert response.status_code == 200
         assert refresh_calls == [True]

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -201,44 +201,55 @@ async def test_5xx_mode_raises_transport_server_error(
 
 
 # ---------------------------------------------------------------------------
-# expired_csrf → return RpcResponse (PR 12.8 will intercept in AuthRefresh)
+# expired_csrf → raise httpx.HTTPStatusError (AuthRefreshMiddleware catches)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_expired_csrf_mode_returns_400_response_for_now(
+async def test_expired_csrf_mode_raises_http_status_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``expired_csrf`` mode returns the 400 response as-is — pending PR 12.8.
+    """``expired_csrf`` mode raises the raw ``httpx.HTTPStatusError``.
 
-    PR 12.8's AuthRefreshMiddleware will intercept 400 responses and drive
-    the refresh-then-retry flow. Until then, the response propagates.
+    PR 12.8 wired AuthRefreshMiddleware outside this middleware in the
+    final chain ordering. AuthRefresh catches via ``is_auth_error``
+    (which recognizes 400/401/403 from Google's auth-shape responses)
+    and drives the refresh-then-retry flow. Pre-PR-12.6 this happened
+    naturally because the legacy ``_SyntheticErrorTransport`` returned
+    the synthetic 400 below httpx and the leaf's auth-refresh branch
+    handled it.
     """
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
     terminal, calls = _recording_terminal()
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], terminal)
 
-    response = await chain(make_request())
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(make_request())
 
     assert calls == []  # leaf NOT reached
-    assert response.response.status_code == 400
+    assert excinfo.value.response.status_code == 400
+    assert "HTTP 400" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
-async def test_expired_csrf_response_propagates_request_context(
+async def test_expired_csrf_response_carries_synthetic_request_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """For the returned-response path (400), context is propagated."""
+    """The raised HTTPStatusError wraps a synthetic ``httpx.Response`` whose
+    ``.request`` mirrors the chain envelope."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
     middleware = ErrorInjectionMiddleware()
     chain = build_chain([middleware], _static_terminal(httpx.Response(200, content=b"unreached")))
 
-    request_context = {"log_label": "RPC LIST_NOTEBOOKS", "rpc_method": "LIST_NOTEBOOKS"}
-    request = make_request(context=request_context)
-    response = await chain(request)
+    custom_url = "https://example.test/_/LabsTailwindUi/data/batchexecute?authuser=0"
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(make_request(url=custom_url))
 
-    assert response.context is request.context
+    response = excinfo.value.response
+    assert response.status_code == 400
+    assert response.request is not None
+    assert str(response.request.url) == custom_url
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_error_injection_middleware.py
+++ b/tests/unit/test_error_injection_middleware.py
@@ -326,6 +326,110 @@ async def test_retry_outside_error_injection_retries_synthetic_5xx(
 
 
 # ---------------------------------------------------------------------------
+# End-to-end: AuthRefresh + ErrorInjection drives refresh on synthetic 400
+# (codex iter-1 finding on PR 12.8 — locks in the regression fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_outside_error_injection_triggers_refresh_on_expired_csrf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: chain ``[AuthRefresh, ErrorInjection]`` refreshes on synthetic 400.
+
+    Codex iter-1 catch on PR 12.8: PR 12.6 broke the refresh-on-synthetic-400
+    path by returning an ``RpcResponse`` from :class:`ErrorInjectionMiddleware`
+    for ``expired_csrf`` mode. PR 12.8 fixes by raising raw
+    ``httpx.HTTPStatusError`` so :class:`AuthRefreshMiddleware` outside it
+    catches via ``is_auth_error`` and drives refresh-then-retry.
+
+    This is the missing E2E counterpart to the ``[Retry, ErrorInjection]``
+    pair above — without it the integration is only validated by two
+    independent unit tests (the leaf raises 400; AuthRefresh catches 400)
+    but never end-to-end on a real two-middleware chain.
+
+    Test shape: env var stays on across the retry leg, so the retry leg
+    also raises ``HTTPStatusError(400)``. The exactly-once contract from
+    ADR-009 §"Retry semantics" means refresh runs exactly once and the
+    second 400 propagates without recursion.
+    """
+    from notebooklm._core_helpers import is_auth_error as auth_error_predicate
+    from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
+
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        refresh_calls.append(None)
+
+    auth_refresh = AuthRefreshMiddleware(
+        refresh_callable=refresh,
+        is_auth_error=auth_error_predicate,
+        refresh_callback_enabled=lambda: True,
+        refresh_retry_delay=lambda: 0.0,
+    )
+    error_injection = ErrorInjectionMiddleware()
+    chain = build_chain(
+        [auth_refresh, error_injection],
+        _static_terminal(httpx.Response(200, content=b"unreached-because-env-is-on")),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    # AuthRefresh caught the synthetic 400 from ErrorInjection and drove
+    # ONE refresh — the retry leg's 400 propagates unchanged (exactly-once
+    # contract). Without PR 12.8's fix, ErrorInjection would have RETURNED
+    # a 400 RpcResponse, AuthRefresh would have seen no exception, refresh
+    # would never have fired, and ``refresh_calls`` would be empty.
+    assert len(refresh_calls) == 1
+    assert excinfo.value.response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_outside_error_injection_completes_when_env_flips_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end happy path: ``[AuthRefresh, ErrorInjection]`` retries successfully.
+
+    Companion to the test above: when the env var is flipped off during
+    refresh (production analogue: a real ``__Secure-1PSIDTS`` rotation
+    succeeded and the retry no longer hits the synthetic 400 path), the
+    chain returns 200 cleanly. This pins the full refresh-then-retry
+    success path, not just the propagation path.
+    """
+    from notebooklm._core_helpers import is_auth_error as auth_error_predicate
+    from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
+
+    monkeypatch.setenv(ERROR_INJECT_ENV_VAR, "expired_csrf")
+    refresh_calls: list[None] = []
+
+    async def refresh() -> None:
+        # Simulate a successful token rotation that disarms the injector
+        # before the retry leg runs.
+        refresh_calls.append(None)
+        monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
+
+    auth_refresh = AuthRefreshMiddleware(
+        refresh_callable=refresh,
+        is_auth_error=auth_error_predicate,
+        refresh_callback_enabled=lambda: True,
+        refresh_retry_delay=lambda: 0.0,
+    )
+    error_injection = ErrorInjectionMiddleware()
+    chain = build_chain(
+        [auth_refresh, error_injection],
+        _static_terminal(httpx.Response(200, content=b"after-refresh-success")),
+    )
+
+    response = await chain(make_request(context={"log_label": "RPC LIST_NOTEBOOKS"}))
+
+    assert len(refresh_calls) == 1
+    assert response.response.status_code == 200
+    assert response.response.content == b"after-refresh-success"
+
+
+# ---------------------------------------------------------------------------
 # Builder caching
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `AuthRefreshMiddleware` (6th and FINAL middleware per ADR-009). Realizes the canonical chain ordering end-to-end: **`[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`**.
- LIFTS the auth-refresh-once retry out of `AuthedTransport.perform_authed_post`. The leaf is now a *pure* single-attempt POST.
- **Restored contracts** (regression-fixes for codex iter-1 catches):
  1. **Auth-refresh-once-per-logical-call** — PR 12.7 broke this interim. Fixed via `context["auth_refreshed"]` flag tracked across chain re-invocations from `RetryMiddleware`. Sequence `401 → refresh → 429 → Retry retry → 401` now refreshes ONCE, not twice.
  2. **ErrorInjection expired_csrf (400)** — PR 12.6 broke the refresh-on-synthetic-400 path by returning `RpcResponse`. PR 12.8 fixes by raising raw `httpx.HTTPStatusError` so AuthRefreshMiddleware catches it.

## Behavior preservation
- Same auth-refresh trigger (`is_auth_error` for 400/401/403). Live-bound through `notebooklm._core` module globals so `monkeypatch.setattr` still drives the path.
- Same coalesced single-flight refresh via `AuthRefreshCoordinator.await_refresh`.
- Same `_TransportAuthExpired` raise on refresh-callable failure.
- Same `refresh_retry_delay` sleep after successful refresh.
- Same `rpc_auth_retries` metric increment.
- Same log messages — bit-for-bit match for log-grep alerts.

## ADR-009 closure callbacks deferred to PR 13.x
Plan envisioned `rebuild_headers` + `build_request_factory` callbacks; chain envelope (`RpcRequest.url`/`headers`/`body`) is still empty in production (leaf builds from `context['build_request']`). Simple `await next_call(request)` re-invocation is sufficient — leaf re-snapshots auth and re-builds. Full callback contract activates in PR 13.x when envelope carries url/headers/body.

## Known interim regression (documented in `_core_transport.py`)
**Semaphore backpressure scope**: pre-PR-12.7 the leaf's RPC semaphore wrapped the FULL retry budget. PRs 12.7+12.8 moved retry out of the leaf — each retry now releases + re-acquires. Smoothing is now per-attempt, not per-call. Chain-level semaphore primitive is a viable follow-up.

## Polish receipts (per /execute-task SKILL.md)

| Stage | Result |
|---|---|
| 4.1 simplifier | Fixed 2 docstring inaccuracies in `_middleware_auth_refresh.py` constructor params |
| 4.2 gemini | LGTM. 3 [Important] all by-plan-design, 2 nits |
| 4.2 claude | 0 [Critical], 2 [Important] both flagged for PR 12.9 cleanup (`has_refresh_callback` property + `_live_is_auth_error` helper), 5 nits |
| 4.2 codex | 0 [Critical], 2 [Important] — caught the **two load-bearing regressions** (auth-refresh-once across mixed retries + ErrorInjection 400 bypass). Both fixed inline. Plus `globals()` simplification (nit) applied |
| 4.3 ultrathink | Triple-review convergence caught both codex finds; PR 12.9 cleanup list updated |

## Tier-12 status after this PR
**8/9 PRs landed.** PR 12.9 cleanup is the last:
- Delete `_TransportAuthExpired` leaf raise sites (unused post-12.8)
- Delete unused `is_auth_error`/`sleep` constructor args on `AuthedTransport`
- Delete `_SyntheticErrorTransport` class
- De-duplicate `_load_builder` between middleware + legacy transport
- Promote `_auth_coord._refresh_callback is not None` to a public `has_refresh_callback` property
- Replace `lambda exc: is_auth_error(exc)` indirections with a module-level `_live_is_auth_error` helper
- Finalize ADR-009

## Test plan

- [x] ruff format/check: clean
- [x] mypy `src/notebooklm`: 133 source files, 0 errors
- [x] `pytest -n auto tests/unit`: 4760 passed (+24 new vs PR 12.7 baseline)
- [x] `pytest -n auto tests/integration`: 674 passed
- [ ] CI green on remote
- [ ] Bot reviews addressed
- [ ] `mergeStateStatus` CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic auth-refresh-and-retry layer to transparently recover from expired credentials during requests.

* **Bug Fixes**
  * Improved retry behavior: clearer handling of rate limits, server errors, and auth-shaped failures with a single refresh-and-retry attempt.
  * Restored exception-based flow for synthetic auth errors so refresh logic can trigger reliably.

* **Tests**
  * Extensive unit and integration tests added/updated to validate refresh, retry, and error propagation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->