### PR TITLE
refactor(artifacts): pass storage_path explicitly into ArtifactDownloadService (#838)

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -81,8 +81,9 @@ def _is_trusted_download_host(netloc: str) -> bool:
 class ArtifactDownloadService:
     """Download operations extracted from :class:`ArtifactsAPI`."""
 
-    def __init__(self, api: Any):
+    def __init__(self, api: Any, storage_path: Path | None):
         self._api = api
+        self._storage_path = storage_path
 
     async def download_audio(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
@@ -441,7 +442,7 @@ class ArtifactDownloadService:
         """Download multiple files using httpx with proper cookie handling."""
         result = DownloadResult()
 
-        cookies = await asyncio.to_thread(_load_httpx_cookies, self._api._storage_path)
+        cookies = await asyncio.to_thread(_load_httpx_cookies, self._storage_path)
 
         async with httpx.AsyncClient(
             cookies=cookies,
@@ -529,7 +530,7 @@ class ArtifactDownloadService:
         temp_file = Path(temp_path_str)
 
         try:
-            cookies = await asyncio.to_thread(_load_httpx_cookies, self._api._storage_path)
+            cookies = await asyncio.to_thread(_load_httpx_cookies, self._storage_path)
             timeout = httpx.Timeout(connect=10.0, read=30.0, write=30.0, pool=30.0)
 
             try:

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -213,13 +213,12 @@ class ArtifactsAPI:
         """
         self._runtime = runtime
         self._notebooks = notebooks
-        self._storage_path = storage_path
         self._mind_maps = mind_maps
         self._note_service = note_service
         self._poll_registry = PollRegistry()
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
-        self._downloads = ArtifactDownloadService(self)
+        self._downloads = ArtifactDownloadService(self, storage_path)
         self._polling = _artifact_polling.ArtifactPollingService(
             runtime,
             self._poll_registry,

--- a/tests/integration/concurrency/test_download_blocks_loop.py
+++ b/tests/integration/concurrency/test_download_blocks_loop.py
@@ -95,7 +95,7 @@ def _assert_offloaded_to_worker_thread(
 
 
 @pytest.fixture
-def mock_artifacts_api() -> tuple[ArtifactsAPI, MagicMock]:
+def mock_artifacts_api(tmp_path: Path) -> tuple[ArtifactsAPI, MagicMock]:
     """``ArtifactsAPI`` wired to a mock ``Session``.
 
     Same shape as the unit-test fixture in ``tests/unit/test_artifact_downloads.py``
@@ -117,6 +117,7 @@ def mock_artifacts_api() -> tuple[ArtifactsAPI, MagicMock]:
         notebooks=MagicMock(),
         mind_maps=mind_maps,
         note_service=note_service,
+        storage_path=tmp_path / "fake_storage_state.json",
     )
     return api, mock_core
 
@@ -367,7 +368,6 @@ async def test_download_urls_batch_cookie_load_runs_off_loop_thread(
     the first request.
     """
     api, _ = mock_artifacts_api
-    api._storage_path = tmp_path / "fake_storage_state.json"
 
     loop_thread_id = threading.get_ident()
     captured: list[int] = []
@@ -410,7 +410,6 @@ async def test_download_url_cookie_load_runs_off_loop_thread(
     the time the HTTP step runs.
     """
     api, _ = mock_artifacts_api
-    api._storage_path = tmp_path / "fake_storage_state.json"
     output_path = tmp_path / "download.bin"
 
     # URL must clear the production trusted-domain check

--- a/tests/unit/concurrency/test_download_collision.py
+++ b/tests/unit/concurrency/test_download_collision.py
@@ -26,7 +26,8 @@ from notebooklm import NotebookLMClient
 def _stub_storage_cookies(monkeypatch: pytest.MonkeyPatch) -> None:
     """Bypass on-disk storage_state.json lookup in `_download_url`.
 
-    `_download_url` calls `load_httpx_cookies(path=self._storage_path)`
+    `ArtifactDownloadService.download_url` calls
+    `load_httpx_cookies(path=self._storage_path)`
     which raises `FileNotFoundError` on a clean CI runner that hasn't
     been through `notebooklm login`. We don't care about the cookies for
     this test (the mock transport doesn't validate auth) — return an

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -780,3 +780,59 @@ class TestDownloadDataTable:
 
             with pytest.raises(ArtifactParseError):
                 await api.download_data_table("nb_123", "/tmp/data.csv")
+
+
+class TestStoragePathEncapsulation:
+    """Regression guard for issue #838.
+
+    ``ArtifactDownloadService`` must read the storage path it was
+    constructed with, not via a sibling reach-in to
+    ``ArtifactsAPI._storage_path``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_download_url_uses_constructor_storage_path(self, tmp_path):
+        from notebooklm._artifact_downloads import ArtifactDownloadService
+
+        sentinel = tmp_path / "sentinel_storage.json"
+        # MagicMock has no real ``_storage_path`` — any reach-in attempt
+        # via ``self._api._storage_path`` would yield the mock's auto-spec
+        # rather than the sentinel, failing the equality check below.
+        api = MagicMock()
+        service = ArtifactDownloadService(api, sentinel)
+
+        captured: list[object] = []
+
+        class _StopAfterCapture(Exception):
+            pass
+
+        def recording(path):
+            captured.append(path)
+            raise _StopAfterCapture
+
+        with patch("notebooklm._artifacts.load_httpx_cookies", new=recording):
+            with pytest.raises(_StopAfterCapture):
+                await service.download_url(
+                    "https://storage.googleapis.com/x.bin", str(tmp_path / "out.bin")
+                )
+
+        assert captured == [sentinel]
+
+    @pytest.mark.asyncio
+    async def test_download_urls_batch_uses_constructor_storage_path(self, tmp_path):
+        from notebooklm._artifact_downloads import ArtifactDownloadService
+
+        sentinel = tmp_path / "sentinel_storage.json"
+        api = MagicMock()
+        service = ArtifactDownloadService(api, sentinel)
+
+        captured: list[object] = []
+
+        def recording(path):
+            captured.append(path)
+            return {}
+
+        with patch("notebooklm._artifacts.load_httpx_cookies", new=recording):
+            await service.download_urls_batch([])
+
+        assert captured == [sentinel]

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -810,11 +810,13 @@ class TestStoragePathEncapsulation:
             captured.append(path)
             raise _StopAfterCapture
 
-        with patch("notebooklm._artifacts.load_httpx_cookies", new=recording):
-            with pytest.raises(_StopAfterCapture):
-                await service.download_url(
-                    "https://storage.googleapis.com/x.bin", str(tmp_path / "out.bin")
-                )
+        with (
+            patch("notebooklm._artifacts.load_httpx_cookies", new=recording),
+            pytest.raises(_StopAfterCapture),
+        ):
+            await service.download_url(
+                "https://storage.googleapis.com/x.bin", str(tmp_path / "out.bin")
+            )
 
         assert captured == [sentinel]
 

--- a/tests/unit/test_download_result.py
+++ b/tests/unit/test_download_result.py
@@ -85,8 +85,8 @@ def mock_artifacts_api(tmp_path):
         notebooks=MagicMock(),
         mind_maps=MagicMock(spec=NoteBackedMindMapService),
         note_service=MagicMock(spec=NoteService),
+        storage_path=tmp_path / "storage.json",
     )
-    api._storage_path = str(tmp_path / "storage.json")
     return api, mock_core
 
 


### PR DESCRIPTION
Closes #838.

## Summary

- `ArtifactDownloadService` previously reached into its parent's private attribute via `self._api._storage_path` at 2 sites (`_artifact_downloads.py:444, :532`). Add `storage_path: Path | None` to the constructor; pass it explicitly from `ArtifactsAPI` at wiring time.
- Drop the now-dead `self._storage_path = storage_path` write on `ArtifactsAPI` (no remaining readers after the fix; surfaced by /polish review).
- Fix 3 tests that mutated `api._storage_path` post-construction — under the snapshot-at-construction design those mutations are silently dead. Pass `storage_path=` into the `ArtifactsAPI` fixtures instead. (Surfaced by /polish review — without this, the encapsulation refactor would silently degrade what those tests claim to cover.)
- Add `TestStoragePathEncapsulation` regression guard pinning the new contract: `ArtifactDownloadService` reads its constructor-time path, not `self._api._storage_path`.
- Update stale comment in `tests/unit/concurrency/test_download_collision.py`.

## Test plan

- [x] `uv run pytest` — 5596 passed, 14 skipped (was 5594; +2 regression guards in `TestStoragePathEncapsulation`)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean
- [x] `uv run ruff check` — clean
- [x] Targeted: `tests/unit/test_artifact_downloads.py tests/unit/test_download_result.py tests/integration/concurrency/test_download_blocks_loop.py tests/unit/concurrency/test_download_collision.py` — all pass

## Polish notes

/polish ran (code-simplifier + 3-model review + ultrathink) before opening. Findings addressed:
- **Important** (Claude+Codex consensus): Three tests mutated `api._storage_path` post-construction → fixed.
- **Important** (Claude): No regression guard for the new constructor contract → added `TestStoragePathEncapsulation`.
- **Important** (Claude): `ArtifactsAPI._storage_path` became write-only dead state → removed the assignment.
- **Rejected** (agy): Add `storage_path: Path | None = None` default — defeats the fix's intent (required-positional is the contract).
- **Rejected** (agy): Replace `api._download_url(...)` with `self.download_url(...)` — verified the indirection is a real test seam (5 monkeypatches in `tests/unit/test_artifact_downloads.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Encapsulated storage configuration for artifact downloads so cookie handling uses the service's configured storage rather than external/shared state.

* **Tests**
  * Added regression tests and updated test fixtures to validate storage configuration and ensure concurrent download tests use per-test storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->