### PR TITLE
fix(cli/download): bulk exit-code, --name filter, dry-run filename parity

### DIFF
--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -275,6 +275,44 @@ async def _download_artifacts_generic(
             if download_all:
                 output_dir = Path(output_path) if output_path else Path(default_output_dir)
 
+                # Apply --name filter before previewing/downloading. Match the
+                # case-insensitive substring semantics used by
+                # ``select_artifact`` for the single-artifact path so the two
+                # entry points stay consistent. If the filter excludes every
+                # artifact, return the same legacy error envelope as
+                # ``select_artifact`` does on a name miss (caller exits 1 via
+                # the top-level "error" key check in ``_run_artifact_download``).
+                if name:
+                    name_lower = name.lower()
+                    filtered_artifacts = [
+                        a for a in type_artifacts if name_lower in str(a["title"]).lower()
+                    ]
+                    if not filtered_artifacts:
+                        return {
+                            "error": (
+                                f"No artifacts matching '{name}'. "
+                                f"Available: {', '.join(str(a['title']) for a in type_artifacts)}"
+                            ),
+                        }
+                    type_artifacts = filtered_artifacts
+
+                # Pre-compute the final filename per artifact so dry-run and
+                # execution agree on duplicate-title disambiguation. The
+                # execution loop below mutates ``existing_names`` as it goes;
+                # dry-run iterates the same way so its preview reflects the
+                # ``Title (2).ext`` / ``Title (3).ext`` suffixes the execution
+                # path would write.
+                planned_filenames: list[str] = []
+                existing_names: set[str] = set()
+                for artifact in type_artifacts:
+                    item_name = artifact_title_to_filename(
+                        str(artifact["title"]),
+                        file_extension,
+                        existing_names,
+                    )
+                    existing_names.add(item_name)
+                    planned_filenames.append(item_name)
+
                 if dry_run:
                     return {
                         "dry_run": True,
@@ -285,40 +323,33 @@ async def _download_artifacts_generic(
                             {
                                 "id": a["id"],
                                 "title": a["title"],
-                                "filename": artifact_title_to_filename(
-                                    str(a["title"]),
-                                    file_extension,
-                                    set(),
-                                ),
+                                "filename": item_name,
                             }
-                            for a in type_artifacts
+                            for a, item_name in zip(type_artifacts, planned_filenames, strict=True)
                         ],
                     }
 
                 output_dir.mkdir(parents=True, exist_ok=True)
 
-                results = []
-                existing_names: set[str] = set()
+                artifacts_results: list[dict[str, Any]] = []
                 total = len(type_artifacts)
+                succeeded_count = 0
+                failed_count = 0
+                skipped_count = 0
 
-                for i, artifact in enumerate(type_artifacts, 1):
+                for i, (artifact, item_name) in enumerate(
+                    zip(type_artifacts, planned_filenames, strict=True), 1
+                ):
                     # Progress indicator
                     if not json_output:
                         console.print(f"[dim]Downloading {i}/{total}:[/dim] {artifact['title']}")
 
-                    # Generate safe name
-                    item_name = artifact_title_to_filename(
-                        str(artifact["title"]),
-                        file_extension,
-                        existing_names,
-                    )
-                    existing_names.add(item_name)
                     item_path = output_dir / item_name
 
                     # Resolve conflicts
                     resolved_path, skip_info = _resolve_conflict(item_path)
                     if skip_info or resolved_path is None:
-                        results.append(
+                        artifacts_results.append(
                             {
                                 "id": artifact["id"],
                                 "title": artifact["title"],
@@ -329,6 +360,7 @@ async def _download_artifacts_generic(
                                 ),
                             }
                         )
+                        skipped_count += 1
                         continue
 
                     # Update if auto-renamed
@@ -342,7 +374,7 @@ async def _download_artifacts_generic(
                             nb_id_resolved, str(item_path), artifact_id=str(artifact["id"])
                         )
 
-                        results.append(
+                        artifacts_results.append(
                             {
                                 "id": artifact["id"],
                                 "title": artifact["title"],
@@ -351,8 +383,9 @@ async def _download_artifacts_generic(
                                 "status": "downloaded",
                             }
                         )
+                        succeeded_count += 1
                     except Exception as e:
-                        results.append(
+                        artifacts_results.append(
                             {
                                 "id": artifact["id"],
                                 "title": artifact["title"],
@@ -361,13 +394,26 @@ async def _download_artifacts_generic(
                                 "error": str(e),
                             }
                         )
+                        failed_count += 1
 
-                return {
+                # Per P1.T4: ANY per-item failure must surface to a non-zero
+                # exit code. ``_run_artifact_download`` keys exit-code policy
+                # on the presence of the top-level ``"error"`` field, so we
+                # only add it when there are failures — keeping the all-success
+                # envelope exit-0-clean while making partial / total failure
+                # automation-friendly via the documented counts.
+                envelope: dict[str, Any] = {
                     "operation": "download_all",
                     "output_dir": str(output_dir),
                     "total": total,
-                    "results": results,
+                    "succeeded_count": succeeded_count,
+                    "failed_count": failed_count,
+                    "skipped_count": skipped_count,
+                    "artifacts": artifacts_results,
                 }
+                if failed_count > 0:
+                    envelope["error"] = True
+                return envelope
 
             # Single artifact selection
             try:
@@ -470,9 +516,12 @@ def _display_download_result(result: dict, artifact_type: str) -> None:
 
     # Download all results
     if result.get("operation") == "download_all":
-        downloaded = [r for r in result["results"] if r.get("status") == "downloaded"]
-        skipped = [r for r in result["results"] if r.get("status") == "skipped"]
-        failed = [r for r in result["results"] if r.get("status") == "failed"]
+        # Per P1.T4 envelope: per-item entries live under ``artifacts``
+        # (alongside ``error: true`` / ``failed_count`` / ``succeeded_count``).
+        items = result.get("artifacts", [])
+        downloaded = [r for r in items if r.get("status") == "downloaded"]
+        skipped = [r for r in items if r.get("status") == "skipped"]
+        failed = [r for r in items if r.get("status") == "failed"]
 
         console.print(
             f"[bold]Downloaded {len(downloaded)}/{result['total']} {artifact_type} files to:[/bold] {result['output_dir']}"

--- a/src/notebooklm/cli/download.py
+++ b/src/notebooklm/cli/download.py
@@ -285,13 +285,13 @@ async def _download_artifacts_generic(
                 if name:
                     name_lower = name.lower()
                     filtered_artifacts = [
-                        a for a in type_artifacts if name_lower in str(a["title"]).lower()
+                        a for a in type_artifacts if name_lower in a["title"].lower()
                     ]
                     if not filtered_artifacts:
                         return {
                             "error": (
                                 f"No artifacts matching '{name}'. "
-                                f"Available: {', '.join(str(a['title']) for a in type_artifacts)}"
+                                f"Available: {', '.join(a['title'] for a in type_artifacts)}"
                             ),
                         }
                     type_artifacts = filtered_artifacts
@@ -306,7 +306,7 @@ async def _download_artifacts_generic(
                 existing_names: set[str] = set()
                 for artifact in type_artifacts:
                     item_name = artifact_title_to_filename(
-                        str(artifact["title"]),
+                        artifact["title"],
                         file_extension,
                         existing_names,
                     )
@@ -492,7 +492,16 @@ async def _download_artifacts_generic(
 
 def _display_download_result(result: dict, artifact_type: str) -> None:
     """Display download results in user-friendly format."""
-    if "error" in result:
+    # The legacy single-failure / name-not-found path emits
+    # ``{"error": "<msg>"}`` (free-form string) and exits via the short-circuit
+    # below. The P1.T4 bulk-failure envelope emits
+    # ``{"error": True, "failed_count": ..., "succeeded_count": ...,
+    # "artifacts": [...]}`` — the boolean flag is only there so
+    # ``_run_artifact_download`` can key its exit-code policy on the presence
+    # of the "error" key. For text mode we still want the full downloaded /
+    # skipped / failed breakdown to render, so only short-circuit on the
+    # legacy string-error shape.
+    if isinstance(result.get("error"), str):
         console.print(f"[red]Error:[/red] {result['error']}")
         if "suggestion" in result:
             console.print(f"[dim]{result['suggestion']}[/dim]")

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -683,8 +683,14 @@ class TestDownloadAll:
         # One file should be downloaded
         downloaded_files = list(output_dir.glob("*.mp3"))
         assert len(downloaded_files) == 1
-        # Output should mention failure
-        assert "failed" in result.output.lower() or "1" in result.output
+        # The text-mode renderer must show the structured "Failed" section
+        # listing the actual error, not just the boolean "Error: True" guard.
+        # ``"1" in result.output`` was an unreliable assertion because the
+        # progress indicator ``Downloading 1/2:`` always emits a "1".
+        output_lower = result.output.lower()
+        assert "failed" in output_lower
+        assert "network error" in output_lower
+        assert "error: true" not in output_lower
 
 
 class TestDownloadAllExitCodeContract:
@@ -785,6 +791,59 @@ class TestDownloadAllExitCodeContract:
         assert payload.get("failed_count") == 1
         assert payload.get("succeeded_count") == 1
         assert len(payload.get("artifacts", [])) == 2
+
+    def test_partial_failure_text_mode_shows_breakdown(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """The text-mode renderer must show the structured Downloaded/Failed
+        breakdown on partial failure — NOT short-circuit to ``Error: True``.
+
+        Regression guard for the reviewer-flagged renderer bug: setting
+        ``envelope["error"] = True`` to drive exit-code policy used to hit the
+        renderer's generic ``if "error" in result`` early-return guard and
+        swallow the per-item breakdown. The renderer now keys off the legacy
+        string-error shape only, so the typed-counts envelope falls through to
+        the ``download_all`` summary block.
+        """
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+            call_count = 0
+
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise Exception("Network error")
+                Path(output_path).write_bytes(b"audio content")
+                return output_path
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_1", "First Audio", 1),
+                    make_artifact("audio_2", "Second Audio", 1),
+                ]
+            )
+            mock_client.artifacts.download_audio = mock_download_audio
+            mock_client_cls.return_value = mock_client
+
+            # No --json: text-mode renderer must show the full breakdown.
+            result = runner.invoke(
+                cli, ["download", "audio", "--all", str(output_dir), "-n", "nb_123"]
+            )
+
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        # The Rich breakdown sections must appear ("Downloaded:" and "Failed:")
+        # along with the actual error message — proving the renderer did not
+        # short-circuit on the boolean error flag.
+        assert "downloaded" in output_lower
+        assert "failed" in output_lower
+        assert "network error" in output_lower
+        assert "first audio" in output_lower
+        assert "second audio" in output_lower
+        # And explicitly NOT the boolean-leak text.
+        assert "error: true" not in output_lower
 
     def test_all_success_keeps_zero_exit_and_no_error_key(
         self, runner, mock_auth, mock_fetch_tokens, tmp_path

--- a/tests/unit/cli/test_download.py
+++ b/tests/unit/cli/test_download.py
@@ -644,7 +644,12 @@ class TestDownloadAll:
         assert not output_dir.exists()
 
     def test_download_all_with_failures(self, runner, mock_auth, mock_fetch_tokens, tmp_path):
-        """Test --all continues on individual artifact failures."""
+        """Test --all continues on individual artifact failures.
+
+        Per P1.T4 contract: ANY per-item failure must propagate to a non-zero
+        exit code (the loop still attempts every artifact, but the command does
+        not silently report success when some artifacts failed).
+        """
         with patch_client_for_module("download") as mock_client_cls:
             mock_client = create_mock_client()
 
@@ -672,13 +677,397 @@ class TestDownloadAll:
                 cli, ["download", "audio", "--all", str(output_dir), "-n", "nb_123"]
             )
 
-        # Should still succeed overall (partial download)
-        assert result.exit_code == 0
+        # Loop still attempts every artifact (so the second succeeds), but exit
+        # is non-zero because at least one item failed.
+        assert result.exit_code != 0
         # One file should be downloaded
         downloaded_files = list(output_dir.glob("*.mp3"))
         assert len(downloaded_files) == 1
         # Output should mention failure
         assert "failed" in result.output.lower() or "1" in result.output
+
+
+class TestDownloadAllExitCodeContract:
+    """P1.T4 §1 — `--all` failure exit-code + JSON envelope.
+
+    Contract: ANY per-item failure inside the `--all` loop must produce a
+    non-zero exit code AND a top-level envelope of shape
+    ``{"error": true, "failed_count": N, "succeeded_count": M, "artifacts": [...]}``
+    so automation callers can distinguish partial from total failure without
+    walking every per-item entry.
+    """
+
+    def test_all_fail_exits_nonzero_with_envelope(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """When every artifact fails, exit non-zero with full failure envelope."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+                raise Exception("Network error")
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_1", "First Audio", 1),
+                    make_artifact("audio_2", "Second Audio", 1),
+                ]
+            )
+            mock_client.artifacts.download_audio = mock_download_audio
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--json",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload.get("error") is True
+        assert payload.get("failed_count") == 2
+        assert payload.get("succeeded_count") == 0
+        # Per-item entries preserved under the new "artifacts" key.
+        assert len(payload.get("artifacts", [])) == 2
+        statuses = [a.get("status") for a in payload["artifacts"]]
+        assert statuses.count("failed") == 2
+
+    def test_partial_failure_exits_nonzero_with_envelope(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """When some succeed and some fail, exit non-zero and report both counts."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+            call_count = 0
+
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise Exception("Network error")
+                Path(output_path).write_bytes(b"audio content")
+                return output_path
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_1", "First Audio", 1),
+                    make_artifact("audio_2", "Second Audio", 1),
+                ]
+            )
+            mock_client.artifacts.download_audio = mock_download_audio
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--json",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload.get("error") is True
+        assert payload.get("failed_count") == 1
+        assert payload.get("succeeded_count") == 1
+        assert len(payload.get("artifacts", [])) == 2
+
+    def test_all_success_keeps_zero_exit_and_no_error_key(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """When every artifact succeeds, exit zero and omit the error key."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+                Path(output_path).write_bytes(b"audio content")
+                return output_path
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_1", "First Audio", 1),
+                    make_artifact("audio_2", "Second Audio", 1),
+                ]
+            )
+            mock_client.artifacts.download_audio = mock_download_audio
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--json",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert "error" not in payload
+        assert payload.get("failed_count") == 0
+        assert payload.get("succeeded_count") == 2
+
+
+class TestDownloadAllNameFilter:
+    """P1.T4 §2 — `--all --name <name>` filter applied to the artifact list."""
+
+    def test_name_filter_restricts_downloads(self, runner, mock_auth, mock_fetch_tokens, tmp_path):
+        """`--all --name "Beta"` must download only matching artifacts (substring,
+        case-insensitive), not every artifact in the notebook."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+            downloaded_ids: list[str | None] = []
+
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+                downloaded_ids.append(artifact_id)
+                Path(output_path).write_bytes(b"audio content")
+                return output_path
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_alpha", "Alpha Briefing", 1),
+                    make_artifact("audio_beta1", "Beta Chapter One", 1),
+                    make_artifact("audio_beta2", "Beta Chapter Two", 1),
+                    make_artifact("audio_gamma", "Gamma Recap", 1),
+                ]
+            )
+            mock_client.artifacts.download_audio = mock_download_audio
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--name",
+                    "beta",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert sorted(downloaded_ids) == ["audio_beta1", "audio_beta2"]
+        downloaded_files = list(output_dir.glob("*.mp3"))
+        assert len(downloaded_files) == 2
+
+    def test_name_filter_dry_run_previews_only_matches(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """`--all --name <name> --dry-run` previews only matching artifacts."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_alpha", "Alpha Briefing", 1),
+                    make_artifact("audio_beta1", "Beta Chapter One", 1),
+                    make_artifact("audio_gamma", "Gamma Recap", 1),
+                ]
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--name",
+                    "beta",
+                    "--dry-run",
+                    "--json",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload.get("dry_run") is True
+        assert payload.get("count") == 1
+        assert len(payload.get("artifacts", [])) == 1
+        assert payload["artifacts"][0]["id"] == "audio_beta1"
+
+    def test_name_filter_no_matches_returns_error(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """`--all --name <name>` with no matches: error envelope, non-zero exit."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_alpha", "Alpha Briefing", 1),
+                    make_artifact("audio_gamma", "Gamma Recap", 1),
+                ]
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--name",
+                    "nonexistent",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code != 0
+        # Output should mention the filter that produced no matches
+        assert "nonexistent" in result.output.lower() or "no" in result.output.lower()
+
+
+class TestDownloadAllDryRunFilenameParity:
+    """P1.T4 §3 — dry-run and execution must produce the same final filenames.
+
+    Previously, the dry-run preview passed an empty `existing_names` set to
+    ``artifact_title_to_filename`` for every artifact in the loop, so duplicate
+    titles all collapsed to the same base filename in preview output. The
+    execution path accumulates an ``existing_names`` set across iterations and
+    auto-renames duplicates to ``Title (2).ext``, ``Title (3).ext``, etc.
+    Dry-run must mirror the same disambiguation.
+    """
+
+    def test_dry_run_disambiguates_duplicate_titles(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """Three artifacts with the same title produce three distinct filenames
+        in dry-run output, matching what the execution path would emit."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir = tmp_path / "downloads"
+
+            mock_client.artifacts.list = AsyncMock(
+                return_value=[
+                    make_artifact("audio_1", "Duplicate Title", 1),
+                    make_artifact("audio_2", "Duplicate Title", 1),
+                    make_artifact("audio_3", "Duplicate Title", 1),
+                ]
+            )
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--dry-run",
+                    "--json",
+                    str(output_dir),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload.get("dry_run") is True
+        filenames = [a["filename"] for a in payload["artifacts"]]
+        # All three filenames must be distinct (the second and third get
+        # auto-renamed via (2)/(3) suffixes — same as the execution path).
+        assert len(set(filenames)) == 3
+        assert "Duplicate Title.mp3" in filenames
+        assert "Duplicate Title (2).mp3" in filenames
+        assert "Duplicate Title (3).mp3" in filenames
+
+    def test_dry_run_matches_execution_filenames(
+        self, runner, mock_auth, mock_fetch_tokens, tmp_path
+    ):
+        """The filenames listed in dry-run must be the actual filenames the
+        execution path writes to disk."""
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir_dry = tmp_path / "dry"
+
+            artifacts_payload = [
+                make_artifact("audio_1", "Duplicate Title", 1),
+                make_artifact("audio_2", "Duplicate Title", 1),
+            ]
+
+            mock_client.artifacts.list = AsyncMock(return_value=artifacts_payload)
+            mock_client_cls.return_value = mock_client
+
+            # First: dry-run pass.
+            result_dry = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--dry-run",
+                    "--json",
+                    str(output_dir_dry),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+            assert result_dry.exit_code == 0
+            payload_dry = json.loads(result_dry.output)
+            dry_filenames = sorted(a["filename"] for a in payload_dry["artifacts"])
+
+        # Second: real execution pass (separate patch context — runner resets
+        # the client mock between invocations).
+        with patch_client_for_module("download") as mock_client_cls:
+            mock_client = create_mock_client()
+            output_dir_exec = tmp_path / "exec"
+
+            async def mock_download_audio(notebook_id, output_path, artifact_id=None):
+                Path(output_path).write_bytes(b"audio content")
+                return output_path
+
+            mock_client.artifacts.list = AsyncMock(return_value=artifacts_payload)
+            mock_client.artifacts.download_audio = mock_download_audio
+            mock_client_cls.return_value = mock_client
+
+            result_exec = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "--all",
+                    "--json",
+                    str(output_dir_exec),
+                    "-n",
+                    "nb_123",
+                ],
+            )
+
+        assert result_exec.exit_code == 0
+        payload_exec = json.loads(result_exec.output)
+        exec_filenames = sorted(a["filename"] for a in payload_exec["artifacts"])
+        assert dry_filenames == exec_filenames
 
     def test_download_all_with_no_clobber(self, runner, mock_auth, mock_fetch_tokens, tmp_path):
         """Test --all --no-clobber skips existing files."""


### PR DESCRIPTION
## Summary

Three surgical fixes to `notebooklm download --all` per **P1.T4** of `.sisyphus/plans/cli-audit-fixes.md`:

1. **Bulk failure exit-code** (audit § B) — any per-item failure inside the `--all` loop now propagates to a non-zero exit code. The `--all` JSON envelope carries `{"error": true, "failed_count": N, "succeeded_count": M, "skipped_count": K, "artifacts": [...]}` when `failed_count > 0`. Per-item `{status, ...}` entries preserved under the spec's `artifacts` key (renamed from `results`).
2. **`--all --name <filter>` honored** (single-lens IMPORTANT) — the `--name` flag was silently ignored on the `--all` branch; it now applies the same case-insensitive substring match used by `select_artifact` on the single-artifact path. No-match returns the legacy `{"error": "<msg>"}` shape (free-form, exits 1) — parity with the existing single-artifact name-not-found case.
3. **Dry-run filename parity** (iter-2 MINOR) — filenames are now planned once before the dry-run / execute split so duplicate titles get matching `Title (2).ext`, `Title (3).ext` suffixes in both branches.

## Task body

Verbatim from the plan ([`.sisyphus/plans/cli-audit-fixes.md` § P1.T4](https://github.com/teng-lin/notebooklm-py/blob/main/.sisyphus/plans/cli-audit-fixes.md)):

> 1. Bulk `download --all` failures must propagate to exit code (lines 354, 747). Decision on partial-success semantics: **exit non-zero if ANY artifact download fails** (not just "all fail"). The audit only proved the "all fail" case but partial-failure-with-exit-0 is the same automation-breaking bug. Emit a top-level `{"error": true, "failed_count": N, "succeeded_count": M, "artifacts": [...]}` envelope so callers can distinguish total failure from partial. The current per-artifact `{"status": "failed"}` entries stay so callers can identify which ones.
> 2. `download --all --name` ignores filter (lines 274, 512) — apply `--name` to the artifact list before previewing/downloading in the `download_all` branch.
> 3. Dry-run duplicate filenames (lines 278-295, 300-315) — share the `existing_names` set between dry-run preview and execution.

## Envelope deltas (intentional, called out for reviewers)

| Change | Spec | Choice | Rationale |
|---|---|---|---|
| Per-item key | `artifacts` (in spec) | `artifacts` (renamed from `results`) | Matches spec wording. No test or doc pinned the old key (grep-confirmed). |
| Extra count | only `failed_count` / `succeeded_count` in spec | added `skipped_count` | Symmetry with text-mode renderer's `[downloaded, skipped, failed]` taxonomy; strictly additive and useful for JSON consumers. |
| No-match path | spec only covers post-loop failure | kept legacy `{"error": "<msg>"}` | The typed-counts envelope is meaningful only after the loop ran (per-item entries to count). A pre-loop filter no-match has zero items to report; the free-form envelope is the right shape and still exits 1 via the same key-presence check. |

## Acceptance criteria (from the plan)

- [x] `notebooklm download --all --notebook NB` where every artifact fails → exit ≠ 0.
- [x] `notebooklm download --all --name "foo" --notebook NB` only downloads artifacts whose title matches "foo".
- [x] `notebooklm download --all --dry-run --notebook NB` shows same final filenames as the actual run (for the in-loop duplicate case — on-disk-collision-aware dry-run is out of scope and was already not supported).

## Test plan

- [x] **TDD red-first**: three new test classes added before implementation, confirmed red, then implementation turned them green.
  - `TestDownloadAllExitCodeContract` — all-fail, partial-failure, all-success.
  - `TestDownloadAllNameFilter` — filter restricts, dry-run preview, no-match error.
  - `TestDownloadAllDryRunFilenameParity` — duplicate-title disambiguation, dry-run-matches-execution.
- [x] Existing `test_download_all_with_failures` updated for the new `exit_code != 0` contract (was the bug the audit captured).
- [x] All 72 tests in `tests/unit/cli/test_download.py` pass.
- [x] Full `tests/unit` + `tests/integration` suite passes: **5581 passed, 44 skipped, 0 failed**.
- [x] `ruff format`, `ruff check src/notebooklm/cli`, `mypy src/notebooklm/cli --ignore-missing-imports` all clean.

## Deferred polish findings

- None — the two design notes called out above (`skipped_count` addition, no-match envelope shape) were considered during the polish gate's ultrathink stage and judged intentional.

## Plan / phase context

- Plan: `.sisyphus/plans/cli-audit-fixes.md` § P1.T4
- Phase: Phase 1, Wave 1.A (parallel with P1.T2, P1.T5–T10).
- Blocks: P3.T2 (per the dependency table in the plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `--all --name` filter to correctly apply before filename generation
  * Ensured dry-run previews display identical filenames to actual downloads
  * Improved error handling and exit codes when `--all` downloads encounter failures

* **Improvements**
  * Enhanced JSON output structure with per-artifact status tracking and accurate counts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->