### PR TITLE
test: stabilization-window hygiene bundle (audit §8 items 1, 2, 5)

### DIFF
--- a/tests/cassette_patterns.py
+++ b/tests/cassette_patterns.py
@@ -823,8 +823,9 @@ def is_clean(text: str) -> tuple[bool, list[str]]:
 # =============================================================================
 #
 # These helpers exist so error-shape cassettes can be generated whose
-# responses match the shapes our client's exception mapping in
-# ``src/notebooklm/_core.py`` keys on:
+# responses match the shapes our client's exception mapping (see
+# :mod:`notebooklm._session_helpers` for ``is_auth_error`` and the retry
+# middleware for 429/5xx) keys on:
 #
 #   - HTTP 429  -> ``_TransportRateLimited`` -> ``RateLimitError``
 #   - HTTP 5xx  -> ``_TransportServerError`` -> ``ServerError``
@@ -873,15 +874,15 @@ def build_synthetic_error_response(
     """Return a ``(status_code, body, headers)`` triple for a synthetic error.
 
     The shape is intentionally minimal; the client's exception mapping keys on
-    the HTTP status code (see ``_core.py:is_auth_error`` and the 429 / 5xx
-    branches in ``_perform_authed_post``), so a syntactically-valid Google
-    error-shaped body is sufficient.
+    the HTTP status code (see :func:`notebooklm._session_helpers.is_auth_error`
+    and the 429 / 5xx branches in the retry middleware), so a
+    syntactically-valid Google error-shaped body is sufficient.
 
     For the ``expired_csrf`` mode we return HTTP 400 — not 401 — because that
     matches the documented Google contract: NotebookLM returns 400 (not 401/403)
     when the embedded CSRF token has expired, which is why ``is_auth_error``
-    treats 400 as an auth-refresh trigger. See ``is_auth_error`` in
-    ``src/notebooklm/_core.py``.
+    treats 400 as an auth-refresh trigger. See
+    :func:`notebooklm._session_helpers.is_auth_error`.
 
     Args:
         mode: One of ``VALID_ERROR_MODES``.

--- a/tests/integration/cli_vcr/test_chat.py
+++ b/tests/integration/cli_vcr/test_chat.py
@@ -65,4 +65,3 @@ class TestGetConversationTurnsCommand:
         assert result.exit_code == 0, result.output
         assert "What question should I" in result.output
         assert "Based on the sources" in result.output
-

--- a/tests/integration/cli_vcr/test_chat.py
+++ b/tests/integration/cli_vcr/test_chat.py
@@ -66,35 +66,3 @@ class TestGetConversationTurnsCommand:
         assert "What question should I" in result.output
         assert "Based on the sources" in result.output
 
-    @pytest.mark.skip(
-        reason=(
-            "Cassette not yet recorded. To record: set NOTEBOOKLM_VCR_RECORD=1 and run "
-            "'notebooklm history --save' against real API. "
-            "Cassette must capture GET_LAST_CONVERSATION_ID + GET_CONVERSATION_TURNS "
-            "+ CREATE_NOTE + UPDATE_NOTE."
-        )
-    )
-    def test_history_save(self, runner, mock_auth_for_vcr, mock_context):
-        """'history --save' saves all conversation history as a note."""
-        with notebooklm_vcr.use_cassette("chat_history_save.yaml"):
-            result = runner.invoke(cli, ["history", "--save"])
-            assert result.exit_code == 0
-            assert "Saved as note" in result.output
-
-
-class TestAskSaveAsNoteCommand:
-    """Test 'notebooklm ask --save-as-note' command."""
-
-    @pytest.mark.skip(
-        reason=(
-            "Cassette not yet recorded. To record: set NOTEBOOKLM_VCR_RECORD=1 and run "
-            "'notebooklm ask \"...\" --save-as-note' against real API. "
-            "Cassette must capture GenerateFreeFormStreamed + CREATE_NOTE + UPDATE_NOTE."
-        )
-    )
-    def test_ask_save_as_note(self, runner, mock_auth_for_vcr, mock_context):
-        """'ask --save-as-note' saves the answer as a note."""
-        with notebooklm_vcr.use_cassette("chat_ask_save_as_note.yaml"):
-            result = runner.invoke(cli, ["ask", "What is this about?", "--save-as-note"])
-            assert result.exit_code == 0
-            assert "Saved as note" in result.output

--- a/tests/unit/test_chat_refactor.py
+++ b/tests/unit/test_chat_refactor.py
@@ -372,9 +372,13 @@ class TestChatBlOverride:
     async def test_default_bl_is_pinned_constant(
         self, httpx_mock, monkeypatch, mock_get_conversation_id
     ):
-        """With ``NOTEBOOKLM_BL`` unset, the URL falls back to ``DEFAULT_BL``."""
-        from notebooklm._env import DEFAULT_BL
+        """With ``NOTEBOOKLM_BL`` unset, the URL falls back to the pinned default.
 
+        The expected literal is duplicated here on purpose: importing
+        ``DEFAULT_BL`` from the SUT and asserting equality would be a
+        tautology — any wrong-value edit to ``_env.DEFAULT_BL`` would still
+        pass. The literal pin catches that.
+        """
         monkeypatch.delenv("NOTEBOOKLM_BL", raising=False)
 
         auth = AuthTokens(
@@ -396,7 +400,10 @@ class TestChatBlOverride:
         request = next(
             r for r in httpx_mock.get_requests() if "GenerateFreeFormStreamed" in str(r.url)
         )
-        assert _extract_query_param(str(request.url), "bl") == DEFAULT_BL
+        assert (
+            _extract_query_param(str(request.url), "bl")
+            == "boq_labs-tailwind-frontend_20260301.03_p0"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -97,9 +97,9 @@ synthetic_error_cassette_name = _cassette_patterns.synthetic_error_cassette_name
 SYNTHETIC_ERROR_CASSETTE_PREFIX = _cassette_patterns.SYNTHETIC_ERROR_CASSETTE_PREFIX
 VALID_ERROR_MODES = _cassette_patterns.VALID_ERROR_MODES
 
-# env var name shared with ``src/notebooklm/_error_injection.py``. Kept in
+# env var name shared with :mod:`notebooklm._error_injection`. Kept in
 # sync as a local copy so the VCR-only replay path (which does not import
-# ``notebooklm._error_injection``) can still parse the env var without
+# :mod:`notebooklm._error_injection`) can still parse the env var without
 # dragging the production module in. Unit tests in
 # ``tests/unit/test_vcr_config.py`` import ``ERROR_INJECT_ENV_VAR`` directly
 # from the canonical home — this duplication covers ONLY the VCR-replay
@@ -178,7 +178,7 @@ def _substitute_synthetic_error(response: dict[str, Any]) -> dict[str, Any]:
     synthetic-error shape from :mod:`tests.cassette_patterns`.
 
     The error-injection middleware in
-    ``src/notebooklm/_middleware_error_injection.py`` already substitutes
+    :mod:`notebooklm._middleware_error_injection` already substitutes
     the live response BEFORE it reaches VCR, so in normal recording this hook
     sees the synthetic shape already. This pass exists so that:
 

--- a/tests/vcr_config.py
+++ b/tests/vcr_config.py
@@ -97,12 +97,13 @@ synthetic_error_cassette_name = _cassette_patterns.synthetic_error_cassette_name
 SYNTHETIC_ERROR_CASSETTE_PREFIX = _cassette_patterns.SYNTHETIC_ERROR_CASSETTE_PREFIX
 VALID_ERROR_MODES = _cassette_patterns.VALID_ERROR_MODES
 
-# env var name shared with ``src/notebooklm/_core.py``. Kept in sync
-# as a local copy so the VCR-only replay path (which does not import
-# ``notebooklm._core``) can still parse the env var without dragging the
-# production module in. The unit tests in ``tests/unit/test_vcr_config.py``
-# import ``ERROR_INJECT_ENV_VAR`` directly from ``notebooklm._core`` — the
-# duplication here covers ONLY the VCR-replay path, not the unit-test path.
+# env var name shared with ``src/notebooklm/_error_injection.py``. Kept in
+# sync as a local copy so the VCR-only replay path (which does not import
+# ``notebooklm._error_injection``) can still parse the env var without
+# dragging the production module in. Unit tests in
+# ``tests/unit/test_vcr_config.py`` import ``ERROR_INJECT_ENV_VAR`` directly
+# from the canonical home — this duplication covers ONLY the VCR-replay
+# path, not the unit-test path.
 ERROR_INJECT_ENV_VAR = "NOTEBOOKLM_VCR_RECORD_ERRORS"
 
 
@@ -128,9 +129,10 @@ def get_error_injection_mode() -> str | None:
     ``None`` so plumbing never crashes on a typo — the unit tests assert the
     typo path explicitly. The value comparison is case-insensitive.
 
-    This helper mirrors ``_get_error_injection_mode`` in ``_core.py``; both
-    sides validate against the same canonical set in
-    :mod:`tests.cassette_patterns` so they cannot drift.
+    This helper mirrors ``_get_error_injection_mode`` in
+    :mod:`notebooklm._error_injection`; both sides validate against the
+    same canonical set in :mod:`tests.cassette_patterns` so they cannot
+    drift.
     """
     raw = os.environ.get(ERROR_INJECT_ENV_VAR, "").strip().lower()
     if not raw:
@@ -175,7 +177,8 @@ def _substitute_synthetic_error(response: dict[str, Any]) -> dict[str, Any]:
     :data:`VALID_ERROR_MODES`), rewrite the response shape to the canonical
     synthetic-error shape from :mod:`tests.cassette_patterns`.
 
-    The transport wrapper in ``src/notebooklm/_core.py`` already substitutes
+    The error-injection middleware in
+    ``src/notebooklm/_middleware_error_injection.py`` already substitutes
     the live response BEFORE it reaches VCR, so in normal recording this hook
     sees the synthetic shape already. This pass exists so that:
 
@@ -227,7 +230,8 @@ def scrub_response(response: dict[str, Any]) -> dict[str, Any]:
     Synthetic-error recording: when ``NOTEBOOKLM_VCR_RECORD_ERRORS`` is set to a valid mode,
     :func:`_substitute_synthetic_error` runs FIRST so that downstream scrub
     steps see the canonical synthetic shape rather than whatever the wire
-    produced (the transport wrapper in ``_core.py`` normally already
+    produced (the error-injection middleware in
+    :mod:`notebooklm._middleware_error_injection` normally already
     substituted, but this pass closes the loop for VCR-only test paths).
     """
     # synthetic-error substitution (no-op when env var unset).


### PR DESCRIPTION
## Summary

Three independent cleanups surfaced by the post-PR-10 test-suite audit. Each is small and orthogonal; bundled because each on its own is too small for a PR.

- **§8-1: Tautology fix** — `test_default_bl_is_pinned_constant` imported `DEFAULT_BL` from the SUT and asserted the wire param `== DEFAULT_BL`. A wrong-value edit to `_env.DEFAULT_BL` would still pass. Now pins the literal string `"boq_labs-tailwind-frontend_20260301.03_p0"`.
- **§8-2: Zombie skip removal** — deleted `test_history_save` and `test_ask_save_as_note` in `tests/integration/cli_vcr/test_chat.py`. Both parked behind `pytest.mark.skip` with a "to record: `NOTEBOOKLM_VCR_RECORD=1`" note that nobody had executed in months. Equivalent unit coverage already exists at `tests/unit/cli/test_chat.py::test_ask_save_as_note_creates_note` and friends.
- **§8-5: Stale `_core.py` refs swept** — `tests/vcr_config.py` and `tests/cassette_patterns.py` referred to `_core.py` in present tense; updated to point at the post-demolition homes (`_error_injection`, `_session_helpers`, `_middleware_error_injection`).

No production code changed.

## Test plan

- [x] `uv run pytest tests/unit/test_chat_refactor.py tests/integration/cli_vcr/test_chat.py tests/unit/test_vcr_config.py` — 65/65 pass
- [ ] CI green
- [ ] Reviewer confirms unit coverage replaces the deleted cli_vcr tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CLI history test now asserts specific Q&A preview output
  * Removed a previously skipped history-save test
  * Adjusted a unit test to pin the expected default query parameter value

* **Documentation**
  * Updated test comments/docstrings to reference the correct error-handling and configuration locations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->