### PR TITLE
fix(rpc-health): surface httpx class name on empty error message

### DIFF
--- a/scripts/check_rpc_health.py
+++ b/scripts/check_rpc_health.py
@@ -269,7 +269,9 @@ async def make_rpc_request(
     except httpx.HTTPStatusError as e:
         return None, f"HTTP {e.response.status_code}"
     except httpx.RequestError as e:
-        return None, str(e)
+        # ``httpx.ReadTimeout`` can stringify to ``""``; fall back to the
+        # class name so callers don't mislabel it as an empty response (#864).
+        return None, str(e) or type(e).__name__
 
 
 async def make_rpc_call(
@@ -292,7 +294,7 @@ async def make_rpc_call(
         Tuple of (list of RPC IDs found in response, error message or None)
     """
     response_text, error = await make_rpc_request(client, auth, method, params, source_path)
-    if error:
+    if error is not None:
         return [], error
     if response_text is None:
         return [], "Empty response from server"
@@ -343,7 +345,7 @@ async def test_rpc_method(
         status=CheckStatus.ERROR,
         expected_id=expected_id,
         found_ids=found_ids,
-        error=error or "RPC ID not found in response",
+        error=error if error is not None else "RPC ID not found in response",
     )
 
 
@@ -371,7 +373,7 @@ async def test_rpc_method_with_data(
     expected_id = method.value
 
     response_text, error = await make_rpc_request(client, auth, method, params, source_path)
-    if error:
+    if error is not None:
         return CheckResult(
             method=method,
             status=CheckStatus.ERROR,
@@ -630,7 +632,7 @@ async def check_method(
     # Make the call
     found_ids, error = await make_rpc_call(client, auth, method, params)
 
-    if error:
+    if error is not None:
         # Check if error response still contains our expected ID
         if expected_id in found_ids:
             return CheckResult(

--- a/tests/unit/test_check_rpc_health.py
+++ b/tests/unit/test_check_rpc_health.py
@@ -224,6 +224,99 @@ async def test_make_rpc_request_uses_flat_cookie_header_and_auth_route() -> None
     assert "authuser" not in default_query
 
 
+# Regression fixtures for issue #864: ``httpx.ReadTimeout`` raised from
+# anyio's bare ``TimeoutError()`` has ``str(e) == ""``. Without the
+# class-name fallback the empty error string is swallowed by ``if error:``
+# checks and mislabeled as "Empty response from server". Each call site
+# that consumes ``make_rpc_request`` gets its own regression test below.
+
+
+class _TimingOutClient:
+    async def post(self, url: str, *, content: str, headers: dict[str, str]) -> httpx.Response:
+        raise httpx.ReadTimeout("")
+
+
+@pytest.fixture
+def timing_out_auth() -> check_rpc_health.AuthTokens:
+    return check_rpc_health.AuthTokens(
+        cookies={"SID": "sid"},
+        csrf_token="csrf",
+        session_id="session",
+    )
+
+
+@pytest.mark.asyncio
+async def test_make_rpc_request_surfaces_class_name_for_empty_message_errors(
+    timing_out_auth: check_rpc_health.AuthTokens,
+) -> None:
+    response_text, error = await make_rpc_request(
+        _TimingOutClient(),
+        timing_out_auth,
+        check_rpc_health.RPCMethod.GET_SUGGESTED_REPORTS,
+        [[2], "nb"],
+    )
+    assert response_text is None
+    assert error == "ReadTimeout"
+
+
+@pytest.mark.asyncio
+async def test_make_rpc_call_propagates_empty_message_errors_without_relabeling(
+    timing_out_auth: check_rpc_health.AuthTokens,
+) -> None:
+    found_ids, error = await check_rpc_health.make_rpc_call(
+        _TimingOutClient(),
+        timing_out_auth,
+        check_rpc_health.RPCMethod.GET_SUGGESTED_REPORTS,
+        [[2], "nb"],
+    )
+    assert found_ids == []
+    assert error == "ReadTimeout"
+
+
+@pytest.mark.asyncio
+async def test_test_rpc_method_with_data_propagates_empty_message_errors(
+    timing_out_auth: check_rpc_health.AuthTokens,
+) -> None:
+    result, data = await check_rpc_health.test_rpc_method_with_data(
+        _TimingOutClient(),
+        timing_out_auth,
+        check_rpc_health.RPCMethod.CREATE_NOTEBOOK,
+        ["Title"],
+    )
+    assert data is None
+    assert result.status is CheckStatus.ERROR
+    assert result.error == "ReadTimeout"
+
+
+@pytest.mark.asyncio
+async def test_check_method_propagates_empty_message_errors(
+    timing_out_auth: check_rpc_health.AuthTokens,
+) -> None:
+    # ``check_method`` is the third call site that consumes the
+    # ``(found_ids, error)`` tuple. Pin its behavior so the
+    # class-name fallback can't silently regress only here.
+    result = await check_rpc_health.check_method(
+        _TimingOutClient(),
+        timing_out_auth,
+        check_rpc_health.RPCMethod.GET_SOURCE,
+        notebook_id="nb",
+    )
+    assert result.status is CheckStatus.ERROR
+    assert result.error == "ReadTimeout"
+
+
+def test_is_transient_error_pins_readtimeout_as_non_transient() -> None:
+    # Pinned policy (see scripts/check_rpc_health.py docstring + the
+    # comment on TRANSIENT_ERROR_MARKERS): transport timeouts are
+    # treated as real failures so the canary can flag silent breakage.
+    # If this policy ever changes, update this test deliberately —
+    # don't drop it. See #864 for the discussion.
+    assert is_transient_error("ReadTimeout") is False
+    assert is_transient_error("ConnectTimeout") is False
+    assert is_transient_error("WriteTimeout") is False
+    assert is_transient_error("PoolTimeout") is False
+
+
 @pytest.mark.asyncio
 async def test_setup_temp_resources_uses_canonical_create_notebook_payload(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Fixes #864 — the nightly RPC health check was filing fresh GitHub issues every time the network blipped during `GET_SUGGESTED_REPORTS`, labelling them with a misleading `"Empty response from server"` message that masked the real failure (a transport-layer timeout).

## Root cause (verified against httpx 0.28.1 + a non-responding TCP socket)

Real `httpx.ReadTimeout('')` raised in real network conditions has `str(e) == ''`. The underlying chain:

1. anyio's `fail_after()` raises a bare `TimeoutError()` with empty `str()`.
2. httpcore wraps it as `httpcore.ReadTimeout('')`.
3. httpx's `map_httpcore_exceptions` (verified in source: `message = str(exc); raise mapped_exc(message)`) propagates the empty string into `httpx.ReadTimeout('')`.
4. `make_rpc_request` caught `httpx.RequestError`, returned `(None, str(e))` = `(None, '')`.
5. `make_rpc_call` (and `test_rpc_method_with_data`, and `check_method`) did `if error:` — empty string is falsy → branch skipped.
6. Fell through to `if response_text is None:` → returned `([], "Empty response from server")`.
7. `is_transient_error("Empty response from server")` → False → exit code 3 → workflow opened #864.

The script's existing comment about `GET_SUGGESTED_REPORTS` "trip[ping] the empty-response guard against a freshly-created temp notebook" (scripts/check_rpc_health.py:478-484) misdiagnoses the mechanism — empirically, an actually-empty 200 body passes through the parser and produces MISMATCH, not ERROR. The "guard" only fires from the empty-`str(e)` path above.

## Fix (defense in depth)

1. **`make_rpc_request`**: fall back to `type(e).__name__` when `str(e)` is empty, so the surfaced error always identifies the exception class (`ReadTimeout`, `ConnectError`, `WriteTimeout`, …) instead of an empty string.
2. **All three downstream call sites** (`make_rpc_call:294`, `test_rpc_method_with_data:373`, `check_method:633`) tighten `if error:` → `if error is not None:`. Same intent applied to `test_rpc_method:348`'s `error or "..."` default.

Both layers are needed: layer 1 ensures the error string is identifiable today; layer 2 ensures the downstream logic remains correct even if layer 1 ever regresses.

## Tests

Five new regression tests (`tests/unit/test_check_rpc_health.py`):

- `test_make_rpc_request_surfaces_class_name_for_empty_message_errors`
- `test_make_rpc_call_propagates_empty_message_errors_without_relabeling`
- `test_test_rpc_method_with_data_propagates_empty_message_errors`
- `test_check_method_propagates_empty_message_errors`

  Each drives a `_TimingOutClient` that raises `httpx.ReadTimeout('')` through its respective call site and asserts the surfaced error is `"ReadTimeout"`, not `"Empty response from server"`.

- `test_is_transient_error_pins_readtimeout_as_non_transient` — pins the script's **current** policy (see deferred follow-up below).

## Deferred follow-up (intentionally NOT in this PR)

Post-fix, transient network timeouts will still file health-check issues, but with the correct `"ReadTimeout"` label. Two reviewers (codex + agy) flagged that to fully stop the false-positive issue creation, the fix should also expand `TRANSIENT_ERROR_MARKERS` to include `"ReadTimeout"` / `"ConnectTimeout"` / etc.

I'm **not** doing that in this PR because:

1. The script's docstring (lines 8-12) explicitly classifies timeouts as **non-transient by design**: _"3 - One or more RPC methods returned a non-transient ERROR (timeouts, parse failures, unexpected HTTP errors)"_.
2. The `TRANSIENT_ERROR_MARKERS` comment (lines 1035-1045) doubles down: _"timeouts, parse failures, unexpected HTTP errors\] is treated as a real failure so the nightly canary can flag silent breakage. Keep this list narrow on purpose: broadening it would mask real RPC drift."_

Changing that policy is a separate decision from fixing the masking bug. The new `is_transient_error("ReadTimeout") is False` test pins the current policy so any future flip is intentional, not accidental.

A separate stale-comment cleanup at `scripts/check_rpc_health.py:478-484` (the "empty-response guard" misdiagnosis) is also worth doing in a follow-up.

## Test plan

- [x] `uv run ruff format scripts/check_rpc_health.py tests/unit/test_check_rpc_health.py` — clean
- [x] `uv run ruff check scripts/check_rpc_health.py tests/unit/test_check_rpc_health.py` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues
- [x] `uv run pytest tests/unit/test_check_rpc_health.py -q` — 35 passed (5 new)
- [x] `uv run pytest` — 5473 passed, 51 skipped (no regressions)
- [ ] Next scheduled canary run confirms the misleading `"Empty response from server"` no longer appears, and any timeout failures now surface as `"ReadTimeout"` (or similar) in the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced RPC health-check error detection to properly surface timeout errors with empty messages, preventing them from being incorrectly treated as successful responses and ensuring accurate health status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/874?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->