### PR TITLE
refactor(session): narrow RpcOwner + _AuthedTransportHost Protocols, add providers (PR 3 of 8)

### DIFF
--- a/src/notebooklm/_authed_transport.py
+++ b/src/notebooklm/_authed_transport.py
@@ -17,7 +17,6 @@ __all__ = [
     "_stream_post_with_size_cap",
 ]
 
-import asyncio
 import logging
 import time
 from collections.abc import Callable
@@ -238,18 +237,22 @@ class _AuthedTransportHost(Protocol):
     those into chain middlewares, and PR 12.9 lifted the RPC
     semaphore + queue-wait recording up to
     :meth:`Session._perform_authed_post` (so the slot wraps the
-    whole chain invocation, not just one HTTP attempt). The Protocol
-    now declares only the members the leaf still touches:
+    whole chain invocation, not just one HTTP attempt).
 
-    - ``_kernel`` (the streaming-POST transport, post-PR #850)
-    - ``_http_client`` (only checked for pre-open ``None``)
-    - ``_bound_loop`` (event-loop affinity guard)
+    Session-shrink PR 3 narrowed the Protocol further: the
+    ``_http_client`` pre-open guard moved to a
+    :meth:`Kernel.get_http_client` call (which raises the historical
+    ``RuntimeError`` when the client is unopened), and the bound-loop
+    affinity check moved UP to :meth:`Session._perform_authed_post` so
+    it fires once per chain invocation (not once per leaf attempt). The
+    Protocol now declares only the members the leaf still touches:
+
+    - ``_kernel`` (concrete-class reference; streaming-POST transport
+      + pre-open guard via ``get_http_client()``)
     - ``_snapshot`` (fresh ``_AuthSnapshot`` per attempt)
     """
 
     _kernel: Kernel
-    _http_client: httpx.AsyncClient | None
-    _bound_loop: asyncio.AbstractEventLoop | None
 
     async def _snapshot(self) -> _AuthSnapshot: ...
 
@@ -301,17 +304,17 @@ class AuthedTransport:
         deadlock — ``asyncio.Semaphore`` is not reentrant.
         """
         host = self._host
-        # Fast-path: reject pre-open calls before loop checks and semaphore acquisition.
-        if host._http_client is None:
-            raise RuntimeError("Client not initialized. Use 'async with' context.")
+        # Pre-open guard: ``Kernel.get_http_client()`` raises the historical
+        # ``RuntimeError("Client not initialized. Use 'async with' context.")``
+        # when the HTTP client hasn't been opened yet. Session-shrink PR 3
+        # routed this through the kernel accessor so the Protocol can drop
+        # ``_http_client`` without losing the early-fail surface.
+        host._kernel.get_http_client()
 
-        # Event-loop affinity guard. Placed before any further awaits so
-        # cross-loop misuse never gets past the boundary.
-        if host._bound_loop is not None and asyncio.get_running_loop() is not host._bound_loop:
-            raise RuntimeError(
-                "NotebookLMClient is bound to a different event loop. "
-                "Each client is per-loop; create a new client in the target loop."
-            )
+        # Event-loop affinity guard moved UP to
+        # :meth:`Session._perform_authed_post` (session-shrink PR 3) so the
+        # check fires once per chain invocation rather than once per leaf
+        # attempt. The leaf no longer reads ``host._bound_loop``.
 
         start = time.perf_counter()
 

--- a/src/notebooklm/_rpc_executor.py
+++ b/src/notebooklm/_rpc_executor.py
@@ -8,10 +8,13 @@ import json
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from typing import Any, NoReturn, Protocol
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol
 from urllib.parse import urlencode
 
 import httpx
+
+if TYPE_CHECKING:
+    from ._kernel import Kernel
 
 from ._authed_transport import (
     _AuthSnapshot,
@@ -52,10 +55,12 @@ class DecodeResponse(Protocol):
 
 
 class RpcOwner(Protocol):
-    _timeout: float
-    _refresh_callback: Callable[[], Awaitable[Any]] | None
-    _refresh_retry_delay: float
-    _http_client: Any
+    # Concrete-class reference (NOT a bridge attribute). Used by
+    # :meth:`RpcExecutor.execute_with_telemetry` for the pre-open guard
+    # via :meth:`Kernel.get_http_client`, which raises the historical
+    # ``RuntimeError("Client not initialized. Use 'async with' context.")``
+    # when the client hasn't been opened yet.
+    _kernel: Kernel
 
     async def _perform_authed_post(
         self,
@@ -107,11 +112,17 @@ class RpcExecutor:
         decode_response_late_bound: DecodeResponse,
         is_auth_error: Callable[[Exception], bool],
         sleep: Callable[[float], Awaitable[Any]],
+        timeout_provider: Callable[[], float],
+        refresh_callback_enabled_provider: Callable[[], bool],
+        refresh_retry_delay_provider: Callable[[], float],
     ):
         self._owner = owner
         self._decode_response = decode_response_late_bound
         self._is_auth_error = is_auth_error
         self._sleep = sleep
+        self._timeout_provider = timeout_provider
+        self._refresh_callback_enabled_provider = refresh_callback_enabled_provider
+        self._refresh_retry_delay_provider = refresh_retry_delay_provider
 
     async def execute_with_telemetry(
         self,
@@ -146,8 +157,13 @@ class RpcExecutor:
         every method default-resolves to ``UNCLASSIFIED`` (silent + no
         behavior change); Wave 2 will populate variant entries.
         """
-        if not self._owner._http_client:
-            raise RuntimeError("Client not initialized. Use 'async with' context.")
+        # Pre-open guard — preserves the historical ``RuntimeError`` surface by
+        # routing through ``Kernel.get_http_client()`` (which raises the same
+        # message when the client hasn't been opened). Going through the
+        # kernel accessor instead of the now-narrowed :class:`RpcOwner`
+        # Protocol attribute keeps the early-fail behavior intact while
+        # removing ``_http_client`` from the Protocol surface.
+        self._owner._kernel.get_http_client()
 
         # Only the outer call mints a request id; the decode-time retry path
         # (``_is_retry=True``) inherits the parent's id so a single
@@ -304,7 +320,7 @@ class RpcExecutor:
             elapsed = time.perf_counter() - start
             if (
                 not _is_retry
-                and self._owner._refresh_callback is not None
+                and self._refresh_callback_enabled_provider()
                 and self._is_auth_error(exc)
             ):
                 refreshed = await self.try_refresh_and_retry(
@@ -410,7 +426,7 @@ class RpcExecutor:
             raise RPCTimeoutError(
                 f"Request timed out calling {method.name}",
                 method_id=method.value,
-                timeout_seconds=self._owner._timeout,
+                timeout_seconds=self._timeout_provider(),
                 original_error=exc,
             ) from exc
 
@@ -447,8 +463,9 @@ class RpcExecutor:
             logger.warning("Token refresh failed: %s", refresh_error)
             raise original_error from refresh_error
 
-        if self._owner._refresh_retry_delay > 0:
-            await self._sleep(self._owner._refresh_retry_delay)
+        refresh_retry_delay = self._refresh_retry_delay_provider()
+        if refresh_retry_delay > 0:
+            await self._sleep(refresh_retry_delay)
 
         logger.info("Token refresh successful, retrying RPC %s", method.name)
         return await self._owner.rpc_call(

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -60,7 +60,28 @@ from .auth import (
 from .types import ClientMetricsSnapshot, RpcTelemetryEvent
 
 if TYPE_CHECKING:
+    from ._authed_transport import _AuthedTransportHost
+    from ._rpc_executor import RpcOwner
     from .types import ConnectionLimits
+
+    def _assert_session_satisfies_protocols(s: "Session") -> None:
+        """Compile-time guard: :class:`Session` MUST satisfy the narrowed
+        :class:`RpcOwner` and :class:`_AuthedTransportHost` Protocols.
+
+        Session-shrink PR 3 narrowed both Protocols by removing
+        ``_timeout``, ``_refresh_callback``, ``_refresh_retry_delay``,
+        ``_http_client``, and ``_bound_loop`` declarations. The compat
+        bridges still exist on :class:`Session` (later PRs retire them);
+        what this assertion guarantees is that the narrowed Protocol
+        shape — only ``_kernel`` + methods for :class:`RpcOwner`, only
+        ``_kernel`` + ``_snapshot()`` for :class:`_AuthedTransportHost` —
+        is satisfied by :class:`Session`. mypy verifies this during
+        ``mypy src/notebooklm``; the function is a no-op at runtime
+        (gated by ``TYPE_CHECKING``).
+        """
+        _owner: RpcOwner = s
+        _host: _AuthedTransportHost = s
+
 
 from .rpc import RPCMethod
 
@@ -373,9 +394,10 @@ class Session:
         #
         # Event-loop affinity guard rationale: the lifecycle captures
         # ``asyncio.get_running_loop()`` in ``_bound_loop`` at ``open()`` time
-        # and the cross-loop check in ``_perform_authed_post`` (via
-        # :class:`AuthedTransport`) does a cheap ``is`` comparison against
-        # it. Each client is per-loop — the asyncio primitives we hold
+        # and the cross-loop check in ``_perform_authed_post`` does a cheap
+        # ``is`` comparison against it. (Session-shrink PR 3 lifted this
+        # check up out of :class:`AuthedTransport` and into
+        # ``Session._perform_authed_post``.) Each client is per-loop — the asyncio primitives we hold
         # (``_reqid_lock``, ``_refresh_lock``, ``_auth_snapshot_lock``,
         # ``_rpc_semaphore``, the ``httpx.AsyncClient``
         # pool, in-flight tasks like ``_refresh_task`` / ``_keepalive_task``)
@@ -530,12 +552,14 @@ class Session:
     # ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``)
     # are preserved here as ``@property`` bridges. The
     # ``_connect_timeout`` / ``_limits`` bridges were dropped in
-    # D1-audit-full (zero external callers). The ``_timeout`` bridge is
-    # retained because ``RpcExecutor`` (``_rpc_executor.py``) reads
-    # ``self._owner._timeout`` via the :class:`RpcOwner` Protocol; removing
-    # it would surface as ``AttributeError`` on every RPC call.
-    # ``Session.__init__`` eager-constructs ``_lifecycle`` (and ``_kernel``),
-    # so the bridges delegate directly without lazy backfill.
+    # D1-audit-full (zero external callers). After session-shrink PR 3
+    # narrowed :class:`RpcOwner` + :class:`_AuthedTransportHost` to drop
+    # these attribute names, the bridges are no longer Protocol-required —
+    # they survive purely to support test monkeypatches that write to
+    # ``core._<bridge>``; later session-shrink PRs (4–6) retire them as
+    # the test readers migrate. ``Session.__init__`` eager-constructs
+    # ``_lifecycle`` (and ``_kernel``), so the bridges delegate directly
+    # without lazy backfill.
     # ------------------------------------------------------------------
 
     @property
@@ -552,9 +576,10 @@ class Session:
 
     @_bound_loop.setter
     def _bound_loop(self, value: asyncio.AbstractEventLoop | None) -> None:
-        # Required by the ``_AuthedTransportHost`` Protocol (declares
-        # ``_bound_loop`` as a settable variable). No external SET sites,
-        # but the Protocol contract demands a settable property.
+        # Retained for test monkeypatch writers (no external SET sites in
+        # prod; bridge demolition is tracked in session-shrink PR 6 once
+        # those tests migrate). Post-PR-3 the ``_AuthedTransportHost``
+        # Protocol no longer declares ``_bound_loop``.
         self._lifecycle._bound_loop = value
 
     @property
@@ -584,11 +609,11 @@ class Session:
 
     @_timeout.setter
     def _timeout(self, value: float) -> None:
-        # Required by ``RpcOwner`` Protocol (``_rpc_executor.py``) which
-        # declares ``_timeout: float`` as a settable variable. Pre-extraction
-        # ``_timeout`` was a plain ivar so attribute assignment worked
-        # implicitly; the property bridge needs an explicit setter to
-        # preserve that contract.
+        # Retained for test monkeypatch writers. Post-PR-3, ``RpcExecutor``
+        # reads via ``self._timeout_provider()`` (which closes over
+        # ``self._lifecycle._timeout`` directly), so ``RpcOwner`` no longer
+        # declares ``_timeout`` and the setter is not Protocol-required —
+        # it survives until the test readers migrate (session-shrink PR 6).
         self._lifecycle._timeout = value
 
     # ``_connect_timeout`` and ``_limits`` compat bridges dropped
@@ -828,6 +853,9 @@ class Session:
                 decode_response_late_bound=_decode_response_late_bound,
                 is_auth_error=_live_is_auth_error,
                 sleep=_sleep_late_bound,
+                timeout_provider=lambda: self._lifecycle._timeout,
+                refresh_callback_enabled_provider=lambda: self._auth_coord.has_refresh_callback,
+                refresh_retry_delay_provider=lambda: self._refresh_retry_delay,
             )
             self._rpc_executor = executor
         return executor
@@ -1057,6 +1085,14 @@ class Session:
         intentionally stay empty until PRs 12.5/12.7/12.8 begin populating
         them as middlewares strip behavior out of :class:`AuthedTransport`.
         """
+        # Event-loop affinity guard. Session-shrink PR 3 lifted this OUT of
+        # ``AuthedTransport.perform_authed_post`` (where it ran once per
+        # leaf attempt) and up to here, so the check fires once per chain
+        # invocation. ``assert_bound_loop`` is a no-op when ``bound_loop``
+        # is ``None`` (pre-open / fresh fixture); it raises only when the
+        # currently-running loop differs from the one captured at
+        # ``open()``-time.
+        self.assert_bound_loop()
         request = RpcRequest(
             url="",
             headers={},

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -421,10 +421,14 @@ def test_no_session_compat_bridges() -> None:
     """Every test file outside ALLOWLIST + CARVE_OUT_MODULES must be clean."""
     failures: list[str] = []
     for path in _collect_test_files():
+<<<<<<< HEAD
         # Use as_posix() so the comparison against ALLOWLIST (forward-slash
         # POSIX paths) is correct on Windows, where ``str(Path)`` produces
         # backslashes that miss every allowlist entry.
         rel = path.relative_to(REPO_ROOT).as_posix()
+=======
+        rel = str(path.relative_to(REPO_ROOT))
+>>>>>>> a2ba837 (chore(session-shrink): doc correction + AST lint scaffolding for bridge retirement)
         if rel in ALLOWLIST or is_carve_out(rel):
             continue
         violations = _scan_file(path)

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -421,14 +421,10 @@ def test_no_session_compat_bridges() -> None:
     """Every test file outside ALLOWLIST + CARVE_OUT_MODULES must be clean."""
     failures: list[str] = []
     for path in _collect_test_files():
-<<<<<<< HEAD
         # Use as_posix() so the comparison against ALLOWLIST (forward-slash
         # POSIX paths) is correct on Windows, where ``str(Path)`` produces
         # backslashes that miss every allowlist entry.
         rel = path.relative_to(REPO_ROOT).as_posix()
-=======
-        rel = str(path.relative_to(REPO_ROOT))
->>>>>>> a2ba837 (chore(session-shrink): doc correction + AST lint scaffolding for bridge retirement)
         if rel in ALLOWLIST or is_carve_out(rel):
             continue
         violations = _scan_file(path)

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -551,6 +551,13 @@ def _build_rpc_executor() -> Any:
         decode_response_late_bound=_decode,
         is_auth_error=_is_auth_error,
         sleep=_sleep,
+        # Session-shrink PR 3: providers replace direct owner-attr reads
+        # for the values that used to live on the :class:`RpcOwner`
+        # Protocol. The ``MagicMock`` owner still holds the legacy ivars,
+        # so each provider just reads through.
+        timeout_provider=lambda: owner._timeout,
+        refresh_callback_enabled_provider=lambda: owner._refresh_callback is not None,
+        refresh_retry_delay_provider=lambda: owner._refresh_retry_delay,
     )
     return executor, owner, captured
 

--- a/tests/unit/test_rpc_executor.py
+++ b/tests/unit/test_rpc_executor.py
@@ -133,6 +133,14 @@ def _executor(
         decode_response_late_bound=decode_response_late_bound or _decode,
         is_auth_error=is_auth_error or (lambda exc: False),
         sleep=sleep or _no_sleep,
+        # Session-shrink PR 3 narrowed :class:`RpcOwner` and added
+        # constructor-time providers for the values that used to be
+        # read off the owner directly. The ``_Owner`` stub still holds
+        # the legacy ivars so individual tests can mutate them — the
+        # providers simply read through to those ivars.
+        timeout_provider=lambda: owner._timeout,
+        refresh_callback_enabled_provider=lambda: owner._refresh_callback is not None,
+        refresh_retry_delay_provider=lambda: owner._refresh_retry_delay,
     )
 
 


### PR DESCRIPTION
## Summary

**PR 3 of 8** in the session-shrink arc. **Stacked on PR #914 (PR 1 — fixture migration)**, which is itself stacked on PR #913 (PR 0). The architectural change that unblocks PR 5 + PR 6.

### Protocol narrowing
- `RpcOwner` (`_rpc_executor.py`): dropped `_timeout`, `_refresh_callback`, `_refresh_retry_delay`, `_http_client`. Added `_kernel: Kernel` for the pre-open guard.
- `_AuthedTransportHost` (`_authed_transport.py`): dropped `_http_client`, `_bound_loop`. Kept `_kernel`, `_snapshot()`.

### Constructor-time providers in `RpcExecutor`
3 new kwargs (`timeout_provider`, `refresh_callback_enabled_provider`, `refresh_retry_delay_provider`) mirroring the existing `MiddlewareChainBuilder` provider pattern. The 4 ivar read sites in `_rpc_executor.py` are routed through providers. Pre-open guard preserved via `self._owner._kernel.get_http_client()` (identical RuntimeError surface).

### Bound-loop affinity check lifted
- `AuthedTransport.perform_authed_post` no longer carries the cross-loop check.
- `Session._perform_authed_post` now invokes `self.assert_bound_loop()` at the top of the method body, before request construction or middleware invocation. Runs once per chain invocation (was once per leaf attempt under `RetryMiddleware`); equivalent because a coroutine cannot change loops mid-execution.

### TYPE_CHECKING Protocol-satisfaction assertion
Added to `src/notebooklm/_session.py:62-83`:
```python
if TYPE_CHECKING:
    from ._authed_transport import _AuthedTransportHost
    from ._rpc_executor import RpcOwner

    def _assert_session_satisfies_protocols(s: "Session") -> None:
        _owner: RpcOwner = s
        _host: _AuthedTransportHost = s
```
Lives in `src/` (not `tests/`) because the canonical mypy invocation doesn't type-check `tests/`. Zero runtime cost.

**Verified the guard has teeth**: temporarily injected a bogus attribute into `RpcOwner` during review → mypy immediately flagged both the inline annotation and the `RpcExecutor(self, ...)` call site.

### Test fixture updates
- `tests/unit/test_rpc_executor.py::_executor` and `tests/unit/test_idempotency_registry.py::_build_rpc_executor` — add 3 provider lambdas reading from the unchanged `_Owner` ivars. Underlying owner mocks unchanged.

## Test plan
- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy src/notebooklm --ignore-missing-imports` — clean (139 source files; Protocol-satisfaction assertion enforced)
- [x] `uv run pytest tests/_lint/test_no_session_compat_bridges.py -v` — 18/18 passed
- [x] `uv run pytest tests/unit -q` — 4883 passed, 44 skipped
- [x] `uv run pytest tests/integration -q` — 676 passed, 5 skipped

## Polish history

- **Stage 4.1 (code-simplifier)**: 1 fix applied — cached `_refresh_retry_delay_provider()` result in `try_refresh_and_retry` (single provider call per retry).
- **Stage 4.2 (claude + codex review, agy excluded)** — both **APPROVE**:
  - Claude reviewer verified the Protocol-satisfaction guard has teeth (injected bogus attr → mypy caught it).
  - Both flagged stale-comment rationale in 4 places (in-scope) → applied.
  - 1 cross-file finding (`test_session_lifecycle.py:438,460` and `test_logging_correlation.py:262` stale docstrings) → deferred to PR 7.
- **Stage 4.3 (ultrathink)**: no additional findings.

## Deferred (to PR 7 sweep)
- `tests/unit/test_session_lifecycle.py:438,460` — stale "guard lives in `AuthedTransport`" docstrings (file not in PR 3 diff).
- `tests/unit/test_logging_correlation.py:262` — stale "`_owner._http_client` guard" comment (file is from PR 1).

## Known
- Branch is behind PR #913's most recent commit (`4de9e70` — Windows path-separator fix). Will inherit when PR 0 merges and this branch rebases. PR 3's own Windows CI may show the same pre-fix failure pattern until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to transport and RPC execution architecture, enhancing code maintainability and dependency management patterns while maintaining existing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->