### PR TITLE
fix(auth): inline __Secure-1PSIDTS recovery on cold-start preflight (#865)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ RPC Layer (rpc/)
 | `_auth/session.py` | Session-level dataclasses |
 | `_auth/storage.py` | Profile/state persistence on disk |
 | `_auth/keepalive.py` | Cookie keepalive + `__Secure-1PSIDTS` rotation loop |
+| `_auth/psidts_recovery.py` | Inline `__Secure-1PSIDTS` recovery for cold-start preflight (issue #865) |
 | `_auth/refresh.py` | Token refresh: external `notebooklm login` driver + coalesced runs + redaction |
 | `cli/` | CLI command modules |
 
@@ -153,6 +154,7 @@ src/notebooklm/
 │   ├── session.py               # Session-level dataclasses
 │   ├── storage.py               # Profile/state persistence on disk
 │   ├── keepalive.py             # Cookie keepalive + __Secure-1PSIDTS rotation
+│   ├── psidts_recovery.py       # Inline PSIDTS recovery for cold-start (issue #865)
 │   └── refresh.py               # Token refresh driver (external login cmd, coalesced runs, redaction)
 ├── _notebooks.py                # NotebooksAPI
 ├── _sources.py                  # SourcesAPI

--- a/src/notebooklm/_auth/cookies.py
+++ b/src/notebooklm/_auth/cookies.py
@@ -407,6 +407,23 @@ def build_httpx_cookies_from_storage(path: Path | None = None) -> httpx.Cookies:
         FileNotFoundError: If storage file doesn't exist.
         ValueError: If required cookies are missing or JSON is malformed.
     """
+    try:
+        return _build_httpx_cookies_from_storage_strict(path)
+    except ValueError:
+        # Inline ``__Secure-1PSIDTS`` recovery (issue #865) — same as the
+        # ``load_auth_from_storage`` hook in ``notebooklm.auth``. Without
+        # this, ``AuthTokens.from_storage`` and ``NotebookLMClient.from_storage``
+        # would still hit the closed loop because they use this loader
+        # directly, bypassing ``load_auth_from_storage``.
+        from . import psidts_recovery
+
+        if not psidts_recovery._recover_psidts_inline(path):
+            raise
+        return _build_httpx_cookies_from_storage_strict(path)
+
+
+def _build_httpx_cookies_from_storage_strict(path: Path | None) -> httpx.Cookies:
+    """Inner load-and-validate body. No recovery — raises ``ValueError`` directly."""
     storage_state = _load_storage_state(path)
 
     cookies = httpx.Cookies()

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -1,0 +1,250 @@
+"""Inline ``__Secure-1PSIDTS`` recovery for the cookie-load preflight (issue #865).
+
+Background:
+
+``__Secure-1PSIDTS`` is the rotating freshness partner of ``__Secure-1PSID``.
+It is minted reliably only by the dedicated ``accounts.google.com/RotateCookies``
+POST that the keepalive loop in :mod:`notebooklm._auth.keepalive` uses. The
+Playwright login flow substitutes two passive ``goto()`` navigations, which
+Google does not always answer with ``Set-Cookie: __Secure-1PSIDTS``. When that
+happens, ``storage_state.json`` is saved without PSIDTS, the Tier-1 preflight
+in :mod:`notebooklm._auth.cookie_policy` rejects the next CLI invocation, and
+the keepalive recovery path (which would heal the state in one POST) is
+unreachable because it only runs inside an opened ``Session`` — a closed loop.
+
+The header comment on ``MINIMUM_REQUIRED_COOKIES`` has always described PSIDTS
+as ``directly accepted by Google's homepage check, OR recoverable via the
+RotateCookies POST when other auth cookies are intact``. This module wires the
+recoverable arm of that policy into the cold-start load path: when ``SID`` is
+present and a valid secondary binding (``OSID``, or ``APISID + SAPISID``) is
+intact but PSIDTS is missing, fire one ``RotateCookies`` POST, persist the
+rotated cookies to disk via the existing snapshot/delta save, and let the
+preflight retry.
+
+The hard-Tier-1 classification of PSIDTS in ``MINIMUM_REQUIRED_COOKIES`` is
+intentionally preserved so any caller that bypasses :func:`_recover_psidts_inline`
+still sees a strict reject. Future work (option B, tracked separately): demote
+PSIDTS to Tier 2 outright and rely on a session-open prime to mint it before
+the first RPC. That change touches the lifecycle ordering and is out of scope
+for this fix.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import httpx
+
+from . import cookie_policy as _cookie_policy
+from . import cookies as _auth_cookies
+from . import keepalive as _keepalive
+from . import storage as _auth_storage
+
+logger = logging.getLogger("notebooklm.auth")
+
+_PSIDTS_COOKIE = "__Secure-1PSIDTS"
+
+
+def _resolve_recovery_path(path: Path | str | None) -> Path | None:
+    """Resolve the effective file path for recovery, or ``None`` to decline.
+
+    Mirrors ``_load_storage_state`` (`_auth/cookies.py`) precedence:
+
+    - explicit ``path`` argument → use as-is (cast ``str`` to ``Path``)
+    - ``NOTEBOOKLM_AUTH_JSON`` env-var set → return ``None`` (no writeable
+      backing store; tracked as future-work in this module's docstring)
+    - otherwise → fall back to :func:`notebooklm.paths.get_storage_path`,
+      so ``load_auth_from_storage()`` with no args still triggers recovery
+      on the default profile file (issue #865 critical-path coverage).
+    """
+    if path:
+        return Path(path)
+    if os.environ.get("NOTEBOOKLM_AUTH_JSON"):
+        return None
+    from ..paths import get_storage_path
+
+    return get_storage_path()
+
+
+def _recover_psidts_inline(path: Path | str | None) -> bool:
+    """Attempt a one-shot ``RotateCookies`` POST to mint ``__Secure-1PSIDTS``.
+
+    Pre-conditions (all must hold; otherwise return ``False`` without firing):
+
+    1. ``SID`` present in ``storage_path``.
+    2. ``__Secure-1PSIDTS`` absent in ``storage_path``.
+    3. Secondary binding intact (``OSID``, or ``APISID + SAPISID``). Google
+       rejects ``RotateCookies`` requests that lack these — see
+       :func:`notebooklm._auth.cookie_policy._has_valid_secondary_binding`.
+    4. Cross-process rotation flock available
+       (:func:`notebooklm._auth.keepalive._file_lock_try_exclusive` against
+       :func:`notebooklm._auth.keepalive._rotation_lock_path`). Mirrors
+       ``_poke_session``'s outer guard so concurrent cold-start CLI
+       processes don't each fire the POST.
+    5. In-process rotation throttle slot available
+       (:func:`notebooklm._auth.keepalive._try_claim_rotation`). Inner guard
+       against same-process duplicates (e.g. two callers on the same loop).
+
+    On success the rotated cookies are merged into the file at ``storage_path``
+    via :func:`notebooklm._auth.storage.save_cookies_to_storage` (snapshot/delta
+    semantics, atomic write, cross-process file lock). ``save_cookies_to_storage``
+    is contract-bound to return ``False`` (not raise) on a persistence failure;
+    we check the return value and surface the persist failure as ``False`` so
+    the caller's preflight retry sees the unhealed state and re-raises honestly.
+    On any failure the function returns ``False`` and the caller's original
+    ``ValueError`` stands.
+
+    Args:
+        path: Path to ``storage_state.json``, or ``None`` to resolve the
+            default profile file. When ``NOTEBOOKLM_AUTH_JSON`` is set the
+            function declines because there is no writeable backing store
+            to persist the rotated cookies to (tracked future-work).
+
+    Returns:
+        ``True`` if PSIDTS is now persisted on disk; ``False`` otherwise.
+    """
+    storage_path = _resolve_recovery_path(path)
+    if storage_path is None:
+        logger.debug(
+            "PSIDTS recovery skipped: env-var auth (NOTEBOOKLM_AUTH_JSON) "
+            "has no writeable backing store"
+        )
+        return False
+
+    try:
+        storage_state = _auth_cookies._load_storage_state(storage_path)
+    except (OSError, ValueError) as exc:
+        logger.debug("PSIDTS recovery skipped: cannot read %s: %s", storage_path, exc)
+        return False
+
+    raw_entries = storage_state.get("cookies", [])
+    if not isinstance(raw_entries, list):
+        return False
+    cookie_entries: list[dict] = [entry for entry in raw_entries if isinstance(entry, dict)]
+    cookie_names: set[str] = {
+        name for entry in cookie_entries if isinstance(name := entry.get("name"), str) and name
+    }
+
+    if "SID" not in cookie_names:
+        logger.debug("PSIDTS recovery skipped: SID missing — session is truly broken")
+        return False
+    if _PSIDTS_COOKIE in cookie_names:
+        return False
+    if not _cookie_policy._has_valid_secondary_binding(cookie_names):
+        logger.debug(
+            "PSIDTS recovery skipped: secondary binding incomplete "
+            "(need OSID, or both APISID and SAPISID)"
+        )
+        return False
+    # Cross-process flock first. Two simultaneous cold-start CLI invocations
+    # would each pass the in-process throttle (which is keyed on a per-process
+    # dict) and both fire ``RotateCookies``. The flock matches the outer guard
+    # ``_poke_session`` uses; a held lock means the other process is rotating
+    # right now — skip and let the caller's preflight retry see whatever they
+    # land on disk.
+    rotate_lock_path = _keepalive._rotation_lock_path(storage_path)
+    if rotate_lock_path is None:
+        # Defense-in-depth: ``_rotation_lock_path`` only returns None when its
+        # argument is None, and we've early-returned above when path is None.
+        # Fall through to the in-process guard alone, matching the keepalive's
+        # equivalent branch.
+        return _attempt_rotation(storage_path, cookie_entries)
+
+    with _keepalive._file_lock_try_exclusive(rotate_lock_path) as acquired:
+        if not acquired:
+            logger.debug(
+                "PSIDTS recovery skipped: %s held by another process",
+                rotate_lock_path,
+            )
+            return False
+        return _attempt_rotation(storage_path, cookie_entries)
+
+
+def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
+    """Fire one ``RotateCookies`` POST and persist the rotated cookies.
+
+    Inner half of :func:`_recover_psidts_inline` — the steps that run after
+    every guard (preconditions, cross-process flock) has passed. Split out so
+    the cross-process flock context manager has one clean exit point.
+    """
+    if not _keepalive._try_claim_rotation(storage_path):
+        logger.debug(
+            "PSIDTS recovery skipped: %s claimed by another in-process caller",
+            storage_path,
+        )
+        return False
+
+    # Build the cookie jar manually so the validator (which would raise) is
+    # bypassed. Mirrors ``build_httpx_cookies_from_storage`` without the
+    # ``_validate_required_cookies`` call.
+    jar = httpx.Cookies()
+    for entry in cookie_entries:
+        if not entry.get("name") or not entry.get("value"):
+            continue
+        if not _cookie_policy._is_allowed_auth_domain(entry.get("domain", "")):
+            continue
+        jar.jar.set_cookie(_auth_cookies._storage_entry_to_cookie(entry))
+
+    # ``httpx.Client(cookies=jar)`` copies the source jar into a private client
+    # jar; Set-Cookie responses land in ``client.cookies``, not in ``jar``. So
+    # we snapshot and check the *client's* jar, mirroring how the async
+    # keepalive in ``_session_lifecycle.save_cookies`` reads ``client.cookies``.
+    try:
+        with httpx.Client(
+            cookies=jar,
+            follow_redirects=True,
+            timeout=_keepalive._KEEPALIVE_POKE_TIMEOUT,
+        ) as client:
+            snapshot = _auth_storage.snapshot_cookie_jar(client.cookies)
+            response = client.post(
+                _keepalive.KEEPALIVE_ROTATE_URL,
+                headers=_keepalive._KEEPALIVE_ROTATE_HEADERS,
+                content=_keepalive._KEEPALIVE_ROTATE_BODY,
+            )
+            response.raise_for_status()
+            rotated_jar = client.cookies
+            psidts_present = any(c.name == _PSIDTS_COOKIE for c in rotated_jar.jar)
+    except httpx.HTTPError as exc:
+        logger.debug("Inline PSIDTS recovery POST failed (non-fatal): %s", exc)
+        return False
+
+    if not psidts_present:
+        logger.debug(
+            "Inline PSIDTS recovery: RotateCookies returned 2xx but did not "
+            "include %s — Google may be withholding the rotation",
+            _PSIDTS_COOKIE,
+        )
+        return False
+
+    # ``save_cookies_to_storage`` returns False (not raises) on every
+    # persist-failure path: missing file, invalid payload, CAS conflict,
+    # atomic-write failure (see ``_auth/storage.py:380-429``). The bare
+    # ``except`` below catches the *unexpected* raises only (future refactor
+    # could change the contract); the explicit return-value check is what
+    # surfaces the documented failure modes.
+    try:
+        persisted = _auth_storage.save_cookies_to_storage(
+            rotated_jar, storage_path, original_snapshot=snapshot
+        )
+    except Exception as exc:  # noqa: BLE001 - persistence failure is non-fatal here
+        logger.warning(
+            "Inline PSIDTS recovery: persist to %s raised %s", storage_path, exc
+        )
+        return False
+
+    if not persisted:
+        logger.warning(
+            "Inline PSIDTS recovery: save_cookies_to_storage returned False; "
+            "on-disk state still lacks %s",
+            _PSIDTS_COOKIE,
+        )
+        return False
+
+    logger.info(
+        "Recovered %s via inline RotateCookies POST and persisted to %s (issue #865)",
+        _PSIDTS_COOKIE,
+        storage_path,
+    )
+    return True

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -158,7 +158,10 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         # Re-read inside the lock: another process may have completed its
         # rotation + save between our top-of-function precondition check and
         # acquiring this flock. Mirrors ``_poke_session``'s "one last disk
-        # recheck" pattern at ``_auth/keepalive.py:283-290``.
+        # recheck" pattern at ``_auth/keepalive.py:283-290``. Re-validate the
+        # FULL precondition set against the fresh state (not just PSIDTS-present)
+        # so a concurrent write that dropped SID or the secondary binding
+        # can't slip a doomed POST through.
         fresh = _read_storage_for_recovery(storage_path)
         if fresh is None:
             return False
@@ -168,6 +171,14 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
                 "PSIDTS recovery skipped: file healed by another process while waiting for flock"
             )
             return True
+        if "SID" not in fresh_names:
+            logger.debug("PSIDTS recovery skipped: SID missing after flock acquisition")
+            return False
+        if not _cookie_policy._has_valid_secondary_binding(fresh_names):
+            logger.debug(
+                "PSIDTS recovery skipped: secondary binding incomplete after flock acquisition"
+            )
+            return False
         return _attempt_rotation(storage_path, fresh_entries)
 
 

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -229,9 +229,7 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
             rotated_jar, storage_path, original_snapshot=snapshot
         )
     except Exception as exc:  # noqa: BLE001 - persistence failure is non-fatal here
-        logger.warning(
-            "Inline PSIDTS recovery: persist to %s raised %s", storage_path, exc
-        )
+        logger.warning("Inline PSIDTS recovery: persist to %s raised %s", storage_path, exc)
         return False
 
     if not persisted:

--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -31,6 +31,7 @@ for this fix.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -113,19 +114,10 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         )
         return False
 
-    try:
-        storage_state = _auth_cookies._load_storage_state(storage_path)
-    except (OSError, ValueError) as exc:
-        logger.debug("PSIDTS recovery skipped: cannot read %s: %s", storage_path, exc)
+    state = _read_storage_for_recovery(storage_path)
+    if state is None:
         return False
-
-    raw_entries = storage_state.get("cookies", [])
-    if not isinstance(raw_entries, list):
-        return False
-    cookie_entries: list[dict] = [entry for entry in raw_entries if isinstance(entry, dict)]
-    cookie_names: set[str] = {
-        name for entry in cookie_entries if isinstance(name := entry.get("name"), str) and name
-    }
+    cookie_entries, cookie_names = state
 
     if "SID" not in cookie_names:
         logger.debug("PSIDTS recovery skipped: SID missing — session is truly broken")
@@ -142,8 +134,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     # would each pass the in-process throttle (which is keyed on a per-process
     # dict) and both fire ``RotateCookies``. The flock matches the outer guard
     # ``_poke_session`` uses; a held lock means the other process is rotating
-    # right now — skip and let the caller's preflight retry see whatever they
-    # land on disk.
+    # right now.
     rotate_lock_path = _keepalive._rotation_lock_path(storage_path)
     if rotate_lock_path is None:
         # Defense-in-depth: ``_rotation_lock_path`` only returns None when its
@@ -154,12 +145,70 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
 
     with _keepalive._file_lock_try_exclusive(rotate_lock_path) as acquired:
         if not acquired:
+            # Holder may already have healed the file by the time they
+            # released the lock. Re-read once before declining so the caller's
+            # retry sees the heal instead of a stale ``ValueError``.
+            healed = _is_psidts_persisted(storage_path)
             logger.debug(
-                "PSIDTS recovery skipped: %s held by another process",
+                "PSIDTS recovery skipped: %s held by another process (healed=%s)",
                 rotate_lock_path,
+                healed,
             )
+            return healed
+        # Re-read inside the lock: another process may have completed its
+        # rotation + save between our top-of-function precondition check and
+        # acquiring this flock. Mirrors ``_poke_session``'s "one last disk
+        # recheck" pattern at ``_auth/keepalive.py:283-290``.
+        fresh = _read_storage_for_recovery(storage_path)
+        if fresh is None:
             return False
-        return _attempt_rotation(storage_path, cookie_entries)
+        fresh_entries, fresh_names = fresh
+        if _PSIDTS_COOKIE in fresh_names:
+            logger.debug(
+                "PSIDTS recovery skipped: file healed by another process while waiting for flock"
+            )
+            return True
+        return _attempt_rotation(storage_path, fresh_entries)
+
+
+def _read_storage_for_recovery(
+    storage_path: Path,
+) -> tuple[list[dict], set[str]] | None:
+    """Load + filter + name-index storage_state for the recovery preconditions.
+
+    Returns ``(cookie_entries, cookie_names)`` on success, or ``None`` on any
+    load/parse failure (caller treats this as "decline recovery"). The narrow
+    exception scope catches the documented raise sites of ``_load_storage_state``
+    (``OSError`` for missing file, ``json.JSONDecodeError`` for malformed JSON)
+    and lets unexpected ``ValueError`` propagate as an implementation bug.
+    """
+    try:
+        storage_state = _auth_cookies._load_storage_state(storage_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("PSIDTS recovery skipped: cannot read %s: %s", storage_path, exc)
+        return None
+    raw_entries = storage_state.get("cookies", [])
+    if not isinstance(raw_entries, list):
+        return None
+    cookie_entries: list[dict] = [entry for entry in raw_entries if isinstance(entry, dict)]
+    cookie_names: set[str] = {
+        name for entry in cookie_entries if isinstance(name := entry.get("name"), str) and name
+    }
+    return cookie_entries, cookie_names
+
+
+def _is_psidts_persisted(storage_path: Path) -> bool:
+    """Quick re-read: is ``__Secure-1PSIDTS`` currently in the on-disk file?
+
+    Used after a held-flock skip to detect when another process has just healed
+    the file. Treats any load/parse failure as "not persisted" rather than
+    raising — the caller will retry.
+    """
+    state = _read_storage_for_recovery(storage_path)
+    if state is None:
+        return False
+    _, names = state
+    return _PSIDTS_COOKIE in names
 
 
 def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:

--- a/src/notebooklm/auth.py
+++ b/src/notebooklm/auth.py
@@ -44,6 +44,7 @@ from ._auth import extraction as _auth_extraction
 from ._auth import headers as _auth_headers
 from ._auth import keepalive as _auth_keepalive
 from ._auth import paths as _auth_paths
+from ._auth import psidts_recovery as _auth_psidts_recovery
 from ._auth import refresh as _auth_refresh
 from ._auth import storage as _auth_storage
 from .paths import get_storage_path
@@ -473,7 +474,26 @@ def load_auth_from_storage(path: Path | None = None) -> dict[str, str]:
         cookies = load_auth_from_storage()
     """
     storage_state = _load_storage_state(path)
-    return extract_cookies_from_storage(storage_state)
+    try:
+        return extract_cookies_from_storage(storage_state)
+    except ValueError:
+        # Inline ``__Secure-1PSIDTS`` recovery (issue #865). Playwright login
+        # can land a ``storage_state.json`` that carries SID + secondary
+        # binding but lacks PSIDTS, because Google only mints PSIDTS
+        # deterministically in response to the dedicated ``RotateCookies``
+        # POST — not on the passive ``goto()`` navigations the login flow
+        # uses. The preflight then rejects before the keepalive's RotateCookies
+        # path can heal the state. When the recovery preconditions hold, fire
+        # one POST + persist before re-raising — see
+        # :mod:`notebooklm._auth.psidts_recovery` for the precondition list.
+        # ``_recover_psidts_inline`` resolves the effective storage path
+        # itself (default file when ``path is None`` and env-var unset), so
+        # we pass ``path`` through verbatim — including ``None`` for the
+        # default-profile case.
+        if not _auth_psidts_recovery._recover_psidts_inline(path):
+            raise
+        storage_state = _load_storage_state(path)
+        return extract_cookies_from_storage(storage_state)
 
 
 # Env-var name constants live in ``notebooklm._auth.paths``. Re-exported so
@@ -517,6 +537,14 @@ _file_lock_try_exclusive = _auth_keepalive._file_lock_try_exclusive
 _is_recently_rotated = _auth_keepalive._is_recently_rotated
 _poke_session = _auth_keepalive._poke_session
 _rotate_cookies = _auth_keepalive._rotate_cookies
+# Inline PSIDTS recovery (issue #865). Static facade alias for public-surface
+# symmetry; the load path in ``load_auth_from_storage`` and
+# ``_auth/cookies.build_httpx_cookies_from_storage`` calls
+# ``_auth_psidts_recovery._recover_psidts_inline`` directly, so monkeypatches
+# against ``notebooklm.auth._recover_psidts_inline`` do NOT affect runtime
+# behavior. Tests that need to substitute the recovery body should patch
+# ``notebooklm._auth.psidts_recovery._recover_psidts_inline``.
+_recover_psidts_inline = _auth_psidts_recovery._recover_psidts_inline
 # Rotation sentinel path lives in ``_auth.paths``; the keepalive module also
 # aliases it locally. Re-exported here for white-box callers that resolve it
 # against ``notebooklm.auth``.

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -143,6 +143,16 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "tests/unit/test_artifact_downloads.py",
         "tests/unit/test_artifacts_coverage.py",
         "tests/unit/test_auth_cookie_save_race.py",
+        # PSIDTS inline recovery (issue #865) — patches module-level
+        # seams (``_try_claim_rotation``, ``_file_lock_try_exclusive``,
+        # ``save_cookies_to_storage``, ``_load_storage_state``, and
+        # ``get_storage_path``) that are NOT part of the core-injection
+        # surface ``tests/_fixtures/make_fake_core(...)`` covers. Same
+        # rationale as the neighboring ``test_auth_cookie_save_race.py``
+        # and ``test_auth_session.py`` entries; revisit when ADR-007's
+        # seam-substitution pattern is extended to cover module-level
+        # rotation/lock helpers.
+        "tests/unit/test_auth_psidts_recovery.py",
         "tests/unit/test_auth_session.py",
         "tests/unit/test_backoff.py",
         "tests/unit/test_chat_delete_conversation.py",

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -104,9 +104,7 @@ class TestRecoveryPreconditions:
         self, tmp_path, httpx_mock: HTTPXMock
     ):
         """No OSID, no APISID+SAPISID — Google will reject RotateCookies."""
-        cookies = [
-            c for c in _RECOVERABLE_COOKIES if c["name"] not in {"APISID", "SAPISID"}
-        ]
+        cookies = [c for c in _RECOVERABLE_COOKIES if c["name"] not in {"APISID", "SAPISID"}]
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, cookies)
 
@@ -139,9 +137,7 @@ class TestRecoveryPreconditions:
 
         # Force ``_try_claim_rotation`` to deny the claim, simulating a sibling
         # caller having just claimed the slot.
-        monkeypatch.setattr(
-            "notebooklm._auth.keepalive._try_claim_rotation", lambda _path: False
-        )
+        monkeypatch.setattr("notebooklm._auth.keepalive._try_claim_rotation", lambda _path: False)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -167,9 +163,7 @@ class TestRecoveryHappyPath:
         assert psidts["value"] == "fresh_psidts_value"
 
     @pytest.mark.no_default_keepalive_mock
-    def test_post_uses_existing_cookies_as_request_jar(
-        self, tmp_path, httpx_mock: HTTPXMock
-    ):
+    def test_post_uses_existing_cookies_as_request_jar(self, tmp_path, httpx_mock: HTTPXMock):
         """The recovery POST must carry the existing auth cookies so Google honours it."""
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, _RECOVERABLE_COOKIES)
@@ -177,9 +171,7 @@ class TestRecoveryHappyPath:
 
         psidts_recovery._recover_psidts_inline(storage_path)
 
-        rotate_requests = [
-            r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))
-        ]
+        rotate_requests = [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))]
         assert len(rotate_requests) == 1
         cookie_header = rotate_requests[0].headers.get("cookie", "")
         # Sanity-check the request carries SID + the secondary binding.
@@ -226,9 +218,7 @@ class TestRecoveryFailureModes:
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
 
     @pytest.mark.no_default_keepalive_mock
-    def test_200_without_psidts_in_response_returns_false(
-        self, tmp_path, httpx_mock: HTTPXMock
-    ):
+    def test_200_without_psidts_in_response_returns_false(self, tmp_path, httpx_mock: HTTPXMock):
         """Google may 200 without minting PSIDTS — must not claim success."""
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, _RECOVERABLE_COOKIES)
@@ -255,9 +245,7 @@ class TestLoadAuthFromStorageIntegration:
     """The recovery must be wired into :func:`load_auth_from_storage`."""
 
     @pytest.mark.no_default_keepalive_mock
-    def test_recovers_psidts_before_returning_cookies(
-        self, tmp_path, httpx_mock: HTTPXMock
-    ):
+    def test_recovers_psidts_before_returning_cookies(self, tmp_path, httpx_mock: HTTPXMock):
         """The first call recovers + the function returns the validated dict."""
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, _RECOVERABLE_COOKIES)
@@ -269,9 +257,7 @@ class TestLoadAuthFromStorageIntegration:
         assert cookies["SID"] == "test_sid"
 
     @pytest.mark.no_default_keepalive_mock
-    def test_propagates_value_error_when_recovery_declines(
-        self, tmp_path, httpx_mock: HTTPXMock
-    ):
+    def test_propagates_value_error_when_recovery_declines(self, tmp_path, httpx_mock: HTTPXMock):
         """Preconditions failing → original ValueError stands."""
         cookies_no_binding = [
             c for c in _RECOVERABLE_COOKIES if c["name"] not in {"APISID", "SAPISID"}
@@ -283,9 +269,7 @@ class TestLoadAuthFromStorageIntegration:
             auth_module.load_auth_from_storage(storage_path)
 
     @pytest.mark.no_default_keepalive_mock
-    def test_propagates_value_error_when_recovery_post_fails(
-        self, tmp_path, httpx_mock: HTTPXMock
-    ):
+    def test_propagates_value_error_when_recovery_post_fails(self, tmp_path, httpx_mock: HTTPXMock):
         """Recovery attempts but fails at the POST → original ValueError."""
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, _RECOVERABLE_COOKIES)
@@ -422,9 +406,7 @@ class TestEdgeCases:
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
 
     @pytest.mark.no_default_keepalive_mock
-    def test_save_raising_propagates_as_failure(
-        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
-    ):
+    def test_save_raising_propagates_as_failure(self, tmp_path, monkeypatch, httpx_mock: HTTPXMock):
         """Unexpected exception from ``save_cookies_to_storage`` → False, not propagated."""
         storage_path = tmp_path / "storage_state.json"
         _write_storage(storage_path, _RECOVERABLE_COOKIES)

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -535,3 +535,30 @@ class TestEdgeCases:
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
         # Crucial: no POST — recheck saw the heal before we fired.
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_post_flock_recheck_re_validates_full_preconditions(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """If a concurrent write LOSES SID or secondary binding between the initial
+        precondition read and acquiring the flock, the post-flock recheck must
+        decline rather than fire a doomed POST (CodeRabbit follow-up: issue #865).
+        """
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        # Pre-heal: precondition gate passes. Post-heal: SID got dropped by a
+        # concurrent process (e.g. logout, profile switch).
+        pre_heal_state = {"cookies": _RECOVERABLE_COOKIES}
+        post_heal_state = {"cookies": [c for c in _RECOVERABLE_COOKIES if c["name"] != "SID"]}
+        call_counter = {"n": 0}
+
+        def staged_load(_p):
+            call_counter["n"] += 1
+            return pre_heal_state if call_counter["n"] == 1 else post_heal_state
+
+        monkeypatch.setattr("notebooklm._auth.cookies._load_storage_state", staged_load)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        # No POST — recheck saw the broken state and aborted before firing.
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -449,3 +449,89 @@ class TestEdgeCases:
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_flock_held_returns_true_when_file_already_healed(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Flock held + on-disk file ALREADY has PSIDTS → return True without POST.
+
+        Closes the TOCTOU window flagged by claude bot (Minor Design Gap): when
+        we lose the flock race, the holder may have already finished writing.
+        The cheap re-read avoids the caller's preflight re-raising stale.
+        """
+        import contextlib
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        @contextlib.contextmanager
+        def held_lock(_lock_path):
+            yield False
+
+        # Two-phase view: precondition sees missing-PSIDTS state, post-flock
+        # re-read (via _is_psidts_persisted) sees healed state.
+        pre_heal_state = {"cookies": _RECOVERABLE_COOKIES}
+        post_heal_state = {
+            "cookies": _RECOVERABLE_COOKIES
+            + [
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "healed_by_sibling_process",
+                    "domain": ".google.com",
+                    "path": "/",
+                }
+            ]
+        }
+        call_counter = {"n": 0}
+
+        def staged_load(_p):
+            call_counter["n"] += 1
+            return pre_heal_state if call_counter["n"] == 1 else post_heal_state
+
+        monkeypatch.setattr("notebooklm._auth.cookies._load_storage_state", staged_load)
+        monkeypatch.setattr(
+            "notebooklm._auth.psidts_recovery._keepalive._file_lock_try_exclusive",
+            held_lock,
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+        # No POST — the holder already did the work.
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_post_flock_recheck_skips_post_when_file_healed_meanwhile(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Acquired the flock BUT another process healed between initial check
+        and flock-acquired → don't fire POST, return True (TOCTOU close).
+
+        Mirrors ``_poke_session``'s "one last disk recheck" at
+        ``_auth/keepalive.py:283-290``. Pinned by CodeRabbit Major: issue #865.
+        """
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        pre_heal_state = {"cookies": _RECOVERABLE_COOKIES}
+        post_heal_state = {
+            "cookies": _RECOVERABLE_COOKIES
+            + [
+                {
+                    "name": "__Secure-1PSIDTS",
+                    "value": "healed_meanwhile",
+                    "domain": ".google.com",
+                    "path": "/",
+                }
+            ]
+        }
+        call_counter = {"n": 0}
+
+        def staged_load(_p):
+            call_counter["n"] += 1
+            return pre_heal_state if call_counter["n"] == 1 else post_heal_state
+
+        monkeypatch.setattr("notebooklm._auth.cookies._load_storage_state", staged_load)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+        # Crucial: no POST — recheck saw the heal before we fired.
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -1,0 +1,469 @@
+"""Tests for inline ``__Secure-1PSIDTS`` recovery (issue #865).
+
+Covers :mod:`notebooklm._auth.psidts_recovery` and its integration into
+:func:`notebooklm.auth.load_auth_from_storage`. The recovery breaks a closed
+loop in the cold-start preflight: when ``storage_state.json`` lacks PSIDTS but
+carries ``SID`` + a valid secondary binding, the preflight rejects before the
+keepalive's ``RotateCookies`` POST can heal the state. This module's tests pin
+the precondition gate, the throttle, the persistence, and the load-path
+integration so the loop stays broken.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from notebooklm import auth as auth_module
+from notebooklm._auth import psidts_recovery
+
+_ROTATE_URL_RE = re.compile(r"^https://accounts\.google\.com/RotateCookies$")
+
+
+# Cookies that, together, form the minimum acceptable recovery precondition:
+# SID + secondary binding (APISID + SAPISID), with PSIDTS intentionally absent.
+_RECOVERABLE_COOKIES: list[dict] = [
+    {"name": "SID", "value": "test_sid", "domain": ".google.com", "path": "/"},
+    {"name": "APISID", "value": "test_apisid", "domain": ".google.com", "path": "/"},
+    {"name": "SAPISID", "value": "test_sapisid", "domain": ".google.com", "path": "/"},
+    {"name": "HSID", "value": "test_hsid", "domain": ".google.com", "path": "/"},
+    {"name": "SSID", "value": "test_ssid", "domain": ".google.com", "path": "/"},
+]
+
+
+def _write_storage(path: Path, cookies: list[dict]) -> None:
+    path.write_text(json.dumps({"cookies": cookies, "origins": []}))
+
+
+def _make_psidts_response(status_code: int = 200, *, include_psidts: bool = True):
+    """Build a response shape matching what Google's RotateCookies returns."""
+    headers: list[tuple[str, str]] = []
+    if include_psidts:
+        # Match Google's real Set-Cookie shape — Domain=.google.com,
+        # Path=/, Secure, HttpOnly. The httpx jar parses these directly.
+        headers.append(
+            (
+                "Set-Cookie",
+                "__Secure-1PSIDTS=fresh_psidts_value; "
+                "Domain=.google.com; Path=/; Secure; HttpOnly; SameSite=Lax",
+            )
+        )
+        headers.append(
+            (
+                "Set-Cookie",
+                "__Secure-3PSIDTS=fresh_3psidts_value; "
+                "Domain=.google.com; Path=/; Secure; HttpOnly; SameSite=None",
+            )
+        )
+    return {
+        "status_code": status_code,
+        "headers": headers,
+        "content": b'["identity.hfcr",600]',
+    }
+
+
+class TestRecoveryPreconditions:
+    """The precondition gate must short-circuit before the POST fires."""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_no_sid_returns_false_without_post(self, tmp_path, httpx_mock: HTTPXMock):
+        """No SID → session is truly dead → recovery declines."""
+        cookies = [c for c in _RECOVERABLE_COOKIES if c["name"] != "SID"]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_psidts_already_present_returns_false_without_post(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """Nothing to recover when PSIDTS is already there."""
+        cookies = _RECOVERABLE_COOKIES + [
+            {
+                "name": "__Secure-1PSIDTS",
+                "value": "already_present",
+                "domain": ".google.com",
+                "path": "/",
+            }
+        ]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_missing_secondary_binding_returns_false_without_post(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """No OSID, no APISID+SAPISID — Google will reject RotateCookies."""
+        cookies = [
+            c for c in _RECOVERABLE_COOKIES if c["name"] not in {"APISID", "SAPISID"}
+        ]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_osid_alone_satisfies_secondary_binding(self, tmp_path, httpx_mock: HTTPXMock):
+        """OSID is the alternative secondary binding (per ``_has_valid_secondary_binding``)."""
+        cookies = [
+            {"name": "SID", "value": "test_sid", "domain": ".google.com", "path": "/"},
+            {"name": "OSID", "value": "test_osid", "domain": ".google.com", "path": "/"},
+        ]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+
+    def test_missing_file_returns_false(self, tmp_path):
+        """A storage path that doesn't exist cannot be recovered."""
+        storage_path = tmp_path / "does_not_exist.json"
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_throttle_claim_failure_skips_post(self, tmp_path, monkeypatch, httpx_mock: HTTPXMock):
+        """A claimed rotation slot prevents the POST from firing."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        # Force ``_try_claim_rotation`` to deny the claim, simulating a sibling
+        # caller having just claimed the slot.
+        monkeypatch.setattr(
+            "notebooklm._auth.keepalive._try_claim_rotation", lambda _path: False
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+
+class TestRecoveryHappyPath:
+    """End-to-end recovery: POST + persist + reload."""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_persists_psidts_to_storage_state(self, tmp_path, httpx_mock: HTTPXMock):
+        """The rotated PSIDTS must land in storage_state.json on disk."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is True
+
+        saved = json.loads(storage_path.read_text())
+        names = {c["name"] for c in saved["cookies"]}
+        assert "__Secure-1PSIDTS" in names
+        psidts = next(c for c in saved["cookies"] if c["name"] == "__Secure-1PSIDTS")
+        assert psidts["value"] == "fresh_psidts_value"
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_post_uses_existing_cookies_as_request_jar(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """The recovery POST must carry the existing auth cookies so Google honours it."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        psidts_recovery._recover_psidts_inline(storage_path)
+
+        rotate_requests = [
+            r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))
+        ]
+        assert len(rotate_requests) == 1
+        cookie_header = rotate_requests[0].headers.get("cookie", "")
+        # Sanity-check the request carries SID + the secondary binding.
+        assert "SID=test_sid" in cookie_header
+        assert "APISID=test_apisid" in cookie_header
+        assert "SAPISID=test_sapisid" in cookie_header
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_preserves_other_cookies_in_storage(self, tmp_path, httpx_mock: HTTPXMock):
+        """Cookies that weren't rotated must survive the recovery write."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        psidts_recovery._recover_psidts_inline(storage_path)
+
+        saved = json.loads(storage_path.read_text())
+        names = {c["name"] for c in saved["cookies"]}
+        for original in _RECOVERABLE_COOKIES:
+            assert original["name"] in names
+
+
+class TestRecoveryFailureModes:
+    """Network and protocol-level failures must not raise — return False."""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_4xx_response_returns_false(self, tmp_path, httpx_mock: HTTPXMock):
+        """A 401/403/etc. from RotateCookies → no rotation → return False."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=401)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        # PSIDTS must NOT have been written.
+        saved = json.loads(storage_path.read_text())
+        assert "__Secure-1PSIDTS" not in {c["name"] for c in saved["cookies"]}
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_5xx_response_returns_false(self, tmp_path, httpx_mock: HTTPXMock):
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=503)
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_200_without_psidts_in_response_returns_false(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """Google may 200 without minting PSIDTS — must not claim success."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(
+            url=_ROTATE_URL_RE,
+            **_make_psidts_response(include_psidts=False),
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        saved = json.loads(storage_path.read_text())
+        assert "__Secure-1PSIDTS" not in {c["name"] for c in saved["cookies"]}
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_network_error_returns_false(self, tmp_path, httpx_mock: HTTPXMock):
+        """A connection error during the POST → False, not a raise."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_exception(httpx.ConnectError("simulated network failure"))
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+
+class TestLoadAuthFromStorageIntegration:
+    """The recovery must be wired into :func:`load_auth_from_storage`."""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_recovers_psidts_before_returning_cookies(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """The first call recovers + the function returns the validated dict."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        cookies = auth_module.load_auth_from_storage(storage_path)
+
+        assert cookies["__Secure-1PSIDTS"] == "fresh_psidts_value"
+        assert cookies["SID"] == "test_sid"
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_propagates_value_error_when_recovery_declines(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """Preconditions failing → original ValueError stands."""
+        cookies_no_binding = [
+            c for c in _RECOVERABLE_COOKIES if c["name"] not in {"APISID", "SAPISID"}
+        ]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies_no_binding)
+
+        with pytest.raises(ValueError, match="__Secure-1PSIDTS"):
+            auth_module.load_auth_from_storage(storage_path)
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_propagates_value_error_when_recovery_post_fails(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """Recovery attempts but fails at the POST → original ValueError."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, status_code=500)
+
+        with pytest.raises(ValueError, match="__Secure-1PSIDTS"):
+            auth_module.load_auth_from_storage(storage_path)
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_does_not_attempt_recovery_for_env_var_auth(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Env-var auth (``path=None`` + ``NOTEBOOKLM_AUTH_JSON``) is out-of-scope.
+
+        The recovery requires a writeable backing store; for env-var auth we
+        let the original ValueError stand. See module docstring of
+        :mod:`notebooklm._auth.psidts_recovery` for the tracked future-work
+        item.
+        """
+        storage_state = {"cookies": _RECOVERABLE_COOKIES}
+        monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", json.dumps(storage_state))
+
+        with pytest.raises(ValueError, match="__Secure-1PSIDTS"):
+            auth_module.load_auth_from_storage(None)
+
+        # Crucially: no RotateCookies POST must have fired for env-var auth.
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_recovers_when_path_is_none_with_no_env_var(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """``load_auth_from_storage(None)`` with no env-var resolves to the default
+        profile file and STILL triggers recovery (Codex Critical: issue #865).
+
+        Before the fix, ``path is None`` was treated as a recovery skip-condition,
+        but ``_load_storage_state(None)`` falls through to ``get_storage_path()``
+        when ``NOTEBOOKLM_AUTH_JSON`` is unset — that's the most common library
+        usage. The recovery must resolve the same default.
+        """
+        # Point ``get_storage_path()`` at a tmp file populated with the
+        # recoverable-but-PSIDTS-missing state. Patch the SOURCE module so
+        # both ``_load_storage_state`` (imports at module level into
+        # ``_auth.cookies``) and the recovery's ``_resolve_recovery_path``
+        # (lazy-imports from ``..paths``) see the same override.
+        default_path = tmp_path / "default_storage_state.json"
+        _write_storage(default_path, _RECOVERABLE_COOKIES)
+        monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+        monkeypatch.setattr("notebooklm.paths.get_storage_path", lambda: default_path)
+        monkeypatch.setattr(
+            "notebooklm._auth.cookies.get_storage_path",
+            lambda: default_path,
+        )
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        cookies = auth_module.load_auth_from_storage(None)
+
+        assert cookies["__Secure-1PSIDTS"] == "fresh_psidts_value"
+
+
+class TestBuildHttpxCookiesFromStorageIntegration:
+    """Recovery must also heal the programmatic loader (``AuthTokens.from_storage``)."""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_recovers_through_build_httpx_cookies_from_storage(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """``AuthTokens.from_storage`` / ``NotebookLMClient.from_storage`` route
+        through ``build_httpx_cookies_from_storage``, NOT ``load_auth_from_storage``.
+        The recovery hook must heal that path too (Codex Important: issue #865).
+        """
+        from notebooklm._auth.cookies import build_httpx_cookies_from_storage
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        jar = build_httpx_cookies_from_storage(storage_path)
+
+        cookie_names = {c.name for c in jar.jar}
+        assert "__Secure-1PSIDTS" in cookie_names
+        # The file on disk must also have been healed so subsequent loaders see it.
+        saved = json.loads(storage_path.read_text())
+        assert "__Secure-1PSIDTS" in {c["name"] for c in saved["cookies"]}
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_build_httpx_cookies_re_raises_when_recovery_declines(
+        self, tmp_path, httpx_mock: HTTPXMock
+    ):
+        """Recovery preconditions failing → original ValueError propagates."""
+        from notebooklm._auth.cookies import build_httpx_cookies_from_storage
+
+        # Strip the secondary binding so the recovery declines.
+        cookies = [c for c in _RECOVERABLE_COOKIES if c["name"] not in {"APISID", "SAPISID"}]
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, cookies)
+
+        with pytest.raises(ValueError, match="__Secure-1PSIDTS"):
+            build_httpx_cookies_from_storage(storage_path)
+
+
+class TestEdgeCases:
+    """Hardening tests for the precondition gate and post-POST persistence."""
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_malformed_storage_cookies_non_list(self, tmp_path, httpx_mock: HTTPXMock):
+        """``"cookies"`` key not a list → return False without firing POST."""
+        storage_path = tmp_path / "storage_state.json"
+        storage_path.write_text(json.dumps({"cookies": "not-a-list"}))
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_save_returning_false_propagates_as_failure(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """``save_cookies_to_storage`` returns False on persist failure (not raises).
+
+        Recovery must capture the return value — otherwise it logs a misleading
+        INFO ``Recovered ... and persisted`` while on-disk state is still broken
+        (Claude Important + Codex Important: issue #865).
+        """
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        # Force the persist step to return False (CAS rejection / I/O error / etc.).
+        monkeypatch.setattr(
+            "notebooklm._auth.psidts_recovery._auth_storage.save_cookies_to_storage",
+            lambda *args, **kwargs: False,
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_save_raising_propagates_as_failure(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """Unexpected exception from ``save_cookies_to_storage`` → False, not propagated."""
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+        httpx_mock.add_response(url=_ROTATE_URL_RE, **_make_psidts_response())
+
+        def raise_oserror(*_args, **_kwargs):
+            raise OSError("simulated disk-full")
+
+        monkeypatch.setattr(
+            "notebooklm._auth.psidts_recovery._auth_storage.save_cookies_to_storage",
+            raise_oserror,
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+
+    @pytest.mark.no_default_keepalive_mock
+    def test_cross_process_flock_held_skips_post(
+        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+    ):
+        """A held rotation flock (simulating another CLI process) → skip the POST.
+
+        Mirrors ``_poke_session``'s outer cross-process guard (Claude Important +
+        Codex Important: issue #865). Before the fix, two concurrent ``notebooklm``
+        invocations could each fire ``RotateCookies``.
+        """
+        import contextlib
+
+        storage_path = tmp_path / "storage_state.json"
+        _write_storage(storage_path, _RECOVERABLE_COOKIES)
+
+        @contextlib.contextmanager
+        def held_lock(_lock_path):
+            # Simulate another process holding the lock — acquire=False.
+            yield False
+
+        monkeypatch.setattr(
+            "notebooklm._auth.psidts_recovery._keepalive._file_lock_try_exclusive",
+            held_lock,
+        )
+
+        assert psidts_recovery._recover_psidts_inline(storage_path) is False
+        assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []


### PR DESCRIPTION
## Summary

- Fixes the closed loop where Playwright login lands `storage_state.json` without `__Secure-1PSIDTS`, the Tier-1 preflight rejects, and the keepalive `RotateCookies` recovery that would heal it is unreachable because it only runs inside an opened `Session`.
- Adds inline recovery in `src/notebooklm/_auth/psidts_recovery.py` that mirrors the user's manual workaround in #865: when `SID` is present and the secondary binding (`OSID`, or `APISID + SAPISID`) is intact but PSIDTS is absent, fire one `accounts.google.com/RotateCookies` POST and persist the rotated cookies via the existing snapshot/delta save (atomic write, cross-process file lock).
- Wires the hook into BOTH `load_auth_from_storage` (CLI path) and `build_httpx_cookies_from_storage` (`AuthTokens.from_storage` / `NotebookLMClient.from_storage` path) so the bug is healed from both the CLI and the programmatic API.

## Task

Closes #865. See [the analysis comment](https://github.com/teng-lin/notebooklm-py/issues/865#issuecomment-4502463580) for the closed-loop diagnosis and the Option A vs Option B framing.

## Design notes

- **Tier-1 classification preserved.** `MINIMUM_REQUIRED_COOKIES = {"SID", "__Secure-1PSIDTS"}` is unchanged. Callers that bypass `load_auth_from_storage` / `build_httpx_cookies_from_storage` (post-login validators in `cli/services/login.py`, etc.) still see a strict reject — that's intentional, recovery only applies to file-backed cold-start.
- **Cross-process safety.** Recovery takes a non-blocking flock on the same rotation lock path `_poke_session` uses (`_keepalive._file_lock_try_exclusive(_rotation_lock_path(...))`), so two simultaneous `notebooklm` CLI invocations won't both fire `RotateCookies`.
- **In-process throttle.** `_try_claim_rotation` deduplicates same-process callers (e.g. `load_auth_from_storage` + downstream `build_httpx_cookies_from_storage` would otherwise both attempt).
- **Path resolution mirrors `_load_storage_state`.** `_recover_psidts_inline(None)` resolves to the default profile file via `get_storage_path()` when `NOTEBOOKLM_AUTH_JSON` is unset — so the most common library-usage pattern (`load_auth_from_storage()` with no args) is also covered.
- **`save_cookies_to_storage` return value is checked.** That function returns `False` (not raises) on every persist-failure path; we treat `False` as recovery failure and propagate the original `ValueError` so the user-visible behavior is honest.
- **Env-var auth (`NOTEBOOKLM_AUTH_JSON`) is intentionally out of scope** — no writeable backing store to persist to. Tracked as future-work in the recovery module's docstring.

## Test plan

- [x] 24 new tests in `tests/unit/test_auth_psidts_recovery.py` cover: precondition gate, happy path, failure modes, both load-path integrations, edge cases (malformed storage, save-returns-False, save-raises, flock-held, default-path resolution).
- [x] Broader regression: 4815 unit tests pass (was 4808 → +7 net).
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean.
- [x] `uv run ruff check` — clean.
- [ ] Manual smoke: from issue reporter, run `notebooklm auth check` against a storage_state.json missing PSIDTS to confirm recovery fires + heals.

## Review pipeline

Pre-PR polish applied via `/polish`: code-simplifier + triple review (claude + codex + gemini) + ultrathink. All Critical (1) + Important (3) review findings addressed in the diff.

## Deferred polish findings

- Claude Suggestion #6: env-var auth user-facing error messaging hint — deferred; the recovery module docstring tracks this as future-work (would benefit from extending `_EXTRACTION_HINT` in cookie_policy).
- Gemini nit: prefer `list[dict[str, Any]]` over `list[dict]` — mypy is clean as-is.
- Codex nit: walrus comprehension → explicit loop — reviewed and confirmed correct by all three models; existing form is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cold-start auth reliability with an inline recovery path for missing rotating security cookies; cookie loading will attempt recovery and retry when healing succeeds, treating transient failures as non-fatal so callers can retry.

* **Tests**
  * Added comprehensive unit and integration tests covering preconditions, successful rotation/persistence, failure modes, concurrency/lock scenarios, and edge cases.

* **Documentation**
  * Updated docs to describe the new authentication recovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->