### PR TITLE
fix(notes): order cancel-time cleanup so DELETE_NOTE waits for shielded UPDATE_NOTE

### DIFF
--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -249,15 +249,17 @@ class NoteService:
                 # bounded.
                 async def _finalize_then_cleanup() -> None:
                     try:
-                        await update_task
-                    except Exception:  # noqa: BLE001 — log and proceed to delete
-                        logger.debug(
-                            "Shielded UPDATE_NOTE failed before cleanup for note %s in notebook %s",
-                            note_id,
-                            notebook_id,
-                            exc_info=True,
-                        )
-                    await self._delete_note_best_effort(notebook_id, note_id)
+                        try:
+                            await update_task
+                        except Exception:  # noqa: BLE001 — log and proceed to delete
+                            logger.debug(
+                                "Shielded UPDATE_NOTE failed before cleanup for note %s in notebook %s",
+                                note_id,
+                                notebook_id,
+                                exc_info=True,
+                            )
+                    finally:
+                        await self._delete_note_best_effort(notebook_id, note_id)
 
                 cleanup_task = asyncio.create_task(_finalize_then_cleanup())
                 _cleanup_tasks.add(cleanup_task)

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -223,18 +223,43 @@ class NoteService:
             # the shield, a cancel arriving between CREATE_NOTE and
             # UPDATE_NOTE completion leaves an orphan row with no
             # title/content.
+            #
+            # ``update_task`` is a freestanding ``asyncio.Task`` (not a
+            # bare coroutine) so the cancel-time cleanup branch can await
+            # it before issuing the best-effort DELETE_NOTE. If we instead
+            # fired DELETE_NOTE in parallel with the still-running
+            # shielded UPDATE_NOTE (the pattern coderabbit flagged on PR
+            # #875), delete could complete first and update could then
+            # write to an already-soft-deleted row — observable as an
+            # inconsistent row state on the server side and a swallowed
+            # exception in the cleanup task.
+            update_task = asyncio.create_task(
+                self.update_note(notebook_id, note_id, content, title)
+            )
             try:
-                await asyncio.shield(self.update_note(notebook_id, note_id, content, title))
+                await asyncio.shield(update_task)
             except asyncio.CancelledError:
-                # Fire-and-forget orphan-row cleanup; the re-raise
-                # MUST NOT await the cleanup task. Strong-ref via
-                # ``_cleanup_tasks`` so the loop's weak-ref Task
-                # storage cannot GC it mid-flight (RUF006); the
-                # done-callback discards on completion so the set
-                # stays bounded.
-                cleanup_task = asyncio.create_task(
-                    self._delete_note_best_effort(notebook_id, note_id)
-                )
+                # Ordered fire-and-forget cleanup: first wait for the
+                # shielded UPDATE_NOTE to finish (success OR error),
+                # THEN issue the best-effort DELETE_NOTE. The re-raise
+                # MUST NOT await the wrapper task. Strong-ref via
+                # ``_cleanup_tasks`` so the loop's weak-ref Task storage
+                # cannot GC the wrapper mid-flight (RUF006); the
+                # done-callback discards on completion so the set stays
+                # bounded.
+                async def _finalize_then_cleanup() -> None:
+                    try:
+                        await update_task
+                    except Exception:  # noqa: BLE001 — log and proceed to delete
+                        logger.debug(
+                            "Shielded UPDATE_NOTE failed before cleanup for note %s in notebook %s",
+                            note_id,
+                            notebook_id,
+                            exc_info=True,
+                        )
+                    await self._delete_note_best_effort(notebook_id, note_id)
+
+                cleanup_task = asyncio.create_task(_finalize_then_cleanup())
                 _cleanup_tasks.add(cleanup_task)
                 cleanup_task.add_done_callback(_cleanup_tasks.discard)
                 raise

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -271,16 +271,75 @@ class TestCreateNoteCancellation:
         with pytest.raises(asyncio.CancelledError):
             await asyncio.wait_for(task, timeout=1)
 
-        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
-        # Cleanup is scheduled but not awaited before the outer cancellation propagates.
-        assert not cleanup_finished.is_set()
-        # ``asyncio.shield`` keeps UPDATE_NOTE running after the outer task is cancelled.
+        # Ordered cleanup (coderabbit feedback on PR #875): the cleanup
+        # wrapper task is scheduled at cancel time but DELETE_NOTE only
+        # fires AFTER the shielded UPDATE_NOTE finishes. Before
+        # releasing UPDATE_NOTE, neither should have run — update is
+        # still suspended on its event and delete is gated on the
+        # update completing.
         assert not update_finished.is_set()
+        assert not cleanup_started.is_set()
+        assert not cleanup_finished.is_set()
 
+        # Release the shielded UPDATE_NOTE; the cleanup task then
+        # observes update_task completion and proceeds to DELETE_NOTE.
         update_can_finish.set()
         await asyncio.wait_for(update_finished.wait(), timeout=1)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        assert not cleanup_finished.is_set()
+
         cleanup_can_finish.set()
         await asyncio.wait_for(cleanup_finished.wait(), timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_cancellation_cleanup_runs_even_when_update_raises(
+        self,
+        mock_session: FakeSession,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the shielded UPDATE_NOTE raises after cancellation, the
+        best-effort DELETE_NOTE cleanup still fires.
+
+        Coderabbit feedback on PR #875 (the ordered-cleanup change)
+        added this guard: the cleanup wrapper logs and swallows any
+        UPDATE_NOTE exception so the DELETE_NOTE half always runs.
+        Without it, an update-side error would leave the orphan row
+        the shield was supposed to protect against.
+        """
+        service = NoteService(mock_session)
+        mock_session.rpc_call.return_value = [["note_456"]]
+        update_started = asyncio.Event()
+        update_can_finish = asyncio.Event()
+        cleanup_started = asyncio.Event()
+
+        async def failing_update_note(
+            notebook_id: str,
+            note_id: str,
+            content: str,
+            title: str,
+        ) -> None:
+            update_started.set()
+            await update_can_finish.wait()
+            raise RuntimeError("simulated UPDATE_NOTE failure after shield")
+
+        async def fake_delete_note_best_effort(notebook_id: str, note_id: str) -> None:
+            assert (notebook_id, note_id) == ("nb_456", "note_456")
+            cleanup_started.set()
+
+        monkeypatch.setattr(service, "update_note", failing_update_note)
+        monkeypatch.setattr(service, "_delete_note_best_effort", fake_delete_note_best_effort)
+
+        task = asyncio.create_task(service.create_note("nb_456", title="T", content="b"))
+        await asyncio.wait_for(update_started.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
+
+        # Release the shielded UPDATE_NOTE; it will raise — the
+        # cleanup wrapper must catch+log and still issue the
+        # DELETE_NOTE side.
+        update_can_finish.set()
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
 
 
 class TestPrivacy:

--- a/tests/unit/test_note_service.py
+++ b/tests/unit/test_note_service.py
@@ -335,6 +335,14 @@ class TestCreateNoteCancellation:
         with pytest.raises(asyncio.CancelledError):
             await asyncio.wait_for(task, timeout=1)
 
+        # Ordered-cleanup guarantee on the failing-update path: even
+        # though we're about to make UPDATE_NOTE raise, DELETE_NOTE
+        # must still wait for that update to complete before firing —
+        # cleanup must NOT have started while UPDATE_NOTE is still in
+        # flight. (Mirrors the pre-release assertion in the
+        # success-path test above.)
+        assert not cleanup_started.is_set()
+
         # Release the shielded UPDATE_NOTE; it will raise — the
         # cleanup wrapper must catch+log and still issue the
         # DELETE_NOTE side.


### PR DESCRIPTION
## Summary

Follow-up to PR #875 (Phase 6 of the capability-refactor arc) addressing a race condition that coderabbit[bot] flagged on the merged PR. The race is in `NoteService.create_note`'s cancel-time cleanup path:

* `asyncio.shield(update_note)` keeps UPDATE_NOTE running through an outer cancel.
* The original cancel handler immediately scheduled the best-effort DELETE_NOTE, in parallel with the still-running UPDATE_NOTE.
* Possible interleaving: DELETE_NOTE completes first → server soft-deletes the row → the shielded UPDATE_NOTE then runs against the already-deleted row.

## Fix

* Schedule UPDATE_NOTE as a freestanding `asyncio.Task` up front.
* In the cancel handler, create an ordered cleanup wrapper that **first** awaits the update task (logging+swallowing any error), then runs `_delete_note_best_effort`.
* Strong-ref via `_cleanup_tasks` so the wrapper task isn't GC'd mid-flight (RUF006).
* The re-raise still does NOT await the wrapper — cancel propagation stays prompt.

## Test plan

- [x] Rewrote `test_cancellation_schedules_best_effort_cleanup` to assert the new ordering — DELETE_NOTE must NOT fire until UPDATE_NOTE finishes
- [x] New `test_cancellation_cleanup_runs_even_when_update_raises` guard pins the "swallow update exception, still issue delete" behaviour — without it, an update-side exception would mask the cleanup the shield enables
- [x] Integration regression test `tests/integration/concurrency/test_note_create_cancel.py` (audit §28 guard) already shaped around the post-release ordering and still passes unchanged
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` → clean
- [x] `uv run ruff check / format --check src/notebooklm tests` → clean
- [x] `uv run pytest` → 5557 passed, 14 skipped

## References

- Triggered by coderabbit[bot] comment on PR #875 ([thread](https://github.com/teng-lin/notebooklm-py/pull/875#discussion_r3277654018))
- Closes the deferred finding flagged by the Phase 6 worker after PR #875 merged before this could be addressed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling during note creation so updates reliably finish before cleanup starts, preventing race conditions. This makes note creation and cancellation more consistent and reduces cases where incomplete updates or premature cleanup caused unexpected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->