### PR TITLE
fix(cli/language): JSON error schema matches shared helper

### DIFF
--- a/src/notebooklm/cli/language.py
+++ b/src/notebooklm/cli/language.py
@@ -17,7 +17,7 @@ from ..io import atomic_update_json
 from ..paths import get_config_path, get_home_dir
 from .auth_runtime import get_auth_tokens
 from .options import json_option
-from .rendering import console, json_output_response
+from .rendering import console, json_error_response, json_output_response
 from .runtime import run_async
 
 logger = logging.getLogger(__name__)
@@ -329,16 +329,16 @@ def language_set(ctx, code, local, json_output):
     # Validate the language code
     if code not in SUPPORTED_LANGUAGES:
         if json_output:
-            json_output_response(
-                {
-                    "error": "INVALID_LANGUAGE",
-                    "message": f"Unknown language code: {code}",
-                    "hint": "Run 'notebooklm language list' to see supported codes",
-                }
+            # Match the shared JSON error schema from ``cli/rendering.py``:
+            # ``{"error": True, "code": ..., "message": ..., **extra}``.
+            # ``json_error_response`` exits non-zero, so the call below does not return.
+            json_error_response(
+                "INVALID_LANGUAGE",
+                f"Unknown language code: {code}",
+                extra={"hint": "Run 'notebooklm language list' to see supported codes"},
             )
-        else:
-            console.print(f"[red]Unknown language code: {code}[/red]")
-            console.print("\nRun [cyan]notebooklm language list[/cyan] to see supported codes.")
+        console.print(f"[red]Unknown language code: {code}[/red]")
+        console.print("\nRun [cyan]notebooklm language list[/cyan] to see supported codes.")
         raise SystemExit(1)
 
     # Save locally first

--- a/src/notebooklm/cli/language.py
+++ b/src/notebooklm/cli/language.py
@@ -331,7 +331,8 @@ def language_set(ctx, code, local, json_output):
         if json_output:
             # Match the shared JSON error schema from ``cli/rendering.py``:
             # ``{"error": True, "code": ..., "message": ..., **extra}``.
-            # ``json_error_response`` exits non-zero, so the call below does not return.
+            # ``json_error_response`` is ``NoReturn``; execution never reaches
+            # the text-mode ``console.print`` lines below when this branch fires.
             json_error_response(
                 "INVALID_LANGUAGE",
                 f"Unknown language code: {code}",

--- a/tests/unit/cli/test_language.py
+++ b/tests/unit/cli/test_language.py
@@ -173,12 +173,21 @@ class TestLanguageSetCommand:
         assert data["name"] == "Français"
 
     def test_language_set_invalid_json_output(self, runner, mock_config_file):
-        """Test 'language set --json' with invalid code outputs JSON error."""
+        """``language set --json`` with invalid code emits the shared JSON error schema.
+
+        The error payload must match ``json_error_response`` in ``cli/rendering.py``
+        so machine-readable error handling is uniform across CLI commands:
+        ``{"error": true, "code": "INVALID_LANGUAGE", "message": ..., "hint": ...}``.
+        """
         result = runner.invoke(cli, ["language", "set", "xyz", "--json"])
 
         assert result.exit_code == 1
         data = json.loads(result.output)
-        assert data["error"] == "INVALID_LANGUAGE"
+        assert data["error"] is True
+        assert data["code"] == "INVALID_LANGUAGE"
+        assert "xyz" in data["message"]
+        assert "hint" in data
+        assert "language list" in data["hint"].lower()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- `notebooklm language set INVALID --json` previously emitted a divergent schema (`{"error": "INVALID_LANGUAGE", ...}`) where every other CLI command uses the canonical schema from `cli/rendering.py`: `{"error": true, "code": "...", "message": "...", **extra}`.
- Route the invalid-code branch through `json_error_response()` so machine-readable error handling is uniform across the CLI.
- Exit code is unchanged (still 1, via the helper's `raise SystemExit(1)`). Text-mode output is unchanged.

## Task

`.sisyphus/plans/cli-audit-fixes.md` § P1.T10 (audit § B § minor: language error schema).

## Schema change (breaking for JSON consumers of `language set --json` errors)

Before:
```json
{ "error": "INVALID_LANGUAGE", "message": "...", "hint": "..." }
```

After (matches every other JSON-mode CLI error):
```json
{ "error": true, "code": "INVALID_LANGUAGE", "message": "...", "hint": "..." }
```

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check src/notebooklm/cli` — clean
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` — clean
- [x] `uv run pytest tests/unit tests/integration` — 5568 passed, 49 skipped
- [x] Updated `tests/unit/cli/test_language.py::test_language_set_invalid_json_output` asserts the canonical schema (`error: True`, `code: INVALID_LANGUAGE`, message includes the bad code, hint mentions `language list`).

## Deferred polish findings

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized JSON error response for invalid language codes: responses now include a boolean `error`, an `INVALID_LANGUAGE` code, a `message` that echoes the invalid input, and a `hint` referencing how to list languages.
* **Tests**
  * Updated tests to assert the new standardized JSON error schema for invalid-language requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->