### PR TITLE
feat(core): define Session/Kernel contracts

### DIFF
--- a/docs/adr/0010-session-kernel-split.md
+++ b/docs/adr/0010-session-kernel-split.md
@@ -1,0 +1,87 @@
+# ADR-010: Session/Kernel split
+
+## Status
+
+Accepted (Tier 13 PR 13.1).
+
+## Context
+
+`ClientCore` currently owns orchestration, RPC encoding/decoding, drain
+tracking, request-id allocation, cookie access, HTTP lifecycle, and the
+feature-facing capability surface. The Tier-12 middleware chain isolated
+cross-cutting transport concerns, but feature APIs still depend on
+per-feature `_<X>Core` Protocols and shared base Protocols in
+`src/notebooklm/_capabilities.py`.
+
+That shape blocks the Tier-13 decomposition: feature APIs need one stable
+orchestration contract, transport code needs a smaller HTTP-only contract,
+and Artifacts needs one close-time hook registration affordance without
+expanding the general Session surface.
+
+## Decision
+
+Tier 13 uses three structural contracts in
+`src/notebooklm/_session_contracts.py`:
+
+- `Session: Protocol` has exactly five members: `rpc_call`,
+  `transport_post`, `next_reqid`, `assert_bound_loop`, and
+  `operation_scope`.
+- `Kernel: Protocol` has exactly three members: `post`, `cookies`, and
+  `aclose`.
+- `DrainHookRegistration: Protocol` has exactly one member:
+  `register_drain_hook`.
+
+`Session.transport_post` accepts the existing public-ish
+`BuildRequest` alias from `src/notebooklm/_request_types.py`. New session
+contracts must not expose `_BuildRequest` in signatures.
+
+This PR is type-only. It defines the contracts and documentation, but it
+does not create concrete `_session.py` or `_kernel.py` modules, rename
+`ClientCore`, move cookies, move `httpx` lifecycle, or wire new runtime
+behavior.
+
+Later Tier-13 PRs delete `src/notebooklm/_capabilities.py` and all
+per-feature `_<X>Core` Protocols after feature APIs are retyped to the
+new contracts. `DrainHookRegistration` remains separate from `Session` so
+Artifacts can register close-time polling cleanup without adding
+feature-specific lifecycle methods to the five-member Session surface.
+
+## Consequences
+
+Wanted:
+
+- Feature APIs converge on one semantic orchestration surface instead of
+  composing many narrow capability fragments.
+- The transport boundary is small enough for a concrete Kernel to own
+  `httpx.AsyncClient` lifecycle and cookies without also owning RPC
+  orchestration.
+- Artifacts gets an explicit, typed drain-hook seam while other features
+  remain typed only against `Session`.
+- The `BuildRequest` alias prevents new Protocol signatures from leaking
+  `_BuildRequest`.
+
+Unwanted:
+
+- During the migration window both the old `_capabilities.py` Protocols
+  and the new contracts coexist.
+- `ClientCore` does not structurally satisfy every new contract in this
+  PR; concrete conformance lands with the later extraction and retyping
+  PRs.
+
+## Alternatives considered
+
+Keep per-feature `_<X>Core` Protocols. Rejected because the endpoint would
+still duplicate the same core session operations across eight modules and
+keep `_capabilities.py` as a permanent coordination point.
+
+Add `register_drain_hook` to `Session`. Rejected because it would expand
+the general feature contract for an Artifacts-only lifecycle need and
+break the five-member Session gate.
+
+Expose a `Kernel.stream` member. Rejected because chat receives a fully
+buffered `httpx.Response`; the streaming byte iteration is an internal
+transport implementation detail, not a consumer-facing Kernel operation.
+
+Move concrete classes in this PR. Rejected because PR 13.1 is deliberately
+type-only; `_session.py` and `_kernel.py` are reserved for later concrete
+implementation PRs.

--- a/docs/adr/0010-session-kernel-split.md
+++ b/docs/adr/0010-session-kernel-split.md
@@ -71,8 +71,8 @@ Unwanted:
 ## Alternatives considered
 
 Keep per-feature `_<X>Core` Protocols. Rejected because the endpoint would
-still duplicate the same core session operations across eight modules and
-keep `_capabilities.py` as a permanent coordination point.
+still duplicate the same core session operations across feature sub-client
+modules and keep `_capabilities.py` as a permanent coordination point.
 
 Add `register_drain_hook` to `Session`. Rejected because it would expand
 the general feature contract for an Artifacts-only lifecycle need and

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ Pure bug fixes, additive RPC method IDs, and CLI ergonomics changes do not requi
 | [0007](0007-test-monkeypatch-policy.md) | Test monkeypatch policy | Accepted |
 | [0008](0008-cli-services-extraction-pattern.md) | `cli/services/` extraction pattern | Accepted (retroactive) |
 | [0009](0009-middleware-chain.md) | Middleware chain for cross-cutting transport concerns | Accepted (Tier 12 PR 12.1) |
+| [0010](0010-session-kernel-split.md) | Session/Kernel split | Accepted (Tier 13 PR 13.1) |
 
 ADR-007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/src/notebooklm/_session_contracts.py
+++ b/src/notebooklm/_session_contracts.py
@@ -1,0 +1,80 @@
+"""Type-only contracts for the Tier-13 Session/Kernel split.
+
+This module defines the narrow structural Protocols that later Tier-13 PRs
+will wire into concrete classes. It intentionally contains no runtime
+implementation and no import of the concrete ``ClientCore``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import AbstractAsyncContextManager
+from typing import Any, Protocol
+
+import httpx
+
+from ._request_types import BuildRequest
+from .rpc.types import RPCMethod
+
+
+class Session(Protocol):
+    """Orchestration surface consumed by feature APIs after Tier 13."""
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
+    ) -> Any: ...
+
+    async def transport_post(
+        self,
+        build_request: BuildRequest,
+        parse_label: str,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response: ...
+
+    async def next_reqid(self, step: int = 100000) -> int: ...
+
+    def assert_bound_loop(self) -> None: ...
+
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]: ...
+
+
+class Kernel(Protocol):
+    """Pure transport surface owned by the concrete Kernel in PR 13.2."""
+
+    async def post(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes,
+    ) -> httpx.Response: ...
+
+    @property
+    def cookies(self) -> httpx.Cookies: ...
+
+    async def aclose(self) -> None: ...
+
+
+class DrainHookRegistration(Protocol):
+    """Narrow close-time hook registration surface for Artifacts."""
+
+    def register_drain_hook(
+        self,
+        name: str,
+        hook: Callable[[], Awaitable[None]],
+    ) -> None: ...
+
+
+__all__ = [
+    "DrainHookRegistration",
+    "Kernel",
+    "Session",
+]

--- a/src/notebooklm/_session_contracts.py
+++ b/src/notebooklm/_session_contracts.py
@@ -3,6 +3,11 @@
 This module defines the narrow structural Protocols that later Tier-13 PRs
 will wire into concrete classes. It intentionally contains no runtime
 implementation and no import of the concrete ``ClientCore``.
+
+``Session.rpc_call`` deliberately mirrors the existing ``CoreRPCProvider``
+signature, including the transitional ``_is_retry`` parameter, so feature
+retyping can happen without changing call semantics before ``_capabilities.py``
+is deleted later in Tier 13.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_session_contracts.py
+++ b/tests/unit/test_session_contracts.py
@@ -1,0 +1,175 @@
+"""Typing checks for the Tier-13 Session/Kernel protocol contracts."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
+from typing import Any
+
+import httpx
+
+from notebooklm._request_types import BuildRequest
+from notebooklm._session_contracts import DrainHookRegistration, Kernel, Session
+from notebooklm.rpc.types import RPCMethod
+
+
+class _NoopOperationScope:
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return False
+
+
+class _SessionImpl:
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
+    ) -> Any:
+        return None
+
+    async def transport_post(
+        self,
+        build_request: BuildRequest,
+        parse_label: str,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    async def next_reqid(self, step: int = 100000) -> int:
+        return step
+
+    def assert_bound_loop(self) -> None:
+        return None
+
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        return _NoopOperationScope()
+
+
+class _KernelImpl:
+    async def post(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes,
+    ) -> httpx.Response:
+        return httpx.Response(200, content=body)
+
+    @property
+    def cookies(self) -> httpx.Cookies:
+        return httpx.Cookies()
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _DrainHookRegistrationImpl:
+    def register_drain_hook(
+        self,
+        name: str,
+        hook: Callable[[], Awaitable[None]],
+    ) -> None:
+        return None
+
+
+def _public_contract_members(protocol: type[Any]) -> set[str]:
+    return {name for name in protocol.__dict__ if not name.startswith("_")}
+
+
+def test_session_protocol_has_exactly_five_members() -> None:
+    assert _public_contract_members(Session) == {
+        "rpc_call",
+        "transport_post",
+        "next_reqid",
+        "assert_bound_loop",
+        "operation_scope",
+    }
+
+
+def test_kernel_protocol_has_exactly_three_members() -> None:
+    assert _public_contract_members(Kernel) == {"post", "cookies", "aclose"}
+
+
+def test_drain_hook_registration_protocol_has_exactly_one_member() -> None:
+    assert _public_contract_members(DrainHookRegistration) == {"register_drain_hook"}
+
+
+def test_session_protocol_signatures_are_pinned() -> None:
+    rpc_call = inspect.signature(Session.rpc_call)
+    assert list(rpc_call.parameters) == [
+        "self",
+        "method",
+        "params",
+        "source_path",
+        "allow_null",
+        "_is_retry",
+        "disable_internal_retries",
+        "operation_variant",
+    ]
+    assert rpc_call.parameters["source_path"].default == "/"
+    assert rpc_call.parameters["allow_null"].default is False
+    assert rpc_call.parameters["_is_retry"].default is False
+    assert rpc_call.parameters["disable_internal_retries"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert rpc_call.parameters["disable_internal_retries"].default is False
+    assert rpc_call.parameters["operation_variant"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert rpc_call.parameters["operation_variant"].default is None
+
+    transport_post = inspect.signature(Session.transport_post)
+    assert transport_post.parameters["build_request"].annotation == "BuildRequest"
+    assert transport_post.parameters["parse_label"].annotation == "str"
+    assert transport_post.parameters["disable_internal_retries"].kind is (
+        inspect.Parameter.KEYWORD_ONLY
+    )
+    assert "_BuildRequest" not in str(transport_post)
+
+    next_reqid = inspect.signature(Session.next_reqid)
+    assert next_reqid.parameters["step"].default == 100000
+    assert next_reqid.return_annotation == "int"
+
+    operation_scope = inspect.signature(Session.operation_scope)
+    assert operation_scope.return_annotation == "AbstractAsyncContextManager[None]"
+
+
+def test_kernel_and_drain_hook_signatures_are_pinned() -> None:
+    post = inspect.signature(Kernel.post)
+    assert list(post.parameters) == ["self", "url", "headers", "body"]
+    assert post.parameters["headers"].annotation == "Mapping[str, str]"
+    assert post.parameters["body"].annotation == "bytes"
+    assert post.return_annotation == "httpx.Response"
+
+    cookies = inspect.signature(Kernel.cookies.fget)
+    assert cookies.return_annotation == "httpx.Cookies"
+
+    aclose = inspect.signature(Kernel.aclose)
+    assert list(aclose.parameters) == ["self"]
+    assert aclose.return_annotation == "None"
+
+    register_drain_hook = inspect.signature(DrainHookRegistration.register_drain_hook)
+    assert list(register_drain_hook.parameters) == ["self", "name", "hook"]
+    assert register_drain_hook.parameters["hook"].annotation == "Callable[[], Awaitable[None]]"
+    assert register_drain_hook.return_annotation == "None"
+
+
+def test_structural_implementations_satisfy_protocols() -> None:
+    session: Session = _SessionImpl()
+    kernel: Kernel = _KernelImpl()
+    drain_hooks: DrainHookRegistration = _DrainHookRegistrationImpl()
+
+    assert isinstance(session, _SessionImpl)
+    assert isinstance(kernel, _KernelImpl)
+    assert isinstance(drain_hooks, _DrainHookRegistrationImpl)

--- a/tests/unit/test_session_contracts.py
+++ b/tests/unit/test_session_contracts.py
@@ -24,7 +24,7 @@ class _NoopOperationScope:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         traceback: TracebackType | None,
-    ) -> bool:
+    ) -> bool | None:
         return False
 
 
@@ -152,6 +152,7 @@ def test_kernel_and_drain_hook_signatures_are_pinned() -> None:
     assert post.parameters["body"].annotation == "bytes"
     assert post.return_annotation == "httpx.Response"
 
+    # Protocol properties expose the getter signature through ``fget``.
     cookies = inspect.signature(Kernel.cookies.fget)
     assert cookies.return_annotation == "httpx.Cookies"
 
@@ -166,10 +167,15 @@ def test_kernel_and_drain_hook_signatures_are_pinned() -> None:
 
 
 def test_structural_implementations_satisfy_protocols() -> None:
+    # These assignments are the contract check: mypy verifies that each
+    # implementation structurally satisfies its Protocol. Runtime
+    # ``isinstance`` checks would only prove the concrete class identity
+    # unless the Protocols became ``@runtime_checkable``, which is weaker than
+    # the signature-level static check and not needed for this type-only PR.
     session: Session = _SessionImpl()
     kernel: Kernel = _KernelImpl()
     drain_hooks: DrainHookRegistration = _DrainHookRegistrationImpl()
 
-    assert isinstance(session, _SessionImpl)
-    assert isinstance(kernel, _KernelImpl)
-    assert isinstance(drain_hooks, _DrainHookRegistrationImpl)
+    assert session is not None
+    assert kernel is not None
+    assert drain_hooks is not None


### PR DESCRIPTION
## Summary
- add type-only Session, Kernel, and DrainHookRegistration protocols in `_session_contracts.py`
- pin protocol member counts/signatures with focused unit tests
- document ADR-010 and add it to the ADR index

## Notes
- Tier 13 PR 13.1, rebased onto `origin/main` after PR #847 merged.
- No runtime behavior changes.

## Verification
- `uv run pre-commit run --all-files`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pytest -n auto`
- `uv run pytest tests/integration tests/e2e -m vcr -n auto`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an architectural decision record documenting the Session/Kernel split contract design.
  * Clarifies intended API surface and notes this is documentation-only with no runtime behavior changes.

* **Tests**
  * Added unit tests to validate the Session, Kernel, and DrainHookRegistration protocol/contract shapes and signatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->