### PR TITLE
refactor(client): rename _core to _session and delete compat alias (Phase 2 Wave 3)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -370,7 +370,7 @@ class Session:
         _resolved_limits = limits if limits is not None else ConnectionLimits()
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
-        # by integration tests against ``client._core``. The refresh
+        # by integration tests against ``client._session``. The refresh
         # callback + the four refresh/auth-snapshot ivars (``_refresh_lock``,
         # ``_refresh_task``, ``_refresh_callback``, ``_auth_snapshot_lock``)
         # live on ``self._auth_coord``, constructed below alongside the other
@@ -1457,7 +1457,7 @@ class Session:
 
         Compatibility surface preserved so ``RpcExecutor.execute``
         (``_rpc_executor.py:275``), ``_chat_transport`` (``_chat_transport.py:64``),
-        and direct callers (``client._core._perform_authed_post(...)``) keep
+        and direct callers (``client._session._perform_authed_post(...)``) keep
         the same keyword-only signature. The body now builds an
         :class:`RpcRequest` with the three keyword-only args stashed into
         ``context`` and dispatches into :attr:`_authed_post_chain`.

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -289,9 +289,6 @@ class NotebookLMClient:
             cookie_saver=cookie_saver,
             cookie_rotator=cookie_rotator,
         )
-        # Compatibility alias for tests and private callers that still inspect
-        # ``client._core`` directly.
-        self._core = self._session
 
         # Wire the upload pipeline explicitly with the concrete capability
         # surfaces (UploadRuntime via the Session, plus Kernel and AuthMetadata).
@@ -311,7 +308,7 @@ class NotebookLMClient:
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
         )
-        self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
+        self.notebooks = NotebooksAPI(self._session, sources_api=self.sources)
         # Phase 5 wiring per docs/refactor.md Migration Plan steps 6-7:
         # the legacy single-service handoff (``MindMapService(self._session)``
         # passed as ``mind_map_service=``) is replaced with the explicit
@@ -319,14 +316,6 @@ class NotebookLMClient:
         # raw row primitives; NoteBackedMindMapService is the mind-map-only
         # adapter the download path uses; the artifact-generation path uses
         # NoteService.create_note directly to persist a generated mind map.
-        #
-        # We pass ``self._session`` rather than the ``self._core`` alias because
-        # ``Session`` directly satisfies ``ArtifactsRuntime`` (RpcCaller +
-        # AsyncWorkRuntime + DrainHookRegistration) and the ``_core`` alias
-        # exists only for legacy callers that pre-date the runtime split. The
-        # ``_core`` alias is preserved indefinitely for back-compat (per
-        # refactor.md Non-Goals — see ADR-013); retiring it is a future
-        # arc and is out of scope here.
         note_service = NoteService(self._session)
         mind_maps = NoteBackedMindMapService(note_service)
         self.artifacts = ArtifactsAPI(
@@ -343,25 +332,25 @@ class NotebookLMClient:
         # has NotesAPI delegate via constructor injection.
         self.chat = ChatAPI(self._session, notebooks=self.notebooks)
         self.notes = NotesAPI(
-            self._core,
+            self._session,
             notes=note_service,
             mind_maps=mind_maps,
             save_chat_answer=self.chat.save_answer_as_note,
         )
         # Pure-RPC features (Phase 1 retypes: typed as `rpc: RpcCaller`).
-        self.research = ResearchAPI(self._core)
-        self.settings = SettingsAPI(self._core)
-        self.sharing = SharingAPI(self._core)
+        self.research = ResearchAPI(self._session)
+        self.settings = SettingsAPI(self._session)
+        self.sharing = SharingAPI(self._session)
 
     @property
     def auth(self) -> AuthTokens:
         """Get the authentication tokens."""
-        return self._core.auth
+        return self._session.auth
 
     async def __aenter__(self) -> NotebookLMClient:
         """Open the client connection."""
         logger.debug("Opening NotebookLM client")
-        await self._core.open()
+        await self._session.open()
         return self
 
     async def __aexit__(
@@ -393,7 +382,7 @@ class NotebookLMClient:
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new operations and wait for in-flight operations to finish."""
-        await self._core.drain(timeout=timeout)
+        await self._session.drain(timeout=timeout)
 
     async def close(
         self,
@@ -421,7 +410,7 @@ class NotebookLMClient:
                 await self.drain(timeout=drain_timeout)
             except TimeoutError as drain_exc:
                 try:
-                    await self._core.close()
+                    await self._session.close()
                 except Exception as close_exc:
                     logger.warning(
                         "Suppressing close() error after drain timeout to preserve timeout "
@@ -431,13 +420,13 @@ class NotebookLMClient:
                     raise drain_exc from close_exc
                 raise
             else:
-                await self._core.close()
+                await self._session.close()
                 return
-        await self._core.close()
+        await self._session.close()
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client."""
-        return self._core.metrics_snapshot()
+        return self._session.metrics_snapshot()
 
     async def rpc_call(
         self,
@@ -499,7 +488,7 @@ class NotebookLMClient:
         # not-None / None branches into one expression.
         resolved_source_path = "/" if source_path is None else source_path
         resolved_is_retry = bool(_is_retry)
-        return await self._core.rpc_call(
+        return await self._session.rpc_call(
             method=method,
             params=params,
             source_path=resolved_source_path,
@@ -512,7 +501,7 @@ class NotebookLMClient:
     @property
     def is_connected(self) -> bool:
         """Check if the client is connected."""
-        return self._core.is_open
+        return self._session.is_open
 
     @classmethod
     async def from_storage(
@@ -627,4 +616,4 @@ class NotebookLMClient:
         Raises:
             ValueError: If token extraction fails (page structure may have changed).
         """
-        return await refresh_auth_session(self._core)
+        return await refresh_auth_session(self._session)

--- a/tests/integration/concurrency/test_aexit_exception_masking.py
+++ b/tests/integration/concurrency/test_aexit_exception_masking.py
@@ -60,28 +60,28 @@ async def test_body_raises_and_close_raises_body_wins(
     client = NotebookLMClient(auth_tokens)
 
     # Capture the http client reference BEFORE entering the cm — successful
-    # close sets `client._core._http_client = None`, so we need our own ref.
+    # close sets `client._session._http_client = None`, so we need our own ref.
     async with client:
-        http_client_ref = client._core._http_client
+        http_client_ref = client._session._http_client
         assert http_client_ref is not None
 
         # Patch _core.close to raise after closing the transport, so we
         # exercise the exception-arbitration path. Forward to the original
         # close so the leak-shield path also runs.
-        original_close = client._core.close
+        original_close = client._session.close
 
         async def _close_then_raise() -> None:
             await original_close()
             raise RuntimeError("synthetic close failure")
 
         with (
-            patch.object(client._core, "close", _close_then_raise),
+            patch.object(client._session, "close", _close_then_raise),
             caplog.at_level(logging.WARNING),
             pytest.raises(ValueError, match="user error"),
         ):
             async with client:
                 # Sanity: client is open here.
-                assert client._core._http_client is not None
+                assert client._session._http_client is not None
                 raise ValueError("user error")
 
     # 1. The body's ValueError propagated (verified by pytest.raises above).
@@ -109,7 +109,7 @@ async def test_body_succeeds_and_close_raises_close_propagates(
         raise RuntimeError("close failed")
 
     with (
-        patch.object(client._core, "close", _bad_close),
+        patch.object(client._session, "close", _bad_close),
         pytest.raises(RuntimeError, match="close failed"),
     ):
         async with client:
@@ -127,12 +127,12 @@ async def test_cancel_mid_close_does_not_leak_transport(
     the cancel.
     """
     client = NotebookLMClient(auth_tokens)
-    await client._core.open()
-    http_client_ref = client._core._http_client
+    await client._session.open()
+    http_client_ref = client._session._http_client
     assert http_client_ref is not None
 
     # Wrap close() in a task so we can cancel it.
-    close_task = asyncio.create_task(client._core.close())
+    close_task = asyncio.create_task(client._session.close())
     # Yield once so close() can start, then cancel.
     await asyncio.sleep(0)
     close_task.cancel()

--- a/tests/integration/concurrency/test_artifact_poll_dedupe.py
+++ b/tests/integration/concurrency/test_artifact_poll_dedupe.py
@@ -131,7 +131,7 @@ async def test_scenario_a_two_waiters_share_one_poll_loop(_auth_tokens):
         # ensure both have been scheduled before releasing the poll —
         # extra yields are safer than too few.
         for _ in range(50):
-            if len(client._core._pending_polls) >= 1 and (
+            if len(client._session._pending_polls) >= 1 and (
                 w1.done() is False and w2.done() is False
             ):
                 # Both have parked; allow the poll to fire.
@@ -240,8 +240,8 @@ async def test_scenario_c_pending_polls_empty_after_success(_auth_tokens):
         # synchronously when the task transitions, but yield once to be
         # safe across event loops.
         await asyncio.sleep(0)
-        assert client._core._pending_polls == {}, (
-            f"registry leaked entries on success path: {client._core._pending_polls!r}"
+        assert client._session._pending_polls == {}, (
+            f"registry leaked entries on success path: {client._session._pending_polls!r}"
         )
 
 
@@ -280,7 +280,7 @@ async def test_scenario_d_pending_polls_empty_after_exception(_auth_tokens):
 
         # Spin briefly for both to register on the shared future.
         for _ in range(50):
-            if len(client._core._pending_polls) >= 1 and not (w1.done() or w2.done()):
+            if len(client._session._pending_polls) >= 1 and not (w1.done() or w2.done()):
                 break
             await asyncio.sleep(0.01)
         both_attached.set()
@@ -293,8 +293,8 @@ async def test_scenario_d_pending_polls_empty_after_exception(_auth_tokens):
             await asyncio.wait_for(w2, timeout=TEST_TIMEOUT_S)
 
         await asyncio.sleep(0)
-        assert client._core._pending_polls == {}, (
-            f"registry leaked on exception path: {client._core._pending_polls!r}"
+        assert client._session._pending_polls == {}, (
+            f"registry leaked on exception path: {client._session._pending_polls!r}"
         )
         assert poll_call_count == 1, (
             f"expected 1 poll, got {poll_call_count} (dedupe must hold on exception path)"
@@ -363,7 +363,7 @@ async def test_scenario_e_orphan_exception_does_not_log_unraisable(_auth_tokens,
         # Yield until the poll task has actually run and resolved the
         # future. The registry is the readiness signal.
         for _ in range(50):
-            if not client._core._pending_polls:
+            if not client._session._pending_polls:
                 break
             await asyncio.sleep(0.01)
 
@@ -374,9 +374,9 @@ async def test_scenario_e_orphan_exception_does_not_log_unraisable(_auth_tokens,
         gc.collect()
         await asyncio.sleep(0)
 
-        assert client._core._pending_polls == {}, (
+        assert client._session._pending_polls == {}, (
             "registry leaked on leader-cancel-with-orphan-exception path: "
-            f"{client._core._pending_polls!r}"
+            f"{client._session._pending_polls!r}"
         )
 
         # The poll ran exactly once; the suppression callback consumed

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -151,7 +151,7 @@ def _make_client(transport: httpx.AsyncBaseTransport, auth_tokens) -> NotebookLM
     POSTs route through the mock instead of opening a real socket.
     """
     client = NotebookLMClient(auth_tokens)
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -204,7 +204,7 @@ async def test_concurrent_follow_ups_serialize_on_conversation_id(auth_tokens) -
             return_exceptions=False,
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Sanity: both calls returned their respective answers.
     answers = sorted(r.answer for r in results)
@@ -300,7 +300,7 @@ async def test_different_conversation_ids_run_in_parallel(auth_tokens) -> None:
             client.chat.ask(notebook_id, "qB", source_ids=["src_001"], conversation_id=cid_b),
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert peak_inflight == 2, (
         f"different-conversation follow-ups must run in parallel, "

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -138,7 +138,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -200,7 +200,7 @@ async def test_notebooks_create_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert notebook.id == nb_id_new
     assert notebook.title == title
@@ -242,7 +242,7 @@ async def test_notebooks_create_re_creates_when_probe_finds_nothing(auth_tokens)
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert notebook.id == nb_id_new
     # Two CREATE_NOTEBOOK calls: original (502) + retry (200)
@@ -281,7 +281,7 @@ async def test_notebooks_create_raises_on_ambiguous_probe(auth_tokens) -> None:
         with pytest.raises(RPCError, match="disambiguate"):
             await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ async def test_sources_add_url_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -358,7 +358,7 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -390,7 +390,7 @@ async def test_sources_add_text_raises_when_idempotent_True(auth_tokens) -> None
         with pytest.raises(NonIdempotentRetryError, match="add_text cannot be marked idempotent"):
             await client.sources.add_text("nb_test", "Title", "Content", idempotent=True)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert not seen_request, "add_text(idempotent=True) must raise before issuing any RPC"
 
@@ -425,7 +425,7 @@ async def test_sources_add_text_default_behavior_unchanged(auth_tokens) -> None:
     try:
         source = await client.sources.add_text(notebook_id, title, "the body")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert add_count == 1, f"expected exactly 1 ADD_SOURCE call, got {add_count}"
@@ -471,7 +471,7 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
     try:
         request_count = 0
         with pytest.raises(ServerError):
-            await client._core.rpc_call(
+            await client._session.rpc_call(
                 RPCMethod.LIST_NOTEBOOKS,
                 [None, 1, None, [2]],
                 disable_internal_retries=True,
@@ -480,18 +480,18 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
             f"with disable_internal_retries=True expected 1 POST, got {request_count}"
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # --- without the flag: default retry loop fires ---------------------
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
     try:
         request_count = 0
         with pytest.raises(ServerError):
-            await client._core.rpc_call(
+            await client._session.rpc_call(
                 RPCMethod.LIST_NOTEBOOKS,
                 [None, 1, None, [2]],
             )
         # initial + 2 retries = 3 POSTs
         assert request_count == 3, f"with default retries expected 3 POSTs, got {request_count}"
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()

--- a/tests/integration/concurrency/test_keepalive_path_canonicalize.py
+++ b/tests/integration/concurrency/test_keepalive_path_canonicalize.py
@@ -83,8 +83,8 @@ def test_relative_and_absolute_paths_share_dedupe_key(
     # The dedupe key seen by ``_get_poke_lock`` / ``_try_claim_rotation``
     # / ``_rotation_lock_path`` is exactly this internal field. Both must
     # be canonical and equal.
-    rel_keepalive = client_rel._core._keepalive_storage_path
-    abs_keepalive = client_abs._core._keepalive_storage_path
+    rel_keepalive = client_rel._session._keepalive_storage_path
+    abs_keepalive = client_abs._session._keepalive_storage_path
     assert rel_keepalive is not None
     assert abs_keepalive is not None
     assert rel_keepalive == abs_keepalive, (
@@ -132,8 +132,8 @@ def test_tilde_path_is_expanded(
     client_tilde = NotebookLMClient(_auth_tokens, storage_path=tilde_path)
     client_expanded = NotebookLMClient(_auth_tokens, storage_path=expanded_path)
 
-    tilde_key = client_tilde._core._keepalive_storage_path
-    expanded_key = client_expanded._core._keepalive_storage_path
+    tilde_key = client_tilde._session._keepalive_storage_path
+    expanded_key = client_expanded._session._keepalive_storage_path
     assert tilde_key is not None
     assert expanded_key is not None
     assert tilde_key == expanded_key
@@ -175,7 +175,7 @@ def test_public_storage_path_argument_unchanged(
     assert client.auth.storage_path == raw_path
     assert client.auth.storage_path != target.resolve()
     # And the internal keepalive field IS canonicalized.
-    keepalive_key = client._core._keepalive_storage_path
+    keepalive_key = client._session._keepalive_storage_path
     assert keepalive_key is not None
     assert keepalive_key == target.resolve()
     assert keepalive_key.is_absolute()
@@ -202,8 +202,8 @@ def test_symlink_is_resolved(tmp_path: Path, _auth_tokens: AuthTokens) -> None:
     client_link = NotebookLMClient(_auth_tokens, storage_path=link)
     client_target = NotebookLMClient(_auth_tokens, storage_path=target)
 
-    link_key = client_link._core._keepalive_storage_path
-    target_key = client_target._core._keepalive_storage_path
+    link_key = client_link._session._keepalive_storage_path
+    target_key = client_target._session._keepalive_storage_path
     assert link_key is not None
     assert target_key is not None
     assert link_key == target_key
@@ -213,4 +213,4 @@ def test_symlink_is_resolved(tmp_path: Path, _auth_tokens: AuthTokens) -> None:
 def test_none_storage_path_stays_none(_auth_tokens: AuthTokens) -> None:
     """Canonicalization must be a no-op when there is no storage path."""
     client = NotebookLMClient(_auth_tokens)
-    assert client._core._keepalive_storage_path is None
+    assert client._session._keepalive_storage_path is None

--- a/tests/integration/concurrency/test_note_create_cancel.py
+++ b/tests/integration/concurrency/test_note_create_cancel.py
@@ -57,7 +57,7 @@ def _make_client_with_transport(
 ) -> NotebookLMClient:
     """Wire a ``NotebookLMClient`` to a mock transport, bypassing full open()."""
     client = NotebookLMClient(auth_tokens)
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -201,9 +201,9 @@ async def test_cancel_during_update_note_shields_or_cleans_up(auth_tokens) -> No
     finally:
         # Defensive cleanup so a failing assertion doesn't leak the http
         # client and warn at gc time.
-        if client._core._http_client is not None:
-            await client._core._http_client.aclose()
-            client._core._http_client = None
+        if client._session._http_client is not None:
+            await client._session._http_client.aclose()
+            client._session._http_client = None
 
 
 @pytest.mark.asyncio
@@ -230,6 +230,6 @@ async def test_no_cancel_no_cleanup(auth_tokens) -> None:
             f"over-eager: rpc_ids={rpc_ids!r}"
         )
     finally:
-        if client._core._http_client is not None:
-            await client._core._http_client.aclose()
-            client._core._http_client = None
+        if client._session._http_client is not None:
+            await client._session._http_client.aclose()
+            client._session._http_client = None

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -83,7 +83,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
 
     # NotebookLMClient default — NO ``rate_limit_max_retries`` kwarg.
     client = NotebookLMClient(auth_tokens)
-    assert client._core._rate_limit_max_retries == 3, (
+    assert client._session._rate_limit_max_retries == 3, (
         "rate_limit_max_retries default must be 3; check that NotebookLMClient.__init__ "
         "forwards the Session default."
     )
@@ -91,7 +91,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
         result = await client.notebooks.list()
@@ -116,12 +116,12 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
     mock_post = AsyncMock(return_value=_build_429("1"))
 
     client = NotebookLMClient(auth_tokens)
-    assert client._core._rate_limit_max_retries == 3
+    assert client._session._rate_limit_max_retries == 3
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
         await client.notebooks.list()
@@ -161,7 +161,7 @@ async def test_default_retries_use_exponential_backoff_when_header_missing(
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     sleep_calls: list[float] = []
 
@@ -205,18 +205,18 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     mock_post = AsyncMock(return_value=_build_429("1"))
 
     client = NotebookLMClient(auth_tokens)
-    assert client._core._rate_limit_max_retries == 3
+    assert client._session._rate_limit_max_retries == 3
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     def _build_request(_snap):
         return ("https://example.invalid/x", b"body", None)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(_TransportRateLimited):
-        await client._core._perform_authed_post(
+        await client._session._perform_authed_post(
             build_request=_build_request,
             log_label="test",
             disable_internal_retries=True,

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -122,7 +122,7 @@ def _make_client_with_transport(
         auth_tokens,  # type: ignore[arg-type]
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -225,7 +225,7 @@ async def test_create_artifact_503_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Exactly ONE CREATE_ARTIFACT POST despite ``server_error_max_retries=3``
     # being configured: the PROBE_THEN_CREATE policy forced retries off.
@@ -263,7 +263,7 @@ async def test_create_artifact_429_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(RateLimitError):
             await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert create_count == 1, f"expected 1 CREATE_ARTIFACT POST, got {create_count}"
 
@@ -296,7 +296,7 @@ async def test_generate_mind_map_503_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert mind_map_count == 1, f"expected 1 GENERATE_MIND_MAP POST, got {mind_map_count}"
     assert get_notebook_count == 1
@@ -333,7 +333,7 @@ async def test_create_artifact_happy_path_still_returns_artifact(auth_tokens) ->
     try:
         status = await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert status.task_id == artifact_id
     assert create_count == 1
@@ -379,7 +379,7 @@ async def test_generate_mind_map_happy_path_still_returns_mind_map(auth_tokens) 
     try:
         result = await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert result["mind_map"] == mind_map_dict
     assert result["note_id"] == "note_stub"

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -117,7 +117,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
 
     client = await _build_client_for_test()
     # Eliminate the post-refresh retry delay so the test runs fast.
-    client._core._refresh_retry_delay = 0
+    client._session._refresh_retry_delay = 0
 
     # Track whether refresh_auth ran. We wrap the bound method so the
     # mutation is observable from outside the test. Using ``list[object]``
@@ -131,7 +131,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
 
     # The refresh callback is captured by Session at construction;
     # patch it on the core so the wrapper is what the retry loop sees.
-    client._core._refresh_callback = tracking_refresh
+    client._session._refresh_callback = tracking_refresh
 
     with notebooklm_vcr.use_cassette(CASSETTE_NAME) as cassette:
         async with client:
@@ -141,8 +141,8 @@ async def test_stale_csrf_triggers_refresh_and_retry(
             # The ``update_auth_headers`` call is what actually plumbs the
             # new value into the live ``httpx.AsyncClient``'s default
             # header set.
-            client._core.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
-            client._core.update_auth_headers()
+            client._session.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
+            client._session.update_auth_headers()
 
             # This call's first attempt MUST 400; the rpc_call layer
             # then awaits refresh_auth (interaction 2 in the cassette)
@@ -154,7 +154,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
             # the corrupted value. Asserting the change makes this
             # test fail loudly if a future refactor accidentally
             # short-circuits the retry to "return the 400 unchanged".
-            assert client._core.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
+            assert client._session.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
                 "csrf_token should have been refreshed mid-call"
             )
 

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -28,13 +28,13 @@ class TestAutoRefreshIntegration:
 
         client = NotebookLMClient(auth)
         # Bound methods aren't identical, so compare underlying function
-        assert client._core._refresh_callback is not None
-        assert client._core._refresh_callback.__func__ is NotebookLMClient.refresh_auth
+        assert client._session._refresh_callback is not None
+        assert client._session._refresh_callback.__func__ is NotebookLMClient.refresh_auth
         # ``_refresh_lock`` is lazily created on first ``_await_refresh``.
         # At construction time it is ``None`` so the client can be
         # instantiated outside a running loop; the helper allocates the
         # lock on demand inside the async refresh path.
-        assert client._core._refresh_lock is None
+        assert client._session._refresh_lock is None
 
     @pytest.mark.asyncio
     async def test_full_refresh_flow_http_error(self):
@@ -47,7 +47,7 @@ class TestAutoRefreshIntegration:
 
         client = NotebookLMClient(auth)
         # Override retry delay for faster tests
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         # Track refresh calls
         refresh_calls = []
@@ -55,11 +55,11 @@ class TestAutoRefreshIntegration:
         async def tracking_refresh():
             refresh_calls.append(True)
             # Simulate successful refresh
-            client._core.auth.csrf_token = "new_csrf"
-            client._core.update_auth_headers()
-            return client._core.auth
+            client._session.auth.csrf_token = "new_csrf"
+            client._session.update_auth_headers()
+            return client._session.auth
 
-        client._core._refresh_callback = tracking_refresh
+        client._session._refresh_callback = tracking_refresh
 
         # Mock HTTP responses
         call_count = [0]
@@ -78,7 +78,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             with patch("notebooklm.rpc.decode_response") as mock_decode:
                 mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
@@ -97,17 +97,17 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         refresh_calls = []
 
         async def tracking_refresh():
             refresh_calls.append(True)
-            client._core.auth.csrf_token = "new_csrf"
-            client._core.update_auth_headers()
-            return client._core.auth
+            client._session.auth.csrf_token = "new_csrf"
+            client._session.update_auth_headers()
+            return client._session.auth
 
-        client._core._refresh_callback = tracking_refresh
+        client._session._refresh_callback = tracking_refresh
 
         # Mock HTTP to succeed, but decode_response to fail with auth error first
         async def mock_post(*args, **kwargs):
@@ -125,7 +125,7 @@ class TestAutoRefreshIntegration:
             return [[["nb1"], ["Notebook 1"]]]
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
                 await client.notebooks.list()
@@ -143,12 +143,12 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._core._refresh_retry_delay = 0.1  # 100ms delay
+        client._session._refresh_retry_delay = 0.1  # 100ms delay
 
         async def mock_refresh():
             return auth
 
-        client._core._refresh_callback = mock_refresh
+        client._session._refresh_callback = mock_refresh
 
         call_count = [0]
 
@@ -164,7 +164,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             start_time = asyncio.get_event_loop().time()
 
@@ -186,13 +186,13 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         async def failing_refresh():
             # Simulates refresh_auth detecting redirect to login
             raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
 
-        client._core._refresh_callback = failing_refresh
+        client._session._refresh_callback = failing_refresh
 
         async def mock_post(*args, **kwargs):
             request = httpx.Request("POST", args[0])
@@ -200,7 +200,7 @@ class TestAutoRefreshIntegration:
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             # Should raise the original HTTP error with refresh failure as cause
             with pytest.raises(httpx.HTTPStatusError) as exc_info:

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -123,7 +123,7 @@ class TestErrorPaths:
         # has ONE interaction; with the default retry budget the client would
         # ask for a second cassette response that doesn't exist and VCR would
         # raise ``CannotOverwriteExistingCassetteException``.
-        client._core._rate_limit_max_retries = 0
+        client._session._rate_limit_max_retries = 0
 
         with notebooklm_vcr.use_cassette("error_synthetic_429_rate_limit.yaml") as cassette:
             async with client:
@@ -163,7 +163,7 @@ class TestErrorPaths:
         # is exercised separately by the unit tests in
         # ``test_rate_limit_retry.py`` — here we focus on the terminal
         # exception-mapping branch.
-        client._core._server_error_max_retries = 0
+        client._session._server_error_max_retries = 0
 
         with notebooklm_vcr.use_cassette("error_synthetic_500_server.yaml") as cassette:
             async with client:
@@ -202,7 +202,7 @@ class TestErrorPaths:
         client = NotebookLMClient(_synthetic_auth())
         # Eliminate the post-refresh retry delay so the test runs fast under
         # replay (mirrors ``test_auth_refresh_vcr.py``).
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         # In-process refresh callback that issues NO HTTP traffic. This is
         # what lets the cassette capture only the TWO synthetic batchexecute
@@ -221,11 +221,11 @@ class TestErrorPaths:
             # request-side body would carry the refreshed value if VCR
             # matched on body (it doesn't; the default matcher uses
             # method/path/rpcids).
-            client._core.auth.csrf_token = "refreshed_csrf_token"
-            client._core.update_auth_headers()
-            return client._core.auth
+            client._session.auth.csrf_token = "refreshed_csrf_token"
+            client._session.update_auth_headers()
+            return client._session.auth
 
-        client._core._refresh_callback = stub_refresh
+        client._session._refresh_callback = stub_refresh
 
         with notebooklm_vcr.use_cassette("error_synthetic_stale_csrf.yaml") as cassette:
             async with client:

--- a/tests/integration/test_notes_idempotency.py
+++ b/tests/integration/test_notes_idempotency.py
@@ -68,7 +68,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -169,7 +169,7 @@ async def test_create_note_plain_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.notes.create(notebook_id, title="My Note", content="hello")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert create_count == 1, (
         f"expected exactly 1 CREATE_NOTE (NON_IDEMPOTENT_NO_RETRY), got {create_count}"
@@ -221,7 +221,7 @@ async def test_create_note_saved_from_chat_no_inner_retry_on_5xx(auth_tokens) ->
         with pytest.raises(ServerError):
             await client.notes.create_from_chat(notebook_id, ask_result, title="Chat note")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert create_count == 1, (
         f"expected exactly 1 CREATE_NOTE (saved_from_chat variant, "
@@ -266,7 +266,7 @@ async def test_create_note_happy_path_one_post(auth_tokens) -> None:
     try:
         note = await client.notes.create(notebook_id, title="Happy", content="body")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert note.id == "note_xyz"
     assert create_count == 1

--- a/tests/integration/test_research_idempotency.py
+++ b/tests/integration/test_research_idempotency.py
@@ -69,7 +69,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -160,7 +160,7 @@ async def test_start_fast_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.start(notebook_id, "what is quantum computing?")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # NON_IDEMPOTENT_NO_RETRY forces effective_disable_internal_retries=True
     # so the inner retry loop does not fire — exactly ONE POST.
@@ -192,7 +192,7 @@ async def test_start_deep_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.start(notebook_id, "deep dive query", mode="deep")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert request_count == 1, (
         f"expected exactly 1 START_DEEP_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
@@ -228,7 +228,7 @@ async def test_import_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.import_sources(notebook_id, task_id, sources)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert request_count == 1, (
         f"expected exactly 1 IMPORT_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
@@ -268,7 +268,7 @@ async def test_start_fast_research_happy_path_one_post(auth_tokens) -> None:
     try:
         result = await client.research.start(notebook_id, "test query")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert result is not None
     assert result["task_id"] == "task_xyz"

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -34,14 +34,14 @@ class TestClientInitialization:
     @pytest.mark.asyncio
     async def test_client_initialization(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            assert client._core.auth == auth_tokens
-            assert client._core._http_client is not None
+            assert client._session.auth == auth_tokens
+            assert client._session._http_client is not None
 
     @pytest.mark.asyncio
     async def test_client_context_manager_closes(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            assert client._core._http_client is not None  # client is open
-        assert client._core._http_client is None  # closed after exit
+            assert client._session._http_client is not None  # client is open
+        assert client._session._http_client is None  # closed after exit
 
     @pytest.mark.asyncio
     async def test_close_does_not_sync_in_memory_auth_to_default_storage(self):
@@ -151,7 +151,7 @@ class TestRPCCallHTTPErrors:
         # covered by ``tests/integration/concurrency/test_rate_limit_default.py``;
         # this test documents the explicit-disable contract.
         async with NotebookLMClient(auth_tokens, rate_limit_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 429
@@ -169,7 +169,7 @@ class TestRPCCallHTTPErrors:
         # See ``test_rate_limit_429_with_retry_after_header`` for why this
         # pins ``rate_limit_max_retries=0``.
         async with NotebookLMClient(auth_tokens, rate_limit_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 429
@@ -187,7 +187,7 @@ class TestRPCCallHTTPErrors:
         # See ``test_rate_limit_429_with_retry_after_header`` for why this
         # pins ``rate_limit_max_retries=0``.
         async with NotebookLMClient(auth_tokens, rate_limit_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 429
@@ -208,7 +208,7 @@ class TestRPCCallHTTPErrors:
         # in to auto-refresh), clear the refresh callback so is_auth_error's
         # gate in rpc_call short-circuits and the status mapping runs.
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             core._refresh_callback = None
 
             mock_response = MagicMock()
@@ -225,7 +225,7 @@ class TestRPCCallHTTPErrors:
         # Pin ``server_error_max_retries=0`` to exercise the raise-immediately
         # mapping path. Retry/backoff behavior is covered in core transport tests.
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 500
@@ -241,7 +241,7 @@ class TestRPCCallHTTPErrors:
         # Network errors flow through the same retry loop as 5xx responses;
         # pin to 0 so these mapping tests don't pay backoff sleeps.
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.ConnectTimeout("connect timeout"))
             with pytest.raises(NetworkError):
@@ -250,7 +250,7 @@ class TestRPCCallHTTPErrors:
     @pytest.mark.asyncio
     async def test_read_timeout_raises_rpc_timeout_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.ReadTimeout("read timeout"))
             with pytest.raises(RPCTimeoutError):
@@ -259,7 +259,7 @@ class TestRPCCallHTTPErrors:
     @pytest.mark.asyncio
     async def test_connect_error_raises_network_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.ConnectError("connection refused"))
             with pytest.raises(NetworkError):
@@ -268,7 +268,7 @@ class TestRPCCallHTTPErrors:
     @pytest.mark.asyncio
     async def test_generic_request_error_raises_network_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.RequestError("something went wrong"))
             with pytest.raises(NetworkError):
@@ -281,7 +281,7 @@ class TestRPCCallAuthRetry:
     @pytest.mark.asyncio
     async def test_auth_retry_on_decode_rpc_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
 
             refresh_callback = AsyncMock()
             core._refresh_callback = refresh_callback
@@ -319,7 +319,7 @@ class TestGetHttpClient:
     @pytest.mark.asyncio
     async def test_get_http_client_returns_client_when_initialized(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            http_client = client._core.get_http_client()
+            http_client = client._session.get_http_client()
             assert isinstance(http_client, httpx.AsyncClient)
 
 
@@ -329,7 +329,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_source_ids_from_nested_data(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             mock_notebook_data = [
@@ -352,7 +352,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_data_is_none(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=None):
@@ -363,7 +363,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_data_is_empty_list(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=[]):
@@ -374,7 +374,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_sources_list_is_empty(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             # Notebook with no sources
@@ -390,7 +390,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_data_is_not_list(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             with patch.object(
@@ -403,7 +403,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_notebook_info_missing_sources(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             # notebook_data[0] exists but notebook_info[1] is missing
@@ -424,7 +424,7 @@ class TestCrossDomainCookiePreservation:
     async def test_cookies_preserved_on_cross_domain_redirect(self, auth_tokens):
         """Verify cookies persist when redirecting from notebooklm to accounts.google.com."""
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http_client = core._http_client
 
             # Set initial sentinel cookie in the jar
@@ -445,7 +445,7 @@ class TestCrossDomainCookiePreservation:
     async def test_update_auth_headers_merges_not_replaces(self, auth_tokens):
         """Verify update_auth_headers merges new cookies, preserving live redirect cookies."""
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http_client = core._http_client
 
             # Simulate a live cookie received from accounts.google.com redirect
@@ -471,7 +471,7 @@ class TestCrossDomainCookiePreservation:
         auth_tokens.cookie_jar.set("SID", "test_sid", domain=".google.com")
 
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http = core._http_client
 
             # The .googleusercontent.com cookie must remain on its original domain
@@ -483,7 +483,7 @@ class TestCrossDomainCookiePreservation:
     async def test_update_auth_headers_preserves_redirect_cookies(self, auth_tokens):
         """update_auth_headers must merge, not replace, preserving redirect cookies."""
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http = core._http_client
 
             # Simulate Google setting a cookie during a redirect

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -77,7 +77,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -173,7 +173,7 @@ async def test_delete_notebook_retries_remain_enabled(
             f"(initial + 2 retries), got {request_count}"
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 async def test_delete_source_retries_remain_enabled(
@@ -204,7 +204,7 @@ async def test_delete_source_retries_remain_enabled(
             await client.sources.delete("nb_x", "src_x")
         assert request_count == 3, f"expected 3 POSTs, got {request_count}"
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 async def test_delete_artifact_retries_remain_enabled(
@@ -235,7 +235,7 @@ async def test_delete_artifact_retries_remain_enabled(
             await client.artifacts.delete("nb_x", "art_x")
         assert request_count == 3, f"expected 3 POSTs, got {request_count}"
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 # ===========================================================================
@@ -277,7 +277,7 @@ async def test_refresh_source_emits_rate_limited_warn(
                 ok = await client.sources.refresh("nb_x", "src_x")
                 assert ok is True
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     warn_records = [
         r
@@ -339,7 +339,7 @@ async def test_share_notebook_does_not_retry_on_5xx(
             f"(no blind retry), got {share_count}"
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 # ===========================================================================
@@ -404,7 +404,7 @@ async def test_notebooks_create_probe_propagates_network_error(
         with pytest.raises(NetworkError):
             await client.notebooks.create("Some Title")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Sanity check: the probe was actually attempted and the create fired
     # once before the probe failed. LIST_NOTEBOOKS is UNCLASSIFIED so the
@@ -476,7 +476,7 @@ async def test_notebooks_create_probe_swallows_non_network_exception(
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert notebook.id == nb_id_after_retry
     assert create_call_count == 2, (

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -111,7 +111,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -168,7 +168,7 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -220,7 +220,7 @@ async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_toke
     try:
         source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert file_id in (source.url or "")
@@ -263,7 +263,7 @@ async def test_add_drive_probe_matches_segment_at_end_of_url(auth_tokens) -> Non
     try:
         source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
@@ -332,7 +332,7 @@ async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
         with pytest.raises(ServerError):
             await client.sources.add_drive(notebook_id, target_file_id, title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # The probe must NOT have spuriously matched the unrelated Drive
     # source — instead the wrapper retried, exhausted, and re-raised.
@@ -414,7 +414,7 @@ async def test_register_file_source_probe_short_circuits_when_first_response_los
         ):
             source = await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     # Exactly ONE ADD_SOURCE_FILE register request (no naive re-POST)
@@ -493,7 +493,7 @@ async def test_register_file_source_does_not_match_pre_existing_filename(
         ):
             await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # The pre-existing source's id was never returned — instead, the
     # original transport error propagated after retries were exhausted.
@@ -570,7 +570,7 @@ async def test_register_file_source_baseline_unavailable_raises_on_ambiguity(
         ):
             await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Pre-existing source's id was NOT silently returned — instead the
     # baseline-unavailable ambiguity guard fired.
@@ -632,7 +632,7 @@ async def test_add_text_no_probe_no_retry_under_5xx(
         with pytest.raises(NotebookLMError):
             await client.sources.add_text(notebook_id, title, content)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Exactly ONE ADD_SOURCE attempt: no retry loop, no probe.
     assert add_count == 1, (
@@ -686,7 +686,7 @@ async def test_add_url_probe_network_error_propagates(auth_tokens) -> None:
         with pytest.raises(NetworkError, match="probe synthetic connection error"):
             await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Probe was attempted (the original create failed with 502, then the
     # probe was issued and raised).

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -213,10 +213,10 @@ class TestGetSource:
         )
 
         async with NotebookLMClient(auth_tokens) as client:
-            client._core.rpc_call = first_rpc
+            client._session.rpc_call = first_rpc
             assert await client.sources.list("nb_123") == []
 
-            client._core.rpc_call = second_rpc
+            client._session.rpc_call = second_rpc
             sources = await client.sources.list("nb_123")
 
         first_rpc.assert_awaited_once()

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -26,7 +26,7 @@ a different cancel-injection site:
 - ``__aexit__`` driven through :func:`asyncio.wait_for(timeout=0.1)` so
   the outer cancel reliably arrives while the slowed ``aclose`` is in
   flight — i.e. inside the shielded await.
-- We hold a reference to ``client._core._http_client`` captured before
+- We hold a reference to ``client._session._http_client`` captured before
   the cancel (close nulls the attribute on success) and assert
   ``http_client_ref.is_closed`` is true afterwards — proof that the
   shielded ``aclose`` in the outer ``finally`` ran to completion.
@@ -157,7 +157,7 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
         # Save the transport ref BEFORE the cancel — successful close
         # sets ``_core._http_client = None`` (inner finally), so we'd
         # have no handle otherwise.
-        http_client_ref = client._core._http_client
+        http_client_ref = client._session._http_client
         assert http_client_ref is not None, "open() must have installed a transport"
 
         # Slow down ``aclose()`` so the outer ``wait_for(timeout=0.1)``

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -53,8 +53,8 @@ class TestConfigureChat:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
-        client._core.rpc_call = AsyncMock(return_value=None)
+        client._session._http_client = MagicMock()
+        client._session.rpc_call = AsyncMock(return_value=None)
         return client
 
     @pytest.mark.asyncio
@@ -62,8 +62,8 @@ class TestConfigureChat:
         """Test configure_chat with default settings."""
         await mock_client.chat.configure("notebook_123")
 
-        mock_client._core.rpc_call.assert_called_once()
-        call_args = mock_client._core.rpc_call.call_args
+        mock_client._session.rpc_call.assert_called_once()
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify payload structure
@@ -79,7 +79,7 @@ class TestConfigureChat:
             custom_prompt="Be an expert analyst",
         )
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify custom prompt is included
@@ -105,7 +105,7 @@ class TestConfigureChat:
             response_length=ChatResponseLength.LONGER,
         )
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         assert params[1][0][7] == [[3], [4]]  # Learning guide, longer
@@ -123,7 +123,7 @@ class TestGetSourceGuide:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
+        client._session._http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -140,7 +140,7 @@ class TestGetSourceGuide:
                 ]
             ]
         ]
-        mock_client._core.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
@@ -150,7 +150,7 @@ class TestGetSourceGuide:
     @pytest.mark.asyncio
     async def test_get_source_guide_handles_empty(self, mock_client):
         """Test get_source_guide handles empty response."""
-        mock_client._core.rpc_call = AsyncMock(return_value=None)
+        mock_client._session.rpc_call = AsyncMock(return_value=None)
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
@@ -170,7 +170,7 @@ class TestGetSuggestedReportFormats:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
+        client._session._http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -183,8 +183,8 @@ class TestGetSuggestedReportFormats:
                 ["Summary Brief", "Quick overview...", None, None, "Summarize the...", 1],
             ]
         ]
-        mock_client._core.rpc_call = AsyncMock(return_value=mock_response)
-        mock_client._core.get_notebook = AsyncMock(return_value=[[None, []]])
+        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session.get_notebook = AsyncMock(return_value=[[None, []]])
         mock_client.notebooks.get = AsyncMock(return_value=MagicMock(sources=[]))
 
         result = await mock_client.artifacts.suggest_reports("notebook_123")
@@ -207,8 +207,8 @@ class TestAddSourceDrive:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
-        client._core.rpc_call = AsyncMock(return_value=[["source_id_123"]])
+        client._session._http_client = MagicMock()
+        client._session.rpc_call = AsyncMock(return_value=[["source_id_123"]])
         return client
 
     @pytest.mark.asyncio
@@ -221,7 +221,7 @@ class TestAddSourceDrive:
             mime_type=DriveMimeType.GOOGLE_DOC.value,
         )
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify source data structure - params[0] is [source_data] (single wrap)
@@ -247,7 +247,7 @@ class TestGetNotebookDescription:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
+        client._session._http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -264,7 +264,7 @@ class TestGetNotebookDescription:
                 ],
             ]
         ]
-        mock_client._core.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
 
         result = await mock_client.notebooks.get_description("notebook_123")
 
@@ -286,8 +286,8 @@ class TestPayloadFixes:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
-        client._core.rpc_call = AsyncMock(return_value=True)
+        client._session._http_client = MagicMock()
+        client._session.rpc_call = AsyncMock(return_value=True)
         return client
 
     @pytest.mark.asyncio
@@ -295,7 +295,7 @@ class TestPayloadFixes:
         """Test check_source_freshness uses correct payload structure."""
         await mock_client.sources.check_freshness("notebook_123", "source_456")
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify reference payload: [null, ["source_id"], [2]]
@@ -308,7 +308,7 @@ class TestPayloadFixes:
         """Test refresh_source uses correct payload structure."""
         await mock_client.sources.refresh("notebook_123", "source_456")
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify reference payload: [null, ["source_id"], [2]]

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -575,7 +575,7 @@ class TestSnapshotRefreshedAfterSave:
         client = NotebookLMClient(auth)
         async with client:
             # First save: rotates *PSIDTS in-process to A1, then save propagates.
-            _set_cookie_value(client._core._http_client.cookies, "__Secure-1PSIDTS", "A1")
+            _set_cookie_value(client._session._http_client.cookies, "__Secure-1PSIDTS", "A1")
             await client.refresh_auth()
             assert _cookie_value(storage, "__Secure-1PSIDTS", ".google.com") == "A1"
 
@@ -1153,10 +1153,10 @@ class TestBaselineNotAdvancedOnSaveFailure:
         client = NotebookLMClient(auth, cookie_saver=silent_fail)
 
         async with client:
-            baseline_before = client._core._loaded_cookie_snapshot
-            assert client._core._http_client is not None
-            await client._core.save_cookies(client._core._http_client.cookies)
-            baseline_after = client._core._loaded_cookie_snapshot
+            baseline_before = client._session._loaded_cookie_snapshot
+            assert client._session._http_client is not None
+            await client._session.save_cookies(client._session._http_client.cookies)
+            baseline_after = client._session._loaded_cookie_snapshot
 
         assert baseline_after is baseline_before, (
             "save_cookies must NOT advance _loaded_cookie_snapshot when the "

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -85,7 +85,7 @@ async def test_empty_chain_routes_perform_authed_post_to_transport() -> None:
     Covers the first of the two call paths from master plan line 160:
     direct callers of ``Session._perform_authed_post`` (the chat path
     in ``_chat_transport.py:64`` and any first-party caller via
-    ``client._core._perform_authed_post``).
+    ``client._session._perform_authed_post``).
     """
     expected_response = httpx.Response(status_code=200, content=b"chain-routed")
     fake = FakeAuthedPost(response=expected_response)

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1821,7 +1821,7 @@ class TestGetConversationIdNullRaw:
         async with NotebookLMClient(auth_tokens) as client:
             # Patch rpc_call to return None directly (bypasses decode error)
             with patch.object(
-                client._core,
+                client._session,
                 "rpc_call",
                 new_callable=AsyncMock,
                 return_value=None,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -226,10 +226,10 @@ class TestRefreshAuth:
 
         async def fake_update(csrf: str, session_id: str) -> None:
             calls.append((csrf, session_id))
-            client._core.auth.csrf_token = csrf
-            client._core.auth.session_id = session_id
+            client._session.auth.csrf_token = csrf
+            client._session.auth.session_id = session_id
 
-        monkeypatch.setattr(client._core, "update_auth_tokens", fake_update)
+        monkeypatch.setattr(client._session, "update_auth_tokens", fake_update)
 
         async with client:
             refreshed_auth = await client.refresh_auth()
@@ -237,9 +237,9 @@ class TestRefreshAuth:
         assert calls == [("new_csrf_token_123", "new_session_id_456")]
         assert refreshed_auth.csrf_token == "new_csrf_token_123"
         assert refreshed_auth.session_id == "new_session_id_456"
-        assert client._core.auth is refreshed_auth
-        assert client._core.auth.csrf_token == "new_csrf_token_123"
-        assert client._core.auth.session_id == "new_session_id_456"
+        assert client._session.auth is refreshed_auth
+        assert client._session.auth.csrf_token == "new_csrf_token_123"
+        assert client._session.auth.session_id == "new_session_id_456"
 
     @pytest.mark.asyncio
     async def test_refresh_auth_routes_to_account_email(self, httpx_mock: HTTPXMock):

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -80,7 +80,7 @@ class TestKeepaliveDisabledByDefault:
         """No keepalive task is spawned and no extra HTTP calls fire by default."""
         client = NotebookLMClient(mock_auth)
         async with client:
-            assert client._core._keepalive_task is None
+            assert client._session._keepalive_task is None
             # Give the loop a chance to run; nothing should happen
             await asyncio.sleep(0.1)
 
@@ -108,12 +108,12 @@ class TestKeepaliveLifecycle:
         )
 
         async with client:
-            task = client._core._keepalive_task
+            task = client._session._keepalive_task
             assert task is not None
             assert not task.done()
 
         # Task should be cleaned up; no warnings should be raised.
-        assert client._core._keepalive_task is None
+        assert client._session._keepalive_task is None
         # Either cancelled or finished; never left dangling.
         assert task.done()
 
@@ -127,7 +127,7 @@ class TestKeepaliveFloor:
             keepalive=10.0,
             keepalive_min_interval=60.0,
         )
-        assert client._core._keepalive_interval == 60.0
+        assert client._session._keepalive_interval == 60.0
 
     @pytest.mark.asyncio
     async def test_floor_does_not_lower_higher_interval(self, mock_auth):
@@ -137,7 +137,7 @@ class TestKeepaliveFloor:
             keepalive=600.0,
             keepalive_min_interval=60.0,
         )
-        assert client._core._keepalive_interval == 600.0
+        assert client._session._keepalive_interval == 600.0
 
     @pytest.mark.asyncio
     async def test_none_keeps_disabled(self, mock_auth):
@@ -147,7 +147,7 @@ class TestKeepaliveFloor:
             keepalive=None,
             keepalive_min_interval=60.0,
         )
-        assert client._core._keepalive_interval is None
+        assert client._session._keepalive_interval is None
 
 
 class TestKeepaliveValidation:
@@ -234,8 +234,8 @@ class TestKeepalivePokes:
         async with client:
             await asyncio.sleep(0.4)
             # Task is still running after the failure
-            assert client._core._keepalive_task is not None
-            assert not client._core._keepalive_task.done()
+            assert client._session._keepalive_task is not None
+            assert not client._session._keepalive_task.done()
 
         poke_requests = [r for r in httpx_mock.get_requests() if "RotateCookies" in str(r.url)]
         # First call raised; at least one further successful call must follow.
@@ -351,7 +351,7 @@ class TestKeepaliveExplicitStoragePath:
     def test_explicit_storage_path_normalizes_onto_auth_without_mutating_caller(self, tmp_path):
         """The constructor exposes ``storage_path`` on ``client.auth`` so
         ``refresh_auth()`` and ``Session.close()`` (which read
-        ``self._core.auth.storage_path`` directly, not the keepalive-specific
+        ``self._session.auth.storage_path`` directly, not the keepalive-specific
         path) persist to the same file. Crucially, the caller's original
         ``AuthTokens`` is *not* mutated, so reusing one ``AuthTokens`` across
         multiple ``NotebookLMClient`` instances with different storage paths
@@ -558,7 +558,7 @@ class TestSaveCookiesUnification:
             must route through the snapshot/delta path, never the legacy
             full-merge path.
             """
-            save_calls.append(client_ref["client"]._core._save_lock.locked())
+            save_calls.append(client_ref["client"]._session._save_lock.locked())
             snapshot_kwarg_present.append("original_snapshot" in kwargs)
             return True
 

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -388,7 +388,7 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
         from notebooklm.client import NotebookLMClient
 
         client = NotebookLMClient.__new__(NotebookLMClient)
-        client._core = core
+        client._session = core
 
         # try/finally ensures the mock-transport handlers are unblocked even
         # if a wait_for times out — otherwise pending tasks dangle in the

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -251,8 +251,8 @@ async def test_close_with_drain_closes_transport_after_timeout(auth_tokens: Auth
     async def close_transport() -> None:
         calls.append("close")
 
-    client._core.drain = drain_timeout  # type: ignore[method-assign]
-    client._core.close = close_transport  # type: ignore[method-assign]
+    client._session.drain = drain_timeout  # type: ignore[method-assign]
+    client._session.close = close_transport  # type: ignore[method-assign]
 
     with pytest.raises(TimeoutError, match="deadline"):
         await client.close(drain=True, drain_timeout=0.1)
@@ -272,8 +272,8 @@ async def test_close_with_invalid_drain_does_not_close_transport(auth_tokens: Au
     async def close_transport() -> None:
         calls.append("close")
 
-    client._core.drain = invalid_drain  # type: ignore[method-assign]
-    client._core.close = close_transport  # type: ignore[method-assign]
+    client._session.drain = invalid_drain  # type: ignore[method-assign]
+    client._session.close = close_transport  # type: ignore[method-assign]
 
     with pytest.raises(ValueError, match="bad deadline"):
         await client.close(drain=True, drain_timeout=-1.0)

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1001,7 +1001,7 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
             session_id="session",
         )
     )
-    client._core.rpc_call = AsyncMock(return_value={"ok": True})
+    client._session.rpc_call = AsyncMock(return_value={"ok": True})
 
     # This test intentionally exercises the deprecated kwargs to pin the
     # forwarded keyword-for-keyword shape. Wrapping in pytest.warns keeps
@@ -1019,7 +1019,7 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
         )
 
     assert result == {"ok": True}
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=RPCMethod.CREATE_NOTEBOOK,
         params=["My Notebook"],
         source_path="/notebook/abc",
@@ -1046,12 +1046,12 @@ async def test_client_rpc_call_forwards_default_arguments() -> None:
     )
     # No async context is needed: this test replaces the core RPC coroutine
     # before any real transport initialization can be required.
-    client._core.rpc_call = AsyncMock(return_value=[])
+    client._session.rpc_call = AsyncMock(return_value=[])
 
     result = await client.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     assert result == []
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=RPCMethod.LIST_NOTEBOOKS,
         params=[],
         source_path="/",

--- a/tests/unit/test_rpc_call_public_surface.py
+++ b/tests/unit/test_rpc_call_public_surface.py
@@ -46,7 +46,7 @@ _EXPECTED_OPERATION_VARIANT_MSG = "rpc_call(operation_variant=...) is deprecated
 def _make_client() -> NotebookLMClient:
     """Build a NotebookLMClient with the core RPC patched to an AsyncMock.
 
-    No real transport is initialized; ``client._core.rpc_call`` is
+    No real transport is initialized; ``client._session.rpc_call`` is
     replaced before any authed HTTP path can fire.
     """
     client = NotebookLMClient(
@@ -56,7 +56,7 @@ def _make_client() -> NotebookLMClient:
             session_id="session",
         )
     )
-    client._core.rpc_call = AsyncMock(return_value=[])
+    client._session.rpc_call = AsyncMock(return_value=[])
     return client
 
 
@@ -74,7 +74,7 @@ async def test_default_call_emits_no_deprecation_warning() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         await client.rpc_call(_METHOD, [])
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -97,7 +97,7 @@ async def test_explicit_source_path_root_emits_no_warning() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         await client.rpc_call(_METHOD, [], source_path="/")
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -118,7 +118,7 @@ async def test_non_root_source_path_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_SOURCE_PATH_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/notebook/x",
@@ -145,7 +145,7 @@ async def test_is_retry_explicit_false_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_IS_RETRY_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -166,7 +166,7 @@ async def test_is_retry_explicit_true_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_IS_RETRY_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -187,7 +187,7 @@ async def test_operation_variant_explicit_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_OPERATION_VARIANT_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -174,8 +174,8 @@ async def test_client_close_default_drain_is_true() -> None:
     async def fake_close() -> None:
         pass
 
-    client._core.drain = fake_drain  # type: ignore[method-assign]
-    client._core.close = fake_close  # type: ignore[method-assign]
+    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session.close = fake_close  # type: ignore[method-assign]
 
     await client.close()
 
@@ -196,8 +196,8 @@ async def test_client_close_drain_false_skips_drain() -> None:
     async def fake_close() -> None:
         pass
 
-    client._core.drain = fake_drain  # type: ignore[method-assign]
-    client._core.close = fake_close  # type: ignore[method-assign]
+    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session.close = fake_close  # type: ignore[method-assign]
 
     await client.close(drain=False)
 
@@ -216,8 +216,8 @@ async def test_client_aexit_uses_drain_true_default() -> None:
     async def fake_close() -> None:
         pass
 
-    client._core.drain = fake_drain  # type: ignore[method-assign]
-    client._core.close = fake_close  # type: ignore[method-assign]
+    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session.close = fake_close  # type: ignore[method-assign]
 
     # Drive __aexit__ directly rather than `async with` so we can use the
     # patched core without going through ``open()``.


### PR DESCRIPTION
## Summary

Phase 2 Wave 3 of the v0.5.0 refactor program. Stacked on Wave 2 (`cleanup/a-b-2-3-combined-test-migration`; PR TBD).

Implements PR 6 of [`.sisyphus/plans/refactor-completion-plan.md`](.sisyphus/plans/refactor-completion-plan.md):

- Rename `self._core` → `self._session` in `client.py` (17 sites).
- Rename `client._core` → `client._session` in 29 active test files (~210 hits).
- Delete the `self._core = self._session` alias at `client.py:294`.
- Scrub the now-stale comment blocks at `client.py:292-293` (alias rationale) and `client.py:322-329` (the "we pass `_session` rather than the `_core` alias because…" paragraph that became self-contradictory once the alias was gone).
- Fix 2 doc references in `_session.py` (`:367`, `:1453`) that mentioned `client._core` in narrative prose.
- Fix 1 stale docstring in `tests/unit/test_client_keepalive.py:354` referencing `self._core.auth.storage_path`.

Variants that the broad sed missed (variable names with suffixes/wrappers) were caught by pytest and fixed: `client_rel`/`client_abs`/`client_tilde`/`client_expanded`/`client_link`/`client_target._core` in `test_keepalive_path_canonicalize.py`, and `client_ref["client"]._core` in `test_client_keepalive.py`.

## Out of scope (intentionally preserved)

- `src/notebooklm/_core.py` and the `notebooklm._core.X` module-level re-export shim — Phase 4 PR 10 (Demolition) deletes them.
- Session property bridges — Phase 4 PR 10 deletes them.
- `tests/_lint/test_no_forbidden_monkeypatches.py` lines 28, 33, 104, 174 — 4 intentional docstring examples that pin the lint rule's pattern detection (excluded from sed via `grep -v '/_lint/'`).
- `tests/_fixtures/fake_core.py` — `FakeSession` fixture stays.
- Late-bound `_default_cookie_saver` / `_default_cookie_rotator` in `_session_lifecycle.py` — refer to the `notebooklm._core` MODULE, not the client attribute.
- `NotesAPI._core` and `ChatAPI._core` attributes — separate sub-client classes with their own unrelated `_core` slot.

## Definition of Done (Phase 2 plan)

- [x] `rg 'client\._core\b' src/notebooklm tests/ --type py | grep -v '^src/notebooklm/_core\.py:' | grep -v '^tests/_lint/'` returns 0.
- [x] `rg 'self\._core\b' src/notebooklm/client.py` returns 0.
- [x] `client._core` attribute is GONE from `NotebookLMClient.__init__`.
- [x] `_core.py` shim still exists (deletion is Phase 4 PR 10).
- [x] Session property bridges still exist (deletion is Phase 4 PR 10).

## Test plan

- [x] `uv run ruff format src/notebooklm/client.py src/notebooklm/_session.py` — clean.
- [x] `uv run ruff check src/notebooklm/ tests/` — clean.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 source files).
- [x] `uv run pytest -x` — 5536 passed, 51 skipped (no regressions).

## Stacking

Stacked on Wave 2 (`cleanup/a-b-2-3-combined-test-migration`, PR TBD).
Base branch contains Wave 2 commits `adae56f` (commit A) and `ba9fad4` (commit B).
When Wave 2's PR merges, GitHub will auto-rebase this PR's base to `main`.

## Deferred polish findings

- **Suggestion**: `docs/refactor.md` lines 586-590, 779-783, and 817 contain stale statements about `NotebookLMClient._core` being "not deleted" / "may remain". These become factually inaccurate after this PR merges. Per established convention in recent refactor PRs (#858-#878 also diverged from `docs/refactor.md` without updating it), the stale doc statements are reconciled in the post-refactor cleanup arc rather than in per-PR edits. The authoritative source-of-truth is the `.sisyphus/plans/refactor-completion-plan.md` and `.sisyphus/phases/refactor-completion-plan/phase-2.md` plan documents.

## Polish receipts

- Stage 1 (code-simplifier): 0 findings — mechanical rename; net -11 lines from comment scrubs already improves simplicity.
- Stage 2 (triple review claude+codex+agy): 0 critical, 0 important, 1 suggestion (above), 7 nits (positive verifications). Consensus APPROVE.
- Stage 3 (ultrathink): APPROVE, no concerns. Verified edge cases (external `_core` callers break per intended Phase 2 contract; init ordering preserved; rebase safety against Wave 2 commit B confirmed; doc-lint regex doesn't match narrative prose so `docs/refactor.md` staleness is non-blocking).

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>