### PR TITLE
refactor(core): step 10+11 — delete broad Session protocol; update docs; finalise ADR-013

### DIFF
--- a/docs/adr/0013-composable-session-capabilities.md
+++ b/docs/adr/0013-composable-session-capabilities.md
@@ -2,15 +2,18 @@
 
 ## Status
 
-Accepted (Sunset = capability refactor cutover). This ADR ratifies the
-capability-composition model proposed in `docs/refactor.md` (revision 5,
-dated 2026-05-20) and lands BEFORE the 11-step migration begins, so the
-architectural intent is recorded ahead of any code change. It supersedes
-[ADR-010](0010-session-kernel-split.md) (Session/Kernel split), which is
-re-statused to `Superseded by ADR-013 (#866)` in the same PR.
-The sunset clause clears in Phase 7 of the migration arc, at which point
-the broad `Session` protocol is deleted and this ADR transitions to a
-plain `Accepted` record.
+Accepted.
+
+This ADR ratifies the capability-composition model originally proposed
+in `docs/refactor.md` (revision 5, dated 2026-05-20). It supersedes
+[ADR-010](0010-session-kernel-split.md) (Session/Kernel split), which
+was re-statused to `Superseded by ADR-013 (#866)` when this ADR landed.
+
+The 11-step migration described in `docs/refactor.md` §Migration Plan
+landed in full across Phases 1–7 of the capability refactor arc; the
+broad `Session` protocol was deleted in Phase 7 (refactor.md step 10),
+so this ADR is now a plain `Accepted` record with no outstanding
+sunset clause.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,7 @@ Pure bug fixes, additive RPC method IDs, and CLI ergonomics changes do not requi
 | [0010](0010-session-kernel-split.md) | Session/Kernel split | Superseded by ADR-013 (#866) |
 | [0011](0011-schema-validation-policy.md) | Schema validation policy (strict-decode default) | Accepted (Tier 13 PR 13.9a) |
 | [0012](0012-implementation-surface-convention.md) | Implementation surface convention (underscore-prefix policy) | Accepted (Tier 13 PR 13.9a) |
-| [0013](0013-composable-session-capabilities.md) | Composable Session Capabilities and Feature-Local Runtimes | Accepted (Sunset = capability refactor cutover) |
+| [0013](0013-composable-session-capabilities.md) | Composable Session Capabilities and Feature-Local Runtimes | Accepted |
 
 ADR-007 ships alongside its enforcement substrate: the concrete fixtures (`tests/_fixtures/`) and meta-lint (`tests/_lint/test_no_forbidden_monkeypatches.py`) are added in the same PR (`arch-d1-fixtures-scaffolding`) so the record is grounded in working code rather than an empty placeholder.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -110,9 +110,18 @@ Protocol-shim host interface so it can be unit-tested against a stub `Session`:
 | `_polling_registry.py` | `PollRegistry` | Pending-poll registry shared by long-running artifact generations. |
 | `_cookie_persistence.py` | `CookiePersistence` | Cookie-jar → storage-state serialization, `__Secure-1PSIDTS` rotation. |
 
-The feature-facing session surface is pinned in
-`notebooklm._session_contracts.Session`. Adding or removing a method on that
-Protocol is a contract change for every feature API.
+The feature-facing surface is the set of **capability Protocols** in
+`notebooklm._session_contracts` — `RpcCaller`, `LoopGuard`,
+`OperationScopeProvider`, `AsyncWorkRuntime`, plus the standalone
+`AuthMetadata` and `Kernel` consumed by the upload pipeline. The
+broad `Session` Protocol that previously bundled these together was
+deleted in Phase 7 of the capability refactor (`docs/refactor.md`
+§Migration Plan step 10); each feature now depends on the narrowest
+slice it needs, either by composing the shared Protocols here or by
+defining a feature-local runtime in its own module (`ChatRuntime` in
+`_chat.py`, `ArtifactsRuntime` in `_artifacts.py`, `UploadRuntime` in
+`_source_upload.py`). See ADR-013 for the rationale and the
+promotion criterion (≥2 consumers).
 
 Private service modules sit inside the client layer but below the public
 facades. They own cross-facade composition without importing sibling facades:
@@ -170,9 +179,19 @@ The architecture tests encode the current layer contract:
 5. Add CLI command if user-facing
 
 **New API Class:**
-1. Create `_newfeature.py` with `NewFeatureAPI` class
-2. Add to `client.py`: `self.newfeature = NewFeatureAPI(self._core)`
-3. Export types from `__init__.py`
+1. Create `_newfeature.py` with `NewFeatureAPI` class.
+2. Type the constructor's runtime parameter against the **narrowest
+   shared capability Protocol** it actually uses (`RpcCaller`,
+   `AsyncWorkRuntime`, etc.), or define a feature-local runtime
+   Protocol in your feature module if the slice you need is not
+   shared with any other feature (e.g. `ChatRuntime`, `ArtifactsRuntime`,
+   `UploadRuntime`). Do not type against a broad `Session` — that
+   Protocol was deleted in Phase 7 of the capability refactor; see
+   ADR-013 for the rationale.
+3. Add to `client.py`: `self.newfeature = NewFeatureAPI(self._core)` —
+   the concrete `Session` structurally satisfies every capability
+   Protocol, so the wiring stays straightforward.
+4. Export types from `__init__.py`.
 
 ---
 

--- a/docs/migration-tier-12-to-13.md
+++ b/docs/migration-tier-12-to-13.md
@@ -30,8 +30,14 @@ anything.
   re-exported from the top-level package.
 - **Feature APIs** (`NotebooksAPI`, `SourcesAPI`, `ArtifactsAPI`, `ChatAPI`,
   `ResearchAPI`, `NotesAPI`, `SharingAPI`, `SettingsAPI`) now depend on the
-  `notebooklm._session_contracts.Session` Protocol rather than the concrete
-  `ClientCore`/`Session` class. They continue to be created by
+  **narrow capability Protocols** in `notebooklm._session_contracts`
+  (`RpcCaller`, `LoopGuard`, `OperationScopeProvider`, `AsyncWorkRuntime`)
+  or on feature-local runtime Protocols (`ChatRuntime`, `ArtifactsRuntime`,
+  `UploadRuntime`) defined in their owning modules — not on the concrete
+  `ClientCore`/`Session` class and not on a broad `Session` Protocol. The
+  broad `Session` Protocol that existed transiently between Tier 13 and
+  the capability refactor was deleted in Phase 7 of the refactor arc
+  (see ADR-013 and `docs/refactor.md`). They continue to be created by
   `NotebookLMClient`; only the type they're written against has narrowed.
 
 ## Renamed modules
@@ -73,7 +79,7 @@ change, only their home module did.
 
 | Tier 12 symbol | Tier 13 home | Notes |
 |---|---|---|
-| `notebooklm._core.ClientCore` (class) | `notebooklm._session.Session` | `ClientCore` still resolves via the `_core` shim. New code should use `notebooklm._session.Session`. Feature APIs accept the `notebooklm._session_contracts.Session` Protocol. |
+| `notebooklm._core.ClientCore` (class) | `notebooklm._session.Session` | `ClientCore` still resolves via the `_core` shim. New code should use `notebooklm._session.Session`. Feature APIs accept the narrow capability Protocols in `notebooklm._session_contracts` (`RpcCaller`, `AsyncWorkRuntime`, etc.) or a feature-local runtime; the broad `Session` Protocol was retired in the capability refactor — see ADR-013. |
 | `notebooklm._core.MAX_RETRY_AFTER_SECONDS` | `notebooklm._authed_transport.MAX_RETRY_AFTER_SECONDS` | Re-exported via `_session` and the `_core` shim. |
 | `notebooklm._core.DEFAULT_*` (timeouts, concurrency knobs) | `notebooklm._session_config.DEFAULT_*` | Re-exported via `_session` and the `_core` shim. |
 | `notebooklm._core.AUTH_ERROR_PATTERNS`, `notebooklm._core.is_auth_error` | `notebooklm._session_helpers` | Re-exported via `_session` and the `_core` shim. |
@@ -96,7 +102,7 @@ import from.
 
 | Module | Purpose |
 |---|---|
-| `notebooklm._session_contracts` | `Session`, `Kernel`, `DrainHookRegistration`, `AuthMetadata` Protocols. Feature APIs are typed against `Session` here, not the concrete `Session` class in `_session`. |
+| `notebooklm._session_contracts` | `AuthMetadata`, `Kernel`, and the four shared capability Protocols (`RpcCaller`, `LoopGuard`, `OperationScopeProvider`, `AsyncWorkRuntime`) added in the capability refactor (ADR-013). The originally-shipped broad `Session` Protocol and the standalone `DrainHookRegistration` Protocol were deleted in Phase 7 of the refactor arc; feature-local runtimes (`ChatRuntime`, `ArtifactsRuntime`, `UploadRuntime`) now live in their owning feature modules, and the canonical `DrainHookRegistration` is local to `_artifacts.py`. |
 | `notebooklm._kernel` | Concrete `Kernel` transport core (owns the `httpx.AsyncClient`, exposes `post` / `cookies` / `aclose`). Wrapped by `Session` and consumed by middleware. |
 | `notebooklm._middleware` | Middleware chain primitives (`AuthedHttpClient` Protocol, `Middleware` Protocol, `RequestContext`, chain composition). |
 | `notebooklm._middleware_tracing` | Tier 12 PR 12.3 — request tracing middleware. |

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1074,6 +1074,7 @@ else:
 | `get_history(notebook_id, limit=100, conversation_id=None)` | `str, int, str` | `list[tuple[str, str]]` | Get Q&A pairs from most recent conversation |
 | `get_conversation_id(notebook_id)` | `str` | `str \| None` | Get most recent conversation ID from server |
 | `delete_conversation(notebook_id, conversation_id)` | `str, str` | `bool` | **DESTRUCTIVE.** Permanently delete a server-side conversation (web UI's "Delete history" action). The next `ask()` with no `conversation_id` then starts a brand-new conversation. |
+| `save_answer_as_note(notebook_id, ask_result, *, title=None)` | `str, AskResult, str \| None` | `Note` | Save a chat answer as a citation-rich note ([issue #660](https://github.com/teng-lin/notebooklm-py/issues/660)) — the resulting note's `[N]` markers remain interactive hover-anchored citations in the NotebookLM web UI. Owns the saved-from-chat workflow on `ChatAPI` (the data owner); `client.notes.create_from_chat` is the deprecated forwarder for the same primitive. Raises `ValueError` if `ask_result.references` is empty. When `title is None`, derives `f"Chat: {ask_result.answer[:50].strip().replace(chr(10), ' ')}"`. |
 
 **ask() Parameters:**
 ```python
@@ -1147,6 +1148,18 @@ await client.chat.configure(
     response_length=ChatResponseLength.LONGER,
     custom_prompt="Focus on practical applications"
 )
+
+# Save a chat answer as a citation-rich note (preserves [N] hover links).
+# This is the canonical owner of the saved-from-chat workflow — the data
+# owner (`ChatAPI`) persists, so the answer text and references stay
+# adjacent to the call that produced them.
+result = await client.chat.ask(nb_id, "What fruits are mentioned?")
+if result.references:
+    note = await client.chat.save_answer_as_note(
+        nb_id, result, title="Fruit Citations"
+    )
+    # The NotebookLM server may auto-generate a "smart" title for
+    # citation-rich notes; note.title reflects what the server stored.
 ```
 
 ---
@@ -1258,7 +1271,7 @@ print(f"Imported {len(imported)} sources")
 |--------|------------|---------|-------------|
 | `list(notebook_id)` | `str` | `list[Note]` | List text notes (excludes mind maps) |
 | `create(notebook_id, title="New Note", content="")` | `str, str, str` | `Note` | Create plain-text note (no citation anchors) |
-| `create_from_chat(notebook_id, ask_result, *, title=None)` | `str, AskResult, str \| None` | `Note` | Save a chat answer as a citation-rich note ([issue #660](https://github.com/teng-lin/notebooklm-py/issues/660)) — the resulting note's `[N]` markers remain interactive hover-anchored citations in the NotebookLM web UI. Raises `ValueError` if `ask_result.references` is empty. |
+| `create_from_chat(notebook_id, ask_result, *, title=None)` | `str, AskResult, str \| None` | `Note` | **Deprecated** (emits `DeprecationWarning`) — forwards to `client.chat.save_answer_as_note(...)`, which is now the canonical owner of the saved-from-chat workflow (data ownership, ADR-013). Signature and behavior are preserved bit-for-bit; switch to the chat-owned method at your convenience. |
 | `get(notebook_id, note_id)` | `str, str` | `Optional[Note]` | Get note by ID |
 | `update(notebook_id, note_id, content, title)` | `str, str, str, str` | `None` | Update note content and title |
 | `delete(notebook_id, note_id)` | `str, str` | `bool` | Delete note |
@@ -1277,10 +1290,13 @@ await client.notes.update(nb_id, note.id, "Updated content", "New Title")
 # Delete a note
 await client.notes.delete(nb_id, note.id)
 
-# Save a chat answer as a citation-rich note (preserves [N] hover links)
+# Save a chat answer as a citation-rich note (preserves [N] hover links).
+# Prefer ``client.chat.save_answer_as_note(...)`` (the chat-owned
+# canonical method); ``client.notes.create_from_chat(...)`` is a
+# deprecated forwarder kept for back-compatibility.
 result = await client.chat.ask(nb_id, "What fruits are mentioned?")
 if result.references:
-    note = await client.notes.create_from_chat(nb_id, result, title="Fruit Citations")
+    note = await client.chat.save_answer_as_note(nb_id, result, title="Fruit Citations")
     # Note: the NotebookLM server may auto-generate a "smart" title for
     # citation-rich notes; note.title reflects what the server stored.
 ```

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -875,7 +875,7 @@ params = [
 
 ### RPC: CREATE_NOTE (saved-from-chat variant) (CYK0Xb)
 
-**Source:** `_mind_map.py::save_chat_answer_as_note()` / `_notes.py::create_from_chat()`
+**Source:** `_chat_notes.py::save_chat_answer_as_note()` (canonical owner) — exposed publicly as `ChatAPI.save_answer_as_note(...)`; `NotesAPI.create_from_chat(...)` is a deprecated forwarder that delegates to the same primitive.
 
 **Note:** This is the same RPC method ID as plain CREATE_NOTE above, but uses a **7-element** params array (vs the 5-element blank-note form) and **mode flag `[2]`** to tell the server the note carries a saved chat answer. The server stores per-citation source-passage metadata so `[N]` markers in the answer render as hover-anchored links in the NotebookLM web UI. No follow-up UPDATE_NOTE is needed — this is a single round-trip.
 
@@ -940,7 +940,7 @@ params = [
 
 **Encoding quirks**:
 - Rendering-flag arrays use the integer `0`, not the boolean `false` — `json.dumps(False)` emits `false`, which the server *normalizes* but the wire-channel match is strict. The encoder uses integer `0` to stay byte-exact with the captured request.
-- The server appears to apply a "smart title" pass for `[2]`-mode notes — the captured response title differed from the captured request title (the request sent `"New Saved Note"`; the response stored `"Le Verger de la Connaissance : Le Cas de la Pomme"`). `NotesAPI.create_from_chat()` surfaces the server-stored title in the returned `Note`.
+- The server appears to apply a "smart title" pass for `[2]`-mode notes — the captured response title differed from the captured request title (the request sent `"New Saved Note"`; the response stored `"Le Verger de la Connaissance : Le Cas de la Pomme"`). `ChatAPI.save_answer_as_note()` (and the deprecated `NotesAPI.create_from_chat()` forwarder) surface the server-stored title in the returned `Note`.
 
 **Known gaps**:
 - The `passage_id` UUID at slot `[3][0][5][0][0]` does NOT appear in the streaming chat response shape we currently parse. `_build_source_passage_descriptor` falls back to `chunk_id` as a placeholder when `ChatReference.passage_id` is unset (which is always, in production today). Empirically the server accepts this and the web UI still renders hover anchors. If a future capture reveals where this UUID comes from, populate `ChatReference.passage_id` in `_chat_protocol.py::parse_single_citation()` and the encoder will use it automatically.

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -137,12 +137,11 @@ class DrainHookRegistration(Protocol):
     background tasks, revisit whether ``register_drain_hook`` should
     become shared.
 
-    Note: an identically-shaped ``DrainHookRegistration`` Protocol also
-    exists at ``_session_contracts.py`` for the broad-``Session`` era.
-    Both Protocols are structurally compatible (a real ``Session``
-    satisfies both) and they coexist intentionally during the
-    migration. Phase 7 deletes the ``_session_contracts`` twin; until
-    then, this local copy is the one consumed by ``ArtifactsRuntime``.
+    This is the **canonical and only** ``DrainHookRegistration``
+    Protocol after Phase 7 of the capability refactor — the broad-
+    ``Session``-era twin previously at ``_session_contracts.py`` was
+    deleted in the same refactor arc once artifact polling was
+    confirmed as its only consumer.
     """
 
     def register_drain_hook(

--- a/src/notebooklm/_note_service.py
+++ b/src/notebooklm/_note_service.py
@@ -31,7 +31,7 @@ from .rpc.types import RPCMethod
 from .types import Note
 
 if TYPE_CHECKING:
-    from ._session_contracts import Session
+    from ._session_contracts import RpcCaller
 
 __all__ = ["NoteService"]  # NoteRowKind is intentionally NOT exported
 
@@ -74,20 +74,16 @@ class NoteService:
 
     Owns the ``GET_NOTES_AND_MIND_MAPS`` / ``CREATE_NOTE`` /
     ``UPDATE_NOTE`` / ``DELETE_NOTE`` RPC family. Shared by
-    ``NotesAPI`` (in Phase 6) and by ``NoteBackedMindMapService``
-    (the adapter that powers ``ArtifactsAPI`` mind-map paths).
+    ``NotesAPI`` and by ``NoteBackedMindMapService`` (the adapter
+    that powers ``ArtifactsAPI`` mind-map paths).
 
-    The constructor takes the broad ``Session`` orchestrator for now;
-    Phase 7 will narrow it down to a capability slice (likely
-    :class:`RpcCaller`) once the broad ``Session`` Protocol is retired.
+    Takes the narrow :class:`RpcCaller` capability — note CRUD only
+    needs ``rpc_call(...)``; everything else (drain hooks, transport,
+    loop-affinity guards) is irrelevant to this service.
     """
 
-    def __init__(self, session: Session) -> None:
-        # Phase 7 will narrow this to the minimum capability surface
-        # (RpcCaller is the only one currently exercised). Until then,
-        # accept the broad orchestrator the rest of the codebase passes
-        # around so this module doesn't pin the migration order.
-        self._session = session
+    def __init__(self, rpc: RpcCaller) -> None:
+        self._rpc = rpc
 
     # ------------------------------------------------------------------
     # Row fetch + classification
@@ -101,7 +97,7 @@ class NoteService:
         decide whether to filter via :meth:`classify_row`.
         """
         params = [notebook_id]
-        result = await self._session.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.GET_NOTES_AND_MIND_MAPS,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -204,7 +200,7 @@ class NoteService:
         claude[bot] and gemini-code-assist[bot] on PR #873).
         """
         params = [notebook_id, "", [1], None, title]
-        result = await self._session.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.CREATE_NOTE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -278,7 +274,7 @@ class NoteService:
             note_id,
             [[[content, title, [], 0]]],
         ]
-        await self._session.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.UPDATE_NOTE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -295,7 +291,7 @@ class NoteService:
         without callers seeing a behavioral change.
         """
         params = [notebook_id, None, [note_id]]
-        await self._session.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.DELETE_NOTE,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/_notes.py
+++ b/src/notebooklm/_notes.py
@@ -76,10 +76,14 @@ class NotesAPI:
         """Initialize the notes API.
 
         Args:
-            rpc: RPC dispatch surface. Kept on ``NotesAPI`` so the
-                legacy ``self._core`` attribute (still expected by
-                tests and the ``_core`` shim) continues to point at a
-                live capability. Phase 7 narrows this further.
+            rpc: RPC dispatch surface (the narrow ``RpcCaller``
+                capability). Kept on ``NotesAPI`` so the legacy
+                ``self._core`` attribute (still expected by tests and
+                the ``_core`` shim) continues to point at a live
+                capability. The ``_core`` alias is preserved for
+                back-compat (refactor.md Non-Goals); a future arc may
+                rename the internal slot but it is not in scope for
+                Phase 7.
             notes: Backend note-row primitives. Owns
                 ``fetch_note_rows`` / ``classify_row`` / ``create_note``
                 / ``update_note`` / ``delete_note``.
@@ -94,7 +98,9 @@ class NotesAPI:
         """
         # Preserve the legacy ``self._core`` attribute name so the
         # ``_core`` compatibility shim and tests that inspect
-        # ``client.notes._core`` keep working through Phase 7.
+        # ``client.notes._core`` keep working. The alias is preserved
+        # indefinitely per refactor.md Non-Goals (ADR-013); renaming the
+        # internal slot is a future-arc task.
         self._core = rpc
         self._notes = notes
         self._mind_maps = mind_maps

--- a/src/notebooklm/_session_contracts.py
+++ b/src/notebooklm/_session_contracts.py
@@ -1,23 +1,38 @@
-"""Type-only contracts for the Tier-13 Session/Kernel split.
+"""Type-only contracts shared across feature APIs.
 
-This module defines the narrow structural Protocols that later Tier-13 PRs
-will wire into concrete classes. It intentionally contains no runtime
-implementation and no import of the concrete ``Session``.
+This module defines the narrow structural Protocols feature APIs depend
+on. Per ADR-013, a Protocol lives here only when **shared by ≥2
+features**; single-consumer capabilities (e.g. chat's ``transport_post``
++ ``next_reqid``, artifact polling's ``register_drain_hook``) stay
+local to their owning feature module.
 
-``Session.rpc_call`` deliberately mirrors the legacy feature RPC signature,
-including the transitional ``_is_retry`` parameter, so feature retyping can
-happen without changing call semantics.
+Contents:
+
+* :class:`AuthMetadata` and :class:`Kernel` — selected-account routing
+  metadata + pure transport surface consumed by the upload pipeline.
+* :class:`RpcCaller`, :class:`LoopGuard`, :class:`OperationScopeProvider`,
+  :class:`AsyncWorkRuntime` — the four shared capability Protocols
+  promoted in Phase 1 of the capability refactor.
+
+The broad ``Session`` Protocol that previously bundled all of these
+together was deleted in Phase 7 (refactor.md §Migration Plan step 10).
+Feature APIs that need more than one capability either compose the
+shared Protocols here or define a feature-local runtime in their own
+module (``ChatRuntime`` in ``_chat.py``, ``ArtifactsRuntime`` in
+``_artifacts.py``, ``UploadRuntime`` in ``_source_upload.py``). The
+standalone ``DrainHookRegistration`` Protocol that lived here in the
+broad-``Session`` era was deleted in the same step; the canonical
+``DrainHookRegistration`` is now the local one in ``_artifacts.py``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Mapping
 from contextlib import AbstractAsyncContextManager
 from typing import Any, Protocol
 
 import httpx
 
-from ._request_types import BuildRequest
 from .rpc.types import RPCMethod
 
 
@@ -47,69 +62,19 @@ class Kernel(Protocol):
     async def aclose(self) -> None: ...
 
 
-class Session(Protocol):
-    """Orchestration surface consumed by feature APIs after Tier 13."""
-
-    @property
-    def auth(self) -> AuthMetadata: ...
-
-    @property
-    def kernel(self) -> Kernel: ...
-
-    async def rpc_call(
-        self,
-        method: RPCMethod,
-        params: list[Any],
-        source_path: str = "/",
-        allow_null: bool = False,
-        _is_retry: bool = False,
-        *,
-        disable_internal_retries: bool = False,
-        operation_variant: str | None = None,
-    ) -> Any: ...
-
-    async def transport_post(
-        self,
-        build_request: BuildRequest,
-        parse_label: str,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> httpx.Response: ...
-
-    async def next_reqid(self, step: int = 100000) -> int: ...
-
-    def assert_bound_loop(self) -> None: ...
-
-    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]: ...
-
-    def register_drain_hook(
-        self,
-        name: str,
-        hook: Callable[[], Awaitable[None]],
-    ) -> None: ...
-
-
-class DrainHookRegistration(Protocol):
-    """Narrow close-time hook registration surface for Artifacts."""
-
-    def register_drain_hook(
-        self,
-        name: str,
-        hook: Callable[[], Awaitable[None]],
-    ) -> None: ...
-
-
 class RpcCaller(Protocol):
     """Narrow RPC dispatch surface consumed by pure-RPC feature APIs.
 
-    Mirrors the legacy :meth:`Session.rpc_call` signature exactly so
-    Phase 1 feature retypes do not change call semantics. The transitional
-    ``_is_retry`` parameter and the keyword-only ``disable_internal_retries``
-    / ``operation_variant`` parameters are preserved as-is.
+    Mirrors the legacy ``Session.rpc_call`` signature exactly so feature
+    retypes do not change call semantics. The transitional
+    ``_is_retry`` parameter and the keyword-only
+    ``disable_internal_retries`` / ``operation_variant`` parameters are
+    preserved as-is.
 
-    A concrete :class:`Session` structurally satisfies this Protocol;
-    features that only need to issue RPC calls can depend on this narrower
-    surface to avoid coupling to the rest of the broad ``Session`` Protocol.
+    A concrete :class:`notebooklm._session.Session` structurally
+    satisfies this Protocol; features that only need to issue RPC
+    calls depend on this narrow surface so they are not coupled to
+    transport, loop affinity, or close-time-hook concerns.
     """
 
     async def rpc_call(
@@ -144,10 +109,8 @@ class AsyncWorkRuntime(LoopGuard, OperationScopeProvider, Protocol):
 __all__ = [
     "AsyncWorkRuntime",
     "AuthMetadata",
-    "DrainHookRegistration",
     "Kernel",
     "LoopGuard",
     "OperationScopeProvider",
     "RpcCaller",
-    "Session",
 ]

--- a/src/notebooklm/_sources.py
+++ b/src/notebooklm/_sources.py
@@ -13,7 +13,7 @@ import httpx
 
 from . import _source_upload
 from ._session_config import DEFAULT_MAX_CONCURRENT_UPLOADS
-from ._session_contracts import Session
+from ._session_contracts import RpcCaller
 from ._source_add import SourceAddService
 from ._source_content import SourceContentRenderer
 from ._source_listing import SourceLister
@@ -49,7 +49,7 @@ class SourcesAPI:
 
     def __init__(
         self,
-        session: Session,
+        rpc: RpcCaller,
         *,
         uploader: SourceUploadPipeline,
         upload_timeout: httpx.Timeout | None = None,
@@ -58,7 +58,11 @@ class SourcesAPI:
         """Initialize the sources API.
 
         Args:
-            session: The shared client session.
+            rpc: The narrow :class:`RpcCaller` capability — sources
+                only needs ``rpc_call(...)`` for its own RPC paths
+                (delete, rename, refresh, freshness, drive add, text add).
+                Upload-flow capabilities (``kernel``, ``auth``,
+                ``operation_scope``) are owned by ``uploader``.
             uploader: Stateful file-upload pipeline. REQUIRED — wired explicitly
                 by :class:`NotebookLMClient` (the only composition root that
                 knows the concrete ``Kernel`` + ``AuthMetadata`` +
@@ -84,7 +88,7 @@ class SourcesAPI:
         # constructed by the :class:`NotebookLMClient` composition root and
         # injected via ``uploader=``. They are stored here only as historical
         # attributes for callers that introspect the instance.
-        self._core = session
+        self._rpc = rpc
         self._adder = SourceAddService()
         self._content = SourceContentRenderer(self._rpc_call, logger=logger)
         self._lister = SourceLister(self._rpc_call)
@@ -105,7 +109,7 @@ class SourcesAPI:
         operation_variant: str | None = None,
     ) -> Any:
         """Delegate through the current core RPC method for late-bound test overrides."""
-        return await self._core.rpc_call(
+        return await self._rpc.rpc_call(
             method,
             params,
             source_path=source_path,
@@ -550,7 +554,7 @@ class SourcesAPI:
         """
         logger.debug("Deleting source %s from notebook %s", source_id, notebook_id)
         params = [[[source_id]]]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.DELETE_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -571,7 +575,7 @@ class SourcesAPI:
         """
         logger.debug("Renaming source %s to: %s", source_id, new_title)
         params = [None, [source_id], [[[new_title]]]]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.UPDATE_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -590,7 +594,7 @@ class SourcesAPI:
             True if refresh was initiated.
         """
         params = [None, [source_id], [2]]
-        await self._core.rpc_call(
+        await self._rpc.rpc_call(
             RPCMethod.REFRESH_SOURCE,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -609,7 +613,7 @@ class SourcesAPI:
             True if source is fresh, False if it needs refresh.
         """
         params = [None, [source_id], [2]]
-        result = await self._core.rpc_call(
+        result = await self._rpc.rpc_call(
             RPCMethod.CHECK_SOURCE_FRESHNESS,
             params,
             source_path=f"/notebook/{notebook_id}",

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -301,8 +301,9 @@ class NotebookLMClient:
         # ``Session`` directly satisfies ``ArtifactsRuntime`` (RpcCaller +
         # AsyncWorkRuntime + DrainHookRegistration) and the ``_core`` alias
         # exists only for legacy callers that pre-date the runtime split. The
-        # other sub-APIs still pass ``self._core`` while their own
-        # capability-protocol migrations land; Phase 7 retires the alias.
+        # ``_core`` alias is preserved indefinitely for back-compat (per
+        # refactor.md Non-Goals — see ADR-013); retiring it is a future
+        # arc and is out of scope here.
         note_service = NoteService(self._session)
         mind_maps = NoteBackedMindMapService(note_service)
         self.artifacts = ArtifactsAPI(

--- a/tests/_fixtures/fake_core.py
+++ b/tests/_fixtures/fake_core.py
@@ -1,11 +1,21 @@
 """``make_fake_core`` factory — constructor-injection substrate for sub-clients.
 
 This module provides a single entry point — :func:`make_fake_core` — that
-returns a ``FakeSession`` instance shaped to satisfy the shared
-``Session`` Protocol and explicit feature collaborators. Tests pass the
-result to a sub-client constructor (``NotebooksAPI(fake)``) instead
-of constructing a real ``Session`` and mutating its attributes after
-the fact.
+returns a ``FakeSession`` instance shaped to satisfy the **shared
+capability Protocols** in :mod:`notebooklm._session_contracts`
+(``RpcCaller``, ``LoopGuard``, ``OperationScopeProvider``,
+``AsyncWorkRuntime``, ``AuthMetadata``, ``Kernel``) plus the
+feature-local runtime Protocols (``ChatRuntime``, ``ArtifactsRuntime``,
+``UploadRuntime``) that compose them. Tests pass the result to a
+sub-client constructor (``NotebooksAPI(fake)``) instead of constructing
+a real ``Session`` and mutating its attributes after the fact.
+
+Phase 7 (refactor.md §Migration Plan step 10) deleted the broad
+``Session`` Protocol that this factory's defaults dict previously
+mirrored member-for-member. The dict now lists only the attribute slots
+features actually exercise — promoting an attribute requires a real
+test-site consumer, mirroring the ADR-013 promotion criterion for
+shared Protocols.
 
 See :doc:`docs/adr/0007-test-monkeypatch-policy.md` for the policy that
 makes this factory the only sanctioned substitute for the forbidden
@@ -39,7 +49,11 @@ import httpx
 
 
 class FakeSession:
-    """A duck-typed stand-in for ``Session`` collaborators in tests.
+    """A duck-typed stand-in for capability-Protocol collaborators in tests.
+
+    Named ``FakeSession`` for backward compatibility with the broad-
+    ``Session``-era test sites; the class itself is just an explicit
+    attribute bag and is not pinned to any single Protocol shape.
 
     Attribute storage is explicit (the constructor only sets what's
     passed in) so that accessing an attribute the production code does
@@ -88,58 +102,48 @@ def make_fake_core(**overrides: Any) -> FakeSession:
         get_http_client=MagicMock(return_value=fake_http_client),
     )
 
+    # Phase 7 (refactor.md §Migration Plan step 10) shrunk this dict from
+    # the broad-Session-era 25+ entries to the minimum set that satisfies
+    # the post-refactor capability and feature-local runtime Protocols.
+    # New entries should only be added when a real test site exercises
+    # the attribute — mirroring the ADR-013 promotion criterion for
+    # shared Protocols (≥2 consumers).
     defaults: dict[str, Any] = {
+        # AuthMetadata + Kernel — consumed by SourceUploadPipeline test sites.
         "auth": auth,
         "kernel": kernel,
-        # Session — fresh list per call so tests can mutate without bleeding
+        # RpcCaller — every feature API uses this. Fresh list per call so
+        # tests can mutate the response without bleeding into siblings.
         "rpc_call": AsyncMock(side_effect=lambda *a, **kw: []),
+        # ChatRuntime — chat-only transport + reqid helpers consumed via
+        # the chat composite runtime; kept here so the same FakeSession
+        # can satisfy ChatRuntime, ArtifactsRuntime, and UploadRuntime
+        # for tests that wire the bag through several sub-clients.
         "transport_post": AsyncMock(),
-        # NotebookSourceLister
-        "get_source_ids": AsyncMock(side_effect=lambda *a, **kw: []),
         "next_reqid": AsyncMock(return_value=100000),
-        "_next_reqid": AsyncMock(return_value=100000),
-        # Legacy Session compatibility bridge
-        "poll_registry": MagicMock(),
-        # DrainHookRegistration
+        # AsyncWorkRuntime (LoopGuard + OperationScopeProvider) — used by
+        # ArtifactsAPI polling and SourceUploadPipeline.
+        "assert_bound_loop": MagicMock(return_value=None),
+        "operation_scope": MagicMock(side_effect=_operation_scope),
+        # DrainHookRegistration (local in ``_artifacts.py``) — close-time
+        # hook the artifacts runtime registers against in
+        # ``ArtifactsAPI.__init__``.
         "_drain_hooks": {},
         "register_drain_hook": MagicMock(return_value=None),
-        # Auth routing — used by SourceUploadPipeline tests and compatibility paths
-        "authuser": 0,
-        "account_email": None,
-        "authuser_query": MagicMock(return_value="authuser=0"),
-        "authuser_header": MagicMock(return_value="0"),
-        "get_http_client": MagicMock(return_value=fake_http_client),
-        "live_cookies": MagicMock(return_value=live_cookies),
-        # Legacy transport drain helpers — fresh token object per call so drain tracking
-        # gets unique identities (return_value=object() would share one instance).
-        # The Protocol declares the underscore-private names that Session
-        # exposes directly. The no-underscore aliases below are purely defensive
-        # safety-net defaults — no test site currently calls them on a
-        # FakeSession instance (all no-underscore callers in the test tree
-        # invoke these on TransportDrainTracker, not FakeSession). Kept so a
-        # stray legacy reference lands on a benign mock rather than AttributeError.
-        "_begin_transport_post": AsyncMock(side_effect=lambda *a, **kw: object()),
-        "_begin_transport_task": AsyncMock(side_effect=lambda *a, **kw: object()),
-        "_finish_transport_post": AsyncMock(return_value=None),
-        "_perform_authed_post": AsyncMock(),
-        "begin_transport_post": AsyncMock(side_effect=lambda *a, **kw: object()),
-        "begin_transport_task": AsyncMock(side_effect=lambda *a, **kw: object()),
-        "finish_transport_post": AsyncMock(return_value=None),
-        # Session.operation_scope / upload metrics compatibility
-        "operation_scope": MagicMock(side_effect=_operation_scope),
+        # Upload-pipeline glue: queue-wait recorder consumed by the
+        # ``SourceUploadPipeline`` upload metrics path. Kept on the bag
+        # so test sites that wire a SourcesAPI + uploader pair against a
+        # single FakeSession can rely on it.
         "record_upload_queue_wait": MagicMock(return_value=None),
-        # Session loop affinity
-        "bound_loop": None,
-        "assert_bound_loop": MagicMock(return_value=None),
-        # Auth-route helper alias
-        "_route_url": MagicMock(return_value="https://notebooklm.google.com/_/.../batchexecute"),
+        # NotebookSourceLister stub — exercised by ``test_notebooks.py``
+        # paths that resolve source IDs through the lister collaborator.
+        "get_source_ids": AsyncMock(side_effect=lambda *a, **kw: []),
     }
 
     def _register_drain_hook(name: str, hook: Any) -> None:
         defaults["_drain_hooks"][name] = hook
 
     defaults["register_drain_hook"] = MagicMock(side_effect=_register_drain_hook)
-    defaults["get_http_client"].return_value.cookies = live_cookies
 
     # Validate overrides early so a typo like ``rpc_cal=`` fails loudly
     # rather than landing as an unread attribute.

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -1597,7 +1597,7 @@ class TestAddTextErrorPaths:
         """Test add_text() wraps RPCError in SourceAddError (lines 374-375)."""
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.sources._core,
+                client.sources._rpc,
                 "rpc_call",
                 side_effect=RPCError("Text RPC failed"),
             ):
@@ -1612,7 +1612,7 @@ class TestAddTextErrorPaths:
         """Test add_text() raises SourceAddError when API returns None (line 382)."""
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.sources._core,
+                client.sources._rpc,
                 "rpc_call",
                 new_callable=AsyncMock,
                 return_value=None,
@@ -1631,7 +1631,7 @@ class TestAddTextErrorPaths:
 
         async with NotebookLMClient(auth_tokens) as client:
             with patch.object(
-                client.sources._core,
+                client.sources._rpc,
                 "rpc_call",
                 new_callable=AsyncMock,
                 return_value=source_data,

--- a/tests/unit/test_session_contracts.py
+++ b/tests/unit/test_session_contracts.py
@@ -1,17 +1,34 @@
-"""Typing checks for the Tier-13 Session/Kernel protocol contracts."""
+"""Typing checks for the capability-Protocol contracts in
+``notebooklm._session_contracts``.
+
+Phase 7 (refactor.md §Migration Plan step 10) replaced the broad
+``Session`` Protocol with four shared capability Protocols
+(``RpcCaller``, ``LoopGuard``, ``OperationScopeProvider``,
+``AsyncWorkRuntime``). ``AuthMetadata`` and ``Kernel`` are preserved
+as standalone Protocols for the upload pipeline. The standalone
+``DrainHookRegistration`` Protocol previously kept here was deleted in
+the same step — the canonical ``DrainHookRegistration`` is now local
+to ``_artifacts.py`` since artifact polling is its only consumer.
+"""
 
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Mapping
 from contextlib import AbstractAsyncContextManager
 from types import TracebackType
 from typing import Any
 
 import httpx
 
-from notebooklm._request_types import BuildRequest
-from notebooklm._session_contracts import AuthMetadata, DrainHookRegistration, Kernel, Session
+from notebooklm._session_contracts import (
+    AsyncWorkRuntime,
+    AuthMetadata,
+    Kernel,
+    LoopGuard,
+    OperationScopeProvider,
+    RpcCaller,
+)
 from notebooklm.rpc.types import RPCMethod
 
 
@@ -28,15 +45,7 @@ class _NoopOperationScope:
         return False
 
 
-class _SessionImpl:
-    @property
-    def auth(self) -> AuthMetadata:
-        return _AuthMetadataImpl()
-
-    @property
-    def kernel(self) -> Kernel:
-        return _KernelImpl()
-
+class _RpcCallerImpl:
     async def rpc_call(
         self,
         method: RPCMethod,
@@ -50,30 +59,23 @@ class _SessionImpl:
     ) -> Any:
         return None
 
-    async def transport_post(
-        self,
-        build_request: BuildRequest,
-        parse_label: str,
-        *,
-        disable_internal_retries: bool = False,
-    ) -> httpx.Response:
-        return httpx.Response(200, content=b"")
 
-    async def next_reqid(self, step: int = 100000) -> int:
-        return step
+class _LoopGuardImpl:
+    def assert_bound_loop(self) -> None:
+        return None
 
+
+class _OperationScopeProviderImpl:
+    def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
+        return _NoopOperationScope()
+
+
+class _AsyncWorkRuntimeImpl:
     def assert_bound_loop(self) -> None:
         return None
 
     def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
         return _NoopOperationScope()
-
-    def register_drain_hook(
-        self,
-        name: str,
-        hook: Callable[[], Awaitable[None]],
-    ) -> None:
-        return None
 
 
 class _AuthMetadataImpl:
@@ -103,53 +105,56 @@ class _KernelImpl:
         return None
 
 
-class _DrainHookRegistrationImpl:
-    def register_drain_hook(
-        self,
-        name: str,
-        hook: Callable[[], Awaitable[None]],
-    ) -> None:
-        return None
-
-
 def _public_contract_members(protocol: type[Any]) -> set[str]:
     return {name for name in protocol.__dict__ if not name.startswith("_")}
+
+
+# ----------------------------------------------------------------------
+# Membership pins — one test per Protocol
+# ----------------------------------------------------------------------
 
 
 def test_auth_metadata_protocol_has_exactly_two_members() -> None:
     assert _public_contract_members(AuthMetadata) == {"authuser", "account_email"}
 
 
-def test_session_protocol_has_exactly_eight_members() -> None:
-    assert _public_contract_members(Session) == {
-        "auth",
-        "kernel",
-        "rpc_call",
-        "transport_post",
-        "next_reqid",
-        "assert_bound_loop",
-        "operation_scope",
-        "register_drain_hook",
-    }
-
-
 def test_kernel_protocol_has_exactly_three_members() -> None:
     assert _public_contract_members(Kernel) == {"post", "cookies", "aclose"}
 
 
-def test_drain_hook_registration_protocol_has_exactly_one_member() -> None:
-    assert _public_contract_members(DrainHookRegistration) == {"register_drain_hook"}
+def test_rpc_caller_protocol_has_exactly_one_member() -> None:
+    assert _public_contract_members(RpcCaller) == {"rpc_call"}
 
 
-def test_session_protocol_signatures_are_pinned() -> None:
-    auth = inspect.signature(Session.auth.fget)
-    assert auth.return_annotation == "AuthMetadata"
+def test_loop_guard_protocol_has_exactly_one_member() -> None:
+    assert _public_contract_members(LoopGuard) == {"assert_bound_loop"}
 
-    kernel = inspect.signature(Session.kernel.fget)
-    assert kernel.return_annotation == "Kernel"
 
-    rpc_call = inspect.signature(Session.rpc_call)
-    assert list(rpc_call.parameters) == [
+def test_operation_scope_provider_protocol_has_exactly_one_member() -> None:
+    assert _public_contract_members(OperationScopeProvider) == {"operation_scope"}
+
+
+def test_async_work_runtime_protocol_extends_loop_guard_and_operation_scope_provider() -> None:
+    # ``AsyncWorkRuntime`` inherits both members through Protocol composition.
+    # The union of inherited public members across its MRO must match.
+    mro_members: set[str] = set()
+    for parent in AsyncWorkRuntime.__mro__:
+        mro_members.update(name for name in parent.__dict__ if not name.startswith("_"))
+    assert {"assert_bound_loop", "operation_scope"} <= mro_members
+    assert AsyncWorkRuntime.__mro__[1:3] in (
+        (LoopGuard, OperationScopeProvider),
+        (OperationScopeProvider, LoopGuard),
+    )
+
+
+# ----------------------------------------------------------------------
+# Signature pins — load-bearing for feature retypes
+# ----------------------------------------------------------------------
+
+
+def test_rpc_caller_signature_matches_legacy_session_rpc_call() -> None:
+    sig = inspect.signature(RpcCaller.rpc_call)
+    assert list(sig.parameters) == [
         "self",
         "method",
         "params",
@@ -159,33 +164,13 @@ def test_session_protocol_signatures_are_pinned() -> None:
         "disable_internal_retries",
         "operation_variant",
     ]
-    assert rpc_call.parameters["source_path"].default == "/"
-    assert rpc_call.parameters["allow_null"].default is False
-    assert rpc_call.parameters["_is_retry"].default is False
-    assert rpc_call.parameters["disable_internal_retries"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert rpc_call.parameters["disable_internal_retries"].default is False
-    assert rpc_call.parameters["operation_variant"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert rpc_call.parameters["operation_variant"].default is None
-
-    transport_post = inspect.signature(Session.transport_post)
-    assert transport_post.parameters["build_request"].annotation == "BuildRequest"
-    assert transport_post.parameters["parse_label"].annotation == "str"
-    assert transport_post.parameters["disable_internal_retries"].kind is (
-        inspect.Parameter.KEYWORD_ONLY
-    )
-    assert "_BuildRequest" not in str(transport_post)
-
-    next_reqid = inspect.signature(Session.next_reqid)
-    assert next_reqid.parameters["step"].default == 100000
-    assert next_reqid.return_annotation == "int"
-
-    operation_scope = inspect.signature(Session.operation_scope)
-    assert operation_scope.return_annotation == "AbstractAsyncContextManager[None]"
-
-    register_drain_hook = inspect.signature(Session.register_drain_hook)
-    assert list(register_drain_hook.parameters) == ["self", "name", "hook"]
-    assert register_drain_hook.parameters["hook"].annotation == "Callable[[], Awaitable[None]]"
-    assert register_drain_hook.return_annotation == "None"
+    assert sig.parameters["source_path"].default == "/"
+    assert sig.parameters["allow_null"].default is False
+    assert sig.parameters["_is_retry"].default is False
+    assert sig.parameters["disable_internal_retries"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.parameters["disable_internal_retries"].default is False
+    assert sig.parameters["operation_variant"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert sig.parameters["operation_variant"].default is None
 
 
 def test_auth_metadata_protocol_signatures_are_pinned() -> None:
@@ -196,14 +181,13 @@ def test_auth_metadata_protocol_signatures_are_pinned() -> None:
     assert account_email.return_annotation == "str | None"
 
 
-def test_kernel_and_drain_hook_signatures_are_pinned() -> None:
+def test_kernel_protocol_signatures_are_pinned() -> None:
     post = inspect.signature(Kernel.post)
     assert list(post.parameters) == ["self", "url", "headers", "body"]
     assert post.parameters["headers"].annotation == "Mapping[str, str]"
     assert post.parameters["body"].annotation == "bytes"
     assert post.return_annotation == "httpx.Response"
 
-    # Protocol properties expose the getter signature through ``fget``.
     cookies = inspect.signature(Kernel.cookies.fget)
     assert cookies.return_annotation == "httpx.Cookies"
 
@@ -211,22 +195,36 @@ def test_kernel_and_drain_hook_signatures_are_pinned() -> None:
     assert list(aclose.parameters) == ["self"]
     assert aclose.return_annotation == "None"
 
-    register_drain_hook = inspect.signature(DrainHookRegistration.register_drain_hook)
-    assert list(register_drain_hook.parameters) == ["self", "name", "hook"]
-    assert register_drain_hook.parameters["hook"].annotation == "Callable[[], Awaitable[None]]"
-    assert register_drain_hook.return_annotation == "None"
+
+def test_loop_guard_signature_is_pinned() -> None:
+    sig = inspect.signature(LoopGuard.assert_bound_loop)
+    assert list(sig.parameters) == ["self"]
+    assert sig.return_annotation == "None"
+
+
+def test_operation_scope_provider_signature_is_pinned() -> None:
+    sig = inspect.signature(OperationScopeProvider.operation_scope)
+    assert list(sig.parameters) == ["self", "label"]
+    assert sig.parameters["label"].annotation == "str"
+    assert sig.return_annotation == "AbstractAsyncContextManager[None]"
+
+
+# ----------------------------------------------------------------------
+# Structural conformance — mypy verifies these assignments
+# ----------------------------------------------------------------------
 
 
 def test_structural_implementations_satisfy_protocols() -> None:
-    # These assignments are the contract check: mypy verifies that each
-    # implementation structurally satisfies its Protocol. Runtime
-    # ``isinstance`` checks would only prove the concrete class identity
-    # unless the Protocols became ``@runtime_checkable``, which is weaker than
-    # the signature-level static check and not needed for this type-only PR.
-    session: Session = _SessionImpl()
+    auth: AuthMetadata = _AuthMetadataImpl()
     kernel: Kernel = _KernelImpl()
-    drain_hooks: DrainHookRegistration = _DrainHookRegistrationImpl()
+    rpc: RpcCaller = _RpcCallerImpl()
+    loop_guard: LoopGuard = _LoopGuardImpl()
+    op_scope: OperationScopeProvider = _OperationScopeProviderImpl()
+    async_work: AsyncWorkRuntime = _AsyncWorkRuntimeImpl()
 
-    assert session is not None
+    assert auth is not None
     assert kernel is not None
-    assert drain_hooks is not None
+    assert rpc is not None
+    assert loop_guard is not None
+    assert op_scope is not None
+    assert async_work is not None


### PR DESCRIPTION
## Summary

**Phase 7 (FINAL) of the capability refactor arc** — closes ADR-013.

- Deletes the broad `Session` Protocol (8-member orchestration union) and the standalone `DrainHookRegistration` Protocol from `_session_contracts.py`. Feature APIs now depend on the narrow shared capability Protocols (`RpcCaller`, `LoopGuard`, `OperationScopeProvider`, `AsyncWorkRuntime`) or on feature-local runtimes (`ChatRuntime`, `ArtifactsRuntime`, `UploadRuntime`). The canonical `DrainHookRegistration` is now local to `_artifacts.py`.
- Narrows the two remaining `session: Session` stragglers Phase 5 + Phase 4 left behind:
  - `NoteService.__init__` → `(rpc: RpcCaller)` (closes the Phase 5 TODO).
  - `SourcesAPI.__init__` → `(rpc: RpcCaller, *, uploader)` (Phase 4 narrowed the upload pipeline but not the API).
- Replaces the broad pin test with per-capability membership + signature pins; shrinks `FakeSession` defaults dict from the broad-Session 25+ entries to the minimum-needed-for-capability-Protocols set.
- Re-statuses ADR-013 from `Accepted (Sunset = capability refactor cutover)` to plain `Accepted`.
- Documentation: `docs/development.md` new-feature guidance ("type against narrowest shared capability or feature-local runtime"); `docs/python-api.md` documents new `client.chat.save_answer_as_note(...)` + marks `client.notes.create_from_chat(...)` deprecated; `docs/rpc-reference.md` updates saved-from-chat source attribution to `ChatAPI.save_answer_as_note`; `docs/migration-tier-12-to-13.md` updates 3 cells that previously claimed feature APIs depended on the broad `Session` Protocol.

Preserved (per Non-Goals): `AuthMetadata` + `Kernel` Protocols, concrete `_session.Session.auth` / `.kernel`, `_core.py` shim, `NotebookLMClient._core` attribute alias.

## Test plan

- [x] `uv run pre-commit run --all-files` — passes
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — passes (139 files)
- [x] `uv run ruff check src/notebooklm tests` — passes
- [x] `uv run ruff format --check src/notebooklm tests` — passes
- [x] `uv run pytest --timeout=60` — 5560 passed, 14 skipped
- [x] Drift sweeps: no `^class Session\(` in `_session_contracts.py`; no `^class DrainHookRegistration` in `_session_contracts.py`; zero `from ._session_contracts import Session` in `src/`; old eight-member pin test gone; ADR-013 status grep-matches `^Accepted\.?$`; `_core.py` shim + `NotebookLMClient._core` alias preserved.
- [x] e2e partial run (4 passing before unrelated rate-limit timeout); full e2e gated on real API quota.

## Stacked PR coordination

Stacked on #875 (Phase 6). Initial base is `capability-refactor-full-arc/phase-6-saved-chat-slim-mind-map`. When Phase 6 merges to main, GitHub will auto-retarget the base; I will then rebase onto `origin/main` and force-push-with-lease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ChatAPI.save_answer_as_note() to save chat answers as citation-rich notes with preserved interactive links.

* **Deprecations**
  * NotesAPI.create_from_chat() deprecated; use ChatAPI.save_answer_as_note() instead.

* **Documentation**
  * Updated ADR status and developer/migration guides and API docs to reflect the new session/capability direction and updated onboarding guidance.

* **Tests**
  * Adjusted tests and fixtures to align with the refactored runtime capability surfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->