### PR TITLE
feat(core): move poll registry to artifacts

### DIFF
--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -11,8 +11,9 @@ from typing import Any, Protocol
 
 from ._backoff import compute_backoff_delay
 from ._callbacks import maybe_await_callback
-from ._capabilities import LoopAffinityProvider, PollRegistryProvider, TransportOperationProvider
+from ._capabilities import LoopAffinityProvider, TransportOperationProvider
 from ._loop_affinity import assert_bound_loop
+from ._polling_registry import PollRegistry
 from .rpc import (
     ArtifactStatus,
     ArtifactTypeCode,
@@ -47,7 +48,6 @@ StatusChangeCallback = Callable[[GenerationStatus], object]
 
 
 class ArtifactPollingCapabilities(
-    PollRegistryProvider,
     TransportOperationProvider,
     LoopAffinityProvider,
     Protocol,
@@ -63,9 +63,28 @@ class ArtifactPollingService:
     as call-time callbacks instead of being captured during construction.
     """
 
-    def __init__(self, capabilities: ArtifactPollingCapabilities) -> None:
+    def __init__(
+        self,
+        capabilities: ArtifactPollingCapabilities,
+        poll_registry: PollRegistry | None = None,
+    ) -> None:
         self._capabilities = capabilities
+        self._poll_registry = poll_registry if poll_registry is not None else PollRegistry()
         self._completion_tasks: set[asyncio.Task[None]] = set()
+
+    @property
+    def poll_registry(self) -> PollRegistry:
+        """Return the feature-owned polling registry."""
+        return self._poll_registry
+
+    async def drain(self) -> None:
+        """Cancel and await currently active leader poll tasks."""
+        poll_tasks = self._poll_registry.active_tasks()
+        if not poll_tasks:
+            return
+        for task in poll_tasks:
+            task.cancel()
+        await asyncio.gather(*poll_tasks, return_exceptions=True)
 
     async def poll_status(
         self,
@@ -151,7 +170,7 @@ class ArtifactPollingService:
             )
             initial_interval = poll_interval
 
-        pending = self._capabilities.poll_registry.pending
+        pending = self._poll_registry.pending
         key = (notebook_id, task_id)
 
         existing = pending.get(key)

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -78,13 +78,14 @@ class ArtifactPollingService:
         return self._poll_registry
 
     async def drain(self) -> None:
-        """Cancel and await currently active leader poll tasks."""
+        """Cancel active leader poll tasks and await polling bookkeeping."""
         poll_tasks = self._poll_registry.active_tasks()
-        if not poll_tasks:
-            return
         for task in poll_tasks:
             task.cancel()
-        await asyncio.gather(*poll_tasks, return_exceptions=True)
+        if poll_tasks:
+            await asyncio.gather(*poll_tasks, return_exceptions=True)
+        if self._completion_tasks:
+            await asyncio.gather(*self._completion_tasks, return_exceptions=True)
 
     async def poll_status(
         self,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -20,9 +20,10 @@ from ._capabilities import (
     AuthRouteProvider,
     CoreRPCProvider,
     LoopAffinityProvider,
-    PollRegistryProvider,
     TransportOperationProvider,
 )
+from ._polling_registry import PollRegistry
+from ._session_contracts import DrainHookRegistration
 from .auth import load_httpx_cookies
 from .rpc import (
     ArtifactTypeCode,
@@ -59,9 +60,9 @@ logger = logging.getLogger(__name__)
 class _ArtifactsCore(
     CoreRPCProvider,
     AuthRouteProvider,
-    PollRegistryProvider,
     TransportOperationProvider,
     LoopAffinityProvider,
+    DrainHookRegistration,
     Protocol,
 ):
     """Narrow per-sub-client view of the core required by :class:`ArtifactsAPI`.
@@ -69,11 +70,11 @@ class _ArtifactsCore(
     Co-located with the sub-client that consumes it (per ADR-002). Inherits
     only the capabilities ArtifactsAPI actually uses: ``rpc_call`` (from
     :class:`CoreRPCProvider`), authuser routing (from
-    :class:`AuthRouteProvider`), the shared artifact poll registry (from
-    :class:`PollRegistryProvider`), transport-operation bookkeeping for
+    :class:`AuthRouteProvider`), transport-operation bookkeeping for
     long-running download streams (from :class:`TransportOperationProvider`),
-    and the open-time event loop forwarded into the artifact polling
-    boundary's loop-affinity guard (from :class:`LoopAffinityProvider`).
+    the open-time event loop forwarded into the artifact polling boundary's
+    loop-affinity guard (from :class:`LoopAffinityProvider`), and close-time
+    drain registration (from :class:`DrainHookRegistration`).
     """
 
     pass
@@ -198,10 +199,15 @@ class ArtifactsAPI:
         self._mind_map_service = (
             _mind_map.MindMapService(core) if mind_map_service is None else mind_map_service
         )
+        self._poll_registry = PollRegistry()
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
         self._downloads = ArtifactDownloadService(self)
-        self._polling = _artifact_polling.ArtifactPollingService(self._capabilities)
+        self._polling = _artifact_polling.ArtifactPollingService(
+            self._capabilities,
+            self._poll_registry,
+        )
+        core.register_drain_hook("artifacts.polls", self._polling.drain)
 
     # =========================================================================
     # List/Get Operations
@@ -712,10 +718,10 @@ class ArtifactsAPI:
         Uses exponential backoff for polling to reduce API load.
 
         Concurrent callers for the same ``(notebook_id, task_id)`` share a
-        single underlying poll loop through the ``PollRegistry`` exposed by
-        this API's capabilities. The first caller is the *leader* and drives
-        the poll loop; subsequent *followers* attach to the leader's future
-        without issuing their own ``LIST_ARTIFACTS`` requests. Cancellation is
+        single underlying poll loop through this API's feature-owned
+        ``PollRegistry``. The first caller is the *leader* and drives the poll
+        loop; subsequent *followers* attach to the leader's future without
+        issuing their own ``LIST_ARTIFACTS`` requests. Cancellation is
         per-caller — only the cancelled caller's ``await`` raises
         ``CancelledError``; the underlying poll continues and remaining
         followers still receive the result.

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -16,7 +16,6 @@ from typing import Any, Protocol
 import httpx
 
 from ._core_drain import _TransportOperationToken
-from ._core_polling import PollRegistry
 from .rpc.types import RPCMethod
 
 
@@ -52,15 +51,6 @@ class CoreReqIdProvider(Protocol):
     """Provider for the shared request-id counter."""
 
     async def next_reqid(self, step: int = 100000) -> int: ...
-
-
-class PollRegistryProvider(Protocol):
-    """Provider for the shared artifact polling registry."""
-
-    @property
-    def poll_registry(self) -> PollRegistry:
-        """Return the existing per-core poll registry."""
-        ...
 
 
 class AuthRouteProvider(Protocol):

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -80,7 +80,6 @@ from ._core_helpers import (
 )
 from ._core_lifecycle import ClientLifecycle
 from ._core_metrics import ClientMetrics
-from ._core_polling import PendingPolls, PollRegistry
 from ._core_reqid import DEFAULT_STEP as _REQID_DEFAULT_STEP
 from ._core_reqid import ReqidCounter
 from ._core_rpc import RpcExecutor
@@ -118,6 +117,7 @@ from ._middleware_error_injection import ErrorInjectionMiddleware
 from ._middleware_metrics import MetricsMiddleware
 from ._middleware_retry import RetryMiddleware
 from ._middleware_tracing import TracingMiddleware
+from ._polling_registry import PendingPolls, PollRegistry
 from ._sources import fetch_source_ids
 
 # ``save_cookies_to_storage`` is re-exported as ``notebooklm._core.save_cookies_to_storage``
@@ -464,6 +464,7 @@ class ClientCore:
         # compatibility properties below keep the legacy private attribute
         # names observable for current tests and first-party callers.
         self.cookie_persistence = CookiePersistence(self.auth, _resolved_storage_path)
+        self._drain_hooks: dict[str, Callable[[], Awaitable[None]]] = {}
         self.poll_registry: PollRegistry = PollRegistry()
         self._authed_transport: AuthedTransport | None = None
         self._rpc_executor: RpcExecutor | None = None
@@ -862,15 +863,19 @@ class ClientCore:
     def _pending_polls(self) -> PendingPolls:
         """Deprecated compatibility view of ``poll_registry.pending``.
 
-        Feature APIs now access polling state through ``poll_registry`` or a
-        narrow capability adapter. This bridge remains for external callers and
-        tests that still read or assign ``ClientCore._pending_polls`` directly.
+        The active artifact polling registry is feature-owned. This bridge
+        remains only for external callers and tests that still read or assign
+        ``ClientCore._pending_polls`` directly.
         """
         return self.poll_registry.pending
 
     @_pending_polls.setter
     def _pending_polls(self, value: PendingPolls) -> None:
         self.poll_registry.pending = value
+
+    def register_drain_hook(self, name: str, hook: Callable[[], Awaitable[None]]) -> None:
+        """Register or replace a feature-owned close-time drain hook."""
+        self._drain_hooks[name] = hook
 
     async def next_reqid(self, step: int = _REQID_DEFAULT_STEP) -> int:
         """Atomically increment the request-id counter and return the new value.
@@ -1229,7 +1234,7 @@ class ClientCore:
 
         1. Cancels and joins the keepalive task (so the loop can't issue a
            poke against an already-closed transport).
-        2. Drains in-flight artifact poll tasks held by ``self.poll_registry``.
+        2. Runs registered feature drain hooks.
         3. Saves cookies one last time through ``save_cookies``.
         4. Calls ``aclose()`` under :func:`asyncio.shield` so cancellation
            arriving mid-close cannot leak the underlying httpx transport.

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -465,6 +465,7 @@ class ClientCore:
         # names observable for current tests and first-party callers.
         self.cookie_persistence = CookiePersistence(self.auth, _resolved_storage_path)
         self._drain_hooks: dict[str, Callable[[], Awaitable[None]]] = {}
+        # Compatibility-only: active artifact polling state is owned by ArtifactsAPI.
         self.poll_registry: PollRegistry = PollRegistry()
         self._authed_transport: AuthedTransport | None = None
         self._rpc_executor: RpcExecutor | None = None

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -323,13 +323,10 @@ class ClientLifecycle:
                 refresh_task.cancel()
                 await asyncio.gather(refresh_task, return_exceptions=True)
 
-            async def _run_drain_hook(hook: Callable[[], Awaitable[None]]) -> None:
-                await hook()
-
             drain_hooks = list(host._drain_hooks.values())
             if drain_hooks:
                 await asyncio.gather(
-                    *(_run_drain_hook(hook) for hook in drain_hooks),
+                    *(hook() for hook in drain_hooks),
                     return_exceptions=True,
                 )
 

--- a/src/notebooklm/_core_lifecycle.py
+++ b/src/notebooklm/_core_lifecycle.py
@@ -32,8 +32,8 @@ Design constraints (load-bearing — see ``tests/unit/test_client_keepalive.py``
 * :meth:`open` is idempotent — calling it twice with a live ``_http_client``
   is a no-op, preserving the legacy ``ClientCore.open()`` contract.
 
-* :meth:`close` cancellation ordering: stop keepalive → drain poll tasks →
-  save cookies → shielded Kernel ``aclose()``. Reversing any of these
+* :meth:`close` cancellation ordering: stop keepalive → run registered drain
+  hooks → save cookies → shielded Kernel ``aclose()``. Reversing any of these
   reintroduces the leak modes ``test_core_close.py`` pins down. The shielded
   ``aclose()`` is critical: without it, a ``CancelledError`` arriving
   mid-close leaks the underlying httpx transport.
@@ -68,6 +68,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
@@ -81,7 +82,6 @@ if TYPE_CHECKING:
     from ._core_cookie_persistence import CookiePersistence
     from ._core_drain import TransportDrainTracker
     from ._core_metrics import ClientMetrics
-    from ._core_polling import PollRegistry
     from ._core_reqid import ReqidCounter
     from ._core_rpc import RpcExecutor
     from ._core_transport import AuthedTransport
@@ -99,10 +99,10 @@ class _LifecycleHost(Protocol):
     The Protocol pins exactly which collaborators the lifecycle reaches into
     on the host, so future refactors that move state around ``ClientCore``
     surface as Protocol violations rather than silent ``AttributeError``s
-    at close-time. ``cookie_persistence`` and ``poll_registry`` mirror
-    today's public attribute names on ``ClientCore``; ``_metrics_obj``,
-    ``_drain_tracker``, and ``_auth_coord`` are the post-A1/A2/B1 helper
-    handles. ``_authed_transport`` and ``_rpc_executor`` are nulled out by
+    at close-time. ``cookie_persistence`` mirrors today's public attribute
+    name on ``ClientCore``; ``_drain_hooks``, ``_metrics_obj``,
+    ``_drain_tracker``, and ``_auth_coord`` are helper handles.
+    ``_authed_transport`` and ``_rpc_executor`` are nulled out by
     :meth:`ClientLifecycle.close` so a follow-up ``open()`` rebuilds them
     against the new ``httpx.AsyncClient`` (avoids stale closures over the
     previous client).
@@ -114,7 +114,7 @@ class _LifecycleHost(Protocol):
     _auth_coord: AuthRefreshCoordinator
     _reqid: ReqidCounter
     cookie_persistence: CookiePersistence
-    poll_registry: PollRegistry
+    _drain_hooks: dict[str, Callable[[], Awaitable[None]]]
     _authed_transport: AuthedTransport | None
     _rpc_executor: RpcExecutor | None
 
@@ -288,13 +288,12 @@ class ClientLifecycle:
         ``finally`` so the instance is consistently marked closed even if
         shielded teardown raises.
 
-        Poll-task drain: in-flight artifact poll tasks held by
-        ``host.poll_registry`` are cancelled and awaited before the HTTP
-        client is torn down. Without this, a leader poll waking mid-aclose
-        would issue a request against an already-closed transport and
-        surface as a confusing httpx error. The drain uses
-        ``return_exceptions=True`` so a single misbehaving task can't block
-        the rest of the close sequence.
+        Drain hooks: feature-owned close hooks are awaited before the HTTP
+        client is torn down. Without this, a feature task waking mid-aclose
+        could issue a request against an already-closed transport and surface
+        as a confusing httpx error. The drain uses ``return_exceptions=True``
+        so a single misbehaving hook can't block the rest of the close
+        sequence.
 
         Nulls out ``host._authed_transport`` and ``host._rpc_executor`` so a
         follow-up :meth:`open` rebuilds the transport collaborators against
@@ -324,14 +323,15 @@ class ClientLifecycle:
                 refresh_task.cancel()
                 await asyncio.gather(refresh_task, return_exceptions=True)
 
-            # Drain in-flight artifact poll tasks. Snapshot first so concurrent
-            # registry mutations (a finishing leader removing its entry) don't
-            # race with the cancel/gather pair.
-            poll_tasks = host.poll_registry.active_tasks()
-            if poll_tasks:
-                for task in poll_tasks:
-                    task.cancel()
-                await asyncio.gather(*poll_tasks, return_exceptions=True)
+            async def _run_drain_hook(hook: Callable[[], Awaitable[None]]) -> None:
+                await hook()
+
+            drain_hooks = list(host._drain_hooks.values())
+            if drain_hooks:
+                await asyncio.gather(
+                    *(_run_drain_hook(hook) for hook in drain_hooks),
+                    return_exceptions=True,
+                )
 
             if self._http_client:
                 try:

--- a/src/notebooklm/_core_polling.py
+++ b/src/notebooklm/_core_polling.py
@@ -1,46 +1,15 @@
-"""Polling collaborators for :mod:`notebooklm._core`."""
+"""Compatibility shim for polling registry imports.
 
-from __future__ import annotations
+The registry moved out of ``_core`` ownership in Tier 13 PR 13.3. Keep this
+module as the legacy import path for first-party tests and downstream private
+imports while new code imports from :mod:`notebooklm._polling_registry`.
+"""
 
-import asyncio
-from typing import Any
+from ._polling_registry import PendingPoll, PendingPolls, PollKey, PollRegistry
 
-PollKey = tuple[str, str]
-PendingPoll = tuple[asyncio.Future[Any], asyncio.Task[Any]]
-PendingPolls = dict[PollKey, PendingPoll]
-
-
-class PollRegistry:
-    """Leader/follower polling-dedupe registry for artifact waits.
-
-    Keys are ``(notebook_id, task_id)`` pairs. Values stay in the legacy
-    ``(future, task)`` shape because ``ArtifactsAPI.wait_for_completion`` still
-    owns the poll loop and cleanup behavior in this phase.
-
-    The first waiter for a key is the leader and stores the shared future plus
-    the running poll task. Followers attach to that future via
-    ``asyncio.shield`` so per-caller cancellation does not cancel the shared
-    poll. The task reference is retained alongside the future so the running
-    poll cannot be garbage-collected if the leader is cancelled before
-    followers attach. This registry is per ``ClientCore`` instance, never
-    module-global.
-    """
-
-    def __init__(self, pending: PendingPolls | None = None) -> None:
-        self.pending: PendingPolls = pending if pending is not None else {}
-
-    def active_tasks(self) -> list[asyncio.Task[Any]]:
-        """Return the currently-pending leader poll tasks.
-
-        Used by :meth:`ClientCore.close` to drain in-flight artifact polls
-        before the HTTP transport is torn down — without this, a leader task
-        can wake mid-aclose and issue a request against an already-closed
-        client, surfacing as a confusing httpx error in the user's logs.
-
-        Returns a snapshot list (not a live view) so a caller can iterate and
-        cancel without mutating the underlying ``pending`` mapping mid-loop.
-        Already-completed tasks are filtered out: they have nothing left to
-        cancel, and asking ``asyncio.gather`` to await an already-done task is
-        harmless but noisy in the cancellation path.
-        """
-        return [task for _future, task in self.pending.values() if not task.done()]
+__all__ = [
+    "PendingPoll",
+    "PendingPolls",
+    "PollKey",
+    "PollRegistry",
+]

--- a/src/notebooklm/_polling_registry.py
+++ b/src/notebooklm/_polling_registry.py
@@ -1,0 +1,54 @@
+"""Polling registry owned by feature APIs that share leader tasks."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+PollKey = tuple[str, str]
+PendingPoll = tuple[asyncio.Future[Any], asyncio.Task[Any]]
+PendingPolls = dict[PollKey, PendingPoll]
+
+
+class PollRegistry:
+    """Leader/follower polling-dedupe registry for artifact waits.
+
+    Keys are ``(notebook_id, task_id)`` pairs. Values stay in the legacy
+    ``(future, task)`` shape because ``ArtifactsAPI.wait_for_completion`` owns
+    the poll loop and cleanup behavior.
+
+    The first waiter for a key is the leader and stores the shared future plus
+    the running poll task. Followers attach to that future via
+    ``asyncio.shield`` so per-caller cancellation does not cancel the shared
+    poll. The task reference is retained alongside the future so the running
+    poll cannot be garbage-collected if the leader is cancelled before
+    followers attach. This registry is per owning feature API, never
+    module-global.
+    """
+
+    def __init__(self, pending: PendingPolls | None = None) -> None:
+        self.pending: PendingPolls = pending if pending is not None else {}
+
+    def active_tasks(self) -> list[asyncio.Task[Any]]:
+        """Return the currently-pending leader poll tasks.
+
+        Used by close-time drain hooks to cancel in-flight artifact polls before
+        the HTTP transport is torn down. Without this, a leader task can wake
+        mid-aclose and issue a request against an already-closed client,
+        surfacing as a confusing httpx error in the user's logs.
+
+        Returns a snapshot list (not a live view) so a caller can iterate and
+        cancel without mutating the underlying ``pending`` mapping mid-loop.
+        Already-completed tasks are filtered out: they have nothing left to
+        cancel, and asking ``asyncio.gather`` to await an already-done task is
+        harmless but noisy in the cancellation path.
+        """
+        return [task for _future, task in self.pending.values() if not task.done()]
+
+
+__all__ = [
+    "PendingPoll",
+    "PendingPolls",
+    "PollKey",
+    "PollRegistry",
+]

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -9,7 +9,7 @@ import warnings
 from typing import Any, Protocol
 
 from . import research as _research_pub
-from ._capabilities import CoreRPCProvider, PollRegistryProvider
+from ._capabilities import CoreRPCProvider
 from .exceptions import ResearchTaskMismatchError, ValidationError
 from .rpc import RPCMethod, safe_index
 from .types import CitedSourceSelection
@@ -19,13 +19,12 @@ __all__ = ["CitedSourceSelection", "ResearchAPI"]
 logger = logging.getLogger(__name__)
 
 
-class _ResearchCore(CoreRPCProvider, PollRegistryProvider, Protocol):
+class _ResearchCore(CoreRPCProvider, Protocol):
     """Narrow per-sub-client view of the core required by :class:`ResearchAPI`.
 
     Co-located with the sub-client that consumes it (per ADR-002). Inherits
-    only the capabilities ResearchAPI actually uses: ``rpc_call`` (from
-    :class:`CoreRPCProvider`) and the shared artifact poll registry (from
-    :class:`PollRegistryProvider`).
+    only the capability ResearchAPI actually uses: ``rpc_call`` (from
+    :class:`CoreRPCProvider`).
     """
 
     pass

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -82,6 +82,7 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         # Legacy ClientCore compatibility bridge
         "poll_registry": MagicMock(),
         # DrainHookRegistration
+        "_drain_hooks": {},
         "register_drain_hook": MagicMock(return_value=None),
         # AuthRouteProvider — sync helpers, used during request build
         "authuser": 0,
@@ -114,6 +115,11 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         # Auth-route helper alias
         "_route_url": MagicMock(return_value="https://notebooklm.google.com/_/.../batchexecute"),
     }
+
+    def _register_drain_hook(name: str, hook: Any) -> None:
+        defaults["_drain_hooks"][name] = hook
+
+    defaults["register_drain_hook"] = MagicMock(side_effect=_register_drain_hook)
 
     # Validate overrides early so a typo like ``rpc_cal=`` fails loudly
     # rather than landing as an unread attribute.

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -79,8 +79,10 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         # CoreReqIdProvider — both the public name and the underscore alias
         "next_reqid": AsyncMock(return_value=100000),
         "_next_reqid": AsyncMock(return_value=100000),
-        # PollRegistryProvider
+        # Legacy ClientCore compatibility bridge
         "poll_registry": MagicMock(),
+        # DrainHookRegistration
+        "register_drain_hook": MagicMock(return_value=None),
         # AuthRouteProvider — sync helpers, used during request build
         "authuser": 0,
         "account_email": None,

--- a/tests/unit/concurrency/test_core_close_refresh_race.py
+++ b/tests/unit/concurrency/test_core_close_refresh_race.py
@@ -67,8 +67,7 @@ class _StubHost:
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
-        self.poll_registry = MagicMock()
-        self.poll_registry.active_tasks = MagicMock(return_value=[])
+        self._drain_hooks = {}
         self._authed_transport = None
         self._rpc_executor = None
 

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -5,7 +5,7 @@ import pytest
 
 from notebooklm._artifact_polling import ArtifactPollingService
 from notebooklm._artifacts import ArtifactsAPI, GenerationStatus
-from notebooklm._core_polling import PollRegistry
+from notebooklm._polling_registry import PollRegistry
 from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 
 
@@ -71,8 +71,6 @@ class _FakeTransportProvider:
 def api():
     core = MagicMock()
     # Real registry backing so wait_for_completion can ``dict.get(key)``.
-    core.poll_registry = PollRegistry()
-    core._pending_polls = core.poll_registry.pending
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.bound_loop = None
@@ -135,7 +133,7 @@ async def test_wait_for_completion_no_retry_on_auth_error(api):
 async def test_polling_service_begin_transport_task_receives_spawned_poll_task() -> None:
     token = object()
     provider = _FakeTransportProvider(token=token)
-    service = ArtifactPollingService(provider)
+    service = ArtifactPollingService(provider, provider.poll_registry)
 
     async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
         assert (notebook_id, task_id) == ("nb1", "task1")
@@ -166,7 +164,7 @@ async def test_polling_service_begin_transport_task_receives_spawned_poll_task()
 async def test_polling_service_registers_pending_before_transport_begin_completes() -> None:
     begin_release = asyncio.Event()
     provider = _FakeTransportProvider(begin_release=begin_release)
-    service = ArtifactPollingService(provider)
+    service = ArtifactPollingService(provider, provider.poll_registry)
     poll_call_count = 0
 
     async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
@@ -226,7 +224,7 @@ async def test_polling_service_resolves_wait_before_slow_transport_finish() -> N
     token = object()
     finish_release = asyncio.Event()
     provider = _FakeTransportProvider(token=token, finish_release=finish_release)
-    service = ArtifactPollingService(provider)
+    service = ArtifactPollingService(provider, provider.poll_registry)
 
     async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
         return GenerationStatus(task_id=task_id, status="completed")
@@ -253,7 +251,7 @@ async def test_polling_service_resolves_wait_before_slow_transport_finish() -> N
 async def test_polling_service_finishes_transport_token_once_after_poll_failure() -> None:
     token = object()
     provider = _FakeTransportProvider(token=token)
-    service = ArtifactPollingService(provider)
+    service = ArtifactPollingService(provider, provider.poll_registry)
 
     async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
         raise ValueError(f"poll failed: {notebook_id}/{task_id}")
@@ -281,7 +279,7 @@ async def test_polling_service_cancels_and_drains_spawned_poll_task_if_begin_fai
         begin_error=begin_error,
         yield_before_begin_error=True,
     )
-    service = ArtifactPollingService(provider)
+    service = ArtifactPollingService(provider, provider.poll_registry)
     poll_started = asyncio.Event()
     poll_cancelled = asyncio.Event()
     poll_finally = asyncio.Event()
@@ -321,8 +319,6 @@ async def test_polling_service_cancels_and_drains_spawned_poll_task_if_begin_fai
 @pytest.mark.asyncio
 async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_or_later_waiter():
     core = MagicMock()
-    core.poll_registry = PollRegistry()
-    core._pending_polls = core.poll_registry.pending
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.bound_loop = None
@@ -350,12 +346,11 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
     try:
         await asyncio.wait_for(poll_started.wait(), timeout=test_timeout)
         for _ in range(10):
-            if key in core.poll_registry.pending:
+            if key in api._poll_registry.pending:
                 break
             await asyncio.sleep(0)
 
-        assert core._pending_polls is core.poll_registry.pending
-        assert key in core.poll_registry.pending
+        assert key in api._poll_registry.pending
 
         follower = asyncio.create_task(api.wait_for_completion("nb1", "task1", timeout=60.0))
         await asyncio.sleep(0)
@@ -364,7 +359,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
             await asyncio.wait_for(follower, timeout=test_timeout)
 
         assert not leader.done()
-        assert key in core.poll_registry.pending
+        assert key in api._poll_registry.pending
         assert poll_call_count == 1
 
         later_waiter = asyncio.create_task(api.wait_for_completion("nb1", "task1", timeout=60.0))
@@ -374,8 +369,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
         assert await asyncio.wait_for(leader, timeout=test_timeout) == status_ready
         assert await asyncio.wait_for(later_waiter, timeout=test_timeout) == status_ready
         assert poll_call_count == 1
-        assert core.poll_registry.pending == {}
-        assert core._pending_polls == {}
+        assert api._poll_registry.pending == {}
     finally:
         release_poll.set()
         cleanup_tasks = []

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -248,6 +248,47 @@ async def test_polling_service_resolves_wait_before_slow_transport_finish() -> N
 
 
 @pytest.mark.asyncio
+async def test_polling_service_drain_waits_for_bookkeeping_without_active_polls() -> None:
+    token = object()
+    finish_release = asyncio.Event()
+    provider = _FakeTransportProvider(token=token, finish_release=finish_release)
+    service = ArtifactPollingService(provider, provider.poll_registry)
+
+    async def poll_status(notebook_id: str, task_id: str) -> GenerationStatus:
+        return GenerationStatus(task_id=task_id, status="completed")
+
+    result = await service.wait_for_completion(
+        "nb1",
+        "task1",
+        initial_interval=0.0,
+        max_interval=0.0,
+        timeout=1.0,
+        poll_status=poll_status,
+    )
+
+    assert result.status == "completed"
+    assert provider.poll_registry.active_tasks() == []
+    assert provider.finish_started.is_set()
+    assert not provider.finish_finished.is_set()
+
+    drain_task = asyncio.create_task(service.drain())
+    try:
+        await asyncio.sleep(0)
+        assert not drain_task.done()
+
+        finish_release.set()
+        await asyncio.wait_for(drain_task, timeout=1.0)
+    finally:
+        finish_release.set()
+        if not drain_task.done():
+            drain_task.cancel()
+            await asyncio.gather(drain_task, return_exceptions=True)
+
+    assert provider.finish_finished.is_set()
+    assert provider.finish_tokens == [token]
+
+
+@pytest.mark.asyncio
 async def test_polling_service_finishes_transport_token_once_after_poll_failure() -> None:
     token = object()
     provider = _FakeTransportProvider(token=token)

--- a/tests/unit/test_core_close.py
+++ b/tests/unit/test_core_close.py
@@ -4,9 +4,9 @@ Pins down:
 
 - ``PollRegistry.active_tasks()`` returns the leader poll tasks currently
   parked in the registry, and excludes already-completed tasks.
-- ``ClientCore.close()`` cancels every active poll task and awaits each with
-  ``return_exceptions=True`` so a single misbehaving leader can't block
-  teardown.
+- ``ArtifactsAPI`` owns its poll registry and registers a close-time drain hook
+  so ``ClientCore.close()`` cancels active polls without reaching into feature
+  state.
 - ``NotebookLMClient.close()`` and ``__aexit__`` default to ``drain=True``
   (BREAKING). Old fire-and-forget callers must pass ``drain=False`` to opt out.
 """
@@ -18,8 +18,9 @@ from typing import Any
 
 import pytest
 
+from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._core import ClientCore
-from notebooklm._core_polling import PollRegistry
+from notebooklm._polling_registry import PollRegistry
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
 
@@ -82,14 +83,16 @@ async def test_active_tasks_returns_empty_for_fresh_registry() -> None:
 
 
 # ---------------------------------------------------------------------------
-# ClientCore.close drains active poll tasks
+# ClientCore.close runs feature-owned drain hooks
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_core_close_drains_polls() -> None:
+async def test_core_close_drains_artifact_poll_hook() -> None:
     """``close()`` cancels in-flight poll tasks within 1s and tears down cleanly."""
     core = ClientCore(_auth())
+    artifacts = ArtifactsAPI(core)
+    assert core._drain_hooks["artifacts.polls"] == artifacts._polling.drain
     await core.open()
 
     loop = asyncio.get_running_loop()
@@ -108,7 +111,7 @@ async def test_core_close_drains_polls() -> None:
     # cancel arrives before the task body has run and our
     # ``except CancelledError`` handler never executes.
     await asyncio.sleep(0)
-    core.poll_registry.pending[("nb_1", "task_1")] = (future, task)
+    artifacts._poll_registry.pending[("nb_1", "task_1")] = (future, task)
 
     # Real-time deadline so a regression that fails to cancel surfaces as a
     # 1s timeout rather than hanging the suite.
@@ -119,27 +122,20 @@ async def test_core_close_drains_polls() -> None:
 
 
 @pytest.mark.asyncio
-async def test_core_close_handles_poll_task_raising_during_drain() -> None:
-    """A poll task raising during cancel-drain doesn't block close()."""
+async def test_core_close_absorbs_drain_hook_errors() -> None:
+    """A drain hook raising during close does not block transport teardown."""
     core = ClientCore(_auth())
     await core.open()
 
-    loop = asyncio.get_running_loop()
-    future: asyncio.Future[Any] = loop.create_future()
+    async def angry_hook() -> None:
+        raise RuntimeError("poll cleanup failed")
 
-    async def angry_poll() -> None:
-        try:
-            await asyncio.Event().wait()
-        except asyncio.CancelledError:
-            raise RuntimeError("poll cleanup failed") from None
-
-    task = asyncio.create_task(angry_poll())
-    core.poll_registry.pending[("nb_x", "task_x")] = (future, task)
+    core.register_drain_hook("angry", angry_hook)
 
     # return_exceptions=True in close() means this should NOT propagate.
     await asyncio.wait_for(core.close(), timeout=1.0)
 
-    assert task.done()
+    assert core._http_client is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -68,8 +68,7 @@ class _StubHost:
       open() path so cross-loop misuse can be caught.
     * ``cookie_persistence`` — a ``MagicMock`` with an async ``save``
       coroutine; assertions check it was called with the right args.
-    * ``poll_registry`` — a ``MagicMock`` with ``active_tasks()`` returning
-      a list (defaults to empty so close() doesn't try to drain anything).
+    * ``_drain_hooks`` — close-time hooks registered by feature APIs.
     * ``_authed_transport`` / ``_rpc_executor`` — set to sentinel marker
       values so tests can assert :meth:`ClientLifecycle.close` nulls them.
     """
@@ -94,8 +93,7 @@ class _StubHost:
         self.cookie_persistence = MagicMock()
         self.cookie_persistence.save = AsyncMock()
         self.cookie_persistence.capture_open_snapshot = MagicMock()
-        self.poll_registry = MagicMock()
-        self.poll_registry.active_tasks = MagicMock(return_value=[])
+        self._drain_hooks = {}
         # Sentinels — close() nulls these out.
         self._authed_transport: Any = "AUTHED_TRANSPORT_SENTINEL"
         self._rpc_executor: Any = "RPC_EXECUTOR_SENTINEL"
@@ -334,11 +332,8 @@ async def test_close_when_never_opened_is_noop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_close_drains_poll_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``close()`` snapshots and cancels in-flight poll tasks before tearing
-    down the HTTP client — without this, a leader poll waking mid-aclose
-    would issue a request against an already-closed transport.
-    """
+async def test_close_runs_drain_hooks_before_transport_teardown() -> None:
+    """``close()`` runs feature drain hooks before tearing down the HTTP client."""
     lifecycle = _make_lifecycle()
     host = _StubHost()
 
@@ -350,14 +345,18 @@ async def test_close_drains_poll_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
             raise
 
     parked = asyncio.create_task(_park())
-    # ``active_tasks`` returns the list close() should cancel.
-    host.poll_registry.active_tasks = MagicMock(return_value=[parked])
+
+    async def drain_polls() -> None:
+        parked.cancel()
+        await asyncio.gather(parked, return_exceptions=True)
+
+    host._drain_hooks["artifacts.polls"] = drain_polls
 
     await lifecycle.open(host)
     await lifecycle.close(host)
 
     assert parked.cancelled() or parked.done(), (
-        "close() must cancel any active poll tasks before tearing down the client."
+        "close() must run drain hooks before tearing down the client."
     )
 
 

--- a/tests/unit/test_core_lifecycle.py
+++ b/tests/unit/test_core_lifecycle.py
@@ -347,6 +347,7 @@ async def test_close_runs_drain_hooks_before_transport_teardown() -> None:
     parked = asyncio.create_task(_park())
 
     async def drain_polls() -> None:
+        assert lifecycle._http_client is not None
         parked.cancel()
         await asyncio.gather(parked, return_exceptions=True)
 
@@ -358,6 +359,7 @@ async def test_close_runs_drain_hooks_before_transport_teardown() -> None:
     assert parked.cancelled() or parked.done(), (
         "close() must run drain hooks before tearing down the client."
     )
+    assert lifecycle._http_client is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_core_polling.py
+++ b/tests/unit/test_core_polling.py
@@ -10,7 +10,8 @@ from typing import Any
 import pytest
 
 from notebooklm._core import ClientCore
-from notebooklm._core_polling import PendingPolls, PollRegistry
+from notebooklm._core_polling import PollRegistry as ShimPollRegistry
+from notebooklm._polling_registry import PendingPolls, PollRegistry
 from notebooklm.auth import AuthTokens
 
 
@@ -44,6 +45,7 @@ def test_client_core_exposes_poll_registry_and_pending_polls_bridge() -> None:
 
     assert isinstance(core.poll_registry, PollRegistry)
     assert core._pending_polls is core.poll_registry.pending
+    assert ShimPollRegistry is PollRegistry
 
 
 def test_client_core_pending_polls_assignment_replaces_registry_backing_mapping() -> None:
@@ -87,10 +89,10 @@ async def test_client_core_pending_polls_bridge_preserves_entry_shape() -> None:
             pass
 
 
-def test_core_polling_does_not_import_client_core_at_runtime() -> None:
-    source = (Path(__file__).resolve().parents[2] / "src/notebooklm/_core_polling.py").read_text(
-        encoding="utf-8"
-    )
+def test_polling_registry_does_not_import_client_core_at_runtime() -> None:
+    source = (
+        Path(__file__).resolve().parents[2] / "src/notebooklm/_polling_registry.py"
+    ).read_text(encoding="utf-8")
     tree = ast.parse(source)
 
     forbidden_imports: list[str] = []


### PR DESCRIPTION
## Summary
- Move `PollRegistry` into `_polling_registry` with `_core_polling` retained as a compatibility shim.
- Make `ArtifactsAPI` own the artifact poll registry and register its poll drain through `DrainHookRegistration`.
- Change `ClientLifecycle.close()` to run registered feature drain hooks before cookie save and transport teardown; remove `PollRegistryProvider` from feature capability surfaces and from Research.

## Verification
- `uv run ruff check src/notebooklm tests/unit/test_core_polling.py tests/unit/test_core_close.py tests/unit/test_core_lifecycle.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_artifacts_coverage.py tests/unit/test_quota_failure_detection.py tests/unit/test_artifact_downloads.py tests/unit/test_artifacts_mind_map_injection.py tests/unit/concurrency/test_core_close_refresh_race.py tests/unit/concurrency/test_loop_affinity_guard.py`
- `uv run pytest tests/unit/test_core_polling.py tests/unit/test_core_close.py tests/unit/test_core_lifecycle.py tests/unit/test_artifacts_polling_retries.py tests/unit/concurrency/test_core_close_refresh_race.py tests/unit/concurrency/test_loop_affinity_guard.py -q`
- `uv run pytest tests/unit/test_core_polling.py tests/unit/test_core_close.py tests/unit/test_core_lifecycle.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_artifacts_coverage.py tests/unit/test_quota_failure_detection.py tests/unit/test_artifact_downloads.py tests/unit/test_artifacts_mind_map_injection.py tests/unit/concurrency/test_core_close_refresh_race.py tests/unit/concurrency/test_loop_affinity_guard.py -q`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pytest tests/unit -q`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  - More reliable shutdown: artifact polling is cleanly drained on close, canceling in-flight polls while ensuring teardown continues even if a drain hook errors.
  - Waiters remain insulated from peer cancellations so callers aren’t unexpectedly cancelled.

* **Refactor**
  - Polling state is now owned per feature, simplifying lifecycle wiring and reducing cross-feature interference during polling and shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->