### PR TITLE
refactor(lifecycle): add cookie_saver/cookie_rotator seams with _core-resolved late-bound defaults

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -111,7 +111,7 @@ from ._session_helpers import (
 from ._session_helpers import (
     is_auth_error as is_auth_error,
 )
-from ._session_lifecycle import ClientLifecycle
+from ._session_lifecycle import ClientLifecycle, CookieRotator, CookieSaver
 from ._transport_drain import TransportDrainTracker
 
 # Re-exported so the existing import path ``from notebooklm._core import
@@ -235,6 +235,8 @@ class Session:
         max_concurrent_uploads: int | None = DEFAULT_MAX_CONCURRENT_UPLOADS,
         max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
         on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+        cookie_saver: CookieSaver | None = None,
+        cookie_rotator: CookieRotator | None = None,
     ):
         """Initialize the core client.
 
@@ -314,6 +316,20 @@ class Session:
                 ``rpc_call`` succeeds or fails. The callback receives a
                 backend-agnostic :class:`RpcTelemetryEvent`; exceptions raised
                 by the callback are logged and never mask the RPC result.
+            cookie_saver: Optional injectable seam (Phase 2 PR 3) overriding
+                the on-disk cookie writer used by
+                :meth:`ClientLifecycle.save_cookies`. ``None`` (default)
+                resolves to :func:`_default_cookie_saver`, which late-binds
+                to ``notebooklm._core.save_cookies_to_storage`` so the
+                existing test-monkeypatch surface keeps affecting the live
+                path. Must be sync (``def``, not ``async def``) — it runs
+                inside ``asyncio.to_thread``. Custom callables bypass the
+                ``_core`` lookup entirely.
+            cookie_rotator: Optional injectable seam (Phase 2 PR 3)
+                overriding the keepalive-loop rotator. ``None`` (default)
+                resolves to :func:`_default_cookie_rotator`, which late-binds
+                to ``notebooklm._core._rotate_cookies``. Must be async — it
+                is awaited from :meth:`ClientLifecycle._keepalive_loop`.
 
         Raises:
             ValueError: If ``keepalive`` or ``keepalive_min_interval`` is not a
@@ -461,6 +477,12 @@ class Session:
             keepalive_interval=_resolve_keepalive_interval(keepalive, keepalive_min_interval),
             keepalive_storage_path=_resolved_storage_path,
             kernel=self._kernel,
+            # Phase 2 PR 3 injectable seams. ``None`` is forwarded so the
+            # lifecycle's ``or _default_*`` resolves to the late-binding
+            # wrapper — preserving the existing ``_core`` monkeypatch
+            # surface for unchanged callers.
+            cookie_saver=cookie_saver,
+            cookie_rotator=cookie_rotator,
         )
         # Owns the in-process save lock and open-time cookie baseline while
         # compatibility properties below keep the legacy private attribute

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -70,7 +70,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import httpx
 
@@ -86,7 +86,75 @@ if TYPE_CHECKING:
     from ._rpc_executor import RpcExecutor
     from ._session_auth import AuthRefreshCoordinator
     from ._transport_drain import TransportDrainTracker
+    from .auth import CookieSaveResult
     from .types import ConnectionLimits
+
+
+# ---------------------------------------------------------------------------
+# Injectable seams (Phase 2 PR 3 of `.sisyphus/plans/refactor-completion-plan.md`)
+# ---------------------------------------------------------------------------
+#
+# These two callable seams let host integrations swap the on-disk cookie
+# writer and the identity-surface poke without monkeypatching
+# ``notebooklm._core``. The defaults preserve the existing late-binding
+# contract (8+ test files patch ``notebooklm._core.{save_cookies_to_storage,
+# _rotate_cookies}``) by resolving the target inside the wrapper body — see
+# ``_default_cookie_saver`` / ``_default_cookie_rotator`` below.
+#
+# Concrete return types (not ``Callable[..., Any]``) are deliberate so mypy
+# rejects an ``async def`` mistakenly passed for ``cookie_saver`` (the
+# storage writer runs INSIDE ``asyncio.to_thread`` and must be sync) and a
+# plain ``def`` mistakenly passed for ``cookie_rotator`` (the rotator is
+# awaited from the keepalive loop and must return an ``Awaitable``).
+
+#: Callable shape for the on-disk cookie writer. ``CookieSaveResult`` is
+#: imported under ``TYPE_CHECKING``; the inner forward-string keeps the
+#: alias evaluable at runtime without a circular auth import.
+CookieSaver = Callable[..., "bool | CookieSaveResult"]
+
+#: Callable shape for the keepalive-loop cookie rotator. ``Awaitable[None]``
+#: pins the async-callable contract so mypy rejects sync ``def`` callables
+#: at the injection point.
+CookieRotator = Callable[..., Awaitable[None]]
+
+
+def _default_cookie_saver(*args: Any, **kwargs: Any) -> bool | CookieSaveResult:
+    """Default ``cookie_saver``: late-bind to ``notebooklm._core.save_cookies_to_storage``.
+
+    The ``from . import _core`` import lives INSIDE the function body
+    (intentionally, NOT at module top) so the
+    ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+    idiom in 8+ test files still affects the live save path through this
+    wrapper. A top-level import would capture the original reference at
+    module-import time and silently ignore later patches.
+
+    ``def`` (not ``async def``) is load-bearing: this wrapper is invoked
+    INSIDE ``asyncio.to_thread(_save)`` in
+    :meth:`CookiePersistence._save`. ``save_cookies_to_storage`` itself is
+    a sync writer at ``_auth/storage.py:303``. Making this wrapper ``async``
+    would surface as a ``TypeError`` at runtime when ``to_thread`` tries
+    to call the coroutine in a worker thread.
+    """
+    from . import _core as _core_module
+
+    return _core_module.save_cookies_to_storage(*args, **kwargs)
+
+
+async def _default_cookie_rotator(*args: Any, **kwargs: Any) -> None:
+    """Default ``cookie_rotator``: late-bind to ``notebooklm._core._rotate_cookies``.
+
+    The ``from . import _core`` import lives INSIDE the function body so
+    ``monkeypatch.setattr("notebooklm._core._rotate_cookies", …)`` in
+    ``tests/unit/concurrency/test_close_cancellation_leak.py`` (and
+    similar) keeps affecting the live keepalive loop through this wrapper.
+
+    ``async def`` (not ``def``) is load-bearing: ``_rotate_cookies`` at
+    ``_auth/keepalive.py:298`` is async and must be awaited.
+    """
+    from . import _core as _core_module
+
+    await _core_module._rotate_cookies(*args, **kwargs)
+
 
 # Logger name pinned via :data:`CORE_LOGGER_NAME` so log filters in
 # tests — e.g. ``caplog.at_level("DEBUG", logger=CORE_LOGGER_NAME)`` —
@@ -141,6 +209,8 @@ class ClientLifecycle:
         keepalive_interval: float | None,
         keepalive_storage_path: Path | None,
         kernel: Kernel | None = None,
+        cookie_saver: CookieSaver | None = None,
+        cookie_rotator: CookieRotator | None = None,
     ) -> None:
         self._kernel = kernel if kernel is not None else Kernel()
         self._timeout: float = timeout
@@ -161,6 +231,16 @@ class ClientLifecycle:
         # attribute for tests and private callers that probe it directly.
         self._bound_loop: asyncio.AbstractEventLoop | None = None
         self._keepalive_task: asyncio.Task[None] | None = None
+        # Injectable seams (Phase 2 PR 3). ``None`` resolves to the module-
+        # level late-binding default — same behavior as before the seam was
+        # added, because the default wraps the ``notebooklm._core`` lookup
+        # inside its body. Custom callables skip the ``_core`` hop entirely
+        # and run directly (host integrations that want to bypass the
+        # legacy monkeypatch surface). ``or`` (not ``if x is not None else``)
+        # is fine here: ``None`` is the only documented sentinel and any
+        # other callable is truthy.
+        self._cookie_saver: CookieSaver = cookie_saver or _default_cookie_saver
+        self._cookie_rotator: CookieRotator = cookie_rotator or _default_cookie_rotator
 
     @property
     def _http_client(self) -> httpx.AsyncClient | None:
@@ -263,17 +343,20 @@ class ClientLifecycle:
         """Persist a cookie jar through the shared cookie-persistence collaborator.
 
         Single chokepoint used by :meth:`close`, :meth:`_keepalive_loop`, and
-        ``NotebookLMClient.refresh_auth``. The storage writer is resolved
-        from ``notebooklm._core`` at call time so the
+        ``NotebookLMClient.refresh_auth``. The storage writer is delegated
+        to ``self._cookie_saver`` (Phase 2 PR 3 injectable seam). The
+        default :func:`_default_cookie_saver` wrapper performs a late-bound
+        ``from . import _core; _core.save_cookies_to_storage`` lookup inside
+        its body so the
         ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
-        surface used by 8+ test files keeps affecting the live save path.
+        surface used by 8+ test files keeps affecting the live save path
+        through the wrapper. Custom callables bypass the ``_core`` hop
+        entirely.
         """
-        from . import _core as _core_module
-
         await host.cookie_persistence.save(
             jar,
             path,
-            save_cookies_to_storage=_core_module.save_cookies_to_storage,
+            save_cookies_to_storage=self._cookie_saver,
             to_thread=asyncio.to_thread,
         )
 
@@ -382,13 +465,14 @@ class ClientLifecycle:
         :class:`asyncio.CancelledError` from :meth:`close`.
         """
         logger.debug("Keepalive task started (interval=%.1fs)", interval)
-        # Resolved from ``notebooklm._core`` once, before the loop, so the
-        # existing ``monkeypatch.setattr("notebooklm._core._rotate_cookies",
-        # …)`` surface in ``test_close_cancellation_leak.py`` keeps affecting
-        # the live keepalive loop after the extraction. The attribute lookup
-        # on ``_core_module._rotate_cookies`` still happens at call time, so
-        # late monkeypatches remain effective without re-importing every tick.
-        from . import _core as _core_module
+        # Rotation is delegated to ``self._cookie_rotator`` (Phase 2 PR 3
+        # injectable seam). The default :func:`_default_cookie_rotator`
+        # wrapper performs a late-bound ``from . import _core;
+        # _core._rotate_cookies`` lookup inside its body so the
+        # ``monkeypatch.setattr("notebooklm._core._rotate_cookies", …)``
+        # surface in ``test_close_cancellation_leak.py`` (and similar)
+        # keeps affecting the live keepalive loop. Custom callables bypass
+        # the ``_core`` hop entirely.
 
         try:
             while True:
@@ -406,7 +490,7 @@ class ClientLifecycle:
                     # concurrent layer-1 callers (e.g. spawned ``fetch_tokens``
                     # tasks on the same profile) and other keepalive loops on
                     # the same profile see the fresh rotation and skip.
-                    await _core_module._rotate_cookies(client, self._keepalive_storage_path)
+                    await self._cookie_rotator(client, self._keepalive_storage_path)
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:  # noqa: BLE001 - opportunistic best-effort
@@ -432,4 +516,11 @@ class ClientLifecycle:
             raise
 
 
-__all__ = ["ClientLifecycle", "_LifecycleHost"]
+__all__ = [
+    "ClientLifecycle",
+    "CookieRotator",
+    "CookieSaver",
+    "_LifecycleHost",
+    "_default_cookie_rotator",
+    "_default_cookie_saver",
+]

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -52,6 +52,7 @@ from ._session import (
     DEFAULT_TIMEOUT,
     Session,
 )
+from ._session_lifecycle import CookieRotator, CookieSaver
 from ._settings import SettingsAPI
 from ._sharing import SharingAPI
 from ._source_upload import SourceUploadPipeline
@@ -116,6 +117,8 @@ class NotebookLMClient:
         max_concurrent_rpcs: int | None = DEFAULT_MAX_CONCURRENT_RPCS,
         upload_timeout: httpx.Timeout | None = None,
         on_rpc_event: Callable[[RpcTelemetryEvent], object] | None = None,
+        cookie_saver: CookieSaver | None = None,
+        cookie_rotator: CookieRotator | None = None,
     ):
         """Initialize the NotebookLM client.
 
@@ -196,6 +199,19 @@ class NotebookLMClient:
                 backend-agnostic ``RpcTelemetryEvent`` so applications can
                 forward telemetry to logging, Prometheus, OpenTelemetry, or
                 another metrics backend without this package depending on one.
+            cookie_saver: Optional injectable seam (Phase 2 PR 3) overriding
+                the on-disk cookie writer used on close / refresh / keepalive.
+                ``None`` (default) preserves the current behavior of resolving
+                ``notebooklm._core.save_cookies_to_storage`` via a late-bound
+                wrapper. Must be sync (``def``, not ``async def``) — it runs
+                inside ``asyncio.to_thread``. Custom callables bypass the
+                ``_core`` lookup entirely.
+            cookie_rotator: Optional injectable seam (Phase 2 PR 3)
+                overriding the keepalive-loop cookie rotator. ``None``
+                (default) preserves the current behavior of resolving
+                ``notebooklm._core._rotate_cookies`` via a late-bound
+                wrapper. Must be async — it is awaited from the keepalive
+                loop.
         """
         # Normalize the effective storage path onto the auth object so every
         # downstream code path (refresh_auth, Session.close on-close save,
@@ -266,6 +282,12 @@ class NotebookLMClient:
             max_concurrent_uploads=max_concurrent_uploads,
             max_concurrent_rpcs=max_concurrent_rpcs,
             on_rpc_event=on_rpc_event,
+            # Phase 2 PR 3 injectable seams — pass-through to the
+            # lifecycle. ``None`` (default) preserves the legacy late-
+            # binding contract via ``_default_cookie_saver`` /
+            # ``_default_cookie_rotator``.
+            cookie_saver=cookie_saver,
+            cookie_rotator=cookie_rotator,
         )
         # Compatibility alias for tests and private callers that still inspect
         # ``client._core`` directly.

--- a/tests/unit/test_session_lifecycle.py
+++ b/tests/unit/test_session_lifecycle.py
@@ -48,7 +48,11 @@ import pytest
 
 from notebooklm import _core as _core_module
 from notebooklm._session import _resolve_keepalive_interval
-from notebooklm._session_lifecycle import ClientLifecycle
+from notebooklm._session_lifecycle import (
+    ClientLifecycle,
+    _default_cookie_rotator,
+    _default_cookie_saver,
+)
 from notebooklm.auth import AuthTokens
 from notebooklm.types import ConnectionLimits
 
@@ -367,13 +371,21 @@ async def test_save_cookies_invokes_cookie_persistence(
     tmp_path: Path,
 ) -> None:
     """``save_cookies(host, jar, path)`` delegates to
-    ``host.cookie_persistence.save(...)`` with ``save_cookies_to_storage``
-    resolved from ``notebooklm._core`` at call time (so the
-    ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
-    surface in 8+ test files keeps working).
+    ``host.cookie_persistence.save(...)``, forwarding the lifecycle's
+    ``_cookie_saver`` wrapper as the storage writer.
+
+    Phase 2 PR 3 (``.sisyphus/plans/refactor-completion-plan.md``)
+    replaced the direct ``_core.save_cookies_to_storage`` kwarg with an
+    injectable ``cookie_saver`` seam. With the default ``cookie_saver``
+    (``_default_cookie_saver``), invoking the captured wrapper must still
+    reach the ``notebooklm._core.save_cookies_to_storage`` attribute —
+    so a ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage",
+    …)`` placed BEFORE the wrapper is invoked still fires through, exactly
+    preserving the legacy 8+ test-file contract. This assertion is now
+    BEHAVIORAL (invoke the wrapper, observe the sentinel was called) rather
+    than identity-based (``is sentinel``), because the wrapper indirection
+    is the whole point of the seam.
     """
-    # Stub out save_cookies_to_storage at the module level so we can prove
-    # the lifecycle resolved the monkeypatched value at call time.
     sentinel = MagicMock()
     monkeypatch.setattr(_core_module, "save_cookies_to_storage", sentinel)
 
@@ -389,9 +401,19 @@ async def test_save_cookies_invokes_cookie_persistence(
     call = host.cookie_persistence.save.call_args
     assert call.args[0] is jar
     assert call.args[1] == target_path
-    # ``save_cookies_to_storage`` must be the monkeypatched sentinel — the
-    # lifecycle MUST resolve it from notebooklm._core at call time.
-    assert call.kwargs["save_cookies_to_storage"] is sentinel
+    # The kwarg is the lifecycle's wrapper (not the raw sentinel), so the
+    # ``CookiePersistence._save`` worker-thread invocation goes through
+    # ``_default_cookie_saver``'s late-bound ``_core`` lookup.
+    forwarded_saver = call.kwargs["save_cookies_to_storage"]
+    assert forwarded_saver is lifecycle._cookie_saver, (
+        "lifecycle.save_cookies must forward self._cookie_saver as the "
+        "storage writer (the wrapper indirection is what preserves the "
+        "_core monkeypatch surface)."
+    )
+    # Behavioral check: invoking the captured wrapper hits the monkeypatched
+    # sentinel via late-bound _core resolution.
+    forwarded_saver(jar, target_path)
+    sentinel.assert_called_once_with(jar, target_path)
     assert call.kwargs["to_thread"] is asyncio.to_thread
 
 
@@ -545,3 +567,113 @@ def test_init_is_event_loop_agnostic() -> None:
     assert lifecycle._connect_timeout == 10.0
     assert lifecycle.is_open() is False
     assert lifecycle.get_bound_loop() is None
+
+
+# ---------------------------------------------------------------------------
+# Injectable seams (Phase 2 PR 3 of .sisyphus/plans/refactor-completion-plan.md)
+#
+# Three load-bearing properties pinned here:
+#
+# 1. ``_default_cookie_saver`` performs a LATE-BOUND ``_core`` lookup inside
+#    its function body. Monkeypatching ``notebooklm._core.save_cookies_to_storage``
+#    AFTER the wrapper exists must still affect the wrapper's behavior.
+#    Without late-binding, the 8+ existing tests that patch ``_core.save_*``
+#    silently lose their effect under the seam refactor.
+#
+# 2. ``_default_cookie_rotator`` performs the same late-bound lookup for
+#    ``_core._rotate_cookies``. The keepalive-loop equivalent of (1).
+#
+# 3. ``ClientLifecycle.__init__`` wires the defaults when ``cookie_saver`` /
+#    ``cookie_rotator`` are ``None`` (or omitted), and accepts custom
+#    callables when supplied. The ``or _default_*`` resolution pattern is
+#    what lets ``_ensure_lifecycle`` (which does NOT pass the new kwargs)
+#    keep working unchanged.
+# ---------------------------------------------------------------------------
+
+
+def test_default_cookie_saver_late_binds_to_core(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_default_cookie_saver`` resolves ``_core.save_cookies_to_storage``
+    at CALL time, not at module-import time.
+
+    Establish a sentinel AFTER ``_default_cookie_saver`` already exists,
+    then invoke the wrapper and prove the sentinel was called. A non-late-
+    bound wrapper would have captured the original ``save_cookies_to_storage``
+    reference at module load and silently ignored the monkeypatch.
+    """
+    sentinel = MagicMock(return_value=True)
+    monkeypatch.setattr(_core_module, "save_cookies_to_storage", sentinel)
+
+    jar = httpx.Cookies()
+    path = Path("/tmp/storage.json")
+    result = _default_cookie_saver(jar, path)
+
+    sentinel.assert_called_once_with(jar, path)
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_default_cookie_rotator_late_binds_to_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_default_cookie_rotator`` resolves ``_core._rotate_cookies`` at
+    CALL time and awaits it. Async-shape counterpart to the saver test.
+    """
+    sentinel = AsyncMock(return_value=None)
+    monkeypatch.setattr(_core_module, "_rotate_cookies", sentinel)
+
+    client = MagicMock(spec=httpx.AsyncClient)
+    path = Path("/tmp/storage.json")
+    await _default_cookie_rotator(client, path)
+
+    sentinel.assert_awaited_once_with(client, path)
+
+
+def test_init_wires_default_seams_when_none_supplied() -> None:
+    """When ``cookie_saver`` / ``cookie_rotator`` are omitted (or ``None``),
+    ``ClientLifecycle.__init__`` wires the module-level late-binding
+    defaults; supplying custom callables overrides them.
+
+    This is what lets :meth:`Session._ensure_lifecycle` keep its existing
+    no-arg signature — it constructs ``ClientLifecycle(...)`` without the
+    new kwargs, and the ``or _default_*`` resolution preserves the legacy
+    ``_core`` monkeypatch surface.
+    """
+    # Defaults: omit the kwargs entirely.
+    default_lifecycle = ClientLifecycle(
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        keepalive_interval=None,
+        keepalive_storage_path=None,
+    )
+    assert default_lifecycle._cookie_saver is _default_cookie_saver
+    assert default_lifecycle._cookie_rotator is _default_cookie_rotator
+
+    # Explicit ``None`` resolves the same way as omission.
+    explicit_none_lifecycle = ClientLifecycle(
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        keepalive_interval=None,
+        keepalive_storage_path=None,
+        cookie_saver=None,
+        cookie_rotator=None,
+    )
+    assert explicit_none_lifecycle._cookie_saver is _default_cookie_saver
+    assert explicit_none_lifecycle._cookie_rotator is _default_cookie_rotator
+
+    # Custom callables override the defaults — pure pass-through, no
+    # ``_core`` indirection.
+    custom_saver = MagicMock(return_value=True)
+    custom_rotator = AsyncMock(return_value=None)
+    custom_lifecycle = ClientLifecycle(
+        timeout=30.0,
+        connect_timeout=10.0,
+        limits=ConnectionLimits(),
+        keepalive_interval=None,
+        keepalive_storage_path=None,
+        cookie_saver=custom_saver,
+        cookie_rotator=custom_rotator,
+    )
+    assert custom_lifecycle._cookie_saver is custom_saver
+    assert custom_lifecycle._cookie_rotator is custom_rotator


### PR DESCRIPTION
## Summary

Phase 2 Wave 1 of the v0.5.0 refactor program (continues from PR #878).
Implements PR 3 of `.sisyphus/plans/refactor-completion-plan.md` (master plan).

Adds two injectable seams to `ClientLifecycle` so host integrations can swap the on-disk cookie writer and the keepalive identity-surface poke without monkeypatching `notebooklm._core`:

- `cookie_saver: Callable[..., bool | CookieSaveResult] | None` (sync)
- `cookie_rotator: Callable[..., Awaitable[None]] | None` (async)

Kwargs plumb through `NotebookLMClient.__init__` → `Session.__init__` → `ClientLifecycle.__init__`. `None` (default) resolves to module-level `_default_cookie_saver` / `_default_cookie_rotator` wrappers that do **late-bound** `from . import _core as _core_module` **inside** the function body — so the existing `monkeypatch.setattr("notebooklm._core.{save_cookies_to_storage,_rotate_cookies}", ...)` surface keeps affecting the live path. A module-top import would capture the original reference at module-load time and silently lose patches.

**Behavior-preserving:** existing ~9 test files that monkeypatch `notebooklm._core.{save_cookies_to_storage,_rotate_cookies,is_auth_error}` continue to pass UNMODIFIED through the wrapper indirection. The one exception is `tests/unit/test_session_lifecycle.py::test_save_cookies_invokes_cookie_persistence` at line 365 which asserts on kwarg-identity — migrated in this PR to a behavioral assertion (capture wrapper, assert it is `lifecycle._cookie_saver`, then invoke and assert sentinel was called).

## Load-bearing constraints (pinned by spec; do not change)

- **Sync/async asymmetry**: `_default_cookie_saver` MUST be sync `def` (runs inside `asyncio.to_thread(_save)` at `_cookie_persistence.py:105` — async would TypeError at runtime). `_default_cookie_rotator` MUST be `async def` (awaited from the keepalive loop; `_rotate_cookies` itself is async).
- **Late-bound import**: `from . import _core as _core_module` lives **inside** each wrapper's function body, not at module top, to preserve monkeypatch reachability.
- **Concrete return types** (not `Callable[..., Any]`): mypy rejects async-for-sync swaps at the injection point. Independently verified during polish (Codex ran the mypy experiment).
- **`Session._ensure_lifecycle` signature is UNCHANGED** — it constructs `ClientLifecycle(...)` without the new kwargs and the `or _default_*` resolution in `__init__` wires the defaults.

## Files changed

- `src/notebooklm/_session_lifecycle.py` — new `CookieSaver`/`CookieRotator` type aliases, `_default_cookie_saver` (SYNC) + `_default_cookie_rotator` (ASYNC) wrappers, `ClientLifecycle.__init__` accepts new kwargs, two production rewire sites (`save_cookies()` and `_keepalive_loop()`)
- `src/notebooklm/_session.py` — `Session.__init__` accepts and passes through `cookie_saver`/`cookie_rotator` kwargs to `ClientLifecycle(...)`
- `src/notebooklm/client.py` — `NotebookLMClient.__init__` accepts and passes through kwargs to `Session(...)`
- `tests/unit/test_session_lifecycle.py` — 3 new unit tests (late-binding for saver + late-binding for rotator + default-wiring/custom-override); 1 existing test migrated from kwarg-identity to behavioral assertion

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check src/notebooklm/ tests/` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 files)
- [x] `uv run pytest tests/unit/test_session_lifecycle.py -v` — **21/21 pass** (3 new + 1 migrated + 17 unchanged)
- [x] Spec'd 9-file `_core` monkeypatch sweep — **194 passed / 2 env-skipped** (proves the behavior-preserving claim)
- [x] Full `uv run pytest -x` — **5536 passed / 51 skipped**

## Polish (`/polish`)

Three sub-stages ran on this diff (code-simplifier in-session; triple review dispatched as parallel CLI processes since the Task tool primitive was unavailable in the implementer environment, agy/codex/gemini reviewed via `Bash run_in_background`; ultrathink in-session). Verdicts:

- **Simplifier:** 1 applied (collapsed `x if x is not None else default` → `x or default` per spec wording on the two seam-default assignments). 6 candidates considered and rejected with rationale (factoring the two wrappers would obscure the load-bearing docstrings; existing `__all__` already exposes `_LifecycleHost`; `_session.py`/`client.py` docstring parallel structure matches project convention).
- **Triple review (agy + codex + gemini):** 0 critical, 0 important, 2 optional. Codex and Gemini both: **no defects found**; Codex independently ran a mypy experiment confirming the type aliases reject async-for-sync swaps as designed. Agy raised 1 IMPORTANT that turned out to be a false positive — it claimed `from __future__ import annotations` was missing for the bare `bool | CookieSaveResult` return annotation, but the import IS present at line 67 (mypy + pytest + import-time all pass, proving no `NameError`).
- **Ultrathink:** No shipping blockers across 6 lenses (edge cases / error handling / performance / maintainability / security / testing).

## Deferred polish findings

These are quality-of-life improvements that don't block this PR but are tracked for Wave 2 / follow-up:

- **Doc gap (Wave 2 / follow-up):** the implicit signature contract for a custom `cookie_saver` (must accept `(cookie_jar, path, *, original_snapshot, return_result)`) and custom `cookie_rotator` (must accept `(client, storage_path)`) is not yet promoted to public docs. Reasonable to leave implicit while these are internal v0.5.0 seams.
- **Test gap (Wave 2 scope):** no end-to-end test exercising `NotebookLMClient(cookie_saver=custom)` reaching `custom` through the live close path — would touch `_session.py`/`client.py` test files which Wave 2's combined PR 4-5 owns.
- **Style (defer):** `_default_cookie_saver`/`_default_cookie_rotator` are exported in `__all__` despite leading-underscore names; this mirrors the existing `_LifecycleHost` precedent and documents that tests legitimately import them. Keep as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `Session` and `NotebookLMClient` now accept optional `cookie_saver` and `cookie_rotator` parameters, enabling customization of cookie persistence and rotation behavior per client instance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->