### PR TITLE
refactor(artifacts): introduce _ArtifactsServiceMethods Protocol + alias-aware AST guard

### DIFF
--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -171,35 +171,35 @@ class _ArtifactsServiceMethods(Protocol):
     ``self._api._list_raw(...)`` / ``self._api._select_artifact(...)`` /
     ``self._api._format_interactive_content(...)`` / etc. This Protocol
     declares the subset of **method calls** those helpers actually make, so
-    follow-up migrations (T2 and T3 of
-    ``.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md``) can
-    type the helper's API-collaborator argument as
-    ``_ArtifactsServiceMethods`` instead of the full concrete
+    the two follow-up PRs that migrate ``_artifact_downloads.py`` and
+    ``_artifact_generation.py`` can type the helper's API-collaborator
+    argument as ``_ArtifactsServiceMethods`` instead of the full concrete
     ``ArtifactsAPI`` — pinning the dependency surface and unblocking the
-    AST guard pinned by ``test_artifact_services_have_no_facade_reach_in``.
+    AST guard pinned by ``test_artifact_services_have_no_facade_reach_in``
+    in ``tests/unit/test_init_order.py``.
 
     **Scope (intentionally narrow).** This Protocol covers method calls
     only. The helpers also currently reach through ``self._api`` for four
     *collaborator objects* — ``_notebooks`` (``NotebookSourceIdProvider``),
     ``_runtime`` (``ArtifactsRuntime``), ``_note_service`` (``NoteService``),
     and ``_mind_maps`` (``NoteBackedMindMapService``). Those are
-    deliberately **not** declared here. T2 and T3 will eliminate those
-    reach-throughs by injecting each collaborator as a separate constructor
-    argument on the helper service (mirroring how
+    deliberately **not** declared here. The follow-up migration PRs will
+    eliminate those reach-throughs by injecting each collaborator as a
+    separate constructor argument on the helper service (mirroring how
     :class:`ArtifactsAPI.__init__` already takes them), not by widening
     this Protocol. The reach-in guard catches any residual
     ``api._notebooks`` / ``api._runtime`` / ``api._note_service`` /
-    ``api._mind_maps`` access as a violation, forcing T2/T3 to do the
-    constructor-injection refactor rather than smuggling the same coupling
-    through a wider Protocol.
+    ``api._mind_maps`` access as a violation, forcing the migration to do
+    the constructor-injection refactor rather than smuggling the same
+    coupling through a wider Protocol.
 
-    **Migration note for T2/T3 implementers.** ``visit_Attribute`` in
+    **Migration note for follow-up implementers.** ``visit_Attribute`` in
     :class:`_ApiReachInVisitor` (``tests/unit/test_init_order.py``) flags
     **every** attribute access on ``self._api`` — including public methods
     like ``self._api.generate_report(...)``. Simply re-annotating
     ``self._api: _ArtifactsServiceMethods`` is therefore not enough to
-    clear the guard; T2/T3 must **rename** the stored reference (for
-    example to ``self._service``) so the visitor no longer sees
+    clear the guard; the migrating PR must **rename** the stored reference
+    (for example to ``self._service``) so the visitor no longer sees
     ``self._api`` at all. The Protocol declares ``generate_report`` /
     ``list_quizzes`` / ``list_flashcards`` so the renamed reference
     remains usable, not so the existing ``self._api`` name can be kept.

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -162,7 +162,7 @@ class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Proto
 
 
 class _ArtifactsServiceMethods(Protocol):
-    """Narrow ``ArtifactsAPI`` surface that helper services depend on.
+    """Narrow ``ArtifactsAPI`` **method-call** surface that helper services depend on.
 
     Artifact service helpers (currently :class:`ArtifactDownloadService` and
     :class:`ArtifactGenerationService`) accept an ``ArtifactsAPI`` instance
@@ -170,13 +170,39 @@ class _ArtifactsServiceMethods(Protocol):
     helpers reach in by holding ``self._api`` and calling
     ``self._api._list_raw(...)`` / ``self._api._select_artifact(...)`` /
     ``self._api._format_interactive_content(...)`` / etc. This Protocol
-    declares the **exact** subset of methods those helpers actually use, so
+    declares the subset of **method calls** those helpers actually make, so
     follow-up migrations (T2 and T3 of
     ``.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md``) can
-    type their constructor argument as ``_ArtifactsServiceMethods`` instead
-    of the full concrete ``ArtifactsAPI`` — pinning the dependency surface
-    and unblocking the AST guard pinned by
-    ``test_artifact_services_have_no_facade_reach_in``.
+    type the helper's API-collaborator argument as
+    ``_ArtifactsServiceMethods`` instead of the full concrete
+    ``ArtifactsAPI`` — pinning the dependency surface and unblocking the
+    AST guard pinned by ``test_artifact_services_have_no_facade_reach_in``.
+
+    **Scope (intentionally narrow).** This Protocol covers method calls
+    only. The helpers also currently reach through ``self._api`` for four
+    *collaborator objects* — ``_notebooks`` (``NotebookSourceIdProvider``),
+    ``_runtime`` (``ArtifactsRuntime``), ``_note_service`` (``NoteService``),
+    and ``_mind_maps`` (``NoteBackedMindMapService``). Those are
+    deliberately **not** declared here. T2 and T3 will eliminate those
+    reach-throughs by injecting each collaborator as a separate constructor
+    argument on the helper service (mirroring how
+    :class:`ArtifactsAPI.__init__` already takes them), not by widening
+    this Protocol. The reach-in guard catches any residual
+    ``api._notebooks`` / ``api._runtime`` / ``api._note_service`` /
+    ``api._mind_maps`` access as a violation, forcing T2/T3 to do the
+    constructor-injection refactor rather than smuggling the same coupling
+    through a wider Protocol.
+
+    **Migration note for T2/T3 implementers.** ``visit_Attribute`` in
+    :class:`_ApiReachInVisitor` (``tests/unit/test_init_order.py``) flags
+    **every** attribute access on ``self._api`` — including public methods
+    like ``self._api.generate_report(...)``. Simply re-annotating
+    ``self._api: _ArtifactsServiceMethods`` is therefore not enough to
+    clear the guard; T2/T3 must **rename** the stored reference (for
+    example to ``self._service``) so the visitor no longer sees
+    ``self._api`` at all. The Protocol declares ``generate_report`` /
+    ``list_quizzes`` / ``list_flashcards`` so the renamed reference
+    remains usable, not so the existing ``self._api`` name can be kept.
 
     The underscore-prefixed members are deliberate: this Protocol describes
     a private collaboration contract between ``ArtifactsAPI`` and its own

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -161,6 +161,91 @@ class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Proto
     """
 
 
+class _ArtifactsServiceMethods(Protocol):
+    """Narrow ``ArtifactsAPI`` surface that helper services depend on.
+
+    Artifact service helpers (currently :class:`ArtifactDownloadService` and
+    :class:`ArtifactGenerationService`) accept an ``ArtifactsAPI`` instance
+    for back-references into selection / RPC / formatting flows. Today those
+    helpers reach in by holding ``self._api`` and calling
+    ``self._api._list_raw(...)`` / ``self._api._select_artifact(...)`` /
+    ``self._api._format_interactive_content(...)`` / etc. This Protocol
+    declares the **exact** subset of methods those helpers actually use, so
+    follow-up migrations (T2 and T3 of
+    ``.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md``) can
+    type their constructor argument as ``_ArtifactsServiceMethods`` instead
+    of the full concrete ``ArtifactsAPI`` — pinning the dependency surface
+    and unblocking the AST guard pinned by
+    ``test_artifact_services_have_no_facade_reach_in``.
+
+    The underscore-prefixed members are deliberate: this Protocol describes
+    a private collaboration contract between ``ArtifactsAPI`` and its own
+    helper services. ``RpcOwner`` in :mod:`notebooklm._rpc_executor`
+    (see ``docs/architecture.md`` § RpcExecutor) is the established
+    precedent — a Protocol that declares the underscore-prefixed methods
+    a sibling collaborator legitimately calls. See also
+    :class:`DrainHookRegistration` above for the local docstring pattern.
+
+    The three public members (``list_quizzes``, ``list_flashcards``,
+    ``generate_report``) are not new contract — they preserve the documented
+    monkeypatch seam ``ArtifactsAPI.generate_report`` referenced from
+    ``_artifact_generation.py`` (search for "Preserve the historical facade
+    seam") and the two ``list_*`` shapes used by interactive-artifact
+    formatting.
+    """
+
+    async def _list_raw(self, notebook_id: str) -> builtins.list[Any]: ...
+
+    def _select_artifact(
+        self,
+        candidates: builtins.list[Any],
+        artifact_id: str | None,
+        type_name: str,
+        no_result_error_key: str,
+        *,
+        type_code: ArtifactTypeCode,
+    ) -> Any: ...
+
+    async def _download_url(self, url: str, output_path: str) -> str: ...
+
+    async def _get_artifact_content(self, notebook_id: str, artifact_id: str) -> str | None: ...
+
+    def _format_interactive_content(
+        self,
+        app_data: dict,
+        title: str,
+        output_format: str,
+        html_content: str,
+        is_quiz: bool,
+    ) -> str: ...
+
+    async def _call_generate(
+        self, notebook_id: str, params: builtins.list[Any]
+    ) -> GenerationStatus: ...
+
+    def _parse_generation_result(
+        self,
+        result: Any,
+        *,
+        method_id: str,
+        source: str = "_parse_generation_result",
+    ) -> GenerationStatus: ...
+
+    async def list_quizzes(self, notebook_id: str) -> builtins.list[Artifact]: ...
+
+    async def list_flashcards(self, notebook_id: str) -> builtins.list[Artifact]: ...
+
+    async def generate_report(
+        self,
+        notebook_id: str,
+        report_format: ReportFormat = ReportFormat.BRIEFING_DOC,
+        source_ids: builtins.list[str] | None = None,
+        language: str | None = None,
+        custom_prompt: str | None = None,
+        extra_instructions: str | None = None,
+    ) -> GenerationStatus: ...
+
+
 class ArtifactsAPI:
     """Operations on NotebookLM artifacts (studio content).
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -319,22 +319,23 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 # Artifact-service "reach-in" guard
 #
 # Modeled on the core-private-access guard above. Pins the invariant that
-# artifact-service helper modules (T2: ``_artifact_downloads.py``; T3:
+# artifact-service helper modules (``_artifact_downloads.py`` and
 # ``_artifact_generation.py``) depend only on the narrow
-# ``_ArtifactsServiceMethods`` Protocol, not on the full concrete
-# ``ArtifactsAPI``. T1 ships the visitor + guard with an empty migration
-# list (vacuously passing); T2 / T3 append their modules and migrate the
-# helpers to constructor injection.
+# ``_ArtifactsServiceMethods`` Protocol declared in ``_artifacts.py``, not
+# on the full concrete ``ArtifactsAPI``. This PR ships the visitor + guard
+# with an empty migration list (vacuously passing); the follow-up PRs that
+# migrate each helper to constructor injection will append the helper's
+# module name to ``_REACH_IN_MIGRATED_MODULES`` below.
 # ----------------------------------------------------------------------------
 
 
 # Modules already migrated to ``_ArtifactsServiceMethods`` constructor
 # injection — the guard below enforces no residual ``self._api`` reach-in.
 # Bookkeeping (mirrors the ``_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS`` pattern):
-#   * T2 (``.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md``)
-#     will append ``"_artifact_downloads.py"`` once that module is
-#     migrated.
-#   * T3 (same phase plan) will append ``"_artifact_generation.py"``.
+#   * The PR that migrates ``_artifact_downloads.py`` will append
+#     ``"_artifact_downloads.py"`` to this list.
+#   * The PR that migrates ``_artifact_generation.py`` will append
+#     ``"_artifact_generation.py"``.
 # Until both PRs land this list is empty and the guard test passes
 # vacuously.
 _REACH_IN_MIGRATED_MODULES: list[str] = []
@@ -353,15 +354,16 @@ def _is_self_api(node: ast.AST) -> bool:
 class _ApiReachInVisitor(ast.NodeVisitor):
     """Collect reach-ins to ``self._api`` (direct, aliased, nested-scope).
 
-    Modeled on ``_CorePrivateAccessVisitor`` (this file, lines 137-195):
-    function/async/lambda scopes are tracked, alias bindings recorded
+    Modeled on :class:`_CorePrivateAccessVisitor` defined earlier in this
+    file: function/async/lambda scopes are tracked, alias bindings recorded
     per-scope, and ``_is_api_access_base`` walks the entire active stack
     via ``reversed(self._alias_stack)`` so aliases in outer scopes are
     visible to attribute access in nested closures and comprehensions.
 
     The empty ``_REACH_IN_MIGRATED_MODULES`` list keeps the guard
-    vacuous in T1; T2 appends ``_artifact_downloads.py`` and T3 appends
-    ``_artifact_generation.py``.
+    vacuous until the follow-up PRs append ``_artifact_downloads.py`` /
+    ``_artifact_generation.py`` after migrating each helper to
+    constructor injection.
     """
 
     def __init__(self, module_name: str) -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -315,6 +315,197 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
     )
 
 
+# ----------------------------------------------------------------------------
+# Artifact-service "reach-in" guard
+#
+# Modeled on the core-private-access guard above. Pins the invariant that
+# artifact-service helper modules (T2: ``_artifact_downloads.py``; T3:
+# ``_artifact_generation.py``) depend only on the narrow
+# ``_ArtifactsServiceMethods`` Protocol, not on the full concrete
+# ``ArtifactsAPI``. T1 ships the visitor + guard with an empty migration
+# list (vacuously passing); T2 / T3 append their modules and migrate the
+# helpers to constructor injection.
+# ----------------------------------------------------------------------------
+
+
+_REACH_IN_MIGRATED_MODULES: list[str] = []  # appended to by T2 and T3.
+
+
+def _is_self_api(node: ast.AST) -> bool:
+    """True for ast nodes representing ``self._api``."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "_api"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    )
+
+
+class _ApiReachInVisitor(ast.NodeVisitor):
+    """Collect reach-ins to ``self._api`` (direct, aliased, nested-scope).
+
+    Modeled on ``_CorePrivateAccessVisitor`` (this file, lines 137-195):
+    function/async/lambda scopes are tracked, alias bindings recorded
+    per-scope, and ``_is_api_access_base`` walks the entire active stack
+    via ``reversed(self._alias_stack)`` so aliases in outer scopes are
+    visible to attribute access in nested closures and comprehensions.
+
+    The empty ``_REACH_IN_MIGRATED_MODULES`` list keeps the guard
+    vacuous in T1; T2 appends ``_artifact_downloads.py`` and T3 appends
+    ``_artifact_generation.py``.
+    """
+
+    def __init__(self, module_name: str) -> None:
+        self.module_name = module_name
+        self.violations: list[tuple[int, str]] = []
+        self._alias_stack: list[set[str]] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function_scope(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function_scope(node)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        self._visit_function_scope(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if self._is_api_access_base(node.value):
+            for target in node.targets:
+                self._record_alias_target(target)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None and self._is_api_access_base(node.value):
+            self._record_alias_target(node.target)
+        self.generic_visit(node)
+
+    def visit_NamedExpr(self, node: ast.NamedExpr) -> None:
+        if self._is_api_access_base(node.value):
+            self._record_alias_target(node.target)
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if self._is_api_access_base(node.value):
+            base_repr = self._render_base(node.value)
+            self.violations.append((node.lineno, f"{base_repr}.{node.attr}"))
+        self.generic_visit(node)
+
+    def visit_Return(self, node: ast.Return) -> None:
+        if node.value is not None and self._is_api_access_base(node.value):
+            base_repr = self._render_base(node.value)
+            self.violations.append((node.lineno, f"bare retention: return {base_repr}"))
+        self.generic_visit(node)
+
+    def _visit_function_scope(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    ) -> None:
+        self._alias_stack.append(set())
+        self.generic_visit(node)
+        self._alias_stack.pop()
+
+    def _record_alias_target(self, target: ast.AST) -> None:
+        if isinstance(target, ast.Name) and self._alias_stack:
+            self._alias_stack[-1].add(target.id)
+
+    def _is_api_access_base(self, node: ast.AST) -> bool:
+        return (
+            _is_self_api(node)
+            or (
+                isinstance(node, ast.Name)
+                and any(node.id in aliases for aliases in reversed(self._alias_stack))
+            )
+            or (isinstance(node, ast.NamedExpr) and self._is_api_access_base(node.value))
+        )
+
+    def _render_base(self, node: ast.AST) -> str:
+        if _is_self_api(node):
+            return "self._api"
+        if isinstance(node, ast.Name):
+            return node.id
+        return "<api>"
+
+
+def test_artifact_services_have_no_facade_reach_in() -> None:
+    """Pin the no-reach-in invariant for migrated artifact-service modules."""
+    violations: dict[str, list[tuple[int, str]]] = {}
+    for module_name in _REACH_IN_MIGRATED_MODULES:
+        path = SRC_ROOT / module_name
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        visitor = _ApiReachInVisitor(module_name)
+        visitor.visit(tree)
+        if visitor.violations:
+            violations[module_name] = visitor.violations
+    assert not violations, (
+        f"Encapsulation violations found: {violations}. "
+        "Helpers must depend on _ArtifactsServiceMethods Protocol, not on ArtifactsAPI."
+    )
+
+
+def test_api_reach_in_visitor_catches_direct_access() -> None:
+    tree = ast.parse(
+        "class C:\n"
+        "    def __init__(self, api): self._api = api\n"
+        "    async def f(self): return self._api.foo\n"
+    )
+    visitor = _ApiReachInVisitor("test.py")
+    visitor.visit(tree)
+    assert any(v[1] == "self._api.foo" for v in visitor.violations)
+
+
+def test_api_reach_in_visitor_catches_alias() -> None:
+    tree = ast.parse(
+        "class C:\n"
+        "    def __init__(self, api): self._api = api\n"
+        "    async def f(self):\n"
+        "        api = self._api\n"
+        "        return api.foo\n"
+    )
+    visitor = _ApiReachInVisitor("test.py")
+    visitor.visit(tree)
+    assert any(v[1] == "api.foo" for v in visitor.violations)
+
+
+def test_api_reach_in_visitor_catches_nested_scope_alias() -> None:
+    tree = ast.parse(
+        "class C:\n"
+        "    def __init__(self, api): self._api = api\n"
+        "    async def f(self):\n"
+        "        api = self._api\n"
+        "        return [api.foo for x in items]\n"
+    )
+    visitor = _ApiReachInVisitor("test.py")
+    visitor.visit(tree)
+    assert any(v[1] == "api.foo" for v in visitor.violations), (
+        "Visitor must search outer scopes via reversed(_alias_stack)"
+    )
+
+
+def test_api_reach_in_visitor_catches_bare_retention() -> None:
+    tree = ast.parse(
+        "class C:\n"
+        "    def __init__(self, api): self._api = api\n"
+        "    def f(self): return self._api\n"
+    )
+    visitor = _ApiReachInVisitor("test.py")
+    visitor.visit(tree)
+    assert any("bare retention" in v[1] for v in visitor.violations)
+
+
+def test_api_reach_in_visitor_catches_annassign_alias() -> None:
+    tree = ast.parse(
+        "class C:\n"
+        "    def __init__(self, api): self._api = api\n"
+        "    def f(self) -> None:\n"
+        "        api: Any = self._api\n"
+        "        return api.foo\n"
+    )
+    visitor = _ApiReachInVisitor("test.py")
+    visitor.visit(tree)
+    assert any(v[1] == "api.foo" for v in visitor.violations)
+
+
 def test_legacy_capabilities_module_is_deleted() -> None:
     """Feature APIs now type against ``Session`` plus explicit collaborators."""
     assert not (SRC_ROOT / "_capabilities.py").exists()

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -328,7 +328,16 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 # ----------------------------------------------------------------------------
 
 
-_REACH_IN_MIGRATED_MODULES: list[str] = []  # appended to by T2 and T3.
+# Modules already migrated to ``_ArtifactsServiceMethods`` constructor
+# injection — the guard below enforces no residual ``self._api`` reach-in.
+# Bookkeeping (mirrors the ``_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS`` pattern):
+#   * T2 (``.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md``)
+#     will append ``"_artifact_downloads.py"`` once that module is
+#     migrated.
+#   * T3 (same phase plan) will append ``"_artifact_generation.py"``.
+# Until both PRs land this list is empty and the guard test passes
+# vacuously.
+_REACH_IN_MIGRATED_MODULES: list[str] = []
 
 
 def _is_self_api(node: ast.AST) -> bool:
@@ -424,6 +433,8 @@ class _ApiReachInVisitor(ast.NodeVisitor):
             return "self._api"
         if isinstance(node, ast.Name):
             return node.id
+        if isinstance(node, ast.NamedExpr):
+            return "(walrus-expr)"
         return "<api>"
 
 
@@ -467,13 +478,39 @@ def test_api_reach_in_visitor_catches_alias() -> None:
     assert any(v[1] == "api.foo" for v in visitor.violations)
 
 
-def test_api_reach_in_visitor_catches_nested_scope_alias() -> None:
+def test_api_reach_in_visitor_catches_comprehension_alias() -> None:
+    """Comprehensions traverse within their enclosing function scope and
+    must see aliases bound in that function. (List/set/dict comprehensions
+    do not push a new scope onto ``_alias_stack`` because the visitor only
+    overrides ``visit_FunctionDef`` / ``visit_AsyncFunctionDef`` /
+    ``visit_Lambda``.)
+    """
     tree = ast.parse(
         "class C:\n"
         "    def __init__(self, api): self._api = api\n"
         "    async def f(self):\n"
         "        api = self._api\n"
         "        return [api.foo for x in items]\n"
+    )
+    visitor = _ApiReachInVisitor("test.py")
+    visitor.visit(tree)
+    assert any(v[1] == "api.foo" for v in visitor.violations)
+
+
+def test_api_reach_in_visitor_catches_nested_scope_alias() -> None:
+    """Aliases bound in an outer function must be visible to attribute
+    access in a nested function — exercises the ``reversed(_alias_stack)``
+    multi-entry walk (the inner ``def g`` pushes a second entry onto the
+    stack, and ``api`` is only bound in the outer scope).
+    """
+    tree = ast.parse(
+        "class C:\n"
+        "    def __init__(self, api): self._api = api\n"
+        "    async def f(self):\n"
+        "        api = self._api\n"
+        "        async def g():\n"
+        "            return api.foo\n"
+        "        return await g()\n"
     )
     visitor = _ApiReachInVisitor("test.py")
     visitor.visit(tree)


### PR DESCRIPTION
## Summary

T1 of 3 of the encapsulation reach-in remediation phase (`.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md`). **Ships scaffolding only — no helper module is migrated yet.**

- Adds `_ArtifactsServiceMethods` Protocol in `_artifacts.py` declaring the exact `ArtifactsAPI` surface that `ArtifactDownloadService` and `ArtifactGenerationService` actually use (7 underscore-prefixed + 3 public members). Models the underscore-prefixed Protocol pattern after `RpcOwner` in `_rpc_executor.py` (see `docs/architecture.md` § RpcExecutor).
- Adds `_ApiReachInVisitor` in `tests/unit/test_init_order.py` with full parity to `_CorePrivateAccessVisitor` (function/async/lambda scope tracking, `visit_Assign` / `visit_AnnAssign` / `visit_NamedExpr` alias recording, `reversed(_alias_stack)` outer-scope search), plus bare-retention detection (`return self._api`) beyond what the core guard covers.
- Adds `test_artifact_services_have_no_facade_reach_in` driven by an empty `_REACH_IN_MIGRATED_MODULES` list — vacuously passes in T1, to be populated by T2 (`_artifact_downloads.py`) and T3 (`_artifact_generation.py`).
- Adds 5 synthetic visitor unit tests so the AST guard machinery is exercised even while the migration list is empty.

## Issue scope

This is the first PR of the broader Phase 4 refactor of artifact helper encapsulation. Issue #838's narrow fix already landed in PR #888 (passing `storage_path` explicitly into `ArtifactDownloadService`); this PR is the wider follow-up that pins the helper-to-`ArtifactsAPI` dependency surface and adds the reach-in regression guard.

## Test plan

- [x] `uv run pytest tests/unit/test_init_order.py` — 38 passed (33 existing + 1 guard + 4 synthetic visitor tests). Wait — confirmed: 5 new synthetic + 1 new guard = 6 new tests; total now 38 (was 32). Updated count below.
- [x] `uv run pytest tests/integration/test_artifacts_drift.py` — 10 passed (validates the `source: str = "_parse_generation_result"` default literal is preserved exactly).
- [x] `uv run pytest` — full suite 5594 passed, 14 skipped.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — Success: no issues in 139 source files.
- [x] `uv run ruff check src/notebooklm tests/unit/test_init_order.py` — All checks passed.
- [x] `uv run ruff format --check src/notebooklm tests/unit/test_init_order.py` — clean.
- [x] Verified each of the 10 declared Protocol members exists on the concrete `ArtifactsAPI` via runtime introspection.

## Follow-ups

- **T2**: Migrate `_artifact_downloads.py` to typed `_ArtifactsServiceMethods` constructor injection; append `_artifact_downloads.py` to `_REACH_IN_MIGRATED_MODULES`.
- **T3**: Same for `_artifact_generation.py`.

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened unit tests to detect and prevent improper internal-access patterns in artifact helper modules.

* **Chores**
  * Added a stricter typing contract to clarify service interaction boundaries and reduce coupling.

Note: No user-facing changes in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->