### PR TITLE
docs(core): Tier 12→13 migration doc + __all__ on collaborators (Tier 13 PR 13.9b)

### DIFF
--- a/docs/migration-tier-12-to-13.md
+++ b/docs/migration-tier-12-to-13.md
@@ -1,0 +1,136 @@
+# Migration: Tier 12 → Tier 13
+
+Tier 12 ("middleware chain") and Tier 13 ("Session/Kernel split") restructured
+the **private** core layer of `notebooklm-py`. The **public** API
+(`NotebookLMClient`, `AuthTokens`, the dataclasses re-exported from
+`notebooklm`, the exceptions, the enums, and `notebooklm.rpc.RPCMethod`) is
+unchanged — `client.notebooks.list()`, `client.sources.add_url(...)`,
+`client.chat.ask(...)`, `client.artifacts.generate_audio(...)` and friends keep
+the same signatures and behavior.
+
+This page catalogs the renames, moves, and deletions for first-party callers
+or test suites that imported underscore-prefixed (`notebooklm._...`)
+internals. Underscore-prefixed names are **not** part of the documented public
+surface ([`docs/stability.md`](stability.md)) and may move again in future
+tiers; the table below is provided as a courtesy for downstream code that
+needs to migrate.
+
+If your code only uses the documented public API, you do not need to do
+anything.
+
+## Quick guidance
+
+- **Stop importing from `notebooklm._core`** for new code. The module is now a
+  compatibility shim that re-exports the concrete `Session` orchestrator from
+  `notebooklm._session`. Existing imports still resolve, but the symbols
+  documented below live on their final home modules now and the shim may be
+  removed in a later refactor.
+- **Prefer the public surface** — `notebooklm.NotebookLMClient`,
+  `notebooklm.AuthTokens`, `notebooklm.rpc.RPCMethod`, and the types/exceptions
+  re-exported from the top-level package.
+- **Feature APIs** (`NotebooksAPI`, `SourcesAPI`, `ArtifactsAPI`, `ChatAPI`,
+  `ResearchAPI`, `NotesAPI`, `SharingAPI`, `SettingsAPI`) now depend on the
+  `notebooklm._session_contracts.Session` Protocol rather than the concrete
+  `ClientCore`/`Session` class. They continue to be created by
+  `NotebookLMClient`; only the type they're written against has narrowed.
+
+## Renamed modules
+
+The following private modules were renamed without any change to the symbols
+they expose. Every named export carries forward; only the file path changed.
+
+**The old `_core_*` module paths no longer resolve.** Tier 13 PR 13.8 removed
+the per-module shims; `import notebooklm._core_auth` (and the other rows
+below) now raises `ImportError`. Update your imports to the new path on the
+right.
+
+| Tier 12 path | Tier 13 path |
+|---|---|
+| `notebooklm._core_auth` | `notebooklm._session_auth` |
+| `notebooklm._core_cache` | `notebooklm._conversation_cache` |
+| `notebooklm._core_constants` | `notebooklm._session_config` |
+| `notebooklm._core_cookie_persistence` | `notebooklm._cookie_persistence` |
+| `notebooklm._core_drain` | `notebooklm._transport_drain` |
+| `notebooklm._core_error_injection` | `notebooklm._error_injection` |
+| `notebooklm._core_helpers` | `notebooklm._session_helpers` |
+| `notebooklm._core_lifecycle` | `notebooklm._session_lifecycle` |
+| `notebooklm._core_metrics` | `notebooklm._client_metrics` |
+| `notebooklm._core_polling` | `notebooklm._polling_registry` |
+| `notebooklm._core_reqid` | `notebooklm._reqid_counter` |
+| `notebooklm._core_rpc` | `notebooklm._rpc_executor` |
+| `notebooklm._core_transport` | `notebooklm._authed_transport` |
+
+`notebooklm._core` itself still exists as a compatibility shim that re-exports
+the `Session` class (aliased as `ClientCore` for legacy callers) plus the
+constants and helpers in the table below. New code should import from the
+post-rename modules directly.
+
+## Moved and renamed symbols
+
+The Session/Kernel split (Tier 13) introduced new home modules for the
+orchestrator and its transport collaborator. Existing helper names did not
+change, only their home module did.
+
+| Tier 12 symbol | Tier 13 home | Notes |
+|---|---|---|
+| `notebooklm._core.ClientCore` (class) | `notebooklm._session.Session` | `ClientCore` still resolves via the `_core` shim. New code should use `notebooklm._session.Session`. Feature APIs accept the `notebooklm._session_contracts.Session` Protocol. |
+| `notebooklm._core.MAX_RETRY_AFTER_SECONDS` | `notebooklm._authed_transport.MAX_RETRY_AFTER_SECONDS` | Re-exported via `_session` and the `_core` shim. |
+| `notebooklm._core.DEFAULT_*` (timeouts, concurrency knobs) | `notebooklm._session_config.DEFAULT_*` | Re-exported via `_session` and the `_core` shim. |
+| `notebooklm._core.AUTH_ERROR_PATTERNS`, `notebooklm._core.is_auth_error` | `notebooklm._session_helpers` | Re-exported via `_session` and the `_core` shim. |
+| `notebooklm._core.ERROR_INJECT_ENV_VAR` | `notebooklm._error_injection.ERROR_INJECT_ENV_VAR` | Re-exported via `_session` and the `_core` shim. |
+| `notebooklm._core._SyntheticErrorTransport` (class) | _Removed_ | Synthetic-error substitution moved into `notebooklm._middleware_error_injection.ErrorInjectionMiddleware` in Tier 12 PR 12.6. The env-var resolver (`_get_error_injection_mode`) and startup guard (`_refuse_synthetic_error_outside_test_context`) survive in `notebooklm._error_injection`. |
+| `notebooklm._core.AuthRefreshCoordinator` | `notebooklm._session_auth.AuthRefreshCoordinator` | The class itself is unchanged; only the home module moved. The shim still re-exports it. |
+| `notebooklm._core.TransportDrainTracker` | `notebooklm._transport_drain.TransportDrainTracker` | Same — shim re-exports. |
+| `notebooklm._core.ClientMetrics` | `notebooklm._client_metrics.ClientMetrics` | Same — shim re-exports. |
+| `notebooklm._core.ReqidCounter` | `notebooklm._reqid_counter.ReqidCounter` | Same — shim re-exports. |
+| `notebooklm._core.CookiePersistence` | `notebooklm._cookie_persistence.CookiePersistence` | Same — shim re-exports. |
+| `notebooklm._core.ClientLifecycle` | `notebooklm._session_lifecycle.ClientLifecycle` | Same — shim re-exports. |
+| `notebooklm._core.RpcExecutor` | `notebooklm._rpc_executor.RpcExecutor` | Same — shim re-exports. |
+| `notebooklm._core.AuthedTransport` | `notebooklm._authed_transport.AuthedTransport` | Same — shim re-exports. |
+
+## New modules introduced by Tier 12 / 13
+
+These modules did not exist before Tier 12 began. They are listed here so that
+first-party callers and test suites looking for the new seams know where to
+import from.
+
+| Module | Purpose |
+|---|---|
+| `notebooklm._session_contracts` | `Session`, `Kernel`, `DrainHookRegistration`, `AuthMetadata` Protocols. Feature APIs are typed against `Session` here, not the concrete `Session` class in `_session`. |
+| `notebooklm._kernel` | Concrete `Kernel` transport core (owns the `httpx.AsyncClient`, exposes `post` / `cookies` / `aclose`). Wrapped by `Session` and consumed by middleware. |
+| `notebooklm._middleware` | Middleware chain primitives (`AuthedHttpClient` Protocol, `Middleware` Protocol, `RequestContext`, chain composition). |
+| `notebooklm._middleware_tracing` | Tier 12 PR 12.3 — request tracing middleware. |
+| `notebooklm._middleware_metrics` | Tier 12 PR 12.4 — metrics collection middleware. |
+| `notebooklm._middleware_drain` | Tier 12 PR 12.5 — drain bookkeeping middleware. |
+| `notebooklm._middleware_error_injection` | Tier 12 PR 12.6 — test-only error-injection middleware. |
+| `notebooklm._middleware_retry` | Tier 12 PR 12.7 — 429 / 5xx retry middleware. |
+| `notebooklm._middleware_auth_refresh` | Tier 12 PR 12.8 — auth-refresh-on-401 middleware. |
+| `notebooklm._middleware_semaphore` | Tier 12 PR 12.9 — global RPC concurrency cap. |
+| `notebooklm._chat_transport` | Chat-domain consumer-side error mapping over `AuthedTransport`. Replaces the chat-side wrapper that previously lived on `_core.rpc_call`. |
+| `notebooklm._request_types` | Shared dataclasses + type aliases for authed-POST request construction. Re-exports `_AuthSnapshot` and `_BuildRequest` from `_authed_transport` under the public-without-underscore names `AuthSnapshot` / `BuildRequest`, plus a new `BuildRequestResult` tuple type. |
+
+## Deleted symbols
+
+| Symbol | Replacement |
+|---|---|
+| `notebooklm._core._SyntheticErrorTransport` | `notebooklm._middleware_error_injection.ErrorInjectionMiddleware` (chain-resident; mode is still resolved from `NOTEBOOKLM_VCR_RECORD_ERRORS` via `_error_injection._get_error_injection_mode`). |
+| Strict-decode opt-in | `NOTEBOOKLM_STRICT_DECODE` now defaults to `1` (flipped in Tier 13 PR 13.9a). Set it to `0` to restore the legacy lenient decode. See [ADR-011](adr/0011-schema-validation-policy.md). |
+
+## Public API guarantee
+
+No public symbol moved or changed signature during Tier 12 or Tier 13. The
+following still work exactly as documented:
+
+```python
+from notebooklm import NotebookLMClient, AuthTokens
+from notebooklm.rpc import RPCMethod
+
+async with await NotebookLMClient.from_storage() as client:
+    notebooks = await client.notebooks.list()
+    await client.sources.add_url(notebook_id, url)
+    result = await client.chat.ask(notebook_id, question)
+    status = await client.artifacts.generate_audio(notebook_id)
+```
+
+See [`docs/python-api.md`](python-api.md) for the canonical public API
+reference and [`docs/stability.md`](stability.md) for the stability contract.

--- a/docs/migration-tier-12-to-13.md
+++ b/docs/migration-tier-12-to-13.md
@@ -109,12 +109,12 @@ import from.
 | `notebooklm._chat_transport` | Chat-domain consumer-side error mapping over `AuthedTransport`. Replaces the chat-side wrapper that previously lived on `_core.rpc_call`. |
 | `notebooklm._request_types` | Shared dataclasses + type aliases for authed-POST request construction. Re-exports `_AuthSnapshot` and `_BuildRequest` from `_authed_transport` under the public-without-underscore names `AuthSnapshot` / `BuildRequest`, plus a new `BuildRequestResult` dataclass. |
 
-## Deleted symbols
+## Deleted symbols and changed defaults
 
-| Symbol | Replacement |
+| Symbol or default | Replacement / new behavior |
 |---|---|
-| `notebooklm._core._SyntheticErrorTransport` | `notebooklm._middleware_error_injection.ErrorInjectionMiddleware` (chain-resident; mode is still resolved from `NOTEBOOKLM_VCR_RECORD_ERRORS` via `_error_injection._get_error_injection_mode`). |
-| Strict-decode opt-in | `NOTEBOOKLM_STRICT_DECODE` now defaults to `1` (flipped in Tier 13 PR 13.9a). Set it to `0` to restore the legacy lenient decode. See [ADR-011](adr/0011-schema-validation-policy.md). |
+| `notebooklm._core._SyntheticErrorTransport` (deleted) | `notebooklm._middleware_error_injection.ErrorInjectionMiddleware` (chain-resident; mode is still resolved from `NOTEBOOKLM_VCR_RECORD_ERRORS` via `_error_injection._get_error_injection_mode`). |
+| Strict-decode opt-in (changed default) | `NOTEBOOKLM_STRICT_DECODE` now defaults to `1` (flipped in Tier 13 PR 13.9a). Set it to `0` to restore the legacy lenient decode. See [ADR-011](adr/0011-schema-validation-policy.md). |
 
 ## Public API guarantee
 

--- a/docs/migration-tier-12-to-13.md
+++ b/docs/migration-tier-12-to-13.md
@@ -107,7 +107,7 @@ import from.
 | `notebooklm._middleware_auth_refresh` | Tier 12 PR 12.8 — auth-refresh-on-401 middleware. |
 | `notebooklm._middleware_semaphore` | Tier 12 PR 12.9 — global RPC concurrency cap. |
 | `notebooklm._chat_transport` | Chat-domain consumer-side error mapping over `AuthedTransport`. Replaces the chat-side wrapper that previously lived on `_core.rpc_call`. |
-| `notebooklm._request_types` | Shared dataclasses + type aliases for authed-POST request construction. Re-exports `_AuthSnapshot` and `_BuildRequest` from `_authed_transport` under the public-without-underscore names `AuthSnapshot` / `BuildRequest`, plus a new `BuildRequestResult` tuple type. |
+| `notebooklm._request_types` | Shared dataclasses + type aliases for authed-POST request construction. Re-exports `_AuthSnapshot` and `_BuildRequest` from `_authed_transport` under the public-without-underscore names `AuthSnapshot` / `BuildRequest`, plus a new `BuildRequestResult` dataclass. |
 
 ## Deleted symbols
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -577,6 +577,11 @@ tracing where a particular ivar lives.
 Feature APIs depend on the shared `notebooklm._session_contracts.Session`
 Protocol rather than concrete session internals.
 
+If you previously imported from `notebooklm._core_*` modules, see
+[`docs/migration-tier-12-to-13.md`](migration-tier-12-to-13.md) for the
+Tier 12 → Tier 13 rename table. The legacy `notebooklm._core` import path
+still resolves via a compatibility shim.
+
 ---
 
 ## API Reference

--- a/src/notebooklm/_authed_transport.py
+++ b/src/notebooklm/_authed_transport.py
@@ -2,6 +2,21 @@
 
 from __future__ import annotations
 
+__all__ = [
+    "MAX_RETRY_AFTER_SECONDS",
+    "MAX_RPC_RESPONSE_BYTES",
+    "AuthedTransport",
+    "_AuthedTransportHost",
+    "_AuthSnapshot",
+    "_BuildRequest",
+    "_PostBody",
+    "_TransportAuthExpired",
+    "_TransportRateLimited",
+    "_TransportServerError",
+    "_parse_retry_after",
+    "_stream_post_with_size_cap",
+]
+
 import asyncio
 import logging
 import time

--- a/src/notebooklm/_conversation_cache.py
+++ b/src/notebooklm/_conversation_cache.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ["MAX_CONVERSATION_CACHE_SIZE", "ConversationCache"]
+
 from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any

--- a/src/notebooklm/_cookie_persistence.py
+++ b/src/notebooklm/_cookie_persistence.py
@@ -1,6 +1,8 @@
-"""Cookie persistence collaborator for :mod:`notebooklm._core`."""
+"""Cookie persistence collaborator for :mod:`notebooklm._session`."""
 
 from __future__ import annotations
+
+__all__ = ["CookiePersistence", "SaveCookiesToStorage"]
 
 import threading
 from collections.abc import Awaitable, Callable

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ["DecodeResponse", "RpcExecutor", "RpcOwner"]
+
 import json
 import logging
 import time

--- a/tests/unit/test_tier_13_all_exports.py
+++ b/tests/unit/test_tier_13_all_exports.py
@@ -1,0 +1,95 @@
+"""Pin the ``__all__`` lists added in Tier 13 PR 13.9b.
+
+The Session/Kernel split (Tier 13) renamed several private modules out of the
+``_core_*`` namespace; PR 13.9b adds ``__all__`` to the collaborator modules
+that lacked one so the surface they expose to first-party callers (and test
+suites) is machine-checkable.
+
+These pins guard against silent surface drift (e.g. someone exports a new
+helper from ``_authed_transport`` without updating ``__all__`` or the
+migration doc). They are NOT public-API contracts — see
+``docs/stability.md`` for the public surface — but they pin the documented
+internal surface listed in ``docs/migration-tier-12-to-13.md``.
+"""
+
+from __future__ import annotations
+
+import notebooklm._authed_transport as authed_transport_module
+import notebooklm._conversation_cache as conversation_cache_module
+import notebooklm._cookie_persistence as cookie_persistence_module
+import notebooklm._rpc_executor as rpc_executor_module
+
+EXPECTED_AUTHED_TRANSPORT_ALL: list[str] = [
+    "MAX_RETRY_AFTER_SECONDS",
+    "MAX_RPC_RESPONSE_BYTES",
+    "AuthedTransport",
+    "_AuthedTransportHost",
+    "_AuthSnapshot",
+    "_BuildRequest",
+    "_PostBody",
+    "_TransportAuthExpired",
+    "_TransportRateLimited",
+    "_TransportServerError",
+    "_parse_retry_after",
+    "_stream_post_with_size_cap",
+]
+
+EXPECTED_RPC_EXECUTOR_ALL: list[str] = ["DecodeResponse", "RpcExecutor", "RpcOwner"]
+
+EXPECTED_CONVERSATION_CACHE_ALL: list[str] = [
+    "MAX_CONVERSATION_CACHE_SIZE",
+    "ConversationCache",
+]
+
+EXPECTED_COOKIE_PERSISTENCE_ALL: list[str] = [
+    "CookiePersistence",
+    "SaveCookiesToStorage",
+]
+
+
+def _check_module_all(module: object, expected: list[str], label: str) -> None:
+    actual = list(module.__all__)
+    assert actual == expected, (
+        f"{label}.__all__ drifted from the audited list.\n"
+        f"missing: {sorted(set(expected) - set(actual))}\n"
+        f"extra:   {sorted(set(actual) - set(expected))}\n"
+        f"order:   actual={actual!r}\n"
+        f"          expected={expected!r}"
+    )
+    # Every name in __all__ must resolve on the module.
+    for name in expected:
+        assert hasattr(module, name), (
+            f"{label}.__all__ lists {name!r} but the module has no such attribute"
+        )
+
+
+def test_authed_transport_all_pinned() -> None:
+    _check_module_all(
+        authed_transport_module,
+        EXPECTED_AUTHED_TRANSPORT_ALL,
+        "notebooklm._authed_transport",
+    )
+
+
+def test_rpc_executor_all_pinned() -> None:
+    _check_module_all(
+        rpc_executor_module,
+        EXPECTED_RPC_EXECUTOR_ALL,
+        "notebooklm._rpc_executor",
+    )
+
+
+def test_conversation_cache_all_pinned() -> None:
+    _check_module_all(
+        conversation_cache_module,
+        EXPECTED_CONVERSATION_CACHE_ALL,
+        "notebooklm._conversation_cache",
+    )
+
+
+def test_cookie_persistence_all_pinned() -> None:
+    _check_module_all(
+        cookie_persistence_module,
+        EXPECTED_COOKIE_PERSISTENCE_ALL,
+        "notebooklm._cookie_persistence",
+    )

--- a/tests/unit/test_type_boundaries.py
+++ b/tests/unit/test_type_boundaries.py
@@ -23,6 +23,7 @@ PUBLIC_DOC_ROOTS = (PROJECT_ROOT / "README.md", PROJECT_ROOT / "docs")
 INTERNAL_ARCHITECTURE_DOCS = {
     PROJECT_ROOT / "docs" / "development.md",
     PROJECT_ROOT / "docs" / "rpc-development.md",
+    PROJECT_ROOT / "docs" / "migration-tier-12-to-13.md",
 }
 
 # Add names here only for explicit facade wrappers that must keep a public


### PR DESCRIPTION
## Summary

Wave-9b of the Tier-12/13 greenfield migration. Pure additive documentation + machine-checkable internal-export pins. **No behavior change, no public surface change.**

- **New `docs/migration-tier-12-to-13.md`** — catalogs 13 renamed private modules (`_core_*` → final post-t13-8 names), symbol-level moves with their final home and shim status, the new Tier 12 / 13 modules (`_session_contracts`, `_kernel`, `_middleware*`, `_chat_transport`, `_request_types`), the one deleted symbol (`_SyntheticErrorTransport`), and the public-API-unchanged guarantee.
- **`__all__` added** to four collaborator modules that lacked one: `_authed_transport.py`, `_rpc_executor.py`, `_conversation_cache.py`, `_cookie_persistence.py`. Matches the existing pattern from `_session_helpers.py`, `_polling_registry.py`, etc.
- **`tests/unit/test_tier_13_all_exports.py`** — pins the four `__all__` sets so silent drift fails CI (mirrors the `test_public_surface.py` pattern).
- **`docs/python-api.md`** "Internal module map" section now cross-links the migration doc.

## Task spec

`.sisyphus/phases/tier-12-13-greenfield-migration/phase-2.md` → `### t13-9b-followup-allexports-and-migration-doc` (lines ~114-128).

Originally scoped as a stacked PR on `tier-13/t13-8-retire-core-files`; t13-8 merged as #859 while this was in flight, so the PR opens directly against `main` with one commit on top.

Excluded per spec MUST NOT DO:
- No changes to `_core_*.py`, `_session*.py`, `_kernel.py`, `_capabilities.py`, or feature modules.
- No public API broadening (`__init__.py` untouched).
- No strict-decode flip (already in t13-9a / PR #856).
- No new ADRs.

## Test plan

- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (136 source files)
- [x] `uv run pytest -n auto` — 5499 passed, 20 skipped
- [x] `uv run pytest tests/integration tests/e2e -m vcr -n auto` — 152 passed, 4 skipped
- [x] Every migration-doc claim cross-checked at runtime via `hasattr()` introspection (`_core` shim resolves all 14 documented symbols; `_core_*` modules no longer resolve as documented; ADR-011 link points to the correct file).
- [x] `__all__` pins verified by 4 new tests + manual external-import audit (every name in each `__all__` is consumed by callers in `src/` or `tests/`).

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a migration guide for Tier 12 → Tier 13 and updated Python API docs with guidance for legacy imports; public API surface unchanged.
* **Chores**
  * Declared and stabilized module public exports for several components to control visible API and prevent accidental surface drift.
* **Tests**
  * Added tests that pin and validate exported symbol lists and updated the internal-docs allowlist to include the new migration document.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->