### PR TITLE
feat(core): extract transport Kernel

### DIFF
--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -104,6 +104,7 @@ from ._core_transport import (
 from ._core_transport import (
     _TransportServerError as _TransportServerError,
 )
+from ._kernel import Kernel
 from ._middleware import (
     Middleware,
     NextCall,
@@ -424,10 +425,9 @@ class ClientCore:
         # inter-helper contract for the upcoming B2/C1 extractions; do not
         # rename.
         self._auth_coord = AuthRefreshCoordinator(refresh_callback=refresh_callback)
-        # HTTP-client lifecycle — owns ``_http_client``, ``_bound_loop``,
-        # ``_keepalive_task``, ``_keepalive_interval``,
-        # ``_keepalive_storage_path``, ``_timeout``, ``_connect_timeout``,
-        # ``_limits``. Compat properties further down preserve the legacy
+        # HTTP-client lifecycle — owns loop binding, keepalive, and close
+        # ordering while delegating the live ``httpx.AsyncClient`` to
+        # ``self._kernel``. Compat properties further down preserve the legacy
         # ivar names. The ``_resolve_keepalive_interval`` clamp now lives in
         # :mod:`notebooklm._core_helpers` and is re-exported above so
         # ``from notebooklm._core import _resolve_keepalive_interval`` keeps
@@ -451,12 +451,14 @@ class ClientCore:
         _resolved_storage_path: Path | None = (
             keepalive_storage_path if keepalive_storage_path is not None else auth.storage_path
         )
+        self._kernel = Kernel(async_client_factory=httpx.AsyncClient)
         self._lifecycle = ClientLifecycle(
             timeout=timeout,
             connect_timeout=connect_timeout,
             limits=_resolved_limits,
             keepalive_interval=_resolve_keepalive_interval(keepalive, keepalive_min_interval),
             keepalive_storage_path=_resolved_storage_path,
+            kernel=self._kernel,
         )
         # Owns the in-process save lock and open-time cookie baseline while
         # compatibility properties below keep the legacy private attribute
@@ -741,12 +743,14 @@ class ClientCore:
                 # Lazy import to break the types.py -> _core.py cycle.
                 from .types import ConnectionLimits
 
+                self._kernel = Kernel(async_client_factory=httpx.AsyncClient)
                 self._lifecycle = ClientLifecycle(
                     timeout=DEFAULT_TIMEOUT,
                     connect_timeout=DEFAULT_CONNECT_TIMEOUT,
                     limits=ConnectionLimits(),
                     keepalive_interval=None,
                     keepalive_storage_path=None,
+                    kernel=self._kernel,
                 )
 
     @property
@@ -1449,6 +1453,20 @@ class ClientCore:
         result = await self._authed_post_chain(request)
         return result.response
 
+    async def transport_post(
+        self,
+        build_request: _BuildRequest,
+        parse_label: str,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response:
+        """Session transport facade required by the Tier-13 contract."""
+        return await self._perform_authed_post(
+            build_request=build_request,
+            log_label=parse_label,
+            disable_internal_retries=disable_internal_retries,
+        )
+
     async def _await_refresh(self) -> None:
         """Run / join the shared refresh task.
 
@@ -1570,9 +1588,8 @@ class ClientCore:
         Raises:
             RuntimeError: If client is not initialized.
         """
-        if not self._http_client:
-            raise RuntimeError("Client not initialized. Use 'async with' context.")
-        return self._http_client
+        self._ensure_lifecycle()
+        return self._kernel.get_http_client()
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
         """Extract all source IDs from a notebook.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -1461,6 +1461,8 @@ class ClientCore:
         disable_internal_retries: bool = False,
     ) -> httpx.Response:
         """Session transport facade required by the Tier-13 contract."""
+        # ``Session`` exposes ``parse_label`` for the later feature retype.
+        # The existing transport leaf still calls the same value ``log_label``.
         return await self._perform_authed_post(
             build_request=build_request,
             log_label=parse_label,
@@ -1589,7 +1591,7 @@ class ClientCore:
             RuntimeError: If client is not initialized.
         """
         self._ensure_lifecycle()
-        return self._kernel.get_http_client()
+        return self._lifecycle.get_http_client()
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
         """Extract all source IDs from a notebook.

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -284,9 +284,9 @@ class ClientLifecycle:
         :func:`asyncio.shield` — without the shield, a ``CancelledError``
         arriving during keepalive teardown or the cookie save would skip
         ``aclose()`` and leak the underlying httpx transport.
-        ``self._http_client = None`` runs in an inner ``finally`` so the
-        instance is consistently marked closed even if the shielded
-        ``aclose()`` itself raises.
+        :meth:`Kernel.aclose` clears the live HTTP client in its own
+        ``finally`` so the instance is consistently marked closed even if
+        shielded teardown raises.
 
         Poll-task drain: in-flight artifact poll tasks held by
         ``host.poll_registry`` are cancelled and awaited before the HTTP

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -1,9 +1,11 @@
 """HTTP-client lifecycle helper for :class:`ClientCore`.
 
-Owns the HTTP-client lifecycle state and behavior that historically lived
-inline on ``ClientCore``:
+Owns the session-side open/close ordering that historically lived inline on
+``ClientCore`` while delegating the raw HTTP transport to
+:class:`notebooklm._kernel.Kernel`:
 
-* ``_http_client`` — the live ``httpx.AsyncClient`` (or ``None`` when closed).
+* ``_http_client`` — compatibility property backed by the concrete Kernel's
+  live ``httpx.AsyncClient`` (or ``None`` when closed).
 * ``_bound_loop`` — the event loop ``open()`` ran on; the cross-loop affinity
   guard in :meth:`ClientCore._perform_authed_post` (via
   :class:`AuthedTransport`) compares against this captured reference.
@@ -31,10 +33,10 @@ Design constraints (load-bearing — see ``tests/unit/test_client_keepalive.py``
   is a no-op, preserving the legacy ``ClientCore.open()`` contract.
 
 * :meth:`close` cancellation ordering: stop keepalive → drain poll tasks →
-  save cookies → shielded ``aclose()`` → null out ``_http_client``. Reversing
-  any of these reintroduces the leak modes ``test_core_close.py`` pins down.
-  The shielded ``aclose()`` is critical: without it, a ``CancelledError``
-  arriving mid-close leaks the underlying httpx transport.
+  save cookies → shielded Kernel ``aclose()``. Reversing any of these
+  reintroduces the leak modes ``test_core_close.py`` pins down. The shielded
+  ``aclose()`` is critical: without it, a ``CancelledError`` arriving
+  mid-close leaks the underlying httpx transport.
 
 * :meth:`open` no longer wraps the inner transport for synthetic-error
   injection — Tier-12 PR 12.6 lifted that path into the chain
@@ -58,8 +60,8 @@ Field names (``_http_client``, ``_bound_loop``, ``_keepalive_task``,
 ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``,
 ``_connect_timeout``, ``_limits``) deliberately mirror the legacy
 ``ClientCore`` ivars so the compat ``@property`` bridges on ``ClientCore``
-can delegate via ``return self._lifecycle._<attr>`` and stay readable for
-reviewers grepping the codebase.
+can stay readable for reviewers grepping the codebase. ``_http_client`` is now
+a property bridge to the Kernel rather than lifecycle-owned storage.
 """
 
 from __future__ import annotations
@@ -71,7 +73,8 @@ from typing import TYPE_CHECKING, Protocol
 
 import httpx
 
-from .auth import AuthTokens, build_cookie_jar
+from ._kernel import Kernel
+from .auth import AuthTokens
 
 if TYPE_CHECKING:
     from ._core_auth import AuthRefreshCoordinator
@@ -136,7 +139,9 @@ class ClientLifecycle:
         limits: ConnectionLimits,
         keepalive_interval: float | None,
         keepalive_storage_path: Path | None,
+        kernel: Kernel | None = None,
     ) -> None:
+        self._kernel = kernel if kernel is not None else Kernel()
         self._timeout: float = timeout
         self._connect_timeout: float = connect_timeout
         # ``ConnectionLimits`` is constructed by the caller (``ClientCore``
@@ -150,10 +155,19 @@ class ClientLifecycle:
         # stays in one place — the seam helper.
         self._keepalive_interval: float | None = keepalive_interval
         self._keepalive_storage_path: Path | None = keepalive_storage_path
-        # Lazily set inside :meth:`open` / nulled inside :meth:`close`.
-        self._http_client: httpx.AsyncClient | None = None
+        # The live HTTP client is owned by ``self._kernel``. The
+        # ``_http_client`` property below preserves the historical lifecycle
+        # attribute for tests and private callers that probe it directly.
         self._bound_loop: asyncio.AbstractEventLoop | None = None
         self._keepalive_task: asyncio.Task[None] | None = None
+
+    @property
+    def _http_client(self) -> httpx.AsyncClient | None:
+        return self._kernel.http_client
+
+    @_http_client.setter
+    def _http_client(self, value: httpx.AsyncClient | None) -> None:
+        self._kernel.http_client = value
 
     # ------------------------------------------------------------------
     # State accessors
@@ -218,40 +232,16 @@ class ClientLifecycle:
         # legacy ``self._draining = False`` line.
         host._drain_tracker._draining = False
 
-        # Use granular timeouts: shorter connect timeout helps detect network
-        # issues faster, while longer read/write timeouts accommodate slow
-        # responses.
-        timeout = httpx.Timeout(
-            connect=self._connect_timeout,
-            read=self._timeout,
-            write=self._timeout,
-            pool=self._timeout,
+        # Delegate HTTP-client construction and open-time cookie baseline
+        # capture to the concrete transport kernel. The lifecycle still owns
+        # loop binding and open/close ordering.
+        await self._kernel.open(
+            auth=host.auth,
+            timeout=self._timeout,
+            connect_timeout=self._connect_timeout,
+            limits=self._limits,
+            capture_cookie_snapshot=host.cookie_persistence.capture_open_snapshot,
         )
-
-        # Build cookies jar for cross-domain redirect support. Use the
-        # pre-built jar if available, otherwise build one from the persisted
-        # cookie list (or storage_path).
-        cookies = host.auth.cookie_jar or build_cookie_jar(
-            cookies=host.auth.cookies,
-            storage_path=host.auth.storage_path,
-        )
-
-        self._http_client = httpx.AsyncClient(
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            },
-            cookies=cookies,
-            timeout=timeout,
-            follow_redirects=True,
-            limits=self._limits.to_httpx_limits(),
-        )
-
-        # Capture the open-time snapshot AFTER the AsyncClient is built (httpx
-        # normalizes domains on ingest) but BEFORE any rotation could possibly
-        # fire. When AuthTokens carries a snapshot from a failed pre-client
-        # save, keep it so the unpersisted delta can be retried instead of
-        # treating the already-mutated jar as clean.
-        host.cookie_persistence.capture_open_snapshot(self._http_client.cookies)
 
         # Spawn the keepalive task once the client is ready.
         if self._keepalive_interval is not None:
@@ -346,7 +336,7 @@ class ClientLifecycle:
                     # naturally with any keepalive save still finishing in a
                     # worker thread — close() owns the freshest jar and must
                     # win, not the older snapshot.
-                    await self.save_cookies(host, self._http_client.cookies)
+                    await self.save_cookies(host, self._kernel.cookies)
                 except Exception as e:
                     logger.warning("Failed to sync refreshed cookies during close: %s", e)
         finally:
@@ -356,9 +346,8 @@ class ClientLifecycle:
                     # the transport. The shielded aclose runs to completion;
                     # ``self._http_client = None`` then makes ``is_open``
                     # return False correctly.
-                    await asyncio.shield(self._http_client.aclose())
+                    await asyncio.shield(self._kernel.aclose())
                 finally:
-                    self._http_client = None
                     # Null out the transport collaborators so a follow-up
                     # ``open()`` rebuilds them against the new
                     # ``httpx.AsyncClient`` (the old ones close over the

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -186,6 +186,10 @@ class ClientLifecycle:
         """
         return self._bound_loop
 
+    def get_http_client(self) -> httpx.AsyncClient:
+        """Return the live HTTP client via the concrete Kernel."""
+        return self._kernel.get_http_client()
+
     # ------------------------------------------------------------------
     # Open / close
     # ------------------------------------------------------------------

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -260,6 +260,7 @@ class AuthedTransport:
         the parameter once the legacy non-chain code path is retired.
         """
         host = self._host
+        # Fast-path: reject pre-open calls before loop checks and semaphore acquisition.
         if host._http_client is None:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
 

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -10,11 +10,14 @@ from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import httpx
 
 from .exceptions import RPCResponseTooLargeError
+
+if TYPE_CHECKING:
+    from ._kernel import Kernel
 
 # Upper bound on Retry-After wait. Caps both integer-seconds and HTTP-date forms
 # so a malicious or buggy server can't force a multi-hour pause.
@@ -205,6 +208,7 @@ async def _stream_post_with_size_cap(
 
 
 class _AuthedTransportHost(Protocol):
+    _kernel: Kernel
     _http_client: httpx.AsyncClient | None
     _bound_loop: asyncio.AbstractEventLoop | None
     _refresh_callback: Callable[[], Awaitable[Any]] | None
@@ -258,7 +262,6 @@ class AuthedTransport:
         host = self._host
         if host._http_client is None:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
-        client = host._http_client
 
         # Event-loop affinity guard. Placed before
         # semaphore acquisition so cross-loop misuse never reserves a slot.
@@ -319,11 +322,10 @@ class AuthedTransport:
                 # is invoked before any body chunk is read so the chain
                 # middlewares see the same :class:`httpx.HTTPStatusError`
                 # they did when this used ``client.post``.
-                response = await _stream_post_with_size_cap(
-                    client,
+                response = await host._kernel.post(
                     url,
-                    body=body,
                     headers=headers,
+                    body=body,
                 )
             except (httpx.HTTPStatusError, httpx.RequestError) as exc:
                 # --- 429: raise for ``RetryMiddleware`` to catch --------

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -38,7 +38,10 @@ class Kernel:
 
     @property
     def cookies(self) -> httpx.Cookies:
-        """Return the live HTTP client's cookie jar."""
+        """Return the live HTTP client's cookie jar.
+
+        Raises ``RuntimeError`` if called before :meth:`open`.
+        """
         return self.get_http_client().cookies
 
     def get_http_client(self) -> httpx.AsyncClient:
@@ -57,6 +60,8 @@ class Kernel:
         capture_cookie_snapshot: Callable[[httpx.Cookies], object],
     ) -> None:
         """Build the HTTP client and capture its normalized cookie baseline."""
+        # ClientLifecycle owns the primary idempotency guard. Keep this
+        # secondary guard so direct Kernel callers also preserve the live client.
         if self._http_client is not None:
             return
 

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -72,9 +72,13 @@ class Kernel:
             write=timeout,
             pool=timeout,
         )
-        cookies = auth.cookie_jar or build_cookie_jar(
-            cookies=auth.cookies,
-            storage_path=auth.storage_path,
+        cookies = (
+            auth.cookie_jar
+            if auth.cookie_jar is not None
+            else build_cookie_jar(
+                cookies=auth.cookies,
+                storage_path=auth.storage_path,
+            )
         )
 
         self._http_client = self._async_client_factory(

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -34,6 +34,7 @@ class Kernel:
 
     @http_client.setter
     def http_client(self, value: httpx.AsyncClient | None) -> None:
+        # Test-injection seam for tests that assign through ClientCore._http_client.
         self._http_client = value
 
     @property

--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -1,0 +1,110 @@
+"""Concrete transport kernel for NotebookLM session operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+import httpx
+
+from ._core_transport import _PostBody, _stream_post_with_size_cap
+from .auth import AuthTokens, build_cookie_jar
+from .types import ConnectionLimits
+
+
+class Kernel:
+    """Own the live HTTP transport and cookie jar.
+
+    Session lifecycle code decides when to open and close. The kernel owns the
+    concrete ``httpx.AsyncClient`` instance, its cookie jar, raw POST execution,
+    and shielded teardown target.
+    """
+
+    def __init__(
+        self,
+        *,
+        async_client_factory: Callable[..., httpx.AsyncClient] = httpx.AsyncClient,
+    ) -> None:
+        self._async_client_factory = async_client_factory
+        self._http_client: httpx.AsyncClient | None = None
+
+    @property
+    def http_client(self) -> httpx.AsyncClient | None:
+        """Return the live HTTP client, or ``None`` when closed."""
+        return self._http_client
+
+    @http_client.setter
+    def http_client(self, value: httpx.AsyncClient | None) -> None:
+        self._http_client = value
+
+    @property
+    def cookies(self) -> httpx.Cookies:
+        """Return the live HTTP client's cookie jar."""
+        return self.get_http_client().cookies
+
+    def get_http_client(self) -> httpx.AsyncClient:
+        """Return the live HTTP client or raise the legacy not-open error."""
+        if self._http_client is None:
+            raise RuntimeError("Client not initialized. Use 'async with' context.")
+        return self._http_client
+
+    async def open(
+        self,
+        *,
+        auth: AuthTokens,
+        timeout: float,
+        connect_timeout: float,
+        limits: ConnectionLimits,
+        capture_cookie_snapshot: Callable[[httpx.Cookies], object],
+    ) -> None:
+        """Build the HTTP client and capture its normalized cookie baseline."""
+        if self._http_client is not None:
+            return
+
+        http_timeout = httpx.Timeout(
+            connect=connect_timeout,
+            read=timeout,
+            write=timeout,
+            pool=timeout,
+        )
+        cookies = auth.cookie_jar or build_cookie_jar(
+            cookies=auth.cookies,
+            storage_path=auth.storage_path,
+        )
+
+        self._http_client = self._async_client_factory(
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            },
+            cookies=cookies,
+            timeout=http_timeout,
+            follow_redirects=True,
+            limits=limits.to_httpx_limits(),
+        )
+        capture_cookie_snapshot(self._http_client.cookies)
+
+    async def post(
+        self,
+        url: str,
+        headers: Mapping[str, str] | None,
+        body: _PostBody,
+    ) -> httpx.Response:
+        """Issue a raw buffered POST through the live HTTP client."""
+        return await _stream_post_with_size_cap(
+            self.get_http_client(),
+            url,
+            body=body,
+            headers=dict(headers) if headers is not None else None,
+        )
+
+    async def aclose(self) -> None:
+        """Close the live HTTP client and mark the kernel closed."""
+        client = self._http_client
+        if client is None:
+            return
+        try:
+            await client.aclose()
+        finally:
+            self._http_client = None
+
+
+__all__ = ["Kernel"]

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
+import notebooklm._kernel as kernel_module
 from notebooklm._kernel import Kernel
 from notebooklm.auth import AuthTokens
 from notebooklm.types import ConnectionLimits
@@ -71,7 +72,7 @@ async def test_open_preserves_explicit_empty_cookie_jar(monkeypatch: pytest.Monk
     def fail_build_cookie_jar(**_: object) -> httpx.Cookies:
         raise AssertionError("explicit cookie_jar should not be rebuilt")
 
-    monkeypatch.setattr("notebooklm._kernel.build_cookie_jar", fail_build_cookie_jar)
+    monkeypatch.setattr(kernel_module, "build_cookie_jar", fail_build_cookie_jar)
     kernel = Kernel()
     await kernel.open(
         auth=AuthTokens(

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -33,7 +33,35 @@ async def test_open_builds_http_client_and_captures_live_cookie_snapshot() -> No
     )
     try:
         assert kernel.http_client is not None
-        assert captured == [kernel.cookies]
+        assert len(captured) == 1
+        assert captured[0] is kernel.cookies
+    finally:
+        await kernel.aclose()
+
+
+@pytest.mark.asyncio
+async def test_open_is_idempotent() -> None:
+    kernel = Kernel()
+    captured: list[httpx.Cookies] = []
+
+    await kernel.open(
+        auth=_auth_tokens(),
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        capture_cookie_snapshot=captured.append,
+    )
+    first_client = kernel.http_client
+    await kernel.open(
+        auth=_auth_tokens(),
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        capture_cookie_snapshot=captured.append,
+    )
+    try:
+        assert kernel.http_client is first_client
+        assert len(captured) == 1
     finally:
         await kernel.aclose()
 

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -1,0 +1,96 @@
+"""Unit tests for the concrete transport Kernel."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from notebooklm._kernel import Kernel
+from notebooklm.auth import AuthTokens
+from notebooklm.types import ConnectionLimits
+
+
+def _auth_tokens() -> AuthTokens:
+    return AuthTokens(
+        csrf_token="csrf",
+        session_id="sid",
+        cookies={"SID": "cookie-value"},
+        storage_path=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_builds_http_client_and_captures_live_cookie_snapshot() -> None:
+    kernel = Kernel()
+    captured: list[httpx.Cookies] = []
+
+    await kernel.open(
+        auth=_auth_tokens(),
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        capture_cookie_snapshot=captured.append,
+    )
+    try:
+        assert kernel.http_client is not None
+        assert captured == [kernel.cookies]
+    finally:
+        await kernel.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_uses_live_http_client_streaming_post() -> None:
+    seen_requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(200, content=b"ok")
+
+    transport = httpx.MockTransport(handler)
+
+    def async_client_factory(**kwargs: object) -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=transport, **kwargs)  # type: ignore[arg-type]
+
+    kernel = Kernel(async_client_factory=async_client_factory)
+    await kernel.open(
+        auth=_auth_tokens(),
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        capture_cookie_snapshot=lambda _: None,
+    )
+    try:
+        response = await kernel.post(
+            "https://example.com/batchexecute",
+            headers={"X-Test": "yes"},
+            body=b"payload",
+        )
+    finally:
+        await kernel.aclose()
+
+    assert response.text == "ok"
+    assert len(seen_requests) == 1
+    request = seen_requests[0]
+    assert request.method == "POST"
+    assert str(request.url) == "https://example.com/batchexecute"
+    assert request.headers["X-Test"] == "yes"
+    assert request.content == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_aclose_marks_kernel_closed_and_is_idempotent() -> None:
+    kernel = Kernel()
+    await kernel.open(
+        auth=_auth_tokens(),
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        capture_cookie_snapshot=lambda _: None,
+    )
+
+    await kernel.aclose()
+    await kernel.aclose()
+
+    assert kernel.http_client is None
+    with pytest.raises(RuntimeError, match="Client not initialized"):
+        kernel.get_http_client()

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -67,6 +67,32 @@ async def test_open_is_idempotent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_open_preserves_explicit_empty_cookie_jar(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_build_cookie_jar(**_: object) -> httpx.Cookies:
+        raise AssertionError("explicit cookie_jar should not be rebuilt")
+
+    monkeypatch.setattr("notebooklm._kernel.build_cookie_jar", fail_build_cookie_jar)
+    kernel = Kernel()
+    await kernel.open(
+        auth=AuthTokens(
+            csrf_token="csrf",
+            session_id="sid",
+            cookies={},
+            cookie_jar=httpx.Cookies(),
+            storage_path=None,
+        ),
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        capture_cookie_snapshot=lambda _: None,
+    )
+    try:
+        assert kernel.http_client is not None
+    finally:
+        await kernel.aclose()
+
+
+@pytest.mark.asyncio
 async def test_post_uses_live_http_client_streaming_post() -> None:
     seen_requests: list[httpx.Request] = []
 


### PR DESCRIPTION
## Summary
- add concrete transport Kernel owning the live httpx.AsyncClient, cookies, raw POST, and aclose
- keep ClientLifecycle responsible for loop binding, keepalive/auth-refresh/drain ordering, and close orchestration while delegating transport operations to Kernel
- route the authed POST leaf through Kernel.post and add focused Kernel unit coverage

## Verification
- uv run ruff check src/notebooklm tests/unit/test_kernel.py
- uv run mypy src/notebooklm --ignore-missing-imports
- uv run pytest tests/unit/test_kernel.py tests/unit/test_core_lifecycle.py tests/unit/test_core_transport.py -q
- uv run pytest tests/integration/test_core.py tests/integration/concurrency/test_pool_tuning.py tests/unit/test_client_keepalive.py tests/unit/concurrency/test_close_cancellation_leak.py tests/unit/concurrency/test_core_close_refresh_race.py -q
- uv run pytest tests/unit -q
- uv run pytest -n auto
- uv run pytest tests/integration tests/e2e -m vcr -n auto
- uv run pre-commit run --all-files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session-level POST facade allowing optional parse-label mapping and control over internal retries.

* **Refactor**
  * Centralized HTTP client and cookie/session ownership into a dedicated session manager for more reliable initialization, shutdown, and cookie persistence.
  * Transport now delegates HTTP execution to the centralized session manager for consistent request behavior and error handling.

* **Tests**
  * Added unit tests covering session lifecycle, POST behavior, and cookie snapshot handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->