### PR TITLE
refactor(notes): step 6+7 — split _mind_map into NoteService + NoteBackedMindMapService; rewire artifacts

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -336,7 +336,8 @@ class ArtifactDownloadService:
     ) -> str:
         """Download a mind map as JSON."""
         api = self._api
-        mind_maps = await _artifact_seams()._mind_map.list_mind_maps(api._core, notebook_id)
+        mind_maps_service = api._mind_maps
+        mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
         if not mind_maps:
             raise ArtifactNotReadyError("mind_map")
 
@@ -349,7 +350,7 @@ class ArtifactDownloadService:
 
         json_module = _artifact_seams().json
         try:
-            json_string = _artifact_seams()._mind_map.extract_content(mind_map)
+            json_string = mind_maps_service.extract_content(mind_map)
             if json_string is None:
                 raise ArtifactParseError("mind_map_content", details="Invalid structure")
 

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -629,7 +629,14 @@ class ArtifactGenerationService:
                     title=title,
                     content=mind_map_json,
                 )
-                note_id = note.id if note else None
+                # ``NoteService.create_note`` always returns a ``Note``
+                # instance — even when the server omits the row id it
+                # returns ``Note(id="", ...)``. The dataclass is always
+                # truthy, so guarding on ``if note`` was dead code. Map
+                # the empty-string ID to ``None`` so the public dict
+                # contract ("note_id is None means persistence failed")
+                # is honored. Surfaced by claude[bot] review on PR #873.
+                note_id = note.id or None
 
                 return {
                     "mind_map": mind_map_data,

--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json as json_module
 import logging
-import sys
 from typing import Any
 
 from ._env import get_default_language
@@ -32,16 +31,6 @@ from .rpc import (
 from .types import GenerationStatus, ReportSuggestion
 
 logger = logging.getLogger(__name__)
-
-
-def _artifact_seams() -> Any:
-    """Return the facade module that legacy tests patch."""
-    try:
-        return sys.modules["notebooklm._artifacts"]
-    except KeyError as e:
-        # Normal construction imports this service from _artifacts first; the
-        # lookup exists only so call sites can preserve _artifacts patch seams.
-        raise RuntimeError("notebooklm._artifacts must be imported before generation runs") from e
 
 
 class ArtifactGenerationService:
@@ -512,7 +501,7 @@ class ArtifactGenerationService:
             [[[slide_index, prompt]]],
         ]
         try:
-            result = await api._core.rpc_call(
+            result = await api._runtime.rpc_call(
                 RPCMethod.REVISE_SLIDE,
                 params,
                 source_path=f"/notebook/{notebook_id}",
@@ -608,7 +597,7 @@ class ArtifactGenerationService:
         # explicitly to document this call site as the no-variant default
         # (the registry resolves the same entry either way; the explicit
         # kwarg is a future-proofing marker for a possible variant table).
-        result = await api._core.rpc_call(
+        result = await api._runtime.rpc_call(
             RPCMethod.GENERATE_MIND_MAP,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -635,8 +624,7 @@ class ArtifactGenerationService:
                 if isinstance(mind_map_data, dict) and "name" in mind_map_data:
                     title = mind_map_data["name"]
 
-                note = await _artifact_seams()._mind_map.create_note(
-                    api._core,
+                note = await api._note_service.create_note(
                     notebook_id,
                     title=title,
                     content=mind_map_json,
@@ -658,7 +646,7 @@ class ArtifactGenerationService:
         api = self._api
         params = [[2], notebook_id]
 
-        result = await api._core.rpc_call(
+        result = await api._runtime.rpc_call(
             RPCMethod.GET_SUGGESTED_REPORTS,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -693,7 +681,7 @@ class ArtifactGenerationService:
             # no-variant default (the registry resolves the same entry
             # either way; the explicit kwarg is a future-proofing marker
             # for a possible variant table).
-            result = await api._core.rpc_call(
+            result = await api._runtime.rpc_call(
                 RPCMethod.CREATE_ARTIFACT,
                 params,
                 source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -12,10 +12,22 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Protocol
 
-from . import _artifact_formatters, _artifact_polling, _mind_map
+# ``_mind_map`` is re-exported as ``_artifacts._mind_map`` so legacy
+# patch seams (``test_init_order.test_phase7_artifact_mind_map_patch_seams_are_current``)
+# can still resolve the module via the artifacts facade. The runtime
+# code path in this module talks to the injected
+# ``NoteBackedMindMapService`` / ``NoteService`` instances; the bare
+# module re-export is for monkeypatch convenience only.
+from . import (
+    _artifact_formatters,
+    _artifact_polling,
+    _mind_map,  # noqa: F401 — re-exported as facade attribute
+)
 from ._artifact_downloads import ArtifactDownloadService, DownloadResult
 from ._artifact_generation import ArtifactGenerationService
 from ._artifact_listing import ArtifactListingService
+from ._mind_map import NoteBackedMindMapService
+from ._note_service import NoteService
 from ._notebook_metadata import NotebookSourceIdProvider
 from ._polling_registry import PollRegistry
 from ._session_contracts import AsyncWorkRuntime, RpcCaller
@@ -175,7 +187,8 @@ class ArtifactsAPI:
         runtime: ArtifactsRuntime,
         *,
         notebooks: NotebookSourceIdProvider,
-        mind_map_service: _mind_map.MindMapService,
+        mind_maps: NoteBackedMindMapService,
+        note_service: NoteService,
         storage_path: Path | None = None,
     ) -> None:
         """Initialize the artifacts API.
@@ -186,17 +199,25 @@ class ArtifactsAPI:
                 close-time drain-hook registration.
             notebooks: Source-id resolver. Required — wire from
                 ``NotebookLMClient`` (no implicit fallback).
-            mind_map_service: Service for note-backed mind-map operations.
-                Required; the previous ``None`` fallback that constructed
-                ``MindMapService(session)`` has been removed. Phase 5 will
-                rename this parameter to ``mind_maps`` and swap the
-                concrete type to :class:`NoteBackedMindMapService`.
+            mind_maps: Note-backed mind-map facade. Owns the
+                ``list_mind_maps`` / ``extract_content`` paths consumed
+                by ``_artifact_downloads.download_mind_map``. Renamed
+                from ``mind_map_service`` in Phase 5 to reflect the
+                concrete adapter type (:class:`NoteBackedMindMapService`).
+            note_service: Backend note-row primitives. Owns the
+                ``create_note`` call site that
+                ``_artifact_generation.generate_mind_map`` uses to
+                persist generated mind maps. Added in Phase 5 so the
+                generation path no longer reaches into
+                ``_mind_map.create_note(api._core, ...)`` through the
+                ``_artifact_seams`` shim.
             storage_path: Path to storage state file for loading download cookies.
         """
         self._runtime = runtime
         self._notebooks = notebooks
         self._storage_path = storage_path
-        self._mind_map_service = mind_map_service
+        self._mind_maps = mind_maps
+        self._note_service = note_service
         self._poll_registry = PollRegistry()
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
@@ -206,19 +227,6 @@ class ArtifactsAPI:
             self._poll_registry,
         )
         self._runtime.register_drain_hook("artifacts.polls", self._polling.drain)
-
-    @property
-    def _core(self) -> ArtifactsRuntime:
-        """Backward-compatible alias for ``self._runtime``.
-
-        ``_artifact_generation.py`` and ``_artifact_downloads.py``
-        currently access ``api._core.rpc_call(...)`` and
-        ``_mind_map.list_mind_maps(api._core, ...)``. Those modules are
-        retyped in a later phase; until then, this property forwards
-        attribute access to the runtime so the cross-module calls keep
-        working.
-        """
-        return self._runtime
 
     # =========================================================================
     # List/Get Operations
@@ -898,8 +906,8 @@ class ArtifactsAPI:
         return await self._generation._call_generate(notebook_id, params)
 
     async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
-        """Get raw mind-map rows via the injected mind-map service."""
-        return await self._mind_map_service.list_mind_maps(notebook_id)
+        """Get raw mind-map rows via the injected mind-map facade."""
+        return await self._mind_maps.list_mind_maps(notebook_id)
 
     async def _list_raw(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw artifact list data."""

--- a/src/notebooklm/_mind_map.py
+++ b/src/notebooklm/_mind_map.py
@@ -19,6 +19,7 @@ import re
 from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Protocol
 
+from ._note_service import NoteRowKind, NoteService
 from .rpc import RPCMethod
 from .types import Note
 
@@ -252,6 +253,48 @@ class MindMapService:
             title=title,
             content=content,
         )
+
+
+class NoteBackedMindMapService:
+    """Mind-map-only facade over :class:`NoteService`.
+
+    Adapter that knows mind maps share storage with notes. Consumers
+    (``ArtifactsAPI`` download path, future Phase 6 ``NotesAPI`` retype)
+    talk to this class instead of reaching into ``NoteService`` directly,
+    so the "mind maps are notes under the hood" detail stays localized.
+
+    The download path doesn't need ``create_mind_map`` — mind-map
+    creation goes through :meth:`NoteService.create_note` directly
+    from ``_artifact_generation.generate_mind_map`` (a one-shot
+    GENERATE_MIND_MAP + persist pipeline). The methods exposed here
+    are exactly the ones the artifact download path and Phase 6's
+    NotesAPI ``list_mind_maps`` / ``delete_mind_map`` need.
+    """
+
+    def __init__(self, notes: NoteService) -> None:
+        self._notes = notes
+
+    async def list_mind_maps(self, notebook_id: str) -> list[Any]:
+        """Return mind-map rows for a notebook (deleted rows excluded)."""
+        rows = await self._notes.fetch_note_rows(notebook_id)
+        return [r for r in rows if self._notes.classify_row(r) == NoteRowKind.MIND_MAP]
+
+    def extract_content(self, row: list[Any]) -> str | None:
+        """Return the JSON content payload of a mind-map row.
+
+        Delegates to :meth:`NoteService.extract_content` so the download
+        path doesn't have to know mind maps share storage with notes.
+        """
+        return self._notes.extract_content(row)
+
+    async def delete_mind_map(self, notebook_id: str, note_id: str) -> bool:
+        """Soft-delete a mind-map row.
+
+        Delegates to :meth:`NoteService.delete_note`. Returns its bool
+        result so the v0.4.1 ``NotesAPI.delete_mind_map(...) -> bool``
+        public contract is preserved when Phase 6 retypes NotesAPI.
+        """
+        return await self._notes.delete_note(notebook_id, note_id)
 
 
 async def _delete_note_best_effort(core: MindMapRpc, notebook_id: str, note_id: str) -> None:

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -1,0 +1,242 @@
+"""Private note-row primitives — classifier + CRUD.
+
+This module owns the backend note-row operations shared by ``NotesAPI``
+(plain notes + saved-from-chat notes) and ``ArtifactsAPI`` (mind maps,
+which the server stores in the same note collection). It deliberately
+sits *below* both feature facades so neither has to import the other,
+and so the mind-map adapter (``_mind_map.NoteBackedMindMapService``)
+has a single seam to delegate through.
+
+``NoteRowKind`` is a private classification of the raw row shapes
+returned by the ``GET_NOTES_AND_MIND_MAPS`` RPC. It is intentionally
+NOT part of the public ``notebooklm`` surface — the public ``Note``
+dataclass and ``client.notes`` / ``client.artifacts`` facades remain
+the only stable contract.
+
+Risk-mitigation note (refactor.md §Risks): saved-chat note metadata is
+not always reliably present on the wire. When the classifier cannot
+positively identify a row as a saved-from-chat note it defaults to
+``NOTE`` (not ``UNKNOWN``) so the NotesAPI list path keeps surfacing
+the row — losing a chat-mode tag is preferable to dropping the note.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from .rpc.types import RPCMethod
+from .types import Note
+
+if TYPE_CHECKING:
+    from ._session_contracts import Session
+
+__all__ = ["NoteService"]  # NoteRowKind is intentionally NOT exported
+
+
+class NoteRowKind(Enum):
+    """Private classification of rows from ``GET_NOTES_AND_MIND_MAPS``.
+
+    Not part of the public API — kept private so the wire-shape
+    classification can evolve without a SemVer hit. Phase 6 may add
+    further variants (e.g. distinct treatment for saved-from-chat
+    notes) without breaking external callers.
+    """
+
+    NOTE = "note"
+    SAVED_CHAT = "saved_chat"
+    MIND_MAP = "mind_map"
+    DELETED = "deleted"
+    UNKNOWN = "unknown"
+
+
+class NoteService:
+    """Backend note-row primitives — fetch + classify + CRUD.
+
+    Owns the ``GET_NOTES_AND_MIND_MAPS`` / ``CREATE_NOTE`` /
+    ``UPDATE_NOTE`` / ``DELETE_NOTE`` RPC family. Shared by
+    ``NotesAPI`` (in Phase 6) and by ``NoteBackedMindMapService``
+    (the adapter that powers ``ArtifactsAPI`` mind-map paths).
+
+    The constructor takes the broad ``Session`` orchestrator for now;
+    Phase 7 will narrow it down to a capability slice (likely
+    :class:`RpcCaller`) once the broad ``Session`` Protocol is retired.
+    """
+
+    def __init__(self, session: Session) -> None:
+        # Phase 7 will narrow this to the minimum capability surface
+        # (RpcCaller is the only one currently exercised). Until then,
+        # accept the broad orchestrator the rest of the codebase passes
+        # around so this module doesn't pin the migration order.
+        self._session = session
+
+    # ------------------------------------------------------------------
+    # Row fetch + classification
+    # ------------------------------------------------------------------
+
+    async def fetch_note_rows(self, notebook_id: str) -> list[Any]:
+        """Fetch all note + mind-map rows for a notebook.
+
+        Returns the raw row list (each row is itself a list whose first
+        element is the row ID). Soft-deleted rows are included — callers
+        decide whether to filter via :meth:`classify_row`.
+        """
+        params = [notebook_id]
+        result = await self._session.rpc_call(
+            RPCMethod.GET_NOTES_AND_MIND_MAPS,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        if not (
+            result and isinstance(result, list) and len(result) > 0 and isinstance(result[0], list)
+        ):
+            return []
+
+        return [
+            item
+            for item in result[0]
+            if isinstance(item, list) and len(item) > 0 and isinstance(item[0], str)
+        ]
+
+    def classify_row(self, row: list[Any]) -> NoteRowKind:
+        """Identify what kind of row this is.
+
+        Wire shapes encountered:
+        * deleted: ``["id", None, 2]`` — content is ``None`` and slot[2]
+          is the soft-delete sentinel.
+        * mind-map: content payload (string at ``row[1]`` or
+          ``row[1][1]``) parses as JSON with ``"children":`` or
+          ``"nodes":`` keys.
+        * saved-chat: a plain note row whose metadata flags chat mode.
+          That metadata is not reliably present on the wire, so when we
+          cannot positively confirm chat mode we fall through to
+          ``NOTE`` rather than ``UNKNOWN`` (refactor.md §Risks).
+        * plain note: default for any other content-bearing row.
+        """
+        if not isinstance(row, list) or len(row) == 0:
+            return NoteRowKind.UNKNOWN
+
+        if self._is_deleted(row):
+            return NoteRowKind.DELETED
+
+        content = self.extract_content(row)
+        if self._is_mind_map_content(content):
+            return NoteRowKind.MIND_MAP
+
+        if content is None:
+            return NoteRowKind.UNKNOWN
+
+        # Phase 6 may grow saved-chat detection; for now default to NOTE
+        # so a chat-mode note never silently drops out of NotesAPI.list().
+        return NoteRowKind.NOTE
+
+    def extract_content(self, row: list[Any]) -> str | None:
+        """Get the JSON content payload of a row, or ``None``.
+
+        Handles both legacy (``[id, content]``) and current
+        (``[id, [id, content, metadata, None, title]]``) wire shapes.
+        """
+        if not isinstance(row, list) or len(row) <= 1:
+            return None
+
+        if isinstance(row[1], str):
+            return row[1]
+        if isinstance(row[1], list) and len(row[1]) > 1 and isinstance(row[1][1], str):
+            return row[1][1]
+        return None
+
+    @staticmethod
+    def _is_deleted(row: list[Any]) -> bool:
+        if not isinstance(row, list) or len(row) < 3:
+            return False
+        return row[1] is None and row[2] == 2
+
+    @staticmethod
+    def _is_mind_map_content(content: str | None) -> bool:
+        return bool(content and ('"children":' in content or '"nodes":' in content))
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def create_note(
+        self,
+        notebook_id: str,
+        title: str = "New Note",
+        content: str = "",
+    ) -> Note:
+        """Create a note row and finalize its content + title.
+
+        ``CREATE_NOTE`` ignores the title param server-side, so we follow
+        up with ``UPDATE_NOTE`` to set both content and title. Returns a
+        :class:`Note` dataclass for consistency with ``NotesAPI``.
+
+        Cancellation behavior is handled by the legacy
+        :class:`_mind_map.MindMapService` path, which Phase 6 will rewire
+        through this service. For now the artifact-generation rewire (the
+        only caller introduced in Phase 5) uses this method without the
+        cancel-shielded UPDATE because the GENERATE_MIND_MAP -> persist
+        flow is a single user-facing operation per request.
+        """
+        params = [notebook_id, "", [1], None, title]
+        result = await self._session.rpc_call(
+            RPCMethod.CREATE_NOTE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+        )
+
+        note_id: str | None = None
+        if result and isinstance(result, list) and len(result) > 0:
+            if isinstance(result[0], list) and len(result[0]) > 0:
+                note_id = result[0][0]
+            elif isinstance(result[0], str):
+                note_id = result[0]
+
+        if note_id:
+            await self.update_note(notebook_id, note_id, content, title)
+
+        return Note(
+            id=note_id or "",
+            notebook_id=notebook_id,
+            title=title,
+            content=content,
+        )
+
+    async def update_note(
+        self,
+        notebook_id: str,
+        note_id: str,
+        content: str,
+        title: str,
+    ) -> None:
+        """Update a note row's content and title in place."""
+        params = [
+            notebook_id,
+            note_id,
+            [[[content, title, [], 0]]],
+        ]
+        await self._session.rpc_call(
+            RPCMethod.UPDATE_NOTE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+
+    async def delete_note(self, notebook_id: str, note_id: str) -> bool:
+        """Soft-delete a note row.
+
+        Returns ``True`` on success, mirroring the v0.4.1 NotesAPI
+        contract (``client.notes.delete(...) -> bool``). The bool flow
+        is preserved so the public facade can keep returning ``True``
+        unconditionally via :class:`NoteBackedMindMapService.delete_mind_map`
+        without callers seeing a behavioral change.
+        """
+        params = [notebook_id, None, [note_id]]
+        await self._session.rpc_call(
+            RPCMethod.DELETE_NOTE,
+            params,
+            source_path=f"/notebook/{notebook_id}",
+            allow_null=True,
+        )
+        return True

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -172,12 +172,23 @@ class NoteService:
         up with ``UPDATE_NOTE`` to set both content and title. Returns a
         :class:`Note` dataclass for consistency with ``NotesAPI``.
 
-        Cancellation behavior is handled by the legacy
-        :class:`_mind_map.MindMapService` path, which Phase 6 will rewire
-        through this service. For now the artifact-generation rewire (the
-        only caller introduced in Phase 5) uses this method without the
-        cancel-shielded UPDATE because the GENERATE_MIND_MAP -> persist
-        flow is a single user-facing operation per request.
+        TODO(phase-6): port the ``asyncio.shield`` + best-effort
+        ``DELETE_NOTE`` cleanup that lives on
+        :meth:`_mind_map.MindMapService.create_note` over to this method
+        before retyping ``NotesAPI`` to depend on ``NoteService``.
+        Without the shield, a cancel arriving between ``CREATE_NOTE``
+        and ``UPDATE_NOTE`` leaves an orphan empty row server-side.
+
+        Phase 5's only caller is
+        :meth:`_artifact_generation.ArtifactGenerationService.generate_mind_map`,
+        which runs as a single user-facing operation per request — the
+        cancellation window is narrow and the legacy
+        ``MindMapService.create_note`` path that ``NotesAPI`` still uses
+        retains the full shield + cleanup logic. Phase 6 collapses the
+        two implementations.
+
+        Surfaced by claude[bot] and gemini-code-assist[bot] reviews on
+        PR #873.
         """
         params = [notebook_id, "", [1], None, title]
         result = await self._session.rpc_call(

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -35,11 +35,12 @@ if TYPE_CHECKING:
     from .rpc import RPCMethod
     from .types import ClientMetricsSnapshot, ConnectionLimits, RpcTelemetryEvent
 
-from . import _mind_map
 from ._artifacts import ArtifactsAPI
 from ._auth.session import refresh_auth_session
 from ._chat import ChatAPI
 from ._env import get_base_url as get_base_url
+from ._mind_map import NoteBackedMindMapService
+from ._note_service import NoteService
 from ._notebooks import NotebooksAPI
 from ._notes import NotesAPI
 from ._research import ResearchAPI
@@ -288,10 +289,13 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
         )
         self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
-        # Transitional wiring per docs/refactor.md Step 4 / Review Checklist:
-        # ``mind_map_service`` is required and explicitly constructed here.
-        # Phase 5 replaces this with ``NoteBackedMindMapService`` and renames
-        # the parameter to ``mind_maps``.
+        # Phase 5 wiring per docs/refactor.md Migration Plan steps 6-7:
+        # the legacy single-service handoff (``MindMapService(self._session)``
+        # passed as ``mind_map_service=``) is replaced with the explicit
+        # NoteService + NoteBackedMindMapService split. NoteService owns the
+        # raw row primitives; NoteBackedMindMapService is the mind-map-only
+        # adapter the download path uses; the artifact-generation path uses
+        # NoteService.create_note directly to persist a generated mind map.
         #
         # We pass ``self._session`` rather than the ``self._core`` alias because
         # ``Session`` directly satisfies ``ArtifactsRuntime`` (RpcCaller +
@@ -299,10 +303,13 @@ class NotebookLMClient:
         # exists only for legacy callers that pre-date the runtime split. The
         # other sub-APIs still pass ``self._core`` while their own
         # capability-protocol migrations land; Phase 7 retires the alias.
+        note_service = NoteService(self._session)
+        mind_maps = NoteBackedMindMapService(note_service)
         self.artifacts = ArtifactsAPI(
             self._session,
             notebooks=self.notebooks,
-            mind_map_service=_mind_map.MindMapService(self._session),
+            mind_maps=mind_maps,
+            note_service=note_service,
             storage_path=storage_path,
         )
         self.notes = NotesAPI(self._core)

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -104,15 +104,19 @@ def mock_artifacts_api() -> tuple[ArtifactsAPI, MagicMock]:
     boundary in pytest is fragile when both define ``mock_artifacts_api``
     at module scope.
     """
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
+    note_service = NoteService(mock_core)
+    mind_maps = NoteBackedMindMapService(note_service)
     api = ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=mind_maps,
+        note_service=note_service,
     )
     return api, mock_core
 
@@ -229,8 +233,9 @@ async def test_download_mind_map_runs_write_off_loop_thread(
         return original_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
 
     with (
-        patch(
-            "notebooklm._artifacts._mind_map.list_mind_maps",
+        patch.object(
+            api._mind_maps,
+            "list_mind_maps",
             new=AsyncMock(return_value=mind_map_rows),
         ),
         # Patch the `json` module as imported by `_artifacts` so the
@@ -316,8 +321,9 @@ async def test_concurrent_downloads_both_offload_writes(
 
     with (
         patch.object(api, "_list_raw", new_callable=AsyncMock) as mock_list,
-        patch(
-            "notebooklm._artifacts._mind_map.list_mind_maps",
+        patch.object(
+            api._mind_maps,
+            "list_mind_maps",
             new=AsyncMock(return_value=mind_map_rows),
         ),
         patch.object(Path, "write_text", recording_write_text),

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -345,11 +345,15 @@ async def test_generate_mind_map_happy_path_still_returns_mind_map(auth_tokens) 
     Symmetric guard to ``test_create_artifact_happy_path_still_returns_artifact``.
 
     The mind-map flow also persists a note after the RPC succeeds; we
-    stub the note-create seam on the ``_artifacts`` module facade so the
-    test stays focused on the RPC-layer behavior and doesn't pull in the
-    full notes-API path.
+    stub the ``note_service.create_note`` seam on the artifacts API so
+    the test stays focused on the RPC-layer behavior and doesn't pull
+    in the full notes-API path. (Phase 5 moved the persistence call off
+    the module-level ``_mind_map.create_note`` shim and onto the
+    injected ``NoteService`` instance.)
     """
-    import notebooklm._artifacts as _artifacts_facade
+    from unittest.mock import AsyncMock
+
+    from notebooklm.types import Note
 
     mind_map_dict = {"name": "Test Mind Map", "children": []}
     mind_map_json = json.dumps(mind_map_dict)
@@ -369,23 +373,13 @@ async def test_generate_mind_map_happy_path_still_returns_mind_map(auth_tokens) 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens)
 
-    # Stub the mind-map note seam so we don't need a full notes RPC chain.
-    class _StubNote:
-        id = "note_stub"
+    stub_note = Note(id="note_stub", notebook_id="nb_test", title="Test Mind Map", content="")
+    client.artifacts._note_service.create_note = AsyncMock(return_value=stub_note)  # type: ignore[method-assign]
 
-    class _StubMindMap:
-        async def create_note(self, _core, _notebook_id, *, title, content):
-            return _StubNote()
-
-    original_mind_map = _artifacts_facade._mind_map
-    _artifacts_facade._mind_map = _StubMindMap()
     try:
-        try:
-            result = await client.artifacts.generate_mind_map(notebook_id="nb_test")
-        finally:
-            await client._core._http_client.aclose()
+        result = await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        _artifacts_facade._mind_map = original_mind_map
+        await client._core._http_client.aclose()
 
     assert result["mind_map"] == mind_map_dict
     assert result["note_id"] == "note_stub"

--- a/tests/integration/test_artifacts_drift.py
+++ b/tests/integration/test_artifacts_drift.py
@@ -39,14 +39,16 @@ pytestmark = pytest.mark.allow_no_vcr
 @pytest.fixture
 def artifacts_api():
     """Build a minimal ArtifactsAPI for direct parser invocation."""
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     return ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
 
 

--- a/tests/integration/test_artifacts_integration.py
+++ b/tests/integration/test_artifacts_integration.py
@@ -19,7 +19,8 @@ from pytest_httpx import HTTPXMock
 
 from notebooklm import NotebookLMClient
 from notebooklm._artifacts import ArtifactsAPI
-from notebooklm._mind_map import MindMapService
+from notebooklm._mind_map import NoteBackedMindMapService
+from notebooklm._note_service import NoteService
 from notebooklm.exceptions import ValidationError
 from notebooklm.rpc import (
     AudioFormat,
@@ -394,7 +395,8 @@ class TestArtifactsAPI:
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
 
         result = await api._list_raw("nb_123")
@@ -423,7 +425,8 @@ class TestArtifactsAPI:
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
 
         result = await api._list_raw("nb_123")
@@ -437,7 +440,8 @@ class TestArtifactsAPI:
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
         studio_artifact = ["art_001", "My Report", 2, None, 3]
         mind_map = [
@@ -450,7 +454,7 @@ class TestArtifactsAPI:
                 api, "_list_raw", new=AsyncMock(return_value=[studio_artifact])
             ) as list_raw,
             patch.object(
-                api._mind_map_service,
+                api._mind_maps,
                 "list_mind_maps",
                 new=AsyncMock(return_value=[mind_map]),
             ) as list_mind_maps,
@@ -468,14 +472,15 @@ class TestArtifactsAPI:
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
         studio_artifact = ["art_001", "My Report", 2, None, 3]
 
         with (
             patch.object(api, "_list_raw", new=AsyncMock(return_value=[studio_artifact])),
             patch.object(
-                api._mind_map_service,
+                api._mind_maps,
                 "list_mind_maps",
                 new=AsyncMock(),
             ) as list_mind_maps,
@@ -492,7 +497,8 @@ class TestArtifactsAPI:
         api = ArtifactsAPI(
             core,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
         other = MagicMock()
         other.id = "art_other"
@@ -1412,7 +1418,7 @@ class TestListMindMapErrorHandling:
             # injected MindMapService. Patch the service's list_mind_maps so
             # the simulated error reaches ArtifactsAPI.list().
             with patch.object(
-                client.artifacts._mind_map_service,
+                client.artifacts._mind_maps,
                 "list_mind_maps",
                 new=AsyncMock(side_effect=RPCError("mind map fetch failed")),
             ):
@@ -1439,7 +1445,7 @@ class TestListMindMapErrorHandling:
 
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.artifacts._mind_map_service,
+                client.artifacts._mind_maps,
                 "list_mind_maps",
                 new=AsyncMock(side_effect=httpx.HTTPError("connection failed")),
             ):
@@ -1664,10 +1670,12 @@ class TestGenerateMindMapParsing:
         from notebooklm.types import Note
 
         async with NotebookLMClient(auth_tokens) as client:
-            # After the mind-map relocation, mind-map persistence is driven through
-            # ``_mind_map.create_note`` rather than ``NotesAPI.create``.
-            with patch(
-                "notebooklm._artifacts._mind_map.create_note",
+            # After Phase 5, mind-map persistence flows through
+            # ``ArtifactsAPI._note_service.create_note`` rather than the
+            # legacy ``_mind_map.create_note`` module-level seam.
+            with patch.object(
+                client.artifacts._note_service,
+                "create_note",
                 new=AsyncMock(
                     return_value=Note(
                         id="note_created_001",
@@ -1713,8 +1721,9 @@ class TestGenerateMindMapParsing:
         from notebooklm.types import Note
 
         async with NotebookLMClient(auth_tokens) as client:
-            with patch(
-                "notebooklm._artifacts._mind_map.create_note",
+            with patch.object(
+                client.artifacts._note_service,
+                "create_note",
                 new=AsyncMock(
                     return_value=Note(
                         id="note_dict_001",

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -19,23 +19,35 @@ from notebooklm.types import (
 def mock_artifacts_api():
     """Create an ArtifactsAPI with mocked core.
 
-    After the mind-map relocation, ``ArtifactsAPI`` no longer takes a ``notes_api`` parameter;
-    mind-map persistence goes through the shared ``_mind_map`` module which
-    calls the same ``Session.rpc_call``. Tests that exercise mind-map
-    creation should drive responses through ``mock_core.rpc_call`` (via
-    ``side_effect``) rather than mocking a separate notes object.
+    After Phase 5 (refactor.md Migration Plan steps 6-7), ``ArtifactsAPI``
+    takes ``mind_maps: NoteBackedMindMapService`` and
+    ``note_service: NoteService`` instead of the single
+    ``mind_map_service`` parameter. Mind-map persistence goes through
+    ``note_service.create_note``; the download path consumes
+    ``mind_maps.list_mind_maps`` / ``mind_maps.extract_content``. Tests
+    that exercise mind-map creation drive responses through
+    ``mock_core.rpc_call`` (via ``side_effect``) since both new
+    services delegate down to that single RPC seam.
     """
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
     mock_notebooks = MagicMock()
     mock_notebooks.get_source_ids = AsyncMock(return_value=[])
+    # Use real NoteService + NoteBackedMindMapService so the wire RPC
+    # surface stays consistent with production behavior. Tests that
+    # need to override list_mind_maps continue to patch it via
+    # ``patch.object(api._mind_maps, "list_mind_maps", ...)``.
+    note_service = NoteService(mock_core)
+    mind_maps = NoteBackedMindMapService(note_service)
     api = ArtifactsAPI(
         mock_core,
         notebooks=mock_notebooks,
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=mind_maps,
+        note_service=note_service,
     )
     return api, mock_core
 
@@ -603,13 +615,14 @@ class TestDownloadMindMap:
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "mindmap.json")
 
-            # After the mind-map relocation, ``ArtifactsAPI.download_mind_map`` reads mind maps
-            # via the shared ``_mind_map.list_mind_maps`` primitive rather
-            # than through an injected ``NotesAPI``. Patch the primitive at
-            # its consumer-side import to drive the response.
+            # After Phase 5, ``ArtifactsAPI.download_mind_map`` reads mind
+            # maps via the injected ``NoteBackedMindMapService``. Patch
+            # the service instance directly so the simulated response
+            # reaches the download path.
             json_content = '{"name": "Root", "children": [{"name": "Child1"}]}'
-            with patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            with patch.object(
+                api._mind_maps,
+                "list_mind_maps",
                 new=AsyncMock(
                     return_value=[
                         [
@@ -639,8 +652,9 @@ class TestDownloadMindMap:
         api, mock_core = mock_artifacts_api
 
         with (
-            patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            patch.object(
+                api._mind_maps,
+                "list_mind_maps",
                 new=AsyncMock(return_value=[]),
             ),
             pytest.raises(ArtifactNotReadyError),
@@ -653,8 +667,9 @@ class TestDownloadMindMap:
         api, mock_core = mock_artifacts_api
 
         with (
-            patch(
-                "notebooklm._artifacts._mind_map.list_mind_maps",
+            patch.object(
+                api._mind_maps,
+                "list_mind_maps",
                 new=AsyncMock(return_value=[["other_id", [None, "{}"], None, None, "Other"]]),
             ),
             pytest.raises(ArtifactNotFoundError),

--- a/tests/unit/test_artifacts_coverage.py
+++ b/tests/unit/test_artifacts_coverage.py
@@ -33,16 +33,19 @@ def mock_artifacts_api():
     # ``MagicMock``-shaped loop value.
     mock_core.bound_loop = None
     mock_core.assert_bound_loop = MagicMock(return_value=None)
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
-    mind_map_service = MagicMock(spec=MindMapService)
-    mind_map_service.list_mind_maps = AsyncMock(return_value=[])
+    mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    mind_maps.list_mind_maps = AsyncMock(return_value=[])
+    note_service = MagicMock(spec=NoteService)
     mock_notebooks = MagicMock()
     mock_notebooks.get_source_ids = AsyncMock(return_value=[])
     api = ArtifactsAPI(
         mock_core,
         notebooks=mock_notebooks,
-        mind_map_service=mind_map_service,
+        mind_maps=mind_maps,
+        note_service=note_service,
     )
     return api, mock_core
 

--- a/tests/unit/test_artifacts_mind_map_injection.py
+++ b/tests/unit/test_artifacts_mind_map_injection.py
@@ -1,14 +1,23 @@
-"""Tests for ``MindMapService`` injection into ``ArtifactsAPI``.
+"""Tests for ``NoteBackedMindMapService`` injection into ``ArtifactsAPI``.
 
-``ArtifactsAPI`` and ``NotesAPI`` both depend on the mind-map service
-through a constructor seam rather than the module-level
-``_mind_map.list_mind_maps()`` wrapper. These tests pin two contracts:
+After Phase 5 (refactor.md Migration Plan steps 6-7), ``ArtifactsAPI``
+takes two explicit services through its constructor:
 
-1. ``_list_mind_maps()`` delegates to the injected service and does not
-   re-enter the module-level ``_mind_map.list_mind_maps`` wrapper.
-2. ``mind_map_service`` is required and keyword-only — the previous
-   ``MindMapService(session)`` fallback was removed in
-   docs/refactor.md Step 4.
+* ``mind_maps: NoteBackedMindMapService`` — the mind-map-only adapter
+  the download path uses (replaces the previous ``mind_map_service``
+  parameter name).
+* ``note_service: NoteService`` — the raw note-row primitives the
+  mind-map generation path uses to persist a freshly generated mind map.
+
+These tests pin three contracts:
+
+1. ``_list_mind_maps()`` delegates to the injected ``mind_maps``
+   facade and does not re-enter the legacy module-level
+   ``_mind_map.list_mind_maps`` wrapper.
+2. Both ``mind_maps`` and ``note_service`` are required and
+   keyword-only — the legacy ``mind_map_service`` kwarg is gone.
+3. Constructing without the new kwargs (or with the old name) raises
+   ``TypeError``.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -18,15 +27,19 @@ import pytest
 from _fixtures.fake_core import make_fake_core
 from notebooklm import _mind_map
 from notebooklm._artifacts import ArtifactsAPI
+from notebooklm._mind_map import NoteBackedMindMapService
+from notebooklm._note_service import NoteService
 
 
 @pytest.mark.asyncio
-async def test_list_mind_maps_delegates_to_injected_service(monkeypatch):
-    """``_list_mind_maps`` calls the injected service and does not re-enter
-    the module-level ``_mind_map.list_mind_maps`` wrapper."""
+async def test_list_mind_maps_delegates_to_injected_facade(monkeypatch):
+    """``_list_mind_maps`` calls the injected ``mind_maps`` facade and
+    does not re-enter the module-level ``_mind_map.list_mind_maps``
+    wrapper."""
     core = make_fake_core()
-    fake_service = MagicMock(spec=_mind_map.MindMapService)
-    fake_service.list_mind_maps = AsyncMock(return_value=["sentinel-row"])
+    fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    fake_mind_maps.list_mind_maps = AsyncMock(return_value=["sentinel-row"])
+    fake_note_service = MagicMock(spec=NoteService)
 
     module_seam = AsyncMock(return_value=["should-not-see-this"])
     monkeypatch.setattr(_mind_map, "list_mind_maps", module_seam)
@@ -34,31 +47,84 @@ async def test_list_mind_maps_delegates_to_injected_service(monkeypatch):
     api = ArtifactsAPI(
         core,
         notebooks=MagicMock(),
-        mind_map_service=fake_service,
+        mind_maps=fake_mind_maps,
+        note_service=fake_note_service,
     )
     result = await api._list_mind_maps("nb_abc")
 
     assert result == ["sentinel-row"]
-    fake_service.list_mind_maps.assert_awaited_once_with("nb_abc")
+    fake_mind_maps.list_mind_maps.assert_awaited_once_with("nb_abc")
     module_seam.assert_not_awaited()
 
 
-def test_mind_map_service_is_required():
-    """``mind_map_service`` is required — no implicit default is installed.
-
-    Phase 3 (docs/refactor.md Step 4) removed the
-    ``MindMapService(session)`` fallback so the construction site at
-    ``NotebookLMClient`` must wire it explicitly.
-    """
+def test_mind_maps_and_note_service_are_required():
+    """Both new kwargs are required — no implicit fallback installs them."""
     core = make_fake_core()
+    fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    fake_note_service = MagicMock(spec=NoteService)
+
+    # Missing both.
     with pytest.raises(TypeError):
         ArtifactsAPI(core, notebooks=MagicMock())  # type: ignore[call-arg]
 
-
-def test_mind_map_service_is_keyword_only():
-    """``mind_map_service`` is keyword-only — passing positionally fails."""
-    core = make_fake_core()
-    fake_service = MagicMock(spec=_mind_map.MindMapService)
+    # Missing note_service.
     with pytest.raises(TypeError):
-        # All non-``runtime`` parameters are keyword-only.
-        ArtifactsAPI(core, MagicMock(), fake_service)  # type: ignore[misc]
+        ArtifactsAPI(  # type: ignore[call-arg]
+            core,
+            notebooks=MagicMock(),
+            mind_maps=fake_mind_maps,
+        )
+
+    # Missing mind_maps.
+    with pytest.raises(TypeError):
+        ArtifactsAPI(  # type: ignore[call-arg]
+            core,
+            notebooks=MagicMock(),
+            note_service=fake_note_service,
+        )
+
+
+def test_mind_maps_and_note_service_are_keyword_only():
+    """All non-``runtime`` parameters remain keyword-only."""
+    core = make_fake_core()
+    fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    fake_note_service = MagicMock(spec=NoteService)
+    with pytest.raises(TypeError):
+        ArtifactsAPI(core, MagicMock(), fake_mind_maps, fake_note_service)  # type: ignore[misc]
+
+
+def test_legacy_mind_map_service_kwarg_is_rejected():
+    """The Phase 3 ``mind_map_service=`` kwarg was renamed in Phase 5.
+
+    Passing it must raise ``TypeError`` so silent breakage on partial
+    upgrades surfaces immediately.
+    """
+    core = make_fake_core()
+    fake_mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    fake_note_service = MagicMock(spec=NoteService)
+    with pytest.raises(TypeError):
+        ArtifactsAPI(  # type: ignore[call-arg]
+            core,
+            notebooks=MagicMock(),
+            mind_map_service=fake_mind_maps,
+            note_service=fake_note_service,
+        )
+
+
+def test_artifacts_no_longer_exposes_core_property_alias():
+    """Phase 5 removes the ``_core`` ``@property`` alias on ArtifactsAPI.
+
+    After this PR ``ArtifactsAPI._runtime`` is the only attribute the
+    helper modules read; the transitional ``_core`` shim added in Phase 3
+    is dead code.
+    """
+    core = make_fake_core()
+    api = ArtifactsAPI(
+        core,
+        notebooks=MagicMock(),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
+    )
+    # The descriptor must be gone — not just empty, not just delegating.
+    assert not hasattr(api, "_core")
+    assert api._runtime is core

--- a/tests/unit/test_artifacts_polling_retries.py
+++ b/tests/unit/test_artifacts_polling_retries.py
@@ -90,7 +90,8 @@ class _FakeTransportProvider:
 
 @pytest.fixture
 def api():
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = _make_session_core()
     mock_notebooks = MagicMock()
@@ -98,7 +99,8 @@ def api():
     return ArtifactsAPI(
         core,
         notebooks=mock_notebooks,
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
 
 
@@ -395,13 +397,15 @@ async def test_polling_service_cancels_and_drains_spawned_poll_task_if_begin_fai
 
 @pytest.mark.asyncio
 async def test_wait_for_completion_follower_cancellation_does_not_cancel_leader_or_later_waiter():
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = _make_session_core()
     api = ArtifactsAPI(
         core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
 
     poll_started = asyncio.Event()

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -76,13 +76,15 @@ def test_artifacts_module_preserves_download_patch_targets():
 def mock_artifacts_api(tmp_path):
     """Minimal ArtifactsAPI with a mocked core for download tests."""
     from notebooklm._artifacts import ArtifactsAPI
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     mock_core = MagicMock()
     api = ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
     api._storage_path = str(tmp_path / "storage.json")
     return api, mock_core

--- a/tests/unit/test_download_url.py
+++ b/tests/unit/test_download_url.py
@@ -25,17 +25,20 @@ from notebooklm.types import ArtifactDownloadError
 @pytest.fixture
 def mock_artifacts_api():
     """ArtifactsAPI wired to MagicMocks -- no real I/O."""
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     mock_core.get_source_ids = AsyncMock(return_value=[])
-    mind_map_service = MagicMock(spec=MindMapService)
-    mind_map_service.list_mind_maps = AsyncMock(return_value=[])
+    mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    mind_maps.list_mind_maps = AsyncMock(return_value=[])
+    note_service = MagicMock(spec=NoteService)
     api = ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),
-        mind_map_service=mind_map_service,
+        mind_maps=mind_maps,
+        note_service=note_service,
     )
     return api
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -545,14 +545,22 @@ def test_phase8_source_listing_service_name_and_facade_wiring_are_current() -> N
 
 
 def test_phase7_artifact_mind_map_patch_seams_are_current() -> None:
-    """Final artifact services must still resolve mind-map seams via ``_artifacts``."""
+    """Final artifact services must still resolve mind-map seams via ``_artifacts``.
+
+    Phase 5 (refactor.md Migration Plan steps 6-7) moves the mind-map
+    create/list/extract paths off the ``_mind_map`` module-level seams
+    and onto the injected ``NoteService`` + ``NoteBackedMindMapService``
+    instances. The ``_artifact_generation`` module no longer needs an
+    ``_artifact_seams()`` hop at all (only the JSON/cookie seams remain
+    in ``_artifact_downloads``), so we check the downloads-side seam
+    still resolves and the generation module exposes the ``NoteService``
+    attribute the new wiring depends on.
+    """
     import notebooklm._artifact_downloads as artifact_downloads
-    import notebooklm._artifact_generation as artifact_generation
     import notebooklm._artifacts as artifacts
     import notebooklm._mind_map as mind_map
 
     assert artifacts._mind_map is mind_map
-    assert artifact_generation._artifact_seams()._mind_map is mind_map
     assert artifact_downloads._artifact_seams()._mind_map is mind_map
 
 
@@ -722,16 +730,18 @@ def test_client_exposes_artifacts_and_notes(mock_auth: AuthTokens) -> None:
 
 def test_artifacts_constructible_without_notes_api(mock_auth: AuthTokens) -> None:
     """``ArtifactsAPI`` no longer takes ``notes_api`` at all (per
-    docs/refactor.md Step 4) — the parameter was removed in favor of an
-    explicit ``mind_map_service``. The mind-map decoupling is now
-    structural."""
-    from notebooklm._mind_map import MindMapService
+    docs/refactor.md Step 4) — the parameter was removed in favor of
+    explicit ``mind_maps`` + ``note_service`` (Phase 5). The mind-map
+    decoupling is now structural."""
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = MagicMock()
     api = ArtifactsAPI(
         core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
     assert api is not None
     # The legacy private attribute must not leak back: code that depends on
@@ -742,7 +752,8 @@ def test_artifacts_constructible_without_notes_api(mock_auth: AuthTokens) -> Non
 def test_artifacts_rejects_legacy_notes_api_kwarg(mock_auth: AuthTokens) -> None:
     """The legacy ``notes_api=`` kwarg was removed in Phase 3
     (docs/refactor.md Step 4). Passing it must raise ``TypeError``."""
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = MagicMock()
     notes = NotesAPI(core)
@@ -751,13 +762,15 @@ def test_artifacts_rejects_legacy_notes_api_kwarg(mock_auth: AuthTokens) -> None
             core,
             notes_api=notes,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
 
 
 def test_artifacts_before_notes_construction_order(mock_auth: AuthTokens) -> None:
     """Both construction orders must succeed and produce working APIs."""
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = MagicMock()
 
@@ -765,7 +778,8 @@ def test_artifacts_before_notes_construction_order(mock_auth: AuthTokens) -> Non
         return ArtifactsAPI(
             core,
             notebooks=MagicMock(),
-            mind_map_service=MagicMock(spec=MindMapService),
+            mind_maps=MagicMock(spec=NoteBackedMindMapService),
+            note_service=MagicMock(spec=NoteService),
         )
 
     artifacts_first = _make_artifacts()
@@ -829,16 +843,20 @@ def _make_core_for_mind_map_flow() -> tuple[MagicMock, list[tuple[Any, Any]]]:
 
 
 def _build_artifacts_with_real_mind_map_service(core: MagicMock) -> ArtifactsAPI:
-    """Build an ``ArtifactsAPI`` whose ``mind_map_service`` is a real
-    ``MindMapService(core)`` so the mind-map flow exercises the live RPC
-    callbacks against the canned ``core.rpc_call``.
+    """Build an ``ArtifactsAPI`` whose mind-map services are real
+    instances backed by ``core`` so the mind-map flow exercises the
+    live RPC callbacks against the canned ``core.rpc_call``.
     """
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
+    note_service = NoteService(core)
+    mind_maps = NoteBackedMindMapService(note_service)
     return ArtifactsAPI(
         core,
         notebooks=MagicMock(get_source_ids=AsyncMock(return_value=["src_1"])),
-        mind_map_service=MindMapService(core),
+        mind_maps=mind_maps,
+        note_service=note_service,
     )
 
 

--- a/tests/unit/test_note_backed_mind_map_service.py
+++ b/tests/unit/test_note_backed_mind_map_service.py
@@ -1,0 +1,117 @@
+"""Unit tests for the ``NoteBackedMindMapService`` facade.
+
+This service is the adapter that knows mind maps share storage with
+plain notes. It delegates everything to a wrapped :class:`NoteService`
+so the artifact download path doesn't have to know about the note row
+shape, and the Phase 6 NotesAPI retype gets a clean ``mind_maps``
+parameter to wire.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from notebooklm._mind_map import NoteBackedMindMapService
+from notebooklm._note_service import NoteRowKind, NoteService
+
+
+@pytest.fixture
+def mock_notes() -> MagicMock:
+    notes = MagicMock(spec=NoteService)
+    return notes
+
+
+@pytest.fixture
+def service(mock_notes: MagicMock) -> NoteBackedMindMapService:
+    return NoteBackedMindMapService(mock_notes)
+
+
+class TestListMindMaps:
+    @pytest.mark.asyncio
+    async def test_list_mind_maps_filters_to_mind_map_rows(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        mind_map_row = ["mm_1", json.dumps({"nodes": []})]
+        plain_note = ["note_1", "plain body"]
+        deleted = ["del_1", None, 2]
+        mock_notes.fetch_note_rows = AsyncMock(return_value=[plain_note, mind_map_row, deleted])
+
+        def fake_classify(row: list[object]) -> NoteRowKind:
+            if row is mind_map_row:
+                return NoteRowKind.MIND_MAP
+            if row is deleted:
+                return NoteRowKind.DELETED
+            return NoteRowKind.NOTE
+
+        mock_notes.classify_row = MagicMock(side_effect=fake_classify)
+
+        result = await service.list_mind_maps("nb_abc")
+
+        assert result == [mind_map_row]
+        mock_notes.fetch_note_rows.assert_awaited_once_with("nb_abc")
+
+    @pytest.mark.asyncio
+    async def test_list_mind_maps_returns_empty_when_no_rows(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        mock_notes.fetch_note_rows = AsyncMock(return_value=[])
+        mock_notes.classify_row = MagicMock()
+        assert await service.list_mind_maps("nb_abc") == []
+        mock_notes.classify_row.assert_not_called()
+
+
+class TestExtractContent:
+    def test_extract_content_delegates_to_note_service(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        mock_notes.extract_content = MagicMock(return_value="payload")
+        row = ["mm_1", "payload"]
+
+        result = service.extract_content(row)
+
+        assert result == "payload"
+        mock_notes.extract_content.assert_called_once_with(row)
+
+
+class TestDeleteMindMap:
+    @pytest.mark.asyncio
+    async def test_delete_mind_map_delegates_and_returns_bool(
+        self, service: NoteBackedMindMapService, mock_notes: MagicMock
+    ) -> None:
+        mock_notes.delete_note = AsyncMock(return_value=True)
+
+        assert await service.delete_mind_map("nb_abc", "mm_1") is True
+
+        mock_notes.delete_note.assert_awaited_once_with("nb_abc", "mm_1")
+
+
+class TestEndToEndWithRealNoteService:
+    """Integration check: NoteBackedMindMapService backed by a real
+    :class:`NoteService` must still return mind-map rows correctly."""
+
+    @pytest.mark.asyncio
+    async def test_real_note_service_round_trip(self) -> None:
+        from notebooklm._note_service import NoteService as RealNoteService
+
+        mind_map_payload = json.dumps({"children": [{"name": "c"}]})
+        session = MagicMock()
+        session.rpc_call = AsyncMock(
+            return_value=[
+                [
+                    ["note_1", "plain"],
+                    ["mm_1", mind_map_payload],
+                    ["del_1", None, 2],
+                ]
+            ]
+        )
+
+        notes = RealNoteService(session)
+        svc = NoteBackedMindMapService(notes)
+
+        rows = await svc.list_mind_maps("nb_x")
+
+        assert rows == [["mm_1", mind_map_payload]]
+        assert svc.extract_content(rows[0]) == mind_map_payload

--- a/tests/unit/test_note_backed_mind_map_service.py
+++ b/tests/unit/test_note_backed_mind_map_service.py
@@ -94,18 +94,20 @@ class TestEndToEndWithRealNoteService:
 
     @pytest.mark.asyncio
     async def test_real_note_service_round_trip(self) -> None:
+        from _fixtures.fake_core import make_fake_core
         from notebooklm._note_service import NoteService as RealNoteService
 
         mind_map_payload = json.dumps({"children": [{"name": "c"}]})
-        session = MagicMock()
-        session.rpc_call = AsyncMock(
-            return_value=[
-                [
-                    ["note_1", "plain"],
-                    ["mm_1", mind_map_payload],
-                    ["del_1", None, 2],
+        session = make_fake_core(
+            rpc_call=AsyncMock(
+                return_value=[
+                    [
+                        ["note_1", "plain"],
+                        ["mm_1", mind_map_payload],
+                        ["del_1", None, 2],
+                    ]
                 ]
-            ]
+            )
         )
 
         notes = RealNoteService(session)

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -14,24 +14,26 @@ in ``test_mind_map_service.py``).
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, call
 
 import pytest
 
+from _fixtures.fake_core import FakeSession, make_fake_core
 from notebooklm._note_service import NoteRowKind, NoteService
 from notebooklm.rpc import RPCMethod
 from notebooklm.types import Note
 
 
 @pytest.fixture
-def mock_session() -> MagicMock:
-    session = MagicMock()
-    session.rpc_call = AsyncMock()
-    return session
+def mock_session() -> FakeSession:
+    # ``make_fake_core`` is the ADR-007 sanctioned substrate. We inject a
+    # fresh ``AsyncMock`` for ``rpc_call`` at construction time so per-test
+    # ``.return_value`` / ``.side_effect`` assignment still works.
+    return make_fake_core(rpc_call=AsyncMock(return_value=None))
 
 
 @pytest.fixture
-def service(mock_session: MagicMock) -> NoteService:
+def service(mock_session: FakeSession) -> NoteService:
     return NoteService(mock_session)
 
 
@@ -40,7 +42,7 @@ class TestFetchNoteRows:
 
     @pytest.mark.asyncio
     async def test_fetch_note_rows_filters_invalid_rows(
-        self, service: NoteService, mock_session: MagicMock
+        self, service: NoteService, mock_session: FakeSession
     ) -> None:
         mock_session.rpc_call.return_value = [
             [
@@ -65,7 +67,7 @@ class TestFetchNoteRows:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("payload", [None, [], ["not-a-list"], [[]]])
     async def test_fetch_note_rows_returns_empty_for_malformed_payload(
-        self, service: NoteService, mock_session: MagicMock, payload: object
+        self, service: NoteService, mock_session: FakeSession, payload: object
     ) -> None:
         mock_session.rpc_call.return_value = payload
         assert await service.fetch_note_rows("nb_123") == []
@@ -137,7 +139,7 @@ class TestCrud:
 
     @pytest.mark.asyncio
     async def test_create_note_does_create_then_update(
-        self, service: NoteService, mock_session: MagicMock
+        self, service: NoteService, mock_session: FakeSession
     ) -> None:
         mock_session.rpc_call.side_effect = [[["note_123"]], None]
 
@@ -169,7 +171,7 @@ class TestCrud:
 
     @pytest.mark.asyncio
     async def test_create_note_returns_empty_id_when_server_omits_id(
-        self, service: NoteService, mock_session: MagicMock
+        self, service: NoteService, mock_session: FakeSession
     ) -> None:
         mock_session.rpc_call.return_value = None
 
@@ -182,7 +184,7 @@ class TestCrud:
 
     @pytest.mark.asyncio
     async def test_update_note_sends_existing_payload(
-        self, service: NoteService, mock_session: MagicMock
+        self, service: NoteService, mock_session: FakeSession
     ) -> None:
         await service.update_note("nb_123", "note_123", "Body", "Title")
 
@@ -195,7 +197,7 @@ class TestCrud:
 
     @pytest.mark.asyncio
     async def test_delete_note_returns_true_and_sends_soft_delete(
-        self, service: NoteService, mock_session: MagicMock
+        self, service: NoteService, mock_session: FakeSession
     ) -> None:
         assert await service.delete_note("nb_123", "note_123") is True
 

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -1,0 +1,218 @@
+"""Unit tests for the private ``NoteService`` primitives.
+
+``NoteService`` owns the raw note-row fetch + classify + CRUD
+primitives shared by ``NotesAPI`` (Phase 6 retypes it) and
+``NoteBackedMindMapService`` (the mind-map adapter the artifact
+download path uses).
+
+The classifier behavior is exercised here because it is the only
+new logic introduced in Phase 5 (the CRUD methods mirror the existing
+``MindMapService`` wire payloads, which already have dedicated tests
+in ``test_mind_map_service.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from notebooklm._note_service import NoteRowKind, NoteService
+from notebooklm.rpc import RPCMethod
+from notebooklm.types import Note
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    session = MagicMock()
+    session.rpc_call = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def service(mock_session: MagicMock) -> NoteService:
+    return NoteService(mock_session)
+
+
+class TestFetchNoteRows:
+    """``fetch_note_rows`` returns raw rows or ``[]`` for malformed payloads."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_note_rows_filters_invalid_rows(
+        self, service: NoteService, mock_session: MagicMock
+    ) -> None:
+        mock_session.rpc_call.return_value = [
+            [
+                ["note_1", "Content"],
+                [],
+                "not-a-row",
+                [123, "Non-string ID"],
+                ["note_2", "Content"],
+            ]
+        ]
+
+        rows = await service.fetch_note_rows("nb_123")
+
+        assert rows == [["note_1", "Content"], ["note_2", "Content"]]
+        mock_session.rpc_call.assert_awaited_once_with(
+            RPCMethod.GET_NOTES_AND_MIND_MAPS,
+            ["nb_123"],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("payload", [None, [], ["not-a-list"], [[]]])
+    async def test_fetch_note_rows_returns_empty_for_malformed_payload(
+        self, service: NoteService, mock_session: MagicMock, payload: object
+    ) -> None:
+        mock_session.rpc_call.return_value = payload
+        assert await service.fetch_note_rows("nb_123") == []
+
+
+class TestClassifyRow:
+    """The classifier maps raw rows to ``NoteRowKind`` values."""
+
+    def test_deleted_row_classifies_as_deleted(self, service: NoteService) -> None:
+        assert service.classify_row(["row_1", None, 2]) == NoteRowKind.DELETED
+
+    def test_mind_map_row_via_children_key(self, service: NoteService) -> None:
+        row = ["mm_1", json.dumps({"children": []})]
+        assert service.classify_row(row) == NoteRowKind.MIND_MAP
+
+    def test_mind_map_row_via_nodes_key(self, service: NoteService) -> None:
+        row = ["mm_2", ["mm_2", json.dumps({"nodes": []}), None, None, "Title"]]
+        assert service.classify_row(row) == NoteRowKind.MIND_MAP
+
+    def test_plain_note_row(self, service: NoteService) -> None:
+        row = ["note_1", "This is a regular note body."]
+        assert service.classify_row(row) == NoteRowKind.NOTE
+
+    def test_nested_note_shape_classifies_as_note(self, service: NoteService) -> None:
+        row = ["note_2", ["note_2", "Nested body", None, None, "Nested Title"]]
+        assert service.classify_row(row) == NoteRowKind.NOTE
+
+    def test_unknown_row_with_missing_content(self, service: NoteService) -> None:
+        # Row with an ID but no extractable content (and not soft-deleted)
+        # is intentionally classified as UNKNOWN rather than NOTE so the
+        # caller can distinguish "not a real note" from "empty note".
+        assert service.classify_row(["row_3", 123]) == NoteRowKind.UNKNOWN
+
+    def test_empty_row_classifies_as_unknown(self, service: NoteService) -> None:
+        assert service.classify_row([]) == NoteRowKind.UNKNOWN
+
+    def test_saved_chat_with_unrecognized_metadata_falls_back_to_note(
+        self, service: NoteService
+    ) -> None:
+        """Per refactor.md §Risks: when saved-chat metadata is not
+        positively detectable, the classifier must default to NOTE so
+        the row never silently drops out of ``NotesAPI.list()``.
+        """
+        row = ["chat_note_1", "Saved chat answer body without explicit chat flag."]
+        # No chat-mode metadata on the wire — classifier should still
+        # surface the row as a (plain) note rather than UNKNOWN.
+        assert service.classify_row(row) == NoteRowKind.NOTE
+
+
+class TestExtractContent:
+    """``extract_content`` handles legacy and current wire shapes."""
+
+    def test_extract_content_from_legacy_shape(self, service: NoteService) -> None:
+        assert service.extract_content(["row_1", "legacy"]) == "legacy"
+
+    def test_extract_content_from_nested_shape(self, service: NoteService) -> None:
+        assert (
+            service.extract_content(["row_1", ["row_1", "nested", None, None, "Title"]]) == "nested"
+        )
+
+    def test_extract_content_returns_none_for_unknown_shape(self, service: NoteService) -> None:
+        assert service.extract_content(["row_1", 123]) is None
+        assert service.extract_content(["row_1", ["row_1"]]) is None
+        assert service.extract_content([]) is None
+
+
+class TestCrud:
+    """CRUD methods send the expected wire payloads."""
+
+    @pytest.mark.asyncio
+    async def test_create_note_does_create_then_update(
+        self, service: NoteService, mock_session: MagicMock
+    ) -> None:
+        mock_session.rpc_call.side_effect = [[["note_123"]], None]
+
+        note = await service.create_note(
+            "nb_123",
+            title="Mind Map",
+            content='{"children":[]}',
+        )
+
+        assert note == Note(
+            id="note_123",
+            notebook_id="nb_123",
+            title="Mind Map",
+            content='{"children":[]}',
+        )
+        assert mock_session.rpc_call.await_args_list == [
+            call(
+                RPCMethod.CREATE_NOTE,
+                ["nb_123", "", [1], None, "Mind Map"],
+                source_path="/notebook/nb_123",
+            ),
+            call(
+                RPCMethod.UPDATE_NOTE,
+                ["nb_123", "note_123", [[['{"children":[]}', "Mind Map", [], 0]]]],
+                source_path="/notebook/nb_123",
+                allow_null=True,
+            ),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_create_note_returns_empty_id_when_server_omits_id(
+        self, service: NoteService, mock_session: MagicMock
+    ) -> None:
+        mock_session.rpc_call.return_value = None
+
+        note = await service.create_note("nb_123", title="T", content="body")
+
+        assert note.id == ""
+        # Only CREATE_NOTE should fire; the UPDATE_NOTE skip avoids
+        # poisoning a non-existent row.
+        assert mock_session.rpc_call.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_update_note_sends_existing_payload(
+        self, service: NoteService, mock_session: MagicMock
+    ) -> None:
+        await service.update_note("nb_123", "note_123", "Body", "Title")
+
+        mock_session.rpc_call.assert_awaited_once_with(
+            RPCMethod.UPDATE_NOTE,
+            ["nb_123", "note_123", [[["Body", "Title", [], 0]]]],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_note_returns_true_and_sends_soft_delete(
+        self, service: NoteService, mock_session: MagicMock
+    ) -> None:
+        assert await service.delete_note("nb_123", "note_123") is True
+
+        mock_session.rpc_call.assert_awaited_once_with(
+            RPCMethod.DELETE_NOTE,
+            ["nb_123", None, ["note_123"]],
+            source_path="/notebook/nb_123",
+            allow_null=True,
+        )
+
+
+class TestPrivacy:
+    """``NoteRowKind`` is intentionally not part of the public surface."""
+
+    def test_note_row_kind_not_in_public_exports(self) -> None:
+        import notebooklm
+        import notebooklm.types
+
+        assert "NoteRowKind" not in dir(notebooklm)
+        assert "NoteRowKind" not in dir(notebooklm.types)

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -14,7 +14,8 @@ from notebooklm import (
     get_request_id,
 )
 from notebooklm._artifacts import ArtifactsAPI
-from notebooklm._mind_map import MindMapService
+from notebooklm._mind_map import NoteBackedMindMapService
+from notebooklm._note_service import NoteService
 from notebooklm._session import Session
 from notebooklm._source_upload import SourceUploadPipeline
 from notebooklm._sources import SourcesAPI
@@ -193,7 +194,8 @@ async def test_drain_waits_for_artifact_poll_task(auth_tokens: AuthTokens) -> No
     api = ArtifactsAPI(
         core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
     first_poll_started = asyncio.Event()
     release_first_poll = asyncio.Event()
@@ -335,7 +337,8 @@ async def test_wait_for_completion_status_change_callback(auth_tokens: AuthToken
     api = ArtifactsAPI(
         core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
     statuses = [
         GenerationStatus(task_id="task_1", status="in_progress"),

--- a/tests/unit/test_quota_failure_detection.py
+++ b/tests/unit/test_quota_failure_detection.py
@@ -28,8 +28,9 @@ from notebooklm.types import GenerationStatus
 
 
 def _make_api():
-    """Return an ArtifactsAPI with mocked runtime + mind_map_service."""
-    from notebooklm._mind_map import MindMapService
+    """Return an ArtifactsAPI with mocked runtime + mind-map services."""
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = MagicMock()
     core.rpc_call = AsyncMock()
@@ -39,13 +40,15 @@ def _make_api():
     core.operation_scope = MagicMock(side_effect=lambda _label: _noop_operation_scope())
     core.bound_loop = None
     core.assert_bound_loop = MagicMock(return_value=None)
-    mind_map_service = MagicMock(spec=MindMapService)
+    mind_maps = MagicMock(spec=NoteBackedMindMapService)
+    note_service = MagicMock(spec=NoteService)
     notebooks = MagicMock()
     notebooks.get_source_ids = AsyncMock(return_value=[])
     return ArtifactsAPI(
         core,
         notebooks=notebooks,
-        mind_map_service=mind_map_service,
+        mind_maps=mind_maps,
+        note_service=note_service,
     )
 
 

--- a/tests/unit/test_select_artifact.py
+++ b/tests/unit/test_select_artifact.py
@@ -46,14 +46,16 @@ def _artifact(
 @pytest.fixture
 def api() -> ArtifactsAPI:
     """Build an ArtifactsAPI with no-op runtime / mind-map — only the helper is exercised."""
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     mock_core = MagicMock()
     mock_core.rpc_call = AsyncMock()
     return ArtifactsAPI(
         mock_core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
 
 

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -92,13 +92,15 @@ async def test_session_close_drains_artifact_poll_hook() -> None:
     """``close()`` cancels in-flight poll tasks within 1s and tears down cleanly."""
     from unittest.mock import MagicMock
 
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
     core = Session(_auth())
     artifacts = ArtifactsAPI(
         core,
         notebooks=MagicMock(),
-        mind_map_service=MagicMock(spec=MindMapService),
+        mind_maps=MagicMock(spec=NoteBackedMindMapService),
+        note_service=MagicMock(spec=NoteService),
     )
     assert core._drain_hooks["artifacts.polls"] == artifacts._polling.drain
     await core.open()

--- a/tests/unit/test_source_selection.py
+++ b/tests/unit/test_source_selection.py
@@ -109,15 +109,22 @@ def mock_notebooks_api():
 
 @pytest.fixture
 def mock_mind_map_service():
-    """Bare MagicMock standing in for ``MindMapService``.
+    """Bundle of stand-in services required by ``ArtifactsAPI.__init__``.
 
     These tests exercise generation/encoding paths that never call the
-    mind-map service; the parameter is required by ``ArtifactsAPI.__init__``
-    (per docs/refactor.md Step 4) so we pass a no-op mock.
+    mind-map services. The ``mind_maps`` + ``note_service`` parameters
+    are both required (Phase 5 / refactor.md Migration Plan steps 6-7)
+    so we return a dict of stand-in mocks that construction sites can
+    splat into ``ArtifactsAPI(...)`` calls via
+    ``**mock_mind_map_service``.
     """
-    from notebooklm._mind_map import MindMapService
+    from notebooklm._mind_map import NoteBackedMindMapService
+    from notebooklm._note_service import NoteService
 
-    return MagicMock(spec=MindMapService)
+    return {
+        "mind_maps": MagicMock(spec=NoteBackedMindMapService),
+        "note_service": MagicMock(spec=NoteService),
+    }
 
 
 class TestChatSourceSelection:
@@ -207,7 +214,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_audio_with_explicit_source_ids(self, mock_core, mock_mind_map_service):
         """Test generate_audio with explicitly provided source_ids."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         # Mock successful generation response
         mock_core.rpc_call.return_value = [
@@ -250,9 +257,7 @@ class TestArtifactsSourceSelection:
         self, mock_core, mock_mind_map_service, mock_notebooks_api
     ):
         """Test generate_audio with source_ids=None fetches all sources."""
-        api = ArtifactsAPI(
-            mock_core, notebooks=mock_notebooks_api, mind_map_service=mock_mind_map_service
-        )
+        api = ArtifactsAPI(mock_core, notebooks=mock_notebooks_api, **mock_mind_map_service)
 
         # Mock get_source_ids to return source IDs
         mock_notebooks_api.get_source_ids.return_value = ["src_001", "src_002"]
@@ -282,7 +287,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_video_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_video has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
 
@@ -313,7 +318,7 @@ class TestArtifactsSourceSelection:
         self, mock_core, mock_mind_map_service
     ):
         """Test custom video style prompt is encoded after the style code."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
         mock_core.rpc_call.return_value = [["artifact_456", "Video", 3, None, 1]]
 
         await api.generate_video(
@@ -332,7 +337,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_requires_prompt(
         self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -345,7 +350,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_rejects_empty_prompt(
         self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -359,7 +364,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_custom_style_rejects_blank_prompt(
         self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt is required"):
             await api.generate_video(
@@ -373,7 +378,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_style_prompt_requires_custom_style(
         self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="style_prompt requires"):
             await api.generate_video(
@@ -387,7 +392,7 @@ class TestArtifactsSourceSelection:
     async def test_generate_video_cinematic_rejects_style_prompt(
         self, mock_core, mock_mind_map_service
     ):
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         with pytest.raises(ValidationError, match="cinematic"):
             await api.generate_video(
@@ -400,7 +405,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_report_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_report has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
@@ -431,7 +436,7 @@ class TestArtifactsSourceSelection:
         self, mock_core, mock_mind_map_service
     ):
         """extra_instructions is appended to the built-in prompt with \\n\\n separator."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
         await api.generate_report(
@@ -454,7 +459,7 @@ class TestArtifactsSourceSelection:
         """extra_instructions has no effect when report_format is CUSTOM."""
         from notebooklm.rpc.types import ReportFormat
 
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
         mock_core.rpc_call.return_value = [["artifact_789", "Report", 2, None, 1]]
 
         await api.generate_report(
@@ -475,7 +480,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_quiz_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_quiz has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_quiz", "Quiz", 4, None, 1]]
 
@@ -500,7 +505,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_flashcards_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_flashcards has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_fc", "Flashcards", 4, None, 1]]
 
@@ -520,7 +525,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_infographic_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_infographic has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
 
@@ -540,7 +545,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_infographic_style_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_infographic encodes style in config slot 5."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_info", "Infographic", 7, None, 1]]
 
@@ -561,7 +566,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_slide_deck_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_slide_deck has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_slide", "Slides", 8, None, 1]]
 
@@ -581,7 +586,7 @@ class TestArtifactsSourceSelection:
     @pytest.mark.asyncio
     async def test_generate_data_table_source_encoding(self, mock_core, mock_mind_map_service):
         """Test generate_data_table has correct source encoding format."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_table", "Table", 9, None, 1]]
 
@@ -603,9 +608,7 @@ class TestArtifactsSourceSelection:
         self, mock_core, mock_mind_map_service, mock_notebooks_api
     ):
         """Test generate_mind_map has correct source encoding format."""
-        api = ArtifactsAPI(
-            mock_core, notebooks=mock_notebooks_api, mind_map_service=mock_mind_map_service
-        )
+        api = ArtifactsAPI(mock_core, notebooks=mock_notebooks_api, **mock_mind_map_service)
 
         # Mock get_source_ids to return source IDs
         mock_notebooks_api.get_source_ids.return_value = ["src_mm_1", "src_mm_2"]
@@ -640,7 +643,7 @@ class TestArtifactsSourceSelection:
         self, mock_core, mock_mind_map_service
     ):
         """Test generate_mind_map passes language and instructions to RPC payload."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [['{"name": "Mind Map", "children": []}']]
 
@@ -670,7 +673,7 @@ class TestArtifactsSourceSelection:
         """Test suggest_reports uses GET_SUGGESTED_REPORTS RPC."""
         from notebooklm.rpc.types import RPCMethod
 
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         # Mock the GET_SUGGESTED_REPORTS RPC call
         # Response format: [[[title, description, null, null, prompt, audience_level], ...]]
@@ -697,7 +700,7 @@ class TestEmptySourceIds:
     @pytest.mark.asyncio
     async def test_generate_with_empty_source_list(self, mock_core, mock_mind_map_service):
         """Test generation with empty source_ids list produces empty arrays."""
-        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), mind_map_service=mock_mind_map_service)
+        api = ArtifactsAPI(mock_core, notebooks=MagicMock(), **mock_mind_map_service)
 
         mock_core.rpc_call.return_value = [["artifact_empty", "Audio", 1, None, 1]]
 


### PR DESCRIPTION
## Summary

Phase 5 of the capability-refactor-full-arc plan — fused refactor.md
Migration Plan steps 6 (note-service split) and 7 (mind-map facade +
ArtifactsAPI rewire). Single PR because the two steps depend on each
other.

- Adds `_note_service.py` with private `NoteRowKind` + `NoteService`
  (raw note-row fetch + classify + CRUD).
- Adds `NoteBackedMindMapService` adapter to `_mind_map.py`
  (mind-map-only facade over `NoteService`).
- Rewires `_artifact_generation.generate_mind_map` to call
  `api._note_service.create_note(...)` directly.
- Rewires `_artifact_downloads.download_mind_map` to consume
  `api._mind_maps.list_mind_maps` / `extract_content`.
- Renames `ArtifactsAPI` ctor param `mind_map_service` → `mind_maps`
  and adds required `note_service` kwarg.
- Updates `NotebookLMClient` composition root to wire both new
  services explicitly.

## Intentional deviation from refactor.md:732

The original spec said "no change needed" for the four
`api._core.rpc_call(...)` paths in `_artifact_generation.py`. Phase 5
migrates those to `api._runtime.rpc_call(...)` AND removes the `_core`
`@property` alias on `ArtifactsAPI` that Phase 3 added as a
transitional bridge. The Phase 3 agent's follow-up notes flagged that
property as cruft that should retire when its callers are touched —
Phase 5 takes that cleaner end state.

## Phase boundaries preserved

- `_notes.py` is UNCHANGED — Phase 6 retypes NotesAPI.
- `_chat.py` is UNCHANGED — Phase 6 territory.
- Module-level `_mind_map.py` wrappers all still exist (Phase 6
  removes them after NotesAPI retype).
- `NoteRowKind` stays private — not in `notebooklm.__init__` or
  `notebooklm.types.__all__`.
- Broad `Session` Protocol untouched (Phase 7).
- `_core.py` shim + `NotebookLMClient._core` preserved.

## Test plan

- [x] `uv run pre-commit run --all-files` clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` clean
- [x] `uv run ruff check src/notebooklm tests` clean
- [x] `uv run ruff format --check src/notebooklm tests` clean
- [x] `uv run pytest tests/unit tests/integration` — 5532 passed, 14
      skipped, 0 failures
- [x] All 13 drift-sweep grep assertions from spec §10 pass
- [ ] CI green on the PR
- [ ] `@claude review` feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved mind-map and note persistence plumbing for more reliable creation, saving, and deletion of mind maps.
  * Routed artifact generation and RPC through a unified runtime layer to improve robustness of slide/mind-map/report creation.
* **Tests**
  * Updated and expanded tests and integrations to exercise the new mind-map/note flow, increasing coverage and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->