### PR TITLE
refactor(sources): step 5 — UploadRuntime; rename local RpcCaller→RpcCallback; require uploader

### DIFF
--- a/src/notebooklm/_source_upload.py
+++ b/src/notebooklm/_source_upload.py
@@ -22,7 +22,12 @@ from ._session_config import (
     DEFAULT_MAX_CONCURRENT_UPLOADS,
     normalize_max_concurrent_uploads,
 )
-from ._session_contracts import AuthMetadata, Kernel, Session
+from ._session_contracts import (
+    AuthMetadata,
+    Kernel,
+    OperationScopeProvider,
+    RpcCaller,
+)
 from .auth import authuser_query, format_authuser_value
 from .exceptions import (
     AuthError,
@@ -40,8 +45,17 @@ _SOURCE_ID_UUID_PATTERN = re.compile(
 )
 
 
-class RpcCaller(Protocol):
-    """RPC callback shape used by upload registration."""
+class RpcCallback(Protocol):
+    """RPC callback shape used by upload registration.
+
+    Structurally distinct from :class:`notebooklm._session_contracts.RpcCaller`:
+    this is a **callable** Protocol (``async def __call__(...)``) passed as a
+    keyword argument into :meth:`SourceUploadPipeline.register_file_source`,
+    while the shared ``RpcCaller`` is an **object** Protocol with an
+    ``.rpc_call(...)`` method. They are NOT interchangeable — the local
+    callable form is kept as a structural Protocol (not a ``Callable[...]``
+    alias) so mypy can flag keyword-name typos at call sites.
+    """
 
     async def __call__(
         self,
@@ -54,6 +68,16 @@ class RpcCaller(Protocol):
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
     ) -> Any: ...
+
+
+class UploadRuntime(RpcCaller, OperationScopeProvider, Protocol):
+    """Runtime capabilities required by source upload.
+
+    Combines :class:`RpcCaller` (``rpc_call`` method) and
+    :class:`OperationScopeProvider` (``operation_scope`` async-context
+    manager) — the only ``Session`` surfaces the pipeline needs at runtime.
+    A concrete :class:`Session` structurally satisfies this Protocol.
+    """
 
 
 class RegisterFileSource(Protocol):
@@ -182,7 +206,7 @@ class SourceUploadPipeline:
 
     def __init__(
         self,
-        session: Session,
+        runtime: UploadRuntime,
         kernel: Kernel,
         auth: AuthMetadata,
         upload_timeout: httpx.Timeout | None = None,
@@ -191,7 +215,7 @@ class SourceUploadPipeline:
         record_upload_queue_wait: QueueWaitRecorder | None = None,
         async_client_factory: AsyncClientFactory | None = None,
     ):
-        self._session = session
+        self._runtime = runtime
         self._kernel = kernel
         self._auth = auth
         self._upload_timeout = upload_timeout
@@ -278,7 +302,7 @@ class SourceUploadPipeline:
             raise ValidationError(f"Not a regular file: {file_path}")
 
         filename = file_path.name
-        async with self._session.operation_scope(f"upload:{upload_index}"):
+        async with self._runtime.operation_scope(f"upload:{upload_index}"):
             upload_sem = self.get_upload_semaphore()
             upload_wait_start = monotonic()
             async with upload_sem:
@@ -342,7 +366,7 @@ class SourceUploadPipeline:
         *,
         list_sources: ListSources,
         logger: Any,
-        rpc_call: RpcCaller | None = None,
+        rpc_call: RpcCallback | None = None,
     ) -> str:
         """Register a file source intent and get SOURCE_ID.
 
@@ -369,7 +393,7 @@ class SourceUploadPipeline:
             [2],
             [1, None, None, None, None, None, None, None, None, None, [1]],
         ]
-        rpc_call = rpc_call or self._session.rpc_call
+        rpc_call = rpc_call or self._runtime.rpc_call
 
         # Capture baseline source IDs before the first create attempt so the
         # probe can distinguish "this upload landed" from "a same-named source
@@ -684,7 +708,9 @@ class SourceUploadPipeline:
 
 
 __all__ = [
+    "RpcCallback",
     "SourceUploadPipeline",
+    "UploadRuntime",
     "_SOURCE_ID_UUID_PATTERN",
     "_extract_register_file_source_id",
     "_looks_like_id_string",

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -50,7 +50,8 @@ class SourcesAPI:
     def __init__(
         self,
         session: Session,
-        uploader: SourceUploadPipeline | None = None,
+        *,
+        uploader: SourceUploadPipeline,
         upload_timeout: httpx.Timeout | None = None,
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
     ):
@@ -58,7 +59,12 @@ class SourcesAPI:
 
         Args:
             session: The shared client session.
-            uploader: Stateful file-upload pipeline.
+            uploader: Stateful file-upload pipeline. REQUIRED — wired explicitly
+                by :class:`NotebookLMClient` (the only composition root that
+                knows the concrete ``Kernel`` + ``AuthMetadata`` +
+                ``record_upload_queue_wait`` callback). Direct callers must
+                supply a :class:`SourceUploadPipeline` instance themselves;
+                there is no implicit fallback.
             upload_timeout: Optional override for the ``httpx.Timeout`` used
                 by the resumable-upload start handshake and the finalize
                 POST. ``None`` (default) preserves the original hardcoded
@@ -73,20 +79,19 @@ class SourcesAPI:
                 :meth:`add_file` uploads. The semaphore is owned by this
                 Sources upload pipeline, not by the shared core/session.
         """
+        # ``upload_timeout`` and ``max_concurrent_uploads`` are accepted for
+        # API stability — the actual upload pipeline that honors them is
+        # constructed by the :class:`NotebookLMClient` composition root and
+        # injected via ``uploader=``. They are stored here only as historical
+        # attributes for callers that introspect the instance.
         self._core = session
         self._adder = SourceAddService()
         self._content = SourceContentRenderer(self._rpc_call, logger=logger)
         self._lister = SourceLister(self._rpc_call)
         self._poller = SourcePoller()
         self._upload_timeout = upload_timeout
-        self._uploader = uploader or SourceUploadPipeline(
-            session,
-            session.kernel,
-            session.auth,
-            upload_timeout=upload_timeout,
-            max_concurrent_uploads=max_concurrent_uploads,
-            record_upload_queue_wait=getattr(session, "record_upload_queue_wait", None),
-        )
+        self._max_concurrent_uploads = max_concurrent_uploads
+        self._uploader = uploader
 
     async def _rpc_call(
         self,

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -268,16 +268,20 @@ class NotebookLMClient:
         # ``client._core`` directly.
         self._core = self._session
 
+        # Wire the upload pipeline explicitly with the concrete capability
+        # surfaces (UploadRuntime via the Session, plus Kernel and AuthMetadata).
+        # NotebookLMClient is the only composition root that knows these
+        # internals — SourcesAPI no longer reads them back off the session.
         source_uploader = SourceUploadPipeline(
-            self._core,
-            self._core.kernel,
-            self._core.auth,
+            self._session,
+            self._session.kernel,
+            self._session.auth,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
-            record_upload_queue_wait=self._core.record_upload_queue_wait,
+            record_upload_queue_wait=self._session.record_upload_queue_wait,
         )
         self.sources = SourcesAPI(
-            self._core,
+            self._session,
             uploader=source_uploader,
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,

--- a/tests/integration/concurrency/test_upload_blocks_loop.py
+++ b/tests/integration/concurrency/test_upload_blocks_loop.py
@@ -66,6 +66,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
 
 # mock-based loop-blocking detection tests; no HTTP, no cassette.
@@ -119,7 +120,13 @@ def _make_sources_api() -> tuple[SourcesAPI, MagicMock]:
 
     core.operation_scope.side_effect = operation_scope
     core.record_upload_queue_wait = MagicMock()
-    return SourcesAPI(core), core
+    uploader = SourceUploadPipeline(
+        core,
+        core.kernel,
+        core.auth,
+        record_upload_queue_wait=core.record_upload_queue_wait,
+    )
+    return SourcesAPI(core, uploader=uploader), core
 
 
 class _SlowReadFile:

--- a/tests/unit/test_env_base_url.py
+++ b/tests/unit/test_env_base_url.py
@@ -4,6 +4,7 @@ import pytest
 
 from notebooklm._env import get_base_host, get_base_url
 from notebooklm._session import Session
+from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
@@ -100,7 +101,16 @@ async def test_upload_start_uses_enterprise_url_and_headers(monkeypatch, httpx_m
     core = Session(auth)
     await core.open()
     try:
-        result = await SourcesAPI(core)._start_resumable_upload(
+        api = SourcesAPI(
+            core,
+            uploader=SourceUploadPipeline(
+                core,
+                core.kernel,
+                core.auth,
+                record_upload_queue_wait=core.record_upload_queue_wait,
+            ),
+        )
+        result = await api._start_resumable_upload(
             "nb_123",
             "file.txt",
             12,

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -539,7 +539,7 @@ def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> N
     from notebooklm._sources import SourcesAPI
 
     core = MagicMock()
-    api = SourcesAPI(core)
+    api = SourcesAPI(core, uploader=MagicMock())
 
     assert isinstance(api._lister, SourceLister)
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -15,6 +15,7 @@ from notebooklm import (
 )
 from notebooklm._artifacts import ArtifactsAPI
 from notebooklm._session import Session
+from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
 from notebooklm.auth import AuthTokens
 from notebooklm.rpc import RPCMethod
@@ -281,7 +282,15 @@ async def test_upload_progress_callback_receives_byte_counts(
     core = Session(auth_tokens)
     await core.open()
     try:
-        api = SourcesAPI(core)
+        api = SourcesAPI(
+            core,
+            uploader=SourceUploadPipeline(
+                core,
+                core.kernel,
+                core.auth,
+                record_upload_queue_wait=core.record_upload_queue_wait,
+            ),
+        )
         test_file = tmp_path / "upload.txt"
         content = b"hello progress"
         test_file.write_bytes(content)

--- a/tests/unit/test_source_add_service.py
+++ b/tests/unit/test_source_add_service.py
@@ -347,7 +347,7 @@ async def test_raw_url_helpers_disable_internal_retries(service: SourceAddServic
 @pytest.mark.asyncio
 async def test_sources_api_add_url_uses_late_bound_facade_hooks() -> None:
     core = MagicMock()
-    api = SourcesAPI(core)
+    api = SourcesAPI(core, uploader=MagicMock())
     api._extract_youtube_video_id = MagicMock(return_value="video")  # type: ignore[method-assign]
     api._add_youtube_source = AsyncMock(return_value=source_response("yt", "Video"))  # type: ignore[method-assign]
     api._add_url_source = AsyncMock()  # type: ignore[method-assign]

--- a/tests/unit/test_source_polling_service.py
+++ b/tests/unit/test_source_polling_service.py
@@ -288,7 +288,7 @@ async def test_wait_for_sources_catches_base_exception_and_drains_siblings(
 
 @pytest.mark.asyncio
 async def test_sources_api_wait_until_ready_delegates_with_call_time_dependencies() -> None:
-    api = SourcesAPI(MagicMock())
+    api = SourcesAPI(MagicMock(), uploader=MagicMock())
     ready = Source(id="src_1", status=SourceStatus.READY)
 
     with patch.object(api._poller, "wait_until_ready", new_callable=AsyncMock) as delegate:
@@ -307,7 +307,7 @@ async def test_sources_api_wait_until_ready_delegates_with_call_time_dependencie
 
 @pytest.mark.asyncio
 async def test_sources_api_wait_until_ready_resolves_sources_sleep_and_monotonic() -> None:
-    api = SourcesAPI(MagicMock())
+    api = SourcesAPI(MagicMock(), uploader=MagicMock())
     processing = Source(id="src_1", status=SourceStatus.PROCESSING)
     ready = Source(id="src_1", status=SourceStatus.READY)
 
@@ -325,7 +325,7 @@ async def test_sources_api_wait_until_ready_resolves_sources_sleep_and_monotonic
 
 @pytest.mark.asyncio
 async def test_sources_api_wait_for_sources_uses_late_bound_wait_until_ready() -> None:
-    api = SourcesAPI(MagicMock())
+    api = SourcesAPI(MagicMock(), uploader=MagicMock())
     api.wait_until_ready = AsyncMock(
         side_effect=[
             Source(id="src_1", status=SourceStatus.READY),

--- a/tests/unit/test_source_status.py
+++ b/tests/unit/test_source_status.py
@@ -101,7 +101,7 @@ class TestWaitUntilReady:
     def sources_api(self):
         """Create a SourcesAPI with mocked core."""
         core = MagicMock()
-        return SourcesAPI(core)
+        return SourcesAPI(core, uploader=MagicMock())
 
     @pytest.mark.asyncio
     async def test_returns_immediately_if_ready(self, sources_api):
@@ -302,7 +302,7 @@ class TestWaitUntilRegistered:
     @pytest.fixture
     def sources_api(self):
         core = MagicMock()
-        return SourcesAPI(core)
+        return SourcesAPI(core, uploader=MagicMock())
 
     @pytest.mark.asyncio
     async def test_wait_until_registered_returns_on_processing(self, sources_api):
@@ -405,7 +405,7 @@ class TestWaitForSources:
     def sources_api(self):
         """Create a SourcesAPI with mocked core."""
         core = MagicMock()
-        return SourcesAPI(core)
+        return SourcesAPI(core, uploader=MagicMock())
 
     @pytest.mark.asyncio
     async def test_waits_for_multiple_sources(self, sources_api):

--- a/tests/unit/test_sources_upload.py
+++ b/tests/unit/test_sources_upload.py
@@ -71,8 +71,20 @@ def mock_core():
 
 @pytest.fixture
 def sources_api(mock_core):
-    """Create SourcesAPI with mocked core."""
-    return SourcesAPI(mock_core)
+    """Create SourcesAPI with mocked core.
+
+    The uploader is constructed explicitly from the same mocked core so the
+    upload-path tests still exercise the real :class:`SourceUploadPipeline`
+    while honoring the now-required ``uploader=`` kwarg on
+    :class:`SourcesAPI`.
+    """
+    uploader = SourceUploadPipeline(
+        mock_core,
+        mock_core.kernel,
+        mock_core.auth,
+        record_upload_queue_wait=mock_core.record_upload_queue_wait,
+    )
+    return SourcesAPI(mock_core, uploader=uploader)
 
 
 def _self_session_auth_attr_read(node: ast.AST, attr: str) -> bool:


### PR DESCRIPTION
## Summary

Phase 4 of the capability-refactor arc (`docs/refactor.md` §Sources And Upload + ADR-013).

- Define `UploadRuntime(RpcCaller, OperationScopeProvider, Protocol)` in `_source_upload.py`; retype `SourceUploadPipeline.__init__` first arg from `session: Session` to `runtime: UploadRuntime`. `Kernel` + `AuthMetadata` remain separate positional args per ADR-013 §Decision.
- Make `uploader` REQUIRED (keyword-only) on `SourcesAPI`; remove the fallback that constructed `SourceUploadPipeline` from `session.kernel`, `session.auth`, and `getattr(session, "record_upload_queue_wait", None)`. `NotebookLMClient` remains the sole composition root that wires those internals.
- Wire `Kernel + AuthMetadata + record_upload_queue_wait` explicitly through `NotebookLMClient.__init__` using `self._session.*`.

## Critical: RENAMED, not deleted

The local callable Protocol `RpcCaller` at `_source_upload.py:43-56` is **renamed to `RpcCallback`**, not deleted. It is structurally distinct from the shared `_session_contracts.RpcCaller`:

- Local (now `RpcCallback`): callable Protocol — `async def __call__(*, method, params, …)`. Used as `register_file_source(rpc_call=…)` callback.
- Shared (`_session_contracts.RpcCaller`): object Protocol with `.rpc_call(…)` method. Used by `UploadRuntime` and pure-RPC features.

They cannot substitute for each other. The local one is kept as a structural Protocol (not a `Callable[…, Awaitable[Any]]` alias) to preserve mypy errors on keyword typos.

## Drift sweeps

- `^class UploadRuntime` in `_source_upload.py` → 1
- `^class RpcCallback` in `_source_upload.py` → 1
- `^class RpcCaller` in `_source_upload.py` → 0 (renamed)
- `session.kernel` / `session.auth` / `record_upload_queue_wait` fallback refs in `_sources.py` → 0
- `uploader=None` default in `_sources.py` → 0
- `_core.py` shim untouched

## Test plan

- [x] All 11 direct-construction test sites updated to pass `uploader=` explicitly (`MagicMock` for non-upload tests, real `SourceUploadPipeline` for upload-path tests).
- [x] `uv run pytest` — 5505 passed, 14 skipped.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (136 files).
- [x] `uv run ruff check src/notebooklm tests` — clean.
- [x] `uv run ruff format --check src/notebooklm tests` — clean.
- [x] `uv run pre-commit run --all-files` — clean.

## Wave 3 coordination

Touches `src/notebooklm/client.py` (Sources wiring lines) and `tests/_fixtures/fake_core.py` (no changes needed — FakeSession already satisfies `UploadRuntime` via existing `rpc_call` + `operation_scope` defaults). Phase 2 (chat) and Phase 3 (artifacts) touch different constructor-call lines in `client.py` — coordinator may need to resolve conflicts at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured upload pipeline dependencies for improved modularity and cleaner separation of concerns between upload runtime and API layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->