### PR TITLE
refactor(tests): migrate _core monkeypatches to canonical seams + rename client._core (Phase 2 Waves 2-3 combined)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -1189,14 +1189,18 @@ class Session:
 
         The adapters intentionally resolve through this module at call time so
         existing tests and private callers that monkeypatch
-        ``notebooklm._core.is_auth_error`` or ``notebooklm._core.asyncio.sleep``
+        ``notebooklm._core.is_auth_error`` (Wave 3 will rename this seam) or
+        ``notebooklm._session.asyncio.sleep`` (Phase 2 PR 5 canonical target —
+        previously the deprecated ``notebooklm._core.asyncio.sleep`` shim)
         still affect live transport behavior after the collaborator has been
         constructed. Backoff jitter routes through ``notebooklm._backoff``,
         which in turn calls ``random.uniform`` on the shared module.
         ``tests/unit/test_authed_transport.py`` relies on monkeypatching
-        ``notebooklm._core.random.uniform`` to reach that jitter path; keep the
-        otherwise-unused module import so the path stays available. Attribute
-        patches on the singleton ``random`` module are visible to all importers.
+        ``notebooklm._session.random.uniform`` (Phase 2 PR 5 canonical
+        target — previously the deprecated ``notebooklm._core.random.uniform``
+        shim) to reach that jitter path; keep the otherwise-unused module
+        import so the path stays available. Attribute patches on the
+        singleton ``random`` module are visible to all importers.
         """
         transport = getattr(self, "_authed_transport", None)
         if transport is None:
@@ -1210,9 +1214,12 @@ class Session:
         The adapters resolve through this module at call time so existing
         monkeypatches of ``notebooklm.rpc.decode_response`` (Phase 2 PR 5
         canonical target — previously the deprecated
-        ``notebooklm._core.decode_response`` shim), ``notebooklm._core.is_auth_error``,
-        and ``notebooklm._core.asyncio.sleep`` keep affecting live RPC
-        behavior after the collaborator has been constructed.
+        ``notebooklm._core.decode_response`` shim),
+        ``notebooklm._core.is_auth_error`` (Wave 3 will rename this seam),
+        and ``notebooklm._session.asyncio.sleep`` (Phase 2 PR 5 canonical
+        target — previously the deprecated ``notebooklm._core.asyncio.sleep``
+        shim) keep affecting live RPC behavior after the collaborator has
+        been constructed.
         """
         executor = getattr(self, "_rpc_executor", None)
         if executor is None:
@@ -1248,10 +1255,14 @@ class Session:
         """Persist a cookie jar through the shared cookie-persistence collaborator.
 
         Thin facade over :meth:`ClientLifecycle.save_cookies`. The storage
-        writer ``save_cookies_to_storage`` is resolved from this module at
-        call time inside the lifecycle helper so existing
-        ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
-        sites continue to affect the live save path.
+        writer resolves through ``self._lifecycle._cookie_saver`` — by
+        default the Wave-1 ``_default_cookie_saver`` wrapper that
+        late-binds to ``notebooklm._core.save_cookies_to_storage`` so the
+        legacy ``monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", …)``
+        idiom keeps affecting the live save path. Phase 2 PR 4 added the
+        ``cookie_saver=`` constructor kwarg as the preferred test-side
+        seam; passing a custom callable there bypasses the ``_core``
+        indirection entirely.
         """
         self._ensure_lifecycle()
         await self._lifecycle.save_cookies(self, jar, path)

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -178,9 +178,15 @@ _AUTH_COORD_INIT_LOCK = threading.Lock()
 
 
 def _decode_response_late_bound(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
-    from . import _core
+    # Phase 2 PR 5 (``.sisyphus/plans/refactor-completion-plan.md``):
+    # imports ``decode_response`` from the canonical :mod:`notebooklm.rpc`
+    # surface rather than the legacy ``notebooklm._core`` compatibility
+    # shim. Tests that patched ``notebooklm._core.decode_response`` are
+    # re-targeted to ``notebooklm.rpc.decode_response`` in the same
+    # commit so the live RPC decode path stays patchable end-to-end.
+    from .rpc import decode_response
 
-    return _core.decode_response(raw, rpc_id, allow_null=allow_null)
+    return decode_response(raw, rpc_id, allow_null=allow_null)
 
 
 def _sleep_late_bound(seconds: float) -> Awaitable[Any]:
@@ -1202,10 +1208,11 @@ class Session:
         """Return the RPC execution collaborator, lazily initialized.
 
         The adapters resolve through this module at call time so existing
-        monkeypatches of ``notebooklm._core.decode_response``,
-        ``notebooklm._core.is_auth_error``, and
-        ``notebooklm._core.asyncio.sleep`` keep affecting live RPC behavior
-        after the collaborator has been constructed.
+        monkeypatches of ``notebooklm.rpc.decode_response`` (Phase 2 PR 5
+        canonical target — previously the deprecated
+        ``notebooklm._core.decode_response`` shim), ``notebooklm._core.is_auth_error``,
+        and ``notebooklm._core.asyncio.sleep`` keep affecting live RPC
+        behavior after the collaborator has been constructed.
         """
         executor = getattr(self, "_rpc_executor", None)
         if executor is None:

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -370,7 +370,7 @@ class Session:
         _resolved_limits = limits if limits is not None else ConnectionLimits()
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
-        # by integration tests against ``client._core``. The refresh
+        # by integration tests against ``client._session``. The refresh
         # callback + the four refresh/auth-snapshot ivars (``_refresh_lock``,
         # ``_refresh_task``, ``_refresh_callback``, ``_auth_snapshot_lock``)
         # live on ``self._auth_coord``, constructed below alongside the other
@@ -1457,7 +1457,7 @@ class Session:
 
         Compatibility surface preserved so ``RpcExecutor.execute``
         (``_rpc_executor.py:275``), ``_chat_transport`` (``_chat_transport.py:64``),
-        and direct callers (``client._core._perform_authed_post(...)``) keep
+        and direct callers (``client._session._perform_authed_post(...)``) keep
         the same keyword-only signature. The body now builds an
         :class:`RpcRequest` with the three keyword-only args stashed into
         ``context`` and dispatches into :attr:`_authed_post_chain`.

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -118,7 +118,7 @@ CookieSaver = Callable[..., "bool | CookieSaveResult"]
 CookieRotator = Callable[..., Awaitable[None]]
 
 
-def _default_cookie_saver(*args: Any, **kwargs: Any) -> bool | CookieSaveResult:
+def _default_cookie_saver(*args: Any, **kwargs: Any) -> "bool | CookieSaveResult":
     """Default ``cookie_saver``: late-bind to ``notebooklm._core.save_cookies_to_storage``.
 
     The ``from . import _core`` import lives INSIDE the function body

--- a/src/notebooklm/_session_lifecycle.py
+++ b/src/notebooklm/_session_lifecycle.py
@@ -118,7 +118,7 @@ CookieSaver = Callable[..., "bool | CookieSaveResult"]
 CookieRotator = Callable[..., Awaitable[None]]
 
 
-def _default_cookie_saver(*args: Any, **kwargs: Any) -> "bool | CookieSaveResult":
+def _default_cookie_saver(*args: Any, **kwargs: Any) -> bool | CookieSaveResult:
     """Default ``cookie_saver``: late-bind to ``notebooklm._core.save_cookies_to_storage``.
 
     The ``from . import _core`` import lives INSIDE the function body

--- a/src/notebooklm/client.py
+++ b/src/notebooklm/client.py
@@ -289,9 +289,6 @@ class NotebookLMClient:
             cookie_saver=cookie_saver,
             cookie_rotator=cookie_rotator,
         )
-        # Compatibility alias for tests and private callers that still inspect
-        # ``client._core`` directly.
-        self._core = self._session
 
         # Wire the upload pipeline explicitly with the concrete capability
         # surfaces (UploadRuntime via the Session, plus Kernel and AuthMetadata).
@@ -311,7 +308,7 @@ class NotebookLMClient:
             upload_timeout=upload_timeout,
             max_concurrent_uploads=max_concurrent_uploads,
         )
-        self.notebooks = NotebooksAPI(self._core, sources_api=self.sources)
+        self.notebooks = NotebooksAPI(self._session, sources_api=self.sources)
         # Phase 5 wiring per docs/refactor.md Migration Plan steps 6-7:
         # the legacy single-service handoff (``MindMapService(self._session)``
         # passed as ``mind_map_service=``) is replaced with the explicit
@@ -319,14 +316,6 @@ class NotebookLMClient:
         # raw row primitives; NoteBackedMindMapService is the mind-map-only
         # adapter the download path uses; the artifact-generation path uses
         # NoteService.create_note directly to persist a generated mind map.
-        #
-        # We pass ``self._session`` rather than the ``self._core`` alias because
-        # ``Session`` directly satisfies ``ArtifactsRuntime`` (RpcCaller +
-        # AsyncWorkRuntime + DrainHookRegistration) and the ``_core`` alias
-        # exists only for legacy callers that pre-date the runtime split. The
-        # ``_core`` alias is preserved indefinitely for back-compat (per
-        # refactor.md Non-Goals — see ADR-013); retiring it is a future
-        # arc and is out of scope here.
         note_service = NoteService(self._session)
         mind_maps = NoteBackedMindMapService(note_service)
         self.artifacts = ArtifactsAPI(
@@ -343,25 +332,25 @@ class NotebookLMClient:
         # has NotesAPI delegate via constructor injection.
         self.chat = ChatAPI(self._session, notebooks=self.notebooks)
         self.notes = NotesAPI(
-            self._core,
+            self._session,
             notes=note_service,
             mind_maps=mind_maps,
             save_chat_answer=self.chat.save_answer_as_note,
         )
         # Pure-RPC features (Phase 1 retypes: typed as `rpc: RpcCaller`).
-        self.research = ResearchAPI(self._core)
-        self.settings = SettingsAPI(self._core)
-        self.sharing = SharingAPI(self._core)
+        self.research = ResearchAPI(self._session)
+        self.settings = SettingsAPI(self._session)
+        self.sharing = SharingAPI(self._session)
 
     @property
     def auth(self) -> AuthTokens:
         """Get the authentication tokens."""
-        return self._core.auth
+        return self._session.auth
 
     async def __aenter__(self) -> NotebookLMClient:
         """Open the client connection."""
         logger.debug("Opening NotebookLM client")
-        await self._core.open()
+        await self._session.open()
         return self
 
     async def __aexit__(
@@ -393,7 +382,7 @@ class NotebookLMClient:
 
     async def drain(self, timeout: float | None = None) -> None:
         """Stop accepting new operations and wait for in-flight operations to finish."""
-        await self._core.drain(timeout=timeout)
+        await self._session.drain(timeout=timeout)
 
     async def close(
         self,
@@ -421,7 +410,7 @@ class NotebookLMClient:
                 await self.drain(timeout=drain_timeout)
             except TimeoutError as drain_exc:
                 try:
-                    await self._core.close()
+                    await self._session.close()
                 except Exception as close_exc:
                     logger.warning(
                         "Suppressing close() error after drain timeout to preserve timeout "
@@ -431,13 +420,13 @@ class NotebookLMClient:
                     raise drain_exc from close_exc
                 raise
             else:
-                await self._core.close()
+                await self._session.close()
                 return
-        await self._core.close()
+        await self._session.close()
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client."""
-        return self._core.metrics_snapshot()
+        return self._session.metrics_snapshot()
 
     async def rpc_call(
         self,
@@ -499,7 +488,7 @@ class NotebookLMClient:
         # not-None / None branches into one expression.
         resolved_source_path = "/" if source_path is None else source_path
         resolved_is_retry = bool(_is_retry)
-        return await self._core.rpc_call(
+        return await self._session.rpc_call(
             method=method,
             params=params,
             source_path=resolved_source_path,
@@ -512,7 +501,7 @@ class NotebookLMClient:
     @property
     def is_connected(self) -> bool:
         """Check if the client is connected."""
-        return self._core.is_open
+        return self._session.is_open
 
     @classmethod
     async def from_storage(
@@ -627,4 +616,4 @@ class NotebookLMClient:
         Raises:
             ValueError: If token extraction fails (page structure may have changed).
         """
-        return await refresh_auth_session(self._core)
+        return await refresh_auth_session(self._session)

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -137,7 +137,6 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "tests/integration/test_side_effects_idempotency.py",
         "tests/integration/test_sources_idempotency.py",
         "tests/unit/cli/conftest.py",
-        "tests/unit/concurrency/test_close_cancellation_leak.py",
         "tests/unit/concurrency/test_download_collision.py",
         "tests/unit/test_api_coverage.py",
         "tests/unit/test_artifact_downloads.py",
@@ -153,10 +152,8 @@ _ALLOWLIST: frozenset[str] = frozenset(
         # seam-substitution pattern is extended to cover module-level
         # rotation/lock helpers.
         "tests/unit/test_auth_psidts_recovery.py",
-        "tests/unit/test_auth_session.py",
         "tests/unit/test_backoff.py",
         "tests/unit/test_chat_delete_conversation.py",
-        "tests/unit/test_client_keepalive.py",
         "tests/unit/test_session_lifecycle.py",
         "tests/unit/test_rpc_executor.py",
         "tests/unit/test_authed_transport.py",
@@ -182,7 +179,6 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "tests/unit/test_rpc_call_public_surface.py",
         "tests/unit/test_quota_failure_detection.py",
         "tests/unit/test_rpc_overrides.py",
-        "tests/unit/test_save_lock_contract.py",
         "tests/unit/test_select_artifact.py",
         "tests/unit/test_sharing_manager.py",
         "tests/unit/test_sharing_types.py",

--- a/tests/_lint/test_no_forbidden_monkeypatches.py
+++ b/tests/_lint/test_no_forbidden_monkeypatches.py
@@ -154,6 +154,17 @@ _ALLOWLIST: frozenset[str] = frozenset(
         "tests/unit/test_auth_psidts_recovery.py",
         "tests/unit/test_backoff.py",
         "tests/unit/test_chat_delete_conversation.py",
+        # Phase 2 PR 5 migrated this file's ``asyncio.to_thread`` patch
+        # off the legacy ``notebooklm._core.asyncio.to_thread`` shim onto
+        # its canonical importing module
+        # (``notebooklm._session_lifecycle.asyncio.to_thread``, where
+        # ``ClientLifecycle.save_cookies`` sources it). The new patch
+        # target is still a string-target into the ``notebooklm.*``
+        # namespace, so the file lands on the allowlist with the rest of
+        # the stdlib-seam patchers (``test_authed_transport.py``,
+        # ``test_rpc_executor.py``, ``test_side_effects_idempotency.py``,
+        # …) until ADR-007's pattern is extended to stdlib seams.
+        "tests/unit/test_cookie_persistence.py",
         "tests/unit/test_session_lifecycle.py",
         "tests/unit/test_rpc_executor.py",
         "tests/unit/test_authed_transport.py",

--- a/tests/integration/concurrency/test_aexit_exception_masking.py
+++ b/tests/integration/concurrency/test_aexit_exception_masking.py
@@ -60,28 +60,28 @@ async def test_body_raises_and_close_raises_body_wins(
     client = NotebookLMClient(auth_tokens)
 
     # Capture the http client reference BEFORE entering the cm — successful
-    # close sets `client._core._http_client = None`, so we need our own ref.
+    # close sets `client._session._http_client = None`, so we need our own ref.
     async with client:
-        http_client_ref = client._core._http_client
+        http_client_ref = client._session._http_client
         assert http_client_ref is not None
 
         # Patch _core.close to raise after closing the transport, so we
         # exercise the exception-arbitration path. Forward to the original
         # close so the leak-shield path also runs.
-        original_close = client._core.close
+        original_close = client._session.close
 
         async def _close_then_raise() -> None:
             await original_close()
             raise RuntimeError("synthetic close failure")
 
         with (
-            patch.object(client._core, "close", _close_then_raise),
+            patch.object(client._session, "close", _close_then_raise),
             caplog.at_level(logging.WARNING),
             pytest.raises(ValueError, match="user error"),
         ):
             async with client:
                 # Sanity: client is open here.
-                assert client._core._http_client is not None
+                assert client._session._http_client is not None
                 raise ValueError("user error")
 
     # 1. The body's ValueError propagated (verified by pytest.raises above).
@@ -109,7 +109,7 @@ async def test_body_succeeds_and_close_raises_close_propagates(
         raise RuntimeError("close failed")
 
     with (
-        patch.object(client._core, "close", _bad_close),
+        patch.object(client._session, "close", _bad_close),
         pytest.raises(RuntimeError, match="close failed"),
     ):
         async with client:
@@ -127,12 +127,12 @@ async def test_cancel_mid_close_does_not_leak_transport(
     the cancel.
     """
     client = NotebookLMClient(auth_tokens)
-    await client._core.open()
-    http_client_ref = client._core._http_client
+    await client._session.open()
+    http_client_ref = client._session._http_client
     assert http_client_ref is not None
 
     # Wrap close() in a task so we can cancel it.
-    close_task = asyncio.create_task(client._core.close())
+    close_task = asyncio.create_task(client._session.close())
     # Yield once so close() can start, then cancel.
     await asyncio.sleep(0)
     close_task.cancel()

--- a/tests/integration/concurrency/test_artifact_poll_dedupe.py
+++ b/tests/integration/concurrency/test_artifact_poll_dedupe.py
@@ -131,7 +131,7 @@ async def test_scenario_a_two_waiters_share_one_poll_loop(_auth_tokens):
         # ensure both have been scheduled before releasing the poll —
         # extra yields are safer than too few.
         for _ in range(50):
-            if len(client._core._pending_polls) >= 1 and (
+            if len(client._session._pending_polls) >= 1 and (
                 w1.done() is False and w2.done() is False
             ):
                 # Both have parked; allow the poll to fire.
@@ -240,8 +240,8 @@ async def test_scenario_c_pending_polls_empty_after_success(_auth_tokens):
         # synchronously when the task transitions, but yield once to be
         # safe across event loops.
         await asyncio.sleep(0)
-        assert client._core._pending_polls == {}, (
-            f"registry leaked entries on success path: {client._core._pending_polls!r}"
+        assert client._session._pending_polls == {}, (
+            f"registry leaked entries on success path: {client._session._pending_polls!r}"
         )
 
 
@@ -280,7 +280,7 @@ async def test_scenario_d_pending_polls_empty_after_exception(_auth_tokens):
 
         # Spin briefly for both to register on the shared future.
         for _ in range(50):
-            if len(client._core._pending_polls) >= 1 and not (w1.done() or w2.done()):
+            if len(client._session._pending_polls) >= 1 and not (w1.done() or w2.done()):
                 break
             await asyncio.sleep(0.01)
         both_attached.set()
@@ -293,8 +293,8 @@ async def test_scenario_d_pending_polls_empty_after_exception(_auth_tokens):
             await asyncio.wait_for(w2, timeout=TEST_TIMEOUT_S)
 
         await asyncio.sleep(0)
-        assert client._core._pending_polls == {}, (
-            f"registry leaked on exception path: {client._core._pending_polls!r}"
+        assert client._session._pending_polls == {}, (
+            f"registry leaked on exception path: {client._session._pending_polls!r}"
         )
         assert poll_call_count == 1, (
             f"expected 1 poll, got {poll_call_count} (dedupe must hold on exception path)"
@@ -363,7 +363,7 @@ async def test_scenario_e_orphan_exception_does_not_log_unraisable(_auth_tokens,
         # Yield until the poll task has actually run and resolved the
         # future. The registry is the readiness signal.
         for _ in range(50):
-            if not client._core._pending_polls:
+            if not client._session._pending_polls:
                 break
             await asyncio.sleep(0.01)
 
@@ -374,9 +374,9 @@ async def test_scenario_e_orphan_exception_does_not_log_unraisable(_auth_tokens,
         gc.collect()
         await asyncio.sleep(0)
 
-        assert client._core._pending_polls == {}, (
+        assert client._session._pending_polls == {}, (
             "registry leaked on leader-cancel-with-orphan-exception path: "
-            f"{client._core._pending_polls!r}"
+            f"{client._session._pending_polls!r}"
         )
 
         # The poll ran exactly once; the suppression callback consumed

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -151,7 +151,7 @@ def _make_client(transport: httpx.AsyncBaseTransport, auth_tokens) -> NotebookLM
     POSTs route through the mock instead of opening a real socket.
     """
     client = NotebookLMClient(auth_tokens)
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -204,7 +204,7 @@ async def test_concurrent_follow_ups_serialize_on_conversation_id(auth_tokens) -
             return_exceptions=False,
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Sanity: both calls returned their respective answers.
     answers = sorted(r.answer for r in results)
@@ -300,7 +300,7 @@ async def test_different_conversation_ids_run_in_parallel(auth_tokens) -> None:
             client.chat.ask(notebook_id, "qB", source_ids=["src_001"], conversation_id=cid_b),
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert peak_inflight == 2, (
         f"different-conversation follow-ups must run in parallel, "

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -464,7 +464,7 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     # --- with disable_internal_retries=True: exactly 1 POST ------------
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -138,7 +138,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -200,7 +200,7 @@ async def test_notebooks_create_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert notebook.id == nb_id_new
     assert notebook.title == title
@@ -242,7 +242,7 @@ async def test_notebooks_create_re_creates_when_probe_finds_nothing(auth_tokens)
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert notebook.id == nb_id_new
     # Two CREATE_NOTEBOOK calls: original (502) + retry (200)
@@ -281,7 +281,7 @@ async def test_notebooks_create_raises_on_ambiguous_probe(auth_tokens) -> None:
         with pytest.raises(RPCError, match="disambiguate"):
             await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ async def test_sources_add_url_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -358,7 +358,7 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -390,7 +390,7 @@ async def test_sources_add_text_raises_when_idempotent_True(auth_tokens) -> None
         with pytest.raises(NonIdempotentRetryError, match="add_text cannot be marked idempotent"):
             await client.sources.add_text("nb_test", "Title", "Content", idempotent=True)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert not seen_request, "add_text(idempotent=True) must raise before issuing any RPC"
 
@@ -425,7 +425,7 @@ async def test_sources_add_text_default_behavior_unchanged(auth_tokens) -> None:
     try:
         source = await client.sources.add_text(notebook_id, title, "the body")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert add_count == 1, f"expected exactly 1 ADD_SOURCE call, got {add_count}"
@@ -471,7 +471,7 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
     try:
         request_count = 0
         with pytest.raises(ServerError):
-            await client._core.rpc_call(
+            await client._session.rpc_call(
                 RPCMethod.LIST_NOTEBOOKS,
                 [None, 1, None, [2]],
                 disable_internal_retries=True,
@@ -480,18 +480,18 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
             f"with disable_internal_retries=True expected 1 POST, got {request_count}"
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # --- without the flag: default retry loop fires ---------------------
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
     try:
         request_count = 0
         with pytest.raises(ServerError):
-            await client._core.rpc_call(
+            await client._session.rpc_call(
                 RPCMethod.LIST_NOTEBOOKS,
                 [None, 1, None, [2]],
             )
         # initial + 2 retries = 3 POSTs
         assert request_count == 3, f"with default retries expected 3 POSTs, got {request_count}"
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()

--- a/tests/integration/concurrency/test_keepalive_path_canonicalize.py
+++ b/tests/integration/concurrency/test_keepalive_path_canonicalize.py
@@ -83,8 +83,8 @@ def test_relative_and_absolute_paths_share_dedupe_key(
     # The dedupe key seen by ``_get_poke_lock`` / ``_try_claim_rotation``
     # / ``_rotation_lock_path`` is exactly this internal field. Both must
     # be canonical and equal.
-    rel_keepalive = client_rel._core._keepalive_storage_path
-    abs_keepalive = client_abs._core._keepalive_storage_path
+    rel_keepalive = client_rel._session._keepalive_storage_path
+    abs_keepalive = client_abs._session._keepalive_storage_path
     assert rel_keepalive is not None
     assert abs_keepalive is not None
     assert rel_keepalive == abs_keepalive, (
@@ -132,8 +132,8 @@ def test_tilde_path_is_expanded(
     client_tilde = NotebookLMClient(_auth_tokens, storage_path=tilde_path)
     client_expanded = NotebookLMClient(_auth_tokens, storage_path=expanded_path)
 
-    tilde_key = client_tilde._core._keepalive_storage_path
-    expanded_key = client_expanded._core._keepalive_storage_path
+    tilde_key = client_tilde._session._keepalive_storage_path
+    expanded_key = client_expanded._session._keepalive_storage_path
     assert tilde_key is not None
     assert expanded_key is not None
     assert tilde_key == expanded_key
@@ -175,7 +175,7 @@ def test_public_storage_path_argument_unchanged(
     assert client.auth.storage_path == raw_path
     assert client.auth.storage_path != target.resolve()
     # And the internal keepalive field IS canonicalized.
-    keepalive_key = client._core._keepalive_storage_path
+    keepalive_key = client._session._keepalive_storage_path
     assert keepalive_key is not None
     assert keepalive_key == target.resolve()
     assert keepalive_key.is_absolute()
@@ -202,8 +202,8 @@ def test_symlink_is_resolved(tmp_path: Path, _auth_tokens: AuthTokens) -> None:
     client_link = NotebookLMClient(_auth_tokens, storage_path=link)
     client_target = NotebookLMClient(_auth_tokens, storage_path=target)
 
-    link_key = client_link._core._keepalive_storage_path
-    target_key = client_target._core._keepalive_storage_path
+    link_key = client_link._session._keepalive_storage_path
+    target_key = client_target._session._keepalive_storage_path
     assert link_key is not None
     assert target_key is not None
     assert link_key == target_key
@@ -213,4 +213,4 @@ def test_symlink_is_resolved(tmp_path: Path, _auth_tokens: AuthTokens) -> None:
 def test_none_storage_path_stays_none(_auth_tokens: AuthTokens) -> None:
     """Canonicalization must be a no-op when there is no storage path."""
     client = NotebookLMClient(_auth_tokens)
-    assert client._core._keepalive_storage_path is None
+    assert client._session._keepalive_storage_path is None

--- a/tests/integration/concurrency/test_note_create_cancel.py
+++ b/tests/integration/concurrency/test_note_create_cancel.py
@@ -57,7 +57,7 @@ def _make_client_with_transport(
 ) -> NotebookLMClient:
     """Wire a ``NotebookLMClient`` to a mock transport, bypassing full open()."""
     client = NotebookLMClient(auth_tokens)
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -201,9 +201,9 @@ async def test_cancel_during_update_note_shields_or_cleans_up(auth_tokens) -> No
     finally:
         # Defensive cleanup so a failing assertion doesn't leak the http
         # client and warn at gc time.
-        if client._core._http_client is not None:
-            await client._core._http_client.aclose()
-            client._core._http_client = None
+        if client._session._http_client is not None:
+            await client._session._http_client.aclose()
+            client._session._http_client = None
 
 
 @pytest.mark.asyncio
@@ -230,6 +230,6 @@ async def test_no_cancel_no_cleanup(auth_tokens) -> None:
             f"over-eager: rpc_ids={rpc_ids!r}"
         )
     finally:
-        if client._core._http_client is not None:
-            await client._core._http_client.aclose()
-            client._core._http_client = None
+        if client._session._http_client is not None:
+            await client._session._http_client.aclose()
+            client._session._http_client = None

--- a/tests/integration/concurrency/test_pool_tuning.py
+++ b/tests/integration/concurrency/test_pool_tuning.py
@@ -67,7 +67,7 @@ async def test_default_limits_passed_to_async_client(auth_tokens) -> None:
         captured["limits"] = kwargs.get("limits")  # type: ignore[assignment]
         return real_async_client(**kwargs)  # type: ignore[arg-type]
 
-    with patch("notebooklm._core.httpx.AsyncClient", side_effect=_capturing_client):
+    with patch("notebooklm._session.httpx.AsyncClient", side_effect=_capturing_client):
         async with NotebookLMClient(auth_tokens):
             pass
 
@@ -92,7 +92,7 @@ async def test_custom_limits_passed_to_async_client(auth_tokens) -> None:
         captured["limits"] = kwargs.get("limits")  # type: ignore[assignment]
         return real_async_client(**kwargs)  # type: ignore[arg-type]
 
-    with patch("notebooklm._core.httpx.AsyncClient", side_effect=_capturing_client):
+    with patch("notebooklm._session.httpx.AsyncClient", side_effect=_capturing_client):
         async with NotebookLMClient(auth_tokens, limits=custom):
             pass
 

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -83,7 +83,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
 
     # NotebookLMClient default — NO ``rate_limit_max_retries`` kwarg.
     client = NotebookLMClient(auth_tokens)
-    assert client._core._rate_limit_max_retries == 3, (
+    assert client._session._rate_limit_max_retries == 3, (
         "rate_limit_max_retries default must be 3; check that NotebookLMClient.__init__ "
         "forwards the Session default."
     )
@@ -91,7 +91,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
         result = await client.notebooks.list()
@@ -116,12 +116,12 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
     mock_post = AsyncMock(return_value=_build_429("1"))
 
     client = NotebookLMClient(auth_tokens)
-    assert client._core._rate_limit_max_retries == 3
+    assert client._session._rate_limit_max_retries == 3
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
         await client.notebooks.list()
@@ -161,7 +161,7 @@ async def test_default_retries_use_exponential_backoff_when_header_missing(
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     sleep_calls: list[float] = []
 
@@ -205,18 +205,18 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     mock_post = AsyncMock(return_value=_build_429("1"))
 
     client = NotebookLMClient(auth_tokens)
-    assert client._core._rate_limit_max_retries == 3
+    assert client._session._rate_limit_max_retries == 3
 
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._core._http_client = mock_http
+    client._session._http_client = mock_http
 
     def _build_request(_snap):
         return ("https://example.invalid/x", b"body", None)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(_TransportRateLimited):
-        await client._core._perform_authed_post(
+        await client._session._perform_authed_post(
             build_request=_build_request,
             log_label="test",
             disable_internal_retries=True,

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -122,7 +122,7 @@ def _make_client_with_transport(
         auth_tokens,  # type: ignore[arg-type]
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -225,7 +225,7 @@ async def test_create_artifact_503_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Exactly ONE CREATE_ARTIFACT POST despite ``server_error_max_retries=3``
     # being configured: the PROBE_THEN_CREATE policy forced retries off.
@@ -263,7 +263,7 @@ async def test_create_artifact_429_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(RateLimitError):
             await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert create_count == 1, f"expected 1 CREATE_ARTIFACT POST, got {create_count}"
 
@@ -296,7 +296,7 @@ async def test_generate_mind_map_503_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert mind_map_count == 1, f"expected 1 GENERATE_MIND_MAP POST, got {mind_map_count}"
     assert get_notebook_count == 1
@@ -333,7 +333,7 @@ async def test_create_artifact_happy_path_still_returns_artifact(auth_tokens) ->
     try:
         status = await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert status.task_id == artifact_id
     assert create_count == 1
@@ -379,7 +379,7 @@ async def test_generate_mind_map_happy_path_still_returns_mind_map(auth_tokens) 
     try:
         result = await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert result["mind_map"] == mind_map_dict
     assert result["note_id"] == "note_stub"

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -117,7 +117,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
 
     client = await _build_client_for_test()
     # Eliminate the post-refresh retry delay so the test runs fast.
-    client._core._refresh_retry_delay = 0
+    client._session._refresh_retry_delay = 0
 
     # Track whether refresh_auth ran. We wrap the bound method so the
     # mutation is observable from outside the test. Using ``list[object]``
@@ -131,7 +131,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
 
     # The refresh callback is captured by Session at construction;
     # patch it on the core so the wrapper is what the retry loop sees.
-    client._core._refresh_callback = tracking_refresh
+    client._session._refresh_callback = tracking_refresh
 
     with notebooklm_vcr.use_cassette(CASSETTE_NAME) as cassette:
         async with client:
@@ -141,8 +141,8 @@ async def test_stale_csrf_triggers_refresh_and_retry(
             # The ``update_auth_headers`` call is what actually plumbs the
             # new value into the live ``httpx.AsyncClient``'s default
             # header set.
-            client._core.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
-            client._core.update_auth_headers()
+            client._session.auth.csrf_token = "INVALID_CSRF_FOR_TEST"
+            client._session.update_auth_headers()
 
             # This call's first attempt MUST 400; the rpc_call layer
             # then awaits refresh_auth (interaction 2 in the cassette)
@@ -154,7 +154,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
             # the corrupted value. Asserting the change makes this
             # test fail loudly if a future refactor accidentally
             # short-circuits the retry to "return the 400 unchanged".
-            assert client._core.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
+            assert client._session.auth.csrf_token != "INVALID_CSRF_FOR_TEST", (
                 "csrf_token should have been refreshed mid-call"
             )
 

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -28,13 +28,13 @@ class TestAutoRefreshIntegration:
 
         client = NotebookLMClient(auth)
         # Bound methods aren't identical, so compare underlying function
-        assert client._core._refresh_callback is not None
-        assert client._core._refresh_callback.__func__ is NotebookLMClient.refresh_auth
+        assert client._session._refresh_callback is not None
+        assert client._session._refresh_callback.__func__ is NotebookLMClient.refresh_auth
         # ``_refresh_lock`` is lazily created on first ``_await_refresh``.
         # At construction time it is ``None`` so the client can be
         # instantiated outside a running loop; the helper allocates the
         # lock on demand inside the async refresh path.
-        assert client._core._refresh_lock is None
+        assert client._session._refresh_lock is None
 
     @pytest.mark.asyncio
     async def test_full_refresh_flow_http_error(self):
@@ -47,7 +47,7 @@ class TestAutoRefreshIntegration:
 
         client = NotebookLMClient(auth)
         # Override retry delay for faster tests
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         # Track refresh calls
         refresh_calls = []
@@ -55,11 +55,11 @@ class TestAutoRefreshIntegration:
         async def tracking_refresh():
             refresh_calls.append(True)
             # Simulate successful refresh
-            client._core.auth.csrf_token = "new_csrf"
-            client._core.update_auth_headers()
-            return client._core.auth
+            client._session.auth.csrf_token = "new_csrf"
+            client._session.update_auth_headers()
+            return client._session.auth
 
-        client._core._refresh_callback = tracking_refresh
+        client._session._refresh_callback = tracking_refresh
 
         # Mock HTTP responses
         call_count = [0]
@@ -78,7 +78,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             with patch("notebooklm.rpc.decode_response") as mock_decode:
                 mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
@@ -97,17 +97,17 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         refresh_calls = []
 
         async def tracking_refresh():
             refresh_calls.append(True)
-            client._core.auth.csrf_token = "new_csrf"
-            client._core.update_auth_headers()
-            return client._core.auth
+            client._session.auth.csrf_token = "new_csrf"
+            client._session.update_auth_headers()
+            return client._session.auth
 
-        client._core._refresh_callback = tracking_refresh
+        client._session._refresh_callback = tracking_refresh
 
         # Mock HTTP to succeed, but decode_response to fail with auth error first
         async def mock_post(*args, **kwargs):
@@ -125,7 +125,7 @@ class TestAutoRefreshIntegration:
             return [[["nb1"], ["Notebook 1"]]]
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
                 await client.notebooks.list()
@@ -143,12 +143,12 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._core._refresh_retry_delay = 0.1  # 100ms delay
+        client._session._refresh_retry_delay = 0.1  # 100ms delay
 
         async def mock_refresh():
             return auth
 
-        client._core._refresh_callback = mock_refresh
+        client._session._refresh_callback = mock_refresh
 
         call_count = [0]
 
@@ -164,7 +164,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             start_time = asyncio.get_event_loop().time()
 
@@ -186,13 +186,13 @@ class TestAutoRefreshIntegration:
         )
 
         client = NotebookLMClient(auth)
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         async def failing_refresh():
             # Simulates refresh_auth detecting redirect to login
             raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
 
-        client._core._refresh_callback = failing_refresh
+        client._session._refresh_callback = failing_refresh
 
         async def mock_post(*args, **kwargs):
             request = httpx.Request("POST", args[0])
@@ -200,7 +200,7 @@ class TestAutoRefreshIntegration:
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
         async with client:
-            install_post_as_stream(None, client._core._http_client, mock_post)
+            install_post_as_stream(None, client._session._http_client, mock_post)
 
             # Should raise the original HTTP error with refresh failure as cause
             with pytest.raises(httpx.HTTPStatusError) as exc_info:

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -80,7 +80,7 @@ class TestAutoRefreshIntegration:
         async with client:
             install_post_as_stream(None, client._core._http_client, mock_post)
 
-            with patch("notebooklm._core.decode_response") as mock_decode:
+            with patch("notebooklm.rpc.decode_response") as mock_decode:
                 mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
                 await client.notebooks.list()
 
@@ -127,7 +127,7 @@ class TestAutoRefreshIntegration:
         async with client:
             install_post_as_stream(None, client._core._http_client, mock_post)
 
-            with patch("notebooklm._core.decode_response", side_effect=mock_decode):
+            with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
                 await client.notebooks.list()
 
         assert len(refresh_calls) == 1, "Should have refreshed once"
@@ -168,7 +168,7 @@ class TestAutoRefreshIntegration:
 
             start_time = asyncio.get_event_loop().time()
 
-            with patch("notebooklm._core.decode_response", return_value=[]):
+            with patch("notebooklm.rpc.decode_response", return_value=[]):
                 await client.notebooks.list()
 
             elapsed = asyncio.get_event_loop().time() - start_time

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -123,7 +123,7 @@ class TestErrorPaths:
         # has ONE interaction; with the default retry budget the client would
         # ask for a second cassette response that doesn't exist and VCR would
         # raise ``CannotOverwriteExistingCassetteException``.
-        client._core._rate_limit_max_retries = 0
+        client._session._rate_limit_max_retries = 0
 
         with notebooklm_vcr.use_cassette("error_synthetic_429_rate_limit.yaml") as cassette:
             async with client:
@@ -163,7 +163,7 @@ class TestErrorPaths:
         # is exercised separately by the unit tests in
         # ``test_rate_limit_retry.py`` — here we focus on the terminal
         # exception-mapping branch.
-        client._core._server_error_max_retries = 0
+        client._session._server_error_max_retries = 0
 
         with notebooklm_vcr.use_cassette("error_synthetic_500_server.yaml") as cassette:
             async with client:
@@ -202,7 +202,7 @@ class TestErrorPaths:
         client = NotebookLMClient(_synthetic_auth())
         # Eliminate the post-refresh retry delay so the test runs fast under
         # replay (mirrors ``test_auth_refresh_vcr.py``).
-        client._core._refresh_retry_delay = 0
+        client._session._refresh_retry_delay = 0
 
         # In-process refresh callback that issues NO HTTP traffic. This is
         # what lets the cassette capture only the TWO synthetic batchexecute
@@ -221,11 +221,11 @@ class TestErrorPaths:
             # request-side body would carry the refreshed value if VCR
             # matched on body (it doesn't; the default matcher uses
             # method/path/rpcids).
-            client._core.auth.csrf_token = "refreshed_csrf_token"
-            client._core.update_auth_headers()
-            return client._core.auth
+            client._session.auth.csrf_token = "refreshed_csrf_token"
+            client._session.update_auth_headers()
+            return client._session.auth
 
-        client._core._refresh_callback = stub_refresh
+        client._session._refresh_callback = stub_refresh
 
         with notebooklm_vcr.use_cassette("error_synthetic_stale_csrf.yaml") as cassette:
             async with client:

--- a/tests/integration/test_notes_idempotency.py
+++ b/tests/integration/test_notes_idempotency.py
@@ -68,7 +68,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -169,7 +169,7 @@ async def test_create_note_plain_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.notes.create(notebook_id, title="My Note", content="hello")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert create_count == 1, (
         f"expected exactly 1 CREATE_NOTE (NON_IDEMPOTENT_NO_RETRY), got {create_count}"
@@ -221,7 +221,7 @@ async def test_create_note_saved_from_chat_no_inner_retry_on_5xx(auth_tokens) ->
         with pytest.raises(ServerError):
             await client.notes.create_from_chat(notebook_id, ask_result, title="Chat note")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert create_count == 1, (
         f"expected exactly 1 CREATE_NOTE (saved_from_chat variant, "
@@ -266,7 +266,7 @@ async def test_create_note_happy_path_one_post(auth_tokens) -> None:
     try:
         note = await client.notes.create(notebook_id, title="Happy", content="body")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert note.id == "note_xyz"
     assert create_count == 1

--- a/tests/integration/test_research_idempotency.py
+++ b/tests/integration/test_research_idempotency.py
@@ -69,7 +69,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -160,7 +160,7 @@ async def test_start_fast_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.start(notebook_id, "what is quantum computing?")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # NON_IDEMPOTENT_NO_RETRY forces effective_disable_internal_retries=True
     # so the inner retry loop does not fire — exactly ONE POST.
@@ -192,7 +192,7 @@ async def test_start_deep_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.start(notebook_id, "deep dive query", mode="deep")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert request_count == 1, (
         f"expected exactly 1 START_DEEP_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
@@ -228,7 +228,7 @@ async def test_import_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.import_sources(notebook_id, task_id, sources)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert request_count == 1, (
         f"expected exactly 1 IMPORT_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
@@ -268,7 +268,7 @@ async def test_start_fast_research_happy_path_one_post(auth_tokens) -> None:
     try:
         result = await client.research.start(notebook_id, "test query")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert result is not None
     assert result["task_id"] == "task_xyz"

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -71,6 +71,10 @@ class TestClientInitialization:
 
         await core.close()
 
+        # Assert the injected saver was actually invoked — otherwise the
+        # test could pass via an early exit that never reaches the saver,
+        # silently weakening the regression guard.
+        boom_save.assert_called_once()
         assert core._http_client is None
 
     @pytest.mark.asyncio

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -296,7 +296,7 @@ class TestRPCCallAuthRetry:
             mock_post = AsyncMock(return_value=success_response)
             install_post_as_stream(None, core._http_client, mock_post)
             with patch(
-                "notebooklm._core.decode_response",
+                "notebooklm.rpc.decode_response",
                 side_effect=[
                     RPCError("authentication expired"),
                     ["result_data"],

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -46,11 +46,15 @@ class TestClientInitialization:
     @pytest.mark.asyncio
     async def test_close_does_not_sync_in_memory_auth_to_default_storage(self):
         auth = AuthTokens(cookies={"SID": "scratch"}, csrf_token="csrf", session_id="session")
-        core = Session(auth)
+        # Inject the cookie-saver seam directly (Phase 2 PR 4 — replaces the
+        # legacy ``_core.save_cookies_to_storage`` string-target monkeypatch
+        # with a constructor-injection seam wired through
+        # ``ClientLifecycle._cookie_saver``).
+        mock_save = MagicMock(return_value=False)
+        core = Session(auth, cookie_saver=mock_save)
         await core.open()
 
-        with patch("notebooklm._core.save_cookies_to_storage") as mock_save:
-            await core.close()
+        await core.close()
 
         mock_save.assert_not_called()
         assert core._http_client is None
@@ -58,11 +62,14 @@ class TestClientInitialization:
     @pytest.mark.asyncio
     async def test_close_closes_http_client_when_cookie_sync_fails(self, auth_tokens, tmp_path):
         auth_tokens.storage_path = tmp_path / "storage_state.json"
-        core = Session(auth_tokens)
+        # Inject a cookie-saver that raises so the test exercises the
+        # close()-handles-saver-failure path without monkeypatching the
+        # legacy ``_core.save_cookies_to_storage`` seam.
+        boom_save = MagicMock(side_effect=RuntimeError("boom"))
+        core = Session(auth_tokens, cookie_saver=boom_save)
         await core.open()
 
-        with patch("notebooklm._core.save_cookies_to_storage", side_effect=RuntimeError("boom")):
-            await core.close()
+        await core.close()
 
         assert core._http_client is None
 

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -34,14 +34,14 @@ class TestClientInitialization:
     @pytest.mark.asyncio
     async def test_client_initialization(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            assert client._core.auth == auth_tokens
-            assert client._core._http_client is not None
+            assert client._session.auth == auth_tokens
+            assert client._session._http_client is not None
 
     @pytest.mark.asyncio
     async def test_client_context_manager_closes(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            assert client._core._http_client is not None  # client is open
-        assert client._core._http_client is None  # closed after exit
+            assert client._session._http_client is not None  # client is open
+        assert client._session._http_client is None  # closed after exit
 
     @pytest.mark.asyncio
     async def test_close_does_not_sync_in_memory_auth_to_default_storage(self):
@@ -151,7 +151,7 @@ class TestRPCCallHTTPErrors:
         # covered by ``tests/integration/concurrency/test_rate_limit_default.py``;
         # this test documents the explicit-disable contract.
         async with NotebookLMClient(auth_tokens, rate_limit_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 429
@@ -169,7 +169,7 @@ class TestRPCCallHTTPErrors:
         # See ``test_rate_limit_429_with_retry_after_header`` for why this
         # pins ``rate_limit_max_retries=0``.
         async with NotebookLMClient(auth_tokens, rate_limit_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 429
@@ -187,7 +187,7 @@ class TestRPCCallHTTPErrors:
         # See ``test_rate_limit_429_with_retry_after_header`` for why this
         # pins ``rate_limit_max_retries=0``.
         async with NotebookLMClient(auth_tokens, rate_limit_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 429
@@ -208,7 +208,7 @@ class TestRPCCallHTTPErrors:
         # in to auto-refresh), clear the refresh callback so is_auth_error's
         # gate in rpc_call short-circuits and the status mapping runs.
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             core._refresh_callback = None
 
             mock_response = MagicMock()
@@ -225,7 +225,7 @@ class TestRPCCallHTTPErrors:
         # Pin ``server_error_max_retries=0`` to exercise the raise-immediately
         # mapping path. Retry/backoff behavior is covered in core transport tests.
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             mock_response = MagicMock()
             mock_response.status_code = 500
@@ -241,7 +241,7 @@ class TestRPCCallHTTPErrors:
         # Network errors flow through the same retry loop as 5xx responses;
         # pin to 0 so these mapping tests don't pay backoff sleeps.
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.ConnectTimeout("connect timeout"))
             with pytest.raises(NetworkError):
@@ -250,7 +250,7 @@ class TestRPCCallHTTPErrors:
     @pytest.mark.asyncio
     async def test_read_timeout_raises_rpc_timeout_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.ReadTimeout("read timeout"))
             with pytest.raises(RPCTimeoutError):
@@ -259,7 +259,7 @@ class TestRPCCallHTTPErrors:
     @pytest.mark.asyncio
     async def test_connect_error_raises_network_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.ConnectError("connection refused"))
             with pytest.raises(NetworkError):
@@ -268,7 +268,7 @@ class TestRPCCallHTTPErrors:
     @pytest.mark.asyncio
     async def test_generic_request_error_raises_network_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens, server_error_max_retries=0) as client:
-            core = client._core
+            core = client._session
 
             _install_error_post(core, httpx.RequestError("something went wrong"))
             with pytest.raises(NetworkError):
@@ -281,7 +281,7 @@ class TestRPCCallAuthRetry:
     @pytest.mark.asyncio
     async def test_auth_retry_on_decode_rpc_error(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
 
             refresh_callback = AsyncMock()
             core._refresh_callback = refresh_callback
@@ -319,7 +319,7 @@ class TestGetHttpClient:
     @pytest.mark.asyncio
     async def test_get_http_client_returns_client_when_initialized(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            http_client = client._core.get_http_client()
+            http_client = client._session.get_http_client()
             assert isinstance(http_client, httpx.AsyncClient)
 
 
@@ -329,7 +329,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_source_ids_from_nested_data(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             mock_notebook_data = [
@@ -352,7 +352,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_data_is_none(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=None):
@@ -363,7 +363,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_data_is_empty_list(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             with patch.object(core, "rpc_call", new_callable=AsyncMock, return_value=[]):
@@ -374,7 +374,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_sources_list_is_empty(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             # Notebook with no sources
@@ -390,7 +390,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_data_is_not_list(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             with patch.object(
@@ -403,7 +403,7 @@ class TestGetSourceIds:
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_notebook_info_missing_sources(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             notebooks = client.notebooks
 
             # notebook_data[0] exists but notebook_info[1] is missing
@@ -424,7 +424,7 @@ class TestCrossDomainCookiePreservation:
     async def test_cookies_preserved_on_cross_domain_redirect(self, auth_tokens):
         """Verify cookies persist when redirecting from notebooklm to accounts.google.com."""
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http_client = core._http_client
 
             # Set initial sentinel cookie in the jar
@@ -445,7 +445,7 @@ class TestCrossDomainCookiePreservation:
     async def test_update_auth_headers_merges_not_replaces(self, auth_tokens):
         """Verify update_auth_headers merges new cookies, preserving live redirect cookies."""
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http_client = core._http_client
 
             # Simulate a live cookie received from accounts.google.com redirect
@@ -471,7 +471,7 @@ class TestCrossDomainCookiePreservation:
         auth_tokens.cookie_jar.set("SID", "test_sid", domain=".google.com")
 
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http = core._http_client
 
             # The .googleusercontent.com cookie must remain on its original domain
@@ -483,7 +483,7 @@ class TestCrossDomainCookiePreservation:
     async def test_update_auth_headers_preserves_redirect_cookies(self, auth_tokens):
         """update_auth_headers must merge, not replace, preserving redirect cookies."""
         async with NotebookLMClient(auth_tokens) as client:
-            core = client._core
+            core = client._session
             http = core._http_client
 
             # Simulate Google setting a cookie during a redirect

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -158,7 +158,7 @@ async def test_delete_notebook_retries_remain_enabled(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
@@ -193,7 +193,7 @@ async def test_delete_source_retries_remain_enabled(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
@@ -224,7 +224,7 @@ async def test_delete_artifact_retries_remain_enabled(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
@@ -323,7 +323,7 @@ async def test_share_notebook_does_not_retry_on_5xx(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=5)
@@ -396,7 +396,7 @@ async def test_notebooks_create_probe_propagates_network_error(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens)

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -77,7 +77,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -173,7 +173,7 @@ async def test_delete_notebook_retries_remain_enabled(
             f"(initial + 2 retries), got {request_count}"
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 async def test_delete_source_retries_remain_enabled(
@@ -204,7 +204,7 @@ async def test_delete_source_retries_remain_enabled(
             await client.sources.delete("nb_x", "src_x")
         assert request_count == 3, f"expected 3 POSTs, got {request_count}"
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 async def test_delete_artifact_retries_remain_enabled(
@@ -235,7 +235,7 @@ async def test_delete_artifact_retries_remain_enabled(
             await client.artifacts.delete("nb_x", "art_x")
         assert request_count == 3, f"expected 3 POSTs, got {request_count}"
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 # ===========================================================================
@@ -277,7 +277,7 @@ async def test_refresh_source_emits_rate_limited_warn(
                 ok = await client.sources.refresh("nb_x", "src_x")
                 assert ok is True
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     warn_records = [
         r
@@ -339,7 +339,7 @@ async def test_share_notebook_does_not_retry_on_5xx(
             f"(no blind retry), got {share_count}"
         )
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
 
 # ===========================================================================
@@ -404,7 +404,7 @@ async def test_notebooks_create_probe_propagates_network_error(
         with pytest.raises(NetworkError):
             await client.notebooks.create("Some Title")
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Sanity check: the probe was actually attempted and the create fired
     # once before the probe failed. LIST_NOTEBOOKS is UNCLASSIFIED so the
@@ -476,7 +476,7 @@ async def test_notebooks_create_probe_swallows_non_network_exception(
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert notebook.id == nb_id_after_retry
     assert create_call_count == 2, (

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -624,7 +624,7 @@ async def test_add_text_no_probe_no_retry_under_5xx(
     async def _no_sleep(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", _no_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", _no_sleep)
 
     transport = httpx.MockTransport(handler)
     client = _make_client_with_transport(transport, auth_tokens)

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -111,7 +111,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._core._http_client = httpx.AsyncClient(
+    client._session._http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -168,7 +168,7 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -220,7 +220,7 @@ async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_toke
     try:
         source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert file_id in (source.url or "")
@@ -263,7 +263,7 @@ async def test_add_drive_probe_matches_segment_at_end_of_url(auth_tokens) -> Non
     try:
         source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
@@ -332,7 +332,7 @@ async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
         with pytest.raises(ServerError):
             await client.sources.add_drive(notebook_id, target_file_id, title)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # The probe must NOT have spuriously matched the unrelated Drive
     # source — instead the wrapper retried, exhausted, and re-raised.
@@ -414,7 +414,7 @@ async def test_register_file_source_probe_short_circuits_when_first_response_los
         ):
             source = await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     assert source.id == src_id
     # Exactly ONE ADD_SOURCE_FILE register request (no naive re-POST)
@@ -493,7 +493,7 @@ async def test_register_file_source_does_not_match_pre_existing_filename(
         ):
             await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # The pre-existing source's id was never returned — instead, the
     # original transport error propagated after retries were exhausted.
@@ -570,7 +570,7 @@ async def test_register_file_source_baseline_unavailable_raises_on_ambiguity(
         ):
             await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Pre-existing source's id was NOT silently returned — instead the
     # baseline-unavailable ambiguity guard fired.
@@ -632,7 +632,7 @@ async def test_add_text_no_probe_no_retry_under_5xx(
         with pytest.raises(NotebookLMError):
             await client.sources.add_text(notebook_id, title, content)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Exactly ONE ADD_SOURCE attempt: no retry loop, no probe.
     assert add_count == 1, (
@@ -686,7 +686,7 @@ async def test_add_url_probe_network_error_propagates(auth_tokens) -> None:
         with pytest.raises(NetworkError, match="probe synthetic connection error"):
             await client.sources.add_url(notebook_id, url)
     finally:
-        await client._core._http_client.aclose()
+        await client._session._http_client.aclose()
 
     # Probe was attempted (the original create failed with 502, then the
     # probe was issued and raised).

--- a/tests/integration/test_sources_integration.py
+++ b/tests/integration/test_sources_integration.py
@@ -213,10 +213,10 @@ class TestGetSource:
         )
 
         async with NotebookLMClient(auth_tokens) as client:
-            client._core.rpc_call = first_rpc
+            client._session.rpc_call = first_rpc
             assert await client.sources.list("nb_123") == []
 
-            client._core.rpc_call = second_rpc
+            client._session.rpc_call = second_rpc
             sources = await client.sources.list("nb_123")
 
         first_rpc.assert_awaited_once()

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -135,8 +135,11 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
         rotate_entered.set()
         await hang_event.wait()
 
-    monkeypatch.setattr("notebooklm._core._rotate_cookies", _hanging_rotate)
-
+    # Phase 2 PR 4: inject the cookie-rotator seam directly. Prior to the
+    # injectable seam, this test monkeypatched
+    # ``notebooklm._core._rotate_cookies``; the rotator now flows through
+    # ``NotebookLMClient(..., cookie_rotator=...)`` -> ``ClientLifecycle``.
+    #
     # ``keepalive_min_interval`` clamps short intervals up to its floor
     # (default 60s). Pass ``keepalive_min_interval=0.01`` so a 0.05s
     # keepalive actually fires within the test window.
@@ -144,6 +147,7 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
         keepalive_auth,
         keepalive=0.05,
         keepalive_min_interval=0.01,
+        cookie_rotator=_hanging_rotate,
     )
 
     # Open the client and let the keepalive loop enter ``_rotate_cookies``

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -26,7 +26,7 @@ a different cancel-injection site:
 - ``__aexit__`` driven through :func:`asyncio.wait_for(timeout=0.1)` so
   the outer cancel reliably arrives while the slowed ``aclose`` is in
   flight — i.e. inside the shielded await.
-- We hold a reference to ``client._core._http_client`` captured before
+- We hold a reference to ``client._session._http_client`` captured before
   the cancel (close nulls the attribute on success) and assert
   ``http_client_ref.is_closed`` is true afterwards — proof that the
   shielded ``aclose`` in the outer ``finally`` ran to completion.
@@ -157,7 +157,7 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
         # Save the transport ref BEFORE the cancel — successful close
         # sets ``_core._http_client = None`` (inner finally), so we'd
         # have no handle otherwise.
-        http_client_ref = client._core._http_client
+        http_client_ref = client._session._http_client
         assert http_client_ref is not None, "open() must have installed a transport"
 
         # Slow down ``aclose()`` so the outer ``wait_for(timeout=0.1)``

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -53,8 +53,8 @@ class TestConfigureChat:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
-        client._core.rpc_call = AsyncMock(return_value=None)
+        client._session._http_client = MagicMock()
+        client._session.rpc_call = AsyncMock(return_value=None)
         return client
 
     @pytest.mark.asyncio
@@ -62,8 +62,8 @@ class TestConfigureChat:
         """Test configure_chat with default settings."""
         await mock_client.chat.configure("notebook_123")
 
-        mock_client._core.rpc_call.assert_called_once()
-        call_args = mock_client._core.rpc_call.call_args
+        mock_client._session.rpc_call.assert_called_once()
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify payload structure
@@ -79,7 +79,7 @@ class TestConfigureChat:
             custom_prompt="Be an expert analyst",
         )
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify custom prompt is included
@@ -105,7 +105,7 @@ class TestConfigureChat:
             response_length=ChatResponseLength.LONGER,
         )
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         assert params[1][0][7] == [[3], [4]]  # Learning guide, longer
@@ -123,7 +123,7 @@ class TestGetSourceGuide:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
+        client._session._http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -140,7 +140,7 @@ class TestGetSourceGuide:
                 ]
             ]
         ]
-        mock_client._core.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
@@ -150,7 +150,7 @@ class TestGetSourceGuide:
     @pytest.mark.asyncio
     async def test_get_source_guide_handles_empty(self, mock_client):
         """Test get_source_guide handles empty response."""
-        mock_client._core.rpc_call = AsyncMock(return_value=None)
+        mock_client._session.rpc_call = AsyncMock(return_value=None)
 
         result = await mock_client.sources.get_guide("notebook_123", "source_456")
 
@@ -170,7 +170,7 @@ class TestGetSuggestedReportFormats:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
+        client._session._http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -183,8 +183,8 @@ class TestGetSuggestedReportFormats:
                 ["Summary Brief", "Quick overview...", None, None, "Summarize the...", 1],
             ]
         ]
-        mock_client._core.rpc_call = AsyncMock(return_value=mock_response)
-        mock_client._core.get_notebook = AsyncMock(return_value=[[None, []]])
+        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session.get_notebook = AsyncMock(return_value=[[None, []]])
         mock_client.notebooks.get = AsyncMock(return_value=MagicMock(sources=[]))
 
         result = await mock_client.artifacts.suggest_reports("notebook_123")
@@ -207,8 +207,8 @@ class TestAddSourceDrive:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
-        client._core.rpc_call = AsyncMock(return_value=[["source_id_123"]])
+        client._session._http_client = MagicMock()
+        client._session.rpc_call = AsyncMock(return_value=[["source_id_123"]])
         return client
 
     @pytest.mark.asyncio
@@ -221,7 +221,7 @@ class TestAddSourceDrive:
             mime_type=DriveMimeType.GOOGLE_DOC.value,
         )
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify source data structure - params[0] is [source_data] (single wrap)
@@ -247,7 +247,7 @@ class TestGetNotebookDescription:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
+        client._session._http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -264,7 +264,7 @@ class TestGetNotebookDescription:
                 ],
             ]
         ]
-        mock_client._core.rpc_call = AsyncMock(return_value=mock_response)
+        mock_client._session.rpc_call = AsyncMock(return_value=mock_response)
 
         result = await mock_client.notebooks.get_description("notebook_123")
 
@@ -286,8 +286,8 @@ class TestPayloadFixes:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._core._http_client = MagicMock()
-        client._core.rpc_call = AsyncMock(return_value=True)
+        client._session._http_client = MagicMock()
+        client._session.rpc_call = AsyncMock(return_value=True)
         return client
 
     @pytest.mark.asyncio
@@ -295,7 +295,7 @@ class TestPayloadFixes:
         """Test check_source_freshness uses correct payload structure."""
         await mock_client.sources.check_freshness("notebook_123", "source_456")
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify reference payload: [null, ["source_id"], [2]]
@@ -308,7 +308,7 @@ class TestPayloadFixes:
         """Test refresh_source uses correct payload structure."""
         await mock_client.sources.refresh("notebook_123", "source_456")
 
-        call_args = mock_client._core.rpc_call.call_args
+        call_args = mock_client._session.rpc_call.call_args
         params = call_args[0][1]
 
         # Verify reference payload: [null, ["source_id"], [2]]

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -575,7 +575,7 @@ class TestSnapshotRefreshedAfterSave:
         client = NotebookLMClient(auth)
         async with client:
             # First save: rotates *PSIDTS in-process to A1, then save propagates.
-            _set_cookie_value(client._core._http_client.cookies, "__Secure-1PSIDTS", "A1")
+            _set_cookie_value(client._session._http_client.cookies, "__Secure-1PSIDTS", "A1")
             await client.refresh_auth()
             assert _cookie_value(storage, "__Secure-1PSIDTS", ".google.com") == "A1"
 
@@ -1153,10 +1153,10 @@ class TestBaselineNotAdvancedOnSaveFailure:
         client = NotebookLMClient(auth, cookie_saver=silent_fail)
 
         async with client:
-            baseline_before = client._core._loaded_cookie_snapshot
-            assert client._core._http_client is not None
-            await client._core.save_cookies(client._core._http_client.cookies)
-            baseline_after = client._core._loaded_cookie_snapshot
+            baseline_before = client._session._loaded_cookie_snapshot
+            assert client._session._http_client is not None
+            await client._session.save_cookies(client._session._http_client.cookies)
+            baseline_after = client._session._loaded_cookie_snapshot
 
         assert baseline_after is baseline_before, (
             "save_cookies must NOT advance _loaded_cookie_snapshot when the "

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -1685,7 +1685,7 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
             await both_submitted.wait()
             return func(*args, **kwargs)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.to_thread", fake_to_thread)
+        monkeypatch.setattr("notebooklm._session_lifecycle.asyncio.to_thread", fake_to_thread)
 
         # Two jars representing distinct post-rotation states. The save that
         # acquires ``_save_lock`` first rotates *PSIDTS away from v0; the

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -1121,7 +1121,7 @@ class TestBaselineNotAdvancedOnSaveFailure:
     """
 
     @pytest.mark.asyncio
-    async def test_baseline_unchanged_when_save_returns_false(self, tmp_path, monkeypatch):
+    async def test_baseline_unchanged_when_save_returns_false(self, tmp_path):
         from notebooklm.client import NotebookLMClient
 
         storage = tmp_path / "storage_state.json"
@@ -1143,13 +1143,14 @@ class TestBaselineNotAdvancedOnSaveFailure:
             storage_path=storage,
         )
 
-        client = NotebookLMClient(auth)
-
         # Make every save_cookies_to_storage call return False (silent failure).
+        # Phase 2 PR 4: inject the cookie-saver seam directly via
+        # ``NotebookLMClient(..., cookie_saver=…)`` rather than monkeypatching
+        # the legacy ``notebooklm._core.save_cookies_to_storage`` indirection.
         def silent_fail(jar, path, **kwargs):
             return False
 
-        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", silent_fail)
+        client = NotebookLMClient(auth, cookie_saver=silent_fail)
 
         async with client:
             baseline_before = client._core._loaded_cookie_snapshot
@@ -1642,8 +1643,6 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
             session_id="s",
             storage_path=storage,
         )
-        core = Session(auth)
-        await core.open()
 
         captured_calls: list[tuple[str, dict | None]] = []
         real_save = auth_mod.save_cookies_to_storage
@@ -1660,7 +1659,10 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
             )
             return real_save(jar, path, original_snapshot=original_snapshot, **kwargs)
 
-        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", capture_save)
+        # Phase 2 PR 4: inject the cookie-saver seam via the constructor
+        # rather than monkeypatching ``notebooklm._core.save_cookies_to_storage``.
+        core = Session(auth, cookie_saver=capture_save)
+        await core.open()
 
         # Explicit barrier: each coroutine records its submission and the
         # second arrival sets ``both_submitted``; both then ``await`` the

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -179,11 +179,9 @@ async def test_refresh_auth_session_missing_session_id_wraps_extraction_error() 
 @pytest.mark.asyncio
 async def test_refresh_auth_session_persists_through_client_core_save_cookies(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     storage_path = tmp_path / "storage_state.json"
     auth = _auth(storage_path=storage_path)
-    core = Session(auth)
     calls: list[tuple[Path, bool, object]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -205,7 +203,10 @@ async def test_refresh_auth_session_persists_through_client_core_save_cookies(
         calls.append((path, return_result, original_snapshot))
         return True
 
-    monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", fake_save_cookies_to_storage)
+    # Inject the cookie-saver seam directly (Phase 2 PR 4 — replaces the
+    # legacy ``_core.save_cookies_to_storage`` string-target monkeypatch
+    # with constructor injection through ``ClientLifecycle._cookie_saver``).
+    core = Session(auth, cookie_saver=fake_save_cookies_to_storage)
 
     http_client = httpx.AsyncClient(
         transport=httpx.MockTransport(handler),

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -285,6 +285,75 @@ async def test_auth_refresh_middleware_honors_injected_predicate() -> None:
 
 
 @pytest.mark.asyncio
+async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
+    """Production-chain regression: a real ``HTTPStatusError(401)`` raised
+    by the transport leaf must drive the refresh-and-retry path through
+    ``Session._perform_authed_post``.
+
+    This is the wiring-level counterpart to
+    :func:`test_auth_refresh_middleware_honors_injected_predicate` (which
+    pins the middleware-level contract in isolation). Together they
+    cover both halves of the contract:
+
+    1. ``AuthRefreshMiddleware`` honors its injected predicate.
+    2. ``Session.__init__`` actually wires the middleware with a
+       predicate that recognises real auth errors — currently
+       ``is_auth_error=_live_is_auth_error`` (see
+       ``notebooklm._session._get_authed_transport`` /
+       ``_get_rpc_executor``), where ``_live_is_auth_error`` resolves
+       :func:`notebooklm._session_helpers.is_auth_error` at call time.
+
+    Restored in Phase 2 PR 4 after the migration of
+    ``test_chain_uses_late_bound_is_auth_error`` (which used
+    ``monkeypatch.setattr("notebooklm._core.is_auth_error", lambda exc:
+    True)`` to force ANY exception to be treated as an auth error)
+    deleted the only end-to-end check of that wiring. Codex / agy
+    review caught the regression; this test re-adds the coverage
+    without depending on the soon-to-be-retired ``_core`` indirection
+    by using a real 401 that the canonical predicate already
+    recognises.
+    """
+    refresh_calls: list[bool] = []
+
+    async def refresh() -> AuthTokens:
+        refresh_calls.append(True)
+        return core.auth
+
+    core = _make_core(refresh_callback=refresh)
+    await core.open()
+    try:
+
+        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
+            return "https://example.test/x", "payload", {}
+
+        call_count = {"n": 0}
+
+        async def fake_post(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Real 401 — recognised by ``is_auth_error``, which
+                # ``_live_is_auth_error`` resolves at call time. No
+                # monkeypatch needed: the predicate's natural behavior
+                # drives the refresh path.
+                raise _status_error(401)
+            return _ok_response()
+
+        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+
+        response = await core._perform_authed_post(build_request=build, log_label="test")
+
+        assert response.status_code == 200
+        assert refresh_calls == [True], (
+            "Production chain must drive the refresh-and-retry path on a "
+            "real 401 — proves Session wires AuthRefreshMiddleware with a "
+            "predicate that recognises canonical auth errors."
+        )
+        assert call_count["n"] == 2
+    finally:
+        await core.close()
+
+
+@pytest.mark.asyncio
 async def test_chain_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch):
     """``RetryMiddleware`` resolves ``asyncio.sleep`` at call time and uses
     the shared ``random`` module for jitter, so tests can monkey-patch both
@@ -554,18 +623,15 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
 
         install_post_as_stream(monkeypatch, core._http_client, fake_post)
 
-        # Drive through rpc_call so set_request_id is in scope (rpc_call is
-        # the caller boundary that owns the request-id context).
-        async def fake_decode(*args, **kwargs):
-            return []
-
-        monkeypatch.setattr(
-            "notebooklm.rpc.decode_response",
-            lambda *args, **kwargs: [],
-        )
-
         # Use _perform_authed_post directly inside set_request_id to verify
-        # the helper itself doesn't reset the id.
+        # the helper itself doesn't reset the id. ``_perform_authed_post``
+        # is the transport-level call below ``rpc_call``; it never invokes
+        # ``decode_response``, so no decode_response patch is needed here.
+        # (Pre-Phase-2-PR-5 this test carried a stale
+        # ``monkeypatch.setattr("notebooklm._core.decode_response", …)`` —
+        # dead code from when the test was earlier driven through
+        # ``rpc_call``. Removed in PR 5 alongside the stdlib seam
+        # migration to keep the diff localized to a single review pass.)
         from notebooklm._logging import reset_request_id, set_request_id
 
         token = set_request_id("REQ-stable-1234")

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -35,6 +35,7 @@ import pytest
 from conftest import install_post_as_stream
 from notebooklm._authed_transport import AuthedTransport
 from notebooklm._logging import get_request_id
+from notebooklm._middleware import RpcRequest, RpcResponse
 from notebooklm._session import (
     Session,
     _AuthSnapshot,
@@ -225,52 +226,60 @@ async def test_authed_transport_requires_open_client():
 
 
 @pytest.mark.asyncio
-async def test_chain_uses_late_bound_is_auth_error(monkeypatch):
-    """Tier-12 PR 12.8 lifted auth-refresh into ``AuthRefreshMiddleware``.
+async def test_auth_refresh_middleware_honors_injected_predicate() -> None:
+    """``AuthRefreshMiddleware`` calls ``refresh_callable`` and retries
+    exactly once when the injected ``is_auth_error`` predicate returns
+    ``True``, regardless of the actual HTTP status code.
 
-    The middleware reads ``is_auth_error`` LIVE through
-    ``notebooklm._core``'s module globals (via the lambda in the chain
-    seed) so a test that monkeypatches
-    ``notebooklm._core.is_auth_error`` still drives the refresh path —
-    preserving the pre-PR-12.8 contract where ``AuthedTransport`` read
-    the same module attr live. Drives the chain via
-    ``core._perform_authed_post`` since retry behavior moved out of the
-    leaf.
+    Phase 2 PR 4 (``.sisyphus/plans/refactor-completion-plan.md``)
+    rewrote this test off the legacy ``_core.is_auth_error`` string-target
+    monkeypatch and instead constructs the middleware directly with an
+    injected predicate. The
+    production chain seeds ``AuthRefreshMiddleware`` with
+    ``is_auth_error=_live_is_auth_error`` (see
+    ``notebooklm._session._get_authed_transport``); that wiring is
+    covered separately. Here we pin the middleware-level contract:
+    *whatever* predicate is injected drives the refresh-and-retry
+    decision.
     """
+    from notebooklm._middleware_auth_refresh import AuthRefreshMiddleware
+
     refresh_calls: list[bool] = []
 
-    async def refresh() -> AuthTokens:
+    async def refresh() -> None:
         refresh_calls.append(True)
-        return core.auth
 
-    core = _make_core(refresh_callback=refresh)
-    await core.open()
-    try:
-        # Force the middleware to treat ANY exception as an auth error.
-        # The chain reads ``is_auth_error`` through the module so this
-        # patch takes effect on the next call.
-        monkeypatch.setattr("notebooklm._core.is_auth_error", lambda exc: True)
+    # A 418 (I'm a teapot) — NOT recognised by the production
+    # ``is_auth_error`` (which keys off 400/401/403). The injected
+    # predicate returns True unconditionally, so the middleware treats it
+    # as an auth error and runs the refresh path.
+    boom = _status_error(418)
+    call_count = {"n": 0}
 
-        def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
-            return "https://example.test/x", "payload", {}
+    async def terminal(request):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise boom
+        return RpcResponse(response=_ok_response(), context=request.context)
 
-        call_count = {"n": 0}
+    middleware = AuthRefreshMiddleware(
+        refresh_callable=refresh,
+        is_auth_error=lambda exc: True,
+        refresh_callback_enabled=lambda: True,
+        refresh_retry_delay=lambda: 0.0,
+    )
 
-        async def fake_post(*args, **kwargs):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                raise _status_error(418)
-            return _ok_response()
+    request = RpcRequest(
+        url="https://example.test/x",
+        headers={},
+        body=b"payload",
+        context={"log_label": "test"},
+    )
+    response = await middleware(request, terminal)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
-
-        response = await core._perform_authed_post(build_request=build, log_label="test")
-
-        assert response.status_code == 200
-        assert refresh_calls == [True]
-        assert call_count["n"] == 2
-    finally:
-        await core.close()
+    assert response.response.status_code == 200
+    assert refresh_calls == [True]
+    assert call_count["n"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -54,11 +54,13 @@ def _no_backoff_jitter(monkeypatch):
     Production code adds a small ±20% jitter to the exponential backoff to
     reduce thundering-herd effects across clients. These transport tests
     assert exact sleep schedules (``[1, 2, 4, ...]``), so we patch
-    ``random.uniform`` inside ``notebooklm._core`` to return 0. The 429 path
-    uses ``Retry-After`` instead of jitter, so this fixture has no effect on
-    those tests.
+    ``random.uniform`` on its canonical importing module
+    :mod:`notebooklm._session` (Phase 2 PR 5 migrated this off the
+    deprecated ``notebooklm._core.random.uniform`` shim) to return 0. The
+    429 path uses ``Retry-After`` instead of jitter, so this fixture has
+    no effect on those tests.
     """
-    monkeypatch.setattr("notebooklm._core.random.uniform", lambda a, b: 0.0)
+    monkeypatch.setattr("notebooklm._session.random.uniform", lambda a, b: 0.0)
 
 
 def _make_core(
@@ -189,7 +191,7 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
         # ``RetryMiddleware`` defaults to ``asyncio.sleep`` resolved at call
         # time, so patching the asyncio module's ``sleep`` reaches it
         # through Python's module identity.
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -298,8 +300,8 @@ async def test_chain_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
-        monkeypatch.setattr("notebooklm._core.random.uniform", lambda a, b: 0.2)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.random.uniform", lambda a, b: 0.2)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -334,7 +336,7 @@ async def test_authed_transport_disable_internal_retries_short_circuits(monkeypa
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -558,7 +560,7 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
             return []
 
         monkeypatch.setattr(
-            "notebooklm._core.decode_response",
+            "notebooklm.rpc.decode_response",
             lambda *args, **kwargs: [],
         )
 
@@ -638,7 +640,7 @@ async def test_5xx_retries_then_succeeds(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -674,7 +676,7 @@ async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -711,7 +713,7 @@ async def test_network_error_retries_then_succeeds(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -747,7 +749,7 @@ async def test_network_error_exhausts_budget_raises_transport_server_error(monke
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -780,7 +782,7 @@ async def test_server_error_budget_zero_raises_immediately(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -815,7 +817,7 @@ async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -846,7 +848,7 @@ async def test_5xx_path_does_not_touch_429_path(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -886,7 +888,7 @@ async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
         async def fake_sleep(seconds: float) -> None:
             sleeps.append(seconds)
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         def build(snapshot: _AuthSnapshot) -> tuple[str, str, dict[str, str]]:
             return "https://example.test/x", "payload", {}
@@ -921,7 +923,7 @@ async def test_rpc_call_maps_transport_server_error_to_server_error(monkeypatch)
         async def fake_sleep(seconds: float) -> None:
             pass
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         async def fake_post(*args, **kwargs):
             raise _status_error(503)
@@ -948,7 +950,7 @@ async def test_rpc_call_maps_transport_server_error_network_to_network_error(mon
         async def fake_sleep(seconds: float) -> None:
             pass
 
-        monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
         async def fake_post(*args, **kwargs):
             raise httpx.ConnectError("nope")

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -85,7 +85,7 @@ async def test_empty_chain_routes_perform_authed_post_to_transport() -> None:
     Covers the first of the two call paths from master plan line 160:
     direct callers of ``Session._perform_authed_post`` (the chat path
     in ``_chat_transport.py:64`` and any first-party caller via
-    ``client._core._perform_authed_post``).
+    ``client._session._perform_authed_post``).
     """
     expected_response = httpx.Response(status_code=200, content=b"chain-routed")
     fake = FakeAuthedPost(response=expected_response)

--- a/tests/unit/test_chat_characterization.py
+++ b/tests/unit/test_chat_characterization.py
@@ -1821,7 +1821,7 @@ class TestGetConversationIdNullRaw:
         async with NotebookLMClient(auth_tokens) as client:
             # Patch rpc_call to return None directly (bypasses decode error)
             with patch.object(
-                client._core,
+                client._session,
                 "rpc_call",
                 new_callable=AsyncMock,
                 return_value=None,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -226,10 +226,10 @@ class TestRefreshAuth:
 
         async def fake_update(csrf: str, session_id: str) -> None:
             calls.append((csrf, session_id))
-            client._core.auth.csrf_token = csrf
-            client._core.auth.session_id = session_id
+            client._session.auth.csrf_token = csrf
+            client._session.auth.session_id = session_id
 
-        monkeypatch.setattr(client._core, "update_auth_tokens", fake_update)
+        monkeypatch.setattr(client._session, "update_auth_tokens", fake_update)
 
         async with client:
             refreshed_auth = await client.refresh_auth()
@@ -237,9 +237,9 @@ class TestRefreshAuth:
         assert calls == [("new_csrf_token_123", "new_session_id_456")]
         assert refreshed_auth.csrf_token == "new_csrf_token_123"
         assert refreshed_auth.session_id == "new_session_id_456"
-        assert client._core.auth is refreshed_auth
-        assert client._core.auth.csrf_token == "new_csrf_token_123"
-        assert client._core.auth.session_id == "new_session_id_456"
+        assert client._session.auth is refreshed_auth
+        assert client._session.auth.csrf_token == "new_csrf_token_123"
+        assert client._session.auth.session_id == "new_session_id_456"
 
     @pytest.mark.asyncio
     async def test_refresh_auth_routes_to_account_email(self, httpx_mock: HTTPXMock):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -559,7 +559,7 @@ class TestRpcCallAutoRetry:
         install_post_as_stream(None, core._http_client, mock_post)
         core._http_client.headers = {"Cookie": "old"}
 
-        with patch("notebooklm._core.decode_response", return_value=["result"]):
+        with patch("notebooklm.rpc.decode_response", return_value=["result"]):
             result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
         assert len(refresh_called) == 1, "refresh_callback should be called once"
@@ -604,7 +604,7 @@ class TestRpcCallAutoRetry:
                 raise RPCError("Authentication expired", method_id="wXbhsf")
             return ["result"]
 
-        with patch("notebooklm._core.decode_response", side_effect=mock_decode):
+        with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
             result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
         assert len(refresh_called) == 1, "refresh_callback should be called once"
@@ -789,7 +789,7 @@ class TestRpcCallAutoRetry:
         install_post_as_stream(None, core._http_client, mock_post)
         core._http_client.headers = {"Cookie": "old"}
 
-        with patch("notebooklm._core.decode_response", return_value=["result"]):
+        with patch("notebooklm.rpc.decode_response", return_value=["result"]):
             # Start two concurrent calls
             await asyncio.gather(
                 core.rpc_call(RPCMethod.LIST_NOTEBOOKS, []),
@@ -845,7 +845,7 @@ class TestRpcCallAutoRetry:
         install_post_as_stream(None, core._http_client, mock_post)
         core._http_client.headers = {"Cookie": "old"}
 
-        with patch("notebooklm._core.decode_response", return_value=["result"]):
+        with patch("notebooklm.rpc.decode_response", return_value=["result"]):
             result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
         assert len(refresh_called) == 1, "refresh_callback should be called once on 400"

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -266,12 +266,14 @@ class TestKeepalivePersistenceFailure:
             save_calls.append(path)
             raise OSError("simulated disk full")
 
-        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", boom)
-
+        # Phase 2 PR 4: inject the cookie-saver seam directly at the client
+        # constructor rather than monkeypatching the legacy
+        # ``notebooklm._core.save_cookies_to_storage`` indirection.
         client = NotebookLMClient(
             auth,
             keepalive=0.05,
             keepalive_min_interval=0.01,
+            cookie_saver=boom,
         )
 
         with caplog.at_level("WARNING", logger="notebooklm._core"):
@@ -378,9 +380,7 @@ class TestKeepaliveExplicitStoragePath:
 
     @pytest.mark.asyncio
     @pytest.mark.no_default_keepalive_mock
-    async def test_close_persists_to_explicit_storage_path(
-        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
-    ):
+    async def test_close_persists_to_explicit_storage_path(self, tmp_path, httpx_mock: HTTPXMock):
         """``Session.close()`` calls ``save_cookies_to_storage`` with the
         explicit constructor ``storage_path`` even when keepalive never ran
         and ``auth.storage_path`` was ``None`` originally — proving the
@@ -401,9 +401,8 @@ class TestKeepaliveExplicitStoragePath:
         def spy(cookies, path, **kwargs):
             save_calls.append((cookies, path))
 
-        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
-
-        client = NotebookLMClient(auth, storage_path=storage_path)
+        # Phase 2 PR 4: inject the cookie-saver seam directly.
+        client = NotebookLMClient(auth, storage_path=storage_path, cookie_saver=spy)
         async with client:
             pass  # no RPC calls; keepalive disabled by default
 
@@ -460,7 +459,7 @@ class TestSaveCookiesUnification:
     keepalive, and refresh_auth all route through."""
 
     @pytest.mark.asyncio
-    async def test_save_cookies_takes_in_process_lock_before_writing(self, tmp_path, monkeypatch):
+    async def test_save_cookies_takes_in_process_lock_before_writing(self, tmp_path):
         """``Session.save_cookies`` holds ``_save_lock`` for the duration of
         the worker-thread write, so an older snapshot can't clobber a newer one
         within the same process."""
@@ -473,10 +472,10 @@ class TestSaveCookiesUnification:
             storage_path=tmp_path / "storage_state.json",
         )
         (tmp_path / "storage_state.json").write_text('{"cookies": []}')
-        core = Session(auth)
 
         lock_held_during_save: list[bool] = []
         call_kwargs: list[dict] = []
+        core_ref: dict[str, Session] = {}
 
         def spy(jar, path, **kwargs):
             """Record lock state and the kwargs.
@@ -486,11 +485,13 @@ class TestSaveCookiesUnification:
             ``original_snapshot=`` through, the assertion below catches it
             before production silently reverts to legacy merge.
             """
-            lock_held_during_save.append(core._save_lock.locked())
+            lock_held_during_save.append(core_ref["core"]._save_lock.locked())
             call_kwargs.append(kwargs)
             return True
 
-        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+        # Phase 2 PR 4: inject the cookie-saver seam at construction.
+        core = Session(auth, cookie_saver=spy)
+        core_ref["core"] = core
 
         await core.save_cookies(httpx.Cookies())
 
@@ -505,7 +506,7 @@ class TestSaveCookiesUnification:
 
     @pytest.mark.asyncio
     async def test_refresh_auth_routes_save_through_save_cookies(
-        self, tmp_path, monkeypatch, httpx_mock: HTTPXMock
+        self, tmp_path, httpx_mock: HTTPXMock
     ):
         """``refresh_auth`` no longer calls ``save_cookies_to_storage`` directly;
         it routes through ``Session.save_cookies`` so the in-process lock is
@@ -545,10 +546,9 @@ class TestSaveCookiesUnification:
             content=b'<html><script>window.WIZ_global_data={"SNlM0e":"new_csrf","FdrFJe":"new_sid"};</script></html>',
         )
 
-        client = NotebookLMClient(auth)
-
         save_calls: list[bool] = []
         snapshot_kwarg_present: list[bool] = []
+        client_ref: dict[str, NotebookLMClient] = {}
 
         def spy(jar, path, **kwargs):
             """Record whether ``_save_lock`` is held when refresh_auth's save fires
@@ -558,11 +558,13 @@ class TestSaveCookiesUnification:
             must route through the snapshot/delta path, never the legacy
             full-merge path.
             """
-            save_calls.append(client._core._save_lock.locked())
+            save_calls.append(client_ref["client"]._core._save_lock.locked())
             snapshot_kwarg_present.append("original_snapshot" in kwargs)
             return True
 
-        monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+        # Phase 2 PR 4: inject the cookie-saver seam at construction.
+        client = NotebookLMClient(auth, cookie_saver=spy)
+        client_ref["client"] = client
 
         async with client:
             await client.refresh_auth()

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -80,7 +80,7 @@ class TestKeepaliveDisabledByDefault:
         """No keepalive task is spawned and no extra HTTP calls fire by default."""
         client = NotebookLMClient(mock_auth)
         async with client:
-            assert client._core._keepalive_task is None
+            assert client._session._keepalive_task is None
             # Give the loop a chance to run; nothing should happen
             await asyncio.sleep(0.1)
 
@@ -108,12 +108,12 @@ class TestKeepaliveLifecycle:
         )
 
         async with client:
-            task = client._core._keepalive_task
+            task = client._session._keepalive_task
             assert task is not None
             assert not task.done()
 
         # Task should be cleaned up; no warnings should be raised.
-        assert client._core._keepalive_task is None
+        assert client._session._keepalive_task is None
         # Either cancelled or finished; never left dangling.
         assert task.done()
 
@@ -127,7 +127,7 @@ class TestKeepaliveFloor:
             keepalive=10.0,
             keepalive_min_interval=60.0,
         )
-        assert client._core._keepalive_interval == 60.0
+        assert client._session._keepalive_interval == 60.0
 
     @pytest.mark.asyncio
     async def test_floor_does_not_lower_higher_interval(self, mock_auth):
@@ -137,7 +137,7 @@ class TestKeepaliveFloor:
             keepalive=600.0,
             keepalive_min_interval=60.0,
         )
-        assert client._core._keepalive_interval == 600.0
+        assert client._session._keepalive_interval == 600.0
 
     @pytest.mark.asyncio
     async def test_none_keeps_disabled(self, mock_auth):
@@ -147,7 +147,7 @@ class TestKeepaliveFloor:
             keepalive=None,
             keepalive_min_interval=60.0,
         )
-        assert client._core._keepalive_interval is None
+        assert client._session._keepalive_interval is None
 
 
 class TestKeepaliveValidation:
@@ -234,8 +234,8 @@ class TestKeepalivePokes:
         async with client:
             await asyncio.sleep(0.4)
             # Task is still running after the failure
-            assert client._core._keepalive_task is not None
-            assert not client._core._keepalive_task.done()
+            assert client._session._keepalive_task is not None
+            assert not client._session._keepalive_task.done()
 
         poke_requests = [r for r in httpx_mock.get_requests() if "RotateCookies" in str(r.url)]
         # First call raised; at least one further successful call must follow.
@@ -351,7 +351,7 @@ class TestKeepaliveExplicitStoragePath:
     def test_explicit_storage_path_normalizes_onto_auth_without_mutating_caller(self, tmp_path):
         """The constructor exposes ``storage_path`` on ``client.auth`` so
         ``refresh_auth()`` and ``Session.close()`` (which read
-        ``self._core.auth.storage_path`` directly, not the keepalive-specific
+        ``self._session.auth.storage_path`` directly, not the keepalive-specific
         path) persist to the same file. Crucially, the caller's original
         ``AuthTokens`` is *not* mutated, so reusing one ``AuthTokens`` across
         multiple ``NotebookLMClient`` instances with different storage paths
@@ -558,7 +558,7 @@ class TestSaveCookiesUnification:
             must route through the snapshot/delta path, never the legacy
             full-merge path.
             """
-            save_calls.append(client_ref["client"]._core._save_lock.locked())
+            save_calls.append(client_ref["client"]._session._save_lock.locked())
             snapshot_kwarg_present.append("original_snapshot" in kwargs)
             return True
 

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -388,7 +388,7 @@ async def test_concurrent_refresh_does_not_corrupt_inflight_rpc_request(rpc_firs
         from notebooklm.client import NotebookLMClient
 
         client = NotebookLMClient.__new__(NotebookLMClient)
-        client._core = core
+        client._session = core
 
         # try/finally ensures the mock-transport handlers are unblocked even
         # if a wait_for times out — otherwise pending tasks dangle in the

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -52,10 +52,21 @@ def test_client_core_exposes_cookie_persistence_and_private_bridges(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_client_core_save_cookies_uses_core_module_monkeypatches(
+async def test_client_core_save_cookies_routes_through_injected_seam_and_to_thread(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    core = Session(_auth_tokens(tmp_path / "storage_state.json"))
+    """``Session.save_cookies`` routes the write through
+    ``asyncio.to_thread`` (off the loop) and then invokes the
+    constructor-injected ``cookie_saver``.
+
+    Phase 2 PR 4 (``.sisyphus/plans/refactor-completion-plan.md``)
+    migrated the cookie-writer half of this test off the legacy
+    ``_core.save_cookies_to_storage`` string-target monkeypatch:
+    ``save_cookies_to_storage`` is now injected at construction via the
+    ``cookie_saver`` seam (Wave 1's :class:`ClientLifecycle` change).
+    The ``asyncio.to_thread`` patch is migrated to a canonical-module
+    target in Phase 2 PR 5 (next commit).
+    """
     calls: list[str] = []
 
     def fake_save(cookie_jar: httpx.Cookies, path: Path | None = None, **kwargs: Any) -> bool:
@@ -68,8 +79,8 @@ async def test_client_core_save_cookies_uses_core_module_monkeypatches(
         calls.append("to_thread")
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(core_module, "save_cookies_to_storage", fake_save)
     monkeypatch.setattr(core_module.asyncio, "to_thread", fake_to_thread)
+    core = Session(_auth_tokens(tmp_path / "storage_state.json"), cookie_saver=fake_save)
 
     await core.save_cookies(_jar())
 

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -11,7 +11,6 @@ import httpx
 import pytest
 
 import notebooklm._cookie_persistence as persistence_module
-import notebooklm._core as core_module
 from notebooklm._cookie_persistence import CookiePersistence
 from notebooklm._session import Session
 from notebooklm.auth import (
@@ -59,13 +58,16 @@ async def test_client_core_save_cookies_routes_through_injected_seam_and_to_thre
     ``asyncio.to_thread`` (off the loop) and then invokes the
     constructor-injected ``cookie_saver``.
 
-    Phase 2 PR 4 (``.sisyphus/plans/refactor-completion-plan.md``)
-    migrated the cookie-writer half of this test off the legacy
-    ``_core.save_cookies_to_storage`` string-target monkeypatch:
-    ``save_cookies_to_storage`` is now injected at construction via the
-    ``cookie_saver`` seam (Wave 1's :class:`ClientLifecycle` change).
-    The ``asyncio.to_thread`` patch is migrated to a canonical-module
-    target in Phase 2 PR 5 (next commit).
+    Phase 2 PR 4+5 (``.sisyphus/plans/refactor-completion-plan.md``)
+    migrated both halves of this test off the legacy
+    ``_core`` indirection:
+
+    - ``save_cookies_to_storage`` is injected at construction via the
+      ``cookie_saver`` seam (Wave 1's :class:`ClientLifecycle` change).
+    - ``asyncio.to_thread`` is patched on its canonical importing
+      module :mod:`notebooklm._session_lifecycle` (where
+      ``ClientLifecycle.save_cookies`` sources it via
+      ``cookie_persistence.save(to_thread=asyncio.to_thread)``).
     """
     calls: list[str] = []
 
@@ -79,7 +81,7 @@ async def test_client_core_save_cookies_routes_through_injected_seam_and_to_thre
         calls.append("to_thread")
         return func(*args, **kwargs)
 
-    monkeypatch.setattr(core_module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr("notebooklm._session_lifecycle.asyncio.to_thread", fake_to_thread)
     core = Session(_auth_tokens(tmp_path / "storage_state.json"), cookie_saver=fake_save)
 
     await core.save_cookies(_jar())

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -251,8 +251,8 @@ async def test_close_with_drain_closes_transport_after_timeout(auth_tokens: Auth
     async def close_transport() -> None:
         calls.append("close")
 
-    client._core.drain = drain_timeout  # type: ignore[method-assign]
-    client._core.close = close_transport  # type: ignore[method-assign]
+    client._session.drain = drain_timeout  # type: ignore[method-assign]
+    client._session.close = close_transport  # type: ignore[method-assign]
 
     with pytest.raises(TimeoutError, match="deadline"):
         await client.close(drain=True, drain_timeout=0.1)
@@ -272,8 +272,8 @@ async def test_close_with_invalid_drain_does_not_close_transport(auth_tokens: Au
     async def close_transport() -> None:
         calls.append("close")
 
-    client._core.drain = invalid_drain  # type: ignore[method-assign]
-    client._core.close = close_transport  # type: ignore[method-assign]
+    client._session.drain = invalid_drain  # type: ignore[method-assign]
+    client._session.close = close_transport  # type: ignore[method-assign]
 
     with pytest.raises(ValueError, match="bad deadline"):
         await client.close(drain=True, drain_timeout=-1.0)

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -81,7 +81,7 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
         return {"ok": True}
 
     with (
-        patch("notebooklm._core.decode_response", fake_decode),
+        patch("notebooklm.rpc.decode_response", fake_decode),
         correlation_id("batch-42"),
     ):
         result = await core.rpc_call(RPCMethod.GET_NOTEBOOK, ["nb_123"])

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -1001,7 +1001,7 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
             session_id="session",
         )
     )
-    client._core.rpc_call = AsyncMock(return_value={"ok": True})
+    client._session.rpc_call = AsyncMock(return_value={"ok": True})
 
     # This test intentionally exercises the deprecated kwargs to pin the
     # forwarded keyword-for-keyword shape. Wrapping in pytest.warns keeps
@@ -1019,7 +1019,7 @@ async def test_client_rpc_call_delegates_keyword_for_keyword() -> None:
         )
 
     assert result == {"ok": True}
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=RPCMethod.CREATE_NOTEBOOK,
         params=["My Notebook"],
         source_path="/notebook/abc",
@@ -1046,12 +1046,12 @@ async def test_client_rpc_call_forwards_default_arguments() -> None:
     )
     # No async context is needed: this test replaces the core RPC coroutine
     # before any real transport initialization can be required.
-    client._core.rpc_call = AsyncMock(return_value=[])
+    client._session.rpc_call = AsyncMock(return_value=[])
 
     result = await client.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
     assert result == []
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=RPCMethod.LIST_NOTEBOOKS,
         params=[],
         source_path="/",

--- a/tests/unit/test_rpc_call_public_surface.py
+++ b/tests/unit/test_rpc_call_public_surface.py
@@ -46,7 +46,7 @@ _EXPECTED_OPERATION_VARIANT_MSG = "rpc_call(operation_variant=...) is deprecated
 def _make_client() -> NotebookLMClient:
     """Build a NotebookLMClient with the core RPC patched to an AsyncMock.
 
-    No real transport is initialized; ``client._core.rpc_call`` is
+    No real transport is initialized; ``client._session.rpc_call`` is
     replaced before any authed HTTP path can fire.
     """
     client = NotebookLMClient(
@@ -56,7 +56,7 @@ def _make_client() -> NotebookLMClient:
             session_id="session",
         )
     )
-    client._core.rpc_call = AsyncMock(return_value=[])
+    client._session.rpc_call = AsyncMock(return_value=[])
     return client
 
 
@@ -74,7 +74,7 @@ async def test_default_call_emits_no_deprecation_warning() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         await client.rpc_call(_METHOD, [])
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -97,7 +97,7 @@ async def test_explicit_source_path_root_emits_no_warning() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         await client.rpc_call(_METHOD, [], source_path="/")
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -118,7 +118,7 @@ async def test_non_root_source_path_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_SOURCE_PATH_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/notebook/x",
@@ -145,7 +145,7 @@ async def test_is_retry_explicit_false_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_IS_RETRY_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -166,7 +166,7 @@ async def test_is_retry_explicit_true_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_IS_RETRY_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",
@@ -187,7 +187,7 @@ async def test_operation_variant_explicit_emits_deprecation_warning() -> None:
     dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
     assert len(dep) == 1
     assert str(dep[0].message) == _EXPECTED_OPERATION_VARIANT_MSG
-    client._core.rpc_call.assert_awaited_once_with(
+    client._session.rpc_call.assert_awaited_once_with(
         method=_METHOD,
         params=[],
         source_path="/",

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -274,7 +274,7 @@ async def test_core_decode_response_monkeypatch_after_executor_construction(monk
         return {"decoded": rpc_id}
 
     monkeypatch.setattr(core, "_perform_authed_post", fake_perform_authed_post)
-    monkeypatch.setattr("notebooklm._core.decode_response", fake_decode)
+    monkeypatch.setattr("notebooklm.rpc.decode_response", fake_decode)
 
     result = await core._rpc_call_impl(
         RPCMethod.LIST_NOTEBOOKS,
@@ -449,7 +449,7 @@ async def test_core_sleep_monkeypatch_after_executor_construction(monkeypatch) -
 
     monkeypatch.setattr(core, "_await_refresh", fake_await_refresh)
     monkeypatch.setattr(core, "rpc_call", fake_rpc_call)
-    monkeypatch.setattr("notebooklm._core.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("notebooklm._session.asyncio.sleep", fake_sleep)
 
     result = await core._try_refresh_and_retry(
         RPCMethod.LIST_NOTEBOOKS,

--- a/tests/unit/test_save_lock_contract.py
+++ b/tests/unit/test_save_lock_contract.py
@@ -31,7 +31,7 @@ from notebooklm._session import Session
 from notebooklm.auth import AuthTokens
 
 
-def _make_core(tmp_path: Path) -> Session:
+def _make_core(tmp_path: Path, *, cookie_saver=None) -> Session:
     """Build a minimal ``Session`` whose ``save_cookies`` is safe to call.
 
     Order matters: ``AuthTokens.__post_init__`` calls ``build_cookie_jar``,
@@ -39,6 +39,10 @@ def _make_core(tmp_path: Path) -> Session:
     branch (file absent) so construction succeeds, THEN write the baseline
     file so the subsequent ``save_cookies`` call has something to merge
     against.
+
+    ``cookie_saver`` (Phase 2 PR 4) is forwarded to ``Session(...)`` so
+    tests can inject the persistence spy at construction rather than via
+    the legacy ``notebooklm._core.save_cookies_to_storage`` monkeypatch.
     """
     storage_path = tmp_path / "storage_state.json"
     auth = AuthTokens(
@@ -48,12 +52,12 @@ def _make_core(tmp_path: Path) -> Session:
         storage_path=storage_path,
     )
     storage_path.write_text('{"cookies": []}')
-    return Session(auth)
+    return Session(auth, cookie_saver=cookie_saver)
 
 
 @pytest.mark.asyncio
 async def test_save_lock_acquired_off_event_loop_thread(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     """The thread that holds ``_save_lock`` MUST NOT be the event-loop thread.
 
@@ -64,20 +68,25 @@ async def test_save_lock_acquired_off_event_loop_thread(
     without ``asyncio.to_thread``), the spy will see the loop thread holding
     the lock, and this assertion will fail.
     """
-    core = _make_core(tmp_path)
-
     loop_thread = threading.current_thread()
     observed: dict[str, object] = {}
+
+    # ``core`` is closed over by ``spy`` below; we declare a placeholder so
+    # the spy's reference can be resolved before ``_make_core`` returns.
+    core_ref: dict[str, Session] = {}
 
     def spy(jar, path, **kwargs):  # type: ignore[no-untyped-def]
         # ``save_cookies_to_storage`` is called from inside ``with lock:``
         # in ``_save()``. Whichever thread runs this spy is, by definition,
         # the thread currently holding ``_save_lock``.
-        observed["lock_held"] = core._save_lock.locked()
+        observed["lock_held"] = core_ref["core"]._save_lock.locked()
         observed["holder_thread"] = threading.current_thread()
         return True
 
-    monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+    # Phase 2 PR 4: inject the cookie-saver seam via constructor injection
+    # rather than via the legacy ``_core.save_cookies_to_storage`` string-target monkeypatch.
+    core = _make_core(tmp_path, cookie_saver=spy)
+    core_ref["core"] = core
 
     await core.save_cookies(httpx.Cookies())
 
@@ -104,7 +113,7 @@ async def test_save_lock_acquired_off_event_loop_thread(
 
 @pytest.mark.asyncio
 async def test_save_lock_does_not_block_event_loop(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
 ) -> None:
     """While ``_save_lock`` is held by a worker thread, the event loop must
     remain responsive.
@@ -116,8 +125,6 @@ async def test_save_lock_does_not_block_event_loop(
     until the worker released; with the contract intact, the heartbeat
     observes the lock IS held while the loop is still scheduling.
     """
-    core = _make_core(tmp_path)
-
     in_save = threading.Event()
     release_save = threading.Event()
     loop_observations: list[bool] = []
@@ -133,7 +140,8 @@ async def test_save_lock_does_not_block_event_loop(
         )
         return True
 
-    monkeypatch.setattr("notebooklm._core.save_cookies_to_storage", spy)
+    # Phase 2 PR 4: inject the cookie-saver seam at construction.
+    core = _make_core(tmp_path, cookie_saver=spy)
 
     async def heartbeat() -> None:
         # Wait for the worker to enter the spy by polling — using asyncio.sleep

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -174,8 +174,8 @@ async def test_client_close_default_drain_is_true() -> None:
     async def fake_close() -> None:
         pass
 
-    client._core.drain = fake_drain  # type: ignore[method-assign]
-    client._core.close = fake_close  # type: ignore[method-assign]
+    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session.close = fake_close  # type: ignore[method-assign]
 
     await client.close()
 
@@ -196,8 +196,8 @@ async def test_client_close_drain_false_skips_drain() -> None:
     async def fake_close() -> None:
         pass
 
-    client._core.drain = fake_drain  # type: ignore[method-assign]
-    client._core.close = fake_close  # type: ignore[method-assign]
+    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session.close = fake_close  # type: ignore[method-assign]
 
     await client.close(drain=False)
 
@@ -216,8 +216,8 @@ async def test_client_aexit_uses_drain_true_default() -> None:
     async def fake_close() -> None:
         pass
 
-    client._core.drain = fake_drain  # type: ignore[method-assign]
-    client._core.close = fake_close  # type: ignore[method-assign]
+    client._session.drain = fake_drain  # type: ignore[method-assign]
+    client._session.close = fake_close  # type: ignore[method-assign]
 
     # Drive __aexit__ directly rather than `async with` so we can use the
     # patched core without going through ``open()``.


### PR DESCRIPTION
## Summary

Phase 2 Waves 2+3 of the v0.5.0 refactor program, combined into one PR per merge sequencing (Wave 3 was squash-merged onto Wave 2's branch, so they ship together).

**Commits:**
- `adae56f` refactor(tests): migrate `_core` callable monkeypatches to constructor injection (Wave 2 commit A — was master-plan PR 4)
- `ba9fad4` refactor(tests): re-target stdlib seam patches to canonical modules (Wave 2 commit B — was master-plan PR 5; same-commit production flip of `_decode_response_late_bound` from `_core.decode_response` to `notebooklm.rpc.decode_response`)
- `1ddd9b1` refactor(client): rename `_core` to `_session` and delete compat alias (squash of #880; Wave 3 — was master-plan PR 6)
- `dd12807` polish(tests): restore chain-level `is_auth_error` wiring coverage + cleanups (Wave 2 polish stage)

## What landed

- **~9 test files**: callable `monkeypatch.setattr("notebooklm._core.{save_cookies_to_storage,_rotate_cookies,is_auth_error}", ...)` sites migrated to constructor injection via the `cookie_saver` / `cookie_rotator` seams added in PR #879. `is_auth_error` migrated by constructing `AuthRefreshMiddleware(is_auth_error=...)` directly.
- **~10 test files**: stdlib `notebooklm._core.{asyncio,random,decode_response,httpx}.X` patches sed-rewritten to canonical source modules (`_authed_transport.asyncio`, `_session.random`, `notebooklm.rpc.decode_response`, `_session_lifecycle.httpx`). Same-commit production change: `_decode_response_late_bound` at `_session.py:180-184` imports `decode_response` from `notebooklm.rpc` (canonical) instead of via `_core`.
- **~17 sites in `client.py`** + **~210 sites in ~29 test files**: `self._core` / `client._core` renamed to `self._session` / `client._session`. Alias `self._core = self._session` at `client.py:271` deleted. Stale comment blocks scrubbed (`client.py:269-271,322-329`; `_session.py:351,1431`).
- **`tests/_lint/` allowlist** updated for fully-cleaned files.
- **`_core.py` module is UNCHANGED** — Phase 4 PR 10 deletes it.
- **Session property bridges UNCHANGED** — Phase 4 PR 10 deletes them.

## Verification

- `uv run ruff check src/notebooklm/ tests/` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 files)
- `uv run pytest -x` — 5536 passed at the Wave 2 polish stage (Wave 3's rename merged via #880 ran the same suite green; rebase preserves both)

## Stacking history

- Wave 1 (PR #879) — merged as `76b301d`
- Wave 2 + Wave 3 stacked: Wave 3 (PR #880) squash-merged INTO Wave 2's branch as `1ddd9b1`. Wave 2's polish commit `dd12807` rebased on top.
- This PR ships the combined Wave 2 + Wave 3 to main.

## Generated-by footer

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /execute-phase orchestrator pipeline.

Phase 2 implementation references `.sisyphus/plans/refactor-completion-plan.md` (master plan) and `.sisyphus/phases/refactor-completion-plan/phase-2.md` (revision 6 phase plan). Per Phase 4 PR 10 plan, the `_core.py` shim deletion + Session property bridges removal happen in a later PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `cookie_saver` and `cookie_rotator` parameters to `NotebookLMClient` constructor for custom cookie lifecycle management.

* **Refactor**
  * Internal architectural improvements to authentication and session handling for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->