### PR TITLE
refactor(auth-refresh): migrate AST guards + collapse Session.{_snapshot, update_auth_tokens} to delegates (Phase 3 PR 8)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -160,14 +160,19 @@ _OBSERVABILITY_INIT_LOCK = threading.Lock()
 # observability init lock so two threads can't both observe ``hasattr is False``
 # and race to construct competing :class:`AuthRefreshCoordinator` instances.
 #
-# Dual-implementation sites (kept identical for AST guards in
-# ``tests/unit/test_concurrency_refresh_race.py`` that inspect
-# ``inspect.getsource(Session.update_auth_tokens)`` /
-# ``Session._snapshot``):
-#   - ``Session._snapshot`` (this file) ↔ ``AuthRefreshCoordinator.snapshot``
-#   - ``Session.update_auth_tokens`` (this file) ↔ ``AuthRefreshCoordinator.update_auth_tokens``
-# Any change to auth-snapshot invariants must be applied to BOTH sites. Grep
-# anchor for future maintainers: ``_AUTH_COORD_INIT_LOCK``.
+# Auth-snapshot canonical implementation lives on
+# :class:`AuthRefreshCoordinator` (``_session_auth.py`` —
+# ``AuthRefreshCoordinator.snapshot`` / ``.update_auth_tokens``). The
+# :class:`Session` methods of the same name (``Session._snapshot`` /
+# ``Session.update_auth_tokens``) are thin delegates that forward through
+# ``self._auth_coord``; PR 8 collapsed their pre-PR-8 real bodies. The AST
+# guards in ``tests/unit/test_concurrency_refresh_race.py``
+# (``test_snapshot_acquires_auth_snapshot_lock`` /
+# ``test_update_auth_tokens_has_no_await_inside_mutation_block``) inspect
+# the coordinator's source via ``inspect.getsource(...)`` + AST parsing —
+# changes to auth-snapshot invariants must be applied to the coordinator
+# (not the delegates here). Grep anchor for future maintainers:
+# ``_AUTH_COORD_INIT_LOCK``.
 _AUTH_COORD_INIT_LOCK = threading.Lock()
 
 
@@ -1265,9 +1270,9 @@ class Session:
 
         Body lived here pre-PR-8 so the AST guard at
         ``tests/unit/test_concurrency_refresh_race.py::test_snapshot_acquires_auth_snapshot_lock``
-        could inspect ``Session._snapshot.__code__`` for the lock
-        acquire. PR 8 moved the guard to inspect
-        :meth:`AuthRefreshCoordinator.snapshot` (the canonical
+        could inspect ``Session._snapshot`` via ``inspect.getsource(...)``
+        + ``ast.parse(...)`` for the lock acquire. PR 8 moved the guard
+        to inspect :meth:`AuthRefreshCoordinator.snapshot` (the canonical
         implementation), so the body collapses to a delegate here.
 
         The coordinator's body has the same semantic shape (lock acquire
@@ -1288,9 +1293,10 @@ class Session:
 
         Body lived here pre-PR-8 so the AST guard at
         ``tests/unit/test_concurrency_refresh_race.py::test_update_auth_tokens_has_no_await_inside_mutation_block``
-        could inspect ``Session.update_auth_tokens.__code__`` for the
-        no-await invariant inside the csrf/session_id mutation block.
-        PR 8 moved the guard to inspect
+        could inspect ``Session.update_auth_tokens`` via
+        ``inspect.getsource(...)`` + ``ast.parse(...)`` for the no-await
+        invariant inside the csrf/session_id mutation block. PR 8 moved
+        the guard to inspect
         :meth:`AuthRefreshCoordinator.update_auth_tokens` (the canonical
         implementation), so the body collapses to a delegate here. The
         coordinator's body has the same semantic shape (lock acquire →

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import random  # noqa: F401 - tests patch this for _backoff jitter
 import threading
-import time
 import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
@@ -1262,67 +1261,45 @@ class Session:
         return self._auth_coord.get_refresh_lock()
 
     async def _snapshot(self) -> _AuthSnapshot:
-        """Capture the current auth headers as a frozen snapshot.
+        """Delegate to :meth:`AuthRefreshCoordinator.snapshot`.
 
-        Used by ``_perform_authed_post`` to make a single HTTP attempt's
-        URL/body consistent (no mid-attempt mutation from refresh /
-        keepalive). A fresh snapshot is taken on each retry.
-
-        Acquires :attr:`_auth_snapshot_lock` for the four scalar reads so
-        a concurrent ``refresh_auth`` can't interleave between
-        ``csrf_token``/``session_id``/``authuser``/``account_email``
-        reads. The critical section is purely synchronous attribute
-        reads — no ``await``s — so the lock is uncontested in steady
-        state and refresh's tiny write block can't block RPC throughput.
-
-        Body is kept here as real code (rather than delegating to
-        :meth:`AuthRefreshCoordinator.snapshot`) so the AST guard at
+        Body lived here pre-PR-8 so the AST guard at
         ``tests/unit/test_concurrency_refresh_race.py::test_snapshot_acquires_auth_snapshot_lock``
-        — which inspects this method's source and asserts it contains an
-        ``async with`` over ``_auth_snapshot_lock`` — keeps operating on
-        the real implementation. The coordinator method has the same
-        semantic shape (lock acquire → scalar reads → return) but routes
-        the lock-wait metric through the host's ``_metrics_obj`` directly
-        rather than via the ``_record_lock_wait`` facade.
+        could inspect ``Session._snapshot.__code__`` for the lock
+        acquire. PR 8 moved the guard to inspect
+        :meth:`AuthRefreshCoordinator.snapshot` (the canonical
+        implementation), so the body collapses to a delegate here.
 
-        Whole-request atomicity for ``(csrf, sid, cookies)`` on the wire
-        still depends on the no-await invariant between this method
-        returning and ``client.post(...)`` inside
-        :meth:`_perform_authed_post` (see the related AST guard in
+        The coordinator's body has the same semantic shape (lock acquire
+        → four scalar reads → return) but routes the lock-wait metric
+        through ``host._metrics_obj`` directly rather than via the
+        ``_record_lock_wait`` facade. Whole-request atomicity for
+        ``(csrf, sid, cookies)`` on the wire still depends on the
+        no-await invariant between this method returning and
+        ``client.post(...)`` inside :meth:`_perform_authed_post` (see
+        the related AST guard in
         ``tests/unit/test_concurrency_refresh_race.py``).
         """
-        wait_start = time.perf_counter()
-        async with self._get_auth_snapshot_lock():
-            self._record_lock_wait(time.perf_counter() - wait_start)
-            return _AuthSnapshot(
-                csrf_token=self.auth.csrf_token,
-                session_id=self.auth.session_id,
-                authuser=self.auth.authuser,
-                account_email=self.auth.account_email,
-            )
+        self._ensure_auth_coord()
+        return await self._auth_coord.snapshot(self)
 
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
-        """Atomically update auth token scalars under the snapshot lock.
+        """Delegate to :meth:`AuthRefreshCoordinator.update_auth_tokens`.
 
-        The body is kept here as real code (rather than a delegate to
-        :meth:`AuthRefreshCoordinator.update_auth_tokens`) so the AST
-        guard at ``tests/unit/test_concurrency_refresh_race.py:304-334``
-        — which inspects the source of this method and asserts there is
-        no ``await`` inside the csrf/session_id mutation block — keeps
-        operating on the real implementation. The coordinator method
-        has the same semantic shape (lock acquire → two scalar writes)
-        but routes the lock-wait metric through the host's
-        ``_metrics_obj`` directly rather than via ``_record_lock_wait``.
+        Body lived here pre-PR-8 so the AST guard at
+        ``tests/unit/test_concurrency_refresh_race.py::test_update_auth_tokens_has_no_await_inside_mutation_block``
+        could inspect ``Session.update_auth_tokens.__code__`` for the
+        no-await invariant inside the csrf/session_id mutation block.
+        PR 8 moved the guard to inspect
+        :meth:`AuthRefreshCoordinator.update_auth_tokens` (the canonical
+        implementation), so the body collapses to a delegate here. The
+        coordinator's body has the same semantic shape (lock acquire →
+        two scalar writes inside ``try``/``finally``) but routes the
+        lock-wait metric through ``host._metrics_obj`` directly rather
+        than via the ``_record_lock_wait`` facade.
         """
-        lock = self._get_auth_snapshot_lock()
-        wait_start = time.perf_counter()
-        await lock.acquire()
-        self._record_lock_wait(time.perf_counter() - wait_start)
-        try:
-            self.auth.csrf_token = csrf
-            self.auth.session_id = session_id
-        finally:
-            lock.release()
+        self._ensure_auth_coord()
+        await self._auth_coord.update_auth_tokens(self, csrf, session_id)
 
     def _build_url(
         self,

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -164,13 +164,20 @@ class AuthRefreshCoordinator:
 
     # ------------------------------------------------------------------
     # Auth snapshot + token write — the load-bearing AST-guarded pair.
-    # The "no await inside the mutation block" invariant is enforced by
-    # tests/unit/test_concurrency_refresh_race.py against
-    # ``Session.update_auth_tokens``; ``Session`` keeps that method's
-    # body as real code (not a delegate) so the AST guard stays valid. The
-    # coordinator method here is the canonical implementation new callers
-    # should reach for, and the two stay in sync by construction (identical
-    # bodies, reviewed together).
+    # These two methods are the canonical implementations of the
+    # concurrency invariants: ``snapshot`` holds the ``_auth_snapshot_lock``
+    # across four synchronous scalar reads, and ``update_auth_tokens``
+    # forbids any ``await`` inside the csrf/session_id mutation try-block.
+    # The AST guards in ``tests/unit/test_concurrency_refresh_race.py``
+    # (``test_snapshot_acquires_auth_snapshot_lock`` and
+    # ``test_update_auth_tokens_has_no_await_inside_mutation_block``)
+    # inspect THIS module's source via ``inspect.getsource(...)`` + AST
+    # parsing — any structural change to either method body (e.g.
+    # extracting a helper, refactoring the lock dance, adding an
+    # ``await`` mid-mutation) will trip those guards. ``Session._snapshot``
+    # and ``Session.update_auth_tokens`` (`_session.py`) are now thin
+    # delegates that forward through ``self._auth_coord``; there is no
+    # longer a "second body" to keep in sync.
     # ------------------------------------------------------------------
 
     async def snapshot(self, host: _AuthRefreshHost) -> _AuthSnapshot:

--- a/tests/unit/test_concurrency_refresh_race.py
+++ b/tests/unit/test_concurrency_refresh_race.py
@@ -65,7 +65,7 @@ import pytest
 
 from notebooklm._authed_transport import AuthedTransport
 from notebooklm._rpc_executor import RpcExecutor
-from notebooklm._session import Session
+from notebooklm._session_auth import AuthRefreshCoordinator
 from notebooklm.rpc import RPCMethod
 
 _UNIT_CONFTEST_SPEC = importlib.util.spec_from_file_location(
@@ -256,23 +256,28 @@ def test_build_url_does_not_read_self_auth():
 
 
 def test_snapshot_acquires_auth_snapshot_lock():
-    """``Session._snapshot`` must acquire ``_auth_snapshot_lock``.
+    """``AuthRefreshCoordinator.snapshot`` must acquire ``_auth_snapshot_lock``.
 
-    The lock is the only thing that serializes the four-scalar
-    snapshot read with the matching two-scalar write in
+    Post-PR-8, the canonical implementation lives on the coordinator;
+    ``Session._snapshot`` is a one-line delegate. The lock-acquisition
+    contract is invariant under that move — this guard inspects the
+    coordinator method directly.
+
+    The lock is the only thing that serializes the four-scalar snapshot
+    read with the matching two-scalar write in
     ``NotebookLMClient.refresh_auth``. Removing the ``async with`` block
     here would re-open the torn-read window between
-    ``self.auth.csrf_token`` and ``self.auth.session_id`` reads, even
+    ``host.auth.csrf_token`` and ``host.auth.session_id`` reads, even
     though those two attribute reads are individually atomic at the
     Python bytecode level.
 
-    This guard asserts that ``_snapshot``'s body contains an
+    This guard asserts that ``snapshot``'s body contains an
     ``async with`` whose context expression resolves to
-    ``self._get_auth_snapshot_lock()`` (or, defensively, anything
+    ``self.get_auth_snapshot_lock()`` (or, defensively, anything
     referencing ``_auth_snapshot_lock`` so a maintainer who inlines the
     lazy accessor doesn't trip the guard).
     """
-    src = textwrap.dedent(inspect.getsource(Session._snapshot))
+    src = textwrap.dedent(inspect.getsource(AuthRefreshCoordinator.snapshot))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 
@@ -283,7 +288,7 @@ def test_snapshot_acquires_auth_snapshot_lock():
         # Each ``async with X`` may chain multiple items; check each.
         for item in node.items:
             ctx = item.context_expr
-            # Match both call form ``self._get_auth_snapshot_lock()`` and
+            # Match both call form ``self.get_auth_snapshot_lock()`` and
             # direct attribute ``self._auth_snapshot_lock``.
             if isinstance(ctx, ast.Call):
                 ctx = ctx.func
@@ -292,16 +297,25 @@ def test_snapshot_acquires_auth_snapshot_lock():
                 break
 
     assert has_lock_acquisition, (
-        "_snapshot() no longer acquires _auth_snapshot_lock. Atomicity "
-        "contract broken — the four-scalar snapshot read is no longer atomic with the "
-        "refresh-side write block in NotebookLMClient.refresh_auth, exposing "
-        "torn (csrf, sid) reads."
+        "AuthRefreshCoordinator.snapshot no longer acquires "
+        "_auth_snapshot_lock. Atomicity contract broken — the four-scalar "
+        "snapshot read is no longer atomic with the refresh-side write block "
+        "in NotebookLMClient.refresh_auth, exposing torn (csrf, sid) reads."
     )
 
 
 def test_update_auth_tokens_has_no_await_inside_mutation_block():
-    """``update_auth_tokens`` may await lock acquisition, but not while mutating."""
-    src = textwrap.dedent(inspect.getsource(Session.update_auth_tokens))
+    """``AuthRefreshCoordinator.update_auth_tokens`` must not await mid-mutation.
+
+    Post-PR-8, the canonical implementation lives on the coordinator;
+    ``Session.update_auth_tokens`` is a one-line delegate. The no-await
+    invariant inside the csrf/session_id mutation block is invariant
+    under that move — this guard inspects the coordinator method
+    directly. Lock acquisition may await; the mutation block itself may
+    not, because any yield inside it would let a snapshot observe a
+    torn (csrf, session_id) pair.
+    """
+    src = textwrap.dedent(inspect.getsource(AuthRefreshCoordinator.update_auth_tokens))
     tree = ast.parse(src)
     func = next(n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef))
 
@@ -323,13 +337,15 @@ def test_update_auth_tokens_has_no_await_inside_mutation_block():
         None,
     )
     assert mutation_try is not None, (
-        "Could not locate the guarded csrf/session_id mutation block in Session.update_auth_tokens."
+        "Could not locate the guarded csrf/session_id mutation block in "
+        "AuthRefreshCoordinator.update_auth_tokens."
     )
 
     awaits = [node for node in ast.walk(mutation_try) if isinstance(node, ast.Await)]
     assert awaits == [], (
-        "Session.update_auth_tokens must not await inside the critical "
-        "mutation block; doing so would let snapshots observe torn auth tokens."
+        "AuthRefreshCoordinator.update_auth_tokens must not await inside "
+        "the critical mutation block; doing so would let snapshots observe "
+        "torn auth tokens."
     )
 
 


### PR DESCRIPTION
## Summary

Phase 3 Wave 2 of the v0.5.0 refactor program. Stacked atop PR #883 (now merged as `a4b67e9`) and rebased onto main.

**Commits:**
- `e6ef92b` test(refresh): retarget AST guards at `AuthRefreshCoordinator` (Task 8.1)
- `353d31d` refactor(session): collapse `Session._snapshot` + `Session.update_auth_tokens` to one-line delegates (Tasks 8.2 + 8.3)
- `ae53ed5` docs(refresh): update stale comments + delegate docstrings post-collapse (polish)

## What landed

- **`tests/unit/test_concurrency_refresh_race.py`** — the 2 AST guards no longer inspect `Session._snapshot` / `Session.update_auth_tokens` (which are now one-line delegates). Instead they inspect `AuthRefreshCoordinator.snapshot` at `_session_auth.py:176-201` and `AuthRefreshCoordinator.update_auth_tokens` at `:203-226` — the canonical owners.
- **`src/notebooklm/_session.py`** — `Session._snapshot` (was at ~:1305-1343) and `Session.update_auth_tokens` (was at ~:1345-1366) collapsed to one-line delegates calling the coordinator.
- **Functional equivalence**: same lock acquire + same scalar reads/writes; metrics route differs (coordinator routes through its own metrics helper). Concurrency contract preserved.

## Verification

- `uv run ruff check src/notebooklm/ tests/` — clean
- `uv run mypy src/notebooklm --ignore-missing-imports` — clean (140 source files)
- `tests/unit/test_concurrency_refresh_race.py` — both AST guards pass (now inspecting coordinator methods)
- `tests/integration/test_auto_refresh.py` — live refresh path preserved
- 91 cassettes pass (verified by polish stage)

## Stacking

- Originally stacked on PR #883's branch
- PR #883 squash-merged to main as `a4b67e9`
- Orchestrator (me) rebased this branch with `git rebase --onto origin/main 7b6e65a` to drop the 5 PR 7 commits (now in main) and replay only Wave 2's 3 commits on top of main
- Base now = main, head = `ae53ed5`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /execute-phase orchestrator pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring of authentication refresh logic to consolidate implementation and reduce code duplication.

* **Tests**
  * Updated authentication concurrency tests to verify correct handling of simultaneous refresh operations and maintain data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->