### PR TITLE
docs(architecture): add AuthedTransport + Kernel rows (audit #895)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,6 +154,8 @@ utor      Coordinator  Lifecycle ChainBuilder DrainTracker         Counter isten
 | `ReqidCounter` | [`_reqid_counter.py`](../src/notebooklm/_reqid_counter.py) | Monotonic `_reqid` for the chat backend; lock-protected `await core.next_reqid()`. |
 | `CookiePersistence` | [`_cookie_persistence.py`](../src/notebooklm/_cookie_persistence.py) | Cookie-jar persistence + `__Secure-1PSIDTS` rotation. |
 | `IdempotencyRegistry` | [`_idempotency.py`](../src/notebooklm/_idempotency.py) | Policy/classification registry keyed by `(RPCMethod, operation_variant)`. `RpcExecutor.execute()` consults it to resolve `effective_disable_internal_retries` and to inject client tokens for `CLIENT_TOKEN_DEDUPE` methods (most entries are currently `UNCLASSIFIED`, a behaviour-neutral default). Not Session-owned, but part of the RPC dispatch path. Side-effect probing (`idempotent_create(...)`) is a separate mechanism not owned by this registry. |
+| `AuthedTransport` | [`_authed_transport.py`](../src/notebooklm/_authed_transport.py) | Single-attempt authed-POST seam (today's middleware-chain leaf); post-Tier-12 a pure POST, with all retry decisions (429 / 5xx via `RetryMiddleware`; 401 / 403 / 400-CSRF via `AuthRefreshMiddleware`) owned by the chain. Consumes the `_AuthedTransportHost` Protocol declared at module top. |
+| `Kernel` | [`_kernel.py`](../src/notebooklm/_kernel.py) | Pure transport core. Owns the `httpx.AsyncClient` and cookie jar; exposes `post()`, the `cookies` property, and `aclose()` (the close path wraps it in `asyncio.shield` from `ClientLifecycle.close()`). Concrete class behind the `Kernel` Protocol in `_session_contracts.py`; constructed by `Session.__init__()` at `_session.py:398`. The middleware-chain leaf is expected to migrate from `AuthedTransport.perform_authed_post` to `Kernel.post` per the Tier-13 migration plan (row 13.2; chain-leaf contract pinned in [ADR-009](./adr/0009-middleware-chain.md)). |
 
 ## Middleware chain (ADR-009)
 
@@ -201,7 +203,8 @@ RPC dispatch leaf            (RpcExecutor → AuthedTransport → httpx)
 capability-protocol refactor decomposed Session's *implementation* into
 focused collaborators (`RpcExecutor`, `AuthRefreshCoordinator`,
 `ClientLifecycle`, `MiddlewareChainBuilder`, `TransportDrainTracker`,
-`ClientMetrics`, `ReqidCounter`, `CookiePersistence`) but did not shrink
+`ClientMetrics`, `ReqidCounter`, `CookiePersistence`, `AuthedTransport`,
+`Kernel`) but did not shrink
 the facade's *surface*. Two pieces of scaffolding in
 [`_session.py`](../src/notebooklm/_session.py) exist solely to keep the
 legacy `Session.__new__(Session)` test-fixture pattern working:


### PR DESCRIPTION
## Summary

Audit follow-up to merged PR #895 (`b313835`). The post-merge audit found 3 orphan review threads from `gemini-code-assist[bot]` that weren't addressed before merge. This PR:

1. **Applies 2 valid suggestions** — adds `AuthedTransport` and `Kernel` rows to the collaborator table, and expands the debt-section's focused-collaborators tuple to include them.
2. **Pushes back on the 3rd** (`UploadRuntime` missing `record_upload_queue_wait()`) — `_source_upload.py:73-80` shows `UploadRuntime(RpcCaller, OperationScopeProvider, Protocol)` declares no own members. Gemini conflated FakeSession's broader mock surface (`tests/_fixtures/fake_core.py:137`) with the actual Protocol contract. Replies to all 3 threads are sent to #895 alongside this PR.

## What changed

- `docs/architecture.md` collaborator table: new rows for `AuthedTransport` (today's middleware-chain leaf — single-attempt authed POST, post-Tier-12 a pure POST with all retry decisions in the chain) and `Kernel` (concrete transport core owning the `httpx.AsyncClient` + cookie jar; chain-leaf migration target per the Tier-13 plan row 13.2; chain-leaf contract pinned in ADR-009).
- `docs/architecture.md` known-debt section: focused-collaborators tuple expanded with `AuthedTransport`, `Kernel`.

## Test plan

- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 src files, 0 issues).
- [x] `pre-commit run --files docs/architecture.md` — no-op on markdown.
- [x] All citations spot-checked against HEAD `47d6a07`: `_kernel.py:14, 41, 95, 109`; `_authed_transport.py:257, 276`; `_session.py:398, 420`; `_session_contracts.py:49`; `_session_lifecycle.py:433` (the `asyncio.shield` of `Kernel.aclose()`).
- [x] Triple review (claude+codex+agy) — 1 Important fix applied (claude: ADR-009 vs ADR-010 attribution for "Tier-13 row 13.2"; row 13.2 lives in `_middleware_chain.md:75, 142, 219, 474, 486`, not in ADR-010). 1 Optional fix applied (codex: `aclose()` itself isn't shielded; the shield is in `ClientLifecycle.close()`).
- [x] Ultrathink final sweep — "no concerns. Ship."

## Deferred (intentional)

- "Tier-13 migration plan" doesn't link to a specific document yet — only ADR-009 is anchored. Deferred because the broader Tier-13 plan doesn't have a canonical doc path in the repo.
- `_session.py:398` line citation in prose will drift over time. Consistent with the existing debt-section style (`:442`, `:514`, etc.). Repo-wide convention question, out of scope here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify internal system collaborators and their roles in the request handling chain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->