### PR TITLE
refactor(types): drop public_types reflection in _types helpers

### DIFF
--- a/src/notebooklm/_types/artifacts.py
+++ b/src/notebooklm/_types/artifacts.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -51,15 +50,6 @@ _ARTIFACT_TYPE_CODE_MAP: dict[int, ArtifactType] = {
 }
 
 
-def _artifact_warning_state() -> set[tuple[int, int | None]]:
-    public_types = sys.modules.get("notebooklm.types")
-    if public_types is not None:
-        public_state = getattr(public_types, "_warned_artifact_types", None)
-        if isinstance(public_state, set):
-            return public_state
-    return _warned_artifact_types
-
-
 def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     """Convert internal artifact type and variant to user-facing ArtifactType.
 
@@ -78,9 +68,8 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
             return ArtifactType.QUIZ
         else:
             key = (artifact_type, variant)
-            warned_artifact_types = _artifact_warning_state()
-            if key not in warned_artifact_types:
-                warned_artifact_types.add(key)
+            if key not in _warned_artifact_types:
+                _warned_artifact_types.add(key)
                 warnings.warn(
                     f"Unknown QUIZ variant {variant}. "
                     "Consider updating notebooklm-py to the latest version.",
@@ -92,9 +81,8 @@ def _map_artifact_kind(artifact_type: int, variant: int | None) -> ArtifactType:
     result = _ARTIFACT_TYPE_CODE_MAP.get(artifact_type)
     if result is None:
         key = (artifact_type, variant)
-        warned_artifact_types = _artifact_warning_state()
-        if key not in warned_artifact_types:
-            warned_artifact_types.add(key)
+        if key not in _warned_artifact_types:
+            _warned_artifact_types.add(key)
             warnings.warn(
                 f"Unknown artifact type {artifact_type}. "
                 "Consider updating notebooklm-py to the latest version.",

--- a/src/notebooklm/_types/sources.py
+++ b/src/notebooklm/_types/sources.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -80,28 +79,6 @@ _SOURCE_TYPE_COMPAT_MAP: dict[SourceType, str] = {
 }
 
 
-def _source_warning_state() -> set[int]:
-    # Read through the public facade so monkeypatch.setattr(notebooklm.types, ...)
-    # rebinding is reflected in this private implementation.
-    public_types = sys.modules.get("notebooklm.types")
-    if public_types is not None:
-        public_state = getattr(public_types, "_warned_source_types", None)
-        if isinstance(public_state, set):
-            return public_state
-    return _warned_source_types
-
-
-def _source_compat_map() -> dict[SourceType, str]:
-    # Read through the public facade so monkeypatch.setattr(notebooklm.types, ...)
-    # rebinding is reflected in this private implementation.
-    public_types = sys.modules.get("notebooklm.types")
-    if public_types is not None:
-        public_map = getattr(public_types, "_SOURCE_TYPE_COMPAT_MAP", None)
-        if isinstance(public_map, dict):
-            return public_map
-    return _SOURCE_TYPE_COMPAT_MAP
-
-
 def _safe_source_type(type_code: int | None) -> SourceType:
     """Convert internal type code to user-facing SourceType enum."""
     if type_code is None:
@@ -109,9 +86,8 @@ def _safe_source_type(type_code: int | None) -> SourceType:
 
     result = _SOURCE_TYPE_CODE_MAP.get(type_code)
     if result is None:
-        warned_source_types = _source_warning_state()
-        if type_code not in warned_source_types:
-            warned_source_types.add(type_code)
+        if type_code not in _warned_source_types:
+            _warned_source_types.add(type_code)
             warnings.warn(
                 f"Unknown source type code {type_code}. "
                 "Consider updating notebooklm-py to the latest version.",

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -592,8 +592,8 @@ def test_types_private_state_seams_are_live_objects(monkeypatch: pytest.MonkeyPa
     assert _SOURCE_TYPE_COMPAT_MAP is public_types._SOURCE_TYPE_COMPAT_MAP
     source_warnings: set[int] = set()
     artifact_warnings: set[tuple[int | None, int | None]] = set()
-    monkeypatch.setattr(public_types, "_warned_source_types", source_warnings)
-    monkeypatch.setattr(public_types, "_warned_artifact_types", artifact_warnings)
+    monkeypatch.setattr("notebooklm._types.sources._warned_source_types", source_warnings)
+    monkeypatch.setattr("notebooklm._types.artifacts._warned_artifact_types", artifact_warnings)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UnknownTypeWarning)

--- a/tests/unit/test_public_shims.py
+++ b/tests/unit/test_public_shims.py
@@ -578,8 +578,11 @@ def test_types_private_helper_seam_manifest_matches_first_party_imports() -> Non
 
 
 def test_types_private_state_seams_are_live_objects(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Warning de-duplication and compat maps must remain live facade aliases."""
+    """Warning-dedup sets and compat map must remain shared between canonical
+    owners in ``_types/`` and their ``notebooklm.types`` re-exports."""
     import notebooklm.types as public_types
+    from notebooklm._types import artifacts as _artifact_types_seam
+    from notebooklm._types import sources as _source_types_seam
     from notebooklm.types import (
         _SOURCE_TYPE_COMPAT_MAP,
         Artifact,
@@ -592,8 +595,13 @@ def test_types_private_state_seams_are_live_objects(monkeypatch: pytest.MonkeyPa
     assert _SOURCE_TYPE_COMPAT_MAP is public_types._SOURCE_TYPE_COMPAT_MAP
     source_warnings: set[int] = set()
     artifact_warnings: set[tuple[int | None, int | None]] = set()
-    monkeypatch.setattr("notebooklm._types.sources._warned_source_types", source_warnings)
-    monkeypatch.setattr("notebooklm._types.artifacts._warned_artifact_types", artifact_warnings)
+    # ADR-007 seam-aliased object-target form: patch the canonical owners in
+    # ``_types/{sources,artifacts}`` directly. ``notebooklm.types._warned_*``
+    # is a re-export (see ``types.py:117-118``), so the test must target the
+    # canonical home — patching the public facade would rebind only the
+    # facade alias and not the module-global the parser reads.
+    monkeypatch.setattr(_source_types_seam, "_warned_source_types", source_warnings)
+    monkeypatch.setattr(_artifact_types_seam, "_warned_artifact_types", artifact_warnings)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UnknownTypeWarning)


### PR DESCRIPTION
## Summary

- Removes 3 reflective `getattr(public_types, ...)` call sites in `_types/{artifacts,sources}.py` that previously read warning-dedup state and the source-compat map through `sys.modules.get("notebooklm.types")` for facade-rebinding test support.
- Inlines the two warning-state helper functions (`_artifact_warning_state`, `_source_warning_state`) and removes dead helper `_source_compat_map()` (zero callers per `git grep`).
- Drops the now-unused `import sys` in both files.
- Migrates 2 monkeypatch sites in `tests/unit/test_public_shims.py:595-596` from `monkeypatch.setattr(public_types, "_warned_*", ...)` (facade rebinding) to `monkeypatch.setattr("notebooklm._types.{sources,artifacts}._warned_*", ...)` (canonical-owner patching).

Net diff: **-44 / +8 lines across 3 files**.

## Identity preservation

`notebooklm.types._warned_artifact_types`, `notebooklm.types._warned_source_types`, and `notebooklm.types._SOURCE_TYPE_COMPAT_MAP` continue to refer to the same canonical objects via the `types.py:105, 117-118` re-export. Verified inline:

```
$ python -c "
import notebooklm.types as public_types
from notebooklm._types import artifacts, sources
assert public_types._warned_artifact_types is artifacts._warned_artifact_types
assert public_types._warned_source_types is sources._warned_source_types
assert public_types._SOURCE_TYPE_COMPAT_MAP is sources._SOURCE_TYPE_COMPAT_MAP
print('OK: identity preserved')
"
OK: identity preserved
```

## Test compatibility

- `.clear()` calls in `test_public_shims.py:614-615` mutate the canonical set object in-place; subsequent reads through either the canonical name or the facade re-export see the cleared state.
- Identity assertions in `test_types.py` (lines 139, 644-647, 675-677, 690-692, 1134-1136, 1149-1151) continue to pass without modification — they rely on canonical-owner identity preserved through `types.py`'s re-export.
- The 8 other plain-import / dotted-access patterns in `test_public_shims.py` (lines 380, 391-392, 584, 592, 614-615, 636) require no change.

## Phase context

Phase 2 of encapsulation reach-in audit follow-up (Phase 1 was #891, #896, #910). Closes the original audit's IMPORTANT `_types/` reflective bypasses item. Plan: `.sisyphus/phases/encapsulation-audit-phase-2-cleanup/phase-1.md` (Task A). Plan converged through 4 momus iterations + OKAY across 2 native models.

## Test plan

- [x] `git grep -nE 'getattr\(public_types,' src/notebooklm/_types/` → zero hits
- [x] Identity preservation script → `OK: identity preserved`
- [x] `uv run pytest tests/unit/test_public_shims.py tests/unit/test_types.py tests/unit/test_warning_dedupe.py` → 426 passed
- [x] `uv run pytest` (full suite) → 5612 passed, 12 skipped, 34 warnings (pre-existing)
- [x] `uv run ruff check src/notebooklm` → clean
- [x] `uv run ruff format --check` → 451 files already formatted
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` → clean (139 source files)

## Deferred polish findings

None critical. One micro nit (test docstring wording at `test_public_shims.py:581` still says "facade aliases" — substantively still correct since the facade re-exports the canonical owners) deferred as not worth touching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal warning de-duplication and tracking for artifact and source type handling to improve maintainability; no changes to public APIs or user-visible behavior.
* **Tests**
  * Updated tests to validate the adjusted internal warning registries and their shared behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->