### PR TITLE
feat(core): close Tier-12 — SemaphoreMiddleware + cleanup (Tier 12 PR 12.9)

### DIFF
--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -42,16 +42,22 @@ Tier 13. That supersession is *not* performed by this ADR; ADR-002 remains
 ## Context
 
 The post-remediation `ClientCore` orchestrates six cross-cutting concerns
-across every authenticated POST:
+across every authenticated POST. The "Today" column below describes the
+pre-Tier-12 state (when ADR-009 was written, before any chain extraction
+landed); the "Post-Tier-12" column describes where each concern lives
+after PR 12.9 closed the tier. `_SyntheticErrorTransport` was deleted by
+PR 12.9; the chain-layer `ErrorInjectionMiddleware` is the only
+substitution path going forward.
 
-| Concern | Today | Module |
+| Concern | Pre-Tier-12 | Post-Tier-12 (PR 12.9 → today) |
 |---|---|---|
-| In-flight drain tracking | `TransportDrainTracker.begin/end` around the call | `_core_drain.py` |
-| Metrics emission | `ClientMetrics.on_rpc_event` callbacks woven through `AuthedTransport` | `_core_metrics.py` |
-| Retry on 5xx / 429 | inline loops inside `AuthedTransport.perform_authed_post` | `_core_transport.py:243` |
-| Auth refresh on 401 | inline branch inside `AuthedTransport.perform_authed_post` | `_core_transport.py:243`, `_core_auth.py` |
-| Synthetic error injection (tests) | `_SyntheticErrorTransport` wraps the httpx client | `_core_error_injection.py` |
-| Per-attempt tracing/logging | scattered `logger.debug` calls inside the retry loop | `_core_transport.py:243` |
+| In-flight drain tracking | `TransportDrainTracker.begin/end` around the call (`_core_drain.py`) | `DrainMiddleware` (chain pos 0) |
+| Metrics emission | `ClientMetrics.on_rpc_event` callbacks woven through `AuthedTransport` (`_core_metrics.py`) | `MetricsMiddleware` (chain pos 1) |
+| RPC concurrency gate | `asyncio.Semaphore` inside `AuthedTransport.perform_authed_post` | `SemaphoreMiddleware` (chain pos 2) |
+| Retry on 5xx / 429 | inline loops inside `AuthedTransport.perform_authed_post` | `RetryMiddleware` (chain pos 3) |
+| Auth refresh on 401 | inline branch inside `AuthedTransport.perform_authed_post` (`_core_auth.py`) | `AuthRefreshMiddleware` (chain pos 4) |
+| Synthetic error injection (tests) | `_SyntheticErrorTransport` wraps the httpx client (`_core_error_injection.py`) — DELETED PR 12.9 | `ErrorInjectionMiddleware` (chain pos 5) |
+| Per-attempt tracing/logging | scattered `logger.debug` calls inside the retry loop | `TracingMiddleware` (chain pos 6) |
 
 Adding a seventh concern (e.g. an idempotency-routing wrapper for retry
 safety, ADR-005) requires touching `AuthedTransport.perform_authed_post`
@@ -128,7 +134,7 @@ chain operates on already-encoded HTTP requests; encoding/decoding lives
 The chain is composed in this exact order (outermost → innermost):
 
 ```text
-Drain → Metrics → Retry → AuthRefresh → ErrorInjection → Tracing → terminal
+Drain → Metrics → Semaphore → Retry → AuthRefresh → ErrorInjection → Tracing → terminal
 ```
 
 Where `terminal` is `Kernel.post` after PR 13.2, and
@@ -138,17 +144,33 @@ The leftmost middleware in the sequence becomes the outermost wrapper.
 `build_chain` enforces this ordering by composing in reverse (last
 middleware is wrapped first around `terminal`).
 
+`SemaphoreMiddleware` was inserted at chain position 3 in PR 12.9 (see
+"PR 12.9 close-out notes" below) after the first cut of the audit-find
+moved the `max_concurrent_rpcs` slot to `ClientCore._perform_authed_post`
+(outside the chain) and codex caught the resulting Drain-admission
+regression. PR 12.1 originally pinned six middlewares; the chain is seven
+post-PR-12.9.
+
 Per-position rationale:
 
 - **Drain outermost.** Every in-flight call — including ones that haven't
-  reached the transport yet because Retry / AuthRefresh / ErrorInjection
-  haven't released them — must count toward shutdown drain. Putting Drain
-  inside any of those would let a stuck retry escape the drain accounting.
-- **Metrics outside Retry.** Metrics measure end-to-end timing, not
-  per-attempt timing. (`ClientMetrics` already separates the two with
-  `record_rpc_queue_wait` for queue time and the outer span for total.)
-  Placing Metrics inside Retry would emit one metric per attempt, which
-  the existing observers don't expect.
+  reached the transport yet because Semaphore / Retry / AuthRefresh /
+  ErrorInjection haven't released them — must count toward shutdown
+  drain. Putting Drain inside any of those would let a stuck retry (or a
+  queued call waiting for the semaphore) escape the drain accounting.
+- **Metrics outside Semaphore.** Metrics measure end-to-end timing
+  *including* the time a call spent waiting for the `max_concurrent_rpcs`
+  slot. (`ClientMetrics` also tracks `rpc_queue_wait_seconds_total`
+  separately via the `RPC_QUEUE_WAIT_CONTEXT_KEY` plumbing — that's just
+  queue time, while Metrics latency covers queue + work.) Placing Metrics
+  inside Semaphore would exclude queue wait from latency, breaking
+  pre-Tier-12 telemetry semantics.
+- **Semaphore outside Retry.** The `asyncio.Semaphore` is non-reentrant.
+  Placing it inside Retry would let each retry attempt try to acquire a
+  fresh slot, deadlocking under sustained 429s when every slot is held by
+  a retrying call waiting to retry into a slot. Placing it outside Retry
+  bounds the whole retry-and-refresh cohort to one slot per logical RPC
+  (matching the pre-Tier-12 contract).
 - **Retry outside AuthRefresh.** These are orthogonal failure modes — 5xx
   / 429 / network errors trigger `RetryMiddleware`; 401 triggers
   `AuthRefreshMiddleware`. Nesting prevents infinite-loop duplication
@@ -161,14 +183,17 @@ Per-position rationale:
   refresh middleware to run, not for the injection to short-circuit
   before refresh sees it. Putting AuthRefresh inside ErrorInjection would
   invert that.
-- **ErrorInjection inside Retry.** Synthetic transient failures
-  (`_SyntheticErrorTransport`-style) should look like network errors to
-  `RetryMiddleware`. Putting ErrorInjection outside Retry would make the
-  retry path invisible to the test, defeating the purpose.
+- **ErrorInjection inside Retry.** Synthetic transient failures should
+  look like network errors to `RetryMiddleware`. Putting ErrorInjection
+  outside Retry would make the retry path invisible to the test,
+  defeating the purpose. Pre-PR-12.6 this was a transport-layer wrapper
+  (`_SyntheticErrorTransport`); PR 12.6 lifted it into the chain and PR
+  12.9 deleted the transport class — substitution is now exclusively a
+  chain-layer concern.
 - **Tracing innermost.** Tracing logs every actual HTTP attempt, including
   retried ones. Putting Tracing outside Retry would log only one entry
-  per logical call regardless of retries, losing the per-attempt visibility
-  the current `_core_transport.py:243` debug logging provides.
+  per logical call regardless of retries, losing the per-attempt
+  visibility the original `AuthedTransport` debug logging provided.
 
 ### `RpcRequest.context` keys (the chain's metadata vocabulary)
 
@@ -179,14 +204,21 @@ Per-position rationale:
 | `disable_internal_retries` | `bool` | `Session.rpc_call` (post-resolution from `_idempotency.resolve_effective_disable_internal_retries`) | `RetryMiddleware` |
 | `build_request` | `BuildRequest` | `Session.rpc_call` / `Session.transport_post` | chain leaf (adapter into `AuthedTransport.perform_authed_post`) |
 | `log_label` | `str` | `Session.rpc_call` / `Session.transport_post` | chain leaf, `DrainMiddleware`, `TracingMiddleware` |
+| `auth_refreshed` | `bool` | `AuthRefreshMiddleware` (sets to `True` after a successful refresh) | `AuthRefreshMiddleware` (skip-on-replay guard so a `RetryMiddleware` retry doesn't drive a second refresh on a fresh 401) |
+| `rpc_queue_wait_seconds` | `float` | `SemaphoreMiddleware` (writes queue-wait duration on slot acquire) | `ClientCore._perform_authed_post` (forwards to `ClientMetrics.record_rpc_queue_wait`) |
 
 Middlewares are forbidden from inventing new keys without an ADR update.
 The dict is mutable by reference (deliberately, per master plan
 §"Per-request behavior") but read-mostly in practice.
 
-### AuthRefreshMiddleware constructor signature
+### AuthRefreshMiddleware constructor signature (Tier-13 target, NOT shipped in Tier-12)
 
-This is the load-bearing pin. PR 12.8 implements *exactly* this shape:
+The signature pinned in this section is the **target** shape for the
+post-`Kernel.post` rewrite (Tier-13 row 13.2). PR 12.8 SHIPPED a simpler
+interim shape that defers request-rebuilding to the leaf — see "PR 12.9
+close-out notes" §"AuthRefreshMiddleware shipped without rebuild
+closures" for the details and rationale. Until Tier 13 makes the chain
+leaf a pure POST, the closure-callback pair below remains aspirational:
 
 ```python
 class AuthRefreshMiddleware:
@@ -367,40 +399,54 @@ the dataclass is a thin wrapper there.
 Two implementation details landed differently than the PR-12.1 pin and
 are documented here so Tier-13 callers have an authoritative reference.
 
-### RPC concurrency semaphore wraps the chain dispatch, not the leaf
+### `SemaphoreMiddleware` inserted at chain position 2
 
-The `max_concurrent_rpcs` semaphore (default 16; see
-`_core_constants.py:DEFAULT_MAX_CONCURRENT_RPCS`) is acquired in
-`ClientCore._perform_authed_post` *around* the chain dispatch, not inside
-`AuthedTransport.perform_authed_post`. The block looks like:
+The `max_concurrent_rpcs` slot is acquired by `SemaphoreMiddleware`,
+which sits between `MetricsMiddleware` and `RetryMiddleware` in the
+chain. The middleware writes the per-call queue-wait duration to
+`request.context["rpc_queue_wait_seconds"]` and
+`ClientCore._perform_authed_post` forwards that value to
+`ClientMetrics.record_rpc_queue_wait` after the chain returns.
 
-```python
-async with self._get_rpc_semaphore():
-    self._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
-    result = await self._authed_post_chain(request)
-    return result.response
-```
+The placement is constrained by three simultaneous invariants the
+shipped chain must preserve (codex caught the violations in the first
+cut of PR 12.9):
 
-Pre-Tier-12, the semaphore wrapped the entire `AuthedTransport`
-invocation, which included the inline 429/5xx retry loops. After Tier 12
-those loops live in `RetryMiddleware` *inside* the chain. Two reasons the
-semaphore moved up to the chain dispatch:
+1. **Drain admission scope.** `DrainMiddleware` (chain pos 0) increments
+   `_in_flight_posts` for every call that enters the chain, INCLUDING
+   ones still waiting for the `max_concurrent_rpcs` slot. If the
+   semaphore wait happened OUTSIDE the chain (e.g. wrapping the chain
+   dispatch in `_perform_authed_post`), `client.close()` mid-flight
+   would reject queued tasks instead of waiting for them — a regression
+   vs. the PR-12.5-onwards contract.
+2. **Metrics latency includes queue wait.** `MetricsMiddleware`
+   (chain pos 1) starts its `perf_counter` BEFORE `next_call` reaches
+   `SemaphoreMiddleware`. Latency emitted on `rpc_latency_seconds_total`
+   and `RpcTelemetryEvent.elapsed_seconds` covers queue wait + work,
+   matching the pre-PR-12.9 (PR 12.8) telemetry shape where Metrics
+   wrapped the leaf-side semaphore.
+3. **`asyncio.Semaphore` is non-reentrant.** `RetryMiddleware`
+   (chain pos 3) re-invokes its `next_call` on retry attempts. Placing
+   `SemaphoreMiddleware` INSIDE `RetryMiddleware` would have each retry
+   attempt try to acquire a fresh slot, deadlocking under sustained
+   429s when every slot is held by a retrying call waiting to retry
+   into a slot. Placing it OUTSIDE `RetryMiddleware` (chain pos 2)
+   bounds the whole retry-and-refresh cohort to one slot per logical
+   RPC.
 
-1. **Pre-Tier-12 contract preservation.** A logical RPC counted as
-   exactly one semaphore slot regardless of how many retry attempts it
-   made. Moving the semaphore to the leaf would let `RetryMiddleware`'s
-   re-invocations of `next_call` claim additional slots, which under
-   sustained 429s could deadlock the chain (every slot held by a retrying
-   call waiting to retry into a slot).
-2. **`asyncio.Semaphore` is not reentrant.** A `RetryMiddleware` retry is
-   a fresh `await chain(request)` call on the same coroutine, but
-   reacquiring the semaphore from the same task is fine only because the
-   acquire happens *outside* the chain. Wrapping the leaf would risk
-   self-deadlock if a future middleware ever held the slot across
-   `await next_call(...)`.
+The middleware takes a zero-arg async-context-manager factory rather
+than a raw `asyncio.Semaphore`, so production wires
+`SemaphoreMiddleware(self._get_rpc_semaphore)` and the accessor returns
+a `contextlib.nullcontext` when `max_concurrent_rpcs is None` (unbounded
+opt-out) — the `async with` collapses to a no-op for that case.
 
-The chain leaf no longer touches `host._rpc_semaphore`; only
-`ClientCore._perform_authed_post` does.
+History: the first cut of PR 12.9 audit-find #1 wrapped the semaphore
+around `ClientCore._perform_authed_post` directly (outside the chain).
+Codex caught the Drain-admission regression with a reproducible
+`max_concurrent_rpcs=1` test case — queued tasks raised `RuntimeError`
+during shutdown instead of being awaited. `SemaphoreMiddleware`
+restored the contract while keeping the retry-multi-acquisition guard
+the original audit-find existed to provide.
 
 ### `AuthRefreshMiddleware` shipped without rebuild closures
 

--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -9,10 +9,10 @@ type-only scaffolding: the Protocol, dataclasses, and `build_chain` helper
 landed without production wiring. PR 12.2 wired an empty chain into
 `ClientCore`. PRs 12.3 through 12.8 each extracted one cross-cutting
 concern into a dedicated middleware. **PR 12.9 closes the tier** — the
-six-middleware chain `[Drain, Metrics, Retry, AuthRefresh, ErrorInjection,
-Tracing]` is fully wired, the leaf (`AuthedTransport.perform_authed_post`)
-is a pure POST, and the underscore-prefixed compatibility aliases were
-removed. The chain ordering, the `RpcRequest.context` key vocabulary, and
+seven-middleware chain `[Drain, Metrics, Semaphore, Retry, AuthRefresh,
+ErrorInjection, Tracing]` is fully wired, the leaf
+(`AuthedTransport.perform_authed_post`) is a pure POST, and the
+underscore-prefixed compatibility aliases were removed. The chain ordering, the `RpcRequest.context` key vocabulary, and
 the Protocol shape pinned below are the load-bearing contract going
 forward into Tier 13.
 
@@ -144,7 +144,7 @@ The leftmost middleware in the sequence becomes the outermost wrapper.
 `build_chain` enforces this ordering by composing in reverse (last
 middleware is wrapped first around `terminal`).
 
-`SemaphoreMiddleware` was inserted at chain position 3 in PR 12.9 (see
+`SemaphoreMiddleware` was inserted at chain position 2 in PR 12.9 (see
 "PR 12.9 close-out notes" below) after the first cut of the audit-find
 moved the `max_concurrent_rpcs` slot to `ClientCore._perform_authed_post`
 (outside the chain) and codex caught the resulting Drain-admission

--- a/docs/adr/0009-middleware-chain.md
+++ b/docs/adr/0009-middleware-chain.md
@@ -2,16 +2,31 @@
 
 ## Status
 
-Accepted (Tier 12 PR 12.1).
+Accepted (Tier 12 PR 12.1; closed by PR 12.9).
 
-This ADR ships in PR 12.1 of the Tier-12/13 greenfield migration as
-type-only scaffolding. The Protocol, dataclasses, and `build_chain` helper
-land; no production code wires the chain. PR 12.2 wires an empty chain into
-`ClientCore`. PRs 12.3 through 12.8 each extract one cross-cutting concern
-into a dedicated middleware. PR 12.9 closes the tier — removes the
-underscore-prefixed compatibility aliases, confirms the chain ordering, and
-re-statuses this ADR (it stays `Accepted`; the load-bearing contract here
-does not change).
+This ADR shipped in PR 12.1 of the Tier-12/13 greenfield migration as
+type-only scaffolding: the Protocol, dataclasses, and `build_chain` helper
+landed without production wiring. PR 12.2 wired an empty chain into
+`ClientCore`. PRs 12.3 through 12.8 each extracted one cross-cutting
+concern into a dedicated middleware. **PR 12.9 closes the tier** — the
+six-middleware chain `[Drain, Metrics, Retry, AuthRefresh, ErrorInjection,
+Tracing]` is fully wired, the leaf (`AuthedTransport.perform_authed_post`)
+is a pure POST, and the underscore-prefixed compatibility aliases were
+removed. The chain ordering, the `RpcRequest.context` key vocabulary, and
+the Protocol shape pinned below are the load-bearing contract going
+forward into Tier 13.
+
+Two implementation realities diverged from the original PR-12.1 pin and
+are documented in the "PR 12.9 close-out notes" section at the bottom of
+this ADR:
+1. The `AuthRefreshMiddleware` constructor shipped with a simpler shape
+   that defers request-rebuilding to the leaf (`rebuild_headers` /
+   `build_request_factory` closures are NOT yet wired at chain level).
+2. The RPC concurrency semaphore wraps the chain dispatch (not the leaf),
+   restoring pre-Tier-12 "one slot per logical RPC" semantics.
+
+Tier 13 (`Kernel.post` terminal) will revisit (1) — the closure callbacks
+remain pinned as the target shape for the chain-leaf rewrite.
 
 The signatures pinned in this ADR (especially the `AuthRefreshMiddleware`
 constructor, §"AuthRefreshMiddleware constructor signature") are
@@ -346,3 +361,82 @@ accepted for the response side. The request dataclass needs to carry
 extension point for that. The response side just carries
 `httpx.Response` (the field name `RpcResponse.response`) plus context, so
 the dataclass is a thin wrapper there.
+
+## PR 12.9 close-out notes
+
+Two implementation details landed differently than the PR-12.1 pin and
+are documented here so Tier-13 callers have an authoritative reference.
+
+### RPC concurrency semaphore wraps the chain dispatch, not the leaf
+
+The `max_concurrent_rpcs` semaphore (default 16; see
+`_core_constants.py:DEFAULT_MAX_CONCURRENT_RPCS`) is acquired in
+`ClientCore._perform_authed_post` *around* the chain dispatch, not inside
+`AuthedTransport.perform_authed_post`. The block looks like:
+
+```python
+async with self._get_rpc_semaphore():
+    self._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
+    result = await self._authed_post_chain(request)
+    return result.response
+```
+
+Pre-Tier-12, the semaphore wrapped the entire `AuthedTransport`
+invocation, which included the inline 429/5xx retry loops. After Tier 12
+those loops live in `RetryMiddleware` *inside* the chain. Two reasons the
+semaphore moved up to the chain dispatch:
+
+1. **Pre-Tier-12 contract preservation.** A logical RPC counted as
+   exactly one semaphore slot regardless of how many retry attempts it
+   made. Moving the semaphore to the leaf would let `RetryMiddleware`'s
+   re-invocations of `next_call` claim additional slots, which under
+   sustained 429s could deadlock the chain (every slot held by a retrying
+   call waiting to retry into a slot).
+2. **`asyncio.Semaphore` is not reentrant.** A `RetryMiddleware` retry is
+   a fresh `await chain(request)` call on the same coroutine, but
+   reacquiring the semaphore from the same task is fine only because the
+   acquire happens *outside* the chain. Wrapping the leaf would risk
+   self-deadlock if a future middleware ever held the slot across
+   `await next_call(...)`.
+
+The chain leaf no longer touches `host._rpc_semaphore`; only
+`ClientCore._perform_authed_post` does.
+
+### `AuthRefreshMiddleware` shipped without rebuild closures
+
+The original §"AuthRefreshMiddleware constructor signature" pinned a
+shape with two callbacks:
+
+```python
+rebuild_headers: Callable[[AuthSnapshot], Mapping[str, str]]
+build_request_factory: Callable[[AuthSnapshot], BuildRequestResult]
+```
+
+PR 12.8 shipped a simpler `AuthRefreshMiddleware` that catches
+`httpx.HTTPStatusError`, drives the coalesced refresh via
+`AuthRefreshCoordinator.await_refresh`, marks
+`request.context["auth_refreshed"] = True`, and re-invokes `next_call`
+**with the same `RpcRequest`** — the leaf
+(`AuthedTransport.perform_authed_post`) re-reads the now-refreshed
+`AuthSnapshot` from the coordinator and rebuilds headers/url/body inside
+the leaf, exactly as it did pre-Tier-12.
+
+Why deferred: lifting `rebuild_headers` and `build_request_factory` into
+chain-level closures requires the leaf to become a pure POST that accepts
+already-built bytes/headers (i.e. `Kernel.post` from Tier-13 row 13.2).
+Doing it before the `Kernel.post` rewrite would create a third
+request-construction path (chain-side closure + leaf-side rebuild +
+`_chat_transport.send_authed_post` direct path) that all have to stay in
+sync — strictly worse than leaving the leaf authoritative for one more
+tier.
+
+The `AuthSnapshot` and `BuildRequestResult` named dataclasses landed in
+PR 12.1 and live in `_request_types.py`. They are unused by
+`AuthRefreshMiddleware` today but are the target shape for Tier 13.
+
+Tier-13 follow-up (tracked in
+`.sisyphus/plans/tier-12-13-greenfield-migration.md` row 13.2): rewrite
+`AuthRefreshMiddleware` against the pinned closure-callback signature
+once `Kernel.post` is the chain leaf. The signature pinned in
+§"AuthRefreshMiddleware constructor signature" above is the target;
+update this ADR's Status to "Superseded by ADR-010" when that lands.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -492,7 +492,7 @@ class ClientCore:
         # ``AuthRefreshMiddleware`` BETWEEN ``RetryMiddleware`` and
         # ``ErrorInjectionMiddleware`` so the list now reads the
         # **final** ADR-009 ordering
-        # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
+        # ``[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection, Tracing]``
         # (outermost → innermost). ``build_chain`` composes the leftmost
         # entry as the outermost wrapper, so keeping ``TracingMiddleware``
         # at the RIGHT end of the list preserves Tracing as the innermost
@@ -949,10 +949,10 @@ class ClientCore:
         ``_authed_post_chain``. The first call to :meth:`_perform_authed_post`
         on such a fixture would raise ``AttributeError``; this helper
         backfills both slots with the same shape ``__init__`` would have
-        constructed (``[DrainMiddleware, MetricsMiddleware, RetryMiddleware,
-        AuthRefreshMiddleware, ErrorInjectionMiddleware, TracingMiddleware]``-seeded
-        chain around the terminal adapter, matching the seed in
-        ``__init__``).
+        constructed (``[DrainMiddleware, MetricsMiddleware, SemaphoreMiddleware,
+        RetryMiddleware, AuthRefreshMiddleware, ErrorInjectionMiddleware,
+        TracingMiddleware]``-seeded chain around the terminal adapter, matching
+        the seed in ``__init__``).
 
         Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
         :meth:`_ensure_observability_state` is — two threads observing
@@ -1488,10 +1488,23 @@ class ClientCore:
         # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` so the recorder
         # below can forward it to ``ClientMetrics`` without giving the
         # middleware an opinionated ``ClientMetrics`` dependency.
-        result = await self._authed_post_chain(request)
-        queue_wait = request.context.get(RPC_QUEUE_WAIT_CONTEXT_KEY, 0.0)
-        self._record_rpc_queue_wait(queue_wait)
-        return result.response
+        try:
+            result = await self._authed_post_chain(request)
+            return result.response
+        finally:
+            # Record queue wait even if the chain raised — pre-Tier-12
+            # ``AuthedTransport.perform_authed_post`` recorded the wait
+            # immediately after semaphore acquisition, so a failed chain
+            # (RetryMiddleware budget exhaustion, AuthRefreshMiddleware
+            # refresh failure, etc.) MUST still surface the queue-wait
+            # latency. ``SemaphoreMiddleware`` writes the duration to
+            # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` after the
+            # semaphore is acquired; absence of the key means the slot
+            # was never acquired and there's nothing to record (gemini
+            # PR 12.9 finding).
+            queue_wait = request.context.get(RPC_QUEUE_WAIT_CONTEXT_KEY)
+            if queue_wait is not None:
+                self._record_rpc_queue_wait(queue_wait)
 
     async def transport_post(
         self,

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -46,14 +46,13 @@ from ._core_drain import TransportDrainTracker
 # shape; the alias below is the backwards-compat anchor.
 from ._core_drain import _TransportOperationToken as _TransportOperationToken
 
-# Synthetic-error transport plumbing — re-exported so
-# ``tests/unit/test_vcr_config.py``, ``tests/conftest.py``, and
-# ``tests/unit/test_core_lifecycle.py`` (which monkeypatches
-# ``_get_error_injection_mode`` through the ``_core`` module attribute) keep
-# resolving these names as documented. ``_core_lifecycle.ClientLifecycle.open``
-# also reads ``_get_error_injection_mode`` / ``_SyntheticErrorTransport`` via
-# ``from . import _core as _core_module`` at call time so the monkeypatch
-# surface remains hot.
+# Synthetic-error helpers — re-exported so ``tests/conftest.py``,
+# ``tests/unit/test_vcr_config.py``, and any other test that imports
+# them through ``notebooklm._core`` keep resolving them as documented.
+# The pre-Tier-12 ``_SyntheticErrorTransport`` httpx transport was
+# deleted in PR 12.9 (substitution moved into
+# ``ErrorInjectionMiddleware`` in PR 12.6); only the env-var resolver
+# and the startup guard remain.
 from ._core_error_injection import (
     ERROR_INJECT_ENV_VAR as ERROR_INJECT_ENV_VAR,
 )
@@ -62,9 +61,6 @@ from ._core_error_injection import (
 )
 from ._core_error_injection import (
     _refuse_synthetic_error_outside_test_context as _refuse_synthetic_error_outside_test_context,
-)
-from ._core_error_injection import (
-    _SyntheticErrorTransport as _SyntheticErrorTransport,
 )
 
 # Cross-seam helpers — re-exported so ``from notebooklm._core import
@@ -184,6 +180,21 @@ def _decode_response_late_bound(raw: str, rpc_id: str, *, allow_null: bool = Fal
 
 def _sleep_late_bound(seconds: float) -> Awaitable[Any]:
     return asyncio.sleep(seconds)
+
+
+def _live_is_auth_error(exc: Exception) -> bool:
+    """Resolve ``is_auth_error`` through this module's globals at call time.
+
+    Python function-body name lookup hits the module ``__dict__`` on each
+    call, so a ``monkeypatch.setattr("notebooklm._core.is_auth_error",
+    ...)`` swap is observed immediately. Used by every chain seed site
+    that wires ``AuthRefreshMiddleware`` and by ``RpcExecutor`` so the
+    project-wide test idiom of patching the symbol on this module stays
+    live without each seed site re-implementing the lambda. PR 12.9
+    cleanup of the prior inline lambdas / ``globals()["is_auth_error"]``
+    indirections.
+    """
+    return is_auth_error(exc)
 
 
 class ClientCore:
@@ -530,16 +541,12 @@ class ClientCore:
             # with retry budgets.
             AuthRefreshMiddleware(
                 refresh_callable=self._await_refresh,
-                # Resolve through the live module name at call time so
-                # ``monkeypatch.setattr("notebooklm._core.is_auth_error",
-                # ...)`` reaches the chain. Python function-body name
-                # lookup hits the module dict on each call, so this
-                # lambda is already late-bound — a value-import would
-                # freeze the binding at chain-construction time, but this
-                # idiom doesn't (codex iter-1 nit on PR 12.8: simpler
-                # than the prior ``globals()["is_auth_error"]`` indirection).
-                is_auth_error=lambda exc: is_auth_error(exc),
-                refresh_callback_enabled=lambda: self._auth_coord._refresh_callback is not None,
+                # ``_live_is_auth_error`` re-reads ``is_auth_error`` from
+                # this module's globals on every call so test monkeypatches
+                # of ``notebooklm._core.is_auth_error`` reach the chain;
+                # see that helper's docstring for the rationale.
+                is_auth_error=_live_is_auth_error,
+                refresh_callback_enabled=lambda: self._auth_coord.has_refresh_callback,
                 refresh_retry_delay=lambda: self._refresh_retry_delay,
                 metrics=self._metrics_obj,
             ),
@@ -895,13 +902,27 @@ class ClientCore:
         attributes) — the property-bridged ivars' ``hasattr`` probes are
         always True because the descriptors live on the class.
         """
-        if hasattr(self, "_metrics_obj") and hasattr(self, "_drain_tracker"):
+        if (
+            hasattr(self, "_metrics_obj")
+            and hasattr(self, "_drain_tracker")
+            and hasattr(self, "_max_concurrent_rpcs")
+        ):
             return
         with _OBSERVABILITY_INIT_LOCK:
             if not hasattr(self, "_metrics_obj"):
                 self._metrics_obj = ClientMetrics(on_rpc_event=None)
             if not hasattr(self, "_drain_tracker"):
                 self._drain_tracker = TransportDrainTracker()
+            if not hasattr(self, "_max_concurrent_rpcs"):
+                # Audit-find #1 (PR 12.9): the RPC semaphore wraps the
+                # chain dispatch in ``_perform_authed_post`` and reads
+                # this attr to decide whether to gate at all. A
+                # ``__new__``-built fixture must see ``None`` (no gate)
+                # so the first authed-POST call doesn't ``AttributeError``
+                # — the live ``ClientCore.__init__`` path sets it
+                # explicitly to either ``DEFAULT_MAX_CONCURRENT_RPCS`` or
+                # the operator's override.
+                self._max_concurrent_rpcs = None
 
     def _ensure_authed_post_chain(self) -> None:
         """Backfill the middleware chain for tests that construct via ``__new__``.
@@ -967,24 +988,11 @@ class ClientCore:
                     ),
                     AuthRefreshMiddleware(
                         refresh_callable=self._await_refresh,
-                        # Resolve through the live module name at call time so
-                        # ``monkeypatch.setattr("notebooklm._core.is_auth_error",
-                        # ...)`` reaches the chain. Python function-body name
-                        # lookup hits the module dict on each call, so this
-                        # lambda is already late-bound — a value-import would
-                        # freeze the binding at chain-construction time, but
-                        # this idiom doesn't. Kept identical to the ``__init__``
-                        # site (codex iter-1 nit on PR 12.8: simpler than the
-                        # prior ``globals()["is_auth_error"]`` indirection).
-                        is_auth_error=lambda exc: is_auth_error(exc),
-                        refresh_callback_enabled=lambda: (
-                            self._auth_coord._refresh_callback is not None
-                        ),
-                        # ``getattr`` default matches ``__init__``'s argument
-                        # default (``refresh_retry_delay: float = 0.2``) so a
-                        # ``__new__``-built fixture that never set this attr
-                        # sees the same post-refresh sleep as the normal path.
-                        refresh_retry_delay=lambda: getattr(self, "_refresh_retry_delay", 0.2),
+                        # See ``_live_is_auth_error`` for the late-binding
+                        # rationale (mirrors the ``__init__`` seed site).
+                        is_auth_error=_live_is_auth_error,
+                        refresh_callback_enabled=lambda: self._auth_coord.has_refresh_callback,
+                        refresh_retry_delay=lambda: getattr(self, "_refresh_retry_delay", 0.0),
                         metrics=self._metrics_obj,
                     ),
                     ErrorInjectionMiddleware(),
@@ -1163,12 +1171,7 @@ class ClientCore:
         """
         transport = getattr(self, "_authed_transport", None)
         if transport is None:
-            transport = AuthedTransport(
-                self,
-                is_auth_error=lambda exc: is_auth_error(exc),
-                sleep=lambda seconds: asyncio.sleep(seconds),
-                logger=logger,
-            )
+            transport = AuthedTransport(self, logger=logger)
             self._authed_transport = transport
         return transport
 
@@ -1186,7 +1189,7 @@ class ClientCore:
             executor = RpcExecutor(
                 self,
                 decode_response_late_bound=_decode_response_late_bound,
-                is_auth_error=lambda exc: is_auth_error(exc),
+                is_auth_error=_live_is_auth_error,
                 sleep=_sleep_late_bound,
             )
             self._rpc_executor = executor
@@ -1450,8 +1453,23 @@ class ClientCore:
                 "rpc_method": rpc_method,
             },
         )
-        result = await self._authed_post_chain(request)
-        return result.response
+
+        # PR 12.9 audit fix: the RPC concurrency semaphore wraps the
+        # ENTIRE chain invocation (initial attempt + chain-level retries
+        # by RetryMiddleware / AuthRefreshMiddleware). This restores the
+        # pre-Tier-12 "one slot per logical RPC" backpressure contract.
+        # Releasing a slot during RetryMiddleware's backoff sleep would
+        # let new callers burst in just as the current cohort wakes up,
+        # undoing the smoothing the semaphore exists to provide.
+        # ``_get_rpc_semaphore`` returns ``contextlib.nullcontext`` when
+        # ``max_concurrent_rpcs`` is ``None`` (unbounded), so this wrap
+        # is a no-op for clients that opted out.
+        semaphore = self._get_rpc_semaphore()
+        queue_wait_start = time.perf_counter()
+        async with semaphore:
+            self._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
+            result = await self._authed_post_chain(request)
+            return result.response
 
     async def transport_post(
         self,

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -113,6 +113,7 @@ from ._middleware_drain import DrainMiddleware
 from ._middleware_error_injection import ErrorInjectionMiddleware
 from ._middleware_metrics import MetricsMiddleware
 from ._middleware_retry import RetryMiddleware
+from ._middleware_semaphore import RPC_QUEUE_WAIT_CONTEXT_KEY, SemaphoreMiddleware
 from ._middleware_tracing import TracingMiddleware
 from ._sources import fetch_source_ids
 
@@ -518,6 +519,17 @@ class ClientCore:
         self._middlewares: list[Middleware] = [
             DrainMiddleware(self._drain_tracker),
             MetricsMiddleware(self._metrics_obj),
+            # Acquire the ``max_concurrent_rpcs`` slot AFTER Drain admits
+            # the call (so queued tasks count toward shutdown drain) and
+            # AFTER Metrics starts timing (so latency includes queue
+            # wait), but BEFORE Retry can re-enter the inner chain — that
+            # way ``RetryMiddleware``'s retry attempts stay in the same
+            # slot rather than racing to claim another, preserving the
+            # pre-Tier-12 "one slot per logical RPC" contract.
+            # ``_get_rpc_semaphore`` returns ``contextlib.nullcontext``
+            # when ``max_concurrent_rpcs is None`` (unbounded), so the
+            # ``async with`` collapses to a no-op for opted-out clients.
+            SemaphoreMiddleware(self._get_rpc_semaphore),
             # Pass callable budgets so post-construction mutation of
             # ``self._rate_limit_max_retries`` / ``self._server_error_max_retries``
             # (an integration-test idiom; production never mutates these)
@@ -898,9 +910,14 @@ class ClientCore:
     def _ensure_observability_state(self) -> None:
         """Backfill observability fields for tests that construct via ``__new__``.
 
-        Gates on ``_metrics_obj`` AND ``_drain_tracker`` (both real instance
-        attributes) — the property-bridged ivars' ``hasattr`` probes are
-        always True because the descriptors live on the class.
+        Gates on ``_metrics_obj`` AND ``_drain_tracker`` AND
+        ``_max_concurrent_rpcs`` (all three are real instance attributes,
+        not property-bridged ivars whose ``hasattr`` probes would always
+        be True because the descriptors live on the class). The
+        ``_max_concurrent_rpcs`` slot was added by PR 12.9 audit-find #1
+        so a ``__new__``-built fixture can call ``_perform_authed_post``
+        without ``AttributeError`` when ``SemaphoreMiddleware`` reads the
+        accessor.
         """
         if (
             hasattr(self, "_metrics_obj")
@@ -959,16 +976,17 @@ class ClientCore:
             if hasattr(self, "_authed_post_chain"):
                 return
             if not hasattr(self, "_middlewares"):
-                # Mirror ``__init__``'s seeded chain. PR 12.8 lands the
-                # **final** ADR-009 ordering [Drain, Metrics, Retry,
-                # AuthRefresh, ErrorInjection, Tracing]. A ``__new__``-built
-                # fixture must see the same chain shape so all four chain
-                # behaviors (drain admission, retry on 429/5xx,
-                # refresh-and-retry on 4xx auth shapes, synthetic-error
-                # short-circuit) are exercised on fixture-driven
-                # invocations too — otherwise the fixture path and the
-                # live path diverge, which has previously hidden bugs in
-                # Tier-8 cassette-replay tests.
+                # Mirror ``__init__``'s seeded chain. PR 12.9 lands the
+                # **final** ADR-009 ordering [Drain, Metrics, Semaphore,
+                # Retry, AuthRefresh, ErrorInjection, Tracing]. A
+                # ``__new__``-built fixture must see the same chain shape
+                # so all five chain behaviors (drain admission, queue
+                # gating, retry on 429/5xx, refresh-and-retry on 4xx
+                # auth shapes, synthetic-error short-circuit) are
+                # exercised on fixture-driven invocations too —
+                # otherwise the fixture path and the live path diverge,
+                # which has previously hidden bugs in Tier-8
+                # cassette-replay tests.
                 #
                 # ``getattr`` defaults match ``__init__``'s argument
                 # defaults so a ``__new__``-built fixture that never set
@@ -979,6 +997,7 @@ class ClientCore:
                 self._middlewares = [
                     DrainMiddleware(self._drain_tracker),
                     MetricsMiddleware(self._metrics_obj),
+                    SemaphoreMiddleware(self._get_rpc_semaphore),
                     RetryMiddleware(
                         rate_limit_max_retries=lambda: getattr(self, "_rate_limit_max_retries", 3),
                         server_error_max_retries=lambda: getattr(
@@ -1200,13 +1219,15 @@ class ClientCore:
 
         Called automatically by NotebookLMClient.__aenter__. Delegates to
         :meth:`ClientLifecycle.open` — that helper builds the
-        ``httpx.AsyncClient`` (with the opt-in
-        :class:`_SyntheticErrorTransport` wrap when
-        ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set), captures the running
-        event loop into ``self._bound_loop``, and spawns the keepalive
-        task. Idempotent — calling ``open()`` while already open is a
-        no-op. Re-opening after a prior :meth:`close` intentionally
-        replaces the loop binding; :meth:`close` does not unbind so an
+        ``httpx.AsyncClient`` (always the default transport; the
+        ``NOTEBOOKLM_VCR_RECORD_ERRORS`` opt-in is enforced by
+        :class:`ErrorInjectionMiddleware` at chain layer, not by wrapping
+        the transport — see ADR-009 close-out notes), captures the
+        running event loop into ``self._bound_loop``, and spawns the
+        keepalive task. Idempotent — calling ``open()`` while already
+        open is a no-op. Re-opening after a prior :meth:`close`
+        intentionally replaces the loop binding; :meth:`close` does not
+        unbind so an
         accidental cross-loop call after close still raises actionably.
         """
         self._ensure_lifecycle()
@@ -1393,10 +1414,14 @@ class ClientCore:
         late-bound monkeypatches of ``_get_authed_transport`` (e.g. fixtures
         that swap the transport mid-test) still affect live behavior. The
         ``RpcRequest.url`` / ``RpcRequest.headers`` / ``RpcRequest.body``
-        dataclass fields stay unpopulated for the empty chain — PRs
-        12.5/12.7/12.8 begin populating them as middlewares strip behavior
-        out of :class:`AuthedTransport`. See ADR-009 §"RpcRequest.context
-        keys" for the metadata vocabulary.
+        dataclass fields stay unpopulated through Tier-12 — middlewares
+        in PRs 12.3–12.9 carried behavior out of :class:`AuthedTransport`
+        but the leaf still rebuilds the request from ``build_request`` +
+        ``AuthSnapshot`` rather than reading the dataclass fields.
+        Population is deferred to Tier-13 row 13.2 (``Kernel.post``
+        rewrite) — see ADR-009 close-out notes §"AuthRefreshMiddleware
+        shipped without rebuild closures". See ADR-009
+        §"RpcRequest.context keys" for the metadata vocabulary.
         """
         context = request.context
         build_request = context["build_request"]
@@ -1454,22 +1479,19 @@ class ClientCore:
             },
         )
 
-        # PR 12.9 audit fix: the RPC concurrency semaphore wraps the
-        # ENTIRE chain invocation (initial attempt + chain-level retries
-        # by RetryMiddleware / AuthRefreshMiddleware). This restores the
-        # pre-Tier-12 "one slot per logical RPC" backpressure contract.
-        # Releasing a slot during RetryMiddleware's backoff sleep would
-        # let new callers burst in just as the current cohort wakes up,
-        # undoing the smoothing the semaphore exists to provide.
-        # ``_get_rpc_semaphore`` returns ``contextlib.nullcontext`` when
-        # ``max_concurrent_rpcs`` is ``None`` (unbounded), so this wrap
-        # is a no-op for clients that opted out.
-        semaphore = self._get_rpc_semaphore()
-        queue_wait_start = time.perf_counter()
-        async with semaphore:
-            self._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
-            result = await self._authed_post_chain(request)
-            return result.response
+        # The ``max_concurrent_rpcs`` slot is acquired by
+        # :class:`SemaphoreMiddleware` (chain position 2, between Metrics
+        # and Retry) — that placement keeps Drain admitting queued tasks
+        # AND keeps Metrics timing the queue wait, while still bounding
+        # the retry-and-refresh cohort to one slot per logical RPC.
+        # The middleware writes the queue-wait duration to
+        # ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` so the recorder
+        # below can forward it to ``ClientMetrics`` without giving the
+        # middleware an opinionated ``ClientMetrics`` dependency.
+        result = await self._authed_post_chain(request)
+        queue_wait = request.context.get(RPC_QUEUE_WAIT_CONTEXT_KEY, 0.0)
+        self._record_rpc_queue_wait(queue_wait)
+        return result.response
 
     async def transport_post(
         self,

--- a/src/notebooklm/_core_auth.py
+++ b/src/notebooklm/_core_auth.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import httpx
 
+from ._core_constants import CORE_LOGGER_NAME
 from ._core_transport import _AuthSnapshot
 from ._loop_affinity import assert_bound_loop
 from .auth import AuthTokens
@@ -57,10 +58,10 @@ from .auth import AuthTokens
 if TYPE_CHECKING:
     from ._core_metrics import ClientMetrics
 
-# Logger name pinned to ``notebooklm._core`` (not the literal module name)
-# so log filters in tests — e.g. ``caplog.at_level("DEBUG",
-# logger="notebooklm._core")`` — keep matching after the extraction.
-logger = logging.getLogger("notebooklm._core")
+# Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
+# tests — e.g. ``caplog.at_level("DEBUG", logger=CORE_LOGGER_NAME)`` —
+# keep matching after the extraction.
+logger = logging.getLogger(CORE_LOGGER_NAME)
 
 
 class _AuthRefreshHost(Protocol):
@@ -117,6 +118,20 @@ class AuthRefreshCoordinator:
         (which will rebind to a fresh loop).
         """
         self._bound_loop = loop
+
+    @property
+    def has_refresh_callback(self) -> bool:
+        """``True`` iff a refresh callback was wired at construction.
+
+        Used by :class:`notebooklm._middleware_auth_refresh.AuthRefreshMiddleware`
+        to gate the refresh-and-retry branch: a client constructed without
+        a ``refresh_callback`` should propagate auth errors directly,
+        matching the pre-Tier-12 leaf behavior. Exposing this as a
+        property avoids reaching into the private
+        ``_refresh_callback`` attribute from outside the coordinator
+        (PR 12.9 cleanup of the inline lambda the chain seed used pre-12.9).
+        """
+        return self._refresh_callback is not None
 
     # ------------------------------------------------------------------
     # Lazy lock accessors. Both follow the same race-free check-then-assign

--- a/src/notebooklm/_core_constants.py
+++ b/src/notebooklm/_core_constants.py
@@ -12,12 +12,22 @@ below for guidance on when an operator would want to override them via the
 from __future__ import annotations
 
 __all__ = [
+    "CORE_LOGGER_NAME",
     "DEFAULT_CONNECT_TIMEOUT",
     "DEFAULT_KEEPALIVE_MIN_INTERVAL",
     "DEFAULT_MAX_CONCURRENT_RPCS",
     "DEFAULT_MAX_CONCURRENT_UPLOADS",
     "DEFAULT_TIMEOUT",
 ]
+
+# Single source of truth for the logger name every ``_core_*.py`` /
+# ``_middleware_*.py`` seam pins. Tests that filter logs via
+# ``caplog.at_level(..., logger=CORE_LOGGER_NAME)`` (or, more commonly,
+# the literal string) match this name. PR 12.9 audit fix: was previously
+# repeated verbatim across seven modules; promoting it here eliminates
+# the drift risk on rename. Callers do
+# ``logger = logging.getLogger(CORE_LOGGER_NAME)``.
+CORE_LOGGER_NAME = "notebooklm._core"
 
 # Default HTTP timeouts in seconds
 DEFAULT_TIMEOUT = 30.0

--- a/src/notebooklm/_core_error_injection.py
+++ b/src/notebooklm/_core_error_injection.py
@@ -1,55 +1,57 @@
-"""Synthetic HTTP error injection for VCR cassette recording (test-only).
+"""Synthetic HTTP error injection for VCR cassette playback (test-only).
 
-Wires an opt-in :class:`_SyntheticErrorTransport` into the client's HTTP layer
-when ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to one of ``429`` / ``5xx`` /
-``expired_csrf``. The substituted response shape matches what the client's
-exception mapping keys on — see
-``tests/cassette_patterns.py:build_synthetic_error_response``.
+When ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to ``429`` / ``5xx`` /
+``expired_csrf``, :class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`
+short-circuits each chain invocation with the synthetic response built
+by ``tests/cassette_patterns.py:build_synthetic_error_response`` so the
+client's exception-mapping branches (429 → ``RateLimitError``, 5xx →
+``ServerError``, 400-CSRF → ``AuthError``) fire end-to-end.
 
-**Production behavior is unchanged when the env var is unset.** The transport
-wrapper is only constructed when the env var resolves to a valid mode; the
-default ``httpx.AsyncClient`` is built with no explicit transport otherwise.
+**Production behavior is unchanged when the env var is unset.** The
+middleware delegates straight to ``next_call``; the chain leaf
+(``AuthedTransport.perform_authed_post``) runs exactly as it would
+without the middleware in the chain.
 
-This is deliberately wired through the client's HTTP layer (not just the VCR
-config) so the substitution sits BELOW VCR — VCR records the synthetic response
-into the cassette as if it had come from the wire. Wiring it at the VCR-config
-layer only would mean the substitution never ran in record mode, leaving the
-plumbing inert (the Momus iter-1 rejection rationale).
+Pre-Tier-12 history (deleted in PR 12.9): this module previously
+defined a ``_SyntheticErrorTransport`` httpx transport that wrapped the
+``AsyncClient`` BELOW VCR so the substituted response was recorded into
+the cassette. Tier-12 PR 12.6 lifted the substitution into
+``ErrorInjectionMiddleware`` (chain-level, ABOVE VCR), which closed the
+"record synthetic errors into cassettes" workflow — replay-only is the
+documented contract going forward; the synthetic-error cassettes in
+``tests/cassettes/`` are hand-written from the canonical shapes in
+``tests/cassette_patterns.py``. PR 12.9 deleted the legacy transport
+class and its direct-instantiation tests.
 
-Public-on-private contract: :class:`_SyntheticErrorTransport`,
-:func:`_get_error_injection_mode`, and :data:`ERROR_INJECT_ENV_VAR` are
-re-exported from :mod:`notebooklm._core` so ``from notebooklm._core import …``
-keeps working in ``tests/unit/test_vcr_config.py``, ``tests/conftest.py``, and
-``tests/unit/test_core_lifecycle.py`` (which also monkeypatches
-``_get_error_injection_mode`` through the ``_core`` module attribute).
-:mod:`notebooklm._core_lifecycle` resolves both symbols via
-``from . import _core as _core_module; _core_module._get_error_injection_mode()``
-at call time so the monkeypatch surface remains hot.
+Public surface kept:
+
+- :func:`_get_error_injection_mode` — env-var → mode normalization.
+- :func:`_refuse_synthetic_error_outside_test_context` —
+  ``ClientCore.__init__`` calls this so a leaked deploy env raises
+  ``RuntimeError`` instead of silently activating the chain
+  middleware. The guard fires only when ``PYTEST_CURRENT_TEST`` is
+  unset (pytest sets it for every test).
+- :data:`ERROR_INJECT_ENV_VAR` — env-var name (canonical string).
 """
 
 from __future__ import annotations
 
 __all__ = [
     "ERROR_INJECT_ENV_VAR",
-    "_SyntheticErrorTransport",
     "_get_error_injection_mode",
     "_refuse_synthetic_error_outside_test_context",
 ]
 
-import importlib.util
 import logging
 import os
-from collections.abc import Callable
-from pathlib import Path
-from typing import cast
 
-import httpx
+from ._core_constants import CORE_LOGGER_NAME
 
-# Logger name pinned to ``notebooklm._core`` (not the literal module name) so
-# log filters in tests — e.g. ``caplog.at_level(..., logger="notebooklm._core")``
-# — keep matching after this extraction. Mirrors the same pin in
-# :mod:`notebooklm._core_lifecycle`.
-logger = logging.getLogger("notebooklm._core")
+# Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
+# tests — e.g. ``caplog.at_level(..., logger=CORE_LOGGER_NAME)`` — keep
+# matching. Every ``_core_*.py`` / ``_middleware_*.py`` seam shares the
+# same name.
+logger = logging.getLogger(CORE_LOGGER_NAME)
 
 
 ERROR_INJECT_ENV_VAR = "NOTEBOOKLM_VCR_RECORD_ERRORS"
@@ -86,12 +88,12 @@ def _get_error_injection_mode() -> str | None:
 def _refuse_synthetic_error_outside_test_context() -> None:
     """Refuse :class:`ClientCore` instantiation when the test-only env var leaks.
 
-    P1-12: ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is documented as test-only — it
-    substitutes synthetic error responses for every batchexecute RPC. Before
-    this guard, a leaked deploy env (e.g. an unset-on-prod CI variable that
-    slipped through) would silently wrap the production transport in
-    :class:`_SyntheticErrorTransport`, returning fake 429/5xx/expired_csrf
-    responses to live callers.
+    P1-12: ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is documented as test-only.
+    Pre-Tier-12, leaving it set in a deploy env would silently wrap the
+    production transport in the legacy ``_SyntheticErrorTransport``. After
+    Tier-12 the activation moved into ``ErrorInjectionMiddleware``, but
+    the operator-visible blast radius is the same (every chain call
+    returns a fake response). The guard remains load-bearing.
 
     The guard fires only when:
 
@@ -123,121 +125,3 @@ def _refuse_synthetic_error_outside_test_context() -> None:
     )
     logger.warning(message)
     raise RuntimeError(message)
-
-
-class _SyntheticErrorTransport(httpx.AsyncBaseTransport):
-    """Test-only httpx transport that substitutes synthetic error responses.
-
-    Wraps an inner ``httpx.AsyncBaseTransport`` and substitutes a synthetic
-    error response on outgoing batchexecute POSTs, built by
-    ``tests.cassette_patterns.build_synthetic_error_response``. Non-batchexecute
-    traffic (Scotty uploads, ``RotateCookies`` pokes, the homepage GET that
-    extracts CSRF) passes through unchanged because none of those endpoints
-    are in scope for error-shape cassettes.
-
-    Substitution scope is controlled by ``always``:
-
-    - ``always=True`` (the default for record-mode use): every batchexecute
-      POST is substituted. This matters because the client's auth-refresh
-      path re-issues the same RPC; we want the SAME error to fire on every
-      retry inside the recording window so the cassette captures the full
-      retry-and-fail sequence rather than substituting once and then letting
-      a real response slip through on the retry.
-    - ``always=False``: only the FIRST batchexecute POST is substituted; later
-      POSTs fall through to the inner transport. Useful for tests that want
-      to assert the client recovers after a single transient failure.
-
-    This class is OPT-IN — ``ClientCore`` only wraps the transport when
-    ``_get_error_injection_mode()`` returns a non-``None`` value, so removing
-    the env var restores byte-for-byte production behavior.
-    """
-
-    def __init__(
-        self,
-        mode: str,
-        inner: httpx.AsyncBaseTransport,
-        *,
-        always: bool = True,
-    ):
-        self._mode = mode
-        self._inner = inner
-        self._always = always
-        self._fired = False
-        # Resolved lazily on first use so this module doesn't import the test
-        # tree at module load time.
-        self._builder: Callable[[str], tuple[int, bytes, dict[str, str]]] | None = None
-
-    def _is_batchexecute(self, request: httpx.Request) -> bool:
-        # NotebookLM's batchexecute endpoint lives under
-        # ``notebooklm.google.com/_/LabsTailwindUi/data/batchexecute``. We
-        # match on the path suffix so any subdomain / region variant still
-        # triggers substitution.
-        return request.url.path.endswith("/batchexecute")
-
-    def _load_builder(
-        self,
-    ) -> Callable[[str], tuple[int, bytes, dict[str, str]]]:
-        if self._builder is not None:
-            return self._builder
-        # Import lazily and via importlib to avoid a hard dependency on the
-        # tests tree from production code. The env var that gates this whole
-        # path is itself test-only, so this import only ever runs in
-        # recording / unit-test contexts.
-
-        # Walk up from src/notebooklm/_core_error_injection.py to the repo
-        # root, then dive into tests/cassette_patterns.py. This keeps the
-        # lookup robust to installed-package layouts (where ``tests/`` may
-        # not exist) — in that case we raise a clear error rather than
-        # silently no-oping.
-        repo_root = Path(__file__).resolve().parent.parent.parent
-        target = repo_root / "tests" / "cassette_patterns.py"
-        if not target.exists():
-            raise RuntimeError(
-                f"{ERROR_INJECT_ENV_VAR} is set but "
-                f"tests/cassette_patterns.py is not available at {target}. "
-                f"This plumbing is test-only — unset {ERROR_INJECT_ENV_VAR} "
-                f"to restore normal behavior."
-            )
-        spec = importlib.util.spec_from_file_location("_notebooklm_cassette_patterns", target)
-        # NOT ``assert`` — runtime invariant must survive ``python -O``. The
-        # check is defensive (spec_from_file_location on an existing .py file
-        # virtually always succeeds) but if it ever fails the user has clear
-        # remediation via the env var.
-        if spec is None or spec.loader is None:
-            raise RuntimeError(
-                f"Failed to load module spec for {target}. "
-                f"Unset {ERROR_INJECT_ENV_VAR} to restore normal behavior."
-            )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        self._builder = cast(
-            Callable[[str], tuple[int, bytes, dict[str, str]]],
-            mod.build_synthetic_error_response,
-        )
-        return self._builder
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        # Substitute ONLY on POST batchexecute calls. Non-POST traffic on the
-        # same path (a hypothetical GET batchexecute probe, OPTIONS preflight,
-        # etc.) is out of scope for error-shape cassettes and must pass through
-        # unchanged — see CodeRabbit feedback on PR #638.
-        if (
-            request.method.upper() == "POST"
-            and self._is_batchexecute(request)
-            and (self._always or not self._fired)
-        ):
-            self._fired = True
-            status_code, body, headers = self._load_builder()(self._mode)
-            response = httpx.Response(
-                status_code=status_code,
-                headers=headers,
-                content=body,
-                request=request,
-            )
-            # ``httpx.Response`` constructed this way is already "read" — VCR
-            # can serialize it directly via its standard before_record hook.
-            return response
-        return await self._inner.handle_async_request(request)
-
-    async def aclose(self) -> None:
-        await self._inner.aclose()

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -73,6 +73,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import httpx
 
+from ._core_constants import CORE_LOGGER_NAME
 from ._kernel import Kernel
 from .auth import AuthTokens
 
@@ -87,10 +88,10 @@ if TYPE_CHECKING:
     from ._core_transport import AuthedTransport
     from .types import ConnectionLimits
 
-# Logger name pinned to ``notebooklm._core`` (not the literal module name)
-# so log filters in tests — e.g. ``caplog.at_level("DEBUG",
-# logger="notebooklm._core")`` — keep matching after the extraction.
-logger = logging.getLogger("notebooklm._core")
+# Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
+# tests — e.g. ``caplog.at_level("DEBUG", logger=CORE_LOGGER_NAME)`` —
+# keep matching after the extraction.
+logger = logging.getLogger(CORE_LOGGER_NAME)
 
 
 class _LifecycleHost(Protocol):

--- a/src/notebooklm/_core_metrics.py
+++ b/src/notebooklm/_core_metrics.py
@@ -32,13 +32,14 @@ from collections.abc import Callable
 from dataclasses import replace
 
 from ._callbacks import maybe_await_callback
+from ._core_constants import CORE_LOGGER_NAME
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
-# Logger name is pinned to ``notebooklm._core`` (not the literal module name)
-# so users and tests that filter by logger name — e.g.
-# ``caplog.at_level("WARNING", logger="notebooklm._core")`` in
-# ``test_client_keepalive.py`` — keep matching after the extraction.
-logger = logging.getLogger("notebooklm._core")
+# Logger name pinned via :data:`CORE_LOGGER_NAME` so users and tests
+# that filter by logger name — e.g. ``caplog.at_level("WARNING",
+# logger=CORE_LOGGER_NAME)`` in ``test_client_keepalive.py`` — keep
+# matching after the extraction.
+logger = logging.getLogger(CORE_LOGGER_NAME)
 
 
 class ClientMetrics:

--- a/src/notebooklm/_core_transport.py
+++ b/src/notebooklm/_core_transport.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
-from contextlib import AbstractAsyncContextManager
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -85,8 +84,16 @@ class _AuthSnapshot:
 
 
 class _TransportAuthExpired(Exception):
-    """Raised by ``_perform_authed_post`` when the refresh callback itself
+    """Raised by ``AuthRefreshMiddleware`` when the refresh callback itself
     failed during an auth recovery attempt.
+
+    Pre-Tier-12 this was raised by the leaf's auth-refresh-once branch.
+    PR 12.8 lifted that branch into
+    :class:`notebooklm._middleware_auth_refresh.AuthRefreshMiddleware`;
+    the class definition stays here so the existing import path
+    (``from notebooklm._core_transport import _TransportAuthExpired``)
+    keeps working for ``_chat_transport.chat_aware_authed_post`` and its
+    tests.
 
     ``original`` is the transport-layer ``httpx.HTTPStatusError`` that
     triggered the refresh attempt. The refresh callback's error is attached via
@@ -208,39 +215,47 @@ async def _stream_post_with_size_cap(
 
 
 class _AuthedTransportHost(Protocol):
+    """Minimal host surface the post-Tier-12 leaf actually reads.
+
+    Pre-Tier-12 this Protocol declared retry budgets, refresh hooks,
+    metrics increments, the RPC semaphore, queue-wait recording — every
+    cross-cutting concern. Tier-12 PRs 12.4 / 12.5 / 12.7 / 12.8 lifted
+    those into chain middlewares, and PR 12.9 lifted the RPC
+    semaphore + queue-wait recording up to
+    :meth:`ClientCore._perform_authed_post` (so the slot wraps the
+    whole chain invocation, not just one HTTP attempt). The Protocol
+    now declares only the members the leaf still touches:
+
+    - ``_kernel`` (the streaming-POST transport, post-PR #850)
+    - ``_http_client`` (only checked for pre-open ``None``)
+    - ``_bound_loop`` (event-loop affinity guard)
+    - ``_snapshot`` (fresh ``_AuthSnapshot`` per attempt)
+    """
+
     _kernel: Kernel
     _http_client: httpx.AsyncClient | None
     _bound_loop: asyncio.AbstractEventLoop | None
-    _refresh_callback: Callable[[], Awaitable[Any]] | None
-    _refresh_retry_delay: float
-    _rate_limit_max_retries: int
-    _server_error_max_retries: int
-
-    def _get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]: ...
 
     async def _snapshot(self) -> _AuthSnapshot: ...
 
-    async def _await_refresh(self) -> None: ...
-
-    def _record_rpc_queue_wait(self, wait_seconds: float) -> None: ...
-
-    def _increment_metrics(self, **increments: int | float) -> None: ...
-
 
 class AuthedTransport:
-    """Shared authenticated POST retry/refresh pipeline."""
+    """Single-attempt authenticated POST.
+
+    Post-Tier-12 the leaf is a pure POST — every retry decision (429 / 5xx
+    via :class:`RetryMiddleware`, 401/403/400-CSRF via
+    :class:`AuthRefreshMiddleware`) lives in the middleware chain. The
+    constructor's pre-Tier-12 ``is_auth_error`` and ``sleep`` callbacks
+    are gone: the chain owns both.
+    """
 
     def __init__(
         self,
         host: _AuthedTransportHost,
         *,
-        is_auth_error: Callable[[Exception], bool],
-        sleep: Callable[[float], Awaitable[Any]],
         logger: logging.Logger,
     ):
         self._host = host
-        self._is_auth_error = is_auth_error
-        self._sleep = sleep
         self._logger = logger
 
     async def perform_authed_post(
@@ -250,22 +265,33 @@ class AuthedTransport:
         log_label: str,
         disable_internal_retries: bool = False,
     ) -> httpx.Response:
-        """Run an authed POST through the auth-refresh-and-retry pipeline.
+        """Single authed POST attempt.
 
-        Since PR 12.7 this leaf only drives the auth-refresh-once retry;
-        429 / 5xx / network retries live in :class:`RetryMiddleware` above
-        this leaf in the chain. ``disable_internal_retries`` is accepted
-        for signature stability but no longer read here — the middleware
-        reads the flag from ``request.context`` directly. PR 12.9 removes
-        the parameter once the legacy non-chain code path is retired.
+        Pre-Tier-12 this method drove the entire retry-and-refresh
+        pipeline. After PRs 12.5 (Drain) / 12.7 (Retry) / 12.8
+        (AuthRefresh) the leaf is a pure POST — every retry decision
+        happens in the chain.
+
+        ``disable_internal_retries`` is accepted for signature stability
+        but no longer read here — the middleware reads the flag from
+        ``request.context`` directly. PR 12.9 keeps the parameter so the
+        legacy ``_chat_transport`` call site still type-checks; a
+        follow-up post-13.x cleanup can drop it.
+
+        Semaphore wrapping moved UP to ``ClientCore._perform_authed_post``
+        in PR 12.9: the slot is held for the WHOLE chain invocation
+        (initial attempt + all chain-level retries by RetryMiddleware /
+        AuthRefreshMiddleware), restoring the pre-Tier-12 "one slot per
+        logical RPC" backpressure contract. Acquiring it here too would
+        deadlock — ``asyncio.Semaphore`` is not reentrant.
         """
         host = self._host
         # Fast-path: reject pre-open calls before loop checks and semaphore acquisition.
         if host._http_client is None:
             raise RuntimeError("Client not initialized. Use 'async with' context.")
 
-        # Event-loop affinity guard. Placed before
-        # semaphore acquisition so cross-loop misuse never reserves a slot.
+        # Event-loop affinity guard. Placed before any further awaits so
+        # cross-loop misuse never gets past the boundary.
         if host._bound_loop is not None and asyncio.get_running_loop() is not host._bound_loop:
             raise RuntimeError(
                 "NotebookLMClient is bound to a different event loop. "
@@ -274,97 +300,66 @@ class AuthedTransport:
 
         start = time.perf_counter()
 
-        # ---------------------------------------------------------------
-        # Semaphore placement contract — DO NOT MOVE.
-        #
-        # The semaphore wraps the single POST attempt this leaf makes.
-        # ``RetryMiddleware`` (outside this leaf) re-invokes the chain on
-        # 429 / 5xx and ``AuthRefreshMiddleware`` (also outside this leaf,
-        # PR 12.8) re-invokes the chain after a successful refresh. Each
-        # retry re-enters here and re-acquires the semaphore — so one slot
-        # is held per *HTTP attempt*, not per *logical RPC*.
-        #
-        # **Backpressure-scope regression (Tier-12 PRs 12.7 / 12.8 →
-        # follow-up).** Before PR 12.7, this semaphore wrapped the FULL
-        # retry budget (initial + all 429/5xx retries + the
-        # auth-refresh-once retry); PR 12.7 lifted 429/5xx retry into
-        # ``RetryMiddleware`` outside the semaphore; PR 12.8 lifts the
-        # auth-refresh retry too. So the smoothing the semaphore
-        # previously provided across the full retry budget is now
-        # coarser (per-attempt, not per-call). The plan acknowledges
-        # this as an interim consequence of the chain ordering
-        # ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection,
-        # Tracing]``. A chain-level semaphore primitive (or moving the
-        # gate above ``RetryMiddleware``) is a viable follow-up;
-        # PR 12.8 ships the regression so the load-bearing lift can
-        # land. ADR-009 §"Chain ordering rationale" should eventually
-        # reflect this trade-off.
-        # ---------------------------------------------------------------
-        semaphore = host._get_rpc_semaphore()
-        queue_wait_start = time.perf_counter()
-        async with semaphore:
-            host._record_rpc_queue_wait(time.perf_counter() - queue_wait_start)
-            # PR 12.8: the leaf is now a pure POST. 429 and 5xx/network
-            # failures still raise ``_TransportRateLimited`` /
-            # ``_TransportServerError`` so :class:`RetryMiddleware`
-            # (outside this leaf) decides whether to retry; raw
-            # ``httpx.HTTPStatusError`` (e.g. 400 / 401 / 403)
-            # propagates so :class:`AuthRefreshMiddleware` (also outside
-            # this leaf) can catch it via ``is_auth_error`` and drive
-            # refresh-then-retry. ``raise from exc`` preserves the
-            # chained transport exception for diagnostic display.
-            snapshot = await host._snapshot()
-            url, body, headers = build_request(snapshot)
+        # The leaf is a pure POST: 429 and 5xx/network failures raise
+        # ``_TransportRateLimited`` / ``_TransportServerError`` so
+        # :class:`RetryMiddleware` (outside this leaf) decides whether to
+        # retry; raw ``httpx.HTTPStatusError`` (e.g. 400 / 401 / 403)
+        # propagates so :class:`AuthRefreshMiddleware` (also outside this
+        # leaf) can catch it via ``is_auth_error`` and drive
+        # refresh-then-retry. ``raise from exc`` preserves the chained
+        # transport exception for diagnostic display.
+        snapshot = await host._snapshot()
+        url, body, headers = build_request(snapshot)
 
-            try:
-                # Streaming POST with a running size cap. The size guard
-                # lives inside the stream-read loop in
-                # ``_stream_post_with_size_cap``; ``raise_for_status()``
-                # is invoked before any body chunk is read so the chain
-                # middlewares see the same :class:`httpx.HTTPStatusError`
-                # they did when this used ``client.post``.
-                response = await host._kernel.post(
-                    url,
-                    headers=headers,
-                    body=body,
-                )
-            except (httpx.HTTPStatusError, httpx.RequestError) as exc:
-                # --- 429: raise for ``RetryMiddleware`` to catch --------
-                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
-                    retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
-                    raise _TransportRateLimited(
-                        f"{log_label} rate-limited (HTTP 429)",
-                        retry_after=retry_after,
-                        response=exc.response,
-                        original=exc,
-                    ) from exc
+        try:
+            # Streaming POST via :class:`Kernel` (PR #850). The size guard
+            # lives inside ``Kernel.post``'s stream-read loop;
+            # ``raise_for_status()`` is invoked before any body chunk is
+            # read so the chain middlewares see the same
+            # :class:`httpx.HTTPStatusError` they did when this used
+            # ``client.post``.
+            response = await host._kernel.post(
+                url,
+                headers=headers,
+                body=body,
+            )
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            # --- 429: raise for ``RetryMiddleware`` to catch ----------
+            if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 429:
+                retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+                raise _TransportRateLimited(
+                    f"{log_label} rate-limited (HTTP 429)",
+                    retry_after=retry_after,
+                    response=exc.response,
+                    original=exc,
+                ) from exc
 
-                # --- 5xx / network: raise for ``RetryMiddleware`` -------
-                if isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600:
-                    raise _TransportServerError(
-                        f"{log_label} server error (HTTP {exc.response.status_code})",
-                        original=exc,
-                        response=exc.response,
-                        status_code=exc.response.status_code,
-                    ) from exc
-                if isinstance(exc, httpx.RequestError):
-                    raise _TransportServerError(
-                        f"{log_label} network error: {exc}",
-                        original=exc,
-                    ) from exc
+            # --- 5xx / network: raise for ``RetryMiddleware`` ---------
+            if isinstance(exc, httpx.HTTPStatusError) and 500 <= exc.response.status_code < 600:
+                raise _TransportServerError(
+                    f"{log_label} server error (HTTP {exc.response.status_code})",
+                    original=exc,
+                    response=exc.response,
+                    status_code=exc.response.status_code,
+                ) from exc
+            if isinstance(exc, httpx.RequestError):
+                raise _TransportServerError(
+                    f"{log_label} network error: {exc}",
+                    original=exc,
+                ) from exc
 
-                # --- 4xx auth shapes (400/401/403) and everything else:
-                # propagate the raw ``httpx.HTTPStatusError`` so
-                # ``AuthRefreshMiddleware`` outside this leaf decides
-                # whether to refresh-and-retry via ``is_auth_error``.
-                elapsed = time.perf_counter() - start
-                self._logger.debug(
-                    "%s transport error after %.3fs: %s",
-                    log_label,
-                    elapsed,
-                    exc,
-                )
-                raise
+            # --- 4xx auth shapes (400/401/403) and everything else:
+            # propagate the raw ``httpx.HTTPStatusError`` so
+            # ``AuthRefreshMiddleware`` outside this leaf decides whether
+            # to refresh-and-retry via ``is_auth_error``.
+            elapsed = time.perf_counter() - start
+            self._logger.debug(
+                "%s transport error after %.3fs: %s",
+                log_label,
+                elapsed,
+                exc,
+            )
+            raise
 
-            # Success
-            return response
+        # Success
+        return response

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -2,10 +2,11 @@
 
 Per ADR-009 §"Chain ordering", ``AuthRefreshMiddleware`` sits just *inside*
 ``RetryMiddleware`` and just *outside* ``ErrorInjectionMiddleware``. The final
-Tier-12 chain is
-``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]`` — PR 12.8
-inserts ``AuthRefresh`` between ``Retry`` and ``ErrorInjection`` so this
-ordering is now realized end-to-end.
+Tier-12 chain (post-PR 12.9, after ``SemaphoreMiddleware`` was inserted between
+``Metrics`` and ``Retry``) is
+``[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection, Tracing]`` —
+PR 12.8 inserts ``AuthRefresh`` between ``Retry`` and ``ErrorInjection`` so
+this ordering is now realized end-to-end.
 
 This PR lifts the **auth-refresh-once retry** loop out of
 ``AuthedTransport.perform_authed_post`` (the chain leaf). After PR 12.8 the

--- a/src/notebooklm/_middleware_auth_refresh.py
+++ b/src/notebooklm/_middleware_auth_refresh.py
@@ -75,6 +75,7 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from ._core_constants import CORE_LOGGER_NAME
 from ._core_transport import _TransportAuthExpired
 from ._middleware import NextCall, RpcRequest, RpcResponse
 
@@ -144,7 +145,7 @@ class AuthRefreshMiddleware:
         self._refresh_retry_delay = refresh_retry_delay
         # See ``RetryMiddleware._resolve_sleep`` for the lazy-binding rationale.
         self._sleep = sleep
-        self._logger = logger or logging.getLogger("notebooklm._core")
+        self._logger = logger or logging.getLogger(CORE_LOGGER_NAME)
         self._metrics = metrics
 
     def _resolve_sleep(self) -> Callable[[float], Awaitable[object]]:

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -2,8 +2,9 @@
 
 Per ADR-009 §"Chain ordering", ``ErrorInjectionMiddleware`` sits just *inside*
 ``RetryMiddleware`` / ``AuthRefreshMiddleware`` (which extract in PRs 12.7–12.8)
-and just *outside* ``TracingMiddleware``. The final Tier-12 chain is
-``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``. PR 12.6 ships
+and just *outside* ``TracingMiddleware``. The final Tier-12 chain (post-PR 12.9,
+after ``SemaphoreMiddleware`` was inserted between ``Metrics`` and ``Retry``) is
+``[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection, Tracing]``. PR 12.6 ships
 the interim 4-middleware chain ``[Drain, Metrics, ErrorInjection, Tracing]``;
 PRs 12.7–12.8 insert ``Retry`` and ``AuthRefresh`` BETWEEN ``Metrics`` and
 ``ErrorInjection`` so the ordering rationale holds at every step.

--- a/src/notebooklm/_middleware_error_injection.py
+++ b/src/notebooklm/_middleware_error_injection.py
@@ -19,13 +19,11 @@ short-circuits with a synthetic :class:`httpx.Response` built by
 still fires at ``ClientCore`` construction so a leaked deploy env never reaches
 this code path in production.
 
-This PR lifts the substitution from the httpx transport
-(:class:`_core_error_injection._SyntheticErrorTransport`, which previously
-wrapped ``httpx.AsyncClient`` in ``ClientLifecycle``) into the middleware
-chain. After this PR the lifecycle no longer wraps the transport, so the
-class is unused production code; PR 12.9 cleanup deletes it. Direct
-instantiation tests in ``tests/unit/test_vcr_config.py`` still pass because
-the class itself is untouched.
+Tier-12 history: PR 12.6 lifted the substitution from the pre-Tier-12
+httpx transport (``_core_error_injection._SyntheticErrorTransport``,
+which wrapped ``httpx.AsyncClient`` in ``ClientLifecycle``) into this
+middleware. PR 12.9 deleted the legacy transport class outright; this
+middleware is now the only production substitution surface.
 
 Behavior contract:
 
@@ -78,6 +76,7 @@ from typing import cast
 import httpx
 
 from . import _core_error_injection
+from ._core_constants import CORE_LOGGER_NAME
 from ._core_error_injection import ERROR_INJECT_ENV_VAR
 from ._core_transport import (
     _parse_retry_after,
@@ -86,10 +85,10 @@ from ._core_transport import (
 )
 from ._middleware import NextCall, RpcRequest, RpcResponse
 
-# Logger name pinned to ``notebooklm._core`` (not the literal module name) so
-# log filters in tests — e.g. ``caplog.at_level(..., logger="notebooklm._core")``
-# — keep matching the synthetic-error log line the lifecycle previously emitted.
-logger = logging.getLogger("notebooklm._core")
+# Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
+# tests — e.g. ``caplog.at_level(..., logger=CORE_LOGGER_NAME)`` — keep
+# matching the synthetic-error log line the lifecycle previously emitted.
+logger = logging.getLogger(CORE_LOGGER_NAME)
 
 _SyntheticBuilder = Callable[[str], tuple[int, bytes, dict[str, str]]]
 
@@ -214,11 +213,10 @@ class ErrorInjectionMiddleware:
         in recording / unit-test contexts where ``tests/`` is on disk
         relative to ``src/notebooklm/``.
 
-        Mirrors the same lazy-load logic in
-        :class:`_core_error_injection._SyntheticErrorTransport._load_builder`
-        so the synthetic-response shape stays identical between the
-        legacy transport path and the chain path. PR 12.9 removes the
-        legacy path and this duplication along with it.
+        This was previously duplicated in the (now-deleted)
+        ``_core_error_injection._SyntheticErrorTransport._load_builder``;
+        PR 12.9 removed that class so the chain middleware is the single
+        source of truth for synthetic-response loading.
         """
         if self._builder is not None:
             return self._builder

--- a/src/notebooklm/_middleware_metrics.py
+++ b/src/notebooklm/_middleware_metrics.py
@@ -123,7 +123,11 @@ class MetricsMiddleware:
                         status="error",
                         elapsed_seconds=elapsed,
                         request_id=get_request_id(),
-                        error_type=type(exc).__name__,
+                        # PR 12.9 audit fix: ``__qualname__`` matches the
+                        # idiom used by ``TracingMiddleware._middleware_tracing.py``
+                        # so nested exception classes are distinguishable
+                        # in metrics + traces alike.
+                        error_type=type(exc).__qualname__,
                     )
                 )
             raise

--- a/src/notebooklm/_middleware_retry.py
+++ b/src/notebooklm/_middleware_retry.py
@@ -70,6 +70,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from ._backoff import compute_backoff_delay
+from ._core_constants import CORE_LOGGER_NAME
 from ._core_transport import _parse_retry_after, _TransportRateLimited, _TransportServerError
 from ._middleware import NextCall, RpcRequest, RpcResponse
 
@@ -141,7 +142,7 @@ class RetryMiddleware:
         # whatever was imported when the middleware was instantiated,
         # silently bypassing later monkeypatches.
         self._sleep = sleep
-        self._logger = logger or logging.getLogger("notebooklm._core")
+        self._logger = logger or logging.getLogger(CORE_LOGGER_NAME)
         self._metrics = metrics
 
     def _resolve_sleep(self) -> Callable[[float], Awaitable[object]]:

--- a/src/notebooklm/_middleware_semaphore.py
+++ b/src/notebooklm/_middleware_semaphore.py
@@ -1,0 +1,99 @@
+"""SemaphoreMiddleware — RPC concurrency gate for the Tier-12 chain.
+
+Per ADR-009 §"Chain ordering" (revised by PR 12.9), ``SemaphoreMiddleware``
+sits between ``MetricsMiddleware`` and ``RetryMiddleware``. The final chain
+ordering is ``[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection,
+Tracing]``.
+
+PR 12.1 originally pinned six middlewares; PR 12.9 added the seventh after
+codex caught a load-bearing regression in the first cut of the audit-find
+that moved the semaphore around the chain dispatch in
+``ClientCore._perform_authed_post``: queued tasks were no longer counted by
+``DrainMiddleware`` (Drain sat outside the semaphore wait), and Metrics
+latency no longer included RPC queue wait. The middleware insertion restores
+both contracts in one place:
+
+- **Drain admits queued tasks** — ``DrainMiddleware`` (outermost) increments
+  ``_in_flight_posts`` before this middleware acquires the slot, so a
+  ``client.close()`` mid-flight blocks on queued tasks instead of rejecting
+  them once they finally pull a slot.
+- **Metrics latency includes queue wait** — ``MetricsMiddleware`` starts its
+  ``perf_counter`` BEFORE this middleware's ``async with``, matching the
+  pre-PR-12.9 (PR 12.8) telemetry shape.
+- **Retry stays in one slot** — ``RetryMiddleware`` sits INSIDE this
+  middleware, so its retry attempts re-invoke the inner chain (AuthRefresh,
+  ErrorInjection, Tracing, terminal) WITHOUT releasing the semaphore. This
+  preserves the pre-Tier-12 "one slot per logical RPC" backpressure
+  contract.
+
+The semaphore is supplied as a zero-arg async-context-manager factory rather
+than the raw ``asyncio.Semaphore`` so the middleware can be live-bound to
+``ClientCore._get_rpc_semaphore`` — which lazily constructs the semaphore on
+first use (loop affinity) and returns a ``contextlib.nullcontext`` when
+``max_concurrent_rpcs is None`` (unbounded opt-out). A direct semaphore
+binding would have to be reset on loop reuse and would have a 2-call
+recursive-acquire deadlock risk; the factory closure avoids both.
+
+See ``docs/adr/0009-middleware-chain.md`` §"Chain ordering" + "PR 12.9
+close-out notes" for the rationale and ``.sisyphus/plans/
+tier-12-13-greenfield-migration.md`` row 12.9 for the PR sequence.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from typing import Any
+
+from ._middleware import NextCall, RpcRequest, RpcResponse
+
+# ``RpcRequest.context`` key used to communicate the per-call queue-wait
+# duration from this middleware up to ``ClientCore._perform_authed_post``
+# (which forwards it to ``ClientMetrics.record_rpc_queue_wait``). Kept as a
+# named constant so the chain's metadata vocabulary in ADR-009 §"RpcRequest
+# .context keys" can reference it precisely.
+RPC_QUEUE_WAIT_CONTEXT_KEY = "rpc_queue_wait_seconds"
+
+
+class SemaphoreMiddleware:
+    """Chain middleware that holds an :class:`asyncio.Semaphore` slot.
+
+    Conforms to :class:`notebooklm._middleware.Middleware` — the ``__call__``
+    signature matches the Protocol so instances are assignable into a
+    ``Sequence[Middleware]``.
+
+    Constructor input:
+
+    - ``semaphore_factory``: zero-arg callable returning an async context
+      manager. Called once per chain invocation; the returned context manager
+      is entered around ``next_call``. Production wires
+      ``lambda: client_core._get_rpc_semaphore()`` so the live (lazily
+      constructed, loop-bound) semaphore is observed on each call. Tests can
+      pass ``lambda: contextlib.nullcontext()`` to disable gating.
+
+    Side effect: writes the per-call queue-wait duration to
+    ``request.context[RPC_QUEUE_WAIT_CONTEXT_KEY]`` so the host can forward
+    it to ``ClientMetrics.record_rpc_queue_wait`` without giving the
+    middleware a direct ``ClientMetrics`` reference (keeps the middleware
+    opinion-free about metric naming).
+    """
+
+    def __init__(
+        self,
+        semaphore_factory: Callable[[], AbstractAsyncContextManager[Any]],
+    ) -> None:
+        self._semaphore_factory = semaphore_factory
+
+    async def __call__(
+        self,
+        request: RpcRequest,
+        next_call: NextCall,
+    ) -> RpcResponse:
+        queue_wait_start = time.perf_counter()
+        async with self._semaphore_factory():
+            request.context[RPC_QUEUE_WAIT_CONTEXT_KEY] = time.perf_counter() - queue_wait_start
+            return await next_call(request)
+
+
+__all__ = ["RPC_QUEUE_WAIT_CONTEXT_KEY", "SemaphoreMiddleware"]

--- a/tests/integration/concurrency/test_max_concurrent_rpcs.py
+++ b/tests/integration/concurrency/test_max_concurrent_rpcs.py
@@ -231,6 +231,76 @@ async def test_none_disables_cap_and_allows_full_fanout(
     assert peak <= 50
 
 
+async def test_slot_held_across_retry_middleware_retries(
+    mock_transport_concurrent: ConcurrentMockTransport,
+) -> None:
+    """PR-12.9 regression: a logical RPC that retries does NOT release its slot.
+
+    Pre-PR-12.9 the chain leaf held the semaphore around a single POST
+    attempt — when ``RetryMiddleware`` re-invoked the chain on a 429, the
+    leaf released the slot, the retrying call queued behind whatever was
+    already in flight, and (under sustained 429s) every slot could end
+    up held by a retrying call waiting for a slot to retry into.
+    Codex caught this in the PR-12.9 audit. The fix is
+    :class:`SemaphoreMiddleware` at chain position 2 (between Metrics
+    and Retry) so the entire retry cohort stays in ONE slot per logical
+    RPC.
+
+    Test shape:
+    - ``max_concurrent_rpcs=1`` (one slot total).
+    - Two parallel tasks. Each hits ONE 429 then OK on retry.
+    - Total transport hits = 4 (2 originals + 2 retries).
+    - Peak in-flight MUST stay at 1. A value > 1 would mean a retry
+      attempt re-acquired the slot, indicating the gate moved INSIDE
+      ``RetryMiddleware`` again.
+    """
+    import httpx as _httpx
+
+    from .conftest import _default_rpc_response_text
+
+    transport = mock_transport_concurrent
+    transport.set_delay(0.02)
+
+    # Queue: 429, OK, 429, OK. Each logical RPC takes the first 429 and
+    # then succeeds on retry. With cap=1 the second logical RPC cannot
+    # start its first attempt until the first logical RPC's retry is
+    # done — and the retry stays in the same slot, so peak == 1.
+    headers = {"retry-after": "0"}
+    ok_text = _default_rpc_response_text()
+    for status, text in [
+        (429, "rate limited"),
+        (200, ok_text),
+        (429, "rate limited"),
+        (200, ok_text),
+    ]:
+        transport.queue_response(_httpx.Response(status_code=status, text=text, headers=headers))
+
+    core = await _open_core_with_transport(transport, max_concurrent_rpcs=1)
+    # Force fast retry so the test finishes promptly even on a slow box.
+    core._rate_limit_max_retries = 3
+
+    try:
+        results = await asyncio.gather(
+            *[core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []) for _ in range(2)]
+        )
+    finally:
+        await core.close()
+
+    assert len(results) == 2
+    # 4 transport hits = 2 logical RPCs × (1 initial + 1 retry).
+    assert transport.request_count() == 4, (
+        f"expected 4 transport hits (2 logical RPCs × 2 attempts each); "
+        f"got {transport.request_count()}"
+    )
+    peak = transport.get_peak_inflight()
+    assert peak == 1, (
+        f"peak in-flight was {peak} under max_concurrent_rpcs=1 with retries; "
+        f"expected exactly 1. A peak > 1 means RetryMiddleware retries "
+        f"re-acquired the slot, which would put SemaphoreMiddleware INSIDE "
+        f"RetryMiddleware — a chain-ordering regression."
+    )
+
+
 def test_cap_above_pool_max_connections_raises_at_construction(
     auth_tokens: AuthTokens,
 ) -> None:

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -239,39 +239,43 @@ async def test_chain_seeded_with_final_adr_009_ordering() -> None:
     prepended ``MetricsMiddleware``; PR 12.5 prepended ``DrainMiddleware``
     outermost; PR 12.6 inserted ``ErrorInjectionMiddleware`` between
     Metrics and Tracing; PR 12.7 inserted ``RetryMiddleware`` between
-    Metrics and ErrorInjection; PR 12.8 inserts ``AuthRefreshMiddleware``
-    between Retry and ErrorInjection. The list now reads the final
-    ADR-009 ordering
-    ``[Drain, Metrics, Retry, AuthRefresh, ErrorInjection, Tracing]``
+    Metrics and ErrorInjection; PR 12.8 inserted ``AuthRefreshMiddleware``
+    between Retry and ErrorInjection; PR 12.9 inserted
+    ``SemaphoreMiddleware`` between Metrics and Retry (codex catch — see
+    ADR-009 close-out notes). The list now reads the final ADR-009
+    ordering
+    ``[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection, Tracing]``
     (outermost → innermost).
 
     Order rationale (per ADR-009):
     - Drain outermost — every in-flight call counts toward shutdown wait
-    - Metrics outside Retry — end-to-end timing, not per-attempt
+    - Metrics outside Semaphore — latency includes queue wait
+    - Semaphore outside Retry — retry attempts stay in one slot
     - Retry outside AuthRefresh — orthogonal failure modes
     - AuthRefresh outside ErrorInjection — test-injected 401s exercise refresh
     - ErrorInjection inside Retry — synthetic transient failures trigger retry
     - Tracing innermost — logs actual HTTP attempts including retries
 
-    The list is exposed as ``self._middlewares`` so PR 12.9 (cleanup
-    audit) can verify ordering by inspecting the production attribute
-    directly.
+    The list is exposed as ``self._middlewares`` so the cleanup audit can
+    verify ordering by inspecting the production attribute directly.
     """
     from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
     from notebooklm._middleware_drain import DrainMiddleware
     from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
     from notebooklm._middleware_metrics import MetricsMiddleware
     from notebooklm._middleware_retry import RetryMiddleware
+    from notebooklm._middleware_semaphore import SemaphoreMiddleware
     from notebooklm._middleware_tracing import TracingMiddleware
 
     core = _make_core()
-    assert len(core._middlewares) == 6
+    assert len(core._middlewares) == 7
     assert isinstance(core._middlewares[0], DrainMiddleware)
     assert isinstance(core._middlewares[1], MetricsMiddleware)
-    assert isinstance(core._middlewares[2], RetryMiddleware)
-    assert isinstance(core._middlewares[3], AuthRefreshMiddleware)
-    assert isinstance(core._middlewares[4], ErrorInjectionMiddleware)
-    assert isinstance(core._middlewares[5], TracingMiddleware)
+    assert isinstance(core._middlewares[2], SemaphoreMiddleware)
+    assert isinstance(core._middlewares[3], RetryMiddleware)
+    assert isinstance(core._middlewares[4], AuthRefreshMiddleware)
+    assert isinstance(core._middlewares[5], ErrorInjectionMiddleware)
+    assert isinstance(core._middlewares[6], TracingMiddleware)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -102,18 +102,20 @@ def test_perform_authed_post_has_no_await_before_post_per_iteration():
     12.8 the leaf no longer has a ``while`` retry loop — it makes
     exactly one attempt per chain invocation. Each chain-level retry
     (driven by ``RetryMiddleware`` / ``AuthRefreshMiddleware``) re-enters
-    the leaf and re-runs ``_snapshot`` → ``build_request`` → POST.
-    The guard therefore walks the ``try`` block directly inside the
-    ``async with semaphore:`` body.
+    the leaf and re-runs ``_snapshot`` → ``build_request`` → POST. PR
+    12.9 moved the semaphore acquire OUT of the leaf entirely (it now
+    lives in ``SemaphoreMiddleware`` at chain position 2), so the leaf
+    is a pure POST-with-try block — the guard walks the ``try`` block
+    at the top of the function body.
     """
     src = textwrap.dedent(inspect.getsource(AuthedTransport.perform_authed_post))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 
-    # Locate the ``try`` block guarding the POST. Post-PR-12.8 the leaf
-    # has no ``while`` retry loop; the try sits directly inside the
-    # ``async with self._get_rpc_semaphore():`` body (the semaphore
-    # acquire happens once per call, not per iteration).
+    # Locate the ``try`` block guarding the POST. Post-PR-12.9 the leaf
+    # has no ``while`` retry loop and no ``async with`` semaphore wrap;
+    # the try sits at the top of the function body (the semaphore is
+    # held by ``SemaphoreMiddleware`` higher up the chain).
     def _find_first_try(parent: ast.AST) -> ast.Try | None:
         for child in ast.iter_child_nodes(parent):
             if isinstance(child, ast.Try):

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -21,11 +21,11 @@ Specifically pinned here:
   ``path`` arguments AND with the ``save_cookies_to_storage`` value resolved
   from ``notebooklm._core`` at call time (so the monkeypatch surface keeps
   working).
-* The httpx ``AsyncClient`` **is never wrapped in
-  ``_SyntheticErrorTransport``** — Tier-12 PR 12.6 lifted synthetic-error
-  injection into the chain
-  (:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`),
-  so the lifecycle constructs a plain transport regardless of
+* The httpx ``AsyncClient`` **always uses httpx's default transport** —
+  Tier-12 PR 12.6 lifted synthetic-error injection into the chain
+  (:class:`notebooklm._middleware_error_injection.ErrorInjectionMiddleware`)
+  and PR 12.9 deleted the legacy ``_SyntheticErrorTransport`` class.
+  The lifecycle constructs a plain transport regardless of
   ``NOTEBOOKLM_VCR_RECORD_ERRORS``.
 * :meth:`ClientLifecycle._keepalive_loop` **respects the min-interval
   clamp** — ``_resolve_keepalive_interval`` floors the configured interval
@@ -215,11 +215,11 @@ async def test_open_captures_cookie_snapshot() -> None:
 
 
 @pytest.mark.asyncio
-async def test_open_does_not_wrap_synthetic_transport_by_default(
+async def test_open_uses_default_httpx_transport_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Default path: ``_get_error_injection_mode`` returns ``None`` →
-    ``AsyncClient`` is built with no custom transport."""
+    """Default path: ``_get_error_injection_mode`` returns ``None`` → httpx's
+    default ``AsyncHTTPTransport`` is in place (no custom transport wrapping)."""
     monkeypatch.setattr(_core_module, "_get_error_injection_mode", lambda: None)
     lifecycle = _make_lifecycle()
     host = _StubHost()
@@ -228,9 +228,7 @@ async def test_open_does_not_wrap_synthetic_transport_by_default(
     try:
         client = lifecycle._http_client
         assert client is not None
-        # When no custom ``transport=`` is passed to ``AsyncClient``, httpx
-        # builds its own default transport — never a ``_SyntheticErrorTransport``.
-        assert not isinstance(client._transport, _core_module._SyntheticErrorTransport)
+        assert isinstance(client._transport, httpx.AsyncHTTPTransport)
     finally:
         await lifecycle.close(host)
 
@@ -239,16 +237,12 @@ async def test_open_does_not_wrap_synthetic_transport_by_default(
 async def test_open_uses_default_httpx_transport_when_env_var_set(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PR 12.6: ``AsyncClient`` uses httpx's default transport even with env var set.
+    """``AsyncClient`` uses httpx's default transport even with env var set.
 
-    Pre-PR-12.6 the lifecycle wrapped the inner transport in
-    ``_SyntheticErrorTransport`` whenever ``_get_error_injection_mode`` was
-    non-``None``. After PR 12.6 that substitution lives in the chain
-    (``ErrorInjectionMiddleware``), and the lifecycle constructs a plain
-    transport regardless of the env var. Asserted positively (httpx's
-    default ``AsyncHTTPTransport``) rather than as a negative against
-    ``_SyntheticErrorTransport`` so the test stays load-bearing after PR
-    12.9 deletes that class.
+    Pre-Tier-12 the lifecycle wrapped the inner transport in a synthetic
+    httpx transport (deleted in PR 12.9). After Tier-12 the substitution
+    lives in the chain (``ErrorInjectionMiddleware``); the lifecycle
+    constructs a plain transport regardless of the env var.
     """
     monkeypatch.setattr(_core_module, "_get_error_injection_mode", lambda: "429")
     lifecycle = _make_lifecycle()

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -597,6 +597,9 @@ async def test_caller_disable_true_propagates_through_executor(
     )
 
     assert captured["disable_internal_retries"] is True
+    # PR 12.9 audit fix: pin ``rpc_method`` threading too — coderabbit
+    # flagged that the fake captures it but no test asserts on it.
+    assert captured["rpc_method"] == RPCMethod.LIST_NOTEBOOKS.name
 
 
 @pytest.mark.asyncio
@@ -619,3 +622,5 @@ async def test_operation_variant_kwarg_threads_through_executor(
     )
 
     assert captured["disable_internal_retries"] is False
+    # PR 12.9 audit fix: pin ``rpc_method`` threading on this path too.
+    assert captured["rpc_method"] == RPCMethod.LIST_NOTEBOOKS.name

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1228,18 +1228,22 @@ def test_error_injection_symbols_resolve_through_core():
 
     ``test_core_lifecycle.py`` monkeypatches ``_get_error_injection_mode``
     through ``notebooklm._core``, and ``tests/conftest.py`` /
-    ``tests/unit/test_vcr_config.py`` import ``ERROR_INJECT_ENV_VAR`` and
-    ``_SyntheticErrorTransport`` from ``notebooklm._core``. A future refactor
-    that accidentally shadows the re-export (e.g. by reassigning the alias
-    at module scope) would silently break those monkeypatches before any
-    behavior test catches it — these identity pins surface that drift here.
+    ``tests/unit/test_vcr_config.py`` import ``ERROR_INJECT_ENV_VAR`` from
+    ``notebooklm._core``. A future refactor that accidentally shadows the
+    re-export (e.g. by reassigning the alias at module scope) would silently
+    break those monkeypatches before any behavior test catches it — these
+    identity pins surface that drift here.
+
+    PR 12.9 deleted ``_SyntheticErrorTransport`` (the legacy httpx
+    transport that wrapped the ``AsyncClient`` below VCR); the synthetic
+    substitution lives in ``_middleware_error_injection.ErrorInjectionMiddleware``
+    now, so that identity pin is gone.
     """
     import notebooklm._core as _core
     from notebooklm import _core_error_injection
 
     assert _core.ERROR_INJECT_ENV_VAR is _core_error_injection.ERROR_INJECT_ENV_VAR
     assert _core._get_error_injection_mode is _core_error_injection._get_error_injection_mode
-    assert _core._SyntheticErrorTransport is _core_error_injection._SyntheticErrorTransport
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -374,9 +374,11 @@ def test_scrub_response_does_not_corrupt_non_chunked_html_body():
 # 2. The ``before_record_response`` hook in vcr_config.py performs a
 #    defense-in-depth substitution when the env var is set, and is a no-op
 #    when unset.
-# 3. The ``_core.py`` transport wrapper substitutes the FIRST batchexecute
-#    POST without touching non-batchexecute traffic, and is only constructed
-#    when the env var resolves to a valid mode.
+# 3. The chain-layer ``ErrorInjectionMiddleware`` substitutes the synthetic
+#    response on every chain invocation (short-circuiting batchexecute
+#    POSTs) and is only wired into the chain when the env var resolves to
+#    a valid mode. PR 12.6 lifted this from a transport-layer wrapper
+#    (``_SyntheticErrorTransport``, deleted in PR 12.9) into the chain.
 
 build_synthetic_error_response = _cassette_patterns.build_synthetic_error_response
 synthetic_error_cassette_name = _cassette_patterns.synthetic_error_cassette_name

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -27,13 +27,11 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
-import httpx
 import pytest
 
 from notebooklm._core import (
     ERROR_INJECT_ENV_VAR,
     _get_error_injection_mode,
-    _SyntheticErrorTransport,
 )
 
 # Load ``tests/vcr_config.py`` via ``importlib`` rather than mutating
@@ -535,155 +533,24 @@ def test_core_get_error_injection_mode_typo_returns_none(monkeypatch):
     assert _get_error_injection_mode() is None
 
 
-class _RecordingInnerTransport(httpx.AsyncBaseTransport):
-    """Inner transport that records calls so we can assert pass-through."""
-
-    def __init__(self):
-        self.calls: list[httpx.Request] = []
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        self.calls.append(request)
-        return httpx.Response(200, content=b"inner-response", request=request)
-
-    async def aclose(self) -> None:
-        return None
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mode,expected_status",
-    [("429", 429), ("5xx", 500), ("expired_csrf", 400)],
-)
-async def test_synthetic_transport_substitutes_batchexecute(mode, expected_status):
-    """The wrapped transport returns a synthetic response for batchexecute
-    POSTs without ever forwarding them to the inner transport."""
-    inner = _RecordingInnerTransport()
-    wrapper = _SyntheticErrorTransport(mode, inner)
-    async with httpx.AsyncClient(transport=wrapper) as client:
-        resp = await client.post(
-            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
-            content=b"f.req=...",
-        )
-    assert resp.status_code == expected_status
-    assert resp.content  # synthetic body present
-    assert inner.calls == []  # batchexecute did NOT pass through
-
-
-@pytest.mark.asyncio
-async def test_synthetic_transport_passes_non_batchexecute_through():
-    """Non-batchexecute traffic (Scotty uploads, RotateCookies pokes, the
-    homepage GET) MUST pass through unchanged — error-shape cassettes only
-    target batchexecute RPCs."""
-    inner = _RecordingInnerTransport()
-    wrapper = _SyntheticErrorTransport("429", inner)
-    async with httpx.AsyncClient(transport=wrapper) as client:
-        resp = await client.get("https://notebooklm.google.com/")
-    assert resp.status_code == 200
-    assert resp.content == b"inner-response"
-    assert len(inner.calls) == 1
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS", "PUT", "DELETE"])
-async def test_synthetic_transport_only_substitutes_post_on_batchexecute(method):
-    """Even on the batchexecute path, only POST requests are substituted.
-
-    Non-POST methods on /batchexecute (a hypothetical GET probe, an OPTIONS
-    preflight, etc.) are out of scope for error-shape cassettes and must
-    pass through unchanged. Closes CodeRabbit feedback on PR #638.
-    """
-    inner = _RecordingInnerTransport()
-    wrapper = _SyntheticErrorTransport("429", inner)
-    async with httpx.AsyncClient(transport=wrapper) as client:
-        resp = await client.request(
-            method,
-            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
-        )
-    assert resp.status_code == 200
-    assert resp.content == b"inner-response"
-    assert len(inner.calls) == 1
-    # ``_fired`` must NOT have been flipped by a non-POST request.
-    assert wrapper._fired is False
-
-
-@pytest.mark.asyncio
-async def test_synthetic_transport_substitutes_every_batchexecute_call():
-    """With ``always=True`` (the default), every batchexecute POST gets the
-    synthetic response — important because the client's auth-refresh path
-    retries the same RPC and both retries must see the synthetic shape."""
-    inner = _RecordingInnerTransport()
-    wrapper = _SyntheticErrorTransport("5xx", inner, always=True)
-    async with httpx.AsyncClient(transport=wrapper) as client:
-        for _ in range(3):
-            resp = await client.post(
-                "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
-                content=b"f.req=...",
-            )
-            assert resp.status_code == 500
-    assert inner.calls == []
-
-
-@pytest.mark.asyncio
-async def test_synthetic_transport_always_false_fires_once():
-    """``always=False`` substitutes only the FIRST batchexecute POST; later
-    POSTs fall through to the inner transport. Useful for tests that want
-    to assert the client recovers after a single transient failure."""
-    inner = _RecordingInnerTransport()
-    wrapper = _SyntheticErrorTransport("5xx", inner, always=False)
-    async with httpx.AsyncClient(transport=wrapper) as client:
-        first = await client.post(
-            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
-            content=b"f.req=...",
-        )
-        second = await client.post(
-            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
-            content=b"f.req=...",
-        )
-    assert first.status_code == 500
-    assert second.status_code == 200  # passed through
-    assert len(inner.calls) == 1
-
-
-@pytest.mark.asyncio
-async def test_synthetic_transport_no_op_when_env_var_unset_in_clientcore(
-    monkeypatch,
-):
-    """End-to-end: when ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is unset, the
-    ``ClientCore.open()`` path constructs an ``httpx.AsyncClient`` WITHOUT
-    the synthetic transport wrapper — production behavior unchanged.
-
-    We don't actually call the network; we just inspect the underlying
-    transport stack after ``open()`` to confirm no synthetic wrapper is in
-    place. Uses a minimal ``AuthTokens`` instance to construct ``ClientCore``.
-    """
-    monkeypatch.delenv(ERROR_INJECT_ENV_VAR, raising=False)
-    from notebooklm._core import ClientCore
-    from notebooklm.auth import AuthTokens
-
-    auth = AuthTokens(cookies={"SID": "t"}, csrf_token="c", session_id="s")
-    core = ClientCore(auth)
-    try:
-        await core.open()
-        assert core._http_client is not None
-        # When unset, the AsyncClient is built without our wrapper. The
-        # default httpx transport is some private class; we just assert
-        # ours isn't in the chain.
-        transport = core._http_client._transport
-        assert not isinstance(transport, _SyntheticErrorTransport)
-    finally:
-        if core._http_client is not None:
-            await core._http_client.aclose()
+# --- ClientCore wiring after PR 12.6/12.9 -----------------------------------
+#
+# Pre-Tier-12 these tests exercised a ``_SyntheticErrorTransport`` that
+# wrapped the ``httpx.AsyncClient`` BELOW VCR. PR 12.6 lifted the
+# substitution into ``ErrorInjectionMiddleware`` (chain layer, ABOVE VCR)
+# and PR 12.9 deleted the legacy transport class entirely. The only
+# end-to-end assertion left at this layer is "the chain seed contains
+# ``ErrorInjectionMiddleware`` when the env var is set" — substitution
+# behavior is covered exhaustively by
+# ``tests/unit/test_error_injection_middleware.py``.
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("mode", ["429", "5xx", "expired_csrf"])
 async def test_error_injection_middleware_present_when_env_var_set_in_clientcore(monkeypatch, mode):
-    """End-to-end: Tier-12 PR 12.6 lifted synthetic-error injection from the
-    httpx transport into the chain. With the env var set, ``ClientCore``'s
-    middleware list contains an :class:`ErrorInjectionMiddleware` AND the
-    httpx ``AsyncClient`` transport is unwrapped (no
-    ``_SyntheticErrorTransport``) — the substitution happens above the
-    transport now."""
+    """When ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set, ``ClientCore`` wires
+    ``ErrorInjectionMiddleware`` into the chain so each chain invocation
+    short-circuits with the synthetic shape."""
     monkeypatch.setenv(ERROR_INJECT_ENV_VAR, mode)
     from notebooklm._core import ClientCore
     from notebooklm._middleware_error_injection import ErrorInjectionMiddleware
@@ -694,38 +561,13 @@ async def test_error_injection_middleware_present_when_env_var_set_in_clientcore
     try:
         await core.open()
         assert core._http_client is not None
-        # PR 12.6: httpx transport is unwrapped regardless of env var.
-        transport = core._http_client._transport
-        assert not isinstance(transport, _SyntheticErrorTransport)
-        # PR 12.6: chain seed contains an ``ErrorInjectionMiddleware`` that
-        # short-circuits at chain-invocation time when the env var resolves
-        # to a valid mode. The middleware itself doesn't expose the
-        # active mode (it reads the env var per call); env-var-to-mode
+        # The middleware reads the env var per call; env-var-to-mode
         # resolution is covered by the dedicated middleware tests in
         # ``test_error_injection_middleware.py``.
         assert any(isinstance(mw, ErrorInjectionMiddleware) for mw in core._middlewares)
     finally:
         if core._http_client is not None:
             await core._http_client.aclose()
-
-
-# --- (4) lazy-import resolution of the builder ------------------------------
-
-
-@pytest.mark.asyncio
-async def test_synthetic_transport_lazy_loads_builder():
-    """The transport defers importing tests/cassette_patterns.py until the
-    first batchexecute POST fires. This keeps the production module
-    free of test-tree dependencies at import time."""
-    inner = _RecordingInnerTransport()
-    wrapper = _SyntheticErrorTransport("429", inner)
-    assert wrapper._builder is None  # not yet resolved
-    async with httpx.AsyncClient(transport=wrapper) as client:
-        await client.post(
-            "https://notebooklm.google.com/_/LabsTailwindUi/data/batchexecute",
-            content=b"f.req=...",
-        )
-    assert wrapper._builder is not None  # resolved after first use
 
 
 # --- (5) marker plumbing in tests/conftest.py --------------------------------


### PR DESCRIPTION
## Summary

Tier-12 close-out. Final chain: `[Drain, Metrics, Semaphore, Retry, AuthRefresh, ErrorInjection, Tracing]`. `AuthedTransport.perform_authed_post` is now a pure POST — every cross-cutting concern lives in the chain. ADR-009 status flipped to `Accepted (Tier 12 PR 12.1; closed by PR 12.9)`.

## Why a 7th middleware (codex catch)

First cut of audit-find #1 wrapped `max_concurrent_rpcs` around the chain dispatch in `_perform_authed_post` (outside the chain). Codex caught the regression with a reproducible `max_concurrent_rpcs=1` test: queued tasks were no longer counted by `DrainMiddleware`, so `client.close()` mid-flight rejected them with `RuntimeError` instead of awaiting them. Metrics latency also stopped including queue wait.

`SemaphoreMiddleware` between Metrics and Retry restores both contracts in one place — Drain admits queued tasks (chain pos 0), Metrics times the wait (chain pos 1), and Retry stays in one slot (chain pos 3+). Queue-wait duration flows through `rpc_queue_wait_seconds` context key so `ClientCore` forwards to `ClientMetrics.record_rpc_queue_wait` without coupling the middleware to a metrics reference.

A new regression test (`test_slot_held_across_retry_middleware_retries`) asserts peak in-flight stays at 1 when both tasks each hit one 429-then-retry — pins the chain-position invariant against future drift.

## What also lands

* `AuthedTransport.__init__` dropped `is_auth_error` + `sleep` args (now in chain middlewares).
* `_AuthedTransportHost` Protocol slimmed from 8 to 3 members.
* `AuthRefreshCoordinator.has_refresh_callback` property + module-level `_live_is_auth_error` helper replacing inline `globals()`-based late-binding patterns.
* Deleted `_SyntheticErrorTransport` (~115 LOC) — synthetic substitution lives in `ErrorInjectionMiddleware` since PR 12.6.
* `CORE_LOGGER_NAME = "notebooklm._core"` constant; 7 modules consume it.
* `MetricsMiddleware` uses `type(exc).__qualname__` (consistency with `TracingMiddleware`).
* `test_idempotency_registry.py` pins `rpc_method` context-key plumbing.
* `_ensure_observability_state` backfills `_max_concurrent_rpcs = None` for `__new__`-built fixtures.
* ADR-009: 7-middleware chain ordering, context-keys table adds `rpc_queue_wait_seconds` + `auth_refreshed`, §"AuthRefreshMiddleware constructor signature" marked as Tier-13 target (PR 12.8 shipped a simpler interim), concerns table relabeled Pre-Tier-12 / Post-Tier-12, new "PR 12.9 close-out notes" section.

## Reviewers

* Codex: REJECT (load-bearing repro that drove `SemaphoreMiddleware` insertion).
* Claude code-reviewer: OKAY-WITH-NITS (stale comments folded in).
* Code-simplifier: separate commit `cc3c8d0`.
* Gemini: transient capacity-exhausted; skipped.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (134 files)
- [x] `uv run pytest tests/unit tests/integration -n auto -q` — 5426 passed, 57 skipped
- [x] `pre-commit run --all-files` — clean
- [x] Codex's reproducible drain-admission test passes (`in_flight=2`, `t2 success` under `max_concurrent_rpcs=1`)
- [ ] Bot reviews (`@claude review` + auto gemini + auto coderabbit) — to be requested after open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semaphore-based concurrency gating added to preserve one-slot-per-logical-RPC semantics and record queue-wait latency.
  * Middleware exposes queue-wait and auth-refresh context keys for telemetry.

* **Bug Fixes**
  * Retries no longer release concurrency slots; metrics now include queue wait and improved error/retry bounding.
  * Auth-refresh behavior tightened to a single-retry flow.

* **Chores**
  * Synthetic-error (VCR) playback moved into middleware; transport leaf simplified to a single-attempt POST.
  * Core logger name centralized for consistent log filtering.

* **Tests**
  * Added/updated tests to validate semaphore, retry, and middleware wiring behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->