### PR TITLE
fix(test): clean pytest warning summary

### DIFF
--- a/src/notebooklm/_artifact_listing.py
+++ b/src/notebooklm/_artifact_listing.py
@@ -18,6 +18,38 @@ ListRawCallback = Callable[[str], Awaitable[list[Any]]]
 ListMindMapsCallback = Callable[[str], Awaitable[list[Any]]]
 ListArtifactsCallback = Callable[[str], Awaitable[list[Artifact]]]
 
+_ARTIFACT_TYPE_CODES_BY_KIND = {
+    ArtifactType.AUDIO: ArtifactTypeCode.AUDIO.value,
+    ArtifactType.REPORT: ArtifactTypeCode.REPORT.value,
+    ArtifactType.VIDEO: ArtifactTypeCode.VIDEO.value,
+    ArtifactType.MIND_MAP: ArtifactTypeCode.MIND_MAP.value,
+    ArtifactType.INFOGRAPHIC: ArtifactTypeCode.INFOGRAPHIC.value,
+    ArtifactType.SLIDE_DECK: ArtifactTypeCode.SLIDE_DECK.value,
+    ArtifactType.DATA_TABLE: ArtifactTypeCode.DATA_TABLE.value,
+}
+_KNOWN_ARTIFACT_TYPE_CODES = frozenset(_ARTIFACT_TYPE_CODES_BY_KIND.values())
+
+
+def _matches_artifact_type(artifact: Artifact, artifact_type: ArtifactType | None) -> bool:
+    """Return whether ``artifact`` matches ``artifact_type`` without noisy kind warnings."""
+    if artifact_type is None:
+        return True
+
+    if artifact_type == ArtifactType.QUIZ:
+        return artifact._artifact_type == ArtifactTypeCode.QUIZ.value and artifact._variant == 2
+    if artifact_type == ArtifactType.FLASHCARDS:
+        return artifact._artifact_type == ArtifactTypeCode.QUIZ.value and artifact._variant == 1
+    if artifact_type == ArtifactType.UNKNOWN:
+        if artifact._artifact_type == ArtifactTypeCode.QUIZ.value:
+            return artifact._variant not in (1, 2)
+        return artifact._artifact_type not in _KNOWN_ARTIFACT_TYPE_CODES
+
+    type_code = _ARTIFACT_TYPE_CODES_BY_KIND.get(artifact_type)
+    if type_code is not None:
+        return artifact._artifact_type == type_code
+
+    return False
+
 
 class ArtifactListingService:
     """List, filter, and select artifacts without depending on the facade."""
@@ -135,7 +167,7 @@ class ArtifactListingService:
         for art_data in artifacts_data:
             if isinstance(art_data, list) and len(art_data) > 0:
                 artifact = Artifact.from_api_response(art_data)
-                if artifact_type is None or artifact.kind == artifact_type:
+                if _matches_artifact_type(artifact, artifact_type):
                     artifacts.append(artifact)
         return artifacts
 
@@ -149,6 +181,6 @@ class ArtifactListingService:
             if isinstance(mm_data, list):
                 mind_map_artifact = Artifact.from_mind_map(mm_data)
                 if mind_map_artifact is not None:
-                    if artifact_type is None or mind_map_artifact.kind == artifact_type:
+                    if _matches_artifact_type(mind_map_artifact, artifact_type):
                         artifacts.append(mind_map_artifact)
         return artifacts

--- a/tests/e2e/test_notebooks.py
+++ b/tests/e2e/test_notebooks.py
@@ -111,7 +111,8 @@ class TestNotebookSharing:
     @pytest.mark.asyncio
     async def test_share_notebook(self, client, temp_notebook):
         """Test sharing a notebook."""
-        result = await client.notebooks.share(temp_notebook.id, public=True)
+        with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+            result = await client.notebooks.share(temp_notebook.id, public=True)
         # Share returns {"public": bool, "url": str|None, "artifact_id": str|None}
         assert isinstance(result, dict)
         assert result["public"] is True
@@ -121,7 +122,8 @@ class TestNotebookSharing:
     @pytest.mark.asyncio
     async def test_revoke_share_notebook(self, client, temp_notebook):
         """Test revoking notebook sharing."""
-        result = await client.notebooks.share(temp_notebook.id, public=False)
+        with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+            result = await client.notebooks.share(temp_notebook.id, public=False)
         assert isinstance(result, dict)
         assert result["public"] is False
         assert result["url"] is None

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -11,6 +11,7 @@ Cassette-backed coverage for the same API surface lives in
 
 import csv
 import json
+import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,6 +33,7 @@ from notebooklm.types import (
     ArtifactNotReadyError,
     ArtifactParseError,
     ArtifactType,
+    UnknownTypeWarning,
 )
 
 pytestmark = pytest.mark.allow_no_vcr
@@ -727,10 +729,40 @@ class TestArtifactsAPI:
         )
         httpx_mock.add_response(content=response.encode())
 
-        async with NotebookLMClient(auth_tokens) as client:
-            artifacts = await client.artifacts.list_audio("nb_123")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnknownTypeWarning)
+            async with NotebookLMClient(auth_tokens) as client:
+                artifacts = await client.artifacts.list_audio("nb_123")
 
-        assert isinstance(artifacts, list)
+        assert [artifact.id for artifact in artifacts] == ["art_001"]
+
+    @pytest.mark.asyncio
+    async def test_list_unknown_artifacts_suppresses_unknown_type_warnings(
+        self,
+        auth_tokens,
+        httpx_mock: HTTPXMock,
+        build_rpc_response,
+    ):
+        """Filtering for UNKNOWN should not emit warnings while deciding matches."""
+        response = build_rpc_response(
+            RPCMethod.LIST_ARTIFACTS,
+            [
+                ["art_audio", "Audio Overview", 1, None, 3],
+                ["art_quiz_missing_variant", "Quiz", 4, None, 3],
+                ["art_future_type", "Future Artifact", 99, None, 3],
+            ],
+        )
+        httpx_mock.add_response(content=response.encode())
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnknownTypeWarning)
+            async with NotebookLMClient(auth_tokens) as client:
+                artifacts = await client.artifacts.list("nb_123", ArtifactType.UNKNOWN)
+
+        assert [artifact.id for artifact in artifacts] == [
+            "art_quiz_missing_variant",
+            "art_future_type",
+        ]
 
     @pytest.mark.asyncio
     async def test_list_video_artifacts(

--- a/tests/integration/test_notebooks_integration.py
+++ b/tests/integration/test_notebooks_integration.py
@@ -375,7 +375,8 @@ class TestNotebooksAPIAdditional:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.notebooks.share("nb_123", public=True)
+            with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+                result = await client.notebooks.share("nb_123", public=True)
 
         assert result["public"] is True
         assert "nb_123" in result["url"]
@@ -737,7 +738,8 @@ class TestShareEdgeCases:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.notebooks.share("nb_123", public=True, artifact_id="art_456")
+            with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+                result = await client.notebooks.share("nb_123", public=True, artifact_id="art_456")
 
         assert result["public"] is True
         assert result["url"] == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
@@ -755,7 +757,8 @@ class TestShareEdgeCases:
         httpx_mock.add_response(content=response.encode())
 
         async with NotebookLMClient(auth_tokens) as client:
-            result = await client.notebooks.share("nb_123", public=False)
+            with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+                result = await client.notebooks.share("nb_123", public=False)
 
         assert result["public"] is False
         assert result["url"] is None

--- a/tests/integration/test_sharing_vcr.py
+++ b/tests/integration/test_sharing_vcr.py
@@ -67,7 +67,8 @@ class TestSharingVCR:
         """
         auth = await get_vcr_auth()
         async with NotebookLMClient(auth) as client:
-            result = await client.notebooks.share(MUTABLE_NOTEBOOK_ID, public=True)
+            with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+                result = await client.notebooks.share(MUTABLE_NOTEBOOK_ID, public=True)
 
         assert isinstance(result, dict)
         assert result["public"] is True

--- a/tests/integration/test_vcr_comprehensive.py
+++ b/tests/integration/test_vcr_comprehensive.py
@@ -1007,14 +1007,20 @@ class TestResearchAPI:
         """Poll research status."""
         async with vcr_client() as client:
             # Start research first
-            await client.research.start(
+            start_result = await client.research.start(
                 MUTABLE_NOTEBOOK_ID,
                 query="Machine learning fundamentals",
                 source="web",
                 mode="fast",
             )
+            if not start_result or not start_result.get("task_id"):
+                pytest.skip("Could not start research")
+
             # Poll for results
-            result = await client.research.poll(MUTABLE_NOTEBOOK_ID)
+            result = await client.research.poll(
+                MUTABLE_NOTEBOOK_ID,
+                task_id=start_result["task_id"],
+            )
         assert result is not None
         assert "status" in result
 
@@ -1031,11 +1037,14 @@ class TestResearchAPI:
                 source="web",
                 mode="fast",
             )
-            if not start_result:
+            if not start_result or not start_result.get("task_id"):
                 pytest.skip("Could not start research")
 
             # Poll until we have sources (with timeout via cassette)
-            poll_result = await client.research.poll(MUTABLE_NOTEBOOK_ID)
+            poll_result = await client.research.poll(
+                MUTABLE_NOTEBOOK_ID,
+                task_id=start_result["task_id"],
+            )
             if not poll_result.get("sources"):
                 pytest.skip("No research sources found")
 

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -1327,9 +1327,13 @@ class TestAuthInspect:
         raw_cookies = _multiaccount_rookiepy_mock().chrome.return_value
         accounts = [Account(authuser=0, email="alice@example.com", is_default=True)]
 
+        def fake_run_async(awaitable):
+            awaitable.close()
+            return accounts
+
         with (
             patch("notebooklm.auth.enumerate_accounts", return_value=object()),
-            patch_session_login_dual("run_async", return_value=accounts) as mock_run_async,
+            patch_session_login_dual("run_async", side_effect=fake_run_async) as mock_run_async,
         ):
             result = _enumerate_one_jar(raw_cookies, "chrome", browser_profile=None)
 

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -247,7 +247,8 @@ async def test_share_sends_exact_share_artifact_payload_and_returns_deep_link(
     monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
     api = _make_api()
 
-    result = await api.share("nb_123", public=True, artifact_id="art_456")
+    with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+        result = await api.share("nb_123", public=True, artifact_id="art_456")
 
     assert result == {
         "public": True,
@@ -271,7 +272,8 @@ async def test_share_private_sends_disable_payload_and_returns_no_url(
     monkeypatch.delenv("NOTEBOOKLM_BASE_URL", raising=False)
     api = _make_api()
 
-    result = await api.share("nb_123", public=False)
+    with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+        result = await api.share("nb_123", public=False)
 
     assert result == {"public": False, "url": None, "artifact_id": None}
     api._core.rpc_call.assert_awaited_once_with(

--- a/tests/unit/test_playwright_marker_hook.py
+++ b/tests/unit/test_playwright_marker_hook.py
@@ -80,7 +80,16 @@ UNMARKED_TEST = textwrap.dedent(
 ).strip()
 
 
+PYTEST_INI = textwrap.dedent(
+    """
+    [pytest]
+    asyncio_default_fixture_loop_scope = function
+    """
+).strip()
+
+
 def _scaffold(pytester: pytest.Pytester, *, test_body: str) -> None:
+    pytester.makeini(PYTEST_INI)
     # ``pytester.makepyfile`` appends ``.py`` internally via
     # ``Path.with_suffix(".py")``, so keys are passed *without* the
     # extension (idiomatic per the pytest docs).

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -133,7 +133,8 @@ async def test_notebooks_api_default_share_manager_uses_late_bound_rpc_executor_
     replacement_rpc = AsyncMock(return_value=None)
     core.rpc_call = replacement_rpc
 
-    result = await api.share("nb_123", public=True, artifact_id="art_456")
+    with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+        result = await api.share("nb_123", public=True, artifact_id="art_456")
 
     assert result["url"] == "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456"
     replacement_rpc.assert_awaited_once_with(
@@ -153,7 +154,8 @@ async def test_notebooks_api_share_delegates_to_injected_share_manager() -> None
     share_manager.share = AsyncMock(return_value={"public": True, "url": "u", "artifact_id": None})
     api = NotebooksAPI(core, sources_api=MagicMock(), share_manager=share_manager)
 
-    result = await api.share("nb_123", public=True)
+    with pytest.warns(DeprecationWarning, match="NotebooksAPI.share"):
+        result = await api.share("nb_123", public=True)
 
     assert result == {"public": True, "url": "u", "artifact_id": None}
     share_manager.share.assert_awaited_once_with("nb_123", True, None)

--- a/tests/unit/test_tier_enforcement_hook.py
+++ b/tests/unit/test_tier_enforcement_hook.py
@@ -90,6 +90,7 @@ HOOK_SOURCE = textwrap.dedent(
 MARKER_REGISTRATION = textwrap.dedent(
     """
     [pytest]
+    asyncio_default_fixture_loop_scope = function
     markers =
         vcr: vcr-tier
         allow_no_vcr: opt out


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact type filtering logic, especially for unknown and quiz/flashcard artifacts.

* **Deprecations**
  * `NotebooksAPI.share()` now emits a deprecation warning.

* **Updates**
  * Research API polling now uses task-based approach with task identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->