### PR TITLE
fix(test): drop bogus conv_id-changes assertion in delete-conv e2e

### DIFF
--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -102,8 +102,14 @@ class TestChatE2E:
 
         Without an explicit delete, a null-``conversation_id`` ``ask()`` extends
         the most-recent server conversation (see ``ChatAPI.ask`` Note). After
-        deleting, the next null-conv ask must start a brand-new turn-1
-        conversation with a different ``conversation_id``.
+        deleting, the next null-conv ask starts a brand-new turn-1 conversation.
+
+        Note on conversation_id: ``hPTbtc`` (GET_LAST_CONVERSATION_ID) returns a
+        notebook-scoped "current conversation" slot that the server reuses for
+        the next turn-1 after a delete. So ``result2.conversation_id`` may equal
+        ``result1.conversation_id`` even though result2 is a genuinely fresh
+        conversation. The freshness signal is ``turn_number == 1`` /
+        ``is_follow_up is False``, plus the server-side turn count.
         """
         result1 = await client.chat.ask(
             multi_source_notebook_id,
@@ -118,9 +124,16 @@ class TestChatE2E:
             "Start fresh - what are the main themes?",
         )
 
-        assert result2.conversation_id != result1.conversation_id
         assert result2.is_follow_up is False
         assert result2.turn_number == 1
+
+        # Server-side confirmation that result2 really is a fresh conversation
+        # and not a follow-up to result1: the conversation should hold only the
+        # one Q&A pair we just posted.
+        history = await client.chat.get_history(
+            multi_source_notebook_id, conversation_id=result2.conversation_id
+        )
+        assert len(history) == 1
 
     @pytest.mark.asyncio
     async def test_ask_specific_sources(self, client, multi_source_notebook_id):

--- a/tests/e2e/test_chat.py
+++ b/tests/e2e/test_chat.py
@@ -129,7 +129,10 @@ class TestChatE2E:
 
         # Server-side confirmation that result2 really is a fresh conversation
         # and not a follow-up to result1: the conversation should hold only the
-        # one Q&A pair we just posted.
+        # one Q&A pair we just posted. Pin ``result2.conversation_id`` first so
+        # we don't silently fall through to the implicit "current conversation"
+        # that ``get_history`` would resolve on a ``None`` argument.
+        assert result2.conversation_id
         history = await client.chat.get_history(
             multi_source_notebook_id, conversation_id=result2.conversation_id
         )


### PR DESCRIPTION
## Summary

The nightly E2E run [26147106359](https://github.com/teng-lin/notebooklm-py/actions/runs/26147106359) failed (both initial run + 10-min retry) on `tests/e2e/test_chat.py::TestChatE2E::test_delete_conversation_forces_fresh_next_ask`:

```
tests/e2e/test_chat.py:121: in test_delete_conversation_forces_fresh_next_ask
    assert result2.conversation_id != result1.conversation_id
E   assert 'd10d6bfe-…' != 'd10d6bfe-…'
```

The assertion was wrong, not the SDK or the server. Live probe against a multi-source notebook:

```
[pre-ask1]  hPTbtc current conv_id = 'a278d293-...'
[ask1]      conv_id='a278d293-...'  turn=1
[post-ask1] hPTbtc current conv_id = 'a278d293-...'
[delete]    deleted 'a278d293-...'
[post-del]  hPTbtc current conv_id = 'a278d293-...'   ← survives delete
[ask2]      conv_id='a278d293-...'  turn=1  is_follow_up=False
get_history(a278d293-...) → 1 entry: 'Start fresh - what are the main themes?'
```

`hPTbtc` (GET_LAST_CONVERSATION_ID) returns a notebook-scoped "current conversation" **slot** that the server reuses for the next turn-1 after a delete — so `result2.conversation_id == result1.conversation_id` is expected, even though the underlying conversation is genuinely fresh.

## Change

- Drop `assert result2.conversation_id != result1.conversation_id` — wrong premise.
- Keep `result2.turn_number == 1` and `result2.is_follow_up is False` as before.
- Add `len(client.chat.get_history(notebook_id, conversation_id=result2.conv_id)) == 1` as the real server-side freshness proof (the conversation holds only result2's turn, not a follow-up extending result1's history).
- Update the docstring to document the slot-reuse behavior so the next reader doesn't reintroduce the wrong assertion.

## Test plan

- [x] Live probe against `c3f6285f-…` (TypeScript Fundamentals, 5 sources) — confirms `get_history` returns exactly 1 entry post-delete+ask.
- [x] `ruff format` + `ruff check` clean.
- [ ] Nightly e2e on next scheduled run is the real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E testing for conversation deletion: tests now allow server-side reuse of conversation IDs while verifying a fresh conversation by checking turn number resets to 1, is not treated as a follow-up, and conversation history contains a single Q&A entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->