### PR TITLE
test(_auth): migrate test_refresh_cmd_race.py off patch_auth_seam (audit §3)

### DIFF
--- a/tests/integration/concurrency/test_refresh_cmd_race.py
+++ b/tests/integration/concurrency/test_refresh_cmd_race.py
@@ -41,8 +41,8 @@ import threading
 import httpx
 import pytest
 
-from _fixtures import patch_auth_seam
 from notebooklm import auth as auth_mod
+from notebooklm._auth import refresh as _auth_refresh
 
 # Mock-only tests (no real HTTP, no cassette) — opt out of the
 # integration-tree enforcement hook in ``tests/integration/conftest.py``.
@@ -149,11 +149,11 @@ async def test_failed_refresh_does_not_skip_concurrent_waiter(monkeypatch, tmp_p
             self._inner.release()
             return False
 
-    patch_auth_seam(monkeypatch, "_run_refresh_cmd", fake_run_refresh_cmd)
-    patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-    patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-    patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
-    patch_auth_seam(monkeypatch, "_get_refresh_lock", aligned_get_refresh_lock)
+    monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", fake_run_refresh_cmd)
+    monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
+    monkeypatch.setattr(_auth_refresh, "_get_refresh_lock", aligned_get_refresh_lock)
 
     async def caller(jar):
         return await auth_mod._fetch_tokens_with_refresh(jar, storage_path=storage)
@@ -248,10 +248,10 @@ async def test_concurrent_refresh_failure_followup_sees_attempt(monkeypatch, tmp
     def fake_snapshot(_j):
         return None
 
-    patch_auth_seam(monkeypatch, "_run_refresh_cmd", fake_run_refresh_cmd)
-    patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-    patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-    patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
+    monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", fake_run_refresh_cmd)
+    monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
 
     async def caller(jar):
         return await auth_mod._fetch_tokens_with_refresh(jar, storage_path=storage)
@@ -373,10 +373,10 @@ async def test_waiter_cancellation_does_not_kill_inflight_subprocess(monkeypatch
     def fake_snapshot(_j):
         return None
 
-    patch_auth_seam(monkeypatch, "_run_refresh_cmd", fake_run_refresh_cmd)
-    patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-    patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-    patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
+    monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", fake_run_refresh_cmd)
+    monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
 
     async def caller(jar):
         return await auth_mod._fetch_tokens_with_refresh(jar, storage_path=storage)
@@ -496,10 +496,10 @@ async def test_cancel_settle_race_does_not_bump_on_failure(monkeypatch, tmp_path
     def fake_snapshot(_j):
         return None
 
-    patch_auth_seam(monkeypatch, "_run_refresh_cmd", fake_run_refresh_cmd)
-    patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-    patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-    patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
+    monkeypatch.setattr(_auth_refresh, "_run_refresh_cmd", fake_run_refresh_cmd)
+    monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
 
     jar = httpx.Cookies()
     task = asyncio.create_task(auth_mod._fetch_tokens_with_refresh(jar, storage_path=storage))
@@ -583,10 +583,10 @@ async def test_cancel_before_subprocess_registers_no_phantom_bump(monkeypatch, t
     def fake_snapshot(_j):
         return None
 
-    patch_auth_seam(monkeypatch, "_coalesced_run_refresh_cmd", fake_coalesced_run_refresh_cmd)
-    patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-    patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-    patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
+    monkeypatch.setattr(_auth_refresh, "_coalesced_run_refresh_cmd", fake_coalesced_run_refresh_cmd)
+    monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
 
     # Pre-condition: registry is empty for this refresh_key on this loop.
     refresh_key = str(storage.expanduser().resolve())
@@ -690,10 +690,10 @@ async def test_cancel_before_register_with_warm_registry_no_phantom_bump(monkeyp
     def fake_snapshot(_j):
         return None
 
-    patch_auth_seam(monkeypatch, "_coalesced_run_refresh_cmd", fake_coalesced_run_refresh_cmd)
-    patch_auth_seam(monkeypatch, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
-    patch_auth_seam(monkeypatch, "build_httpx_cookies_from_storage", fake_build)
-    patch_auth_seam(monkeypatch, "snapshot_cookie_jar", fake_snapshot)
+    monkeypatch.setattr(_auth_refresh, "_coalesced_run_refresh_cmd", fake_coalesced_run_refresh_cmd)
+    monkeypatch.setattr(_auth_refresh, "_fetch_tokens_with_jar", fake_fetch_tokens_with_jar)
+    monkeypatch.setattr(_auth_refresh, "build_httpx_cookies_from_storage", fake_build)
+    monkeypatch.setattr(_auth_refresh, "snapshot_cookie_jar", fake_snapshot)
 
     jar = httpx.Cookies()
     result = await asyncio.gather(


### PR DESCRIPTION
## Summary

Migrates `tests/integration/concurrency/test_refresh_cmd_race.py` off the
broad `patch_auth_seam` helper to targeted `monkeypatch.setattr` calls,
per the §3 cleanup audit.

- Replaces all 24 `patch_auth_seam(monkeypatch, "<name>", value)` calls
  with `monkeypatch.setattr(_auth_refresh, "<name>", value)`.
- The patched names (`_run_refresh_cmd`, `_coalesced_run_refresh_cmd`,
  `_fetch_tokens_with_jar`, `build_httpx_cookies_from_storage`,
  `snapshot_cookie_jar`, `_get_refresh_lock`) are all read in
  `src/notebooklm/_auth/refresh.py` via module-local aliases (see
  e.g. `snapshot_cookie_jar = _auth_storage.snapshot_cookie_jar` at
  refresh.py:57, used at refresh.py:626 / 801). Patching the canonical
  consumer module is sufficient — no need to shotgun-patch all 7 auth
  modules.
- Drops the now-unused `from _fixtures import patch_auth_seam` import.
- Leaves `tests/_fixtures/auth_seam.py` untouched (separate cleanup PR
  after all 6 callers migrate).

## Test plan

- [x] `uv run pytest tests/integration/concurrency/test_refresh_cmd_race.py` — all 6 tests pass.
- [x] `uv run ruff check tests/integration/concurrency/test_refresh_cmd_race.py` — clean.
- [x] `uv run ruff format --check tests/integration/concurrency/test_refresh_cmd_race.py` — already formatted.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test infrastructure for concurrent refresh scenarios to improve test reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->