### PR TITLE
test(_auth): migrate test_auth_load_blocks_loop.py off patch_auth_seam (audit §3)

### DIFF
--- a/tests/unit/concurrency/test_auth_load_blocks_loop.py
+++ b/tests/unit/concurrency/test_auth_load_blocks_loop.py
@@ -172,6 +172,10 @@ async def test_fetch_tokens_with_domains_save_does_not_block_event_loop(
         # return is fine; mirror the real function's None-by-default.
         time.sleep(_SLEEP_SECONDS)
 
+    # ``fetch_tokens_with_domains`` calls ``save_cookies_to_storage`` via
+    # the module-local alias in ``notebooklm._auth.refresh``
+    # (_auth/refresh.py:58 + :814), so patch the consumer-side name on
+    # that module rather than the canonical home in ``_auth.storage``.
     monkeypatch.setattr(_auth_refresh, "save_cookies_to_storage", _blocking_save)
 
     heartbeats = 0

--- a/tests/unit/concurrency/test_auth_load_blocks_loop.py
+++ b/tests/unit/concurrency/test_auth_load_blocks_loop.py
@@ -33,6 +33,7 @@ import time
 import pytest
 from pytest_httpx import HTTPXMock
 
+import notebooklm._auth.refresh as _auth_refresh
 from notebooklm import auth as auth_module
 from notebooklm.auth import AuthTokens
 
@@ -101,7 +102,7 @@ async def test_from_storage_save_does_not_block_event_loop(
     # module-local alias in ``notebooklm.auth`` (auth.py:86), so patch the
     # consumer-side name on that module rather than the canonical home in
     # ``_auth.storage``.
-    monkeypatch.setattr("notebooklm.auth.save_cookies_to_storage", _blocking_save)
+    monkeypatch.setattr(auth_module, "save_cookies_to_storage", _blocking_save)
 
     heartbeats = 0
     stop = asyncio.Event()
@@ -171,7 +172,7 @@ async def test_fetch_tokens_with_domains_save_does_not_block_event_loop(
         # return is fine; mirror the real function's None-by-default.
         time.sleep(_SLEEP_SECONDS)
 
-    monkeypatch.setattr("notebooklm._auth.refresh.save_cookies_to_storage", _blocking_save)
+    monkeypatch.setattr(_auth_refresh, "save_cookies_to_storage", _blocking_save)
 
     heartbeats = 0
     stop = asyncio.Event()

--- a/tests/unit/concurrency/test_auth_load_blocks_loop.py
+++ b/tests/unit/concurrency/test_auth_load_blocks_loop.py
@@ -33,7 +33,6 @@ import time
 import pytest
 from pytest_httpx import HTTPXMock
 
-from _fixtures import patch_auth_seam
 from notebooklm import auth as auth_module
 from notebooklm.auth import AuthTokens
 
@@ -98,7 +97,11 @@ async def test_from_storage_save_does_not_block_event_loop(
         time.sleep(_SLEEP_SECONDS)
         return True
 
-    patch_auth_seam(monkeypatch, "save_cookies_to_storage", _blocking_save)
+    # ``AuthTokens.from_storage`` calls ``save_cookies_to_storage`` via the
+    # module-local alias in ``notebooklm.auth`` (auth.py:86), so patch the
+    # consumer-side name on that module rather than the canonical home in
+    # ``_auth.storage``.
+    monkeypatch.setattr("notebooklm.auth.save_cookies_to_storage", _blocking_save)
 
     heartbeats = 0
     stop = asyncio.Event()
@@ -168,7 +171,7 @@ async def test_fetch_tokens_with_domains_save_does_not_block_event_loop(
         # return is fine; mirror the real function's None-by-default.
         time.sleep(_SLEEP_SECONDS)
 
-    patch_auth_seam(monkeypatch, "save_cookies_to_storage", _blocking_save)
+    monkeypatch.setattr("notebooklm._auth.refresh.save_cookies_to_storage", _blocking_save)
 
     heartbeats = 0
     stop = asyncio.Event()


### PR DESCRIPTION
## Summary

Migrates the two `patch_auth_seam` call sites in `tests/unit/concurrency/test_auth_load_blocks_loop.py` to direct `monkeypatch.setattr` calls aimed at the actual consumer-side bindings. Drops the now-unused `from _fixtures import patch_auth_seam` import. `tests/_fixtures/auth_seam.py` is left untouched (still used by other callers being migrated in parallel).

- `test_from_storage_save_does_not_block_event_loop` -> patches `notebooklm.auth.save_cookies_to_storage` (consumer is the module-local alias bound at `auth.py:86`, used by `AuthTokens.from_storage`).
- `test_fetch_tokens_with_domains_save_does_not_block_event_loop` -> patches `notebooklm._auth.refresh.save_cookies_to_storage` (consumer is the local alias bound at `_auth/refresh.py:58`, called via `asyncio.to_thread` at `_auth/refresh.py:814`).

## Test plan

- [x] `uv run pytest tests/unit/concurrency/test_auth_load_blocks_loop.py` -> 2 passed
- [x] `uv run ruff check tests/unit/concurrency/test_auth_load_blocks_loop.py` -> All checks passed
- [x] `uv run ruff format tests/unit/concurrency/test_auth_load_blocks_loop.py` -> formatted clean
- [ ] CI green on PR

Audit reference: §3 of the `patch_auth_seam` migration audit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to more directly patch token persistence call sites.
  * Clarified test setup with inline patching and comments while preserving injected blocking behavior and assertions that async/event-loop responsiveness remains intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->