### PR TITLE
docs: address 2 unreplied bot comments from #904

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -292,7 +292,7 @@ All generate commands support:
 - `--language` to set output language (defaults to configured language or 'en')
 - `--json` for machine-readable output (returns `task_id` and `status`)
 - `--retry N` to automatically retry on rate limits with exponential backoff (supported on all subcommands **except** `mind-map`)
-- `--prompt-file PATH` to read description/query from a file (supported on all subcommands **except** `mind-map`; mutually exclusive with positional argument; use for long prompts)
+- `--prompt-file PATH` to read description/query from a file (supported on `ask`, `generate` subcommands except `mind-map`, and `source add-research`; mutually exclusive with positional argument; use for long prompts)
 
 | Type | Command | Options | Download |
 |------|---------|---------|----------|

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1856,7 +1856,7 @@ These RPC method IDs exist in `rpc/types.py` but are either legacy (superseded b
 | RPC ID | Method | Status | Notes |
 |--------|--------|--------|-------|
 
-> _GET_SOURCE (`hizoJc`) was previously listed here as "Broken" but is now active — used by `_source_content.py::get_fulltext()` (see [RPC Method Status](#rpc-method-status) and the detailed section above)._
+> **Note:** `GET_SOURCE` (`hizoJc`) was previously listed here as "Broken" but is now active — used by `_source_content.py::get_fulltext()`. See [RPC Method Status](#rpc-method-status) and the detailed section above.
 
 **Why keep these?** These IDs are preserved in the codebase in case:
 1. Google re-enables or changes their functionality

--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -1856,7 +1856,7 @@ These RPC method IDs exist in `rpc/types.py` but are either legacy (superseded b
 | RPC ID | Method | Status | Notes |
 |--------|--------|--------|-------|
 
-> _GET_SOURCE (`hizoJc`) was previously listed here as "Broken" but is now active — used by `_source_content.py::get_fulltext()` (see [GET_SOURCE quick-reference row](#rpc-summary) and detailed section above)._
+> _GET_SOURCE (`hizoJc`) was previously listed here as "Broken" but is now active — used by `_source_content.py::get_fulltext()` (see [RPC Method Status](#rpc-method-status) and the detailed section above)._
 
 **Why keep these?** These IDs are preserved in the codebase in case:
 1. Google re-enables or changes their functionality


### PR DESCRIPTION
## Summary

Follow-up to merged PR #904. Addresses two coderabbit comments that landed late in the review cycle and weren't fixed before merge:

1. **`SKILL.md:295`** — `--prompt-file` scope clarification. The previous text said "all subcommands **except** `mind-map`", which is misleading when the bullet is read on its own (it's actually only available on `ask`, `generate` subcommands except `mind-map`, and `source add-research`). Now explicit. Source of truth: `src/notebooklm/cli/options.py:277` + the `@prompt_file_option` decorator sites.
2. **`docs/rpc-reference.md:1859`** — broken internal anchor. The GET_SOURCE legacy-table cleanup note in #904's commit `70ad4cd` linked to `#rpc-summary`, which doesn't exist. Repointed to `#rpc-method-status` (the actual heading at line 19). Resolves markdownlint MD051.

## Test plan
- [x] `grep -n "rpc-summary" docs/rpc-reference.md` → 0 hits (fix verified).
- [x] `grep -n "rpc-method-status" docs/rpc-reference.md` → matches both the heading and the new link target.
- [x] `grep -n "all subcommands" SKILL.md` → no longer claims `--prompt-file` is universal.
- [ ] Reviewer: confirm the `--prompt-file` enumeration matches the live `@prompt_file_option` decorator sites (`cli/chat.py:83`, `cli/source.py:822`, all of `cli/generate.py` except the `mind-map` block at lines 988-1005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the `--prompt-file PATH` option: explicitly lists supported subcommands (e.g., ask, generate; excludes mind-map) and notes it is mutually exclusive with the positional argument.
  * Updated RPC reference to mark the previously listed method as active and clarified its documented usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->