### PR TITLE
refactor(core): step 1+2 — add capability protocols; retype pure-RPC features

### DIFF
--- a/src/notebooklm/_notebooks.py
+++ b/src/notebooklm/_notebooks.py
@@ -10,7 +10,7 @@ from ._notebook_metadata import (
     NotebookSourceLister,
     create_default_source_lister,
 )
-from ._session_contracts import Session
+from ._session_contracts import RpcCaller
 from ._settings import build_get_user_settings_params, extract_account_limits
 from ._sharing_manager import ShareManager
 from .exceptions import (
@@ -143,7 +143,7 @@ class NotebooksAPI:
 
     def __init__(
         self,
-        session: Session,
+        rpc: RpcCaller,
         sources_api: NotebookSourceLister | None = None,
         *,
         metadata_service: NotebookMetadataService | None = None,
@@ -152,12 +152,12 @@ class NotebooksAPI:
         """Initialize the notebooks API.
 
         Args:
-            session: The shared client session.
+            rpc: RPC dispatch surface (typically the shared client session).
             sources_api: Optional source lister for cross-API metadata composition.
             metadata_service: Optional explicit metadata service for tests or advanced wiring.
             share_manager: Optional explicit legacy share manager for tests or advanced wiring.
         """
-        self._core = session
+        self._rpc = rpc
         self._sources = sources_api or create_default_source_lister(self._rpc_call)
         self._metadata_service = metadata_service or NotebookMetadataService(
             # Keep notebook lookup late-bound so tests and advanced callers that
@@ -176,15 +176,17 @@ class NotebooksAPI:
         _is_retry: bool = False,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any:
-        """Delegate through the current core RPC method for late-bound overrides."""
-        return await self._core.rpc_call(
+        """Delegate through the current RPC caller for late-bound overrides."""
+        return await self._rpc.rpc_call(
             method,
             params,
             source_path=source_path,
             allow_null=allow_null,
             _is_retry=_is_retry,
             disable_internal_retries=disable_internal_retries,
+            operation_variant=operation_variant,
         )
 
     async def get_source_ids(self, notebook_id: str) -> list[str]:
@@ -267,7 +269,7 @@ class NotebooksAPI:
         """
         logger.debug("Listing notebooks")
         params = [None, 1, None, [2]]
-        result = await self._core.rpc_call(RPCMethod.LIST_NOTEBOOKS, params)
+        result = await self._rpc.rpc_call(RPCMethod.LIST_NOTEBOOKS, params)
 
         if result and isinstance(result, list) and len(result) > 0:
             raw_notebooks = result[0] if isinstance(result[0], list) else result
@@ -325,7 +327,7 @@ class NotebooksAPI:
 
         async def _create() -> Notebook:
             try:
-                result = await self._core.rpc_call(
+                result = await self._rpc.rpc_call(
                     RPCMethod.CREATE_NOTEBOOK,
                     params,
                     disable_internal_retries=True,
@@ -442,7 +444,7 @@ class NotebooksAPI:
 
     async def _get_account_limits(self) -> AccountLimits:
         """Fetch NotebookLM account limits from user settings."""
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_USER_SETTINGS,
             build_get_user_settings_params(),
             source_path="/",
@@ -465,7 +467,7 @@ class NotebooksAPI:
                 this method post-validates the parsed response.
         """
         params = [notebook_id, None, [2], None, 0]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -504,7 +506,7 @@ class NotebooksAPI:
         """
         logger.debug("Deleting notebook: %s", notebook_id)
         params = [[notebook_id], [2]]
-        await self._core.rpc_call(RPCMethod.DELETE_NOTEBOOK, params)
+        await self._rpc.rpc_call(RPCMethod.DELETE_NOTEBOOK, params)
         return True
 
     async def rename(self, notebook_id: str, new_title: str) -> Notebook:
@@ -521,7 +523,7 @@ class NotebooksAPI:
         # Payload format discovered via browser traffic capture:
         # [notebook_id, [[null, null, null, [null, new_title]]]]
         params = [notebook_id, [[None, None, None, [None, new_title]]]]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.RENAME_NOTEBOOK,
             params,
             source_path="/",  # Home page context, not notebook page
@@ -542,7 +544,7 @@ class NotebooksAPI:
             Raw summary text string.
         """
         params = [notebook_id, [2]]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.SUMMARIZE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -578,7 +580,7 @@ class NotebooksAPI:
         """
         # Get raw summary data
         params = [notebook_id, [2]]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.SUMMARIZE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -606,7 +608,7 @@ class NotebooksAPI:
             notebook_id: The notebook ID to remove from recent.
         """
         params = [notebook_id]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.REMOVE_RECENTLY_VIEWED,
             params,
             allow_null=True,
@@ -625,7 +627,7 @@ class NotebooksAPI:
             Raw API response data.
         """
         params = [notebook_id, None, [2], None, 0]
-        return await self._core.rpc_call(
+        return await self._rpc.rpc_call(
             RPCMethod.GET_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_research.py
+++ b/src/notebooklm/_research.py
@@ -9,7 +9,7 @@ import warnings
 from typing import Any
 
 from . import research as _research_pub
-from ._session_contracts import Session
+from ._session_contracts import RpcCaller
 from .exceptions import ResearchTaskMismatchError, ValidationError
 from .rpc import RPCMethod, safe_index
 from .types import CitedSourceSelection
@@ -201,13 +201,13 @@ class ResearchAPI:
                 )
     """
 
-    def __init__(self, session: Session):
+    def __init__(self, rpc: RpcCaller):
         """Initialize the research API.
 
         Args:
-            session: The shared client session.
+            rpc: RPC dispatch surface (typically the shared client session).
         """
-        self._core = session
+        self._rpc = rpc
 
     @staticmethod
     def _parse_result_type(value: Any) -> int | str:
@@ -320,7 +320,7 @@ class ResearchAPI:
             params = [None, [1], [query, source_type], 5, notebook_id]
             rpc_id = RPCMethod.START_DEEP_RESEARCH
 
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             rpc_id,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -389,7 +389,7 @@ class ResearchAPI:
         """
         logger.debug("Polling research status for notebook %s", notebook_id)
         params = [None, None, notebook_id]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.POLL_RESEARCH,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -615,7 +615,7 @@ class ResearchAPI:
 
         params = [None, [1], effective_task_id, notebook_id, source_array]
 
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.IMPORT_RESEARCH,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_session_contracts.py
+++ b/src/notebooklm/_session_contracts.py
@@ -99,9 +99,55 @@ class DrainHookRegistration(Protocol):
     ) -> None: ...
 
 
+class RpcCaller(Protocol):
+    """Narrow RPC dispatch surface consumed by pure-RPC feature APIs.
+
+    Mirrors the legacy :meth:`Session.rpc_call` signature exactly so
+    Phase 1 feature retypes do not change call semantics. The transitional
+    ``_is_retry`` parameter and the keyword-only ``disable_internal_retries``
+    / ``operation_variant`` parameters are preserved as-is.
+
+    A concrete :class:`Session` structurally satisfies this Protocol;
+    features that only need to issue RPC calls can depend on this narrower
+    surface to avoid coupling to the rest of the broad ``Session`` Protocol.
+    """
+
+    async def rpc_call(
+        self,
+        method: RPCMethod,
+        params: list[Any],
+        source_path: str = "/",
+        allow_null: bool = False,
+        _is_retry: bool = False,
+        *,
+        disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
+    ) -> Any: ...
+
+
+class LoopGuard(Protocol):
+    """Loop-affinity assertion surface for features that own async work."""
+
+    def assert_bound_loop(self) -> None: ...
+
+
+class OperationScopeProvider(Protocol):
+    """``operation_scope`` async-context-manager surface for feature APIs."""
+
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]: ...
+
+
+class AsyncWorkRuntime(LoopGuard, OperationScopeProvider, Protocol):
+    """Runtime support for feature-owned async work."""
+
+
 __all__ = [
+    "AsyncWorkRuntime",
     "AuthMetadata",
     "DrainHookRegistration",
     "Kernel",
+    "LoopGuard",
+    "OperationScopeProvider",
+    "RpcCaller",
     "Session",
 ]

--- a/src/notebooklm/_settings.py
+++ b/src/notebooklm/_settings.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Sequence
 from typing import Any
 
-from ._session_contracts import Session
+from ._session_contracts import RpcCaller
 from .rpc import RPCMethod
 from .types import AccountLimits, AccountTier
 
@@ -141,13 +141,13 @@ class SettingsAPI:
     _SET_LANGUAGE_PATH = (2, 4, 0)  # result[2][4][0]
     _GET_SETTINGS_PATH = (0, 2, 4, 0)  # result[0][2][4][0]
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, rpc: RpcCaller) -> None:
         """Initialize the settings API.
 
         Args:
-            session: The shared client session.
+            rpc: RPC dispatch surface (typically the shared client session).
         """
-        self._core = session
+        self._rpc = rpc
 
     async def set_output_language(self, language: str) -> str | None:
         """Set the output language for artifact generation.
@@ -176,7 +176,7 @@ class SettingsAPI:
         # Params structure: [[[null,[[null,null,null,null,["language_code"]]]]]]
         params = [[[None, [[None, None, None, None, [language]]]]]]
 
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.SET_USER_SETTINGS,
             params,
             source_path="/",
@@ -197,7 +197,7 @@ class SettingsAPI:
         """
         logger.debug("Fetching user settings to get output language")
 
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_USER_SETTINGS,
             build_get_user_settings_params(),
             source_path="/",
@@ -215,7 +215,7 @@ class SettingsAPI:
         """
         logger.debug("Fetching user settings to get account limits")
 
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_USER_SETTINGS,
             build_get_user_settings_params(),
             source_path="/",
@@ -236,7 +236,7 @@ class SettingsAPI:
         """
         logger.debug("Fetching user tier")
 
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_USER_TIER,
             build_get_user_tier_params(),
             source_path="/",

--- a/src/notebooklm/_sharing.py
+++ b/src/notebooklm/_sharing.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ._session_contracts import Session
+from ._session_contracts import RpcCaller
 from .rpc import RPCMethod
 from .rpc.types import ShareAccess, SharePermission, ShareViewLevel
 from .types import ShareStatus
@@ -34,13 +34,13 @@ class SharingAPI:
             )
     """
 
-    def __init__(self, session: Session):
+    def __init__(self, rpc: RpcCaller):
         """Initialize the sharing API.
 
         Args:
-            session: The shared client session.
+            rpc: RPC dispatch surface (typically the shared client session).
         """
-        self._core = session
+        self._rpc = rpc
 
     async def get_status(self, notebook_id: str) -> ShareStatus:
         """Get current sharing configuration.
@@ -53,7 +53,7 @@ class SharingAPI:
         """
         logger.debug("Getting share status for notebook: %s", notebook_id)
         params = [notebook_id, [2]]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_SHARE_STATUS,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -87,7 +87,7 @@ class SharingAPI:
             None,
             [2],
         ]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.SHARE_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -119,7 +119,7 @@ class SharingAPI:
             notebook_id,
             [[None, None, None, None, None, None, None, None, [[level.value]]]],
         ]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.RENAME_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -188,7 +188,7 @@ class SharingAPI:
             None,
             [2],
         ]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.SHARE_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -242,7 +242,7 @@ class SharingAPI:
             None,
             [2],
         ]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.SHARE_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -291,6 +291,7 @@ class NotebookLMClient:
         )
         self.notes = NotesAPI(self._core)
         self.chat = ChatAPI(self._core, notebooks=self.notebooks)
+        # Pure-RPC features (Phase 1 retypes: typed as `rpc: RpcCaller`).
         self.research = ResearchAPI(self._core)
         self.settings = SettingsAPI(self._core)
         self.sharing = SharingAPI(self._core)

--- a/tests/_fixtures/conftest.py
+++ b/tests/_fixtures/conftest.py
@@ -14,7 +14,7 @@ Tests can either:
 
        async def test_list_uses_rpc(fake_core):
            fake_core.rpc_call.return_value = [payload]
-           api = NotebooksAPI(core=fake_core)
+           api = NotebooksAPI(fake_core)
            ...
 
 2. Use the ``make_fake_core`` fixture (the factory itself) when each
@@ -22,7 +22,7 @@ Tests can either:
 
        async def test_list_uses_rpc(make_fake_core):
            fake = make_fake_core(rpc_call=AsyncMock(return_value=[payload]))
-           api = NotebooksAPI(core=fake)
+           api = NotebooksAPI(fake)
            ...
 
 3. Or, equivalently, ``from _fixtures import make_fake_core`` and skip

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -3,7 +3,7 @@
 This module provides a single entry point — :func:`make_fake_core` — that
 returns a ``FakeSession`` instance shaped to satisfy the shared
 ``Session`` Protocol and explicit feature collaborators. Tests pass the
-result to a sub-client constructor (``NotebooksAPI(core=fake)``) instead
+result to a sub-client constructor (``NotebooksAPI(fake)``) instead
 of constructing a real ``Session`` and mutating its attributes after
 the fact.
 
@@ -68,7 +68,7 @@ def make_fake_core(**overrides: Any) -> FakeSession:
     Example::
 
         fake = make_fake_core(rpc_call=AsyncMock(return_value=[payload]))
-        api = NotebooksAPI(core=fake)
+        api = NotebooksAPI(fake)
         result = await api.list()
         fake.rpc_call.assert_awaited_once()
     """

--- a/tests/integration/test_get_summary_drift.py
+++ b/tests/integration/test_get_summary_drift.py
@@ -33,7 +33,7 @@ def _make_api(rpc_return):
     api = NotebooksAPI.__new__(NotebooksAPI)
     core = MagicMock()
     core.rpc_call = AsyncMock(return_value=rpc_return)
-    api._core = core
+    api._rpc = core
     return api
 
 

--- a/tests/unit/test_notebook_api.py
+++ b/tests/unit/test_notebook_api.py
@@ -255,13 +255,14 @@ async def test_share_sends_exact_share_artifact_payload_and_returns_deep_link(
         "url": "https://notebooklm.google.com/notebook/nb_123?artifactId=art_456",
         "artifact_id": "art_456",
     }
-    api._core.rpc_call.assert_awaited_once_with(
+    api._rpc.rpc_call.assert_awaited_once_with(
         RPCMethod.SHARE_ARTIFACT,
         [[1], "nb_123", "art_456"],
         source_path="/notebook/nb_123",
         allow_null=True,
         _is_retry=False,
         disable_internal_retries=False,
+        operation_variant=None,
     )
 
 
@@ -276,13 +277,14 @@ async def test_share_private_sends_disable_payload_and_returns_no_url(
         result = await api.share("nb_123", public=False)
 
     assert result == {"public": False, "url": None, "artifact_id": None}
-    api._core.rpc_call.assert_awaited_once_with(
+    api._rpc.rpc_call.assert_awaited_once_with(
         RPCMethod.SHARE_ARTIFACT,
         [[0], "nb_123"],
         source_path="/notebook/nb_123",
         allow_null=True,
         _is_retry=False,
         disable_internal_retries=False,
+        operation_variant=None,
     )
 
 
@@ -312,7 +314,7 @@ class TestCreateNotebookQuotaDetection:
         # observes the CREATE_NOTEBOOK call.
         api = _make_api()
         api.list = AsyncMock(return_value=[])  # baseline empty
-        api._core.rpc_call.return_value = [
+        api._rpc.rpc_call.return_value = [
             "Daily News",
             None,
             "new_notebook_id",
@@ -324,7 +326,7 @@ class TestCreateNotebookQuotaDetection:
         notebook = await api.create("Daily News")
 
         assert notebook.id == "new_notebook_id"
-        api._core.rpc_call.assert_awaited_once_with(
+        api._rpc.rpc_call.assert_awaited_once_with(
             RPCMethod.CREATE_NOTEBOOK,
             build_create_notebook_params("Daily News"),
             disable_internal_retries=True,
@@ -334,7 +336,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_create_invalid_argument_near_paid_limit_raises_limit_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         account_limits = _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(499))
 
@@ -354,7 +356,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_create_invalid_argument_at_paid_limit_raises_limit_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(500))
 
@@ -367,7 +369,7 @@ class TestCreateNotebookQuotaDetection:
     @pytest.mark.asyncio
     async def test_create_invalid_argument_near_free_limit_raises_limit_error(self):
         api = _make_api()
-        api._core.rpc_call = AsyncMock(side_effect=_create_invalid_argument_error())
+        api._rpc.rpc_call = AsyncMock(side_effect=_create_invalid_argument_error())
         _set_account_limit(api, 100)
         api.list = AsyncMock(return_value=_owned_notebooks(100))
 
@@ -381,7 +383,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_create_invalid_argument_uses_account_limit_not_free_boundary(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(100))
 
@@ -394,7 +396,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_create_invalid_argument_away_from_server_limit_preserves_rpc_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(250))
 
@@ -407,7 +409,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_non_quota_rpc_code_preserves_rpc_error_without_listing(self):
         api = _make_api()
         original = _create_invalid_argument_error(rpc_code=13)
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             return_value=AccountLimits(notebook_limit=500)
         )
@@ -427,7 +429,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_non_create_method_preserves_rpc_error_without_listing(self):
         api = _make_api()
         original = _create_invalid_argument_error(method_id=RPCMethod.GET_NOTEBOOK.value)
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             return_value=AccountLimits(notebook_limit=500)
         )
@@ -446,7 +448,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_shared_notebooks_do_not_trigger_owned_quota_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, 500)
         api.list = AsyncMock(return_value=_owned_notebooks(20) + _shared_notebooks(479))
 
@@ -459,7 +461,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_account_limit_failure_preserves_original_create_error_without_listing(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             side_effect=NetworkError("settings failed")
         )
@@ -477,7 +479,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_account_limit_rpc_error_preserves_original_create_error_without_listing(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         api._get_account_limits = AsyncMock(  # type: ignore[method-assign]
             side_effect=RPCError("settings failed")
         )
@@ -494,7 +496,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_missing_account_limit_preserves_original_create_error_without_listing(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, None)
         api.list = AsyncMock(return_value=_owned_notebooks(500))
 
@@ -509,7 +511,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_list_failure_preserves_original_create_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, 500)
         api.list = AsyncMock(side_effect=NetworkError("list failed"))
 
@@ -522,7 +524,7 @@ class TestCreateNotebookQuotaDetection:
     async def test_list_parse_bug_preserves_original_create_error(self):
         api = _make_api()
         original = _create_invalid_argument_error()
-        api._core.rpc_call = AsyncMock(side_effect=original)
+        api._rpc.rpc_call = AsyncMock(side_effect=original)
         _set_account_limit(api, 500)
         api.list = AsyncMock(side_effect=ValueError("bad notebook data"))
 
@@ -534,7 +536,7 @@ class TestCreateNotebookQuotaDetection:
     @pytest.mark.asyncio
     async def test_get_account_limits_uses_user_settings_rpc(self):
         api = _make_api()
-        api._core.rpc_call = AsyncMock(return_value=[[None, [6, 500, 300, 500000, 2]]])
+        api._rpc.rpc_call = AsyncMock(return_value=[[None, [6, 500, 300, 500000, 2]]])
 
         limits = await api._get_account_limits()
 
@@ -543,7 +545,7 @@ class TestCreateNotebookQuotaDetection:
             source_limit=300,
             raw_limits=(6, 500, 300, 500000, 2),
         )
-        api._core.rpc_call.assert_awaited_once_with(
+        api._rpc.rpc_call.assert_awaited_once_with(
             RPCMethod.GET_USER_SETTINGS,
             [None, [1, None, None, None, None, None, None, None, None, None, [1]]],
             source_path="/",
@@ -563,7 +565,7 @@ class TestGetNotebookFailsClosed:
     async def test_get_returns_notebook_on_full_response(self):
         api = _make_api()
         # Realistic shape: [[title, ?, id, ?, ?, [None, False, ...]], ...]
-        api._core.rpc_call = AsyncMock(
+        api._rpc.rpc_call = AsyncMock(
             return_value=[["My Notebook", None, "nb_real_123", None, None, [None, False]]]
         )
 
@@ -576,7 +578,7 @@ class TestGetNotebookFailsClosed:
     async def test_get_raises_on_empty_outer_list(self):
         """Server returned ``[]`` — no notebook at all."""
         api = _make_api()
-        api._core.rpc_call = AsyncMock(return_value=[])
+        api._rpc.rpc_call = AsyncMock(return_value=[])
 
         with pytest.raises(NotebookNotFoundError) as exc_info:
             await api.get("nb_missing")
@@ -587,7 +589,7 @@ class TestGetNotebookFailsClosed:
     @pytest.mark.asyncio
     async def test_get_raises_on_none_response(self):
         api = _make_api()
-        api._core.rpc_call = AsyncMock(return_value=None)
+        api._rpc.rpc_call = AsyncMock(return_value=None)
 
         with pytest.raises(NotebookNotFoundError):
             await api.get("nb_missing")
@@ -596,7 +598,7 @@ class TestGetNotebookFailsClosed:
     async def test_get_raises_on_degenerate_empty_inner(self):
         """``[[]]`` — outer wrapper present but inner notebook payload empty."""
         api = _make_api()
-        api._core.rpc_call = AsyncMock(return_value=[[]])
+        api._rpc.rpc_call = AsyncMock(return_value=[[]])
 
         with pytest.raises(NotebookNotFoundError) as exc_info:
             await api.get("nb_typo")
@@ -608,7 +610,7 @@ class TestGetNotebookFailsClosed:
         """Both id and title parsed to empty string → treat as not found."""
         api = _make_api()
         # Same shape as the happy path but with empty strings in both fields.
-        api._core.rpc_call = AsyncMock(return_value=[["", None, "", None, None, [None, False]]])
+        api._rpc.rpc_call = AsyncMock(return_value=[["", None, "", None, None, [None, False]]])
 
         with pytest.raises(NotebookNotFoundError):
             await api.get("nb_typo")
@@ -622,7 +624,7 @@ class TestGetNotebookFailsClosed:
         returns a Notebook rather than raising.
         """
         api = _make_api()
-        api._core.rpc_call = AsyncMock(
+        api._rpc.rpc_call = AsyncMock(
             return_value=[["Title Only", None, "", None, None, [None, False]]]
         )
 

--- a/tests/unit/test_sharing_manager.py
+++ b/tests/unit/test_sharing_manager.py
@@ -144,6 +144,7 @@ async def test_notebooks_api_default_share_manager_uses_late_bound_rpc_executor_
         allow_null=True,
         _is_retry=False,
         disable_internal_retries=False,
+        operation_variant=None,
     )
 
 

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -137,7 +137,7 @@ async def test_summary_warns_on_indexerror_drift(caplog, monkeypatch):
     # We need a shape that raises IndexError. result[0] is an empty list →
     # result[0][0] raises IndexError.
     mock_core.rpc_call = AsyncMock(return_value=[[]])
-    api._core = mock_core
+    api._rpc = mock_core
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):
         summary = await api.get_summary("nb_summary")
@@ -171,7 +171,7 @@ async def test_description_partial_summary_logs_debug(caplog):
     mock_core = MagicMock()
     # outer[0][0] works but outer[1] raises (no topics shape)
     mock_core.rpc_call = AsyncMock(return_value=[[["the summary"]]])
-    api._core = mock_core
+    api._rpc = mock_core
 
     with caplog.at_level(logging.DEBUG, logger="notebooklm"):
         desc = await api.get_description("nb_partial")


### PR DESCRIPTION
## Summary
- Adds new shared capability Protocols to `_session_contracts.py`: `RpcCaller`, `LoopGuard`, `OperationScopeProvider`, `AsyncWorkRuntime` (additive — broad `Session` untouched, slated for Phase 7 deletion).
- Retypes 4 pure-RPC features (`NotebooksAPI`, `ResearchAPI`, `SettingsAPI`, `SharingAPI`) from broad-Session to `RpcCaller`. Renames `self._core` → `self._rpc` (29 occurrences across the 4 modules).
- Fixes `NotebooksAPI._rpc_call` to accept AND forward the `operation_variant` kwarg required by `RpcCaller`.
- Updates test sites that touched `api._core` (3 files) and updates 2 docstring examples in `tests/_fixtures/`. Two share-manager call-shape assertions now also expect `operation_variant=None` because the shim always forwards it.

## Why
Phase 1 of 7 in the capability refactor arc (ADR-013, ratified in #866). Steps 1+2 from `docs/refactor.md` fused into one PR per the user-selected fused-mode execution. Unblocks Phases 2+3+4 (Wave 3).

## Test plan
- [x] mypy clean (`uv run mypy src/notebooklm --ignore-missing-imports`)
- [x] pytest clean (`uv run pytest`, 5505 passed, 14 skipped)
- [x] Pre-commit clean (`uv run pre-commit run --all-files`)
- [x] Broad `Session` Protocol still present (Phase 7 will delete)
- [x] `_core.py` shim untouched (`git diff main -- src/notebooklm/_core.py` is empty)
- [x] `self._core = self._session` alias preserved in `client.py`
- [x] Each of 4 features uses `self._rpc`; zero `self._core` in those modules
- [x] `NotebooksAPI._rpc_call` accepts AND forwards `operation_variant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal improvements to API architecture dependencies. No changes to end-user functionality or features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->