### PR TITLE
refactor(artifacts): step 4 — local ArtifactsRuntime; remove fallback constructions

### DIFF
--- a/src/notebooklm/_artifact_polling.py
+++ b/src/notebooklm/_artifact_polling.py
@@ -11,7 +11,7 @@ from typing import Any
 from ._backoff import compute_backoff_delay
 from ._callbacks import maybe_await_callback
 from ._polling_registry import PollRegistry
-from ._session_contracts import Session
+from ._session_contracts import AsyncWorkRuntime
 from .rpc import (
     ArtifactStatus,
     ArtifactTypeCode,
@@ -55,10 +55,10 @@ class ArtifactPollingService:
 
     def __init__(
         self,
-        session: Session,
+        runtime: AsyncWorkRuntime,
         poll_registry: PollRegistry | None = None,
     ) -> None:
-        self._session = session
+        self._runtime = runtime
         self._poll_registry = poll_registry if poll_registry is not None else PollRegistry()
 
     @property
@@ -146,7 +146,7 @@ class ArtifactPollingService:
         # P0-2: catch cross-loop wait_for_completion before touching the
         # poll registry (which holds futures bound to the registering
         # loop) or spawning a poll task on a foreign loop.
-        self._session.assert_bound_loop()
+        self._runtime.assert_bound_loop()
         # Backward compatibility: poll_interval overrides initial_interval.
         if poll_interval is not None:
             import warnings
@@ -245,7 +245,7 @@ class ArtifactPollingService:
         poll_status: PollStatusCallback,
         on_status_change: StatusChangeCallback | None,
     ) -> GenerationStatus:
-        async with self._session.operation_scope(f"artifact wait {task_id}"):
+        async with self._runtime.operation_scope(f"artifact wait {task_id}"):
             return await self._run_poll_loop(
                 notebook_id,
                 task_id,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -124,6 +124,13 @@ class DrainHookRegistration(Protocol):
     later adds artifact-style leader/follower polling with shared
     background tasks, revisit whether ``register_drain_hook`` should
     become shared.
+
+    Note: an identically-shaped ``DrainHookRegistration`` Protocol also
+    exists at ``_session_contracts.py`` for the broad-``Session`` era.
+    Both Protocols are structurally compatible (a real ``Session``
+    satisfies both) and they coexist intentionally during the
+    migration. Phase 7 deletes the ``_session_contracts`` twin; until
+    then, this local copy is the one consumed by ``ArtifactsRuntime``.
     """
 
     def register_drain_hook(

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -8,9 +8,9 @@ Quizzes, Flashcards, Infographics, Slide Decks, Data Tables, and Mind Maps.
 import builtins
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol
 
 from . import _artifact_formatters, _artifact_polling, _mind_map
 from ._artifact_downloads import ArtifactDownloadService, DownloadResult
@@ -18,7 +18,7 @@ from ._artifact_generation import ArtifactGenerationService
 from ._artifact_listing import ArtifactListingService
 from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
-from ._session_contracts import DrainHookRegistration, Session
+from ._session_contracts import AsyncWorkRuntime, RpcCaller
 from .auth import load_httpx_cookies
 from .rpc import (
     ArtifactTypeCode,
@@ -51,9 +51,6 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-
-if TYPE_CHECKING:
-    from ._notes import NotesAPI  # retained for backward-compatible type hints
 
 # Private compatibility exports. Tests and downstream code patch these names
 # through ``notebooklm._artifacts`` even though download implementation now
@@ -117,6 +114,35 @@ def _format_interactive_content(
     )
 
 
+class DrainHookRegistration(Protocol):
+    """Narrow close-time hook registration surface, local to artifacts.
+
+    Artifact polling is the only current feature that registers
+    close-time cleanup hooks, so the Protocol stays local to
+    ``_artifacts.py`` rather than being promoted to
+    ``_session_contracts``. If a second consumer (e.g. Deep Research)
+    later adds artifact-style leader/follower polling with shared
+    background tasks, revisit whether ``register_drain_hook`` should
+    become shared.
+    """
+
+    def register_drain_hook(
+        self,
+        name: str,
+        hook: Callable[[], Awaitable[None]],
+    ) -> None: ...
+
+
+class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Protocol):
+    """Runtime capabilities required by the artifacts feature.
+
+    Combines :class:`RpcCaller` (for RPC dispatch),
+    :class:`AsyncWorkRuntime` (for ``assert_bound_loop`` and
+    ``operation_scope``), and :class:`DrainHookRegistration` (for
+    close-time poll-task cleanup).
+    """
+
+
 class ArtifactsAPI:
     """Operations on NotebookLM artifacts (studio content).
 
@@ -139,59 +165,53 @@ class ArtifactsAPI:
 
     def __init__(
         self,
-        session: Session,
-        notes_api: "NotesAPI | None" = None,
-        storage_path: Path | None = None,
+        runtime: ArtifactsRuntime,
         *,
-        mind_map_service: _mind_map.MindMapService | None = None,
-        notebooks: NotebookSourceIdProvider | None = None,
-        drain_hooks: DrainHookRegistration | None = None,
-    ):
+        notebooks: NotebookSourceIdProvider,
+        mind_map_service: _mind_map.MindMapService,
+        storage_path: Path | None = None,
+    ) -> None:
         """Initialize the artifacts API.
 
         Args:
-            session: The shared client session.
-            notes_api: Deprecated. Retained as an optional, ignored
-                keyword for backward compatibility — ``ArtifactsAPI`` no
-                longer depends on :class:`NotesAPI`. Mind-map RPC
-                primitives are accessed through the injected
-                :class:`_mind_map.MindMapService`, so the construction
-                order of ``client.artifacts`` and ``client.notes`` is no
-                longer significant.
+            runtime: Feature-local runtime that provides RPC dispatch,
+                loop-affinity assertion, operation scopes, and
+                close-time drain-hook registration.
+            notebooks: Source-id resolver. Required — wire from
+                ``NotebookLMClient`` (no implicit fallback).
+            mind_map_service: Service for note-backed mind-map operations.
+                Required; the previous ``None`` fallback that constructed
+                ``MindMapService(session)`` has been removed. Phase 5 will
+                rename this parameter to ``mind_maps`` and swap the
+                concrete type to :class:`NoteBackedMindMapService`.
             storage_path: Path to storage state file for loading download cookies.
-            mind_map_service: Optional private service for note-backed
-                mind-map operations. Keyword-only so the public positional
-                constructor contract stays unchanged.
-            notebooks: Optional source-id resolver. Defaults to a
-                ``NotebooksAPI`` wrapper around ``core`` for backward
-                compatibility with tests that construct ``ArtifactsAPI(core)``.
-            drain_hooks: Close-time hook registration surface.
         """
-        self._core = session
-        if notebooks is None:
-            from ._notebooks import NotebooksAPI
-
-            notebooks = NotebooksAPI(session)
+        self._runtime = runtime
         self._notebooks = notebooks
-        # ``notes_api`` is intentionally not stored — it is accepted only
-        # so that existing call sites (tests, third-party code) keep
-        # working through the deprecation cycle.
-        del notes_api
         self._storage_path = storage_path
-        self._mind_map_service = (
-            _mind_map.MindMapService(session) if mind_map_service is None else mind_map_service
-        )
+        self._mind_map_service = mind_map_service
         self._poll_registry = PollRegistry()
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
         self._downloads = ArtifactDownloadService(self)
         self._polling = _artifact_polling.ArtifactPollingService(
-            session,
+            runtime,
             self._poll_registry,
         )
-        if drain_hooks is None:
-            drain_hooks = session
-        drain_hooks.register_drain_hook("artifacts.polls", self._polling.drain)
+        self._runtime.register_drain_hook("artifacts.polls", self._polling.drain)
+
+    @property
+    def _core(self) -> ArtifactsRuntime:
+        """Backward-compatible alias for ``self._runtime``.
+
+        ``_artifact_generation.py`` and ``_artifact_downloads.py``
+        currently access ``api._core.rpc_call(...)`` and
+        ``_mind_map.list_mind_maps(api._core, ...)``. Those modules are
+        retyped in a later phase; until then, this property forwards
+        attribute access to the runtime so the cross-module calls keep
+        working.
+        """
+        return self._runtime
 
     # =========================================================================
     # List/Get Operations
@@ -518,7 +538,7 @@ class ArtifactsAPI:
 
     async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None:
         """Fetch artifact HTML content for quiz/flashcard types."""
-        result = await self._core.rpc_call(
+        result = await self._runtime.rpc_call(
             RPCMethod.GET_INTERACTIVE_HTML,
             [artifact_id],
             source_path=f"/notebook/{notebook_id}",
@@ -633,7 +653,7 @@ class ArtifactsAPI:
         """
         logger.debug("Deleting artifact %s from notebook %s", artifact_id, notebook_id)
         params = [[2], artifact_id]
-        await self._core.rpc_call(
+        await self._runtime.rpc_call(
             RPCMethod.DELETE_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -650,7 +670,7 @@ class ArtifactsAPI:
             new_title: The new title.
         """
         params = [[artifact_id, new_title], [["title"]]]
-        await self._core.rpc_call(
+        await self._runtime.rpc_call(
             RPCMethod.RENAME_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -788,7 +808,7 @@ class ArtifactsAPI:
             Export result with document URL.
         """
         params = [None, artifact_id, None, title, int(export_type)]
-        return await self._core.rpc_call(
+        return await self._runtime.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -812,7 +832,7 @@ class ArtifactsAPI:
             Export result with spreadsheet URL.
         """
         params = [None, artifact_id, None, title, int(ExportType.SHEETS)]
-        return await self._core.rpc_call(
+        return await self._runtime.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -842,7 +862,7 @@ class ArtifactsAPI:
             Export result with document URL.
         """
         params = [None, artifact_id, content, title, int(export_type)]
-        return await self._core.rpc_call(
+        return await self._runtime.rpc_call(
             RPCMethod.EXPORT_ARTIFACT,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -878,7 +898,7 @@ class ArtifactsAPI:
         """Get raw artifact list data."""
         # Keep this facade hop so callers/tests that patch ``api._list_raw``
         # still affect public listing paths that delegate into the service.
-        return await self._listing.list_raw(notebook_id, rpc_call=self._core.rpc_call)
+        return await self._listing.list_raw(notebook_id, rpc_call=self._runtime.rpc_call)
 
     def _select_artifact(
         self,

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -288,6 +288,13 @@ class NotebookLMClient:
         # ``mind_map_service`` is required and explicitly constructed here.
         # Phase 5 replaces this with ``NoteBackedMindMapService`` and renames
         # the parameter to ``mind_maps``.
+        #
+        # We pass ``self._session`` rather than the ``self._core`` alias because
+        # ``Session`` directly satisfies ``ArtifactsRuntime`` (RpcCaller +
+        # AsyncWorkRuntime + DrainHookRegistration) and the ``_core`` alias
+        # exists only for legacy callers that pre-date the runtime split. The
+        # other sub-APIs still pass ``self._core`` while their own
+        # capability-protocol migrations land; Phase 7 retires the alias.
         self.artifacts = ArtifactsAPI(
             self._session,
             notebooks=self.notebooks,

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from .rpc import RPCMethod
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
+from . import _mind_map
 from ._artifacts import ArtifactsAPI
 from ._auth.session import refresh_auth_session
 from ._chat import ChatAPI
@@ -283,11 +284,15 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
         )
         self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
+        # Transitional wiring per docs/refactor.md Step 4 / Review Checklist:
+        # ``mind_map_service`` is required and explicitly constructed here.
+        # Phase 5 replaces this with ``NoteBackedMindMapService`` and renames
+        # the parameter to ``mind_maps``.
         self.artifacts = ArtifactsAPI(
-            self._core,
-            storage_path=storage_path,
+            self._session,
             notebooks=self.notebooks,
-            drain_hooks=self._core,
+            mind_map_service=_mind_map.MindMapService(self._session),
+            storage_path=storage_path,
         )
         self.notes = NotesAPI(self._core)
         self.chat = ChatAPI(self._core, notebooks=self.notebooks)

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -104,10 +104,16 @@ def mock_artifacts_api() -> tuple[ArtifactsAPI, MagicMock]:
     boundary in pytest is fragile when both define ``mock_artifacts_api``
     at module scope.
     """
+    from notebooklm._mind_map import MindMapService
+
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
-    api = ArtifactsAPI(mock_core)
+    api = ArtifactsAPI(
+        mock_core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     return api, mock_core
 
 

--- a/tests/integration/test_artifacts_drift.py
+++ b/tests/integration/test_artifacts_drift.py
@@ -39,10 +39,15 @@ pytestmark = pytest.mark.allow_no_vcr
 @pytest.fixture
 def artifacts_api():
     """Build a minimal ArtifactsAPI for direct parser invocation."""
+    from notebooklm._mind_map import MindMapService
+
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
-    mock_notes = MagicMock()
-    return ArtifactsAPI(mock_core, notes_api=mock_notes)
+    return ArtifactsAPI(
+        mock_core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -19,6 +19,7 @@ from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._mind_map import MindMapService
 from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import (
     AudioFormat,
@@ -390,7 +391,11 @@ class TestArtifactsAPI:
         """_list_raw keeps the exact LIST_ARTIFACTS RPC contract."""
         core = MagicMock()
         core.rpc_call = AsyncMock(return_value=[[]])
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
 
         result = await api._list_raw("nb_123")
 
@@ -415,7 +420,11 @@ class TestArtifactsAPI:
         ]
         core = MagicMock()
         core.rpc_call = AsyncMock(return_value=artifact_rows)
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
 
         result = await api._list_raw("nb_123")
 
@@ -425,7 +434,11 @@ class TestArtifactsAPI:
     async def test_list_uses_facade_list_raw_callback_and_mind_map_service(self):
         """list() resolves facade _list_raw and the injected mind-map service."""
         core = MagicMock()
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
         studio_artifact = ["art_001", "My Report", 2, None, 3]
         mind_map = [
             "mind_map_001",
@@ -452,7 +465,11 @@ class TestArtifactsAPI:
     async def test_list_skips_mind_map_callback_for_non_mind_map_filter(self):
         """Filtering to studio-only kinds must not fetch mind maps."""
         core = MagicMock()
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
         studio_artifact = ["art_001", "My Report", 2, None, 3]
 
         with (
@@ -472,7 +489,11 @@ class TestArtifactsAPI:
     async def test_get_uses_public_list_callback(self):
         """get() delegates through the public list callback."""
         core = MagicMock()
-        api = ArtifactsAPI(core)
+        api = ArtifactsAPI(
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
         other = MagicMock()
         other.id = "art_other"
         found = MagicMock()
@@ -1536,7 +1557,7 @@ class TestReviseSlide:
             err = RPCError("Rate limit exceeded")
             err.rpc_code = "USER_DISPLAYABLE_ERROR"
             with patch.object(
-                client.artifacts._core,
+                client.artifacts._runtime,
                 "rpc_call",
                 AsyncMock(side_effect=err),
             ):
@@ -1564,7 +1585,7 @@ class TestReviseSlide:
             err.rpc_code = "INTERNAL_ERROR"
             with (
                 patch.object(
-                    client.artifacts._core,
+                    client.artifacts._runtime,
                     "rpc_call",
                     AsyncMock(side_effect=err),
                 ),
@@ -2068,7 +2089,7 @@ class TestCallGenerateErrorHandling:
             # Pass source_ids explicitly so get_source_ids (GET_NOTEBOOK) is NOT called.
             # Then patch _core.rpc_call so the CREATE_ARTIFACT call raises the error.
             with patch.object(
-                client.artifacts._core,
+                client.artifacts._runtime,
                 "rpc_call",
                 AsyncMock(side_effect=err),
             ):
@@ -2092,7 +2113,7 @@ class TestCallGenerateErrorHandling:
             # Then patch _core.rpc_call so the CREATE_ARTIFACT call raises the error.
             with (
                 patch.object(
-                    client.artifacts._core,
+                    client.artifacts._runtime,
                     "rpc_call",
                     AsyncMock(side_effect=err),
                 ),

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -25,10 +25,18 @@ def mock_artifacts_api():
     creation should drive responses through ``mock_core.rpc_call`` (via
     ``side_effect``) rather than mocking a separate notes object.
     """
+    from notebooklm._mind_map import MindMapService
+
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
-    api = ArtifactsAPI(mock_core)
+    mock_notebooks = MagicMock()
+    mock_notebooks.get_source_ids = AsyncMock(return_value=[])
+    api = ArtifactsAPI(
+        mock_core,
+        notebooks=mock_notebooks,
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     return api, mock_core
 
 

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -33,14 +33,17 @@ def mock_artifacts_api():
     # ``MagicMock``-shaped loop value.
     mock_core.bound_loop = None
     mock_core.assert_bound_loop = MagicMock(return_value=None)
-    mock_notes = MagicMock()
-    mock_notes.list_mind_maps = AsyncMock(return_value=[])
-    mock_note = MagicMock()
-    mock_note.id = "created_note_123"
-    mock_notes.create = AsyncMock(return_value=mock_note)
+    from notebooklm._mind_map import MindMapService
+
+    mind_map_service = MagicMock(spec=MindMapService)
+    mind_map_service.list_mind_maps = AsyncMock(return_value=[])
     mock_notebooks = MagicMock()
     mock_notebooks.get_source_ids = AsyncMock(return_value=[])
-    api = ArtifactsAPI(mock_core, notes_api=mock_notes, notebooks=mock_notebooks)
+    api = ArtifactsAPI(
+        mock_core,
+        notebooks=mock_notebooks,
+        mind_map_service=mind_map_service,
+    )
     return api, mock_core
 
 

--- a/tests/unit/test_artifacts_mind_map_injection.py
+++ b/tests/unit/test_artifacts_mind_map_injection.py
@@ -2,20 +2,20 @@
 
 ``ArtifactsAPI`` and ``NotesAPI`` both depend on the mind-map service
 through a constructor seam rather than the module-level
-``_mind_map.list_mind_maps()`` wrapper. These tests pin three contracts:
+``_mind_map.list_mind_maps()`` wrapper. These tests pin two contracts:
 
 1. ``_list_mind_maps()`` delegates to the injected service and does not
    re-enter the module-level ``_mind_map.list_mind_maps`` wrapper.
-2. When no ``mind_map_service`` is injected, ``ArtifactsAPI`` installs a
-   default ``MindMapService(core)``.
-3. ``mind_map_service`` is keyword-only so the positional constructor
-   contract stays unchanged.
+2. ``mind_map_service`` is required and keyword-only — the previous
+   ``MindMapService(session)`` fallback was removed in
+   docs/refactor.md Step 4.
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from _fixtures.fake_core import make_fake_core
 from notebooklm import _mind_map
 from notebooklm._artifacts import ArtifactsAPI
 
@@ -24,14 +24,18 @@ from notebooklm._artifacts import ArtifactsAPI
 async def test_list_mind_maps_delegates_to_injected_service(monkeypatch):
     """``_list_mind_maps`` calls the injected service and does not re-enter
     the module-level ``_mind_map.list_mind_maps`` wrapper."""
-    core = MagicMock()
+    core = make_fake_core()
     fake_service = MagicMock(spec=_mind_map.MindMapService)
     fake_service.list_mind_maps = AsyncMock(return_value=["sentinel-row"])
 
     module_seam = AsyncMock(return_value=["should-not-see-this"])
     monkeypatch.setattr(_mind_map, "list_mind_maps", module_seam)
 
-    api = ArtifactsAPI(core, mind_map_service=fake_service)
+    api = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_map_service=fake_service,
+    )
     result = await api._list_mind_maps("nb_abc")
 
     assert result == ["sentinel-row"]
@@ -39,19 +43,22 @@ async def test_list_mind_maps_delegates_to_injected_service(monkeypatch):
     module_seam.assert_not_awaited()
 
 
-def test_default_mind_map_service_installed_when_not_injected():
-    """``ArtifactsAPI(core)`` installs a default ``MindMapService(core)``."""
-    core = MagicMock()
-    api = ArtifactsAPI(core)
-    assert isinstance(api._mind_map_service, _mind_map.MindMapService)
+def test_mind_map_service_is_required():
+    """``mind_map_service`` is required — no implicit default is installed.
+
+    Phase 3 (docs/refactor.md Step 4) removed the
+    ``MindMapService(session)`` fallback so the construction site at
+    ``NotebookLMClient`` must wire it explicitly.
+    """
+    core = make_fake_core()
+    with pytest.raises(TypeError):
+        ArtifactsAPI(core, notebooks=MagicMock())  # type: ignore[call-arg]
 
 
 def test_mind_map_service_is_keyword_only():
-    """``mind_map_service`` is keyword-only so the positional constructor
-    contract (``core, notes_api, storage_path``) stays unchanged."""
-    core = MagicMock()
+    """``mind_map_service`` is keyword-only — passing positionally fails."""
+    core = make_fake_core()
     fake_service = MagicMock(spec=_mind_map.MindMapService)
     with pytest.raises(TypeError):
-        # Attempting to pass mind_map_service positionally must fail because
-        # the constructor declares it after ``*``.
-        ArtifactsAPI(core, None, None, fake_service)  # type: ignore[misc]
+        # All non-``runtime`` parameters are keyword-only.
+        ArtifactsAPI(core, MagicMock(), fake_service)  # type: ignore[misc]

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -90,11 +90,16 @@ class _FakeTransportProvider:
 
 @pytest.fixture
 def api():
+    from notebooklm._mind_map import MindMapService
+
     core = _make_session_core()
-    notes_api = MagicMock()
     mock_notebooks = MagicMock()
     mock_notebooks.get_source_ids = AsyncMock(return_value=[])
-    return ArtifactsAPI(core, notes_api, notebooks=mock_notebooks)
+    return ArtifactsAPI(
+        core,
+        notebooks=mock_notebooks,
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
 
 
 def _make_session_core() -> MagicMock:
@@ -390,8 +395,14 @@ async def test_polling_service_cancels_and_drains_spawned_poll_task_if_begin_fai
 
 @pytest.mark.asyncio
 async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_or_later_waiter():
+    from notebooklm._mind_map import MindMapService
+
     core = _make_session_core()
-    api = ArtifactsAPI(core, MagicMock())
+    api = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
 
     poll_started = asyncio.Event()
     release_poll = asyncio.Event()

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -76,10 +76,14 @@ def test_artifacts_module_preserves_download_patch_targets():
 def mock_artifacts_api(tmp_path):
     """Minimal ArtifactsAPI with a mocked core for download tests."""
     from notebooklm._artifacts import ArtifactsAPI
+    from notebooklm._mind_map import MindMapService
 
     mock_core = MagicMock()
-    mock_notes = MagicMock()
-    api = ArtifactsAPI(mock_core, notes_api=mock_notes)
+    api = ArtifactsAPI(
+        mock_core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     api._storage_path = str(tmp_path / "storage.json")
     return api, mock_core
 

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -25,12 +25,18 @@ from notebooklm.types import ArtifactDownloadError
 @pytest.fixture
 def mock_artifacts_api():
     """ArtifactsAPI wired to MagicMocks -- no real I/O."""
+    from notebooklm._mind_map import MindMapService
+
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
-    mock_notes = MagicMock()
-    mock_notes.list_mind_maps = AsyncMock(return_value=[])
-    api = ArtifactsAPI(mock_core, notes_api=mock_notes)
+    mind_map_service = MagicMock(spec=MindMapService)
+    mind_map_service.list_mind_maps = AsyncMock(return_value=[])
+    api = ArtifactsAPI(
+        mock_core,
+        notebooks=MagicMock(),
+        mind_map_service=mind_map_service,
+    )
     return api
 
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -721,35 +721,58 @@ def test_client_exposes_artifacts_and_notes(mock_auth: AuthTokens) -> None:
 
 
 def test_artifacts_constructible_without_notes_api(mock_auth: AuthTokens) -> None:
-    """``ArtifactsAPI`` must be constructible without ``notes_api`` — that is
-    the whole point of the mind-map decoupling."""
+    """``ArtifactsAPI`` no longer takes ``notes_api`` at all (per
+    docs/refactor.md Step 4) — the parameter was removed in favor of an
+    explicit ``mind_map_service``. The mind-map decoupling is now
+    structural."""
+    from notebooklm._mind_map import MindMapService
+
     core = MagicMock()
-    api = ArtifactsAPI(core)
+    api = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     assert api is not None
     # The legacy private attribute must not leak back: code that depends on
     # ``self._notes`` would re-introduce the coupling.
     assert not hasattr(api, "_notes")
 
 
-def test_artifacts_accepts_legacy_notes_api_kwarg(mock_auth: AuthTokens) -> None:
-    """Existing callers passing ``notes_api=`` must keep working as a no-op
-    for the deprecation cycle."""
+def test_artifacts_rejects_legacy_notes_api_kwarg(mock_auth: AuthTokens) -> None:
+    """The legacy ``notes_api=`` kwarg was removed in Phase 3
+    (docs/refactor.md Step 4). Passing it must raise ``TypeError``."""
+    from notebooklm._mind_map import MindMapService
+
     core = MagicMock()
     notes = NotesAPI(core)
-    api = ArtifactsAPI(core, notes_api=notes)
-    assert api is not None
-    # Even when supplied, the legacy attribute is intentionally not stored.
-    assert not hasattr(api, "_notes")
+    with pytest.raises(TypeError):
+        ArtifactsAPI(  # type: ignore[call-arg]
+            core,
+            notes_api=notes,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
 
 
 def test_artifacts_before_notes_construction_order(mock_auth: AuthTokens) -> None:
     """Both construction orders must succeed and produce working APIs."""
+    from notebooklm._mind_map import MindMapService
+
     core = MagicMock()
-    artifacts_first = ArtifactsAPI(core)
+
+    def _make_artifacts() -> ArtifactsAPI:
+        return ArtifactsAPI(
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=MagicMock(spec=MindMapService),
+        )
+
+    artifacts_first = _make_artifacts()
     notes_first = NotesAPI(core)
     # Build in the opposite order too, just to make the symmetry explicit.
     notes_then = NotesAPI(core)
-    artifacts_then = ArtifactsAPI(core)
+    artifacts_then = _make_artifacts()
     assert artifacts_first is not None
     assert notes_first is not None
     assert artifacts_then is not None
@@ -805,12 +828,26 @@ def _make_core_for_mind_map_flow() -> tuple[MagicMock, list[tuple[Any, Any]]]:
     return core, calls
 
 
+def _build_artifacts_with_real_mind_map_service(core: MagicMock) -> ArtifactsAPI:
+    """Build an ``ArtifactsAPI`` whose ``mind_map_service`` is a real
+    ``MindMapService(core)`` so the mind-map flow exercises the live RPC
+    callbacks against the canned ``core.rpc_call``.
+    """
+    from notebooklm._mind_map import MindMapService
+
+    return ArtifactsAPI(
+        core,
+        notebooks=MagicMock(get_source_ids=AsyncMock(return_value=["src_1"])),
+        mind_map_service=MindMapService(core),
+    )
+
+
 @pytest.mark.asyncio
 async def test_generate_mind_map_works_without_notes_injection() -> None:
     """``generate_mind_map`` must persist the mind map via ``_mind_map``
     primitives, not via an injected ``NotesAPI``."""
     core, calls = _make_core_for_mind_map_flow()
-    api = ArtifactsAPI(core)
+    api = _build_artifacts_with_real_mind_map_service(core)
 
     result = await api.generate_mind_map("nb_123", source_ids=["src_1"])
 
@@ -832,7 +869,7 @@ async def test_artifacts_list_pulls_mind_maps_without_notes_injection(
     """``ArtifactsAPI.list`` must read mind maps through ``_mind_map`` —
     no ``NotesAPI`` reference required."""
     core, _ = _make_core_for_mind_map_flow()
-    api = ArtifactsAPI(core)
+    api = _build_artifacts_with_real_mind_map_service(core)
 
     artifacts = await api.list("nb_123")
     # One mind map should surface from GET_NOTES_AND_MIND_MAPS.
@@ -846,7 +883,7 @@ async def test_download_mind_map_works_without_notes_injection(
     """``download_mind_map`` reaches into mind-map storage via ``_mind_map``
     rather than ``self._notes``."""
     core, _ = _make_core_for_mind_map_flow()
-    api = ArtifactsAPI(core)
+    api = _build_artifacts_with_real_mind_map_service(core)
 
     output = tmp_path / "mm.json"
     returned = await api.download_mind_map("nb_123", str(output))

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -14,6 +14,7 @@ from notebooklm import (
     get_request_id,
 )
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._mind_map import MindMapService
 from notebooklm._session import Session
 from notebooklm._sources import SourcesAPI
 from notebooklm.auth import AuthTokens
@@ -188,7 +189,11 @@ async def test_drain_rejects_child_task_spawned_from_accepted_operation(
 @pytest.mark.asyncio
 async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> None:
     core = Session(auth_tokens)
-    api = ArtifactsAPI(core)
+    api = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     first_poll_started = asyncio.Event()
     release_first_poll = asyncio.Event()
     poll_count = 0
@@ -318,7 +323,11 @@ async def test_upload_progress_callback_receives_byte_counts(
 @pytest.mark.asyncio
 async def test_wait_for_completion_status_change_callback(auth_tokens: AuthTokens) -> None:
     core = Session(auth_tokens)
-    api = ArtifactsAPI(core)
+    api = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     statuses = [
         GenerationStatus(task_id="task_1", status="in_progress"),
         GenerationStatus(task_id="task_1", status="completed", url="https://example.test/out"),

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -28,7 +28,9 @@ from notebooklm.types import GenerationStatus
 
 
 def _make_api():
-    """Return an ArtifactsAPI with mocked core + notes."""
+    """Return an ArtifactsAPI with mocked runtime + mind_map_service."""
+    from notebooklm._mind_map import MindMapService
+
     core = MagicMock()
     core.rpc_call = AsyncMock()
     # Real registry backing so wait_for_completion can ``dict.get(key)``.
@@ -37,12 +39,14 @@ def _make_api():
     core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
     core.bound_loop = None
     core.assert_bound_loop = MagicMock(return_value=None)
-    notes = MagicMock()
-    notes.list_mind_maps = AsyncMock(return_value=[])
-    notes.create = AsyncMock(return_value=MagicMock(id="note_1"))
+    mind_map_service = MagicMock(spec=MindMapService)
     notebooks = MagicMock()
     notebooks.get_source_ids = AsyncMock(return_value=[])
-    return ArtifactsAPI(core, notes_api=notes, notebooks=notebooks)
+    return ArtifactsAPI(
+        core,
+        notebooks=notebooks,
+        mind_map_service=mind_map_service,
+    )
 
 
 @asynccontextmanager

--- a/tests/unit/test_select_artifact.py
+++ b/tests/unit/test_select_artifact.py
@@ -45,11 +45,16 @@ def _artifact(
 
 @pytest.fixture
 def api() -> ArtifactsAPI:
-    """Build an ArtifactsAPI with no-op core / notes — only the helper is exercised."""
+    """Build an ArtifactsAPI with no-op runtime / mind-map — only the helper is exercised."""
+    from notebooklm._mind_map import MindMapService
+
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
-    mock_notes = MagicMock()
-    return ArtifactsAPI(mock_core, notes_api=mock_notes)
+    return ArtifactsAPI(
+        mock_core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
 
 
 class TestSelectArtifactFiltering:

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -90,8 +90,16 @@ async def test_active_tasks_returns_empty_for_fresh_registry() -> None:
 @pytest.mark.asyncio
 async def test_session_close_drains_artifact_poll_hook() -> None:
     """``close()`` cancels in-flight poll tasks within 1s and tears down cleanly."""
+    from unittest.mock import MagicMock
+
+    from notebooklm._mind_map import MindMapService
+
     core = Session(_auth())
-    artifacts = ArtifactsAPI(core)
+    artifacts = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_map_service=MagicMock(spec=MindMapService),
+    )
     assert core._drain_hooks["artifacts.polls"] == artifacts._polling.drain
     await core.open()
 

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -108,19 +108,16 @@ def mock_notebooks_api():
 
 
 @pytest.fixture
-def mock_notes_api():
-    """Placeholder for the legacy ``ArtifactsAPI(core, notes_api)`` signature.
+def mock_mind_map_service():
+    """Bare MagicMock standing in for ``MindMapService``.
 
-    After the mind-map relocation, ``ArtifactsAPI`` no longer reads ``notes_api`` (it consumes
-    the shared ``_mind_map`` module directly). The arg is still accepted for
-    backward compatibility and immediately discarded inside ``__init__``, so
-    this fixture intentionally returns a bare mock — no method stubs, since
-    none of the downstream code paths under test invoke any methods on it.
-    Future readers: if you find yourself adding ``AsyncMock`` setup here,
-    you probably want to drop the second positional arg from the call sites
-    instead.
+    These tests exercise generation/encoding paths that never call the
+    mind-map service; the parameter is required by ``ArtifactsAPI.__init__``
+    (per docs/refactor.md Step 4) so we pass a no-op mock.
     """
-    return MagicMock()
+    from notebooklm._mind_map import MindMapService
+
+    return MagicMock(spec=MindMapService)
 
 
 class TestChatSourceSelection:
@@ -208,9 +205,9 @@ class TestArtifactsSourceSelection:
     """Tests for source selection in ArtifactsAPI generation methods."""
 
     @pytest.mark.asyncio
-    async def test_generate_audio_with_explicit_source_ids(self, mock_core, mock_notes_api):
+    async def test_generate_audio_with_explicit_source_ids(self, mock_core, mock_mind_map_service):
         """Test generate_audio with explicitly provided source_ids."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         # Mock successful generation response
         mock_core.rpc_call.return_value = [
@@ -250,10 +247,12 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_audio_with_none_fetches_all_sources(
-        self, mock_core, mock_notes_api, mock_notebooks_api
+        self, mock_core, mock_mind_map_service, mock_notebooks_api
     ):
         """Test generate_audio with source_ids=None fetches all sources."""
-        api = ArtifactsAPI(mock_core, mock_notes_api, notebooks=mock_notebooks_api)
+        api = ArtifactsAPI(
+            mock_core, notebooks=mock_notebooks_api, mind_map_service=mock_mind_map_service
+        )
 
         # Mock get_source_ids to return source IDs
         mock_notebooks_api.get_source_ids.return_value = ["src_001", "src_002"]
@@ -281,9 +280,9 @@ class TestArtifactsSourceSelection:
         assert source_ids_triple == [[["src_001"]], [["src_002"]]]
 
     @pytest.mark.asyncio
-    async def test_generate_video_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_video_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_video has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
 
@@ -310,9 +309,11 @@ class TestArtifactsSourceSelection:
         assert source_ids_double == [["src_a"], ["src_b"]]
 
     @pytest.mark.asyncio
-    async def test_generate_video_custom_style_prompt_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_video_custom_style_prompt_encoding(
+        self, mock_core, mock_mind_map_service
+    ):
         """Test custom video style prompt is encoded after the style code."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
         mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
 
         await api.generate_video(
@@ -328,8 +329,10 @@ class TestArtifactsSourceSelection:
         assert video_config[6] == "Use hand-drawn diagrams"
 
     @pytest.mark.asyncio
-    async def test_generate_video_custom_style_requires_prompt(self, mock_core, mock_notes_api):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+    async def test_generate_video_custom_style_requires_prompt(
+        self, mock_core, mock_mind_map_service
+    ):
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -340,9 +343,9 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_video_custom_style_rejects_empty_prompt(
-        self, mock_core, mock_notes_api
+        self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -354,9 +357,9 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_video_custom_style_rejects_blank_prompt(
-        self, mock_core, mock_notes_api
+        self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -368,9 +371,9 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_video_style_prompt_requires_custom_style(
-        self, mock_core, mock_notes_api
+        self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt requires"):
             await api.generate_video(
@@ -381,8 +384,10 @@ class TestArtifactsSourceSelection:
             )
 
     @pytest.mark.asyncio
-    async def test_generate_video_cinematic_rejects_style_prompt(self, mock_core, mock_notes_api):
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+    async def test_generate_video_cinematic_rejects_style_prompt(
+        self, mock_core, mock_mind_map_service
+    ):
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="cinematic"):
             await api.generate_video(
@@ -393,9 +398,9 @@ class TestArtifactsSourceSelection:
             )
 
     @pytest.mark.asyncio
-    async def test_generate_report_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_report_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_report has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
@@ -422,9 +427,11 @@ class TestArtifactsSourceSelection:
         assert source_ids_double == [["src_x"], ["src_y"], ["src_z"]]
 
     @pytest.mark.asyncio
-    async def test_generate_report_extra_instructions_appended(self, mock_core, mock_notes_api):
+    async def test_generate_report_extra_instructions_appended(
+        self, mock_core, mock_mind_map_service
+    ):
         """extra_instructions is appended to the built-in prompt with \\n\\n separator."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
         await api.generate_report(
@@ -442,12 +449,12 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_report_extra_instructions_ignored_for_custom(
-        self, mock_core, mock_notes_api
+        self, mock_core, mock_mind_map_service
     ):
         """extra_instructions has no effect when report_format is CUSTOM."""
         from notebooklm.rpc.types import ReportFormat
 
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
         await api.generate_report(
@@ -466,9 +473,9 @@ class TestArtifactsSourceSelection:
         assert prompt == "My custom prompt"
 
     @pytest.mark.asyncio
-    async def test_generate_quiz_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_quiz_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_quiz has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_quiz", "Quiz", 4, None, 1]]
 
@@ -491,9 +498,9 @@ class TestArtifactsSourceSelection:
         assert source_ids_triple == [[["src_1"]], [["src_2"]]]
 
     @pytest.mark.asyncio
-    async def test_generate_flashcards_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_flashcards_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_flashcards has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_fc", "Flashcards", 4, None, 1]]
 
@@ -511,9 +518,9 @@ class TestArtifactsSourceSelection:
         assert source_ids_triple == [[["src_flash"]]]
 
     @pytest.mark.asyncio
-    async def test_generate_infographic_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_infographic_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_infographic has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
 
@@ -531,9 +538,9 @@ class TestArtifactsSourceSelection:
         assert source_ids_triple == [[["src_info_1"]], [["src_info_2"]]]
 
     @pytest.mark.asyncio
-    async def test_generate_infographic_style_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_infographic_style_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_infographic encodes style in config slot 5."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
 
@@ -552,9 +559,9 @@ class TestArtifactsSourceSelection:
         assert infographic_config[5] == InfographicStyle.PROFESSIONAL.value
 
     @pytest.mark.asyncio
-    async def test_generate_slide_deck_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_slide_deck_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_slide_deck has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_slide", "Slides", 8, None, 1]]
 
@@ -572,9 +579,9 @@ class TestArtifactsSourceSelection:
         assert source_ids_triple == [[["src_slide"]]]
 
     @pytest.mark.asyncio
-    async def test_generate_data_table_source_encoding(self, mock_core, mock_notes_api):
+    async def test_generate_data_table_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_data_table has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_table", "Table", 9, None, 1]]
 
@@ -593,10 +600,12 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_mind_map_source_encoding(
-        self, mock_core, mock_notes_api, mock_notebooks_api
+        self, mock_core, mock_mind_map_service, mock_notebooks_api
     ):
         """Test generate_mind_map has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, mock_notes_api, notebooks=mock_notebooks_api)
+        api = ArtifactsAPI(
+            mock_core, notebooks=mock_notebooks_api, mind_map_service=mock_mind_map_service
+        )
 
         # Mock get_source_ids to return source IDs
         mock_notebooks_api.get_source_ids.return_value = ["src_mm_1", "src_mm_2"]
@@ -628,10 +637,10 @@ class TestArtifactsSourceSelection:
 
     @pytest.mark.asyncio
     async def test_generate_mind_map_passes_language_and_instructions(
-        self, mock_core, mock_notes_api
+        self, mock_core, mock_mind_map_service
     ):
         """Test generate_mind_map passes language and instructions to RPC payload."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
 
@@ -655,11 +664,13 @@ class TestArtifactsSourceSelection:
         assert mind_map_config[2] == "ja"
 
     @pytest.mark.asyncio
-    async def test_suggest_reports_uses_get_suggested_reports(self, mock_core, mock_notes_api):
+    async def test_suggest_reports_uses_get_suggested_reports(
+        self, mock_core, mock_mind_map_service
+    ):
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod
 
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         # Mock the GET_SUGGESTED_REPORTS RPC call
         # Response format: [[[title, description, null, null, prompt, audience_level], ...]]
@@ -684,9 +695,9 @@ class TestEmptySourceIds:
     """Tests for edge cases with empty source lists."""
 
     @pytest.mark.asyncio
-    async def test_generate_with_empty_source_list(self, mock_core, mock_notes_api):
+    async def test_generate_with_empty_source_list(self, mock_core, mock_mind_map_service):
         """Test generation with empty source_ids list produces empty arrays."""
-        api = ArtifactsAPI(mock_core, mock_notes_api)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_empty", "Audio", 1, None, 1]]
 


### PR DESCRIPTION
## Summary

Phase 3 of the capability-refactor full arc — see docs/refactor.md Step 4 and ADR-013.

- Add a feature-local `ArtifactsRuntime` (composing `RpcCaller` + `AsyncWorkRuntime` + `DrainHookRegistration`) and the matching `DrainHookRegistration` Protocol inside `_artifacts.py`. The artifacts feature is the only current consumer of close-time poll-drain hooks, so the Protocol stays local rather than being promoted to `_session_contracts.py`.
- Retype `ArtifactsAPI.__init__` to `(runtime, *, notebooks, mind_map_service, storage_path=None)`. Make `notebooks` and `mind_map_service` required; remove the implicit `NotebooksAPI(session)` + `MindMapService(session)` fallbacks, the legacy `notes_api` parameter, and the `drain_hooks` parameter (subsumed by `ArtifactsRuntime.register_drain_hook`).
- Rename `self._core` → `self._runtime` in `_artifacts.py`. Keep a `_core` `@property` alias so the cross-module `api._core` accesses in `_artifact_generation.py` / `_artifact_downloads.py` (Phase 5 territory) keep working unchanged.
- Retype `ArtifactPollingService.__init__` first argument to `runtime: AsyncWorkRuntime`; rename `self._session` → `self._runtime` at all three sites (constructor, `assert_bound_loop`, `operation_scope`).
- `NotebookLMClient` explicitly wires `mind_map_service=_mind_map.MindMapService(self._session)` per the Review Checklist (Step 4 transitional-wiring bullet). Phase 5 replaces this with `NoteBackedMindMapService` and renames the parameter to `mind_maps`.
- `_session_contracts.py` is intentionally untouched — broad `Session.register_drain_hook` and standalone `DrainHookRegistration` both remain; Phase 7 removes them.
- Update ~17 direct `ArtifactsAPI(...)` / `ArtifactPollingService(...)` test construction sites + retarget `client.artifacts._core` patches to `_runtime`.

## Test plan

- [x] `uv run pre-commit run --all-files` — clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- [x] `uv run ruff check src/notebooklm tests` — clean.
- [x] `uv run ruff format --check src/notebooklm tests` — clean.
- [x] `uv run pytest` — 5505 passed, 14 skipped.
- [x] Drift sweeps:
  - `git grep "self._core" src/notebooklm/_artifacts.py` → 0
  - `git grep "self._runtime" src/notebooklm/_artifacts.py` ≥ 1
  - `git grep "drain_hooks" src/notebooklm/_artifacts.py` → 0
  - `git grep "_mind_map.MindMapService(session)" src/notebooklm/_artifacts.py` → 0
  - `git grep "mind_map_service=None\|mind_map_service: .* = None" src/notebooklm/_artifacts.py` → 0
  - `git grep "_mind_map.MindMapService(self._session)" src/notebooklm/client.py` → 1
  - `git grep "^class ArtifactsRuntime\|^class DrainHookRegistration" src/notebooklm/_artifacts.py` → 2
  - `git grep "self._session" src/notebooklm/_artifact_polling.py` → 0

## Refs

- `docs/refactor.md` §Local Artifacts Runtime, §Migration Plan step 4, §Review Checklist.
- ADR-013 — composable session capabilities.
- Master plan: `.sisyphus/plans/capability-refactor-full-arc.md` Phase 3 section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured artifact/runtime integration for clearer ownership and lifecycle handling.
  * Mind‑map service must now be provided explicitly when constructing artifact clients.
  * Added support for registering drain hooks for orderly cleanup on shutdown.

* **Tests**
  * Updated test fixtures and suites to match the new artifact/mind‑map runtime wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->