### PR TITLE
refactor(core): add loop affinity shim for feature APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ RPC Layer (rpc/)
 | `_core_polling.py` | Pending-poll registry for long-running artifact generations |
 | `_core_cookie_persistence.py` | Cookie-jar persistence + `__Secure-1PSIDTS` rotation |
 | `_capabilities.py` | Narrow capability Protocols + `ClientCoreCapabilities` adapter for sub-clients |
-| `_notebooks.py` | `client.notebooks` API |
-| `_sources.py` | `client.sources` API + `fetch_source_ids` module helper |
+| `_notebooks.py` | `client.notebooks` API + source-id resolver |
+| `_sources.py` | `client.sources` API |
 | `_artifacts.py` | `client.artifacts` API |
 | `_chat.py` | `client.chat` API |
 | `rpc/types.py` | RPC method IDs (source of truth) |

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -64,7 +64,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
@@ -121,7 +121,7 @@ class ArtifactGenerationService:
             raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
 
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
@@ -173,7 +173,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
@@ -219,7 +219,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         format_configs = {
             ReportFormat.BRIEFING_DOC: {
@@ -322,7 +322,7 @@ class ArtifactGenerationService:
         """Generate a quiz."""
         api = self._api
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         quantity_code = quantity.value if quantity else None
@@ -369,7 +369,7 @@ class ArtifactGenerationService:
         """Generate flashcards."""
         api = self._api
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         quantity_code = quantity.value if quantity else None
@@ -419,7 +419,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         orientation_code = orientation.value if orientation else None
@@ -463,7 +463,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         format_code = slide_format.value if slide_format else None
@@ -545,7 +545,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
 
@@ -588,7 +588,7 @@ class ArtifactGenerationService:
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._core.get_source_ids(notebook_id)
+            source_ids = await api._notebooks.get_source_ids(notebook_id)
 
         source_ids_nested = nest_source_ids(source_ids, 2)
 

--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -12,7 +12,6 @@ from typing import Any, Protocol
 from ._backoff import compute_backoff_delay
 from ._callbacks import maybe_await_callback
 from ._capabilities import LoopAffinityProvider, TransportOperationProvider
-from ._loop_affinity import assert_bound_loop
 from ._polling_registry import PollRegistry
 from .rpc import (
     ArtifactStatus,
@@ -159,7 +158,7 @@ class ArtifactPollingService:
         # P0-2: catch cross-loop wait_for_completion before touching the
         # poll registry (which holds futures bound to the registering
         # loop) or spawning a poll task on a foreign loop.
-        assert_bound_loop(self._capabilities.bound_loop)
+        self._capabilities.assert_bound_loop()
         # Backward compatibility: poll_interval overrides initial_interval.
         if poll_interval is not None:
             import warnings

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -81,6 +81,7 @@ class _ArtifactsCore(
 
 
 if TYPE_CHECKING:
+    from ._capabilities import SourceListProvider
     from ._notes import NotesAPI  # retained for backward-compatible type hints
 
 # Private compatibility exports. Tests and downstream code patch these names
@@ -172,6 +173,7 @@ class ArtifactsAPI:
         storage_path: Path | None = None,
         *,
         mind_map_service: _mind_map.MindMapService | None = None,
+        notebooks: "SourceListProvider | None" = None,
     ):
         """Initialize the artifacts API.
 
@@ -188,9 +190,17 @@ class ArtifactsAPI:
             mind_map_service: Optional private service for note-backed
                 mind-map operations. Keyword-only so the public positional
                 constructor contract stays unchanged.
+            notebooks: Optional source-id resolver. Defaults to a
+                ``NotebooksAPI`` wrapper around ``core`` for backward
+                compatibility with tests that construct ``ArtifactsAPI(core)``.
         """
         self._core = core
         self._capabilities = core
+        if notebooks is None:
+            from ._notebooks import NotebooksAPI
+
+            notebooks = NotebooksAPI(core)
+        self._notebooks = notebooks
         # ``notes_api`` is intentionally not stored — it is accepted only
         # so that existing call sites (tests, third-party code) keep
         # working through the deprecation cycle.

--- a/src/notebooklm/_capabilities.py
+++ b/src/notebooklm/_capabilities.py
@@ -126,19 +126,24 @@ class UploadConcurrencyProvider(Protocol):
 
 
 class LoopAffinityProvider(Protocol):
-    """Provider for the open-time captured event-loop reference.
+    """Provider for event-loop affinity checks.
 
     Sub-clients that issue ``async`` calls touching loop-bound primitives
     (locks, semaphores, ``httpx.AsyncClient`` pools, condition variables)
-    consult this property and forward it to
-    :func:`notebooklm._loop_affinity.assert_bound_loop` so a cross-loop
-    call surfaces an actionable ``RuntimeError`` at the call site rather
-    than hanging on a lock bound to a dead loop.
+    call :meth:`assert_bound_loop` so a cross-loop call surfaces an
+    actionable ``RuntimeError`` at the call site rather than hanging on a
+    lock bound to a dead loop.
     """
 
     @property
     def bound_loop(self) -> asyncio.AbstractEventLoop | None:
-        """Return the loop ``ClientLifecycle.open`` captured, or ``None``
-        if the client has not yet been opened.
+        """Return the loop ``ClientLifecycle.open`` captured.
+
+        Transitional PR 13.5 surface: retained for one PR cycle while
+        remaining internal helpers migrate to :meth:`assert_bound_loop`.
         """
+        ...
+
+    def assert_bound_loop(self) -> None:
+        """Raise when the current running loop differs from the bound loop."""
         ...

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -8,14 +8,16 @@ import asyncio
 import contextlib
 import logging
 import weakref
-from typing import Any, Protocol, cast
+from typing import Any, Protocol
 
 import httpx
 
 from ._capabilities import (
+    AuthRouteProvider,
     CoreReqIdProvider,
     CoreRPCProvider,
     LoopAffinityProvider,
+    SourceListProvider,
     TransportOperationProvider,
 )
 from ._chat_protocol import (
@@ -48,6 +50,7 @@ logger = logging.getLogger(__name__)
 
 class _ChatCore(
     CoreRPCProvider,
+    AuthRouteProvider,
     TransportOperationProvider,
     CoreReqIdProvider,
     LoopAffinityProvider,
@@ -91,10 +94,6 @@ class _ChatCore(
         # never appeared in the RPC counters and continue not to.
         rpc_method: str | None = None,
     ) -> httpx.Response: ...
-
-
-class _SourceIdsResolver(Protocol):
-    async def get_source_ids(self, notebook_id: str) -> list[str]: ...
 
 
 def _extract_next_turn_content(next_turn: Any) -> str | None:
@@ -166,7 +165,7 @@ class ChatAPI:
         core: _ChatCore,
         *,
         conversation_cache: ConversationCache | None = None,
-        notebooks: _SourceIdsResolver | None = None,
+        notebooks: SourceListProvider | None = None,
     ):
         """Initialize the chat API.
 
@@ -183,7 +182,7 @@ class ChatAPI:
         if notebooks is None:
             from ._notebooks import NotebooksAPI
 
-            notebooks = NotebooksAPI(cast(Any, core))
+            notebooks = NotebooksAPI(core)
         self._notebooks = notebooks
         self._cache = conversation_cache if conversation_cache is not None else ConversationCache()
         # Per-``conversation_id`` lock that serializes follow-up asks on the

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -8,7 +8,7 @@ import asyncio
 import contextlib
 import logging
 import weakref
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 import httpx
 
@@ -16,7 +16,6 @@ from ._capabilities import (
     CoreReqIdProvider,
     CoreRPCProvider,
     LoopAffinityProvider,
-    SourceListProvider,
     TransportOperationProvider,
 )
 from ._chat_protocol import (
@@ -35,7 +34,6 @@ from ._core import _AuthSnapshot
 from ._core_cache import ConversationCache
 from ._core_transport import _BuildRequest
 from ._logging import get_request_id, reset_request_id, set_request_id
-from ._loop_affinity import assert_bound_loop
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import (
     ChatGoal,
@@ -52,7 +50,6 @@ class _ChatCore(
     CoreRPCProvider,
     TransportOperationProvider,
     CoreReqIdProvider,
-    SourceListProvider,
     LoopAffinityProvider,
     Protocol,
 ):
@@ -70,9 +67,8 @@ class _ChatCore(
     ``rpc_call`` (from :class:`CoreRPCProvider`), underscore-private
     transport-operation bookkeeping (from
     :class:`TransportOperationProvider`), the shared request-id counter
-    (from :class:`CoreReqIdProvider`), the source-id enumeration helper
-    (from :class:`SourceListProvider`), and the open-time event-loop
-    reference (from :class:`LoopAffinityProvider`). The single member
+    (from :class:`CoreReqIdProvider`), and the open-time event-loop guard
+    (from :class:`LoopAffinityProvider`). The single member
     declared inline below — ``_perform_authed_post`` — is the underlying
     streaming-chat transport entry point that
     :func:`_chat_transport.chat_aware_authed_post` invokes; it does not
@@ -95,6 +91,10 @@ class _ChatCore(
         # never appeared in the RPC counters and continue not to.
         rpc_method: str | None = None,
     ) -> httpx.Response: ...
+
+
+class _SourceIdsResolver(Protocol):
+    async def get_source_ids(self, notebook_id: str) -> list[str]: ...
 
 
 def _extract_next_turn_content(next_turn: Any) -> str | None:
@@ -166,6 +166,7 @@ class ChatAPI:
         core: _ChatCore,
         *,
         conversation_cache: ConversationCache | None = None,
+        notebooks: _SourceIdsResolver | None = None,
     ):
         """Initialize the chat API.
 
@@ -174,8 +175,16 @@ class ChatAPI:
             conversation_cache: Optional injected cache; defaults to a fresh
                 per-instance ``ConversationCache`` (chat-domain state, no
                 other consumer).
+            notebooks: Optional source-id resolver. Defaults to a
+                ``NotebooksAPI`` wrapper around ``core`` for backward
+                compatibility with tests that construct ``ChatAPI(core)``.
         """
         self._core = core
+        if notebooks is None:
+            from ._notebooks import NotebooksAPI
+
+            notebooks = NotebooksAPI(cast(Any, core))
+        self._notebooks = notebooks
         self._cache = conversation_cache if conversation_cache is not None else ConversationCache()
         # Per-``conversation_id`` lock that serializes follow-up asks on the
         # same conversation. Without this, two
@@ -273,14 +282,14 @@ class ChatAPI:
         # guard at ``_core_transport.py:258-262`` only catches misuse on
         # the POST itself, which is *after* the conversation lock is
         # already held — too late.
-        assert_bound_loop(self._core.bound_loop)
+        self._core.assert_bound_loop()
         logger.debug(
             "Asking question in notebook %s (conversation=%s)",
             notebook_id,
             conversation_id or "new",
         )
         if source_ids is None:
-            source_ids = await self._core.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         is_new_conversation = conversation_id is None
 

--- a/src/notebooklm/_core.py
+++ b/src/notebooklm/_core.py
@@ -103,6 +103,7 @@ from ._core_transport import (
     _TransportServerError as _TransportServerError,
 )
 from ._kernel import Kernel
+from ._loop_affinity import assert_bound_loop
 from ._middleware import (
     Middleware,
     NextCall,
@@ -118,7 +119,6 @@ from ._middleware_retry import RetryMiddleware
 from ._middleware_semaphore import RPC_QUEUE_WAIT_CONTEXT_KEY, SemaphoreMiddleware
 from ._middleware_tracing import TracingMiddleware
 from ._polling_registry import PendingPolls, PollRegistry
-from ._sources import fetch_source_ids
 
 # ``save_cookies_to_storage`` is re-exported as ``notebooklm._core.save_cookies_to_storage``
 # so existing ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
@@ -1063,6 +1063,10 @@ class ClientCore:
         loop = lifecycle.get_bound_loop()
         return loop if isinstance(loop, asyncio.AbstractEventLoop) else None
 
+    def assert_bound_loop(self) -> None:
+        """Raise if this core is used from a loop other than its open-time loop."""
+        assert_bound_loop(self.bound_loop)
+
     def _record_lock_wait(self, wait_seconds: float) -> None:
         self._ensure_observability_state()
         self._metrics_obj.record_lock_wait(wait_seconds)
@@ -1615,18 +1619,3 @@ class ClientCore:
         """
         self._ensure_lifecycle()
         return self._lifecycle.get_http_client()
-
-    async def get_source_ids(self, notebook_id: str) -> list[str]:
-        """Extract all source IDs from a notebook.
-
-        Thin facade over :func:`notebooklm._sources.fetch_source_ids` —
-        retained on :class:`ClientCore` because first-party callers and the
-        test suite continue to invoke ``core.get_source_ids(...)``.
-
-        Args:
-            notebook_id: The notebook ID.
-
-        Returns:
-            List of source IDs. Empty list if no sources or on error.
-        """
-        return await fetch_source_ids(self, notebook_id)

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -200,13 +200,22 @@ class NotebooksAPI:
         )
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
-        """Extract all source IDs from a notebook."""
-        params = [notebook_id, None, [2], None, 0]
-        notebook_data = await self._core.rpc_call(
-            RPCMethod.GET_NOTEBOOK,
-            params,
-            source_path=f"/notebook/{notebook_id}",
-        )
+        """Extract all source IDs from a notebook.
+
+        Fetches notebook data and extracts source IDs for use with chat and
+        artifact generation when targeting specific sources.
+
+        Args:
+            notebook_id: The notebook ID.
+
+        Returns:
+            List of source IDs. Empty list if no sources or on error.
+
+        Note:
+            Source IDs are triple-nested in RPC responses: ``source[0][0]``
+            contains the ID.
+        """
+        notebook_data = await self.get_raw(notebook_id)
 
         source_ids: list[str] = []
         if not notebook_data or not isinstance(notebook_data, list):

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -199,6 +199,64 @@ class NotebooksAPI:
             disable_internal_retries=disable_internal_retries,
         )
 
+    async def get_source_ids(self, notebook_id: str) -> list[str]:
+        """Extract all source IDs from a notebook."""
+        params = [notebook_id, None, [2], None, 0]
+        notebook_data = await self._core.rpc_call(
+            RPCMethod.GET_NOTEBOOK,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+        )
+
+        source_ids: list[str] = []
+        if not notebook_data or not isinstance(notebook_data, list):
+            return source_ids
+
+        # Schema-drift detection points: log WARNING at each isinstance/len
+        # guard that fails on a non-empty response (real drift surfaces here,
+        # not at the safety-net except below).
+        try:
+            if not isinstance(notebook_data[0], list):
+                # notebook_data is already known to be a non-empty list here
+                # (guarded by `if not notebook_data` above).
+                logger.warning(
+                    "get_source_ids: notebook_data[0] shape unexpected for %s "
+                    "(schema drift?). top-type=%s",
+                    notebook_id,
+                    type(notebook_data[0]).__name__,
+                )
+                return source_ids
+
+            notebook_info = notebook_data[0]
+            if not (len(notebook_info) > 1 and isinstance(notebook_info[1], list)):
+                logger.warning(
+                    "get_source_ids: notebook_info[1] not list for %s (schema drift?). len=%d",
+                    notebook_id,
+                    len(notebook_info),
+                )
+                return source_ids
+
+            sources = notebook_info[1]
+            for source in sources:
+                if not (isinstance(source, list) and source):
+                    continue
+                first = source[0]
+                if not (isinstance(first, list) and first):
+                    continue
+                sid = first[0]
+                if isinstance(sid, str):
+                    source_ids.append(sid)
+        except (IndexError, TypeError) as e:
+            # Defense-in-depth: guards above should make this unreachable.
+            logger.warning(
+                "get_source_ids: unexpected exception despite guards for %s: %s",
+                notebook_id,
+                e,
+                exc_info=True,
+            )
+
+        return source_ids
+
     async def list(self) -> list[Notebook]:
         """List all notebooks.
 

--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -209,9 +209,14 @@ class NotebooksAPI:
             notebook_id: The notebook ID.
 
         Returns:
-            List of source IDs. Empty list if no sources or on error.
+            List of source IDs. Empty list when the notebook has no sources or
+            when get_source_ids encounters a schema/validation mismatch while
+            extracting IDs.
 
         Note:
+            RPC, auth, and network errors raised by ``get_raw()`` propagate to
+            the caller; only local source-shape validation failures are caught
+            below and converted to an empty list.
             Source IDs are triple-nested in RPC responses: ``source[0][0]``
             contains the ID.
         """

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 from time import monotonic
-from typing import IO, TYPE_CHECKING, Any, Literal, Protocol
+from typing import IO, Any, Literal, Protocol
 from urllib.parse import urlparse
 
 import httpx
@@ -31,9 +31,6 @@ from .types import (
     Source,
     SourceFulltext,
 )
-
-if TYPE_CHECKING:
-    from ._core import ClientCore
 
 logger = logging.getLogger(__name__)
 
@@ -64,79 +61,6 @@ class _SourcesCore(
 _SOURCE_ID_UUID_PATTERN = _source_upload._SOURCE_ID_UUID_PATTERN
 _extract_register_file_source_id = _source_upload._extract_register_file_source_id
 _looks_like_id_string = _source_upload._looks_like_id_string
-
-
-async def fetch_source_ids(core: "ClientCore", notebook_id: str) -> list[str]:
-    """Extract all source IDs from a notebook.
-
-    Fetches notebook data and extracts source IDs for use with
-    chat and artifact generation when targeting specific sources.
-
-    Args:
-        core: The :class:`ClientCore` instance providing the RPC entry point.
-        notebook_id: The notebook ID.
-
-    Returns:
-        List of source IDs. Empty list if no sources or on error.
-
-    Note:
-        Source IDs are triple-nested in RPC: source[0][0] contains the ID.
-    """
-    params = [notebook_id, None, [2], None, 0]
-    notebook_data = await core.rpc_call(
-        RPCMethod.GET_NOTEBOOK,
-        params,
-        source_path=f"/notebook/{notebook_id}",
-    )
-
-    source_ids: list[str] = []
-    if not notebook_data or not isinstance(notebook_data, list):
-        return source_ids
-
-    # Schema-drift detection points: log WARNING at each isinstance/len
-    # guard that fails on a non-empty response (real drift surfaces here,
-    # not at the safety-net except below).
-    try:
-        if not isinstance(notebook_data[0], list):
-            # notebook_data is already known to be a non-empty list here
-            # (guarded by `if not notebook_data` above).
-            logger.warning(
-                "get_source_ids: notebook_data[0] shape unexpected for %s "
-                "(schema drift?). top-type=%s",
-                notebook_id,
-                type(notebook_data[0]).__name__,
-            )
-            return source_ids
-
-        notebook_info = notebook_data[0]
-        if not (len(notebook_info) > 1 and isinstance(notebook_info[1], list)):
-            logger.warning(
-                "get_source_ids: notebook_info[1] not list for %s (schema drift?). len=%d",
-                notebook_id,
-                len(notebook_info),
-            )
-            return source_ids
-
-        sources = notebook_info[1]
-        for source in sources:
-            if not (isinstance(source, list) and source):
-                continue
-            first = source[0]
-            if not (isinstance(first, list) and first):
-                continue
-            sid = first[0]
-            if isinstance(sid, str):
-                source_ids.append(sid)
-    except (IndexError, TypeError) as e:
-        # Defense-in-depth: guards above should make this unreachable.
-        logger.warning(
-            "get_source_ids: unexpected exception despite guards for %s: %s",
-            notebook_id,
-            e,
-            exc_info=True,
-        )
-
-    return source_ids
 
 
 class SourcesAPI:

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -273,9 +273,13 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
         )
         self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
-        self.artifacts = ArtifactsAPI(self._core, storage_path=storage_path)
+        self.artifacts = ArtifactsAPI(
+            self._core,
+            storage_path=storage_path,
+            notebooks=self.notebooks,
+        )
         self.notes = NotesAPI(self._core)
-        self.chat = ChatAPI(self._core)
+        self.chat = ChatAPI(self._core, notebooks=self.notebooks)
         self.research = ResearchAPI(self._core)
         self.settings = SettingsAPI(self._core)
         self.sharing = SharingAPI(self._core)

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -119,6 +119,7 @@ def make_fake_core(**overrides: Any) -> FakeClientCore:
         "record_upload_queue_wait": MagicMock(return_value=None),
         # LoopAffinityProvider — None is the silent-no-op value
         "bound_loop": None,
+        "assert_bound_loop": MagicMock(return_value=None),
         # Auth-route helper alias
         "_route_url": MagicMock(return_value="https://notebooklm.google.com/_/.../batchexecute"),
     }

--- a/tests/integration/test_core.py
+++ b/tests/integration/test_core.py
@@ -317,12 +317,13 @@ class TestGetHttpClient:
 
 
 class TestGetSourceIds:
-    """Tests for get_source_ids() extracting source IDs from notebook data."""
+    """Tests for NotebooksAPI.get_source_ids() extracting source IDs from notebook data."""
 
     @pytest.mark.asyncio
     async def test_returns_source_ids_from_nested_data(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             core = client._core
+            notebooks = client.notebooks
 
             mock_notebook_data = [
                 [
@@ -337,7 +338,7 @@ class TestGetSourceIds:
             with patch.object(
                 core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
             ):
-                ids = await core.get_source_ids("nb_123")
+                ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == ["src_id_1", "src_id_2"]
 
@@ -345,9 +346,10 @@ class TestGetSourceIds:
     async def test_returns_empty_list_when_data_is_none(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             core = client._core
+            notebooks = client.notebooks
 
             with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=None):
-                ids = await core.get_source_ids("nb_123")
+                ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
 
@@ -355,9 +357,10 @@ class TestGetSourceIds:
     async def test_returns_empty_list_when_data_is_empty_list(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             core = client._core
+            notebooks = client.notebooks
 
             with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=[]):
-                ids = await core.get_source_ids("nb_123")
+                ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
 
@@ -365,6 +368,7 @@ class TestGetSourceIds:
     async def test_returns_empty_list_when_sources_list_is_empty(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             core = client._core
+            notebooks = client.notebooks
 
             # Notebook with no sources
             mock_notebook_data = [["notebook_title", []]]
@@ -372,7 +376,7 @@ class TestGetSourceIds:
             with patch.object(
                 core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
             ):
-                ids = await core.get_source_ids("nb_123")
+                ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
 
@@ -380,11 +384,12 @@ class TestGetSourceIds:
     async def test_returns_empty_list_when_data_is_not_list(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             core = client._core
+            notebooks = client.notebooks
 
             with patch.object(
                 core, "rpc_call", new_callable=AsyncMock, return_value="unexpected_string"
             ):
-                ids = await core.get_source_ids("nb_123")
+                ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
 
@@ -392,6 +397,7 @@ class TestGetSourceIds:
     async def test_returns_empty_list_when_notebook_info_missing_sources(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             core = client._core
+            notebooks = client.notebooks
 
             # notebook_data[0] exists but notebook_info[1] is missing
             mock_notebook_data = [["notebook_title_only"]]
@@ -399,7 +405,7 @@ class TestGetSourceIds:
             with patch.object(
                 core, "rpc_call", new_callable=AsyncMock, return_value=mock_notebook_data
             ):
-                ids = await core.get_source_ids("nb_123")
+                ids = await notebooks.get_source_ids("nb_123")
 
             assert ids == []
 

--- a/tests/unit/concurrency/test_loop_affinity_guard.py
+++ b/tests/unit/concurrency/test_loop_affinity_guard.py
@@ -159,14 +159,15 @@ def test_await_refresh_guards_against_cross_loop_call() -> None:
 def test_wait_for_completion_guards_against_cross_loop_call() -> None:
     """``ArtifactPollingService.wait_for_completion`` must raise on cross-loop misuse.
 
-    The service routes the guard through its capability adapter
-    (``self._capabilities.bound_loop``). A capability fake bound to loop
-    A and a fresh loop B for the call site reproduces the mismatch.
+    The service routes the guard through its capability adapter's
+    ``assert_bound_loop`` method.
     """
     capabilities = MagicMock()
     other_loop = asyncio.new_event_loop()
     try:
-        capabilities.bound_loop = other_loop
+        capabilities.assert_bound_loop = MagicMock(
+            side_effect=RuntimeError("NotebookLM client used from a different event loop")
+        )
 
         service = ArtifactPollingService(capabilities)
 
@@ -189,7 +190,7 @@ def test_wait_for_completion_guards_against_cross_loop_call() -> None:
 def test_chat_ask_guards_against_cross_loop_call() -> None:
     """``ChatAPI.ask`` must raise on cross-loop misuse.
 
-    The chat entry consults its core capability's ``bound_loop`` *before*
+    The chat entry calls its core capability's ``assert_bound_loop`` *before*
     acquiring the per-conversation lock so a cross-loop follow-up doesn't
     hang on a lock bound to a dead loop.
     """
@@ -198,7 +199,9 @@ def test_chat_ask_guards_against_cross_loop_call() -> None:
     capabilities = MagicMock()
     other_loop = asyncio.new_event_loop()
     try:
-        capabilities.bound_loop = other_loop
+        capabilities.assert_bound_loop = MagicMock(
+            side_effect=RuntimeError("NotebookLM client used from a different event loop")
+        )
 
         chat = ChatAPI(capabilities)
 

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -32,15 +32,18 @@ def mock_artifacts_api():
     # guard) so the artifact polling helper does not raise on a
     # ``MagicMock``-shaped loop value.
     mock_core.bound_loop = None
+    mock_core.assert_bound_loop = MagicMock(return_value=None)
     mock_notes = MagicMock()
     mock_notes.list_mind_maps = AsyncMock(return_value=[])
     mock_note = MagicMock()
     mock_note.id = "created_note_123"
     mock_notes.create = AsyncMock(return_value=mock_note)
+    mock_notebooks = MagicMock()
+    mock_notebooks.get_source_ids = AsyncMock(return_value=[])
     # After D2 cutover, sub-clients consume ``ClientCore`` directly typed
     # against their narrow Protocol — the ``MagicMock`` duck-types the
     # required Protocol surface.
-    api = ArtifactsAPI(mock_core, notes_api=mock_notes)
+    api = ArtifactsAPI(mock_core, notes_api=mock_notes, notebooks=mock_notebooks)
     return api, mock_core
 
 

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -79,7 +79,9 @@ def api():
     core.bound_loop = None
     core.assert_bound_loop = MagicMock(return_value=None)
     notes_api = MagicMock()
-    return ArtifactsAPI(core, notes_api)
+    mock_notebooks = MagicMock()
+    mock_notebooks.get_source_ids = AsyncMock(return_value=[])
+    return ArtifactsAPI(core, notes_api, notebooks=mock_notebooks)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -11,10 +11,13 @@ from notebooklm.rpc import AuthError, NetworkError, RPCTimeoutError
 
 class _FakeTransportProvider:
     # ``ArtifactPollingService.wait_for_completion`` calls
-    # ``assert_bound_loop(self._capabilities.bound_loop)`` (P0-2). ``None``
+    # ``self._capabilities.assert_bound_loop()`` (P0-2). ``None``
     # is the documented silent-no-op value for the affinity helper, so
     # this stub stays correct without binding to a real loop.
     bound_loop = None
+
+    def assert_bound_loop(self) -> None:
+        return None
 
     def __init__(
         self,
@@ -74,6 +77,7 @@ def api():
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.bound_loop = None
+    core.assert_bound_loop = MagicMock(return_value=None)
     notes_api = MagicMock()
     return ArtifactsAPI(core, notes_api)
 
@@ -363,6 +367,7 @@ async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.bound_loop = None
+    core.assert_bound_loop = MagicMock(return_value=None)
     api = ArtifactsAPI(core, MagicMock())
 
     poll_started = asyncio.Event()

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -30,7 +30,6 @@ def _make_api():
     """Return an ArtifactsAPI with mocked core + notes."""
     core = MagicMock()
     core.rpc_call = AsyncMock()
-    core.get_source_ids = AsyncMock(return_value=[])
     # Real registry backing so wait_for_completion can ``dict.get(key)``.
     core.poll_registry = PollRegistry()
     core._pending_polls = core.poll_registry.pending
@@ -41,7 +40,9 @@ def _make_api():
     notes = MagicMock()
     notes.list_mind_maps = AsyncMock(return_value=[])
     notes.create = AsyncMock(return_value=MagicMock(id="note_1"))
-    return ArtifactsAPI(core, notes_api=notes)
+    notebooks = MagicMock()
+    notebooks.get_source_ids = AsyncMock(return_value=[])
+    return ArtifactsAPI(core, notes_api=notes, notebooks=notebooks)
 
 
 def _art(artifact_id: str, status: int, artifact_type: int = 1, error_at_3: str | None = None):

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -37,6 +37,7 @@ def _make_api():
     core._begin_transport_task = AsyncMock(return_value=object())
     core._finish_transport_post = AsyncMock()
     core.bound_loop = None
+    core.assert_bound_loop = MagicMock(return_value=None)
     notes = MagicMock()
     notes.list_mind_maps = AsyncMock(return_value=[])
     notes.create = AsyncMock(return_value=MagicMock(id="note_1"))

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -2,7 +2,7 @@
 
 Tests that source_ids are correctly handled when:
 1. Explicitly passed (subset of sources)
-2. None (uses all sources via core.get_source_ids)
+2. None (uses all sources via NotebooksAPI.get_source_ids)
 
 Verifies correct encoding of source IDs in RPC parameters:
 - source_ids_triple = [[[sid]] for sid in source_ids]
@@ -52,7 +52,6 @@ def mock_core(monkeypatch):
         return core.rpc_call.return_value
 
     core.rpc_call.side_effect = _rpc_call_dispatch
-    core.get_source_ids = AsyncMock(return_value=[])
     core.auth = MagicMock()
     core.auth.csrf_token = "test_csrf"
     core.auth.session_id = "test_session"
@@ -63,6 +62,7 @@ def mock_core(monkeypatch):
     core._reqid_counter = 0
     core.next_reqid = AsyncMock(return_value=100000)
     core.bound_loop = None
+    core.assert_bound_loop = MagicMock(return_value=None)
     core.get_http_client = MagicMock()
 
     # Default ``chat_aware_authed_post`` stub: invokes the caller-supplied
@@ -103,6 +103,13 @@ def mock_core(monkeypatch):
     monkeypatch.setattr("notebooklm._chat.chat_aware_authed_post", chat_post_mock)
     core._chat_aware_authed_post_mock = chat_post_mock
     return core
+
+
+@pytest.fixture
+def mock_notebooks_api():
+    notebooks = MagicMock()
+    notebooks.get_source_ids = AsyncMock(return_value=[])
+    return notebooks
 
 
 @pytest.fixture
@@ -148,12 +155,12 @@ class TestChatSourceSelection:
         assert "src_002" in body
 
     @pytest.mark.asyncio
-    async def test_ask_with_none_fetches_all_sources(self, mock_core):
+    async def test_ask_with_none_fetches_all_sources(self, mock_core, mock_notebooks_api):
         """Test ask() with source_ids=None fetches all sources."""
-        api = ChatAPI(mock_core)
+        api = ChatAPI(mock_core, notebooks=mock_notebooks_api)
 
         # Mock get_source_ids to return source IDs
-        mock_core.get_source_ids.return_value = ["src_001", "src_002", "src_003"]
+        mock_notebooks_api.get_source_ids.return_value = ["src_001", "src_002", "src_003"]
 
         result = await api.ask(
             notebook_id="nb_123",
@@ -163,8 +170,8 @@ class TestChatSourceSelection:
 
         assert result.answer == "Default answer long enough to be valid."
 
-        # Verify get_source_ids was called on core
-        mock_core.get_source_ids.assert_called_once_with("nb_123")
+        # Verify get_source_ids was called on notebooks API
+        mock_notebooks_api.get_source_ids.assert_called_once_with("nb_123")
 
     @pytest.mark.asyncio
     async def test_ask_source_encoding_format(self, mock_core):
@@ -247,12 +254,14 @@ class TestArtifactsSourceSelection:
         assert source_ids_double == [["src_001"], ["src_002"]]
 
     @pytest.mark.asyncio
-    async def test_generate_audio_with_none_fetches_all_sources(self, mock_core, mock_notes_api):
+    async def test_generate_audio_with_none_fetches_all_sources(
+        self, mock_core, mock_notes_api, mock_notebooks_api
+    ):
         """Test generate_audio with source_ids=None fetches all sources."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, mock_notes_api, notebooks=mock_notebooks_api)
 
         # Mock get_source_ids to return source IDs
-        mock_core.get_source_ids.return_value = ["src_001", "src_002"]
+        mock_notebooks_api.get_source_ids.return_value = ["src_001", "src_002"]
 
         # Mock the generation RPC call
         mock_core.rpc_call.return_value = [["artifact_123", "Audio", 1, None, 1]]
@@ -265,7 +274,7 @@ class TestArtifactsSourceSelection:
         assert result.task_id == "artifact_123"
 
         # Verify get_source_ids was called
-        mock_core.get_source_ids.assert_called_once_with("nb_123")
+        mock_notebooks_api.get_source_ids.assert_called_once_with("nb_123")
 
         # Verify CREATE_ARTIFACT RPC was called with fetched source IDs
         mock_core.rpc_call.assert_called_once()
@@ -588,12 +597,14 @@ class TestArtifactsSourceSelection:
         assert source_ids_triple == [[["src_table_1"]], [["src_table_2"]]]
 
     @pytest.mark.asyncio
-    async def test_generate_mind_map_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_mind_map_source_encoding(
+        self, mock_core, mock_notes_api, mock_notebooks_api
+    ):
         """Test generate_mind_map has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, mock_notes_api, notebooks=mock_notebooks_api)
 
         # Mock get_source_ids to return source IDs
-        mock_core.get_source_ids.return_value = ["src_mm_1", "src_mm_2"]
+        mock_notebooks_api.get_source_ids.return_value = ["src_mm_1", "src_mm_2"]
 
         # Mock the mind map generation RPC call
         mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
@@ -604,7 +615,7 @@ class TestArtifactsSourceSelection:
         )
 
         # Verify get_source_ids was called
-        mock_core.get_source_ids.assert_called_once_with("nb_123")
+        mock_notebooks_api.get_source_ids.assert_called_once_with("nb_123")
 
         # After the mind-map relocation, ``generate_mind_map`` also drives the CREATE_NOTE +
         # UPDATE_NOTE calls itself (previously delegated to NotesAPI), so
@@ -627,7 +638,6 @@ class TestArtifactsSourceSelection:
         """Test generate_mind_map passes language and instructions to RPC payload."""
         api = ArtifactsAPI(mock_core, mock_notes_api)
 
-        mock_core.get_source_ids.return_value = ["src_1"]
         mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
 
         await api.generate_mind_map(
@@ -730,15 +740,17 @@ class TestEmptySourceIds:
 
 
 class TestGetSourceIds:
-    """Tests for ClientCore.get_source_ids method."""
+    """Tests for NotebooksAPI.get_source_ids method."""
 
     @pytest.mark.asyncio
     async def test_get_source_ids_extracts_correctly(self, auth_tokens):
         """Test get_source_ids correctly extracts source IDs from notebook data."""
         from notebooklm._core import ClientCore
+        from notebooklm._notebooks import NotebooksAPI
 
         core = ClientCore(auth_tokens)
         core.rpc_call = AsyncMock()
+        api = NotebooksAPI(core)
 
         # Mock notebook data with multiple sources
         # Structure: notebook_data[0][1] = sources list
@@ -755,7 +767,7 @@ class TestGetSourceIds:
             ]
         ]
 
-        source_ids = await core.get_source_ids("nb_123")
+        source_ids = await api.get_source_ids("nb_123")
 
         assert source_ids == ["source_aaa", "source_bbb", "source_ccc"]
 
@@ -763,13 +775,15 @@ class TestGetSourceIds:
     async def test_get_source_ids_handles_empty_notebook(self, auth_tokens):
         """Test get_source_ids handles notebook with no sources."""
         from notebooklm._core import ClientCore
+        from notebooklm._notebooks import NotebooksAPI
 
         core = ClientCore(auth_tokens)
         core.rpc_call = AsyncMock()
+        api = NotebooksAPI(core)
 
         core.rpc_call.return_value = [["nb_123", []]]
 
-        source_ids = await core.get_source_ids("nb_123")
+        source_ids = await api.get_source_ids("nb_123")
 
         assert source_ids == []
 
@@ -777,13 +791,15 @@ class TestGetSourceIds:
     async def test_get_source_ids_handles_null_response(self, auth_tokens):
         """Test get_source_ids handles null API response."""
         from notebooklm._core import ClientCore
+        from notebooklm._notebooks import NotebooksAPI
 
         core = ClientCore(auth_tokens)
         core.rpc_call = AsyncMock()
+        api = NotebooksAPI(core)
 
         core.rpc_call.return_value = None
 
-        source_ids = await core.get_source_ids("nb_123")
+        source_ids = await api.get_source_ids("nb_123")
 
         assert source_ids == []
 
@@ -791,9 +807,11 @@ class TestGetSourceIds:
     async def test_get_source_ids_handles_malformed_data(self, auth_tokens):
         """Test get_source_ids handles malformed source data gracefully."""
         from notebooklm._core import ClientCore
+        from notebooklm._notebooks import NotebooksAPI
 
         core = ClientCore(auth_tokens)
         core.rpc_call = AsyncMock()
+        api = NotebooksAPI(core)
 
         # Malformed data - missing nested structure
         # Structure: source[0] must be a list, source[0][0] must be a string
@@ -808,7 +826,7 @@ class TestGetSourceIds:
             ]
         ]
 
-        source_ids = await core.get_source_ids("nb_123")
+        source_ids = await api.get_source_ids("nb_123")
 
         # Should only extract the valid source
         assert source_ids == ["valid_id"]

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -19,14 +19,16 @@ SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 
 @pytest.mark.asyncio
 async def test_get_source_ids_warns_on_top_level_shape_drift(caplog):
-    """_core.py:get_source_ids — non-list at notebook_data[0] triggers WARNING."""
+    """_notebooks.py:get_source_ids — non-list at notebook_data[0] triggers WARNING."""
     from notebooklm._core import ClientCore
+    from notebooklm._notebooks import NotebooksAPI
 
     core = ClientCore.__new__(ClientCore)
     core.rpc_call = AsyncMock(return_value=[{"unexpected": "dict"}])
+    api = NotebooksAPI(core)
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):
-        result = await core.get_source_ids("nb_drift")
+        result = await api.get_source_ids("nb_drift")
 
     assert result == []
     drift_warnings = [
@@ -40,15 +42,17 @@ async def test_get_source_ids_warns_on_top_level_shape_drift(caplog):
 
 @pytest.mark.asyncio
 async def test_get_source_ids_warns_on_inner_shape_drift(caplog):
-    """_core.py:get_source_ids — notebook_info[1] not list triggers WARNING."""
+    """_notebooks.py:get_source_ids — notebook_info[1] not list triggers WARNING."""
     from notebooklm._core import ClientCore
+    from notebooklm._notebooks import NotebooksAPI
 
     core = ClientCore.__new__(ClientCore)
     # notebook_data[0] is a list of length >1 but [1] is not a list
     core.rpc_call = AsyncMock(return_value=[[None, "not a list", "x"]])
+    api = NotebooksAPI(core)
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):
-        result = await core.get_source_ids("nb_inner")
+        result = await api.get_source_ids("nb_inner")
 
     assert result == []
     assert any("schema drift" in r.message and "nb_inner" in r.message for r in caplog.records)
@@ -58,12 +62,14 @@ async def test_get_source_ids_warns_on_inner_shape_drift(caplog):
 async def test_get_source_ids_happy_path_no_warning(caplog):
     """Well-formed payload extracts source ids and emits no warning."""
     from notebooklm._core import ClientCore
+    from notebooklm._notebooks import NotebooksAPI
 
     core = ClientCore.__new__(ClientCore)
     core.rpc_call = AsyncMock(return_value=[[None, [[["src_alpha"]], [["src_beta"]]]]])
+    api = NotebooksAPI(core)
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):
-        result = await core.get_source_ids("nb_happy")
+        result = await api.get_source_ids("nb_happy")
 
     assert result == ["src_alpha", "src_beta"]
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]


### PR DESCRIPTION
## Summary
- add ClientCore/Session assert_bound_loop and route feature loop-affinity checks through the capability method
- move source ID enumeration onto NotebooksAPI and wire NotebooksAPI into ChatAPI and ArtifactsAPI
- keep transitional bound_loop surface while updating tests for the new ownership boundary

## Task
Phase 2 Wave 5: t13-5-loop-affinity-shim

## Test plan
- [x] uv run pytest tests/unit/concurrency/test_loop_affinity_guard.py tests/unit/test_source_selection.py tests/unit/test_artifacts_polling_retries.py tests/unit/test_artifacts_coverage.py tests/unit/test_quota_failure_detection.py tests/unit/test_swallow_observability.py tests/integration/test_core.py
- [x] uv run ruff check <touched files>
- [x] uv run mypy src/notebooklm --ignore-missing-imports
- [x] uv run pytest -n auto --dist=worksteal
- [x] uv run ruff format --check src/notebooklm tests
- [x] uv run pre-commit run --all-files
- [x] git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Move notebook source resolution into a shared notebooks component and enforce event-loop affinity checks for chat and artifact flows.
* **Bug Fixes**
  * Safer notebook parsing: skips malformed entries, logs warnings on unexpected shapes, and returns empty lists for missing/invalid data.
* **Tests**
  * Updated tests to exercise the new source-resolution path and loop-affinity assertions.
* **Documentation**
  * Docs updated to describe the new source-resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->