### PR TITLE
test(_auth): migrate test_client_keepalive.py off patch_auth_seam (audit §3)

### DIFF
--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -176,9 +176,7 @@ class TestKeepalivePokes:
         the loop's pacing is the only thing being tested here.
         """
 
-        from _fixtures import patch_auth_seam
-
-        patch_auth_seam(monkeypatch, "_KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
+        monkeypatch.setattr("notebooklm._auth.keepalive._KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
         httpx_mock.add_response(
             url=ROTATE_URL_RE,
             is_optional=True,
@@ -210,9 +208,7 @@ class TestKeepalivePokes:
         attempt by the in-process claim.
         """
 
-        from _fixtures import patch_auth_seam
-
-        patch_auth_seam(monkeypatch, "_KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
+        monkeypatch.setattr("notebooklm._auth.keepalive._KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
         # First poke: connection error. Subsequent pokes: 204.
         httpx_mock.add_exception(
             url=ROTATE_URL_RE,

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -8,6 +8,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+import notebooklm._auth.keepalive as _auth_keepalive
 from notebooklm.auth import AuthTokens
 from notebooklm.client import NotebookLMClient
 
@@ -176,7 +177,7 @@ class TestKeepalivePokes:
         the loop's pacing is the only thing being tested here.
         """
 
-        monkeypatch.setattr("notebooklm._auth.keepalive._KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
+        monkeypatch.setattr(_auth_keepalive, "_KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
         httpx_mock.add_response(
             url=ROTATE_URL_RE,
             is_optional=True,
@@ -208,7 +209,7 @@ class TestKeepalivePokes:
         attempt by the in-process claim.
         """
 
-        monkeypatch.setattr("notebooklm._auth.keepalive._KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
+        monkeypatch.setattr(_auth_keepalive, "_KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)
         # First poke: connection error. Subsequent pokes: 204.
         httpx_mock.add_exception(
             url=ROTATE_URL_RE,


### PR DESCRIPTION
## Summary

- Migrates the two `patch_auth_seam(monkeypatch, "_KEEPALIVE_RATE_LIMIT_SECONDS", 0.0)` calls in `tests/unit/test_client_keepalive.py` to direct `monkeypatch.setattr` on the constant's canonical home (`notebooklm._auth.keepalive._KEEPALIVE_RATE_LIMIT_SECONDS`).
- Drops the now-unused `from _fixtures import patch_auth_seam` imports from this file.
- Part of the audit §3 cleanup eliminating the legacy auth-facade seam-write-through indirection where tests can simply target the seam module directly.

## Why this is safe

`_KEEPALIVE_RATE_LIMIT_SECONDS` is read only locally inside `_auth/keepalive.py` (see `keepalive.py:162, 204, 256`). There is no other reader that needs the legacy `auth.py` facade to mirror the value, so the direct patch is equivalent.

## Test plan

- [x] `uv run pytest tests/unit/test_client_keepalive.py --no-header` -> 28 passed
- [x] `uv run ruff check tests/unit/test_client_keepalive.py` -> All checks passed
- [x] `uv run ruff format tests/unit/test_client_keepalive.py` -> formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated keepalive task unit tests to use a more direct patching approach for internal rate-limit configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->