### PR TITLE
refactor(auth): hoist shared aliases in _auth/psidts_recovery

### DIFF
--- a/src/notebooklm/_auth/psidts_recovery.py
+++ b/src/notebooklm/_auth/psidts_recovery.py
@@ -43,6 +43,29 @@ from . import cookies as _auth_cookies
 from . import keepalive as _keepalive
 from . import storage as _auth_storage
 
+# ----------------------------------------------------------------------------
+# Cross-module helpers (module-scope aliases)
+# ----------------------------------------------------------------------------
+# These are documented at module scope to make the cross-module surface
+# explicit, matching the precedent at ``_auth/cookies.py:34-40``. The
+# underscored names remain module-private to their owning modules
+# (``_cookie_policy``, ``_keepalive``, ``_auth_cookies``); this module
+# consumes them through documented local aliases.
+#
+# Tests must patch these aliases at this module's path, not at the
+# canonical owner's path, because aliases are import-time bound.
+# ----------------------------------------------------------------------------
+_has_valid_secondary_binding = _cookie_policy._has_valid_secondary_binding
+_is_allowed_auth_domain = _cookie_policy._is_allowed_auth_domain
+_rotation_lock_path = _keepalive._rotation_lock_path
+_file_lock_try_exclusive = _keepalive._file_lock_try_exclusive
+_try_claim_rotation = _keepalive._try_claim_rotation
+_KEEPALIVE_POKE_TIMEOUT = _keepalive._KEEPALIVE_POKE_TIMEOUT
+_KEEPALIVE_ROTATE_HEADERS = _keepalive._KEEPALIVE_ROTATE_HEADERS
+_KEEPALIVE_ROTATE_BODY = _keepalive._KEEPALIVE_ROTATE_BODY
+_load_storage_state = _auth_cookies._load_storage_state
+_storage_entry_to_cookie = _auth_cookies._storage_entry_to_cookie
+
 logger = logging.getLogger("notebooklm.auth")
 
 _PSIDTS_COOKIE = "__Secure-1PSIDTS"
@@ -124,7 +147,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         return False
     if _PSIDTS_COOKIE in cookie_names:
         return False
-    if not _cookie_policy._has_valid_secondary_binding(cookie_names):
+    if not _has_valid_secondary_binding(cookie_names):
         logger.debug(
             "PSIDTS recovery skipped: secondary binding incomplete "
             "(need OSID, or both APISID and SAPISID)"
@@ -135,7 +158,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
     # dict) and both fire ``RotateCookies``. The flock matches the outer guard
     # ``_poke_session`` uses; a held lock means the other process is rotating
     # right now.
-    rotate_lock_path = _keepalive._rotation_lock_path(storage_path)
+    rotate_lock_path = _rotation_lock_path(storage_path)
     if rotate_lock_path is None:
         # Defense-in-depth: ``_rotation_lock_path`` only returns None when its
         # argument is None, and we've early-returned above when path is None.
@@ -143,7 +166,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         # equivalent branch.
         return _attempt_rotation(storage_path, cookie_entries)
 
-    with _keepalive._file_lock_try_exclusive(rotate_lock_path) as acquired:
+    with _file_lock_try_exclusive(rotate_lock_path) as acquired:
         if not acquired:
             # Holder may already have healed the file by the time they
             # released the lock. Re-read once before declining so the caller's
@@ -174,7 +197,7 @@ def _recover_psidts_inline(path: Path | str | None) -> bool:
         if "SID" not in fresh_names:
             logger.debug("PSIDTS recovery skipped: SID missing after flock acquisition")
             return False
-        if not _cookie_policy._has_valid_secondary_binding(fresh_names):
+        if not _has_valid_secondary_binding(fresh_names):
             logger.debug(
                 "PSIDTS recovery skipped: secondary binding incomplete after flock acquisition"
             )
@@ -194,7 +217,7 @@ def _read_storage_for_recovery(
     and lets unexpected ``ValueError`` propagate as an implementation bug.
     """
     try:
-        storage_state = _auth_cookies._load_storage_state(storage_path)
+        storage_state = _load_storage_state(storage_path)
     except (OSError, json.JSONDecodeError) as exc:
         logger.debug("PSIDTS recovery skipped: cannot read %s: %s", storage_path, exc)
         return None
@@ -229,7 +252,7 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
     every guard (preconditions, cross-process flock) has passed. Split out so
     the cross-process flock context manager has one clean exit point.
     """
-    if not _keepalive._try_claim_rotation(storage_path):
+    if not _try_claim_rotation(storage_path):
         logger.debug(
             "PSIDTS recovery skipped: %s claimed by another in-process caller",
             storage_path,
@@ -243,9 +266,9 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
     for entry in cookie_entries:
         if not entry.get("name") or not entry.get("value"):
             continue
-        if not _cookie_policy._is_allowed_auth_domain(entry.get("domain", "")):
+        if not _is_allowed_auth_domain(entry.get("domain", "")):
             continue
-        jar.jar.set_cookie(_auth_cookies._storage_entry_to_cookie(entry))
+        jar.jar.set_cookie(_storage_entry_to_cookie(entry))
 
     # ``httpx.Client(cookies=jar)`` copies the source jar into a private client
     # jar; Set-Cookie responses land in ``client.cookies``, not in ``jar``. So
@@ -255,13 +278,13 @@ def _attempt_rotation(storage_path: Path, cookie_entries: list[dict]) -> bool:
         with httpx.Client(
             cookies=jar,
             follow_redirects=True,
-            timeout=_keepalive._KEEPALIVE_POKE_TIMEOUT,
+            timeout=_KEEPALIVE_POKE_TIMEOUT,
         ) as client:
             snapshot = _auth_storage.snapshot_cookie_jar(client.cookies)
             response = client.post(
                 _keepalive.KEEPALIVE_ROTATE_URL,
-                headers=_keepalive._KEEPALIVE_ROTATE_HEADERS,
-                content=_keepalive._KEEPALIVE_ROTATE_BODY,
+                headers=_KEEPALIVE_ROTATE_HEADERS,
+                content=_KEEPALIVE_ROTATE_BODY,
             )
             response.raise_for_status()
             rotated_jar = client.cookies

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -136,10 +136,10 @@ class TestRecoveryPreconditions:
         _write_storage(storage_path, _RECOVERABLE_COOKIES)
 
         # Force ``_try_claim_rotation`` to deny the claim, simulating a sibling
-        # caller having just claimed the slot.
-        monkeypatch.setattr(
-            "notebooklm._auth.psidts_recovery._try_claim_rotation", lambda _path: False
-        )
+        # caller having just claimed the slot. Patch the local alias on
+        # ``psidts_recovery`` (ADR-007 object-target form) — the recovery path
+        # resolves the symbol via this module's globals at call time.
+        monkeypatch.setattr(psidts_recovery, "_try_claim_rotation", lambda _path: False)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -444,10 +444,10 @@ class TestEdgeCases:
             # Simulate another process holding the lock — acquire=False.
             yield False
 
-        monkeypatch.setattr(
-            "notebooklm._auth.psidts_recovery._file_lock_try_exclusive",
-            held_lock,
-        )
+        # Patch the local alias on ``psidts_recovery`` (ADR-007 object-target
+        # form) — the recovery path resolves ``_file_lock_try_exclusive`` via
+        # this module's globals at call time.
+        monkeypatch.setattr(psidts_recovery, "_file_lock_try_exclusive", held_lock)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -491,11 +491,11 @@ class TestEdgeCases:
             call_counter["n"] += 1
             return pre_heal_state if call_counter["n"] == 1 else post_heal_state
 
-        monkeypatch.setattr("notebooklm._auth.psidts_recovery._load_storage_state", staged_load)
-        monkeypatch.setattr(
-            "notebooklm._auth.psidts_recovery._file_lock_try_exclusive",
-            held_lock,
-        )
+        # Patch the local aliases on ``psidts_recovery`` (ADR-007 object-target
+        # form) — the recovery path resolves these symbols via this module's
+        # globals at call time.
+        monkeypatch.setattr(psidts_recovery, "_load_storage_state", staged_load)
+        monkeypatch.setattr(psidts_recovery, "_file_lock_try_exclusive", held_lock)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
         # No POST — the holder already did the work.
@@ -532,7 +532,10 @@ class TestEdgeCases:
             call_counter["n"] += 1
             return pre_heal_state if call_counter["n"] == 1 else post_heal_state
 
-        monkeypatch.setattr("notebooklm._auth.psidts_recovery._load_storage_state", staged_load)
+        # Patch the local alias on ``psidts_recovery`` (ADR-007 object-target
+        # form) — the recovery path resolves ``_load_storage_state`` via this
+        # module's globals at call time.
+        monkeypatch.setattr(psidts_recovery, "_load_storage_state", staged_load)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
         # Crucial: no POST — recheck saw the heal before we fired.
@@ -559,7 +562,10 @@ class TestEdgeCases:
             call_counter["n"] += 1
             return pre_heal_state if call_counter["n"] == 1 else post_heal_state
 
-        monkeypatch.setattr("notebooklm._auth.psidts_recovery._load_storage_state", staged_load)
+        # Patch the local alias on ``psidts_recovery`` (ADR-007 object-target
+        # form) — the recovery path resolves ``_load_storage_state`` via this
+        # module's globals at call time.
+        monkeypatch.setattr(psidts_recovery, "_load_storage_state", staged_load)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         # No POST — recheck saw the broken state and aborted before firing.

--- a/tests/unit/test_auth_psidts_recovery.py
+++ b/tests/unit/test_auth_psidts_recovery.py
@@ -137,7 +137,9 @@ class TestRecoveryPreconditions:
 
         # Force ``_try_claim_rotation`` to deny the claim, simulating a sibling
         # caller having just claimed the slot.
-        monkeypatch.setattr("notebooklm._auth.keepalive._try_claim_rotation", lambda _path: False)
+        monkeypatch.setattr(
+            "notebooklm._auth.psidts_recovery._try_claim_rotation", lambda _path: False
+        )
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         assert [r for r in httpx_mock.get_requests() if _ROTATE_URL_RE.match(str(r.url))] == []
@@ -443,7 +445,7 @@ class TestEdgeCases:
             yield False
 
         monkeypatch.setattr(
-            "notebooklm._auth.psidts_recovery._keepalive._file_lock_try_exclusive",
+            "notebooklm._auth.psidts_recovery._file_lock_try_exclusive",
             held_lock,
         )
 
@@ -489,9 +491,9 @@ class TestEdgeCases:
             call_counter["n"] += 1
             return pre_heal_state if call_counter["n"] == 1 else post_heal_state
 
-        monkeypatch.setattr("notebooklm._auth.cookies._load_storage_state", staged_load)
+        monkeypatch.setattr("notebooklm._auth.psidts_recovery._load_storage_state", staged_load)
         monkeypatch.setattr(
-            "notebooklm._auth.psidts_recovery._keepalive._file_lock_try_exclusive",
+            "notebooklm._auth.psidts_recovery._file_lock_try_exclusive",
             held_lock,
         )
 
@@ -530,7 +532,7 @@ class TestEdgeCases:
             call_counter["n"] += 1
             return pre_heal_state if call_counter["n"] == 1 else post_heal_state
 
-        monkeypatch.setattr("notebooklm._auth.cookies._load_storage_state", staged_load)
+        monkeypatch.setattr("notebooklm._auth.psidts_recovery._load_storage_state", staged_load)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is True
         # Crucial: no POST — recheck saw the heal before we fired.
@@ -557,7 +559,7 @@ class TestEdgeCases:
             call_counter["n"] += 1
             return pre_heal_state if call_counter["n"] == 1 else post_heal_state
 
-        monkeypatch.setattr("notebooklm._auth.cookies._load_storage_state", staged_load)
+        monkeypatch.setattr("notebooklm._auth.psidts_recovery._load_storage_state", staged_load)
 
         assert psidts_recovery._recover_psidts_inline(storage_path) is False
         # No POST — recheck saw the broken state and aborted before firing.


### PR DESCRIPTION
## Summary

- Adds 10 module-scope aliases (7 functions + 3 constants) in `src/notebooklm/_auth/psidts_recovery.py` for cross-module private symbols imported from sibling `_auth/*` modules.
- Replaces 11 in-function `_module._symbol` call sites with the local aliases (`_has_valid_secondary_binding` is used twice).
- Migrates 6 monkeypatch targets in `tests/unit/test_auth_psidts_recovery.py` from canonical-owner paths to the new alias targets on `psidts_recovery`.

Mirrors the precedent at `_auth/cookies.py:34-40` (which already hoists five `_cookie_policy` private symbols) and at `auth.py:65` (which hoists `_auth_cookies._load_storage_state` at the facade layer).

## Alias surface

| Source module | Symbols hoisted |
|---|---|
| `_cookie_policy` | `_has_valid_secondary_binding`, `_is_allowed_auth_domain` |
| `_keepalive` | `_rotation_lock_path`, `_file_lock_try_exclusive`, `_try_claim_rotation`, `_KEEPALIVE_POKE_TIMEOUT`, `_KEEPALIVE_ROTATE_HEADERS`, `_KEEPALIVE_ROTATE_BODY` |
| `_auth_cookies` | `_load_storage_state`, `_storage_entry_to_cookie` |

`_keepalive.KEEPALIVE_ROTATE_URL` (public — no underscore) is **not** hoisted; PR-B's scope is private reach-ins only.

## Why this matters

- Makes the cross-module private surface this module consumes explicit at the top of the file (the precedent block in `_auth/cookies.py`).
- Decouples in-function call sites from the canonical owner's module path.
- Centralizes the patch surface for tests: import-time aliases are bound at module load, so monkeypatches on the canonical owner would not affect this module's call path. The 6 migrated patches now target the alias directly.

## Test migration

| Test concern | Old patch target | New patch target |
|---|---|---|
| throttle claim deny | `notebooklm._auth.keepalive._try_claim_rotation` | `notebooklm._auth.psidts_recovery._try_claim_rotation` |
| flock held (2 sites) | `notebooklm._auth.psidts_recovery._keepalive._file_lock_try_exclusive` | `notebooklm._auth.psidts_recovery._file_lock_try_exclusive` |
| staged load (3 sites) | `notebooklm._auth.cookies._load_storage_state` | `notebooklm._auth.psidts_recovery._load_storage_state` |

**Intentionally untouched** (out of scope — public symbols):
- `notebooklm._auth.cookies.get_storage_path` (line ~325) — public, no underscore.
- `notebooklm._auth.psidts_recovery._auth_storage.save_cookies_to_storage` (lines ~404, ~421) — `save_cookies_to_storage` is public; the traversal works regardless of PR-B's aliasing.

## Verification

- Source-side scope-fidelity grep returns ONLY the 10 alias-block lines, zero in-function `_module._symbol` hits:
  ```
  git grep -nE '_cookie_policy\._|_keepalive\._|_auth_cookies\._' src/notebooklm/_auth/psidts_recovery.py
  ```
- Test-side scope-fidelity grep returns zero hits (no stale canonical-owner patches, no `psidts_recovery._<submodule>._` traversal patches remain):
  ```
  grep -nE '"notebooklm\._auth\.(keepalive|cookie_policy|cookies)\._|"notebooklm\._auth\.psidts_recovery\._(keepalive|cookie_policy|_auth_cookies)\._' tests/unit/test_auth_psidts_recovery.py
  ```
- `uv run pytest tests/unit/test_auth_psidts_recovery.py -v`: 27 passed.
- `uv run pytest tests/unit/test_warning_dedupe.py -v`: 2 passed (sanity check; different pattern).
- `uv run pytest`: 5612 passed, 12 skipped, 0 failed.
- `uv run mypy src/notebooklm --ignore-missing-imports`: success, 139 files.
- `uv run ruff check src/notebooklm`: all checks passed.

## Test plan

- [ ] CI green
- [ ] Bot review (claude, coderabbitai, agy-code-assist) addressed
- [ ] No regression in the auth subpackage tests

## Context

- Phase 2 of the encapsulation reach-in audit follow-up. Phase 1 (artifact-generation collaborators) landed in #910.
- This PR is one of two parallel PRs in the Phase 2 cleanup wave. The companion PR-A targets `_types/{artifacts,sources}.py` and is disjoint from this one.
- Plan: `.sisyphus/phases/encapsulation-audit-phase-2-cleanup/phase-1.md` (Task B).

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal authentication recovery helpers and streamlined the inline recovery flow to improve reliability.

* **Tests**
  * Updated unit tests to target the revised recovery implementation, preserving existing behavior checks for rotation, locking, and persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->