### PR TITLE
security(logging+auth): redact PSIDTS/PAPISID + close env-leak / url-path gaps

### DIFF
--- a/src/notebooklm/_auth/extraction.py
+++ b/src/notebooklm/_auth/extraction.py
@@ -104,17 +104,49 @@ def extract_wiz_field(html: str, key: str, *, strict: bool = True) -> str | None
     return None
 
 
+# Hosts whose path component may carry credentials and must be redacted in
+# error-message interpolations. These are Google's OAuth surfaces:
+#
+# * ``accounts.google.com`` — the legacy login/consent flow (including
+#   observed redirects of the shape ``/o/oauth2/auth/<token>``).
+# * ``oauth2.googleapis.com`` — the token-exchange endpoint family.
+# * ``oauth2.googleusercontent.com`` — observed grant-code return path in
+#   some OAuth flows. (The wider ``.googleusercontent.com`` family is also
+#   tagged trusted in ``_artifact_downloads.py`` for a related reason; we
+#   scope this list to the ``oauth2`` subdomain because the broader family
+#   carries non-auth payload URLs.)
+#
+# The query/fragment/userinfo stripping below applies to ALL hosts; the
+# path stripping is restricted to this allowlist so non-auth failures
+# still carry enough operator signal (host + path) to be diagnosable.
+# Notable omission: ``www.googleapis.com`` is deliberately NOT in this
+# list — it hosts many non-auth APIs (Drive, Calendar, Storage) where the
+# path is operator signal, not credential. Add the specific subdomain if
+# a future leak path emerges rather than the broad family.
+_AUTH_PATH_REDACT_HOSTS: frozenset[str] = frozenset(
+    {
+        "accounts.google.com",
+        "oauth2.googleapis.com",
+        "oauth2.googleusercontent.com",
+    }
+)
+
+
 def _safe_url(url: str) -> str:
     """Return ``url`` stripped of credential-shaped parts for error display.
 
-    Auth-handshake URLs can carry credentials in three positions, all of
-    which we strip:
+    Auth-handshake URLs can carry credentials in four positions, all of
+    which we strip (the path strip is restricted to known auth hosts):
 
     * **Query string** — ``f.sid=...``, ``continue=...``, ``access_token=...``.
     * **Fragment** — OAuth implicit-flow tokens (``#access_token=...``).
     * **Userinfo** — ``https://TOKEN@host/...`` shapes; ``parsed.netloc``
       preserves the userinfo, so we rebuild from ``hostname`` + optional
       port instead of trusting ``netloc`` directly.
+    * **Path** — restricted to ``_AUTH_PATH_REDACT_HOSTS`` (Google's OAuth
+      hosts) where the path can carry an opaque grant code or token
+      (``/o/oauth2/auth/<token>``). Non-auth hosts keep their path so
+      operators can still identify which endpoint failed.
 
     The surviving ``scheme://host[:port]/path`` is enough context for an
     operator to recognize which endpoint failed without leaking session
@@ -129,7 +161,21 @@ def _safe_url(url: str) -> str:
     # on malformed input, in which case we degrade gracefully to "scheme:///path".
     host = parsed.hostname or ""
     netloc = f"{host}:{parsed.port}" if parsed.port is not None else host
-    return f"{parsed.scheme}://{netloc}{parsed.path}"
+    path = parsed.path or ""
+    host_lc = host.lower()
+    # Match the exact host OR any subdomain — both ``accounts.google.com``
+    # and ``x.accounts.google.com`` count. Driving subdomain matching off the
+    # frozenset (instead of hardcoded ``.endswith`` calls per host) keeps
+    # adding a new host a one-line change.
+    if (
+        path
+        and path != "/"
+        and any(host_lc == h or host_lc.endswith("." + h) for h in _AUTH_PATH_REDACT_HOSTS)
+    ):
+        # Replace with a fixed sentinel so the URL still parses cleanly and
+        # the operator sees the auth-host signal without the path content.
+        path = "/<redacted>"
+    return f"{parsed.scheme}://{netloc}{path}"
 
 
 def extract_csrf_from_html(html: str, final_url: str = "") -> str:

--- a/src/notebooklm/_auth/refresh.py
+++ b/src/notebooklm/_auth/refresh.py
@@ -314,6 +314,14 @@ async def _run_refresh_cmd(storage_path: Path | None = None, profile: str | None
     if not cmd:
         raise RuntimeError(f"{NOTEBOOKLM_REFRESH_CMD_ENV} is not set; cannot refresh cookies.")
     refresh_env = os.environ.copy()
+    # ``NOTEBOOKLM_AUTH_JSON`` carries the full Playwright storage_state — a
+    # credential-equivalent payload. Forwarding it via ``os.environ.copy()``
+    # into the refresh subprocess would inherit it down the tree (visible via
+    # ``/proc/<pid>/environ`` to the same UID) and into any grandchild the
+    # refresh command spawns. The refresh command already receives the
+    # canonical on-disk storage path via ``NOTEBOOKLM_REFRESH_STORAGE_PATH``
+    # (set just below), so the in-env JSON is not needed by the child.
+    refresh_env.pop("NOTEBOOKLM_AUTH_JSON", None)
     refresh_env[_REFRESH_ATTEMPTED_ENV] = "1"
     refresh_env["NOTEBOOKLM_REFRESH_PROFILE"] = resolve_profile(profile)
     refresh_env["NOTEBOOKLM_REFRESH_STORAGE_PATH"] = str(

--- a/src/notebooklm/_logging.py
+++ b/src/notebooklm/_logging.py
@@ -100,11 +100,20 @@ _REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         r"\1***",
     ),
     # Google session cookies — preserve name, redact value. Longer/more-
-    # specific names first so SAPISID/SIDCC/SSID don't get partially shadowed
-    # by a bare-SID match.
+    # specific names appear first as a defensive convention. Python's ``re``
+    # engine backtracks (so ordering is NOT load-bearing for correctness —
+    # the engine retries the next alternative when the trailing ``=`` fails
+    # to match), but longer-first minimizes backtracking on the hot path and
+    # mirrors the canonical Google cookie-family layout. The ``PAPISID``
+    # variants must be enumerated explicitly (NOT covered by the bare
+    # ``APISID`` alternative) so the captured ``\1`` group reflects the full
+    # cookie name in the redacted output, not just the matching suffix.
     (
         re.compile(
-            r"(__Secure-1PSIDCC|__Secure-3PSIDCC|__Secure-1PSID|__Secure-3PSID"
+            r"(__Secure-1PAPISID|__Secure-3PAPISID"
+            r"|__Secure-1PSIDTS|__Secure-3PSIDTS"
+            r"|__Secure-1PSIDCC|__Secure-3PSIDCC"
+            r"|__Secure-1PSID|__Secure-3PSID"
             r"|SAPISID|APISID|SIDCC|HSID|SSID|LSID|SID)=([^;\s,\"'<>]+)"
         ),
         r"\1=***",
@@ -148,7 +157,7 @@ _DEFAULT_DATEFMT = "%H:%M:%S"
 #   \bf\.sid=<sid>                                       -> "f.sid"
 #   (refresh_token|access_token|id_token)= (IGNORECASE)  -> "_token="
 #   \bcode= (IGNORECASE)                                 -> "code="
-#   __Secure-*PSID(CC)?/SAPISID/APISID/SIDCC/HSID/SSID/LSID/SID= -> "sid"
+#   __Secure-*PAPISID/PSID(TS|CC)?/SAPISID/APISID/SIDCC/HSID/SSID/LSID/SID= -> "sid"
 #   Authorization:\s*Bearer (IGNORECASE)                 -> "authorization"
 #   Cookie: (IGNORECASE)                                 -> "cookie"
 #   Set-Cookie: (IGNORECASE)                             -> "set-cookie" (also "cookie")

--- a/tests/unit/test_auth_extraction.py
+++ b/tests/unit/test_auth_extraction.py
@@ -10,6 +10,7 @@ import json
 
 import pytest
 
+from notebooklm._auth.extraction import _safe_url
 from notebooklm.auth import (
     AuthTokens,
     build_httpx_cookies_from_storage,
@@ -557,6 +558,94 @@ class TestFinalUrlScrubbing:
         assert "SECRET_TOKEN_USERINFO" not in message
         # Port is preserved so operators can still identify the endpoint.
         assert "https://x.example:8443/y" in message
+
+
+class TestSafeUrlGoogleAuthHosts:
+    """``_safe_url`` must drop the path component for Google OAuth hosts.
+
+    Background: Google's OAuth endpoints have historically embedded opaque
+    grant codes / tokens in the URL **path** (e.g. ``/o/oauth2/auth/<token>``
+    on ``accounts.google.com``). The original ``_safe_url`` stripped only
+    userinfo / query / fragment — a future redirect format change that put
+    a credential in the path segment would have leaked through
+    ``ValueError("... Redirected to: %s" % final_url)`` (see
+    ``_auth/refresh.py`` ``_fetch_tokens_with_jar``).
+
+    These tests pin the host-restricted path-redaction so non-auth endpoints
+    retain enough operator signal (host + path) to be diagnosable.
+    """
+
+    def test_accounts_google_com_path_redacted(self):
+        """accounts.google.com paths get replaced with /<redacted>."""
+        out = _safe_url("https://accounts.google.com/o/oauth2/auth/SECRET_GRANT_CODE?q=1")
+        assert "SECRET_GRANT_CODE" not in out
+        assert "/o/oauth2/auth" not in out
+        assert out == "https://accounts.google.com/<redacted>"
+
+    def test_oauth2_googleapis_com_path_redacted(self):
+        """oauth2.googleapis.com paths get replaced with /<redacted>."""
+        out = _safe_url("https://oauth2.googleapis.com/token/SECRET_PATH_TOKEN")
+        assert "SECRET_PATH_TOKEN" not in out
+        assert out == "https://oauth2.googleapis.com/<redacted>"
+
+    def test_oauth2_googleusercontent_com_path_redacted(self):
+        """oauth2.googleusercontent.com paths get replaced with /<redacted>."""
+        out = _safe_url("https://oauth2.googleusercontent.com/auth/SECRET_GRANT")
+        assert "SECRET_GRANT" not in out
+        assert out == "https://oauth2.googleusercontent.com/<redacted>"
+
+    def test_unrelated_googleusercontent_subdomain_path_preserved(self):
+        """Non-``oauth2`` subdomains of googleusercontent.com keep their path.
+
+        The wider ``.googleusercontent.com`` family hosts artifact downloads
+        (slide decks, audio) — operator signal there is more useful than the
+        narrow leak risk. Only the ``oauth2`` subdomain is in the redact set.
+        """
+        out = _safe_url("https://lh3.googleusercontent.com/a/AVATAR_PATH")
+        assert "AVATAR_PATH" in out, f"non-auth googleusercontent path lost: {out!r}"
+
+    def test_www_googleapis_com_path_preserved(self):
+        """www.googleapis.com is NOT in the redact set (hosts many non-auth APIs)."""
+        out = _safe_url("https://www.googleapis.com/drive/v3/files/foo")
+        assert "/drive/v3/files/foo" in out
+
+    def test_accounts_google_com_root_path_preserved(self):
+        """Root path ``/`` on Google auth hosts is NOT redacted (no signal to leak)."""
+        assert _safe_url("https://accounts.google.com/") == "https://accounts.google.com/"
+
+    def test_accounts_google_com_subdomain_path_redacted(self):
+        """Subdomains of accounts.google.com also get path-redacted."""
+        out = _safe_url("https://x.accounts.google.com/o/oauth2/auth/TOKEN")
+        assert "TOKEN" not in out
+        assert out == "https://x.accounts.google.com/<redacted>"
+
+    def test_non_google_host_path_preserved(self):
+        """Non-auth hosts keep their path so operators can identify endpoints."""
+        # Regression for ``test_final_url_stripped`` — non-Google host must
+        # round-trip the path through the safe-url pipe.
+        assert _safe_url("https://x.example/y") == "https://x.example/y"
+
+    def test_google_auth_host_case_insensitive(self):
+        """Host comparison must be case-insensitive (RFC 3986 §3.2.2)."""
+        out = _safe_url("https://Accounts.Google.COM/o/oauth2/auth/TOK")
+        assert "TOK" not in out
+        # Hostname casing is preserved verbatim from ``urlparse(...).hostname``
+        # which lowercases the host; the assertion targets the absence of
+        # ``TOK`` regardless of host-casing rendering.
+
+    def test_google_auth_host_query_and_path_both_stripped(self):
+        """Query is dropped by the existing pipe; path is dropped by the new
+        host-restricted rule. A URL with both must lose both."""
+        out = _safe_url(
+            "https://accounts.google.com/o/oauth2/auth/PATH_TOK?continue=https%3A%2F%2Fx.example"
+        )
+        assert "PATH_TOK" not in out
+        assert "continue=" not in out
+        assert out == "https://accounts.google.com/<redacted>"
+
+    def test_empty_url_still_empty(self):
+        """Empty input degenerates cleanly (regression for the existing pipe)."""
+        assert _safe_url("") == ""
 
 
 class TestExtractCookiesEdgeCases:

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -126,7 +126,11 @@ class TestFetchTokens:
         assert "continue=foo" not in message
         assert "f.sid=bar" not in message
         assert "access_token=frag" not in message
-        assert "https://accounts.google.com/signin" in message
+        # Path is redacted for Google auth hosts so a future redirect format
+        # that embeds a token in the path segment cannot leak. The host
+        # itself survives so operators still see the auth-host signal.
+        assert "https://accounts.google.com/<redacted>" in message
+        assert "/signin" not in message
 
     @pytest.mark.asyncio
     async def test_fetch_tokens_sends_cookies_on_account_redirect(self, httpx_mock: HTTPXMock):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -267,13 +267,42 @@ def test_formatter_scrubs_papisid_with_correct_captured_name():
     """``__Secure-[13]PAPISID`` must be matched as its own alternative.
 
     Without an explicit alternative, the engine would match the ``APISID``
-    suffix instead, capturing only ``APISID`` as ``\\1`` while leaving the
-    ``__Secure-1P`` prefix in place. The substituted output still looks
-    correct (``__Secure-1PAPISID=***``) but the captured-name signal in
-    structured logging surfaces would be wrong. This test pins both the
-    leak being closed AND the captured-name shape via the prefix being
-    preserved in the redacted output exactly once.
+    suffix at position 11 instead, capturing only ``APISID`` as ``\\1``
+    while leaving the ``__Secure-1P`` prefix in place. The substituted
+    output looks identical at the surface (``__Secure-1PAPISID=***``)
+    because the unmatched prefix is preserved verbatim, so a string-shape
+    assertion alone cannot distinguish "full name captured" from
+    "coincidental prefix preservation."
+
+    We pin the invariant directly: walk ``_REDACT_PATTERNS`` and assert
+    that the first cookie-pattern match on a PAPISID input has
+    ``group(1) == "__Secure-1PAPISID"``. Removing the PAPISID alternative
+    from the regex would flip ``group(1)`` to ``"APISID"``, which this
+    assertion catches even though the substituted output would still look
+    correct.
     """
+    from notebooklm._logging import _REDACT_PATTERNS
+
+    # Find the cookie pattern (the one whose replacement is "\1=***" and
+    # whose source mentions __Secure-). Don't hardcode an index.
+    cookie_pattern = next(
+        p for p, repl in _REDACT_PATTERNS if repl == r"\1=***" and "__Secure" in p.pattern
+    )
+
+    # group(1) must be the FULL cookie name, not the APISID suffix.
+    m1 = cookie_pattern.search("__Secure-1PAPISID=SECRET_1PAPISID")
+    assert m1 is not None
+    assert m1.group(1) == "__Secure-1PAPISID", (
+        f"capture group resolved to suffix instead of full name: {m1.group(1)!r}"
+    )
+    m3 = cookie_pattern.search("__Secure-3PAPISID=SECRET_3PAPISID")
+    assert m3 is not None
+    assert m3.group(1) == "__Secure-3PAPISID", (
+        f"capture group resolved to suffix instead of full name: {m3.group(1)!r}"
+    )
+
+    # End-to-end shape check via the formatter (regression for the visible
+    # substitution + the no-PAPAPISID corruption guard).
     fmt = RedactingFormatter(logging.Formatter("%(message)s"))
     text = "jar: __Secure-1PAPISID=SECRET_1PAPISID; __Secure-3PAPISID=SECRET_3PAPISID"
     rec = _record(text)
@@ -282,8 +311,6 @@ def test_formatter_scrubs_papisid_with_correct_captured_name():
     assert "SECRET_3PAPISID" not in out
     assert "__Secure-1PAPISID=***" in out
     assert "__Secure-3PAPISID=***" in out
-    # Defense-in-depth: ensure we are not corrupting the cookie name with
-    # an over-eager suffix-match (e.g. ``__Secure-1PAPAPISID=***``).
     assert "PAPAPISID" not in out
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -119,6 +119,16 @@ _GOOGLE_COOKIE_PAIRS = [
     ("__Secure-3PSID", "psid_qrs"),
     ("__Secure-1PSIDCC", "psidcc_xyz"),
     ("__Secure-3PSIDCC", "psidcc_qrs"),
+    # PSIDTS — rotating token-state cookies. Pre-fix these only redacted when
+    # they appeared inside a ``Cookie:`` / ``Set-Cookie:`` header value; a
+    # standalone ``__Secure-1PSIDTS=<value>`` token (as appears in refresh-cmd
+    # stdout/stderr captured at DEBUG) passed through unredacted.
+    ("__Secure-1PSIDTS", "psidts_xyz"),
+    ("__Secure-3PSIDTS", "psidts_qrs"),
+    # PAPISID — auth-API session cookies. Without an explicit alternative the
+    # captured ``\1`` group would resolve to the ``APISID`` suffix only.
+    ("__Secure-1PAPISID", "papisid_xyz"),
+    ("__Secure-3PAPISID", "papisid_qrs"),
     ("SIDCC", "sidcc_val"),
     ("HSID", "hsid_val"),
     ("SSID", "ssid_val"),
@@ -184,6 +194,97 @@ def test_formatter_scrubs_set_cookie_response_header():
     out = fmt.format(rec)
     assert "server_minted_value" not in out
     assert "Set-Cookie: ***" in out
+
+
+def test_formatter_scrubs_psidts_in_non_header_shapes():
+    """Standalone ``__Secure-[13]PSIDTS=<value>`` tokens must be redacted in
+    every HTTP-shaped form they appear in (refresh-cmd stdout/stderr,
+    comma-separated cookie listings) — not just inside a ``Cookie:`` header.
+
+    Pre-fix, the cookie-name alternation listed ``__Secure-[13]PSID`` and
+    ``__Secure-[13]PSIDCC`` but NOT the ``PSIDTS`` (token-state) family. A
+    ``RuntimeError`` traceback containing ``__Secure-1PSIDTS=abc123`` from a
+    refresh subprocess therefore leaked the value verbatim through any error
+    surface that wasn't fronted by the ``Cookie:`` / ``Set-Cookie:`` regex.
+
+    Scope note: JSON-shaped ``"name":"__Secure-1PSIDTS","value":"..."`` is
+    NOT covered by this runtime redactor — that storage-state shape lives in
+    the VCR cassette sanitizer (see ``tests/vcr_config.py`` and
+    ``tests/unit/test_cookie_redaction.py``).
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+
+    cases = [
+        # Refresh-cmd stdout/stderr shape: plain ``name=value`` standalone token.
+        "rotation: __Secure-1PSIDTS=SECRET_PSIDTS_VALUE_A refreshed",
+        # Comma-separated listing.
+        "cookies: __Secure-1PSIDTS=SECRET_PSIDTS_VALUE_B, __Secure-3PSIDTS=SECRET_PSIDTS_VALUE_C",
+    ]
+    for text in cases:
+        rec = _record(text)
+        out = fmt.format(rec)
+        for secret in (
+            "SECRET_PSIDTS_VALUE_A",
+            "SECRET_PSIDTS_VALUE_B",
+            "SECRET_PSIDTS_VALUE_C",
+        ):
+            assert secret not in out, f"PSIDTS value {secret!r} leaked from {text!r}: got {out!r}"
+
+
+def test_formatter_psid_family_redacts_independently():
+    """The PSIDTS / PSIDCC / PSID variants must redact INDEPENDENTLY.
+
+    Python's ``re`` engine backtracks, so the bare ``__Secure-1PSID``
+    alternative does NOT shadow ``__Secure-1PSIDTS`` even if listed first
+    (the engine commits, finds no ``=`` immediately after, then retries
+    the next alternative). The longer-first ordering in the source regex
+    is a defensive convention + microscale perf, not load-bearing for
+    correctness.
+
+    This test pins what IS load-bearing: each of the three suffix variants
+    (``PSID`` / ``PSIDCC`` / ``PSIDTS``) must scrub when present together,
+    independent of any ordering subtlety.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    text = (
+        "jar: __Secure-1PSID=BARE_PSID_VAL; "
+        "__Secure-1PSIDCC=PSIDCC_VAL; "
+        "__Secure-1PSIDTS=PSIDTS_VAL"
+    )
+    rec = _record(text)
+    out = fmt.format(rec)
+    for secret in ("BARE_PSID_VAL", "PSIDCC_VAL", "PSIDTS_VAL"):
+        assert secret not in out, f"{secret} leaked: {out!r}"
+    for redacted in (
+        "__Secure-1PSID=***",
+        "__Secure-1PSIDCC=***",
+        "__Secure-1PSIDTS=***",
+    ):
+        assert redacted in out, f"missing {redacted}: {out!r}"
+
+
+def test_formatter_scrubs_papisid_with_correct_captured_name():
+    """``__Secure-[13]PAPISID`` must be matched as its own alternative.
+
+    Without an explicit alternative, the engine would match the ``APISID``
+    suffix instead, capturing only ``APISID`` as ``\\1`` while leaving the
+    ``__Secure-1P`` prefix in place. The substituted output still looks
+    correct (``__Secure-1PAPISID=***``) but the captured-name signal in
+    structured logging surfaces would be wrong. This test pins both the
+    leak being closed AND the captured-name shape via the prefix being
+    preserved in the redacted output exactly once.
+    """
+    fmt = RedactingFormatter(logging.Formatter("%(message)s"))
+    text = "jar: __Secure-1PAPISID=SECRET_1PAPISID; __Secure-3PAPISID=SECRET_3PAPISID"
+    rec = _record(text)
+    out = fmt.format(rec)
+    assert "SECRET_1PAPISID" not in out
+    assert "SECRET_3PAPISID" not in out
+    assert "__Secure-1PAPISID=***" in out
+    assert "__Secure-3PAPISID=***" in out
+    # Defense-in-depth: ensure we are not corrupting the cookie name with
+    # an over-eager suffix-match (e.g. ``__Secure-1PAPAPISID=***``).
+    assert "PAPAPISID" not in out
 
 
 def test_formatter_handles_nonstring_record_msg():

--- a/tests/unit/test_refresh_cmd_redaction.py
+++ b/tests/unit/test_refresh_cmd_redaction.py
@@ -168,6 +168,75 @@ def test_error_handler_handles_non_string_first_arg(
     assert "Unexpected error: 42" in (captured.out + captured.err)
 
 
+def _capture_refresh_subprocess_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Stub ``subprocess.run`` to record (and return) the ``env`` kwarg it received.
+
+    Returns a dict that the caller can inspect after ``_run_refresh_cmd`` runs;
+    the stub itself returns a zero-exit result so the refresh call completes
+    normally. Mirrors ``_stub_subprocess_run_with_leaky_output`` above.
+    """
+    captured: dict[str, str] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(*_args: Any, **kwargs: Any) -> _Result:
+        captured.update(kwargs.get("env") or {})
+        return _Result()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    return captured
+
+
+def test_refresh_cmd_env_does_not_inherit_auth_json(
+    refresh_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``NOTEBOOKLM_AUTH_JSON`` must be stripped from the refresh subprocess env.
+
+    The env var carries the full Playwright ``storage_state`` (credential-
+    equivalent) when callers route auth through environment instead of disk.
+    ``os.environ.copy()`` would forward it to the refresh subprocess and any
+    grandchildren it spawns, where it is visible via ``/proc/<pid>/environ``
+    to the same UID and inherited by every child.
+
+    Strip it before exec. The refresh command already receives the canonical
+    on-disk path via ``NOTEBOOKLM_REFRESH_STORAGE_PATH``.
+    """
+    monkeypatch.setenv("NOTEBOOKLM_AUTH_JSON", '{"cookies":[{"name":"SID","value":"X"}]}')
+    captured_env = _capture_refresh_subprocess_env(monkeypatch)
+
+    asyncio.run(auth_module._run_refresh_cmd())
+
+    assert captured_env, "subprocess.run was not invoked with an env kwarg"
+    assert "NOTEBOOKLM_AUTH_JSON" not in captured_env, (
+        f"NOTEBOOKLM_AUTH_JSON leaked into refresh subprocess env: keys={sorted(captured_env)}"
+    )
+    # The refresh-routing channel must still be set so the child can locate
+    # the on-disk storage (this is what replaces the env-borne JSON).
+    assert "NOTEBOOKLM_REFRESH_STORAGE_PATH" in captured_env
+    assert "NOTEBOOKLM_REFRESH_PROFILE" in captured_env
+    # Sanity: PATH (or some unrelated parent env var) still propagates so
+    # we are stripping selectively, not wholesale.
+    assert "PATH" in captured_env or "HOME" in captured_env, (
+        "expected unrelated parent env vars to still propagate"
+    )
+
+
+def test_refresh_cmd_env_unaffected_when_auth_json_unset(
+    refresh_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``NOTEBOOKLM_AUTH_JSON`` is not set, ``.pop(..., None)`` is a no-op
+    and the refresh subprocess still runs to completion (regression guard)."""
+    monkeypatch.delenv("NOTEBOOKLM_AUTH_JSON", raising=False)
+    captured_env = _capture_refresh_subprocess_env(monkeypatch)
+
+    asyncio.run(auth_module._run_refresh_cmd())
+    assert "NOTEBOOKLM_AUTH_JSON" not in captured_env
+    assert "NOTEBOOKLM_REFRESH_STORAGE_PATH" in captured_env
+
+
 def test_error_handler_routes_traceback_to_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Summary

Three-model audit (Claude + Codex + Agy) converged on four secret-redaction
gaps reachable from refresh-cmd subprocess output and Google OAuth error
paths. This PR closes the **HTTP-shaped** redaction surface; JSON-shaped
storage_state leakage from refresh stdout is deferred to a follow-up (see
*Out of scope* below).

## Changes

| Change | File | Risk |
|---|---|---|
| Add `__Secure-[13]PSIDTS` + `__Secure-[13]PAPISID` to cookie redaction regex | `_logging.py` | Adds coverage only; no removal |
| `_safe_url` drops path for Google OAuth hosts (`accounts.google.com`, `oauth2.googleapis.com`, `oauth2.googleusercontent.com` + subdomains) | `_auth/extraction.py` | Changes error-message format for those hosts only (not a stable contract) |
| Strip `NOTEBOOKLM_AUTH_JSON` from refresh subprocess env | `_auth/refresh.py` | Removes a credential-equivalent var from child env; refresh script gets the on-disk path via `NOTEBOOKLM_REFRESH_STORAGE_PATH` |
| Fix inline docstring/comment claiming alternation order is load-bearing for correctness (Python `re` backtracks) | `_logging.py` + 1 test | Doc-only |

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 files)
- [x] `uv run ruff check src/notebooklm tests/unit` — clean
- [x] `uv run ruff format --check src/notebooklm tests/unit` — clean
- [x] `uv run pytest -p no:rerunfailures` — **5574 passed, 51 skipped, 0 failed**
- [x] 18 new test cases added across 4 files covering PSIDTS standalone shapes, PAPISID captured-name shape, googleusercontent path redaction, non-Google host preservation, and `NOTEBOOKLM_AUTH_JSON` env strip (with + without env set)

## Polish pipeline

| Stage | Result |
|---|---|
| Code-simplifier | 3 simplifications applied (host-match `any()`, hoisted test imports, extracted env-capture helper) |
| Triple review (claude + codex + agy) | 3 of 5 important findings applied; 2 deferred with rationale |
| Ultrathink | No additional concerns |

### Applied from review
- `oauth2.googleusercontent.com` added to path-redact set (Claude + Agy both flagged)
- `__Secure-[13]PAPISID` added to cookie regex (Agy)
- False-invariant docstring/comment fixed (Codex)

### Deferred (with rationale)
- **`www.googleapis.com` path-redact (Agy):** too broad — hosts many non-auth APIs (Drive, Calendar, Storage) where the path is operator signal, not credential. Add the specific subdomain if a future leak path emerges.
- **JSON-shape PSIDTS redaction in runtime logger (Codex):** real gap but out of original PR scope. The VCR cassette sanitizer already handles JSON shape; the runtime expansion needs a separate PR with broader thinking about JSON-shape patterns and false-positive risk. Documented as a follow-up.

## Out of scope (separate PRs)

- JSON-shape `"name":"__Secure-1PSIDTS","value":"..."` redaction in runtime logger
- `NOTEBOOKLM_REFRESH_CMD_USE_SHELL=1` opt-in hardening
- `_atomic_io.py` `fsync` durability gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redact credential-bearing URL path segments for specific Google OAuth hosts in logs and errors.
  * Ensure refresh subprocesses do not inherit sensitive auth payloads from the parent environment.
  * Expand cookie-name redaction to cover additional secure PSID/PAPISID variants.

* **Tests**
  * Added and updated tests verifying URL path redaction, cookie redaction, and subprocess env sanitization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->