### PR TITLE
fix(cli/session): use --json forwarding + auth check OSError handling

### DIFF
--- a/src/notebooklm/cli/session.py
+++ b/src/notebooklm/cli/session.py
@@ -946,8 +946,13 @@ def register_session_commands(cli):
 
         async def _get():
             async with NotebookLMClient(auth) as client:
-                # Resolve partial ID to full ID
-                resolved_id = await resolve_notebook_id(client, notebook_id)
+                # Resolve partial ID to full ID. Forward ``json_output`` so
+                # the resolver's "Matched: …" partial-ID diagnostic routes
+                # to stderr in --json mode and stdout stays pure parseable
+                # JSON for scripted callers.
+                resolved_id = await resolve_notebook_id(
+                    client, notebook_id, json_output=json_output
+                )
                 nb = await client.notebooks.get(resolved_id)
                 return nb, resolved_id
 
@@ -1421,6 +1426,18 @@ def register_session_commands(cli):
             checks["json_valid"] = True
         except json.JSONDecodeError as e:
             details["error"] = f"Invalid JSON: {e}"
+            _output_auth_check(checks, details, json_output)
+            return
+        except (OSError, UnicodeDecodeError) as e:
+            # ``storage_path.read_text(encoding="utf-8")`` can raise:
+            #   - ``OSError`` subclasses (PermissionError, IsADirectoryError,
+            #     FileNotFoundError if the earlier ``exists()`` race-lost, …)
+            #   - ``UnicodeDecodeError`` if the file exists but isn't valid
+            #     UTF-8 (a corrupted or truncated storage_state.json).
+            # Route both through the same structured renderer so --json
+            # callers get a parseable ``status: "error"`` envelope (with
+            # non-zero exit) instead of a raw Python traceback.
+            details["error"] = f"Storage unreadable: {e}"
             _output_auth_check(checks, details, json_output)
             return
 

--- a/tests/unit/cli/test_auth_subcommands.py
+++ b/tests/unit/cli/test_auth_subcommands.py
@@ -88,6 +88,95 @@ class TestAuthCheckCommand:
         assert output["checks"]["json_valid"] is False
         assert "Invalid JSON" in output["details"]["error"]
 
+    def test_auth_check_unreadable_storage_text_mode(self, runner, mock_storage_path):
+        """`auth check` when storage exists but cannot be read (OSError).
+
+        Regression test for the bug where ``auth check`` caught only
+        ``json.JSONDecodeError``, so an ``OSError`` raised by
+        ``storage_path.read_text(...)`` (e.g. permission denied, or path
+        is a directory) leaked as a raw Python traceback instead of
+        being reported through the structured ``_output_auth_check``
+        renderer.
+
+        Repro: replace the storage file with a directory. Reading a
+        directory as text raises ``IsADirectoryError``, a subclass of
+        ``OSError``.
+
+        Contract: text mode shows the checks table (no traceback) and
+        exits 0 just like the existing invalid-JSON case.
+        """
+        # The fixture yields a path under tmp_path but does not create the
+        # file. Make the path a directory so `read_text` raises
+        # IsADirectoryError instead of FileNotFoundError.
+        if mock_storage_path.exists():
+            mock_storage_path.unlink()
+        mock_storage_path.mkdir()
+
+        result = runner.invoke(cli, ["auth", "check"])
+
+        # No traceback should leak.
+        assert result.exit_code == 0, (
+            f"unexpected traceback / non-zero text-mode exit: "
+            f"stdout={result.output!r} exc={result.exception!r}"
+        )
+        assert result.exception is None or isinstance(result.exception, SystemExit), (
+            f"unhandled exception leaked: {result.exception!r}"
+        )
+        # Structured renderer ran — checks table visible.
+        assert "JSON valid" in result.output
+        assert "fail" in result.output.lower() or "✗" in result.output
+
+    def test_auth_check_unreadable_storage_json_mode(self, runner, mock_storage_path):
+        """`auth check --json` when storage exists but cannot be read (OSError).
+
+        Acceptance criterion (plan P1.T3): "auth check --json with an
+        unreadable storage file emits a structured JSON error (not a
+        raw traceback) and exits non-zero."
+        """
+        if mock_storage_path.exists():
+            mock_storage_path.unlink()
+        mock_storage_path.mkdir()
+
+        result = runner.invoke(cli, ["auth", "check", "--json"])
+
+        # MUST exit non-zero for fail-fast automation.
+        assert result.exit_code != 0, (
+            f"--json mode silently exited 0 on unreadable storage: stdout={result.output!r}"
+        )
+        # Stdout MUST be pure parseable JSON, NOT a Python traceback.
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        # Storage exists (directory does exist), but JSON parsing fails.
+        assert output["checks"]["storage_exists"] is True
+        assert output["checks"]["json_valid"] is False
+        # An error message must be present so callers can log/diagnose.
+        assert output["details"]["error"], f"empty error message on unreadable storage: {output!r}"
+
+    def test_auth_check_non_utf8_storage_json_mode(self, runner, mock_storage_path):
+        """`auth check --json` when storage exists but is not valid UTF-8.
+
+        Same bug class as the OSError leak: ``read_text(encoding="utf-8")``
+        raises ``UnicodeDecodeError`` (a ``ValueError`` subclass, NOT an
+        ``OSError`` subclass) on a binary or corrupted storage file, and
+        the original ``except json.JSONDecodeError`` clause never caught
+        it. Without the broadened handler, the traceback would leak to
+        stderr and stdout would be empty — breaking JSON-parsing callers.
+        """
+        # Write invalid UTF-8 bytes — a 0xff byte at position 0 is never
+        # the start of a valid UTF-8 sequence.
+        mock_storage_path.write_bytes(b"\xff\xfe\xfd not valid utf-8")
+
+        result = runner.invoke(cli, ["auth", "check", "--json"])
+
+        assert result.exit_code != 0, (
+            f"--json mode silently exited 0 on non-UTF-8 storage: stdout={result.output!r}"
+        )
+        output = json.loads(result.output)
+        assert output["status"] == "error"
+        assert output["checks"]["storage_exists"] is True
+        assert output["checks"]["json_valid"] is False
+        assert output["details"]["error"], f"empty error message on non-UTF-8 storage: {output!r}"
+
     def test_auth_check_missing_sid_cookie(self, runner, mock_storage_path):
         """Test auth check when SID cookie is missing."""
         # Valid JSON but no SID cookie

--- a/tests/unit/cli/test_use.py
+++ b/tests/unit/cli/test_use.py
@@ -208,6 +208,71 @@ class TestUseJsonOutput:
         assert data.get("verified") is False
         assert mock_context_file.exists()
 
+    def test_use_json_with_partial_id_keeps_stdout_pure(self, runner, mock_auth, mock_context_file):
+        """`use <partial-id> --json` must NOT print the "Matched: ..." diagnostic to stdout.
+
+        Regression test for the bug where the `use` command called
+        ``resolve_notebook_id(client, notebook_id)`` without forwarding
+        ``json_output``, so the partial-ID-match "Matched: …" diagnostic
+        line went to stdout in JSON mode and broke ``json.loads`` for
+        scripted callers.
+
+        Contract: in `--json` mode, stdout MUST be parseable JSON. The
+        "Matched: …" diagnostic must route to stderr.
+        """
+        full_id = "nb_partial_resolved_full_id"
+        with patch_main_cli_client() as mock_client_cls:
+            mock_client = create_mock_client()
+            # Real resolver path: list() returns the candidates so the
+            # prefix-match branch fires and emits "Matched: …".
+            mock_client.notebooks.list = AsyncMock(
+                return_value=[
+                    Notebook(
+                        id=full_id,
+                        title="Partial Match Notebook",
+                        created_at=datetime(2026, 5, 21),
+                        is_owner=True,
+                    ),
+                ]
+            )
+            mock_client.notebooks.get = AsyncMock(
+                return_value=Notebook(
+                    id=full_id,
+                    title="Partial Match Notebook",
+                    created_at=datetime(2026, 5, 21),
+                    is_owner=True,
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                # NOTE: intentionally do NOT patch resolve_notebook_id —
+                # we want the real partial-ID resolver to run so we can
+                # verify it doesn't pollute stdout with "Matched: …".
+                result = runner.invoke(cli, ["use", "nb_partial", "--json"])
+
+        assert result.exit_code == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        # Hard contract: stdout (what `notebooklm use --json > out.json`
+        # captures) MUST be pure parseable JSON, regardless of what
+        # diagnostics get printed alongside on stderr.
+        data = json.loads(result.stdout)
+        assert data["active_notebook_id"] == full_id
+        assert data["success"] is True
+        # The diagnostic must route to stderr, not stdout.
+        assert "Matched:" not in result.stdout, (
+            f"`use --json` leaked partial-ID diagnostic to stdout: {result.stdout!r}"
+        )
+        # Sanity-check that the diagnostic DID run somewhere (otherwise
+        # this test could silently regress to "resolver didn't emit at
+        # all"). The "Matched: …" line should appear on stderr.
+        assert "Matched:" in result.stderr, (
+            f"resolver diagnostic missing from stderr — test setup may not "
+            f"be exercising the partial-ID match branch: stderr={result.stderr!r}"
+        )
+
 
 class TestUseAuthAwareError:
     """When `notebooklm use <id>` hits an `AuthError` (e.g. expired SID

--- a/tests/unit/cli/test_use.py
+++ b/tests/unit/cli/test_use.py
@@ -6,14 +6,35 @@ helpers live in ``_session_helpers.py``; the proxy-block-aware
 ``patch_session_login_dual`` lives in ``tests/_fixtures``.
 """
 
+import inspect
 import json
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
 
 from notebooklm.notebooklm_cli import cli
 from notebooklm.types import Notebook
 
 from .conftest import create_mock_client, patch_main_cli_client
+
+
+def _split_stream_runner() -> CliRunner:
+    """Return a CliRunner whose stdout and stderr are captured separately.
+
+    The shared ``runner`` fixture in ``conftest.py`` uses ``CliRunner()`` with
+    default settings, which on Click 8.1.x means ``mix_stderr=True`` —
+    ``result.stdout`` then contains a mixed stream and ``result.stderr``
+    raises ``ValueError("stderr not separately captured")``. The
+    ``--json`` purity test needs pure-stdout / pure-stderr access to verify
+    that a diagnostic does not leak into stdout. Click 8.2+ removed
+    ``mix_stderr`` entirely (streams are always separate); 8.1.x supports
+    ``mix_stderr=False``. Detect via ``inspect.signature`` so this is
+    portable across the project's supported Click range (``>=8.0.0,<9``).
+    """
+    if "mix_stderr" in inspect.signature(CliRunner).parameters:
+        return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 class TestUseCommand:
@@ -208,7 +229,7 @@ class TestUseJsonOutput:
         assert data.get("verified") is False
         assert mock_context_file.exists()
 
-    def test_use_json_with_partial_id_keeps_stdout_pure(self, runner, mock_auth, mock_context_file):
+    def test_use_json_with_partial_id_keeps_stdout_pure(self, mock_auth, mock_context_file):
         """`use <partial-id> --json` must NOT print the "Matched: ..." diagnostic to stdout.
 
         Regression test for the bug where the `use` command called
@@ -219,7 +240,14 @@ class TestUseJsonOutput:
 
         Contract: in `--json` mode, stdout MUST be parseable JSON. The
         "Matched: …" diagnostic must route to stderr.
+
+        Uses ``_split_stream_runner()`` instead of the shared ``runner``
+        fixture because the shared one defaults to ``mix_stderr=True`` on
+        Click 8.1.x — that would (a) put the diagnostic into ``stdout``
+        making the bug invisible to this test, and (b) raise on
+        ``result.stderr`` access. Project supports Click ``>=8.0.0,<9``.
         """
+        runner = _split_stream_runner()
         full_id = "nb_partial_resolved_full_id"
         with patch_main_cli_client() as mock_client_cls:
             mock_client = create_mock_client()


### PR DESCRIPTION
## Summary

Two surgical CLI bugs from the [cli-audit](.sisyphus/plans/cli-audit.md), planned as `p1t3-session-surgical` (see [`cli-audit-fixes.md`](.sisyphus/plans/cli-audit-fixes.md) Section P1.T3):

1. **`use --json <partial-id>` leaked diagnostic to stdout.** The partial-ID resolver's `"Matched: ..."` diagnostic was being written to stdout instead of stderr in JSON mode, breaking `json.loads` for scripted callers. Fix: forward `json_output=json_output` to `resolve_notebook_id` so the diagnostic routes to stderr. Every other CLI command already passed this kwarg; `use` was the lone outlier.

2. **`auth check` leaked raw Python traceback on unreadable storage.** The handler caught only `json.JSONDecodeError`, so `read_text(encoding="utf-8")` raising `OSError` (PermissionError, IsADirectoryError, …) or `UnicodeDecodeError` (binary / non-UTF-8 file) crashed without going through the structured `_output_auth_check` renderer. Fix: broaden to `except (OSError, UnicodeDecodeError)` so `--json` callers always get a parseable `{"status": "error", ...}` envelope and non-zero exit.

## Acceptance criteria (from plan)

- [x] `notebooklm use <partial-ID> --json` emits pure JSON on stdout.
- [x] `notebooklm auth check --json` with an unreadable storage file emits a structured JSON error (not a raw traceback) and exits non-zero.

## Test plan

All four new tests are TDD red-first (proven failing against the previous behavior before applying the fix):

- [x] `tests/unit/cli/test_use.py::TestUseJsonOutput::test_use_json_with_partial_id_keeps_stdout_pure` — runs the real (un-mocked) `resolve_notebook_id` and asserts (a) stdout is pure parseable JSON and (b) the `"Matched: ..."` diagnostic appears on stderr.
- [x] `test_auth_check_unreadable_storage_text_mode` — `IsADirectoryError`, asserts no traceback leaked and the structured table renders.
- [x] `test_auth_check_unreadable_storage_json_mode` — same setup, asserts `status: "error"`, exit code non-zero, stdout is parseable JSON.
- [x] `test_auth_check_non_utf8_storage_json_mode` — `UnicodeDecodeError` (binary garbage at byte 0), asserts the same structured envelope.
- [x] Verification gate (clean): `ruff format` + `ruff check src/notebooklm/cli` + `mypy src/notebooklm/cli --ignore-missing-imports` + `pytest tests/unit tests/integration` (5608 passed, 12 skipped, 0 failed).
- [x] Polish ran the full 3-stage gate (code-simplifier + triple review with claude+codex / agy excluded per user-memory feedback-avoid-agy + ultrathink). Codex review caught the `UnicodeDecodeError` half of the bug class, which was folded in with its own regression test.

## Why this is small + complete

Original task scope was 2 surgical fixes. The `UnicodeDecodeError` widening came from the triple-review pass — it is the **same bug class** (storage-file unreadable / unparseable → raw traceback in `--json` mode) and excluding it would have left the bug half-fixed for the next reviewer to file as immediate follow-up. Diff is still surgical: +19 prod, +154 test, 0 opportunistic refactoring.

## Deferred polish findings

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * auth check: now reports unreadable or non‑UTF8 storage as a structured error instead of leaking raw exceptions, with appropriate plain-text and JSON outputs.
  * use (JSON mode): ensures JSON output remains well-formed when resolving partial notebook IDs, keeping diagnostics out of stdout.

* **Tests**
  * Added tests covering unreadable/corrupt storage handling and JSON-output behavior for the use and auth check commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->