### PR TITLE
refactor(artifacts): inject generation-service collaborators + close bidirectional reach

### DIFF
--- a/src/notebooklm/_artifact_generation.py
+++ b/src/notebooklm/_artifact_generation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json as json_module
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ._env import get_default_language
 from .exceptions import ValidationError
@@ -30,14 +30,29 @@ from .rpc import (
 )
 from .types import GenerationStatus, ReportSuggestion
 
+if TYPE_CHECKING:
+    from ._artifacts import ArtifactsRuntime, _ArtifactsServiceMethods
+    from ._note_service import NoteService
+    from ._notebook_metadata import NotebookSourceIdProvider
+
 logger = logging.getLogger(__name__)
 
 
 class ArtifactGenerationService:
     """Artifact generation operations extracted from the public facade."""
 
-    def __init__(self, api: Any):
-        self._api = api
+    def __init__(
+        self,
+        *,
+        runtime: ArtifactsRuntime,
+        methods: _ArtifactsServiceMethods,
+        notebooks: NotebookSourceIdProvider,
+        note_service: NoteService,
+    ) -> None:
+        self._runtime = runtime
+        self._methods = methods
+        self._notebooks = notebooks
+        self._note_service = note_service
 
     async def generate_audio(
         self,
@@ -49,11 +64,10 @@ class ArtifactGenerationService:
         audio_length: AudioLength | None = None,
     ) -> GenerationStatus:
         """Generate an Audio Overview (podcast)."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
@@ -85,7 +99,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_video(
         self,
@@ -98,7 +112,6 @@ class ArtifactGenerationService:
         style_prompt: str | None = None,
     ) -> GenerationStatus:
         """Generate a Video Overview."""
-        api = self._api
         if language is None:
             language = get_default_language()
         normalized_style_prompt = style_prompt.strip() if style_prompt is not None else None
@@ -110,7 +123,7 @@ class ArtifactGenerationService:
             raise ValidationError("style_prompt requires video_style=VideoStyle.CUSTOM")
 
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
@@ -148,7 +161,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_cinematic_video(
         self,
@@ -158,11 +171,10 @@ class ArtifactGenerationService:
         instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a Cinematic Video Overview."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         source_ids_double = nest_source_ids(source_ids, 1)
@@ -192,7 +204,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_report(
         self,
@@ -204,11 +216,10 @@ class ArtifactGenerationService:
         extra_instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a report artifact."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         format_configs = {
             ReportFormat.BRIEFING_DOC: {
@@ -278,7 +289,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_study_guide(
         self,
@@ -292,7 +303,7 @@ class ArtifactGenerationService:
             language = get_default_language()
         # Preserve the historical facade seam for callers/tests that patch
         # ArtifactsAPI.generate_report.
-        return await self._api.generate_report(
+        return await self._methods.generate_report(
             notebook_id,
             report_format=ReportFormat.STUDY_GUIDE,
             source_ids=source_ids,
@@ -309,9 +320,8 @@ class ArtifactGenerationService:
         difficulty: QuizDifficulty | None = None,
     ) -> GenerationStatus:
         """Generate a quiz."""
-        api = self._api
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         quantity_code = quantity.value if quantity else None
@@ -345,7 +355,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_flashcards(
         self,
@@ -356,9 +366,8 @@ class ArtifactGenerationService:
         difficulty: QuizDifficulty | None = None,
     ) -> GenerationStatus:
         """Generate flashcards."""
-        api = self._api
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         quantity_code = quantity.value if quantity else None
@@ -391,7 +400,7 @@ class ArtifactGenerationService:
                 ],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_infographic(
         self,
@@ -404,11 +413,10 @@ class ArtifactGenerationService:
         style: InfographicStyle | None = None,
     ) -> GenerationStatus:
         """Generate an infographic."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         orientation_code = orientation.value if orientation else None
@@ -436,7 +444,7 @@ class ArtifactGenerationService:
                 [[instructions, language, None, orientation_code, detail_code, style_code]],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_slide_deck(
         self,
@@ -448,11 +456,10 @@ class ArtifactGenerationService:
         slide_length: SlideDeckLength | None = None,
     ) -> GenerationStatus:
         """Generate a slide deck."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
         format_code = slide_format.value if slide_format else None
@@ -481,7 +488,7 @@ class ArtifactGenerationService:
                 [[instructions, language, format_code, length_code]],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def revise_slide(
         self,
@@ -491,7 +498,6 @@ class ArtifactGenerationService:
         prompt: str,
     ) -> GenerationStatus:
         """Revise an individual slide in a completed slide deck using a prompt."""
-        api = self._api
         if slide_index < 0:
             raise ValidationError(f"slide_index must be >= 0, got {slide_index}")
 
@@ -501,7 +507,7 @@ class ArtifactGenerationService:
             [[[slide_index, prompt]]],
         ]
         try:
-            result = await api._runtime.rpc_call(
+            result = await self._runtime.rpc_call(
                 RPCMethod.REVISE_SLIDE,
                 params,
                 source_path=f"/notebook/{notebook_id}",
@@ -520,7 +526,9 @@ class ArtifactGenerationService:
             logger.warning("REVISE_SLIDE returned null result for artifact %s", artifact_id)
         # Call through the facade so patches on ArtifactsAPI._parse_generation_result
         # remain effective after extraction.
-        return api._parse_generation_result(result, method_id=RPCMethod.REVISE_SLIDE.value)
+        return self._methods._parse_generation_result(
+            result, method_id=RPCMethod.REVISE_SLIDE.value
+        )
 
     async def generate_data_table(
         self,
@@ -530,11 +538,10 @@ class ArtifactGenerationService:
         instructions: str | None = None,
     ) -> GenerationStatus:
         """Generate a data table."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_triple = nest_source_ids(source_ids, 2)
 
@@ -563,7 +570,7 @@ class ArtifactGenerationService:
                 [None, [instructions, language]],
             ],
         ]
-        return await api._call_generate(notebook_id, params)
+        return await self._methods._call_generate(notebook_id, params)
 
     async def generate_mind_map(
         self,
@@ -573,11 +580,10 @@ class ArtifactGenerationService:
         instructions: str | None = None,
     ) -> dict[str, Any]:
         """Generate an interactive mind map and persist it as a note."""
-        api = self._api
         if language is None:
             language = get_default_language()
         if source_ids is None:
-            source_ids = await api._notebooks.get_source_ids(notebook_id)
+            source_ids = await self._notebooks.get_source_ids(notebook_id)
 
         source_ids_nested = nest_source_ids(source_ids, 2)
 
@@ -597,7 +603,7 @@ class ArtifactGenerationService:
         # explicitly to document this call site as the no-variant default
         # (the registry resolves the same entry either way; the explicit
         # kwarg is a future-proofing marker for a possible variant table).
-        result = await api._runtime.rpc_call(
+        result = await self._runtime.rpc_call(
             RPCMethod.GENERATE_MIND_MAP,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -624,7 +630,7 @@ class ArtifactGenerationService:
                 if isinstance(mind_map_data, dict) and "name" in mind_map_data:
                     title = mind_map_data["name"]
 
-                note = await api._note_service.create_note(
+                note = await self._note_service.create_note(
                     notebook_id,
                     title=title,
                     content=mind_map_json,
@@ -650,10 +656,9 @@ class ArtifactGenerationService:
         notebook_id: str,
     ) -> list[ReportSuggestion]:
         """Get AI-suggested report formats for a notebook."""
-        api = self._api
         params = [[2], notebook_id]
 
-        result = await api._runtime.rpc_call(
+        result = await self._runtime.rpc_call(
             RPCMethod.GET_SUGGESTED_REPORTS,
             params,
             source_path=f"/notebook/{notebook_id}",
@@ -676,9 +681,8 @@ class ArtifactGenerationService:
 
         return suggestions
 
-    async def _call_generate(self, notebook_id: str, params: list[Any]) -> GenerationStatus:
+    async def call_generate(self, notebook_id: str, params: list[Any]) -> GenerationStatus:
         """Make a generation RPC call with error handling."""
-        api = self._api
         artifact_type = params[2][2] if len(params) > 2 and len(params[2]) > 2 else "unknown"
         logger.debug("Generating artifact type=%s in notebook %s", artifact_type, notebook_id)
         try:
@@ -688,7 +692,7 @@ class ArtifactGenerationService:
             # no-variant default (the registry resolves the same entry
             # either way; the explicit kwarg is a future-proofing marker
             # for a possible variant table).
-            result = await api._runtime.rpc_call(
+            result = await self._runtime.rpc_call(
                 RPCMethod.CREATE_ARTIFACT,
                 params,
                 source_path=f"/notebook/{notebook_id}",
@@ -706,9 +710,11 @@ class ArtifactGenerationService:
             raise
         # Call through the facade so patches on ArtifactsAPI._parse_generation_result
         # remain effective after extraction.
-        return api._parse_generation_result(result, method_id=RPCMethod.CREATE_ARTIFACT.value)
+        return self._methods._parse_generation_result(
+            result, method_id=RPCMethod.CREATE_ARTIFACT.value
+        )
 
-    def _parse_generation_result(
+    def parse_generation_result(
         self,
         result: Any,
         *,

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -164,45 +164,44 @@ class ArtifactsRuntime(RpcCaller, AsyncWorkRuntime, DrainHookRegistration, Proto
 class _ArtifactsServiceMethods(Protocol):
     """Narrow ``ArtifactsAPI`` **method-call** surface that helper services depend on.
 
-    Artifact service helpers (currently :class:`ArtifactDownloadService` and
+    Artifact service helpers (:class:`ArtifactDownloadService` and
     :class:`ArtifactGenerationService`) accept an ``ArtifactsAPI`` instance
-    for back-references into selection / RPC / formatting flows. Today those
-    helpers reach in by holding ``self._api`` and calling
-    ``self._api._list_raw(...)`` / ``self._api._select_artifact(...)`` /
-    ``self._api._format_interactive_content(...)`` / etc. This Protocol
-    declares the subset of **method calls** those helpers actually make, so
-    the two follow-up PRs that migrate ``_artifact_downloads.py`` and
-    ``_artifact_generation.py`` can type the helper's API-collaborator
-    argument as ``_ArtifactsServiceMethods`` instead of the full concrete
-    ``ArtifactsAPI`` — pinning the dependency surface and unblocking the
-    AST guard pinned by ``test_artifact_services_have_no_facade_reach_in``
-    in ``tests/unit/test_init_order.py``.
+    via constructor injection (the ``methods=`` kw-arg) for back-references
+    into selection / RPC / formatting flows. The helpers type that argument
+    as ``_ArtifactsServiceMethods`` rather than the full concrete
+    ``ArtifactsAPI`` — pinning the dependency surface to a documented
+    subset and supporting the AST guard pinned by
+    ``test_artifact_services_have_no_facade_reach_in`` in
+    ``tests/unit/test_init_order.py``.
+
+    The migration that introduced this Protocol shipped in three PRs:
+
+      * `#891 <https://github.com/teng-lin/notebooklm-py/pull/891>`_ (T1)
+        introduced the Protocol declaration.
+      * `#896 <https://github.com/teng-lin/notebooklm-py/pull/896>`_ (T2)
+        migrated ``ArtifactDownloadService`` to constructor injection.
+      * `#910 <https://github.com/teng-lin/notebooklm-py/pull/910>`_ (T3)
+        migrated ``ArtifactGenerationService`` and closed the reverse
+        facade-into-service reach by promoting the service-side
+        ``_call_generate`` / ``_parse_generation_result`` methods.
+
+    Both helpers are now fully migrated; no further migration PRs in this
+    series are pending.
 
     **Scope (intentionally narrow).** This Protocol covers method calls
-    only. The helpers also currently reach through ``self._api`` for four
-    *collaborator objects* — ``_notebooks`` (``NotebookSourceIdProvider``),
-    ``_runtime`` (``ArtifactsRuntime``), ``_note_service`` (``NoteService``),
-    and ``_mind_maps`` (``NoteBackedMindMapService``). Those are
-    deliberately **not** declared here. The follow-up migration PRs will
-    eliminate those reach-throughs by injecting each collaborator as a
-    separate constructor argument on the helper service (mirroring how
-    :class:`ArtifactsAPI.__init__` already takes them), not by widening
-    this Protocol. The reach-in guard catches any residual
-    ``api._notebooks`` / ``api._runtime`` / ``api._note_service`` /
-    ``api._mind_maps`` access as a violation, forcing the migration to do
-    the constructor-injection refactor rather than smuggling the same
-    coupling through a wider Protocol.
-
-    **Migration note for follow-up implementers.** ``visit_Attribute`` in
-    :class:`_ApiReachInVisitor` (``tests/unit/test_init_order.py``) flags
-    **every** attribute access on ``self._api`` — including public methods
-    like ``self._api.generate_report(...)``. Simply re-annotating
-    ``self._api: _ArtifactsServiceMethods`` is therefore not enough to
-    clear the guard; the migrating PR must **rename** the stored reference
-    (for example to ``self._service``) so the visitor no longer sees
-    ``self._api`` at all. The Protocol declares ``generate_report`` /
-    ``list_quizzes`` / ``list_flashcards`` so the renamed reference
-    remains usable, not so the existing ``self._api`` name can be kept.
+    only. The four *collaborator objects* the helpers depend on —
+    ``_notebooks`` (``NotebookSourceIdProvider``), ``_runtime``
+    (``ArtifactsRuntime``), ``_note_service`` (``NoteService``), and
+    ``_mind_maps`` (``NoteBackedMindMapService``) — are deliberately
+    **not** declared here. They were eliminated as reach-throughs by
+    injecting each collaborator as a separate constructor argument on the
+    helper service (mirroring how :class:`ArtifactsAPI.__init__` already
+    takes them), rather than by widening this Protocol. The reach-in
+    guard catches any residual ``api._notebooks`` / ``api._runtime`` /
+    ``api._note_service`` / ``api._mind_maps`` access as a violation, so
+    any future re-introduction of a coupling here would have to do
+    constructor injection rather than smuggle the dependency through a
+    wider Protocol.
 
     The underscore-prefixed members are deliberate: this Protocol describes
     a private collaboration contract between ``ArtifactsAPI`` and its own

--- a/src/notebooklm/_artifacts.py
+++ b/src/notebooklm/_artifacts.py
@@ -328,7 +328,12 @@ class ArtifactsAPI:
         self._note_service = note_service
         self._poll_registry = PollRegistry()
         self._listing = ArtifactListingService()
-        self._generation = ArtifactGenerationService(self)
+        self._generation = ArtifactGenerationService(
+            runtime=self._runtime,
+            methods=self,
+            notebooks=self._notebooks,
+            note_service=self._note_service,
+        )
         self._downloads = ArtifactDownloadService(
             methods=self,
             mind_maps=self._mind_maps,
@@ -1015,7 +1020,7 @@ class ArtifactsAPI:
         self, notebook_id: str, params: builtins.list[Any]
     ) -> GenerationStatus:
         """Make a generation RPC call with error handling."""
-        return await self._generation._call_generate(notebook_id, params)
+        return await self._generation.call_generate(notebook_id, params)
 
     async def _list_mind_maps(self, notebook_id: str) -> builtins.list[Any]:
         """Get raw mind-map rows via the injected mind-map facade."""
@@ -1102,7 +1107,7 @@ class ArtifactsAPI:
         source: str = "_parse_generation_result",
     ) -> GenerationStatus:
         """Parse generation API result into GenerationStatus."""
-        return self._generation._parse_generation_result(
+        return self._generation.parse_generation_result(
             result,
             method_id=method_id,
             source=source,

--- a/src/notebooklm/_idempotency.py
+++ b/src/notebooklm/_idempotency.py
@@ -525,8 +525,9 @@ IDEMPOTENCY_REGISTRY._seed_defaults()
 # video, report, quiz, etc.; see ``_artifact_generation.py`` lines 75-99,
 # 143-161, 266-291, ...). Every position is structural — there is no
 # caller-supplied client-token slot. The server allocates the artifact_id
-# in the response (``_parse_generation_result`` line 711 reads
-# ``result[0][0]``), so a CLIENT_TOKEN_DEDUPE classification is impossible.
+# in the response (``ArtifactGenerationService.parse_generation_result``
+# reads ``result[0][0]`` — see ``_artifact_generation.py``), so a
+# CLIENT_TOKEN_DEDUPE classification is impossible.
 #
 # PROBE_THEN_CREATE forces ``effective_disable_internal_retries=True``,
 # which suppresses ``_perform_authed_post``'s inner retry loop. Without

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -5,8 +5,9 @@ token (see ``_artifact_generation.py``: CREATE_ARTIFACT shape at lines 75-99
 / 143-161 / 266-291 / etc., and GENERATE_MIND_MAP shape at lines 595-604).
 Every positional slot is structural — type code, source ids, language,
 config block — and the response is what surfaces a server-allocated
-``artifact_id`` (``_parse_generation_result`` line 711 reads
-``result[0][0]``). Without a token slot, the only safe retry policy is
+``artifact_id`` (``ArtifactGenerationService.parse_generation_result`` in
+``_artifact_generation.py`` reads ``result[0][0]``). Without a token slot,
+the only safe retry policy is
 :attr:`~notebooklm._idempotency.IdempotencyPolicy.PROBE_THEN_CREATE`, which
 forces the transport's inner retry loop OFF so a 5xx after server-side
 commit cannot trigger a duplicate write.
@@ -20,9 +21,10 @@ This file exercises that classification end-to-end:
 3. Happy-path calls still return the artifact / mind-map cleanly.
 
 Wave 2 follow-up: a caller-owned ``idempotent_create`` wrapper around
-``_call_generate`` can later layer probe-and-return semantics on top of
-this foundation (using ``client.artifacts.list()`` as the baseline-diff
-probe). That work is out of scope here per the b-generation task spec.
+``ArtifactGenerationService.call_generate`` can later layer
+probe-and-return semantics on top of this foundation (using
+``client.artifacts.list()`` as the baseline-diff probe). That work is
+out of scope here per the b-generation task spec.
 """
 
 from __future__ import annotations

--- a/tests/unit/test_init_order.py
+++ b/tests/unit/test_init_order.py
@@ -330,11 +330,18 @@ def test_feature_apis_do_not_add_direct_core_private_state_access() -> None:
 # Modules already migrated to ``_ArtifactsServiceMethods`` constructor
 # injection — the guard below enforces no residual ``self._api`` reach-in.
 # Bookkeeping (mirrors the ``_ALLOWED_CORE_PRIVATE_ACCESS_COUNTS`` pattern):
-#   * ``_artifact_downloads.py`` migrated (this PR).
-#   * The PR that migrates ``_artifact_generation.py`` will append
-#     ``"_artifact_generation.py"``.
+#   * ``_artifact_downloads.py`` migrated (PR #896, T2 of the
+#     encapsulation-reach-in-remediation phase).
+#   * ``_artifact_generation.py`` migrated (T3 of the same phase, this
+#     PR; the bidirectional facade↔service reach via
+#     ``ArtifactsAPI._call_generate`` / ``ArtifactsAPI._parse_generation_result``
+#     was closed simultaneously by promoting the service-side methods to
+#     ``call_generate`` / ``parse_generation_result``).
+# Both artifact-service helpers are now constructor-injected. No further
+# migration PRs in this series are pending.
 _REACH_IN_MIGRATED_MODULES: list[str] = [
     "_artifact_downloads.py",
+    "_artifact_generation.py",
 ]
 
 
@@ -359,8 +366,9 @@ class _ApiReachInVisitor(ast.NodeVisitor):
 
     ``_REACH_IN_MIGRATED_MODULES`` enumerates helpers already migrated to
     constructor injection; this guard is actively enforced for those
-    modules. Future migrations should append additional module names
-    (e.g. ``_artifact_generation.py``) to extend enforcement.
+    modules. Both artifact-service helpers
+    (``_artifact_downloads.py`` and ``_artifact_generation.py``) are
+    currently migrated.
     """
 
     def __init__(self, module_name: str) -> None:


### PR DESCRIPTION
## Summary

Final task (T3 of 3) in the encapsulation-reach-in-remediation phase plan
(`.sisyphus/phases/encapsulation-reach-in-remediation/phase-1.md`).
T1 (#891) introduced the `_ArtifactsServiceMethods` Protocol;
T2 (#896) migrated `ArtifactDownloadService`. T3 finishes the migration:

- **`ArtifactGenerationService.__init__`** now takes `runtime`, `methods`, `notebooks`, `note_service` as kw-only collaborators (mirrors the shape T2 used for `ArtifactDownloadService`). The `api: Any` parameter and `self._api` attribute are gone.
- **~30 reach-in sites** in `_artifact_generation.py` rewritten via the mechanical translation:
  - `api._notebooks` → `self._notebooks`
  - `api._runtime` → `self._runtime`
  - `api._note_service` → `self._note_service`
  - `api._call_generate(...)` → `self._methods._call_generate(...)` (Protocol)
  - `api._parse_generation_result(...)` → `self._methods._parse_generation_result(...)` (Protocol)
  - `self._api.generate_report(...)` → `self._methods.generate_report(...)` (preserves the documented monkeypatch seam on `ArtifactsAPI.generate_report`)
- **Bidirectional cleanup in `_artifacts.py`** — closes the *reverse* facade-into-service reach at lines 1018 / 1105 by promoting the two service-side leaves: `_call_generate` → `call_generate` and `_parse_generation_result` → `parse_generation_result` on `ArtifactGenerationService`. The facade hops (`ArtifactsAPI._call_generate` / `ArtifactsAPI._parse_generation_result`) stay underscored — they remain the documented monkeypatch seam.
- **Guard extension** — `"_artifact_generation.py"` appended to `_REACH_IN_MIGRATED_MODULES` in `tests/unit/test_init_order.py`. `_ApiReachInVisitor` now strictly enforces no-reach-in for both artifact-service helpers (downloads + generation).

### Patch seams preserved

The Protocol-mediated facade hops (`self._methods._call_generate(...)` and `self._methods._parse_generation_result(...)`) intentionally route generation back through the `ArtifactsAPI` underscored methods so legacy monkeypatches on `ArtifactsAPI._call_generate` / `ArtifactsAPI._parse_generation_result` remain effective.

### String literal preserved

The `source: str = "_parse_generation_result"` default at `_artifact_generation.py:716` is **unchanged**. It is an opaque identifier surfaced in error reports and asserted verbatim by `tests/integration/test_artifacts_drift.py:169, 181, 213`. The method name changed; the string literal did not.

### TYPE_CHECKING imports

`_ArtifactsServiceMethods` and `ArtifactsRuntime` from `._artifacts` are imported under `TYPE_CHECKING` (forbidden at runtime by `_FORBIDDEN_ARTIFACT_SERVICE_RUNTIME_IMPORT_MODULES`). `from __future__ import annotations` (already at line 3) makes the runtime forward-reference safe.

## Test plan

- [x] `uv run pytest tests/unit/test_init_order.py::test_artifact_services_have_no_facade_reach_in` (guard passes for both modules)
- [x] `uv run pytest tests/integration/test_artifacts_drift.py` (string literal preserved — 10 tests pass, deprecation warnings continue to show `source='_parse_generation_result'`)
- [x] `uv run pytest tests/unit/ -k 'artifact or generation'` (478 passed)
- [x] `uv run pytest` (5612 passed, 12 skipped — full suite green)
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` (Success: no issues)
- [x] `uv run ruff check src/notebooklm` (clean)
- [x] `git grep -nE 'self\._api' src/notebooklm/_artifact_generation.py` → 0 hits
- [x] `git grep -nE '_generation\._call_generate|_generation\._parse_generation_result' src/notebooklm/_artifacts.py` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured the artifact generation service for clearer dependency boundaries and more robust generation plumbing, improving reliability and maintainability.

* **Tests**
  * Strengthened regression tests to enforce encapsulation and initialization order across artifact helper modules, reducing regression risk.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->