### PR TITLE
refactor(chat): step 3 — local ChatRuntime; remove core= alias

### DIFF
--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -295,9 +295,10 @@ class ChatAPI:
 
             # Mint the request-id under the asyncio-safe counter helper so two
             # concurrent ``ask`` calls on the same client never collide. The
-            # previous direct mutation ``self._runtime._reqid_counter += 100000``
-            # raced under ``asyncio.gather`` and produced duplicate ``_reqid``
-            # URL params.
+            # previous direct mutation ``self._core._reqid_counter += 100000``
+            # (``self._core`` was the pre-Phase-2 attribute name, now
+            # ``self._runtime``) raced under ``asyncio.gather`` and produced
+            # duplicate ``_reqid`` URL params.
             reqid = await self._runtime.next_reqid()
 
             def build_request(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:

--- a/src/notebooklm/_chat.py
+++ b/src/notebooklm/_chat.py
@@ -8,7 +8,9 @@ import asyncio
 import contextlib
 import logging
 import weakref
-from typing import Any
+from typing import Any, Protocol
+
+import httpx
 
 from ._authed_transport import _AuthSnapshot
 from ._chat_protocol import (
@@ -26,7 +28,8 @@ from ._chat_transport import chat_aware_authed_post
 from ._conversation_cache import ConversationCache
 from ._logging import get_request_id, reset_request_id, set_request_id
 from ._notebook_metadata import NotebookSourceIdProvider
-from ._session_contracts import Session
+from ._request_types import BuildRequest
+from ._session_contracts import LoopGuard, RpcCaller
 from .exceptions import ChatError, NetworkError, ValidationError
 from .rpc import (
     ChatGoal,
@@ -83,6 +86,27 @@ def _extract_next_turn_content(next_turn: Any) -> str | None:
     return content
 
 
+class ChatRuntime(RpcCaller, LoopGuard, Protocol):
+    """Runtime capabilities required by the chat feature.
+
+    Local to ``_chat.py`` because ``transport_post`` and ``next_reqid`` are
+    chat-specific surfaces today and not shared with any other feature. If
+    another feature later needs the same capability, promote these members
+    to ``_session_contracts.py``; until then keeping them local minimises
+    the chat dependency surface (refactor.md §Local Chat Runtime, ADR-013).
+    """
+
+    async def transport_post(
+        self,
+        build_request: BuildRequest,
+        parse_label: str,
+        *,
+        disable_internal_retries: bool = False,
+    ) -> httpx.Response: ...
+
+    async def next_reqid(self, step: int = 100000) -> int: ...
+
+
 class ChatAPI:
     """Operations for notebook chat/conversations.
 
@@ -105,37 +129,30 @@ class ChatAPI:
 
     def __init__(
         self,
-        session: Session | None = None,
+        runtime: ChatRuntime,
         *,
-        core: Session | None = None,
         conversation_cache: ConversationCache | None = None,
         notebooks: NotebookSourceIdProvider | None = None,
     ):
         """Initialize the chat API.
 
         Args:
-            session: The shared client session.
-            core: Deprecated alias for ``session`` kept for tests and older
-                direct construction sites.
+            runtime: Local :class:`ChatRuntime` providing RPC dispatch,
+                chat-aware transport, request-id minting, and loop-affinity
+                assertion. The concrete :class:`Session` structurally
+                satisfies this protocol.
             conversation_cache: Optional injected cache; defaults to a fresh
                 per-instance ``ConversationCache`` (chat-domain state, no
                 other consumer).
             notebooks: Optional source-id resolver. Defaults to a
-                ``NotebooksAPI`` wrapper around ``core`` for backward
-                compatibility with tests that construct ``ChatAPI(core)``.
+                ``NotebooksAPI`` wrapper around ``runtime`` for backward
+                compatibility with tests that construct ``ChatAPI(fake)``.
         """
-        if session is None:
-            if core is None:
-                raise TypeError("ChatAPI requires a session")
-            session = core
-        elif core is not None:
-            raise TypeError("ChatAPI received both 'session' and 'core'")
-
-        self._core = session
+        self._runtime = runtime
         if notebooks is None:
             from ._notebooks import NotebooksAPI
 
-            notebooks = NotebooksAPI(session)
+            notebooks = NotebooksAPI(runtime)
         self._notebooks = notebooks
         self._cache = conversation_cache if conversation_cache is not None else ConversationCache()
         # Per-``conversation_id`` lock that serializes follow-up asks on the
@@ -234,7 +251,7 @@ class ChatAPI:
         # guard at ``_authed_transport.py:258-262`` only catches misuse on
         # the POST itself, which is *after* the conversation lock is
         # already held — too late.
-        self._core.assert_bound_loop()
+        self._runtime.assert_bound_loop()
         logger.debug(
             "Asking question in notebook %s (conversation=%s)",
             notebook_id,
@@ -278,10 +295,10 @@ class ChatAPI:
 
             # Mint the request-id under the asyncio-safe counter helper so two
             # concurrent ``ask`` calls on the same client never collide. The
-            # previous direct mutation ``self._core._reqid_counter += 100000``
+            # previous direct mutation ``self._runtime._reqid_counter += 100000``
             # raced under ``asyncio.gather`` and produced duplicate ``_reqid``
             # URL params.
-            reqid = await self._core.next_reqid()
+            reqid = await self._runtime.next_reqid()
 
             def build_request(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
                 return self._build_chat_request(
@@ -303,7 +320,7 @@ class ChatAPI:
             reqid_token = None if get_request_id() is not None else set_request_id()
             try:
                 response = await chat_aware_authed_post(
-                    self._core,
+                    self._runtime,
                     build_request=build_request,
                     parse_label="chat.ask",
                 )
@@ -418,7 +435,7 @@ class ChatAPI:
             limit,
         )
         params: list[Any] = [[], None, None, conversation_id, limit]
-        return await self._core.rpc_call(
+        return await self._runtime.rpc_call(
             RPCMethod.GET_CONVERSATION_TURNS,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -437,7 +454,7 @@ class ChatAPI:
         """
         logger.debug("Getting conversation ID for notebook %s", notebook_id)
         params: list[Any] = [[], None, notebook_id, 1]
-        raw = await self._core.rpc_call(
+        raw = await self._runtime.rpc_call(
             RPCMethod.GET_LAST_CONVERSATION_ID,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -593,7 +610,7 @@ class ChatAPI:
             # Param shape captured from web-UI traffic. The trailing 1 is
             # always observed; its meaning is uncharted — treated as a fixed flag.
             params: list[Any] = [[], conversation_id, None, 1]
-            await self._core.rpc_call(
+            await self._runtime.rpc_call(
                 RPCMethod.DELETE_CONVERSATION,
                 params,
                 source_path=f"/notebook/{notebook_id}",
@@ -650,7 +667,7 @@ class ChatAPI:
             [[None, None, None, None, None, None, None, chat_settings]],
         ]
 
-        await self._core.rpc_call(
+        await self._runtime.rpc_call(
             RPCMethod.RENAME_NOTEBOOK,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_chat_transport.py
+++ b/src/notebooklm/_chat_transport.py
@@ -28,17 +28,17 @@ from ._authed_transport import (
 from .exceptions import ChatError, NetworkError
 
 if TYPE_CHECKING:
+    from ._chat import ChatRuntime
     from ._request_types import BuildRequest
-    from ._session_contracts import Session
 
 
 async def chat_aware_authed_post(
-    session: Session,
+    runtime: ChatRuntime,
     *,
     build_request: BuildRequest,
     parse_label: str,
 ) -> httpx.Response:
-    """Chat-side semantic owner around :meth:`Session.transport_post`.
+    """Chat-side semantic owner around :meth:`ChatRuntime.transport_post`.
 
     Wraps the shared transport pipeline with chat-flavored exception
     mapping: transport-layer auth failures become
@@ -52,8 +52,9 @@ async def chat_aware_authed_post(
     executor).
 
     Args:
-        session: Shared client session.
-        build_request: Request builder forwarded to :meth:`Session.transport_post`.
+        runtime: Local chat runtime (typically the shared client session,
+            which structurally satisfies :class:`ChatRuntime`).
+        build_request: Request builder forwarded to :meth:`ChatRuntime.transport_post`.
         parse_label: Caller-friendly label used in log lines and error
             messages (e.g. ``"chat.ask"``).
     """
@@ -63,7 +64,7 @@ async def chat_aware_authed_post(
     # drained client still surfaces ``RuntimeError`` with the chat-friendly
     # label without explicit bracketing here.
     try:
-        return await session.transport_post(
+        return await runtime.transport_post(
             build_request=build_request,
             parse_label=parse_label,
         )

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -290,7 +290,7 @@ class NotebookLMClient:
             drain_hooks=self._core,
         )
         self.notes = NotesAPI(self._core)
-        self.chat = ChatAPI(self._core, notebooks=self.notebooks)
+        self.chat = ChatAPI(self._session, notebooks=self.notebooks)
         # Pure-RPC features (Phase 1 retypes: typed as `rpc: RpcCaller`).
         self.research = ResearchAPI(self._core)
         self.settings = SettingsAPI(self._core)

--- a/tests/unit/test_chat_error_payload.py
+++ b/tests/unit/test_chat_error_payload.py
@@ -12,7 +12,7 @@ class MalformedErrorPayload(list):
 
 
 def test_rate_limit_payload_parse_failure_logs_debug(caplog):
-    api = ChatAPI(core=MagicMock())
+    api = ChatAPI(MagicMock())
 
     with caplog.at_level(logging.DEBUG, logger="notebooklm._chat"):
         api._raise_if_rate_limited(MalformedErrorPayload())

--- a/tests/unit/test_chat_refactor.py
+++ b/tests/unit/test_chat_refactor.py
@@ -205,8 +205,9 @@ class TestChatReqid:
     ):
         """``asyncio.gather(ask*3)`` → three distinct ``_reqid`` URL values.
 
-        Previously, the body did ``self._runtime._reqid_counter += 100000`` under
-        a read-modify-write race; under concurrent gather() this collapsed
+        Previously, the body did ``self._core._reqid_counter += 100000`` under
+        a read-modify-write race (``self._core`` was the pre-Phase-2 attribute
+        name, now ``self._runtime``); under concurrent gather() this collapsed
         to a single reqid value. ``runtime.next_reqid()`` serializes the
         increment under an asyncio.Lock, restoring monotonic distinct ids.
         """

--- a/tests/unit/test_chat_refactor.py
+++ b/tests/unit/test_chat_refactor.py
@@ -205,9 +205,9 @@ class TestChatReqid:
     ):
         """``asyncio.gather(ask*3)`` → three distinct ``_reqid`` URL values.
 
-        Previously, the body did ``self._core._reqid_counter += 100000`` under
+        Previously, the body did ``self._runtime._reqid_counter += 100000`` under
         a read-modify-write race; under concurrent gather() this collapsed
-        to a single reqid value. ``core.next_reqid()`` serializes the
+        to a single reqid value. ``runtime.next_reqid()`` serializes the
         increment under an asyncio.Lock, restoring monotonic distinct ids.
         """
         auth = AuthTokens(


### PR DESCRIPTION
## Summary

Phase 2 of the capability-refactor full arc (refactor.md Step 3 + ADR-013): narrow `ChatAPI`'s session dependency to a local `ChatRuntime` Protocol.

- Add `ChatRuntime(RpcCaller, LoopGuard, Protocol)` in `_chat.py` exposing the four members the chat feature actually uses: `rpc_call`, `assert_bound_loop`, `transport_post`, `next_reqid`. `transport_post` and `next_reqid` stay local because no other feature uses them today.
- Migrate `chat_aware_authed_post(session: Session)` → `(runtime: ChatRuntime)` in `_chat_transport.py`; the helper now calls `runtime.transport_post(...)`. Call site at `_chat.py` updated in the same change.
- Retype `ChatAPI.__init__(runtime: ChatRuntime, *, notebooks=, conversation_cache=)`; remove the deprecated `core=` alias branch entirely. All `self._core` references renamed to `self._runtime`.
- Composition root: `client.py` passes `self._session` to `ChatAPI` (structurally satisfies `ChatRuntime`). Edit is confined to the ChatAPI constructor-call line.

## Wave 3 parallel context

This PR runs in parallel with Phase 3 (artifacts runtime) and Phase 4 (sources+upload runtime). All three touch `client.py` (different constructor-call lines) and `tests/_fixtures/fake_core.py` (no edits needed here — `FakeSession` already exposes `transport_post`, `next_reqid`, `rpc_call`, `assert_bound_loop`). The Phase 2 changes are confined to the `ChatAPI` constructor-call line so sibling PRs can rebase cleanly.

## Non-Goals (explicit)

- `_core.py` shim and `NotebookLMClient._core = self._session` compatibility alias **untouched**.
- Broad `Session` Protocol in `_session_contracts.py` still carries `transport_post` and `next_reqid` (Phase 7 will delete the broad protocol).
- `transport_post` / `next_reqid` are **not** promoted to shared protocols.
- No changes to `_artifacts.py`, `_sources.py`, `_notes.py`, `_source_upload.py`, `_mind_map.py`, or `_artifact_*.py`.

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy src/notebooklm --ignore-missing-imports`
- [x] `uv run ruff check src/notebooklm tests`
- [x] `uv run ruff format --check src/notebooklm tests`
- [x] `uv run pytest` — 5505 passed, 14 skipped
- [x] Drift sweeps: `self._core` in `_chat.py` → 0; `self._runtime` → 9; `core=` in `_chat.py` → 0; `session: Session` in `_chat_transport.py` → 0; `^class ChatRuntime` → 1; `ChatAPI(core=` in `tests/` → 0; broad `Session` keeps `transport_post + next_reqid` → 2.

References: `docs/refactor.md` §Local Chat Runtime + Migration Plan Step 3; `docs/adr/0013-composable-session-capabilities.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Chat subsystem refactored to use a runtime-driven interface, improving request tracing and transport routing for greater reliability and maintainability.
  * Client initialization updated to align with the new runtime approach; tests adjusted accordingly. No user-facing behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->