### PR TITLE
refactor(sources): own upload semaphore in pipeline

### DIFF
--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -11,6 +11,7 @@ dependency cycles. See ADR-002 for the design.
 from __future__ import annotations
 
 import asyncio
+from contextlib import AbstractAsyncContextManager
 from typing import Any, Protocol
 
 import httpx
@@ -108,12 +109,16 @@ class TransportOperationProvider(Protocol):
     async def _finish_transport_post(self, token: _TransportOperationToken) -> None: ...
 
 
-class UploadConcurrencyProvider(Protocol):
-    """Provider for shared source-upload concurrency and queue metrics."""
+class OperationScopeProvider(Protocol):
+    """Provider for structured operation scopes used by Sources uploads."""
 
-    def get_upload_semaphore(self) -> asyncio.Semaphore:
-        """Return the existing per-core upload semaphore."""
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        """Return a drain-tracked operation scope labelled for observability."""
         ...
+
+
+class UploadConcurrencyProvider(Protocol):
+    """Provider for source-upload queue metrics."""
 
     def record_upload_queue_wait(self, wait_seconds: float) -> None:
         """Record how long an upload waited for the semaphore."""

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -6,8 +6,8 @@ import random  # noqa: F401 - tests patch this for _backoff jitter
 import threading
 import time
 import warnings
-from collections.abc import Awaitable, Callable
-from contextlib import AbstractAsyncContextManager, nullcontext
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -36,6 +36,9 @@ from ._core_constants import (
 )
 from ._core_constants import (
     DEFAULT_TIMEOUT as DEFAULT_TIMEOUT,
+)
+from ._core_constants import (
+    normalize_max_concurrent_uploads,
 )
 from ._core_cookie_persistence import CookiePersistence
 from ._core_drain import TransportDrainTracker
@@ -354,27 +357,9 @@ class ClientCore:
                 f"server_error_max_retries must be >= 0, got {server_error_max_retries}"
             )
         self._server_error_max_retries = server_error_max_retries
-        # ``None`` resolves to the default (``DEFAULT_MAX_CONCURRENT_UPLOADS``)
-        # rather than meaning "unbounded" — the FD-exhaustion guard is the
-        # whole point of the knob; an unbounded fan-out of ``add_file`` would
-        # exhaust the per-process FD limit before the upload semaphore could
-        # save us. Reject ``<= 0`` loudly at construction
-        # rather than allowing a silently-misconfigured pipeline.
-        if max_concurrent_uploads is None:
-            self._max_concurrent_uploads = DEFAULT_MAX_CONCURRENT_UPLOADS
-        else:
-            if max_concurrent_uploads < 1:
-                raise ValueError(
-                    f"max_concurrent_uploads must be >= 1, got {max_concurrent_uploads!r}"
-                )
-            self._max_concurrent_uploads = max_concurrent_uploads
-        # Lazily-created (``asyncio.Semaphore()`` needs a running loop in
-        # some Python versions, and ``ClientCore`` can be constructed
-        # outside one). Use ``get_upload_semaphore()`` to fetch the live
-        # semaphore on demand. Per-instance — never module-global — so two
-        # ``NotebookLMClient`` instances in the same process have
-        # independent upload budgets.
-        self._upload_semaphore: asyncio.Semaphore | None = None
+        # Keep fail-fast validation for private ClientCore callers, but the
+        # actual upload semaphore state is owned by ``SourceUploadPipeline``.
+        normalize_max_concurrent_uploads(max_concurrent_uploads)
         # RPC-fanout throttle. ``None`` means "no
         # gate" (caller has an external rate-limiter, or this is a
         # single-shot CLI invocation). Default ``DEFAULT_MAX_CONCURRENT_RPCS``
@@ -390,9 +375,9 @@ class ClientCore:
             if max_concurrent_rpcs < 1:
                 raise ValueError(f"max_concurrent_rpcs must be >= 1, got {max_concurrent_rpcs!r}")
             self._max_concurrent_rpcs = max_concurrent_rpcs
-        # Lazily-created for the same reason as ``_upload_semaphore``
-        # (``asyncio.Semaphore()`` binds to the running loop in some
-        # Python versions). Per-instance, never module-global. When
+        # Lazily-created because ``asyncio.Semaphore()`` binds to the
+        # running loop in some Python versions. Per-instance, never
+        # module-global. When
         # ``_max_concurrent_rpcs is None``, the accessor returns a
         # ``contextlib.nullcontext`` instead — see ``_get_rpc_semaphore``.
         self._rpc_semaphore: asyncio.Semaphore | None = None
@@ -451,7 +436,7 @@ class ClientCore:
         # :class:`AuthedTransport`) does a cheap ``is`` comparison against
         # it. Each client is per-loop — the asyncio primitives we hold
         # (``_reqid_lock``, ``_refresh_lock``, ``_auth_snapshot_lock``,
-        # ``_upload_semaphore``, ``_rpc_semaphore``, the ``httpx.AsyncClient``
+        # ``_rpc_semaphore``, the ``httpx.AsyncClient``
         # pool, in-flight tasks like ``_refresh_task`` / ``_keepalive_task``)
         # are all bound to the loop that ``open()`` ran on; reusing them
         # under a different loop produces hangs and ``RuntimeError`` deep
@@ -1113,6 +1098,19 @@ class ClientCore:
         self._ensure_observability_state()
         await self._drain_tracker.finish_transport_post(token)
 
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        """Return a drain-tracked operation scope for feature-owned work."""
+
+        @asynccontextmanager
+        async def scope() -> AsyncIterator[None]:
+            token = await self._begin_transport_post(label)
+            try:
+                yield None
+            finally:
+                await self._finish_transport_post(token)
+
+        return scope()
+
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new client operations and wait for in-flight ones to finish.
 
@@ -1122,40 +1120,6 @@ class ClientCore:
         """
         self._ensure_observability_state()
         await self._drain_tracker.drain(timeout)
-
-    def get_upload_semaphore(self) -> asyncio.Semaphore:
-        """Return the per-instance upload semaphore, creating it on first use.
-
-        The semaphore caps the number of in-flight ``SourcesAPI.add_file``
-        uploads at ``max_concurrent_uploads`` (default
-        ``DEFAULT_MAX_CONCURRENT_UPLOADS``). Each in-flight upload holds
-        one open file descriptor for its duration, so the cap is also an
-        FD-exhaustion guard.
-
-        Scope of the cap:
-          - The ``async with`` block in ``add_file`` covers FD-open,
-            the two pre-upload RPCs (``_register_file_source`` and
-            ``_start_resumable_upload``), and the streaming upload. The
-            semaphore therefore also serializes those two RPCs — a side
-            effect of the FD guard, not a separate quota.
-          - The cap applies to the *blocking* ``add_file`` call. On
-            post-finalize cancel, the shielded background
-            ``finalize_task`` continues running with the FD still open
-            after ``add_file``'s ``async with`` exits, so the
-            instantaneous open-FD count can briefly exceed
-            ``max_concurrent_uploads`` by the number of concurrently
-            draining background tasks.
-
-        Lazy construction is required because ``asyncio.Semaphore()`` in
-        some Python versions binds to the running event loop at creation
-        time, and ``ClientCore`` can be constructed outside any loop.
-        Callers must invoke this from inside the loop where the upload
-        will run — typically inside the ``async with`` block of
-        ``add_file``.
-        """
-        if self._upload_semaphore is None:
-            self._upload_semaphore = asyncio.Semaphore(self._max_concurrent_uploads)
-        return self._upload_semaphore
 
     def _get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
         """Return the per-instance RPC semaphore (or a null-context).
@@ -1167,7 +1131,7 @@ class ClientCore:
         out of the gate). Otherwise it lazily constructs an
         ``asyncio.Semaphore`` bound to the running loop on first use,
         mirroring the lazy-init pattern of :attr:`_reqid_lock` /
-        :attr:`_auth_snapshot_lock` / :meth:`get_upload_semaphore`.
+        :attr:`_auth_snapshot_lock`.
 
         The check-then-assign is safe without an outer lock because
         asyncio is single-threaded: no other coroutine can execute

--- a/src/notebooklm/_core_constants.py
+++ b/src/notebooklm/_core_constants.py
@@ -18,6 +18,7 @@ __all__ = [
     "DEFAULT_MAX_CONCURRENT_RPCS",
     "DEFAULT_MAX_CONCURRENT_UPLOADS",
     "DEFAULT_TIMEOUT",
+    "normalize_max_concurrent_uploads",
 ]
 
 # Single source of truth for the logger name every ``_core_*.py`` /
@@ -54,3 +55,12 @@ DEFAULT_MAX_CONCURRENT_UPLOADS = 4
 # higher account tier (or an external rate-limiter) can opt out via
 # ``max_concurrent_rpcs=None``.
 DEFAULT_MAX_CONCURRENT_RPCS = 16
+
+
+def normalize_max_concurrent_uploads(max_concurrent_uploads: int | None) -> int:
+    """Normalize and validate the source-upload concurrency limit."""
+    if max_concurrent_uploads is None:
+        return DEFAULT_MAX_CONCURRENT_UPLOADS
+    if max_concurrent_uploads < 1:
+        raise ValueError(f"max_concurrent_uploads must be >= 1, got {max_concurrent_uploads!r}")
+    return max_concurrent_uploads

--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -19,8 +19,12 @@ from ._callbacks import maybe_await_callback
 from ._capabilities import (
     AuthRouteProvider,
     CookieJarProvider,
-    TransportOperationProvider,
+    OperationScopeProvider,
     UploadConcurrencyProvider,
+)
+from ._core_constants import (
+    DEFAULT_MAX_CONCURRENT_UPLOADS,
+    normalize_max_concurrent_uploads,
 )
 from ._env import get_base_url
 from ._idempotency import idempotent_create
@@ -42,7 +46,7 @@ _SOURCE_ID_UUID_PATTERN = re.compile(
 
 class SourceUploadRuntime(
     UploadConcurrencyProvider,
-    TransportOperationProvider,
+    OperationScopeProvider,
     Protocol,
 ):
     """Capabilities needed by public file-upload orchestration."""
@@ -207,6 +211,23 @@ def _looks_like_id_string(candidate: str) -> bool:
 class SourceUploadPipeline:
     """Own file registration and resumable upload orchestration."""
 
+    def __init__(self, max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS):
+        self._max_concurrent_uploads = normalize_max_concurrent_uploads(max_concurrent_uploads)
+        self._upload_semaphore: asyncio.Semaphore | None = None
+
+    def get_upload_semaphore(self) -> asyncio.Semaphore:
+        """Return the Sources-owned upload semaphore, creating it on first use.
+
+        The semaphore caps the section that opens the source FD, registers the
+        source, starts the resumable upload, and streams the body. Lazy
+        construction keeps ``SourceUploadPipeline`` usable outside a running
+        event loop. On post-finalize cancellation, the shielded finalize task
+        may briefly keep an FD open after ``add_file`` exits the semaphore.
+        """
+        if self._upload_semaphore is None:
+            self._upload_semaphore = asyncio.Semaphore(self._max_concurrent_uploads)
+        return self._upload_semaphore
+
     async def add_file(
         self,
         notebook_id: str,
@@ -218,6 +239,7 @@ class SourceUploadPipeline:
         title: str | None = None,
         on_progress: Callable[[int, int], object] | None = None,
         deprecation_warning_stacklevel: int = 2,
+        upload_index: int = 0,
         capabilities: SourceUploadRuntime,
         register_file_source: RegisterFileSource,
         start_resumable_upload: StartResumableUpload,
@@ -248,37 +270,30 @@ class SourceUploadPipeline:
             raise ValidationError(f"Not a regular file: {file_path}")
 
         filename = file_path.name
-        upload_sem = capabilities.get_upload_semaphore()
-        upload_wait_start = monotonic()
-        async with upload_sem:
-            capabilities.record_upload_queue_wait(monotonic() - upload_wait_start)
-            file_obj = open(file_path, "rb")  # noqa: SIM115
-            handed_off = False
-            operation_token = None
-            try:
-                file_size = os.fstat(file_obj.fileno()).st_size
-                operation_token = await capabilities._begin_transport_post(
-                    f"source upload {filename}"
-                )
-                source_id = await register_file_source(notebook_id, filename)
-                upload_url = await start_resumable_upload(
-                    notebook_id,
-                    filename,
-                    file_size,
-                    source_id,
-                )
-                handed_off = True
-                await upload_file_streaming(
-                    upload_url,
-                    file_obj,
-                    filename=filename,
-                    on_progress=on_progress,
-                    total_bytes=file_size,
-                )
-            finally:
+        async with capabilities.operation_scope(f"upload:{upload_index}"):
+            upload_sem = self.get_upload_semaphore()
+            upload_wait_start = monotonic()
+            async with upload_sem:
+                capabilities.record_upload_queue_wait(monotonic() - upload_wait_start)
+                file_obj = open(file_path, "rb")  # noqa: SIM115
+                handed_off = False
                 try:
-                    if operation_token is not None:
-                        await capabilities._finish_transport_post(operation_token)
+                    file_size = os.fstat(file_obj.fileno()).st_size
+                    source_id = await register_file_source(notebook_id, filename)
+                    upload_url = await start_resumable_upload(
+                        notebook_id,
+                        filename,
+                        file_size,
+                        source_id,
+                    )
+                    handed_off = True
+                    await upload_file_streaming(
+                        upload_url,
+                        file_obj,
+                        filename=filename,
+                        on_progress=on_progress,
+                        total_bytes=file_size,
+                    )
                 finally:
                     if not handed_off:
                         file_obj.close()

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -16,9 +16,10 @@ from ._capabilities import (
     AuthRouteProvider,
     CookieJarProvider,
     CoreRPCProvider,
-    TransportOperationProvider,
+    OperationScopeProvider,
     UploadConcurrencyProvider,
 )
+from ._core_constants import DEFAULT_MAX_CONCURRENT_UPLOADS
 from ._source_add import SourceAddService
 from ._source_content import SourceContentRenderer
 from ._source_listing import SourceLister
@@ -41,7 +42,7 @@ class _SourcesCore(
     CoreRPCProvider,
     AuthRouteProvider,
     UploadConcurrencyProvider,
-    TransportOperationProvider,
+    OperationScopeProvider,
     CookieJarProvider,
     Protocol,
 ):
@@ -51,11 +52,10 @@ class _SourcesCore(
     the capabilities SourcesAPI uses through its upload pipeline:
     ``rpc_call`` (from :class:`CoreRPCProvider`), authuser routing
     (from :class:`AuthRouteProvider`), the upload-concurrency semaphore
-    + queue-wait recorder (from :class:`UploadConcurrencyProvider`),
-    transport-operation bookkeeping for the streaming upload POST
-    (from :class:`TransportOperationProvider`), and the live cookie
-    jar consumed by the Scotty upload HTTP path (from
-    :class:`CookieJarProvider`).
+    owned by :class:`SourceUploadPipeline`, queue-wait recording (from
+    :class:`UploadConcurrencyProvider`), structured drain scopes (from
+    :class:`OperationScopeProvider`), and the live cookie jar consumed by
+    the Scotty upload HTTP path (from :class:`CookieJarProvider`).
     """
 
     pass
@@ -156,6 +156,7 @@ class SourcesAPI:
         self,
         core: _SourcesCore,
         upload_timeout: httpx.Timeout | None = None,
+        max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
     ):
         """Initialize the sources API.
 
@@ -171,6 +172,9 @@ class SourcesAPI:
                 defaults, NOT the original 10.0s. Specify all components
                 explicitly (e.g. ``httpx.Timeout(10.0, read=600.0)``) to
                 avoid surprises.
+            max_concurrent_uploads: Ceiling for concurrent
+                :meth:`add_file` uploads. The semaphore is owned by this
+                Sources upload pipeline, not by the shared core/session.
         """
         self._core = core
         self._capabilities = core
@@ -178,7 +182,7 @@ class SourcesAPI:
         self._content = SourceContentRenderer(self._rpc_call, logger=logger)
         self._lister = SourceLister(self._rpc_call)
         self._poller = SourcePoller()
-        self._uploader = SourceUploadPipeline()
+        self._uploader = SourceUploadPipeline(max_concurrent_uploads=max_concurrent_uploads)
         self._upload_timeout = upload_timeout
 
     async def _rpc_call(
@@ -499,9 +503,12 @@ class SourcesAPI:
            ``UPDATE_SOURCE`` is the only way to set one).
 
         Concurrency / FD lifecycle:
-            The upload section runs under
-            ``ClientCore.get_upload_semaphore()`` which bounds simultaneous
-            in-flight uploads at ``max_concurrent_uploads`` (default 4).
+            ``add_file`` enters a drain-tracked ``operation_scope("upload:0")``
+            before waiting on the Sources-owned semaphore, so graceful
+            shutdown tracks both active and semaphore-queued uploads.
+            The upload section runs under the Sources-owned upload
+            pipeline semaphore, which bounds simultaneous in-flight
+            uploads at ``max_concurrent_uploads`` (default 4).
             Each in-flight upload holds **one open file descriptor** for
             the duration of the upload, so the cap doubles as an
             FD-exhaustion guard. The file is opened ONCE during validation

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -267,7 +267,11 @@ class NotebookLMClient:
         # After D2 cutover, sub-clients consume ``ClientCore`` directly,
         # typed against their per-sub-client narrow Protocol (defined
         # co-located in each sub-client file).
-        self.sources = SourcesAPI(self._core, upload_timeout=upload_timeout)
+        self.sources = SourcesAPI(
+            self._core,
+            upload_timeout=upload_timeout,
+            max_concurrent_uploads=max_concurrent_uploads,
+        )
         self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
         self.artifacts = ArtifactsAPI(self._core, storage_path=storage_path)
         self.notes = NotesAPI(self._core)

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -29,7 +29,8 @@ Design choices (documented in ADR-007 "Alternatives considered"):
 
 from __future__ import annotations
 
-import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -71,6 +72,13 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         fake.rpc_call.assert_awaited_once()
     """
 
+    def _operation_scope(_label: str):
+        @asynccontextmanager
+        async def scope() -> AsyncIterator[None]:
+            yield None
+
+        return scope()
+
     defaults: dict[str, Any] = {
         # CoreRPCProvider — fresh list per call so tests can mutate without bleeding
         "rpc_call": AsyncMock(side_effect=lambda *a, **kw: []),
@@ -106,9 +114,8 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         "begin_transport_post": AsyncMock(side_effect=lambda *a, **kw: object()),
         "begin_transport_task": AsyncMock(side_effect=lambda *a, **kw: object()),
         "finish_transport_post": AsyncMock(return_value=None),
-        # UploadConcurrencyProvider — Semaphore must be created inside a running loop
-        # (Python 3.10+ raises RuntimeError otherwise); defer via side_effect.
-        "get_upload_semaphore": MagicMock(side_effect=lambda: asyncio.Semaphore(1)),
+        # OperationScopeProvider / UploadConcurrencyProvider
+        "operation_scope": MagicMock(side_effect=_operation_scope),
         "record_upload_queue_wait": MagicMock(return_value=None),
         # LoopAffinityProvider — None is the silent-no-op value
         "bound_loop": None,

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -59,6 +59,8 @@ from __future__ import annotations
 import asyncio
 import builtins
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -105,6 +107,16 @@ def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
     core.get_http_client.return_value.cookies = MagicMock(name="live_cookie_jar")
     core._begin_transport_post = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
+    core.operation_scope = MagicMock()
+
+    def operation_scope(_label):
+        @asynccontextmanager
+        async def scope() -> AsyncIterator[None]:
+            yield None
+
+        return scope()
+
+    core.operation_scope.side_effect = operation_scope
     core.record_upload_queue_wait = MagicMock()
     return SourcesAPI(core), core
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -150,6 +150,20 @@ async def test_drain_allows_nested_work_inside_accepted_operation(
 
 
 @pytest.mark.asyncio
+async def test_operation_scope_tracks_drain_without_upload_semaphore(
+    auth_tokens: AuthTokens,
+) -> None:
+    core = ClientCore(auth_tokens)
+
+    async with core.operation_scope("plain-operation"):
+        assert core._in_flight_posts == 1
+        assert not hasattr(core, "get_upload_semaphore")
+
+    assert core._in_flight_posts == 0
+    assert "_upload_semaphore" not in core.__dict__
+
+
+@pytest.mark.asyncio
 async def test_drain_rejects_child_task_spawned_from_accepted_operation(
     auth_tokens: AuthTokens,
 ) -> None:

--- a/tests/unit/test_source_upload_pipeline.py
+++ b/tests/unit/test_source_upload_pipeline.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -16,32 +18,24 @@ from notebooklm.types import Source, SourceAddError
 
 class UploadRuntime:
     def __init__(self) -> None:
-        self.semaphore = asyncio.Semaphore(1)
         self.queue_waits: list[float] = []
         self.labels: list[str] = []
-        self.finished: list[object] = []
-
-    def get_upload_semaphore(self) -> asyncio.Semaphore:
-        return self.semaphore
+        self.finished: list[str] = []
 
     def record_upload_queue_wait(self, wait_seconds: float) -> None:
         self.queue_waits.append(wait_seconds)
 
-    async def _begin_transport_post(self, log_label: str) -> object:
-        token = object()
+    def operation_scope(self, log_label: str):
         self.labels.append(log_label)
-        return token
 
-    async def _begin_transport_task(
-        self,
-        task: asyncio.Task[Any],
-        log_label: str,
-    ) -> object:
-        self.labels.append(log_label)
-        return object()
+        @asynccontextmanager
+        async def scope() -> AsyncIterator[None]:
+            try:
+                yield None
+            finally:
+                self.finished.append(log_label)
 
-    async def _finish_transport_post(self, token: object) -> None:
-        self.finished.append(token)
+        return scope()
 
 
 class HttpRuntime:
@@ -107,6 +101,15 @@ def test_extract_register_file_source_id_skips_large_string_candidates() -> None
 
 
 @pytest.mark.asyncio
+async def test_upload_semaphore_is_owned_per_pipeline() -> None:
+    first = SourceUploadPipeline(max_concurrent_uploads=1)
+    second = SourceUploadPipeline(max_concurrent_uploads=1)
+
+    assert first.get_upload_semaphore() is first.get_upload_semaphore()
+    assert first.get_upload_semaphore() is not second.get_upload_semaphore()
+
+
+@pytest.mark.asyncio
 async def test_add_file_uses_late_bound_hooks_and_finishes_transport(
     service: SourceUploadPipeline,
     tmp_path,
@@ -141,10 +144,59 @@ async def test_add_file_uses_late_bound_hooks_and_finishes_transport(
     assert source.id == "src_123"
     assert source.title == "report.pdf"
     assert source.is_processing
-    assert runtime.labels == ["source upload report.pdf"]
-    assert len(runtime.finished) == 1
+    assert runtime.labels == ["upload:0"]
+    assert runtime.finished == ["upload:0"]
+    assert len(runtime.queue_waits) == 1
     register_file_source.assert_awaited_once_with("nb_123", "report.pdf")
     start_resumable_upload.assert_awaited_once_with("nb_123", "report.pdf", 5, "src_123")
+
+
+@pytest.mark.asyncio
+async def test_add_file_operation_scope_wraps_sources_semaphore_wait(tmp_path) -> None:
+    first_file = tmp_path / "first.pdf"
+    second_file = tmp_path / "second.pdf"
+    first_file.write_bytes(b"first")
+    second_file.write_bytes(b"second")
+    runtime = UploadRuntime()
+    service = SourceUploadPipeline(max_concurrent_uploads=1)
+    first_streaming_started = asyncio.Event()
+    release_first_streaming = asyncio.Event()
+
+    async def upload_file_streaming(_upload_url, file_obj, **kwargs):
+        if kwargs["filename"] == "first.pdf":
+            first_streaming_started.set()
+            await release_first_streaming.wait()
+        file_obj.close()
+
+    async def add(path):
+        return await service.add_file(
+            "nb_123",
+            path,
+            capabilities=runtime,
+            register_file_source=AsyncMock(return_value=f"src_{path.stem}"),
+            start_resumable_upload=AsyncMock(return_value="https://upload.example.com/session"),
+            upload_file_streaming=upload_file_streaming,
+            wait_until_ready=AsyncMock(),
+            wait_until_registered=AsyncMock(),
+            rename=AsyncMock(),
+            logger=MagicMock(),
+        )
+
+    first_task = asyncio.create_task(add(first_file))
+    await first_streaming_started.wait()
+
+    second_task = asyncio.create_task(add(second_file))
+    while len(runtime.labels) < 2:
+        await asyncio.sleep(0)
+
+    assert runtime.labels == ["upload:0", "upload:0"]
+    assert len(runtime.queue_waits) == 1
+
+    release_first_streaming.set()
+    sources = await asyncio.gather(first_task, second_task)
+
+    assert [source.id for source in sources] == ["src_first", "src_second"]
+    assert len(runtime.queue_waits) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -4,6 +4,8 @@ import ast
 import inspect
 import textwrap
 import warnings
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -54,6 +56,16 @@ def mock_core():
     )
     core._begin_transport_post = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
+    core.operation_scope = MagicMock()
+
+    def operation_scope(_label):
+        @asynccontextmanager
+        async def scope() -> AsyncIterator[None]:
+            yield None
+
+        return scope()
+
+    core.operation_scope.side_effect = operation_scope
     core.record_upload_queue_wait = MagicMock()
     return core
 
@@ -804,6 +816,7 @@ class TestAddFile:
         assert result.kind == "unknown"
         # 2 RPCs: GET_NOTEBOOK baseline + ADD_SOURCE_FILE register.
         assert mock_core.rpc_call.call_count == 2
+        mock_core.operation_scope.assert_called_once_with("upload:0")
 
     @pytest.mark.asyncio
     async def test_add_file_raises_file_not_found(self, sources_api, mock_core):


### PR DESCRIPTION
## Summary
- move upload semaphore state from ClientCore into SourceUploadPipeline
- route file uploads through operation_scope(\"upload:0\") while keeping semaphore acquisition Sources-specific
- preserve queue-wait metrics and add coverage for queued upload drain tracking/per-pipeline ownership

## Task
Phase 2 Wave 4: t13-4-upload-semaphore

## Test plan
- [x] uv run pre-commit run --all-files
- [x] uv run mypy src/notebooklm --ignore-missing-imports
- [x] uv run pytest -n auto
- [x] uv run pytest tests/integration tests/e2e -m vcr -n auto

## Deferred polish findings
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `max_concurrent_uploads` parameter now available in NotebookLMClient and SourcesAPI to control the maximum number of concurrent file uploads.

* **Refactor**
  * Improved observability and tracking of upload operations through enhanced operation scoping.
  * Restructured upload concurrency management for better resource control and utilization.
  * Removed `drain()` method from the public client API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->