### PR TITLE
test(_auth): migrate test_warning_dedupe.py off patch_auth_seam (audit §3)

### DIFF
--- a/tests/unit/test_warning_dedupe.py
+++ b/tests/unit/test_warning_dedupe.py
@@ -30,7 +30,6 @@ from pathlib import Path
 
 import pytest
 
-from _fixtures import patch_auth_seam
 from notebooklm import auth as auth_module
 
 # Cookie set that passes the Tier 1 required-cookies check but lacks any
@@ -113,7 +112,7 @@ def test_flock_unavailable_warns_exactly_once_under_asyncio_gather(
         # caller that emits the dedupe warning, and only on this state.
         yield "unavailable"
 
-    patch_auth_seam(monkeypatch, "_file_lock", fake_file_lock)
+    monkeypatch.setattr("notebooklm._auth.storage._file_lock", fake_file_lock)
 
     lock_path = tmp_path / ".storage_state.json.lock"
 

--- a/tests/unit/test_warning_dedupe.py
+++ b/tests/unit/test_warning_dedupe.py
@@ -112,7 +112,9 @@ def test_flock_unavailable_warns_exactly_once_under_asyncio_gather(
         # caller that emits the dedupe warning, and only on this state.
         yield "unavailable"
 
-    monkeypatch.setattr("notebooklm._auth.storage._file_lock", fake_file_lock)
+    import notebooklm._auth.storage as _auth_storage
+
+    monkeypatch.setattr(_auth_storage, "_file_lock", fake_file_lock)
 
     lock_path = tmp_path / ".storage_state.json.lock"
 


### PR DESCRIPTION
## Summary
- Replace the single `patch_auth_seam(monkeypatch, "_file_lock", fake_file_lock)` call in `tests/unit/test_warning_dedupe.py` with a direct `monkeypatch.setattr("notebooklm._auth.storage._file_lock", ...)`.
- Drop the now-unused `from _fixtures import patch_auth_seam` import.
- Target is `_auth.storage` because the test exercises `auth_module._file_lock_exclusive`, which is defined in `_auth/storage.py` and consumes `_file_lock` from the same module (line 186). The test docstring/comments already pin the warning flag to the storage seam.

## Test plan
- [x] `uv run pytest tests/unit/test_warning_dedupe.py --no-header` — 2 passed
- [x] `uv run ruff check` — clean
- [x] `uv run ruff format` — no changes

Part of the parallel audit §3 sweep to migrate `patch_auth_seam` callers to direct `monkeypatch.setattr` targeting the canonical `_auth/*` owner.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test module to improve test setup and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->