### PR TITLE
refactor(client): deprecate rpc_call(_is_retry/source_path/operation_variant) for v0.6.0

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,38 @@
+# Deprecations
+
+This page is the **single source of truth** for currently-deprecated APIs in
+`notebooklm-py`. Each row lists what is deprecated, the recommended
+replacement, when the deprecation was introduced, when it is scheduled for
+removal, and any cross-references.
+
+`docs/stability.md` links here rather than duplicating the table; if you need
+the broader stability policy (semver promise, supported Python versions, the
+0.x pre-1.0 semantics), start there.
+
+## Scheduled for removal in v0.6.0
+
+| Deprecated | Replacement | Since | Removal | Notes |
+|------------|-------------|-------|---------|-------|
+| `NOTEBOOKLM_STRICT_DECODE=0` soft-mode | Unset the variable (strict is the only mode) | v0.5.0 | v0.6.0 | Warning at `tests/unit/test_strict_decode_default.py:73`; rationale in `docs/stability.md` "Strict decode" + ADR-011 |
+| `SourcesAPI.add_file(mime_type=...)` | Omit `mime_type` — server infers from filename extension | v0.5.0 | v0.6.0 | Warning emitted at `src/notebooklm/_source_upload.py:287` |
+| `notebooklm source add --mime-type` (file sources) | Omit `--mime-type`; Drive-source `--mime-type` remains live | v0.5.0 | v0.6.0 | Warning at `src/notebooklm/cli/source.py:437` |
+| `ArtifactsAPI.wait_for_completion(poll_interval=...)` | `initial_interval=...` — same cadence, clearer name | v0.5.0 | v0.6.0 | Warning at `src/notebooklm/_artifact_polling.py:154` |
+| `NotesAPI.create_from_chat(...)` | `ChatAPI.save_answer_as_note(...)` | v0.5.0 | v0.6.0 | Warning at `src/notebooklm/_notes.py:192` |
+| `NotebookLMClient.rpc_call(source_path=...)` | Omit the argument, or pass `"/"` explicitly | v0.5.0 | v0.6.0 | Explicit `source_path="/"` is silent (matches default); any other value warns |
+| `NotebookLMClient.rpc_call(_is_retry=...)` | Omit the argument | v0.5.0 | v0.6.0 | Internal-only; any explicit value (`True` or `False`) warns |
+| `NotebookLMClient.rpc_call(operation_variant=...)` | Omit the argument | v0.5.0 | v0.6.0 | Internal-only; will be removed once the mutating-RPC idempotency registry stabilizes |
+
+## How deprecations work in this project
+
+* Every deprecated surface emits a `DeprecationWarning` from the call site
+  the user wrote (`stacklevel=2`), so the warning's `filename`/`lineno`
+  point at user code rather than at the library internals.
+* Default-shape calls remain silent. A deprecation only fires when the
+  caller actually passes the deprecated argument.
+* See `docs/stability.md` "Deprecation Policy" for the broader timeline
+  contract (one MINOR cycle of warnings before removal during 0.x).
+
+## Removed in past versions
+
+For deprecations that have already completed their removal cycle, see
+`docs/stability.md` "Removed in v0.5.0".

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -645,9 +645,10 @@ forwards to the core delegator with today's literal defaults
 (`source_path="/"`, `_is_retry=False`, `operation_variant=None`).
 
 > **Deprecated kwargs (removal in v0.6.0).** `source_path` (when explicitly
-> set to anything other than `"/"`), `_is_retry` (any explicit value), and
-> `operation_variant` (any non-`None` value) emit `DeprecationWarning`.
-> See [`docs/deprecations.md`](deprecations.md) for the canonical removal
+> set to anything other than `"/"`), `_is_retry` (any explicit non-`None`
+> value, including `True` and `False`), and `operation_variant` (any
+> non-`None` value) emit `DeprecationWarning`. See
+> [`docs/deprecations.md`](deprecations.md) for the canonical removal
 > table and migration guidance. New callers should omit all three.
 
 **Long-lived clients:** pass `keepalive=<seconds>` to spawn a background task

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -630,17 +630,25 @@ class NotebookLMClient:
         self,
         method: RPCMethod,
         params: list[Any],
-        source_path: str = "/",
+        source_path: str | None = None,
         allow_null: bool = False,
-        _is_retry: bool = False,
+        _is_retry: bool | None = None,
         *,
         disable_internal_retries: bool = False,
+        operation_variant: str | None = None,
     ) -> Any
 ```
 
 `RPCMethod` is imported from `notebooklm.rpc` for raw-RPC calls; `Any` is
-`typing.Any`. `_is_retry` is present only to preserve parity with the core
-delegator and should normally be left as `False`.
+`typing.Any`. The default-shape call (`client.rpc_call(method, params)`)
+forwards to the core delegator with today's literal defaults
+(`source_path="/"`, `_is_retry=False`, `operation_variant=None`).
+
+> **Deprecated kwargs (removal in v0.6.0).** `source_path` (when explicitly
+> set to anything other than `"/"`), `_is_retry` (any explicit value), and
+> `operation_variant` (any non-`None` value) emit `DeprecationWarning`.
+> See [`docs/deprecations.md`](deprecations.md) for the canonical removal
+> table and migration guidance. New callers should omit all three.
 
 **Long-lived clients:** pass `keepalive=<seconds>` to spawn a background task
 that periodically pokes `accounts.google.com` and persists any rotated

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -183,13 +183,8 @@ for the design rationale behind the default flip.
 
 ### Currently Deprecated
 
-The following are deprecated and will be removed in **v0.6.0**:
-
-| Deprecated | Replacement | Notes |
-|------------|-------------|-------|
-| `SourcesAPI.add_file(mime_type=...)` | omit `mime_type` | Server infers MIME from filename extension |
-| `notebooklm source add --mime-type` for file sources | omit `--mime-type` | Drive-source `--mime-type` remains live |
-| `ArtifactsAPI.wait_for_completion(poll_interval=...)` | `initial_interval=...` | Same polling cadence, clearer name |
+See [`docs/deprecations.md`](deprecations.md) for the canonical list of
+APIs deprecated in v0.5.0 and scheduled for removal in v0.6.0.
 
 ### Removed in v0.5.0
 

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
@@ -420,9 +421,9 @@ class NotebookLMClient:
         self,
         method: RPCMethod,
         params: list[Any],
-        source_path: str = "/",
+        source_path: str | None = None,
         allow_null: bool = False,
-        _is_retry: bool = False,
+        _is_retry: bool | None = None,
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
@@ -432,21 +433,54 @@ class NotebookLMClient:
         This is the public escape hatch for advanced callers who need an
         undocumented RPC before a typed API exists. Prefer the namespaced APIs
         (``client.notebooks``, ``client.sources``, etc.) when possible. Import
-        ``RPCMethod`` from ``notebooklm.rpc``. The ``_is_retry`` parameter is
-        exposed only to mirror ``Session.rpc_call`` exactly; callers should
-        leave it at the default unless they are intentionally reproducing core
-        retry behavior.
+        ``RPCMethod`` from ``notebooklm.rpc``.
 
-        The optional ``operation_variant`` selects a method-variant-specific
-        policy in the mutating-RPC idempotency registry. Most callers should
-        leave it ``None`` (the default) — Wave 2 will add variant entries.
+        .. deprecated:: 0.5.0
+            The following keyword arguments are deprecated and will be removed
+            in v0.6.0 (see :doc:`/deprecations`):
+
+            * ``source_path`` — omit the argument; the default ``"/"`` is
+              applied automatically. Passing ``"/"`` explicitly is still
+              silent (it matches the default).
+            * ``_is_retry`` — internal-only; never reach for this. Any
+              explicit value (``True`` or ``False``) warns, because callers
+              should not bind to this surface at all.
+            * ``operation_variant`` — internal-only; will be removed once
+              the mutating-RPC idempotency registry stabilizes.
+
+        The default-shape call (``client.rpc_call(method, params)``) remains
+        silent and forwards to :meth:`Session.rpc_call` with today's literal
+        defaults.
         """
+        if source_path is not None and source_path != "/":
+            warnings.warn(
+                "rpc_call(source_path=...) is deprecated; removal v0.6.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if _is_retry is not None:
+            warnings.warn(
+                "rpc_call(_is_retry=...) is deprecated; this is internal; removal v0.6.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if operation_variant is not None:
+            warnings.warn(
+                "rpc_call(operation_variant=...) is deprecated; removal v0.6.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        # Coerce sentinels back to today's literal defaults before
+        # delegating, so the forwarded keyword-for-keyword shape stays
+        # identical to the pre-deprecation contract.
+        resolved_source_path = "/" if source_path is None else source_path
+        resolved_is_retry = bool(_is_retry) if _is_retry is not None else False
         return await self._core.rpc_call(
             method=method,
             params=params,
-            source_path=source_path,
+            source_path=resolved_source_path,
             allow_null=allow_null,
-            _is_retry=_is_retry,
+            _is_retry=resolved_is_retry,
             disable_internal_retries=disable_internal_retries,
             operation_variant=operation_variant,
         )

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -472,9 +472,11 @@ class NotebookLMClient:
             )
         # Coerce sentinels back to today's literal defaults before
         # delegating, so the forwarded keyword-for-keyword shape stays
-        # identical to the pre-deprecation contract.
+        # identical to the pre-deprecation contract. ``bool(None) is
+        # False``, so a single ``bool(_is_retry)`` collapses the
+        # not-None / None branches into one expression.
         resolved_source_path = "/" if source_path is None else source_path
-        resolved_is_retry = bool(_is_retry) if _is_retry is not None else False
+        resolved_is_retry = bool(_is_retry)
         return await self._core.rpc_call(
             method=method,
             params=params,

--- a/tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py
+++ b/tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py
@@ -1,0 +1,131 @@
+"""Lint: no unauthorized call to public NotebookLMClient.rpc_call
+with deprecated kwargs (_is_retry, source_path, operation_variant).
+
+Allowlist is keyed on (relative path, enclosing function name) so it
+survives line-number reordering and `pytest.warns(...)` wraps. See
+ADR-007 for the file-/function-level allowlist rationale.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_TESTS_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _TESTS_ROOT.parent
+
+_DEPRECATED_KW: frozenset[str] = frozenset(
+    {
+        "_is_retry",
+        "source_path",
+        "operation_variant",
+    }
+)
+
+# Allowlist of (path-relative-to-repo, enclosing-function-name).
+# Function name "*" means "any function in this file is allowed"
+# (used for the new test file that exists solely to exercise the
+# deprecated surface).
+_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("tests/unit/test_rpc_call_public_surface.py", "*"),
+        (
+            "tests/unit/test_public_shims.py",
+            "test_client_rpc_call_delegates_keyword_for_keyword",
+        ),
+    }
+)
+
+_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        "tests/_lint",  # this file itself contains the kwarg literals
+        "tests/cassettes",  # data only
+        "tests/fixtures",  # data only
+    }
+)
+
+
+def _enclosing_function_name(tree: ast.Module, target: ast.Call) -> str | None:
+    """Return the name of the FunctionDef / AsyncFunctionDef enclosing
+    ``target``, or None if the call is at module scope. Uses parent
+    links computed by walking the tree."""
+    parents: dict[int, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[id(child)] = node
+    cur: ast.AST | None = target
+    while cur is not None:
+        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return cur.name
+        cur = parents.get(id(cur))
+    return None
+
+
+def _is_public_client_rpc_call(node: ast.Call) -> bool:
+    """Match `<receiver>.rpc_call(...)` where the receiver is named
+    like a NotebookLMClient instance, NOT a Session/_core attribute.
+
+    Heuristic (validated against repo audit):
+    - receiver Name "client" / "nbclient" / "notebook_client" -> match
+    - receiver Attribute ending in ".client" (e.g. self.client.rpc_call) -> match
+    - receiver Attribute ending in "._core" / "._session" / ".core" / ".session" -> SKIP
+    """
+    if not isinstance(node.func, ast.Attribute):
+        return False
+    if node.func.attr != "rpc_call":
+        return False
+    recv = node.func.value
+    if isinstance(recv, ast.Name):
+        name = recv.id.lower()
+        # Only flag if the name contains "client" but not "core"/"session"
+        return "client" in name and "core" not in name and "session" not in name
+    if isinstance(recv, ast.Attribute):
+        attr = recv.attr.lower()
+        return "client" in attr and "core" not in attr and "session" not in attr
+    return False
+
+
+def _deprecated_kwargs(node: ast.Call) -> set[str]:
+    return {kw.arg for kw in node.keywords if kw.arg in _DEPRECATED_KW}
+
+
+def _iter_offenders() -> list[tuple[str, int, str | None, set[str]]]:
+    offenders: list[tuple[str, int, str | None, set[str]]] = []
+    for root in (_REPO_ROOT / "src", _REPO_ROOT / "tests"):
+        for path in root.rglob("*.py"):
+            rel = path.relative_to(_REPO_ROOT).as_posix()
+            if any(rel.startswith(skip + "/") for skip in _SKIP_DIRS):
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call) and _is_public_client_rpc_call(node)):
+                    continue
+                kws = _deprecated_kwargs(node)
+                if not kws:
+                    continue
+                func_name = _enclosing_function_name(tree, node)
+                if (rel, "*") in _ALLOWLIST:
+                    continue
+                if func_name is not None and (rel, func_name) in _ALLOWLIST:
+                    continue
+                offenders.append((rel, node.lineno, func_name, kws))
+    return offenders
+
+
+def test_no_unauthorized_deprecated_public_rpc_call_kwargs() -> None:
+    offenders = _iter_offenders()
+    assert offenders == [], (
+        "Unauthorized public client.rpc_call calls with deprecated "
+        "kwargs found. Either remove the deprecated kwarg (preferred), "
+        "wrap the call in pytest.warns(DeprecationWarning), or — if "
+        "the call intentionally exercises the deprecated surface — "
+        "add (relative_path, function_name) to _ALLOWLIST.\n"
+        "Offenders:\n"
+        + "\n".join(
+            f"  {rel}:{lineno}  func={func!r}  kwargs={sorted(kws)}"
+            for rel, lineno, func, kws in offenders
+        )
+    )

--- a/tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py
+++ b/tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py
@@ -45,22 +45,6 @@ _SKIP_DIRS: frozenset[str] = frozenset(
 )
 
 
-def _enclosing_function_name(tree: ast.Module, target: ast.Call) -> str | None:
-    """Return the name of the FunctionDef / AsyncFunctionDef enclosing
-    ``target``, or None if the call is at module scope. Uses parent
-    links computed by walking the tree."""
-    parents: dict[int, ast.AST] = {}
-    for node in ast.walk(tree):
-        for child in ast.iter_child_nodes(node):
-            parents[id(child)] = node
-    cur: ast.AST | None = target
-    while cur is not None:
-        if isinstance(cur, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            return cur.name
-        cur = parents.get(id(cur))
-    return None
-
-
 def _is_public_client_rpc_call(node: ast.Call) -> bool:
     """Match `<receiver>.rpc_call(...)` where the receiver is named
     like a NotebookLMClient instance, NOT a Session/_core attribute.
@@ -89,6 +73,51 @@ def _deprecated_kwargs(node: ast.Call) -> set[str]:
     return {kw.arg for kw in node.keywords if kw.arg in _DEPRECATED_KW}
 
 
+class _OffenderCollector(ast.NodeVisitor):
+    """Single-pass AST visitor that tracks the enclosing FunctionDef /
+    AsyncFunctionDef while walking the tree, so each ``ast.Call`` match
+    already knows its enclosing function name without rebuilding a
+    parent map per call.
+
+    Replaces the previous ``_enclosing_function_name`` helper, which
+    walked the entire tree to rebuild parent links on every match
+    (O(N) per offender). The visitor visits each node exactly once
+    (O(N) per file) regardless of offender count.
+    """
+
+    def __init__(self, rel: str) -> None:
+        super().__init__()
+        self._rel = rel
+        self._func_stack: list[str] = []
+        self.offenders: list[tuple[str, int, str | None, set[str]]] = []
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._func_stack.append(node.name)
+        try:
+            self.generic_visit(node)
+        finally:
+            self._func_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        self._visit_function(node)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        if _is_public_client_rpc_call(node):
+            kws = _deprecated_kwargs(node)
+            if kws:
+                # Innermost enclosing function (or None at module scope).
+                func_name = self._func_stack[-1] if self._func_stack else None
+                allowed_any = (self._rel, "*") in _ALLOWLIST
+                allowed_func = func_name is not None and (self._rel, func_name) in _ALLOWLIST
+                if not (allowed_any or allowed_func):
+                    self.offenders.append((self._rel, node.lineno, func_name, kws))
+        # Recurse into call args (e.g. nested calls) and keep walking.
+        self.generic_visit(node)
+
+
 def _iter_offenders() -> list[tuple[str, int, str | None, set[str]]]:
     offenders: list[tuple[str, int, str | None, set[str]]] = []
     for root in (_REPO_ROOT / "src", _REPO_ROOT / "tests"):
@@ -100,18 +129,9 @@ def _iter_offenders() -> list[tuple[str, int, str | None, set[str]]]:
                 tree = ast.parse(path.read_text(encoding="utf-8"), filename=rel)
             except SyntaxError:
                 continue
-            for node in ast.walk(tree):
-                if not (isinstance(node, ast.Call) and _is_public_client_rpc_call(node)):
-                    continue
-                kws = _deprecated_kwargs(node)
-                if not kws:
-                    continue
-                func_name = _enclosing_function_name(tree, node)
-                if (rel, "*") in _ALLOWLIST:
-                    continue
-                if func_name is not None and (rel, func_name) in _ALLOWLIST:
-                    continue
-                offenders.append((rel, node.lineno, func_name, kws))
+            collector = _OffenderCollector(rel)
+            collector.visit(tree)
+            offenders.extend(collector.offenders)
     return offenders
 
 

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -168,6 +168,18 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "tests/unit/test_notebook_api.py",
         "tests/unit/test_notes_unit.py",
         "tests/unit/test_public_shims.py",
+        # Public ``NotebookLMClient.rpc_call`` deprecation-warning tests
+        # (Phase 1 PR-2). The fixture-injection path
+        # (``make_fake_core(...)``) targets sub-clients constructed with
+        # an externally-supplied core (``NotebooksAPI(fake)``); the
+        # *public* ``NotebookLMClient`` constructs its own ``_core`` via
+        # ``Session(...)`` inside ``__init__`` and exposes no DI seam,
+        # so the same ``client._core.rpc_call = AsyncMock(...)`` pattern
+        # already on the allowlist for the neighboring
+        # ``test_public_shims.py::test_client_rpc_call_delegates_keyword_for_keyword``
+        # is required here. Revisit when ADR-007's seam-substitution
+        # pattern is extended to cover the public-client surface.
+        "tests/unit/test_rpc_call_public_surface.py",
         "tests/unit/test_quota_failure_detection.py",
         "tests/unit/test_rpc_overrides.py",
         "tests/unit/test_save_lock_contract.py",

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1003,14 +1003,20 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
     )
     client._core.rpc_call = AsyncMock(return_value={"ok": True})
 
-    result = await client.rpc_call(
-        RPCMethod.CREATE_NOTEBOOK,
-        ["My Notebook"],
-        source_path="/notebook/abc",
-        allow_null=True,
-        _is_retry=True,
-        disable_internal_retries=True,
-    )
+    # This test intentionally exercises the deprecated kwargs to pin the
+    # forwarded keyword-for-keyword shape. Wrapping in pytest.warns keeps
+    # the existing forwarding asserts alive while documenting that the
+    # call SHOULD emit deprecations (source_path != "/" and explicit
+    # _is_retry both warn).
+    with pytest.warns(DeprecationWarning):
+        result = await client.rpc_call(
+            RPCMethod.CREATE_NOTEBOOK,
+            ["My Notebook"],
+            source_path="/notebook/abc",
+            allow_null=True,
+            _is_retry=True,
+            disable_internal_retries=True,
+        )
 
     assert result == {"ok": True}
     client._core.rpc_call.assert_awaited_once_with(

--- a/tests/unit/test_rpc_call_public_surface.py
+++ b/tests/unit/test_rpc_call_public_surface.py
@@ -1,0 +1,247 @@
+"""Public ``NotebookLMClient.rpc_call`` deprecation-warning surface tests.
+
+These tests pin the v0.5.0 deprecation contract for the three kwargs
+scheduled for removal in v0.6.0 (``source_path``, ``_is_retry``,
+``operation_variant``):
+
+* Default-shape calls (``client.rpc_call(method, params)``) MUST stay
+  silent. The two ``simplefilter("error", DeprecationWarning)`` tests
+  prove this: any stray ``DeprecationWarning`` re-raises as an exception
+  and fails the test.
+* Each deprecated kwarg has a single, exactly-worded warning message.
+  Tests assert via ``str(w.message) == EXPECTED`` (NOT regex) so a typo
+  in the implementation cannot slip past.
+* ``stacklevel=2`` is verified by checking that the captured
+  ``filename`` ends with this test file's name (the caller frame),
+  not ``client.py`` (the implementation frame).
+* Passing all three deprecated kwargs together emits three distinct
+  warnings — the test asserts both ``len(...) == 3`` (catches
+  duplicate-emission regressions) and the exact set of messages.
+
+The narrow ``-W error::DeprecationWarning`` gate in this file's
+verification run (see Phase 1 plan) errors on ANY DeprecationWarning
+during these tests, so every test that expects a warning MUST capture
+it via ``warnings.catch_warnings(record=True)`` + ``simplefilter("always")``.
+
+See ``docs/deprecations.md`` for the canonical removal table.
+"""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import AsyncMock
+
+import pytest
+
+from notebooklm import NotebookLMClient
+from notebooklm.auth import AuthTokens
+from notebooklm.rpc import RPCMethod
+
+_METHOD = RPCMethod.LIST_NOTEBOOKS
+_EXPECTED_SOURCE_PATH_MSG = "rpc_call(source_path=...) is deprecated; removal v0.6.0"
+_EXPECTED_IS_RETRY_MSG = "rpc_call(_is_retry=...) is deprecated; this is internal; removal v0.6.0"
+_EXPECTED_OPERATION_VARIANT_MSG = "rpc_call(operation_variant=...) is deprecated; removal v0.6.0"
+
+
+def _make_client() -> NotebookLMClient:
+    """Build a NotebookLMClient with the core RPC patched to an AsyncMock.
+
+    No real transport is initialized; ``client._core.rpc_call`` is
+    replaced before any authed HTTP path can fire.
+    """
+    client = NotebookLMClient(
+        AuthTokens(
+            cookies={"SID": "test"},
+            csrf_token="csrf",
+            session_id="session",
+        )
+    )
+    client._core.rpc_call = AsyncMock(return_value=[])
+    return client
+
+
+@pytest.mark.asyncio
+async def test_default_call_emits_no_deprecation_warning() -> None:
+    """A bare ``client.rpc_call(method, params)`` MUST be silent.
+
+    ``simplefilter("error", DeprecationWarning)`` re-raises any
+    DeprecationWarning as an exception, so this test fails loudly if
+    the sentinel-default machinery ever warns on the default shape.
+    The delegated call MUST receive today's literal defaults
+    (``source_path="/"``, ``_is_retry=False``, ``operation_variant=None``).
+    """
+    client = _make_client()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        await client.rpc_call(_METHOD, [])
+    client._core.rpc_call.assert_awaited_once_with(
+        method=_METHOD,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_source_path_root_emits_no_warning() -> None:
+    """Explicit ``source_path="/"`` matches the default → silent.
+
+    Callers who are already passing the literal default value get a
+    free pass; we only warn when the value actually differs from the
+    pre-deprecation default behavior.
+    """
+    client = _make_client()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        await client.rpc_call(_METHOD, [], source_path="/")
+    client._core.rpc_call.assert_awaited_once_with(
+        method=_METHOD,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_root_source_path_emits_deprecation_warning() -> None:
+    """Any ``source_path != "/"`` emits exactly one DeprecationWarning."""
+    client = _make_client()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await client.rpc_call(_METHOD, [], source_path="/notebook/x")
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 1
+    assert str(dep[0].message) == _EXPECTED_SOURCE_PATH_MSG
+    client._core.rpc_call.assert_awaited_once_with(
+        method=_METHOD,
+        params=[],
+        source_path="/notebook/x",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_retry_explicit_false_emits_deprecation_warning() -> None:
+    """``_is_retry=False`` still warns: any explicit value is a binding.
+
+    Rationale: ``_is_retry`` is internal and will be removed in v0.6.0.
+    Callers should not reach for it at all; even ``False`` (the
+    historical default) is a sticky reference to the soon-to-disappear
+    kwarg, so we warn them off.
+    """
+    client = _make_client()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await client.rpc_call(_METHOD, [], _is_retry=False)
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 1
+    assert str(dep[0].message) == _EXPECTED_IS_RETRY_MSG
+    client._core.rpc_call.assert_awaited_once_with(
+        method=_METHOD,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_retry_explicit_true_emits_deprecation_warning() -> None:
+    """``_is_retry=True`` emits the same DeprecationWarning."""
+    client = _make_client()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await client.rpc_call(_METHOD, [], _is_retry=True)
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 1
+    assert str(dep[0].message) == _EXPECTED_IS_RETRY_MSG
+    client._core.rpc_call.assert_awaited_once_with(
+        method=_METHOD,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=True,
+        disable_internal_retries=False,
+        operation_variant=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_operation_variant_explicit_emits_deprecation_warning() -> None:
+    """``operation_variant=<str>`` emits exactly one DeprecationWarning."""
+    client = _make_client()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await client.rpc_call(_METHOD, [], operation_variant="x")
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 1
+    assert str(dep[0].message) == _EXPECTED_OPERATION_VARIANT_MSG
+    client._core.rpc_call.assert_awaited_once_with(
+        method=_METHOD,
+        params=[],
+        source_path="/",
+        allow_null=False,
+        _is_retry=False,
+        disable_internal_retries=False,
+        operation_variant="x",
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiple_deprecated_kwargs_emit_multiple_warnings() -> None:
+    """All three deprecated kwargs together → three distinct warnings.
+
+    Asserts BOTH ``len(...) == 3`` (catches accidental
+    duplicate-emission regressions) AND the exact set of messages
+    (catches drift in any single warning text). The order of warnings
+    is intentionally NOT asserted; ``warnings.simplefilter("always")``
+    defeats Python's per-call dedupe so each branch fires once.
+    """
+    client = _make_client()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await client.rpc_call(
+            _METHOD,
+            [],
+            source_path="/notebook/x",
+            _is_retry=True,
+            operation_variant="x",
+        )
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 3
+    dep_msgs = {str(w.message) for w in dep}
+    assert dep_msgs == {
+        _EXPECTED_SOURCE_PATH_MSG,
+        _EXPECTED_IS_RETRY_MSG,
+        _EXPECTED_OPERATION_VARIANT_MSG,
+    }
+
+
+@pytest.mark.asyncio
+async def test_warning_stacklevel_is_two_so_caller_frame_is_user_code() -> None:
+    """``stacklevel=2`` surfaces the caller frame, not ``client.py``.
+
+    We capture the DeprecationWarning and check that ``filename`` ends
+    with this test file's name (the caller). If ``stacklevel`` were 1,
+    ``filename`` would end with ``client.py`` instead.
+    """
+    client = _make_client()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        await client.rpc_call(_METHOD, [], source_path="/x")
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(dep) == 1
+    assert dep[0].filename.endswith("test_rpc_call_public_surface.py"), (
+        f"stacklevel=2 should surface caller frame; got {dep[0].filename}"
+    )


### PR DESCRIPTION
## Summary

Reshapes the public `NotebookLMClient.rpc_call` signature to emit `DeprecationWarning` (stacklevel=2) for the three kwargs scheduled for removal in v0.6.0 (`source_path`, `_is_retry`, `operation_variant`). The default-shape call (`client.rpc_call(method, params)`) stays silent and forwards to `self._core.rpc_call(...)` with today's literal defaults; the keyword-for-keyword delegation contract is preserved.

This implements PR 2 of `docs/refactor-completion-plan.md` (Phase 1 of the orchestrated refactor). The phase plan is `.sisyphus/phases/refactor-completion-plan/phase-1.md` (revision 5).

## Behavior

| Argument | Sentinel default | Warns when | Forwarded as |
|---|---|---|---|
| `source_path: str \| None = None` | `None` | `is not None AND != "/"` | `"/" if None else value` |
| `_is_retry: bool \| None = None` | `None` | `is not None` (any explicit `True`/`False`) | `bool(value) if not None else False` |
| `operation_variant: str \| None = None` (kw-only) | `None` | `is not None` | unchanged |

Exact warning messages (asserted byte-exactly by tests via `str(w.message) == EXPECTED`):

- `rpc_call(source_path=...) is deprecated; removal v0.6.0`
- `rpc_call(_is_retry=...) is deprecated; this is internal; removal v0.6.0`
- `rpc_call(operation_variant=...) is deprecated; removal v0.6.0`

## Files changed (7)

| File | Change |
|---|---|
| `src/notebooklm/client.py` | Add `import warnings`; reshape `rpc_call` to sentinel defaults; emit 3 `DeprecationWarning`s with stacklevel=2; coerce sentinels back to today's literal defaults before delegating |
| `docs/deprecations.md` (new) | Single canonical v0.6.0 removal table (8 rows) |
| `docs/stability.md` | Replace duplicate "Currently Deprecated" table with a cross-link to `docs/deprecations.md` (avoids two sources of truth; "Removed in v0.5.0" section untouched) |
| `tests/unit/test_rpc_call_public_surface.py` (new) | 8 strict-warning tests: default-silence (×2 under `simplefilter("error", DeprecationWarning)`), exact warning text per kwarg (×4), multi-kwarg fanout (×1), stacklevel=2 (×1) |
| `tests/unit/test_public_shims.py` | Migrate `test_client_rpc_call_delegates_keyword_for_keyword` (line 1006) to wrap the deprecated-kwarg call in `pytest.warns(DeprecationWarning)` while preserving forwarding asserts |
| `tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py` (new) | Pytest-collected AST verifier with function-name allowlist (per ADR-007); blocks future deprecated-kwarg regressions. Companion AST lint at `tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py` prevents future public client.rpc_call deprecated-kwarg regressions. |
| `tests/_lint/test_no_forbidden_monkeypatches.py` | Add the new test file to the ADR-007 allowlist with inline justification. The phase-plan-prescribed test pattern uses `client._core.rpc_call = AsyncMock(...)`, which the ADR-007 lint forbids by default. The same pattern is already allowlisted for the neighboring `test_public_shims.py::test_client_rpc_call_delegates_keyword_for_keyword` for the same reason: the public `NotebookLMClient` constructs its own `_core` via `Session(...)` inside `__init__` and exposes no DI seam, so `make_fake_core(...)` (sub-client constructor injection) doesn't apply. Revisit when ADR-007's seam-substitution pattern is extended to cover the public-client surface. |

## Scope notes (MUST NOT DO, per phase plan)

- The body still delegates to `self._core.rpc_call(...)` — the rename to `self._session.rpc_call(...)` is PR 6's job (Phase 2).
- The deprecated kwargs are NOT removed from the signature (that's v0.6.0).
- `Session.rpc_call` is unchanged — the deprecation lives at the public API surface, not the internal seam.

## Out-of-scope follow-up (do NOT block this PR)

File an issue tracking the global `-W error::DeprecationWarning -x` gate. That gate is currently red on `main` due to unrelated `NotesAPI.create_from_chat` calls at `tests/integration/test_save_chat_as_note_integration.py:112` and `tests/integration/test_notes_idempotency.py:222` (a separate cleanup item under the `create_from_chat` deprecation).

## Verification

```bash
uv run ruff format src/notebooklm/client.py tests/unit/test_rpc_call_public_surface.py tests/unit/test_public_shims.py tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py
uv run ruff check src/notebooklm/ tests/
uv run mypy src/notebooklm --ignore-missing-imports
uv run pytest tests/unit/test_rpc_call_public_surface.py -W error::DeprecationWarning -x -v
uv run pytest tests/unit/test_rpc_call_public_surface.py tests/unit/test_public_shims.py tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py -x -v
uv run pytest -x
```

Local results: all green (5533 passed, 51 skipped, 34 unrelated `safe_index` warnings).

## Test plan

- [ ] CI lint+typecheck+test pipeline green
- [ ] Narrow `-W error::DeprecationWarning -x` on `test_rpc_call_public_surface.py` is green (proves the new code emits exactly what's expected; no leaks)
- [ ] AST lint at `tests/_lint/test_no_deprecated_public_rpc_call_kwargs.py` is green (proves no unauthorized deprecated-kwarg call sites)
- [ ] Existing `test_client_rpc_call_delegates_keyword_for_keyword` and `test_client_rpc_call_forwards_default_arguments` still pass (forwarding contract preserved)
- [ ] `docs/deprecations.md` renders cleanly on GitHub

## Deferred polish findings

- AST verifier alias-shadow blind spot (a `c = NotebookLMClient(...); c.rpc_call(_is_retry=True)` would slip past). Accepted given the empirical "only 2 call sites exist" repo audit + the runtime `-W error::DeprecationWarning -x` narrow gate.
- Sphinx `:doc:` markup in the `rpc_call` docstring renders as plain text when not processed by Sphinx. Informational.

Both items are naturally cleaned up in the v0.6.0 removal cycle.

---

Generated with [Claude Code](https://claude.com/claude-code).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical deprecations guide with replacement guidance and removal timeline (v0.6.0).
  * Updated stability and API docs to point to the new deprecations guidance.

* **Deprecation Warnings**
  * Public RPC method now emits DeprecationWarning when specific deprecated keywords are explicitly used; default-shaped calls remain warning-free and warnings use a caller-facing stacklevel.

* **Tests**
  * Added unit tests asserting deprecation-warning behavior and stacklevel.
  * Added a repo lint to detect unauthorized deprecated keyword usage and updated the test allowlist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->