### PR TITLE
refactor(artifacts): inject download-service collaborators

### DIFF
--- a/src/notebooklm/_artifact_downloads.py
+++ b/src/notebooklm/_artifact_downloads.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import httpx
@@ -24,6 +24,10 @@ from .types import (
     ArtifactNotReadyError,
     ArtifactParseError,
 )
+
+if TYPE_CHECKING:
+    from ._artifacts import _ArtifactsServiceMethods
+    from ._mind_map import NoteBackedMindMapService
 
 logger = logging.getLogger(__name__)
 
@@ -81,18 +85,25 @@ def _is_trusted_download_host(netloc: str) -> bool:
 class ArtifactDownloadService:
     """Download operations extracted from :class:`ArtifactsAPI`."""
 
-    def __init__(self, api: Any, storage_path: Path | None):
-        self._api = api
+    def __init__(
+        self,
+        *,
+        methods: _ArtifactsServiceMethods,
+        mind_maps: NoteBackedMindMapService,
+        storage_path: Path | None = None,
+    ) -> None:
+        self._methods = methods
+        self._mind_maps = mind_maps
         self._storage_path = storage_path
 
     async def download_audio(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
     ) -> str:
         """Download an Audio Overview to a file."""
-        api = self._api
-        artifacts_data = await api._list_raw(notebook_id)
+        methods = self._methods
+        artifacts_data = await methods._list_raw(notebook_id)
 
-        audio_art = api._select_artifact(
+        audio_art = methods._select_artifact(
             artifacts_data,
             artifact_id,
             "Audio",
@@ -108,19 +119,19 @@ class ArtifactDownloadService:
                 details="Could not extract download URL from artifact metadata",
             )
 
-        return await api._download_url(url, output_path)
+        return await methods._download_url(url, output_path)
 
     async def download_video(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
     ) -> str:
         """Download a Video Overview to a file."""
-        api = self._api
-        artifacts_data = await api._list_raw(notebook_id)
+        methods = self._methods
+        artifacts_data = await methods._list_raw(notebook_id)
 
         # Note: distinct error keys preserved — specific-ID miss raises
         # "video" (from type_name="Video"); empty-list raises
         # "video_overview" (from type_name_lower).
-        video_art = api._select_artifact(
+        video_art = methods._select_artifact(
             artifacts_data,
             artifact_id,
             "Video",
@@ -136,16 +147,16 @@ class ArtifactDownloadService:
                 details="Could not extract download URL from artifact metadata",
             )
 
-        return await api._download_url(url, output_path)
+        return await methods._download_url(url, output_path)
 
     async def download_infographic(
         self, notebook_id: str, output_path: str, artifact_id: str | None = None
     ) -> str:
         """Download an Infographic to a file."""
-        api = self._api
-        artifacts_data = await api._list_raw(notebook_id)
+        methods = self._methods
+        artifacts_data = await methods._list_raw(notebook_id)
 
-        info_art = api._select_artifact(
+        info_art = methods._select_artifact(
             artifacts_data,
             artifact_id,
             "Infographic",
@@ -159,7 +170,7 @@ class ArtifactDownloadService:
             )
             if not url:
                 raise ArtifactParseError("infographic", details="Could not find metadata")
-            return await api._download_url(url, output_path)
+            return await methods._download_url(url, output_path)
 
         except (IndexError, TypeError) as e:
             raise ArtifactParseError(
@@ -174,13 +185,13 @@ class ArtifactDownloadService:
         output_format: str = "pdf",
     ) -> str:
         """Download a slide deck as PDF or PPTX."""
-        api = self._api
+        methods = self._methods
         if output_format not in ("pdf", "pptx"):
             raise ValidationError(f"Invalid format '{output_format}'. Must be 'pdf' or 'pptx'.")
 
-        artifacts_data = await api._list_raw(notebook_id)
+        artifacts_data = await methods._list_raw(notebook_id)
 
-        slide_art = api._select_artifact(
+        slide_art = methods._select_artifact(
             artifacts_data,
             artifact_id,
             "Slide deck",
@@ -220,7 +231,7 @@ class ArtifactDownloadService:
                 "slide_deck", details=f"Failed to parse structure: {e}", cause=e
             ) from e
 
-        return await api._download_url(url, output_path)
+        return await methods._download_url(url, output_path)
 
     async def download_interactive_artifact(
         self,
@@ -231,7 +242,7 @@ class ArtifactDownloadService:
         artifact_type: str,
     ) -> str:
         """Download quiz or flashcard artifact."""
-        api = self._api
+        methods = self._methods
         valid_formats = ("json", "markdown", "html")
         if output_format not in valid_formats:
             raise ValidationError(
@@ -242,9 +253,9 @@ class ArtifactDownloadService:
         default_title = "Untitled Quiz" if is_quiz else "Untitled Flashcards"
 
         artifacts = (
-            await api.list_quizzes(notebook_id)
+            await methods.list_quizzes(notebook_id)
             if is_quiz
-            else await api.list_flashcards(notebook_id)
+            else await methods.list_flashcards(notebook_id)
         )
         completed = [a for a in artifacts if a.is_completed]
         if not completed:
@@ -259,7 +270,7 @@ class ArtifactDownloadService:
         else:
             artifact = completed[0]
 
-        html_content = await api._get_artifact_content(notebook_id, artifact.id)
+        html_content = await methods._get_artifact_content(notebook_id, artifact.id)
         if not html_content:
             raise ArtifactDownloadError(artifact_type, details="Failed to fetch content")
 
@@ -272,7 +283,7 @@ class ArtifactDownloadService:
             ) from e
 
         title = artifact.title or default_title
-        content = api._format_interactive_content(
+        content = methods._format_interactive_content(
             app_data, title, output_format, html_content, is_quiz
         )
 
@@ -293,10 +304,10 @@ class ArtifactDownloadService:
         artifact_id: str | None = None,
     ) -> str:
         """Download a report artifact as markdown."""
-        api = self._api
-        artifacts_data = await api._list_raw(notebook_id)
+        methods = self._methods
+        artifacts_data = await methods._list_raw(notebook_id)
 
-        report_art = api._select_artifact(
+        report_art = methods._select_artifact(
             artifacts_data,
             artifact_id,
             "Report",
@@ -336,8 +347,7 @@ class ArtifactDownloadService:
         artifact_id: str | None = None,
     ) -> str:
         """Download a mind map as JSON."""
-        api = self._api
-        mind_maps_service = api._mind_maps
+        mind_maps_service = self._mind_maps
         mind_maps = await mind_maps_service.list_mind_maps(notebook_id)
         if not mind_maps:
             raise ArtifactNotReadyError("mind_map")
@@ -379,10 +389,10 @@ class ArtifactDownloadService:
         artifact_id: str | None = None,
     ) -> str:
         """Download a data table as CSV."""
-        api = self._api
-        artifacts_data = await api._list_raw(notebook_id)
+        methods = self._methods
+        artifacts_data = await methods._list_raw(notebook_id)
 
-        table_art = api._select_artifact(
+        table_art = methods._select_artifact(
             artifacts_data,
             artifact_id,
             "Data table",

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -329,7 +329,11 @@ class ArtifactsAPI:
         self._poll_registry = PollRegistry()
         self._listing = ArtifactListingService()
         self._generation = ArtifactGenerationService(self)
-        self._downloads = ArtifactDownloadService(self, storage_path)
+        self._downloads = ArtifactDownloadService(
+            methods=self,
+            mind_maps=self._mind_maps,
+            storage_path=storage_path,
+        )
         self._polling = _artifact_polling.ArtifactPollingService(
             runtime,
             self._poll_registry,

--- a/tests/unit/test_artifact_downloads.py
+++ b/tests/unit/test_artifact_downloads.py
@@ -795,11 +795,14 @@ class TestStoragePathEncapsulation:
         from notebooklm._artifact_downloads import ArtifactDownloadService
 
         sentinel = tmp_path / "sentinel_storage.json"
-        # MagicMock has no real ``_storage_path`` — any reach-in attempt
-        # via ``self._api._storage_path`` would yield the mock's auto-spec
-        # rather than the sentinel, failing the equality check below.
-        api = MagicMock()
-        service = ArtifactDownloadService(api, sentinel)
+        # MagicMock collaborators are inert — the service must read the
+        # ``storage_path`` it was constructed with, not via any
+        # collaborator reach-through.
+        methods = MagicMock()
+        mind_maps = MagicMock()
+        service = ArtifactDownloadService(
+            methods=methods, mind_maps=mind_maps, storage_path=sentinel
+        )
 
         captured: list[object] = []
 
@@ -825,8 +828,11 @@ class TestStoragePathEncapsulation:
         from notebooklm._artifact_downloads import ArtifactDownloadService
 
         sentinel = tmp_path / "sentinel_storage.json"
-        api = MagicMock()
-        service = ArtifactDownloadService(api, sentinel)
+        methods = MagicMock()
+        mind_maps = MagicMock()
+        service = ArtifactDownloadService(
+            methods=methods, mind_maps=mind_maps, storage_path=sentinel
+        )
 
         captured: list[object] = []
 

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -338,7 +338,9 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 #     ``"_artifact_generation.py"``.
 # Until both PRs land this list is empty and the guard test passes
 # vacuously.
-_REACH_IN_MIGRATED_MODULES: list[str] = []
+_REACH_IN_MIGRATED_MODULES: list[str] = [
+    "_artifact_downloads.py",
+]
 
 
 def _is_self_api(node: ast.AST) -> bool:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -357,10 +357,10 @@ class _ApiReachInVisitor(ast.NodeVisitor):
     via ``reversed(self._alias_stack)`` so aliases in outer scopes are
     visible to attribute access in nested closures and comprehensions.
 
-    The empty ``_REACH_IN_MIGRATED_MODULES`` list keeps the guard
-    vacuous until the follow-up PRs append ``_artifact_downloads.py`` /
-    ``_artifact_generation.py`` after migrating each helper to
-    constructor injection.
+    ``_REACH_IN_MIGRATED_MODULES`` enumerates helpers already migrated to
+    constructor injection; this guard is actively enforced for those
+    modules. Future migrations should append additional module names
+    (e.g. ``_artifact_generation.py``) to extend enforcement.
     """
 
     def __init__(self, module_name: str) -> None:

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -322,22 +322,17 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 # artifact-service helper modules (``_artifact_downloads.py`` and
 # ``_artifact_generation.py``) depend only on the narrow
 # ``_ArtifactsServiceMethods`` Protocol declared in ``_artifacts.py``, not
-# on the full concrete ``ArtifactsAPI``. This PR ships the visitor + guard
-# with an empty migration list (vacuously passing); the follow-up PRs that
-# migrate each helper to constructor injection will append the helper's
-# module name to ``_REACH_IN_MIGRATED_MODULES`` below.
+# on the full concrete ``ArtifactsAPI``. Each helper migration PR appends
+# the helper's module name to ``_REACH_IN_MIGRATED_MODULES`` below.
 # ----------------------------------------------------------------------------
 
 
 # Modules already migrated to ``_ArtifactsServiceMethods`` constructor
 # injection — the guard below enforces no residual ``self._api`` reach-in.
 # Bookkeeping (mirrors the ``_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS`` pattern):
-#   * The PR that migrates ``_artifact_downloads.py`` will append
-#     ``"_artifact_downloads.py"`` to this list.
+#   * ``_artifact_downloads.py`` migrated (this PR).
 #   * The PR that migrates ``_artifact_generation.py`` will append
 #     ``"_artifact_generation.py"``.
-# Until both PRs land this list is empty and the guard test passes
-# vacuously.
 _REACH_IN_MIGRATED_MODULES: list[str] = [
     "_artifact_downloads.py",
 ]


### PR DESCRIPTION
## Summary

Closes ~25 reach-in sites in `_artifact_downloads.py` by constructor-injecting `methods` (the narrow `_ArtifactsServiceMethods` Protocol introduced in T1 / PR #891), `mind_maps` (the existing `NoteBackedMindMapService`), and the already-explicit `storage_path` (shipped narrowly in PR #888 for issue #838). Drops the `self._api` back-reference entirely; the constructor is now kwargs-only after `self`.

This is **T2 of 3** in the encapsulation reach-in remediation phase. T1 (#891) introduced `_ArtifactsServiceMethods` and the alias-aware AST guard with an empty `_REACH_IN_MIGRATED_MODULES`. T2 populates that list with `_artifact_downloads.py` so the guard now actively enforces no-reach-in on this module. T3 will follow for `ArtifactGenerationService`.

## What changed

- `_artifact_downloads.py`:
  - `__init__` is now `(*, methods: _ArtifactsServiceMethods, mind_maps: NoteBackedMindMapService, storage_path: Path | None = None)`.
  - Collaborator types imported under `TYPE_CHECKING` only (the runtime-import guard in `test_init_order.py` forbids importing `notebooklm._artifacts` from helper service modules).
  - 8 `api = self._api` aliases collapsed; each method now binds `methods = self._methods` locally where helpful.
  - 1 `api._mind_maps` reach-through replaced with `self._mind_maps`.
  - All `api._list_raw` / `_select_artifact` / `_download_url` / `_get_artifact_content` / `_format_interactive_content` / `list_quizzes` / `list_flashcards` call sites rewritten to go through `self._methods`.
- `_artifacts.py`: `ArtifactDownloadService(self, storage_path)` -> kwargs-only call with `methods=self`, `mind_maps=self._mind_maps`, `storage_path=storage_path`.
- `tests/unit/test_init_order.py`: appends `"_artifact_downloads.py"` to `_REACH_IN_MIGRATED_MODULES`. The guard test now actively enforces no `self._api` reach-in (direct, aliased, or nested-scope) on this module.
- `tests/unit/test_artifact_downloads.py::TestStoragePathEncapsulation`: two regression tests from PR #888 updated to the new kwargs-only signature; they continue to pin the storage-path-comes-from-the-constructor invariant for both `download_url` and `download_urls_batch`.

## Patch-seam preservation

The documented monkeypatch contract is preserved because `methods=self` keeps the patch target on `ArtifactsAPI.<method>` unchanged. Existing tests that patch `ArtifactsAPI.generate_report` / `.list_quizzes` / `.list_flashcards` / `._list_raw` / `._download_url` / `._get_artifact_content` / `._select_artifact` / `._format_interactive_content` continue to flow through.

## Plan reference

`.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md` (Task #2).

## Test plan

- [x] `uv run pytest tests/unit/test_init_order.py::test_artifact_services_have_no_facade_reach_in -v` passes (guard now active for `_artifact_downloads.py`).
- [x] `uv run pytest` full suite: 5558 passed, 51 skipped.
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` passes.
- [x] `uv run ruff check src/notebooklm` passes.
- [x] `git grep -nE 'self\._api' src/notebooklm/_artifact_downloads.py` returns zero hits.
- [x] `git grep -nE 'api\.' src/notebooklm/_artifact_downloads.py` returns zero hits.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch downloads now report which items succeeded or failed, with partial-success visibility.
  * Slide deck downloads validate requested output format (PDF/PPTX) before processing.
  * Interactive artifact downloads now include quizzes and flashcards as available sources.

* **Refactor**
  * Download logic reworked to use clearer, injected service collaborations for artifact retrieval and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->