### PR TITLE
refactor(session): migrate __new__ fixtures + delete _ensure_*() backfill (PR 1 of 8)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -65,11 +65,7 @@ if TYPE_CHECKING:
 from .rpc import RPCMethod
 
 logger = logging.getLogger(__name__)
-_OBSERVABILITY_INIT_LOCK = threading.Lock()
-# Guards ``_auth_coord`` backfill on ``__new__``-built fixtures. Mirrors the
-# observability init lock so two threads can't both observe ``hasattr is False``
-# and race to construct competing :class:`AuthRefreshCoordinator` instances.
-#
+
 # Auth-snapshot canonical implementation lives on
 # :class:`AuthRefreshCoordinator` (``_session_auth.py`` —
 # ``AuthRefreshCoordinator.snapshot`` / ``.update_auth_tokens``). The
@@ -81,9 +77,7 @@ _OBSERVABILITY_INIT_LOCK = threading.Lock()
 # ``test_update_auth_tokens_has_no_await_inside_mutation_block``) inspect
 # the coordinator's source via ``inspect.getsource(...)`` + AST parsing —
 # changes to auth-snapshot invariants must be applied to the coordinator
-# (not the delegates here). Grep anchor for future maintainers:
-# ``_AUTH_COORD_INIT_LOCK``.
-_AUTH_COORD_INIT_LOCK = threading.Lock()
+# (not the delegates here).
 
 
 def _decode_response_late_bound(raw: str, rpc_id: str, *, allow_null: bool = False) -> Any:
@@ -456,46 +450,37 @@ class Session:
         return self.cookie_persistence.loaded_cookie_snapshot
 
     # ``ClientMetrics`` compat bridges. The three observability ivars now live
-    # on ``self._metrics_obj``; the read-side bridges call
-    # ``_ensure_observability_state`` first so a ``__new__``-built fixture
-    # (no ``__init__`` ran) can still read through. Phase 4 deleted the
-    # matching ``.setter`` halves — write on ``self._metrics_obj.X``
-    # directly (after calling ``_ensure_observability_state()`` if you
-    # constructed via ``Session.__new__``).
+    # on ``self._metrics_obj``; the bridges below delegate directly to that
+    # collaborator since ``Session.__init__`` eager-constructs it. Phase 4
+    # deleted the matching ``.setter`` halves — write on
+    # ``self._metrics_obj.X`` directly.
     @property
     def _metrics_lock(self) -> threading.Lock:
-        self._ensure_observability_state()
         return self._metrics_obj._metrics_lock
 
     @property
     def _metrics(self) -> ClientMetricsSnapshot:
-        self._ensure_observability_state()
         return self._metrics_obj._metrics
 
     @property
     def _on_rpc_event(self) -> Callable[[RpcTelemetryEvent], object] | None:
-        self._ensure_observability_state()
         return self._metrics_obj._on_rpc_event
 
     # ``TransportDrainTracker`` compat bridges. The four drain ivars now live
-    # on ``self._drain_tracker``; the read-side bridges call
-    # ``_ensure_observability_state`` first so a ``__new__``-built fixture
-    # (no ``__init__`` ran) can still read through. Phase 4 deleted the
-    # matching ``.setter`` halves — write on ``self._drain_tracker.X``
-    # directly.
+    # on ``self._drain_tracker``; the bridges below delegate directly to that
+    # collaborator since ``Session.__init__`` eager-constructs it. Phase 4
+    # deleted the matching ``.setter`` halves — write on
+    # ``self._drain_tracker.X`` directly.
     @property
     def _in_flight_posts(self) -> int:
-        self._ensure_observability_state()
         return self._drain_tracker._in_flight_posts
 
     @property
     def _draining(self) -> bool:
-        self._ensure_observability_state()
         return self._drain_tracker._draining
 
     @property
     def _drain_condition(self) -> asyncio.Condition | None:
-        self._ensure_observability_state()
         return self._drain_tracker._drain_condition
 
     # ``_operation_depths`` compat bridge dropped (D1-audit-full): zero
@@ -504,61 +489,34 @@ class Session:
     # ------------------------------------------------------------------
     # ``AuthRefreshCoordinator`` compat bridges. Refresh/auth-snapshot state
     # now lives on ``self._auth_coord``; the four legacy ivar names are
-    # preserved as writeable properties so the dozens of test sites that
-    # do ``core._refresh_callback = stub`` / ``core._refresh_lock = asyncio.Lock()``
-    # keep working without modification. ``_ensure_auth_coord`` mirrors the
-    # ``_ensure_observability_state`` backfill so ``__new__``-built fixtures
-    # (no ``__init__`` ran) still resolve cleanly.
+    # preserved as properties so the dozens of test sites that read them keep
+    # working without modification. Only ``_refresh_callback`` retains a setter
+    # (``core._refresh_callback = stub`` is still load-bearing — see
+    # ``tests/integration/test_session_integration.py:217,292``); the other
+    # three are read-only, so writes must go through ``self._auth_coord.<name>``
+    # directly. ``Session.__init__`` eager-constructs the coordinator, so the
+    # bridges delegate directly without lazy backfill.
     # ------------------------------------------------------------------
-
-    def _ensure_auth_coord(self) -> None:
-        """Backfill ``_auth_coord`` for tests that construct via ``__new__``.
-
-        Mirrors :meth:`_ensure_observability_state` — uses a module-level
-        threading lock for double-checked locking so two threads racing
-        through ``hasattr`` cannot both decide they need to construct a
-        coordinator and silently discard each other's locks/refresh task.
-
-        Also primes ``_metrics_obj`` because every coordinator method reaches
-        into ``host._metrics_obj`` (e.g. ``record_lock_wait`` inside
-        :meth:`AuthRefreshCoordinator.snapshot` /
-        :meth:`AuthRefreshCoordinator.update_auth_tokens`). Without this,
-        a ``__new__``-built fixture that calls ``_await_refresh`` /
-        ``_snapshot`` / ``update_auth_tokens`` before any observability
-        compat-bridge setter would surface as
-        ``AttributeError: '_StubCore' has no attribute '_metrics_obj'``
-        rather than backfilling gracefully.
-        """
-        if hasattr(self, "_auth_coord"):
-            return
-        self._ensure_observability_state()
-        with _AUTH_COORD_INIT_LOCK:
-            if not hasattr(self, "_auth_coord"):
-                self._auth_coord = AuthRefreshCoordinator(refresh_callback=None)
 
     @property
     def _refresh_lock(self) -> asyncio.Lock | None:
         """Phase 4 deleted the matching ``.setter``; write on
         ``self._auth_coord._refresh_lock`` directly.
         """
-        self._ensure_auth_coord()
         return self._auth_coord._refresh_lock
 
     @property
     def _refresh_task(self) -> asyncio.Task[AuthTokens] | None:
-        self._ensure_auth_coord()
         return self._auth_coord._refresh_task
 
     # ``_refresh_task`` setter dropped in arch-d2-cutover: zero external callers.
 
     @property
     def _refresh_callback(self) -> Callable[[], Awaitable[AuthTokens]] | None:
-        self._ensure_auth_coord()
         return self._auth_coord._refresh_callback
 
     @_refresh_callback.setter
     def _refresh_callback(self, value: Callable[[], Awaitable[AuthTokens]] | None) -> None:
-        self._ensure_auth_coord()
         self._auth_coord._refresh_callback = value
 
     # ``_auth_snapshot_lock`` compat bridge dropped (D1-audit-full): zero
@@ -576,55 +534,20 @@ class Session:
     # retained because ``RpcExecutor`` (``_rpc_executor.py``) reads
     # ``self._owner._timeout`` via the :class:`RpcOwner` Protocol; removing
     # it would surface as ``AttributeError`` on every RPC call.
-    # ``_ensure_lifecycle`` mirrors the ``_ensure_observability_state`` /
-    # ``_ensure_auth_coord`` backfill so ``__new__``-built fixtures (no
-    # ``__init__`` ran) still resolve cleanly.
+    # ``Session.__init__`` eager-constructs ``_lifecycle`` (and ``_kernel``),
+    # so the bridges delegate directly without lazy backfill.
     # ------------------------------------------------------------------
-
-    def _ensure_lifecycle(self) -> None:
-        """Backfill ``_lifecycle`` for tests that construct via ``__new__``.
-
-        Uses a module-level threading lock (the existing
-        ``_OBSERVABILITY_INIT_LOCK``) for double-checked locking so two
-        threads racing through ``hasattr`` cannot both decide they need to
-        construct a lifecycle and silently discard each other's
-        ``_http_client`` references.
-
-        ``__new__``-built fixtures may not have the underlying timeout /
-        limits attributes; we synthesise a minimally-configured lifecycle
-        in that case (the same shape ``Session.__init__`` would produce
-        for default args).
-        """
-        if hasattr(self, "_lifecycle"):
-            return
-        with _OBSERVABILITY_INIT_LOCK:
-            if not hasattr(self, "_lifecycle"):
-                # Lazy import to break the types.py -> _core.py cycle.
-                from .types import ConnectionLimits
-
-                self._kernel = Kernel(async_client_factory=httpx.AsyncClient)
-                self._lifecycle = ClientLifecycle(
-                    timeout=DEFAULT_TIMEOUT,
-                    connect_timeout=DEFAULT_CONNECT_TIMEOUT,
-                    limits=ConnectionLimits(),
-                    keepalive_interval=None,
-                    keepalive_storage_path=None,
-                    kernel=self._kernel,
-                )
 
     @property
     def _http_client(self) -> httpx.AsyncClient | None:
-        self._ensure_lifecycle()
         return self._lifecycle._http_client
 
     @_http_client.setter
     def _http_client(self, value: httpx.AsyncClient | None) -> None:
-        self._ensure_lifecycle()
         self._lifecycle._http_client = value
 
     @property
     def _bound_loop(self) -> asyncio.AbstractEventLoop | None:
-        self._ensure_lifecycle()
         return self._lifecycle._bound_loop
 
     @_bound_loop.setter
@@ -632,12 +555,10 @@ class Session:
         # Required by the ``_AuthedTransportHost`` Protocol (declares
         # ``_bound_loop`` as a settable variable). No external SET sites,
         # but the Protocol contract demands a settable property.
-        self._ensure_lifecycle()
         self._lifecycle._bound_loop = value
 
     @property
     def _keepalive_task(self) -> asyncio.Task[None] | None:
-        self._ensure_lifecycle()
         return self._lifecycle._keepalive_task
 
     # ``_keepalive_task`` setter dropped in arch-d2-cutover: zero external callers.
@@ -648,12 +569,10 @@ class Session:
         sites); write on ``self._lifecycle._keepalive_interval`` directly
         if a test needs to override it.
         """
-        self._ensure_lifecycle()
         return self._lifecycle._keepalive_interval
 
     @property
     def _keepalive_storage_path(self) -> Path | None:
-        self._ensure_lifecycle()
         return self._lifecycle._keepalive_storage_path
 
     # ``_keepalive_storage_path`` setter dropped in arch-d2-cutover: zero
@@ -661,7 +580,6 @@ class Session:
 
     @property
     def _timeout(self) -> float:
-        self._ensure_lifecycle()
         return self._lifecycle._timeout
 
     @_timeout.setter
@@ -671,7 +589,6 @@ class Session:
         # ``_timeout`` was a plain ivar so attribute assignment worked
         # implicitly; the property bridge needs an explicit setter to
         # preserve that contract.
-        self._ensure_lifecycle()
         self._lifecycle._timeout = value
 
     # ``_connect_timeout`` and ``_limits`` compat bridges dropped
@@ -745,136 +662,21 @@ class Session:
 
     def metrics_snapshot(self) -> ClientMetricsSnapshot:
         """Return cumulative observability counters for this client instance."""
-        self._ensure_observability_state()
         return self._metrics_obj.snapshot()
 
-    def _ensure_observability_state(self) -> None:
-        """Backfill observability fields for tests that construct via ``__new__``.
-
-        Gates on ``_metrics_obj`` AND ``_drain_tracker`` AND
-        ``_max_concurrent_rpcs`` (all three are real instance attributes,
-        not property-bridged ivars whose ``hasattr`` probes would always
-        be True because the descriptors live on the class). The
-        ``_max_concurrent_rpcs`` slot was added by PR 12.9 audit-find #1
-        so a ``__new__``-built fixture can call ``_perform_authed_post``
-        without ``AttributeError`` when ``SemaphoreMiddleware`` reads the
-        accessor.
-        """
-        if (
-            hasattr(self, "_metrics_obj")
-            and hasattr(self, "_drain_tracker")
-            and hasattr(self, "_max_concurrent_rpcs")
-        ):
-            return
-        with _OBSERVABILITY_INIT_LOCK:
-            if not hasattr(self, "_metrics_obj"):
-                self._metrics_obj = ClientMetrics(on_rpc_event=None)
-            if not hasattr(self, "_drain_tracker"):
-                self._drain_tracker = TransportDrainTracker()
-            if not hasattr(self, "_max_concurrent_rpcs"):
-                # Audit-find #1 (PR 12.9): the RPC semaphore wraps the
-                # chain dispatch in ``_perform_authed_post`` and reads
-                # this attr to decide whether to gate at all. A
-                # ``__new__``-built fixture must see ``None`` (no gate)
-                # so the first authed-POST call doesn't ``AttributeError``
-                # — the live ``Session.__init__`` path sets it
-                # explicitly to either ``DEFAULT_MAX_CONCURRENT_RPCS`` or
-                # the operator's override.
-                self._max_concurrent_rpcs = None
-
-    def _ensure_authed_post_chain(self) -> None:
-        """Backfill the middleware chain for tests that construct via ``__new__``.
-
-        Mirrors :meth:`_ensure_observability_state` — a ``__new__``-built
-        fixture skips ``__init__`` and so misses ``_chain_builder``,
-        ``_middlewares``, and ``_authed_post_chain``. The first call to
-        :meth:`_perform_authed_post` on such a fixture would raise
-        ``AttributeError``; this helper backfills all three slots via
-        :class:`MiddlewareChainBuilder` with the same chain shape that
-        ``__init__`` would have produced (ADR-009 ordering pinned by
-        ``tests/unit/test_chain_wiring.py:235`` and at builder level by
-        ``tests/unit/test_middleware_chain_builder.py``).
-
-        Guarded by :data:`_OBSERVABILITY_INIT_LOCK` for the same reason
-        :meth:`_ensure_observability_state` is — two threads observing
-        ``hasattr is False`` simultaneously must not both construct a
-        chain (one would clobber the other and break the
-        ``self._middlewares`` ↔ ``self._authed_post_chain`` linkage).
-        """
-        if hasattr(self, "_authed_post_chain"):
-            return
-        # ``MetricsMiddleware`` needs ``self._metrics_obj``, which a
-        # ``__new__``-built fixture hasn't constructed yet. Run the
-        # observability backfill BEFORE acquiring
-        # ``_OBSERVABILITY_INIT_LOCK`` (its own contract is "no-op when
-        # already initialized" and it takes the same lock internally —
-        # acquiring twice on this thread would deadlock since the lock
-        # is a plain :class:`threading.Lock`, not a reentrant lock).
-        self._ensure_observability_state()
-        with _OBSERVABILITY_INIT_LOCK:
-            if hasattr(self, "_authed_post_chain"):
-                return
-            self._ensure_auth_coord()
-            if not hasattr(self, "_middlewares"):
-                if not hasattr(self, "_chain_builder"):
-                    # __new__-fixture path: __init__ was bypassed. Build
-                    # the builder with safe getattr-defaults mirroring
-                    # __init__'s argument defaults so a fixture that
-                    # never set the attrs still gets sane middleware
-                    # instances. ``_drain_tracker`` and ``_metrics_obj``
-                    # are guaranteed populated by the
-                    # ``_ensure_observability_state()`` call above the
-                    # lock.
-                    self._chain_builder = MiddlewareChainBuilder(
-                        drain_tracker=self._drain_tracker,
-                        metrics=self._metrics_obj,
-                        rpc_semaphore_factory=self._get_rpc_semaphore,
-                        rate_limit_max_retries_provider=lambda: getattr(
-                            self, "_rate_limit_max_retries", 3
-                        ),
-                        server_error_max_retries_provider=lambda: getattr(
-                            self, "_server_error_max_retries", 3
-                        ),
-                        # ``getattr`` default matches ``__init__``'s argument
-                        # default (``refresh_retry_delay: float = 0.2``) so a
-                        # ``__new__``-built fixture that never set this attr
-                        # sees the same post-refresh sleep as the normal
-                        # path. (Restores the alignment first landed in PR
-                        # #850 / commit 73cf680 — inadvertently reverted to
-                        # 0.0 during the PR 12.9 cleanup refactor; CodeRabbit
-                        # caught the regression on PR #883.)
-                        refresh_retry_delay_provider=lambda: getattr(
-                            self, "_refresh_retry_delay", 0.2
-                        ),
-                        refresh_callable=self._await_refresh,
-                        is_auth_error=_live_is_auth_error,
-                        refresh_callback_enabled_provider=(
-                            lambda: self._auth_coord.has_refresh_callback
-                        ),
-                    )
-                self._middlewares = self._chain_builder.build()
-            self._authed_post_chain = build_chain(
-                self._middlewares,
-                self._authed_post_chain_terminal,
-            )
-
     def _increment_metrics(self, **increments: int | float) -> None:
-        self._ensure_observability_state()
         self._metrics_obj.increment(**increments)
 
     def _record_rpc_queue_wait(self, wait_seconds: float) -> None:
-        self._ensure_observability_state()
         self._metrics_obj.record_rpc_queue_wait(wait_seconds)
 
     def record_upload_queue_wait(self, wait_seconds: float) -> None:
         """Record time spent waiting for the upload semaphore."""
-        self._ensure_observability_state()
         self._metrics_obj.record_upload_queue_wait(wait_seconds)
 
     # Session/support surface consumed by feature APIs and private helpers.
     @property
     def kernel(self) -> Kernel:
-        self._ensure_lifecycle()
         return self._kernel
 
     @property
@@ -916,25 +718,20 @@ class Session:
         assert_bound_loop(self.bound_loop)
 
     def _record_lock_wait(self, wait_seconds: float) -> None:
-        self._ensure_observability_state()
         self._metrics_obj.record_lock_wait(wait_seconds)
 
     async def _emit_rpc_event(self, event: RpcTelemetryEvent) -> None:
         """Invoke the optional telemetry callback without affecting RPC behavior."""
-        self._ensure_observability_state()
         await self._metrics_obj.emit_rpc_event(event)
 
     def _get_drain_condition(self) -> asyncio.Condition:
-        self._ensure_observability_state()
         return self._drain_tracker.get_drain_condition()
 
     def _current_operation_depth(self, task: asyncio.Task[Any] | None) -> int:
-        self._ensure_observability_state()
         return self._drain_tracker.current_operation_depth(task)
 
     async def _begin_transport_post(self, log_label: str) -> _TransportOperationToken:
         """Reject new top-level transport work once graceful drain has started."""
-        self._ensure_observability_state()
         return await self._drain_tracker.begin_transport_post(log_label)
 
     async def _begin_transport_task(
@@ -943,11 +740,9 @@ class Session:
         log_label: str,
     ) -> _TransportOperationToken:
         """Admit an internally-spawned task as part of the current operation."""
-        self._ensure_observability_state()
         return await self._drain_tracker.begin_transport_task(task, log_label)
 
     async def _finish_transport_post(self, token: _TransportOperationToken) -> None:
-        self._ensure_observability_state()
         await self._drain_tracker.finish_transport_post(token)
 
     def operation_scope(self, label: str) -> AbstractAsyncContextManager[None]:
@@ -970,7 +765,6 @@ class Session:
         remains in draining mode so shutdown callers do not accidentally admit
         new work after a missed deadline.
         """
-        self._ensure_observability_state()
         await self._drain_tracker.drain(timeout)
 
     def _get_rpc_semaphore(self) -> AbstractAsyncContextManager[Any]:
@@ -1054,7 +848,6 @@ class Session:
         unbind so an
         accidental cross-loop call after close still raises actionably.
         """
-        self._ensure_lifecycle()
         await self._lifecycle.open(self)
 
     async def save_cookies(self, jar: httpx.Cookies, path: Path | None = None) -> None:
@@ -1070,7 +863,6 @@ class Session:
         preferred test-side seam; passing a custom callable there bypasses
         the late-bind hop entirely.
         """
-        self._ensure_lifecycle()
         await self._lifecycle.save_cookies(self, jar, path)
 
     async def close(self) -> None:
@@ -1089,7 +881,6 @@ class Session:
            ``_rpc_executor`` so a follow-up :meth:`open` rebuilds the
            transport collaborators against the new ``httpx.AsyncClient``.
         """
-        self._ensure_lifecycle()
         await self._lifecycle.close(self)
 
     async def _keepalive_loop(self, interval: float) -> None:
@@ -1099,13 +890,11 @@ class Session:
         as a ``Session`` method so ``test_client_keepalive`` and other
         tests that introspect ``core._keepalive_loop`` continue to resolve.
         """
-        self._ensure_lifecycle()
         await self._lifecycle._keepalive_loop(self, interval)
 
     @property
     def is_open(self) -> bool:
         """Check if the HTTP client is open."""
-        self._ensure_lifecycle()
         return self._lifecycle.is_open()
 
     def update_auth_headers(self) -> None:
@@ -1121,7 +910,6 @@ class Session:
         Raises:
             RuntimeError: If client is not initialized.
         """
-        self._ensure_auth_coord()
         self._auth_coord.update_auth_headers(self)
 
     def _get_auth_snapshot_lock(self) -> asyncio.Lock:
@@ -1133,7 +921,6 @@ class Session:
         the ``is None`` check and the assignment unless we ``await`` (and
         the accessor does not).
         """
-        self._ensure_auth_coord()
         return self._auth_coord.get_auth_snapshot_lock()
 
     def _get_refresh_lock(self) -> asyncio.Lock:
@@ -1145,7 +932,6 @@ class Session:
         so the single-flight refresh dedupe in :meth:`_await_refresh` is
         preserved.
         """
-        self._ensure_auth_coord()
         return self._auth_coord.get_refresh_lock()
 
     async def _snapshot(self) -> _AuthSnapshot:
@@ -1168,7 +954,6 @@ class Session:
         the related AST guard in
         ``tests/unit/test_concurrency_refresh_race.py``).
         """
-        self._ensure_auth_coord()
         return await self._auth_coord.snapshot(self)
 
     async def update_auth_tokens(self, csrf: str, session_id: str) -> None:
@@ -1187,7 +972,6 @@ class Session:
         lock-wait metric through ``host._metrics_obj`` directly rather
         than via the ``_record_lock_wait`` facade.
         """
-        self._ensure_auth_coord()
         await self._auth_coord.update_auth_tokens(self, csrf, session_id)
 
     def _build_url(
@@ -1273,7 +1057,6 @@ class Session:
         intentionally stay empty until PRs 12.5/12.7/12.8 begin populating
         them as middlewares strip behavior out of :class:`AuthedTransport`.
         """
-        self._ensure_authed_post_chain()
         request = RpcRequest(
             url="",
             headers={},
@@ -1344,7 +1127,6 @@ class Session:
         replaced only on the next refresh wave once the current task
         transitions to ``done()``.
         """
-        self._ensure_auth_coord()
         await self._auth_coord.await_refresh(self)
 
     async def rpc_call(
@@ -1450,5 +1232,4 @@ class Session:
         Raises:
             RuntimeError: If client is not initialized.
         """
-        self._ensure_lifecycle()
         return self._lifecycle.get_http_client()

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -56,9 +56,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 # Bridge attribute names — see :file:`src/notebooklm/_session.py`
-# bridge block (the ``@property`` declarations between the auth-coord
-# ``_ensure_*`` and the ``get_http_client`` tail). Update this set when
-# a bridge is added or retired.
+# bridge block (the ``@property`` declarations in the
+# ``AuthRefreshCoordinator`` / ``ClientMetrics`` / ``TransportDrainTracker`` /
+# ``ClientLifecycle`` / ``CookiePersistence`` / ``ReqidCounter`` /
+# ``PollingRegistry`` compat-bridge sections, between the constructor wiring
+# and the ``get_http_client`` tail). Update this set when a bridge is added
+# or retired.
 FORBIDDEN_PROPERTIES: frozenset[str] = frozenset(
     {
         # ClientLifecycle bridges
@@ -174,7 +177,6 @@ ALLOWLIST: list[str] = [
     "tests/unit/test_cookie_persistence.py",
     "tests/unit/test_drain_middleware.py",
     "tests/unit/test_idempotency_registry.py",
-    "tests/unit/test_logging_correlation.py",
     "tests/unit/test_metrics_middleware.py",
     "tests/unit/test_observability.py",
     "tests/unit/test_polling_registry.py",
@@ -419,14 +421,10 @@ def test_no_session_compat_bridges() -> None:
     """Every test file outside ALLOWLIST + CARVE_OUT_MODULES must be clean."""
     failures: list[str] = []
     for path in _collect_test_files():
-<<<<<<< HEAD
         # Use as_posix() so the comparison against ALLOWLIST (forward-slash
         # POSIX paths) is correct on Windows, where ``str(Path)`` produces
         # backslashes that miss every allowlist entry.
         rel = path.relative_to(REPO_ROOT).as_posix()
-=======
-        rel = str(path.relative_to(REPO_ROOT))
->>>>>>> a2ba837 (chore(session-shrink): doc correction + AST lint scaffolding for bridge retirement)
         if rel in ALLOWLIST or is_carve_out(rel):
             continue
         violations = _scan_file(path)

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -419,10 +419,14 @@ def test_no_session_compat_bridges() -> None:
     """Every test file outside ALLOWLIST + CARVE_OUT_MODULES must be clean."""
     failures: list[str] = []
     for path in _collect_test_files():
+<<<<<<< HEAD
         # Use as_posix() so the comparison against ALLOWLIST (forward-slash
         # POSIX paths) is correct on Windows, where ``str(Path)`` produces
         # backslashes that miss every allowlist entry.
         rel = path.relative_to(REPO_ROOT).as_posix()
+=======
+        rel = str(path.relative_to(REPO_ROOT))
+>>>>>>> a2ba837 (chore(session-shrink): doc correction + AST lint scaffolding for bridge retirement)
         if rel in ALLOWLIST or is_carve_out(rel):
             continue
         violations = _scan_file(path)

--- a/tests/unit/test_chain_wiring.py
+++ b/tests/unit/test_chain_wiring.py
@@ -333,37 +333,6 @@ async def test_chain_with_test_middleware_observes_request_and_response() -> Non
     assert fake.call_count == 1
 
 
-@pytest.mark.asyncio
-async def test_perform_authed_post_works_on_new_built_fixture() -> None:
-    """A ``__new__``-built fixture can still call ``_perform_authed_post``.
-
-    Mirrors the ``_ensure_observability_state`` /
-    ``_ensure_auth_coord`` / ``_ensure_lifecycle`` backfill pattern: a
-    test that constructs ``Session.__new__(Session)`` (skipping
-    ``__init__``) must still be able to drive the authed-POST path.
-    The :meth:`Session._ensure_authed_post_chain` helper backfills
-    ``_middlewares`` and ``_authed_post_chain`` lazily so the first call
-    succeeds. This regression guard catches the path before any
-    middleware PR (12.3+) inadvertently moves the chain build out of
-    the backfill.
-    """
-    core = Session.__new__(Session)
-    fake = FakeAuthedPost(response=httpx.Response(status_code=200, content=b"new"))
-    _swap_transport(core, fake)
-
-    def build_request(snapshot: Any) -> tuple[str, bytes, dict[str, str] | None]:
-        return ("https://fake/new", b"", None)
-
-    response = await core._perform_authed_post(
-        build_request=build_request,
-        log_label="new-fixture",
-        disable_internal_retries=False,
-    )
-
-    assert response.status_code == 200
-    assert fake.call_count == 1
-
-
 def test_build_chain_empty_returns_terminal_unchanged() -> None:
     """:func:`build_chain` returns the terminal unchanged when ``middlewares`` is empty.
 

--- a/tests/unit/test_client_metrics.py
+++ b/tests/unit/test_client_metrics.py
@@ -13,10 +13,6 @@ invariants the facade depends on:
 * ``emit_rpc_event`` dispatches sync, async, and exception-raising callbacks
   via ``maybe_await_callback`` (back-pressure semantics — never
   fire-and-forget).
-* The ``Session.__new__(Session)`` regression path: setting
-  ``_on_rpc_event`` on a ``__new__``-built core (no ``__init__`` ran) must
-  succeed because the property setter calls ``_ensure_observability_state``
-  before writethrough.
 """
 
 from __future__ import annotations
@@ -28,7 +24,6 @@ import threading
 import pytest
 
 from notebooklm._client_metrics import ClientMetrics
-from notebooklm._session import Session
 from notebooklm.types import ClientMetricsSnapshot, RpcTelemetryEvent
 
 # ---------------------------------------------------------------------------
@@ -302,94 +297,3 @@ async def test_emit_rpc_event_swallows_async_callback_exception(caplog) -> None:
         for r in caplog.records
         if r.levelno == logging.WARNING
     )
-
-
-# ---------------------------------------------------------------------------
-# __new__-backfill regression — Session side
-#
-# These tests verify the property-bridge contract on ``Session``: a
-# ``__new__``-built fixture must be able to (a) set ``_on_rpc_event`` directly
-# and (b) await ``_emit_rpc_event`` without a prior ``__init__``. Both hinge
-# on ``_ensure_observability_state`` lazy-constructing ``_metrics_obj`` on
-# the first access path.
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_new_backfill_emit_event_works_without_init() -> None:
-    """``Session.__new__(Session); await core._emit_rpc_event(...)`` must work.
-
-    Regression guard for the property-descriptor gate failure: after A1
-    turned ``_metrics_lock`` / ``_metrics`` / ``_on_rpc_event`` into class
-    descriptors, the legacy ``hasattr`` short-circuit always returned True
-    and the backfill never ran. The gate now hinges on the real
-    ``_metrics_obj`` instance attribute.
-    """
-    core = Session.__new__(Session)
-    # No __init__ has run; no callback configured.
-    event = RpcTelemetryEvent(method="ASK", status="success", elapsed_seconds=0.0)
-    await core._emit_rpc_event(event)
-    # No callback ⇒ silent no-op. Just assert no AttributeError surfaced.
-
-
-@pytest.mark.asyncio
-async def test_new_backfill_emits_rpc_event_after_explicit_backfill() -> None:
-    """Behaviour test: after ``_ensure_observability_state()`` primes the
-    collaborator, writing ``_on_rpc_event`` directly and then calling
-    ``_emit_rpc_event`` delivers the event.
-
-    Phase 4: the ``Session._on_rpc_event`` setter was removed; tests that
-    bypassed ``__init__`` via ``Session.__new__`` must now call the
-    backfill helper explicitly before writing on the collaborator.
-    """
-    events: list[RpcTelemetryEvent] = []
-    core = Session.__new__(Session)
-    core._ensure_observability_state()  # explicit backfill (was implicit via setter)
-    core._metrics_obj._on_rpc_event = events.append
-
-    event = RpcTelemetryEvent(method="ASK", status="success", elapsed_seconds=0.0)
-    await core._emit_rpc_event(event)
-    assert events == [event]
-
-
-def test_new_backfill_metrics_snapshot_returns_zero_snapshot() -> None:
-    """``metrics_snapshot()`` on a ``__new__``-built core returns the zeroed default.
-
-    Useful for tests that call into ``Session`` helpers (e.g.
-    ``rpc_call``-flavored mocks) without paying for a full ``__init__``.
-    """
-    core = Session.__new__(Session)
-    snapshot = core.metrics_snapshot()
-    assert isinstance(snapshot, ClientMetricsSnapshot)
-    assert snapshot.rpc_calls_started == 0
-    assert snapshot.rpc_calls_succeeded == 0
-
-
-def test_new_backfill_increment_metrics_lazy_construct() -> None:
-    """``_increment_metrics`` lazy-constructs the helper on a ``__new__`` core."""
-    core = Session.__new__(Session)
-    core._increment_metrics(rpc_calls_started=2, rpc_calls_failed=1)
-    snapshot = core.metrics_snapshot()
-    assert snapshot.rpc_calls_started == 2
-    assert snapshot.rpc_calls_failed == 1
-
-
-# ---------------------------------------------------------------------------
-# Phase 4 deleted the ``_metrics_lock``, ``_metrics``, ``_on_rpc_event``
-# setters on ``Session``. The getters stay (with ``_ensure_observability_state``
-# backfill) so reading still works; writers reach into ``_metrics_obj``
-# directly. The round-trip + writethrough tests that pinned the deleted setters
-# were removed (they would tautologically assert that writing direct then
-# reading direct returns the written value). The single setter-removed test
-# above (``test_new_backfill_emits_rpc_event_after_explicit_backfill``)
-# preserves the behaviour-side regression guard.
-# ---------------------------------------------------------------------------
-
-
-def test_metrics_getter_returns_live_snapshot() -> None:
-    """``core._metrics`` getter returns the helper's current snapshot."""
-    core = Session.__new__(Session)
-    core._increment_metrics(rpc_calls_started=7)
-    # The getter delegates to ``self._metrics_obj._metrics``, which has been
-    # rebound by ``increment`` to a new dataclass via ``replace``.
-    assert core._metrics.rpc_calls_started == 7

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -236,6 +236,7 @@ async def test_retry_inherits_parent_request_id():
     """Recursive rpc_call(_is_retry=True) must NOT mint a fresh id — the
     failure→refresh→retry sequence should appear under one prefix."""
     from notebooklm._session import Session
+    from notebooklm.auth import AuthTokens
 
     captured_ids: list[str | None] = []
 
@@ -245,7 +246,6 @@ async def test_retry_inherits_parent_request_id():
         source_path,
         allow_null,
         is_retry,
-        rate_limit_retries=0,
         *,
         disable_internal_retries: bool = False,
         operation_variant: str | None = None,
@@ -259,15 +259,25 @@ async def test_retry_inherits_parent_request_id():
             return await core.rpc_call(method, params, source_path, allow_null, _is_retry=True)
         return "ok"
 
-    core = Session.__new__(Session)
-    core._http_client = object()  # not-None; rpc_call doesn't dereference here
-    core._rpc_call_impl = fake_impl  # type: ignore[method-assign]
+    # Real Session — the executor's ``if not self._owner._http_client`` guard
+    # requires a truthy http_client, so we ``open()`` and let the lifecycle
+    # construct one against the default httpx transport. ``fake_impl`` is
+    # monkeypatched onto ``_rpc_call_impl`` so no actual HTTP call fires;
+    # the test exercises the request-id propagation through the executor
+    # wrapper purely in-process.
+    auth = AuthTokens(cookies={"SID": "test_sid"}, csrf_token="csrf", session_id="sid")
+    core = Session(auth)
+    await core.open()
+    try:
+        core._rpc_call_impl = fake_impl  # type: ignore[method-assign]
 
-    result = await core.rpc_call(method=object(), params=[])  # type: ignore[arg-type]
-    assert result == "ok"
-    assert len(captured_ids) == 2
-    assert captured_ids[0] == captured_ids[1]
-    assert captured_ids[0] is not None
+        result = await core.rpc_call(method=object(), params=[])  # type: ignore[arg-type]
+        assert result == "ok"
+        assert len(captured_ids) == 2
+        assert captured_ids[0] == captured_ids[1]
+        assert captured_ids[0] is not None
+    finally:
+        await core.close()
 
 
 def test_end_to_end_prefix_visible_in_rendered_output():

--- a/tests/unit/test_middleware_chain_builder.py
+++ b/tests/unit/test_middleware_chain_builder.py
@@ -42,22 +42,3 @@ def test_builder_returns_adr_009_order():
     assert isinstance(chain[4], AuthRefreshMiddleware)
     assert isinstance(chain[5], ErrorInjectionMiddleware)
     assert isinstance(chain[6], TracingMiddleware)
-
-
-def test_new_built_session_lazy_builds_chain_via_builder():
-    """A Session created via __new__ must build its chain through the
-    builder when _ensure_authed_post_chain is called. After backfill,
-    the Session must have a _chain_builder attribute (not just
-    _middlewares + _authed_post_chain as the legacy inline backfill
-    produced)."""
-    from notebooklm._session import Session
-
-    s = Session.__new__(Session)
-    s._ensure_authed_post_chain()
-
-    assert hasattr(s, "_chain_builder"), (
-        "post-backfill Session must have _chain_builder; inline-construction fallback regressed"
-    )
-    assert hasattr(s, "_middlewares")
-    assert len(s._middlewares) == 7
-    assert hasattr(s, "_authed_post_chain")

--- a/tests/unit/test_swallow_observability.py
+++ b/tests/unit/test_swallow_observability.py
@@ -20,11 +20,10 @@ SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "notebooklm"
 @pytest.mark.asyncio
 async def test_get_source_ids_warns_on_top_level_shape_drift(caplog):
     """_notebooks.py:get_source_ids — non-list at notebook_data[0] triggers WARNING."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._notebooks import NotebooksAPI
-    from notebooklm._session import Session
 
-    core = Session.__new__(Session)
-    core.rpc_call = AsyncMock(return_value=[{"unexpected": "dict"}])
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[{"unexpected": "dict"}]))
     api = NotebooksAPI(core)
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):
@@ -43,12 +42,11 @@ async def test_get_source_ids_warns_on_top_level_shape_drift(caplog):
 @pytest.mark.asyncio
 async def test_get_source_ids_warns_on_inner_shape_drift(caplog):
     """_notebooks.py:get_source_ids — notebook_info[1] not list triggers WARNING."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._notebooks import NotebooksAPI
-    from notebooklm._session import Session
 
-    core = Session.__new__(Session)
     # notebook_data[0] is a list of length >1 but [1] is not a list
-    core.rpc_call = AsyncMock(return_value=[[None, "not a list", "x"]])
+    core = make_fake_core(rpc_call=AsyncMock(return_value=[[None, "not a list", "x"]]))
     api = NotebooksAPI(core)
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):
@@ -61,11 +59,12 @@ async def test_get_source_ids_warns_on_inner_shape_drift(caplog):
 @pytest.mark.asyncio
 async def test_get_source_ids_happy_path_no_warning(caplog):
     """Well-formed payload extracts source ids and emits no warning."""
+    from _fixtures.fake_core import make_fake_core
     from notebooklm._notebooks import NotebooksAPI
-    from notebooklm._session import Session
 
-    core = Session.__new__(Session)
-    core.rpc_call = AsyncMock(return_value=[[None, [[["src_alpha"]], [["src_beta"]]]]])
+    core = make_fake_core(
+        rpc_call=AsyncMock(return_value=[[None, [[["src_alpha"]], [["src_beta"]]]]])
+    )
     api = NotebooksAPI(core)
 
     with caplog.at_level(logging.WARNING, logger="notebooklm"):

--- a/tests/unit/test_transport_drain.py
+++ b/tests/unit/test_transport_drain.py
@@ -21,10 +21,6 @@ pins the helper-class invariants the facade depends on:
   work).
 * ``current_operation_depth(None)`` returns zero (the documented
   "outside any task" branch).
-* The ``Session.__new__(Session)`` regression path: the drain
-  property setters on a ``__new__``-built core (no ``__init__`` ran)
-  must succeed because the setters call
-  ``_ensure_observability_state`` before writethrough.
 """
 
 from __future__ import annotations
@@ -33,7 +29,6 @@ import asyncio
 
 import pytest
 
-from notebooklm._session import Session
 from notebooklm._transport_drain import TransportDrainTracker, _TransportOperationToken
 
 # ---------------------------------------------------------------------------
@@ -301,63 +296,3 @@ def test_token_is_frozen_dataclass() -> None:
     token = _TransportOperationToken(task=None)
     with pytest.raises(FrozenInstanceError):
         token.task = None  # type: ignore[misc]
-
-
-# ---------------------------------------------------------------------------
-# ``Session.__new__`` backfill regression
-# ---------------------------------------------------------------------------
-
-
-def test_new_backfill_drain_tracker_constructed_on_first_access() -> None:
-    """A ``__new__``-built core must lazy-construct the tracker on first probe.
-
-    Regression guard: ``Session.__new__(Session)`` skips ``__init__``,
-    so neither ``_metrics_obj`` nor ``_drain_tracker`` is set. The first
-    facade-method call must run ``_ensure_observability_state`` and
-    backfill both.
-    """
-    core = Session.__new__(Session)
-    assert not hasattr(core, "_drain_tracker")
-
-    core._ensure_observability_state()
-    assert isinstance(core._drain_tracker, TransportDrainTracker)
-    # The compat properties must read through cleanly.
-    assert core._in_flight_posts == 0
-    assert core._draining is False
-    assert core._drain_condition is None
-
-
-# ---------------------------------------------------------------------------
-# Phase 4 deleted the ``_draining``, ``_drain_condition``, ``_in_flight_posts``
-# setters on ``Session``. The getters stay (with backfill) so reads still work;
-# writers reach into ``_drain_tracker`` directly. The three pure-writethrough
-# tests that pinned those setters were removed (they would tautologically
-# assert that writing direct then reading direct returns the same value).
-# The ``__new__``-fixture invariant is still pinned by
-# ``tests/unit/test_chain_wiring.py::test_perform_authed_post_works_on_new_built_fixture``.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Facade integration — exercise Session delegation through the tracker
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_session_drain_facade_delegates_to_tracker() -> None:
-    """A real ``Session`` instance must route ``drain`` through the tracker.
-
-    Construction via ``__new__`` keeps the test off the full ``__init__``
-    surface (no auth, no httpx). The facade methods still rely on
-    ``_ensure_observability_state`` to backfill, which is exactly the path
-    we want to exercise here.
-    """
-    core = Session.__new__(Session)
-    # Begin/finish through the facade should bump and clear in-flight.
-    token = await core._begin_transport_post("facade-test")
-    assert core._in_flight_posts == 1
-    await core._finish_transport_post(token)
-    assert core._in_flight_posts == 0
-    # Drain with nothing in flight should return immediately and set flag.
-    await core.drain(timeout=0.5)
-    assert core._draining is True


### PR DESCRIPTION
## Summary

**PR 1 of 8** in the session-shrink arc. **Stacked on PR #913 (PR 0 — doc + AST-lint scaffolding).** Will rebase onto `main` once PR 0 merges.

Removes the lazy-init scaffolding that supported `__new__`-built test fixtures, and processes the 13 executable `Session.__new__(Session)` test sites per the converged disposition table.

## Per-site disposition outcome

| # | Action | Where | Reason |
|---|---|---|---|
| 1–9 | **DELETE** | `test_chain_wiring` (1), `test_transport_drain` (2), `test_middleware_chain_builder` (1), `test_client_metrics` (5) | Backfill-regression tests that exist only to verify the lazy-init path being removed |
| 10–12 | **MIGRATE** to `make_fake_core(rpc_call=AsyncMock(...))` | `test_swallow_observability` (3 sites) | `make_fake_core` already supports `rpc_call=` — no defaults extension needed |
| 13 | **REAL-SESSION** rewrite | `test_logging_correlation::test_retry_inherits_parent_request_id` | Test pokes `core._http_client = object()` to fake a non-None http_client; `make_fake_core` would neutralize the code path under test, so we construct a real `Session(AuthTokens(...))` + `open()/close()` + monkeypatched `_rpc_call_impl` |

No fallback `pytest.mark.skip` was needed — the REAL-SESSION rewrite fit cleanly.

## `_session.py` demolition

| What | Before | After |
|---|---|---|
| `def _ensure_*` methods | 4 | 0 |
| `self._ensure_*()` callsites | 48 | 0 |
| `_INIT_LOCK` (`_OBSERVABILITY_INIT_LOCK`, `_AUTH_COORD_INIT_LOCK`) | 2 (+8 usages) | 0 |
| File lines | 1454 | 1232 (-222) |
| Property bridge declarations | 19 | 19 (unchanged — bridge demolition itself is PR 4/5/6) |

Property bridges now delegate directly: `return self._lifecycle._http_client`, etc. No lazy-backfill prefix. `Session.__init__` already eager-constructs every collaborator (verified — see PR 1 review).

Also tightened the `AuthRefreshCoordinator` bridge-section comment to reflect the surviving setter surface (only `_refresh_callback` retains a setter; the other three are read-only — write through `self._auth_coord.<name>` directly).

## AST lint allowlist drain

The `test_allowlist_entries_currently_violate` drain test PR 0 introduced surfaced one entry that this PR's changes made stale: `tests/unit/test_logging_correlation.py`. Removed from `ALLOWLIST`. Allowlist count: 55 → 54.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 files)
- [x] `uv run pytest tests/_lint/test_no_session_compat_bridges.py -v` — 18/18 passed
- [x] `uv run pytest tests/unit -q` — **4883 passed, 44 skipped** (baseline 4892; drop of 9 = the 9 deleted backfill tests exactly)
- [x] `tests/unit/test_logging_correlation.py` 12/12 passed (REAL-SESSION rewrite green)

## Polish history (reviewer context)

- **Stage 4.1 (code-simplifier)**: 0 simplifications warranted; 3 stale-comment cleanups deferred to PR 7 (in untouched files).
- **Stage 4.2 (claude + codex review, agy excluded per user instruction)** — both **APPROVE**:
  - Claude: 0 Critical, 0 Important, 2 minor Suggestions (1 in-scope dead-kwarg → applied; 1 cross-file → deferred to PR 7). Reviewer verified `__init__` eager-construct invariants, retry-correlation contract, `open()` network-freeness, deleted-test coverage analysis.
  - Codex: 0 Critical, 0 Important, 2 minor Suggestions (1 in-scope comment tightening → applied; 1 overlap with Claude → deferred to PR 7). Reviewer verified diff stat, deleted-test scoping.
- **Stage 4.3 (ultrathink)**: no additional findings.

## Deferred (to PR 7 sweep)

- Stale `_ensure_*` comment references in 3 untouched files: `tests/unit/test_session_lifecycle.py:594,652`, `tests/unit/test_session_compat_delegates.py:167`. These are doc-only and don't affect behavior; sweep belongs in PR 7's final cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)