### PR TITLE
test(_lint): consolidate 5 'no _core import' AST guards into tests/_lint/ (audit §8-4)

### DIFF
--- a/tests/_lint/test_no_core_imports.py
+++ b/tests/_lint/test_no_core_imports.py
@@ -56,13 +56,16 @@ def _build_parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
 def _inside_type_checking(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
     while node in parents:
         node = parents[node]
-        if isinstance(node, ast.If) and ast.unparse(node.test) == "TYPE_CHECKING":
+        if isinstance(node, ast.If) and ast.unparse(node.test) in {
+            "TYPE_CHECKING",
+            "typing.TYPE_CHECKING",
+        }:
             return True
     return False
 
 
 def _is_core_module_name(name: str) -> bool:
-    return name == "notebooklm._core" or name.endswith("._core")
+    return name.endswith("._core")
 
 
 def _scan(path: Path, extra_banned: frozenset[str]) -> list[tuple[int, str]]:
@@ -89,8 +92,7 @@ def _scan(path: Path, extra_banned: frozenset[str]) -> list[tuple[int, str]]:
             prefix = "." * level
 
             core_hit = (
-                module == "notebooklm._core"
-                or _is_core_module_name(module)
+                _is_core_module_name(module)
                 or (module == "notebooklm" and "_core" in names)
                 or (level > 0 and module == "_core")
                 or (level > 0 and not module and "_core" in names)
@@ -100,13 +102,15 @@ def _scan(path: Path, extra_banned: frozenset[str]) -> list[tuple[int, str]]:
                 violations.append((node.lineno, f"from {prefix}{module} import {joined}"))
 
             extra_hit_module = module in extra_banned
-            extra_hit_namelist = module == "notebooklm" and (names & extra_short)
+            extra_hit_namelist = (
+                module == "notebooklm" or (level > 0 and not module)
+            ) and (names & extra_short)
             if extra_hit_module:
                 joined = ", ".join(sorted(names))
                 violations.append((node.lineno, f"from {prefix}{module} import {joined}"))
             elif extra_hit_namelist:
                 joined = ", ".join(sorted(names & extra_short))
-                violations.append((node.lineno, f"from notebooklm import {joined}"))
+                violations.append((node.lineno, f"from {prefix}{module} import {joined}"))
 
     return violations
 

--- a/tests/_lint/test_no_core_imports.py
+++ b/tests/_lint/test_no_core_imports.py
@@ -102,9 +102,9 @@ def _scan(path: Path, extra_banned: frozenset[str]) -> list[tuple[int, str]]:
                 violations.append((node.lineno, f"from {prefix}{module} import {joined}"))
 
             extra_hit_module = module in extra_banned
-            extra_hit_namelist = (
-                module == "notebooklm" or (level > 0 and not module)
-            ) and (names & extra_short)
+            extra_hit_namelist = (module == "notebooklm" or (level > 0 and not module)) and (
+                names & extra_short
+            )
             if extra_hit_module:
                 joined = ", ".join(sorted(names))
                 violations.append((node.lineno, f"from {prefix}{module} import {joined}"))

--- a/tests/_lint/test_no_core_imports.py
+++ b/tests/_lint/test_no_core_imports.py
@@ -1,0 +1,126 @@
+"""Meta-lint: no runtime ``notebooklm._core`` imports in load-bearing modules.
+
+Consolidates five per-file AST guards that previously lived inline in:
+
+- ``tests/unit/test_authed_transport.py::test_authed_transport_has_no_runtime_core_imports``
+- ``tests/unit/test_rpc_executor.py::test_rpc_executor_has_no_runtime_core_imports``
+- ``tests/unit/test_auth_session.py::test_auth_session_has_no_runtime_client_or_core_imports``
+- ``tests/unit/test_cookie_persistence.py::test_cookie_persistence_does_not_import_client_core_at_runtime``
+- ``tests/unit/test_polling_registry.py::test_polling_registry_does_not_import_client_core_at_runtime``
+
+Each banned the same shape: runtime ``import notebooklm._core`` (or
+``from notebooklm import _core``) **outside** ``TYPE_CHECKING``.
+``TYPE_CHECKING``-block imports are fine — they don't execute.
+
+After PR 10 demolished ``src/notebooklm/_core.py`` the guard is
+preventive: it stops a future caller from resurrecting the shim.
+Single-file enforcement of a cross-cutting policy doesn't scale, so the
+policy moves here and the per-file copies are deleted.
+
+The string ``"notebooklm._core"`` still survives as ``CORE_LOGGER_NAME``
+at ``src/notebooklm/_session_config.py`` — that's a logger name, not an
+import, and is intentional. Loggers don't trigger module load.
+
+``_auth/session.py`` additionally bans ``notebooklm.client`` (the
+original per-file test caught both axes).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# (relative source path, extra fully-qualified module names also banned).
+# ``notebooklm._core`` and its variants are always banned.
+GUARDED_MODULES: list[tuple[str, frozenset[str]]] = [
+    ("src/notebooklm/_authed_transport.py", frozenset()),
+    ("src/notebooklm/_rpc_executor.py", frozenset()),
+    ("src/notebooklm/_auth/session.py", frozenset({"notebooklm.client", "client"})),
+    ("src/notebooklm/_cookie_persistence.py", frozenset()),
+    ("src/notebooklm/_polling_registry.py", frozenset()),
+]
+
+
+def _build_parent_map(tree: ast.AST) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    return parents
+
+
+def _inside_type_checking(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    while node in parents:
+        node = parents[node]
+        if isinstance(node, ast.If) and ast.unparse(node.test) == "TYPE_CHECKING":
+            return True
+    return False
+
+
+def _is_core_module_name(name: str) -> bool:
+    return name == "notebooklm._core" or name.endswith("._core")
+
+
+def _scan(path: Path, extra_banned: frozenset[str]) -> list[tuple[int, str]]:
+    """Return ``[(lineno, descr), …]`` for runtime forbidden imports in ``path``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    parents = _build_parent_map(tree)
+    extra_short = {n.rsplit(".", 1)[-1] for n in extra_banned}
+
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if _inside_type_checking(node, parents):
+            continue
+
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_core_module_name(alias.name) or alias.name in extra_banned:
+                    violations.append((node.lineno, f"import {alias.name}"))
+            continue
+
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            names = {alias.name for alias in node.names}
+            level = node.level
+            prefix = "." * level
+
+            core_hit = (
+                module == "notebooklm._core"
+                or _is_core_module_name(module)
+                or (module == "notebooklm" and "_core" in names)
+                or (level > 0 and module == "_core")
+                or (level > 0 and not module and "_core" in names)
+            )
+            if core_hit:
+                joined = ", ".join(sorted(names))
+                violations.append((node.lineno, f"from {prefix}{module} import {joined}"))
+
+            extra_hit_module = module in extra_banned
+            extra_hit_namelist = module == "notebooklm" and (names & extra_short)
+            if extra_hit_module:
+                joined = ", ".join(sorted(names))
+                violations.append((node.lineno, f"from {prefix}{module} import {joined}"))
+            elif extra_hit_namelist:
+                joined = ", ".join(sorted(names & extra_short))
+                violations.append((node.lineno, f"from notebooklm import {joined}"))
+
+    return violations
+
+
+@pytest.mark.parametrize(
+    ("rel_path", "extra_banned"),
+    GUARDED_MODULES,
+    ids=[Path(p).stem for p, _ in GUARDED_MODULES],
+)
+def test_no_runtime_core_imports(rel_path: str, extra_banned: frozenset[str]) -> None:
+    """Module must not import ``notebooklm._core`` (or other banned names) at runtime.
+
+    ``TYPE_CHECKING``-block imports are allowed.
+    """
+    path = REPO_ROOT / rel_path
+    violations = _scan(path, extra_banned)
+    assert violations == [], f"{rel_path} has forbidden runtime imports: {violations}"

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -262,7 +262,15 @@ def test_client_refresh_auth_is_facade_only() -> None:
     assert violations == []
 
 
-def test_auth_session_has_no_runtime_client_or_core_imports() -> None:
+def test_auth_session_has_no_runtime_class_imports() -> None:
+    """``_auth/session.py`` must not import ``NotebookLMClient`` or ``Session``.
+
+    Module-level guards against importing ``notebooklm.client`` /
+    ``notebooklm._core`` modules live in
+    ``tests/_lint/test_no_core_imports.py``; this test covers the
+    type-name axis (import the *class* by name from anywhere), which the
+    module-level lint can't see.
+    """
     path = Path(__file__).parents[2] / "src/notebooklm/_auth/session.py"
     tree = ast.parse(path.read_text())
     parents: dict[ast.AST, ast.AST] = {}
@@ -277,30 +285,13 @@ def test_auth_session_has_no_runtime_client_or_core_imports() -> None:
                 return True
         return False
 
+    forbidden_type_names = {"NotebookLMClient", "Session"}
     violations: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if inside_type_checking(node):
             continue
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name in {"notebooklm.client", "notebooklm._core"}:
-                    violations.append((node.lineno, f"import {alias.name}"))
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
+        if isinstance(node, ast.ImportFrom):
             imported_names = {alias.name for alias in node.names}
-            if module in {"notebooklm.client", "notebooklm._core", "client", "_core"}:
-                violations.append((node.lineno, f"from {module} import ..."))
-            if (module == "notebooklm" or (node.level > 0 and module == "")) and imported_names & {
-                "client",
-                "_core",
-            }:
-                imported = ", ".join(sorted(imported_names & {"client", "_core"}))
-                violations.append(
-                    (node.lineno, f"from {'.' * node.level}{module} import {imported}")
-                )
-            if node.level > 0 and module in {"client", "_core"}:
-                violations.append((node.lineno, f"from {'.' * node.level}{module} import ..."))
-            forbidden_type_names = {"NotebookLMClient", "Session"}
             for name in sorted(imported_names & forbidden_type_names):
                 violations.append((node.lineno, name))
 

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -22,11 +22,9 @@ cutover; equivalent coverage lives in ``tests/unit/test_chat_transport.py``.
 
 from __future__ import annotations
 
-import ast
 import asyncio
 import json
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -96,49 +94,6 @@ def _status_error(code: int, *, retry_after: str | None = None) -> httpx.HTTPSta
     request = httpx.Request("POST", "https://example.test/x")
     response = httpx.Response(code, request=request, headers=headers)
     return httpx.HTTPStatusError(f"HTTP {code}", request=request, response=response)
-
-
-def test_authed_transport_has_no_runtime_core_imports():
-    """The collaborator must not create a runtime import cycle back to _core."""
-    path = Path(__file__).parents[2] / "src/notebooklm/_authed_transport.py"
-    tree = ast.parse(path.read_text())
-    parents: dict[ast.AST, ast.AST] = {}
-    for parent in ast.walk(tree):
-        for child in ast.iter_child_nodes(parent):
-            parents[child] = parent
-
-    def inside_type_checking(node: ast.AST) -> bool:
-        while node in parents:
-            node = parents[node]
-            if isinstance(node, ast.If):
-                test = node.test
-                if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
-                    return True
-        return False
-
-    forbidden: list[tuple[int, str]] = []
-    for node in ast.walk(tree):
-        if inside_type_checking(node):
-            continue
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name == "notebooklm._core" or alias.name.endswith("._core"):
-                    forbidden.append((node.lineno, f"import {alias.name}"))
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            names = {alias.name for alias in node.names}
-            if (
-                module == "notebooklm._core"
-                or (module == "notebooklm" and "_core" in names)
-                or (node.level > 0 and module == "_core")
-                or (node.level > 0 and not module and "_core" in names)
-            ):
-                imported = ", ".join(sorted(names))
-                forbidden.append(
-                    (node.lineno, f"from {'.' * node.level}{module} import {imported}")
-                )
-
-    assert forbidden == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import threading
 from pathlib import Path
 from typing import Any
@@ -222,19 +221,3 @@ async def test_cookie_persistence_advances_baseline_only_on_accepted_saves(
     assert persistence.loaded_cookie_snapshot[psidts_key].value == "psidts-final"
 
 
-def test_cookie_persistence_does_not_import_client_core_at_runtime() -> None:
-    source = (
-        Path(__file__).resolve().parents[2] / "src/notebooklm/_cookie_persistence.py"
-    ).read_text(encoding="utf-8")
-    tree = ast.parse(source)
-
-    forbidden_imports: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module in {"_core", "notebooklm._core"}:
-            forbidden_imports.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.Import):
-            forbidden_imports.extend(
-                alias.name for alias in node.names if alias.name == "notebooklm._core"
-            )
-
-    assert forbidden_imports == []

--- a/tests/unit/test_cookie_persistence.py
+++ b/tests/unit/test_cookie_persistence.py
@@ -219,5 +219,3 @@ async def test_cookie_persistence_advances_baseline_only_on_accepted_saves(
     assert persistence.loaded_cookie_snapshot is auth.cookie_snapshot
     assert persistence.loaded_cookie_snapshot[sid_key].value == "sid-final"
     assert persistence.loaded_cookie_snapshot[psidts_key].value == "psidts-final"
-
-

--- a/tests/unit/test_polling_registry.py
+++ b/tests/unit/test_polling_registry.py
@@ -85,5 +85,3 @@ async def test_client_core_pending_polls_bridge_preserves_entry_shape() -> None:
             await task
         except asyncio.CancelledError:
             pass
-
-

--- a/tests/unit/test_polling_registry.py
+++ b/tests/unit/test_polling_registry.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import ast
 import asyncio
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -89,19 +87,3 @@ async def test_client_core_pending_polls_bridge_preserves_entry_shape() -> None:
             pass
 
 
-def test_polling_registry_does_not_import_client_core_at_runtime() -> None:
-    source = (
-        Path(__file__).resolve().parents[2] / "src/notebooklm/_polling_registry.py"
-    ).read_text(encoding="utf-8")
-    tree = ast.parse(source)
-
-    forbidden_imports: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module in {"_core", "notebooklm._core"}:
-            forbidden_imports.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.Import):
-            forbidden_imports.extend(
-                alias.name for alias in node.names if alias.name == "notebooklm._core"
-            )
-
-    assert forbidden_imports == []

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import ast
 from collections.abc import Awaitable, Callable
-from pathlib import Path
 from typing import Any
 
 import httpx
@@ -136,37 +134,6 @@ def _executor(
         is_auth_error=is_auth_error or (lambda exc: False),
         sleep=sleep or _no_sleep,
     )
-
-
-def test_rpc_executor_has_no_runtime_core_imports() -> None:
-    path = Path(__file__).parents[2] / "src/notebooklm/_rpc_executor.py"
-    tree = ast.parse(path.read_text())
-    parents: dict[ast.AST, ast.AST] = {}
-    for parent in ast.walk(tree):
-        for child in ast.iter_child_nodes(parent):
-            parents[child] = parent
-
-    def inside_type_checking(node: ast.AST) -> bool:
-        while node in parents:
-            node = parents[node]
-            if isinstance(node, ast.If) and ast.unparse(node.test) == "TYPE_CHECKING":
-                return True
-        return False
-
-    violations: list[tuple[int, str]] = []
-    for node in ast.walk(tree):
-        if inside_type_checking(node):
-            continue
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name == "notebooklm._core" or alias.name.endswith("._core"):
-                    violations.append((node.lineno, alias.name))
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            if module in {"notebooklm._core", "_core"} or module.endswith("._core"):
-                violations.append((node.lineno, module))
-
-    assert not violations
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Move the runtime `notebooklm._core` import ban from five inline copies in feature-test files into a single parametrized lint test at `tests/_lint/test_no_core_imports.py`.

### Old locations (deleted / trimmed)

- `tests/unit/test_authed_transport.py::test_authed_transport_has_no_runtime_core_imports`
- `tests/unit/test_rpc_executor.py::test_rpc_executor_has_no_runtime_core_imports`
- `tests/unit/test_auth_session.py::test_auth_session_has_no_runtime_client_or_core_imports` (module-level part only — see below)
- `tests/unit/test_cookie_persistence.py::test_cookie_persistence_does_not_import_client_core_at_runtime`
- `tests/unit/test_polling_registry.py::test_polling_registry_does_not_import_client_core_at_runtime`

### New location

`tests/_lint/test_no_core_imports.py` — single parametrized test that:

- always bans `notebooklm._core` (and `._core` variants)
- additionally bans `notebooklm.client` for `_auth/session.py` (the only module with that extra axis)
- uniformly excludes `TYPE_CHECKING`-block imports (two of the per-file copies were missing this and would have over-reported)

### Residual in `test_auth_session.py`

A smaller test stays at `test_auth_session_has_no_runtime_class_imports` for the **type-name** axis: forbidden imports of the `NotebookLMClient` / `Session` *classes* regardless of source module. That's auth-session-specific and can't be expressed at the module-name level.

### Why now

After PR #889 demolished `_core.py`, this guard is preventive — it stops a future caller from resurrecting the shim. Single-file enforcement of a cross-cutting policy doesn't scale.

Identified by the post-PR-10 test-suite audit (`docs/test-suite-audit.md` §8-4).

## Test plan

- [x] `uv run pytest tests/_lint/test_no_core_imports.py` — 5/5 cases pass
- [x] `uv run pytest tests/unit/test_authed_transport.py tests/unit/test_rpc_executor.py tests/unit/test_auth_session.py tests/unit/test_cookie_persistence.py tests/unit/test_polling_registry.py` — 77 passed, 2 skipped (the skips are platform-conditional and pre-existing)
- [x] `uv run ruff check` on the six touched files — All checks passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a centralized meta-lint test that enforces forbidden runtime import patterns across the codebase.
  * Removed several redundant per-file import-guard tests, consolidating checks for consistency and maintainability.
  * Added a focused unit test ensuring certain class-level imports remain type-only (allowed only for type checking).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->