### PR TITLE
test(_auth): migrate test_refresh_lock_registry.py off patch_auth_seam (audit §3)

### DIFF
--- a/tests/unit/test_refresh_lock_registry.py
+++ b/tests/unit/test_refresh_lock_registry.py
@@ -17,8 +17,8 @@ from pathlib import Path
 
 import pytest
 
-from _fixtures import patch_auth_seam
 from notebooklm import auth as auth_mod
+from notebooklm._auth import refresh as _auth_refresh
 
 
 @pytest.fixture(autouse=True)
@@ -145,7 +145,7 @@ class TestResolvedPathEquivalence:
 
         # Force a refresh attempt and short-circuit downstream side effects.
         monkeypatch.setenv(auth_mod.NOTEBOOKLM_REFRESH_CMD_ENV, "dummy")
-        patch_auth_seam(monkeypatch, "_get_refresh_lock", spy_get_refresh_lock)
+        monkeypatch.setattr(_auth_refresh, "_get_refresh_lock", spy_get_refresh_lock)
 
         call_phase = {"first": True}
 
@@ -166,10 +166,10 @@ class TestResolvedPathEquivalence:
         def fake_snapshot(_j):
             return None
 
-        patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-        patch_auth_seam(monkeypatch, "_run_refresh_cmd", fake_run_refresh_cmd)
-        patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-        patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+        monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", fake_run_refresh_cmd)
+        monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+        monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
 
         async def drive(path: Path):
             jar = httpx.Cookies()
@@ -322,11 +322,13 @@ class TestCrossLoopGenerationGuard:
         def wrapped_get_refresh_lock(p):
             return _BarrierLock(original_get_refresh_lock(p))
 
-        patch_auth_seam(monkeypatch, "_run_refresh_cmd", fake_run_refresh_cmd)
-        patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-        patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build_httpx_cookies)
-        patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
-        patch_auth_seam(monkeypatch, "_get_refresh_lock", wrapped_get_refresh_lock)
+        monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", fake_run_refresh_cmd)
+        monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+        monkeypatch.setattr(
+            _auth_refresh, "build_httpx_cookies_from_storage", fake_build_httpx_cookies
+        )
+        monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
+        monkeypatch.setattr(_auth_refresh, "_get_refresh_lock", wrapped_get_refresh_lock)
 
         results: list[BaseException | tuple] = []
         results_lock = threading.Lock()


### PR DESCRIPTION
## Summary
- Replace all 9 `patch_auth_seam(monkeypatch, name, value)` calls in `tests/unit/test_refresh_lock_registry.py` with targeted `monkeypatch.setattr(notebooklm._auth.refresh, name, value)`.
- All patched names (`_get_refresh_lock`, `_fetch_tokens_with_jar`, `_run_refresh_cmd`, `build_httpx_cookies_from_storage`, `snapshot_cookie_jar`) are local aliases inside `notebooklm._auth.refresh` — the broad 7-module sweep that `patch_auth_seam` performs is unnecessary, and patching the canonical refresh module is sufficient.
- Drop the now-unused `from _fixtures import patch_auth_seam` import.

## Why
Part of the audit §3 cleanup migrating off the catch-all `patch_auth_seam` helper toward narrower, production-aligned `monkeypatch.setattr` against the canonical defining module — making the test seams more honest about which module's binding actually drives behavior at the call site.

## Test plan
- [x] `uv run pytest tests/unit/test_refresh_lock_registry.py --no-header` — 7/7 pass
- [x] `uv run ruff check tests/unit/test_refresh_lock_registry.py` — clean
- [x] `uv run ruff format tests/unit/test_refresh_lock_registry.py` — applied

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for authentication refresh logic verification.

*No user-facing changes in this release.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->