### PR TITLE
fix(cli/resolve): UUID-shape check instead of length-based fast-path

### DIFF
--- a/src/notebooklm/cli/download_helpers.py
+++ b/src/notebooklm/cli/download_helpers.py
@@ -3,6 +3,8 @@
 import re
 from typing import TypedDict
 
+from .resolve import FULL_ID_PATTERN
+
 # Reserve space for " (999)" suffix when handling duplicate filenames
 DUPLICATE_SUFFIX_RESERVE = 7
 
@@ -18,8 +20,11 @@ class ArtifactDict(TypedDict):
 def resolve_partial_artifact_id(artifacts: list[ArtifactDict], artifact_id: str) -> str:
     """Resolve a partial artifact ID to a full ID.
 
-    Full IDs (20+ chars) are returned as-is. Shorter IDs are matched as
-    case-insensitive prefixes against the artifact list.
+    Full UUID-shaped IDs (canonical 8-4-4-4-12 hex layout, case-insensitive —
+    see :data:`notebooklm.cli.resolve.FULL_ID_PATTERN`) are returned as-is.
+    Anything else — including a 25-char prefix of a 36-char UUID — is matched
+    as a case-insensitive prefix against the artifact list, so unique prefixes
+    resolve locally rather than reaching the backend as truncated IDs.
 
     Args:
         artifacts: Pre-fetched list of artifacts to search.
@@ -31,7 +36,7 @@ def resolve_partial_artifact_id(artifacts: list[ArtifactDict], artifact_id: str)
     Raises:
         ValueError: If no match found or prefix is ambiguous.
     """
-    if len(artifact_id) >= 20:
+    if FULL_ID_PATTERN.fullmatch(artifact_id):
         return artifact_id
 
     matches = [a for a in artifacts if a["id"].lower().startswith(artifact_id.lower())]

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -17,7 +18,23 @@ from . import rendering as rendering_helpers
 
 ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
-_FULL_ID_MIN_LEN = 20
+
+# Backend entity IDs are canonical UUIDs in the RFC 4122 8-4-4-4-12 hex layout
+# (e.g. ``abc12345-6789-4abc-def0-1234567890ab``). Anything shorter — even a
+# unique 25-char prefix — must go through the local list-and-match path, or it
+# will reach the backend as a truncated ID and 404. The character classes are
+# both upper- and lower-case hex so mixed-case IDs returned by the backend keep
+# fast-pathing. Exposed publicly so `download_helpers.py` shares the same shape
+# rule; the two call sites stay in lockstep until P2.T1 consolidates them.
+#
+# Tightened past the plan's `^[0-9a-fA-F-]{36}$` to the exact 8-4-4-4-12 dash
+# layout so degenerate-but-length-36 inputs (`"-" * 36`, 36 unbroken hex chars,
+# wrong dash placement) cannot bypass local resolution — the looser pattern's
+# false-positives would still 404 against the backend, but rejecting them
+# locally gives the user a clearer error and keeps the contract honest.
+FULL_ID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 
 def validate_id(entity_id: str, entity_name: str = "ID") -> str:
@@ -40,8 +57,15 @@ def validate_id(entity_id: str, entity_name: str = "ID") -> str:
 
 
 def _is_full_id_candidate(entity_id: str) -> bool:
-    """Return whether an ID is long enough to be treated as concrete."""
-    return len(entity_id) >= _FULL_ID_MIN_LEN
+    """Return whether ``entity_id`` is shaped like a concrete backend UUID.
+
+    Only canonical 36-char hex-and-dash strings (case-insensitive) qualify for
+    the fast-path. A 25-char prefix of a 36-char UUID — which is unique enough
+    to be human-pasted — must still go through the local list-and-match path so
+    it can be expanded to the full ID before any backend call. See
+    :data:`FULL_ID_PATTERN`.
+    """
+    return FULL_ID_PATTERN.fullmatch(entity_id) is not None
 
 
 def require_notebook(

--- a/tests/unit/cli/test_artifact.py
+++ b/tests/unit/cli/test_artifact.py
@@ -353,8 +353,10 @@ class TestArtifactGet:
     # -------------------------------------------------------------------------
 
     def test_artifact_get_not_found_pathA_long_id_text_exits_1(self, runner, mock_auth):
-        """Path A: ID ≥20 chars skips partial-resolve; backend None → exit 1."""
-        long_id = "a" * 24
+        """Path A: UUID-shaped ID skips partial-resolve; backend None → exit 1."""
+        # Canonical 36-char UUID — qualifies for the resolver's full-ID fast-path
+        # so artifacts.list is bypassed and the backend ``get`` is hit directly.
+        long_id = "abc12345-6789-4abc-def0-1234567890ab"
         with patch_client_for_module("artifact") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.list = AsyncMock(return_value=[])
@@ -373,7 +375,7 @@ class TestArtifactGet:
 
     def test_artifact_get_not_found_pathA_long_id_json_exits_1(self, runner, mock_auth):
         """Path A under ``--json``: typed JSON error doc + exit 1."""
-        long_id = "a" * 24
+        long_id = "abc12345-6789-4abc-def0-1234567890ab"
         with patch_client_for_module("artifact") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.list = AsyncMock(return_value=[])

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -274,8 +274,10 @@ class TestNoteGet:
     # -------------------------------------------------------------------------
 
     def test_note_get_not_found_pathA_long_id_text_exits_1(self, runner, mock_auth):
-        """Path A: ID ≥20 chars skips partial-resolve; backend None → exit 1."""
-        long_id = "a" * 24
+        """Path A: UUID-shaped ID skips partial-resolve; backend None → exit 1."""
+        # Canonical 36-char UUID — matches the resolver's full-ID fast-path so
+        # notes.list is bypassed and the backend ``get`` is hit directly.
+        long_id = "abc12345-6789-4abc-def0-1234567890ab"
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[])
@@ -294,7 +296,7 @@ class TestNoteGet:
 
     def test_note_get_not_found_pathA_long_id_json_exits_1(self, runner, mock_auth):
         """Path A under ``--json``: typed JSON error doc + exit 1."""
-        long_id = "a" * 24
+        long_id = "abc12345-6789-4abc-def0-1234567890ab"
         with patch_client_for_module("note") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.notes.list = AsyncMock(return_value=[])

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -327,7 +327,7 @@ class TestResolveNotebookId:
 
     @pytest.mark.asyncio
     async def test_exact_short_id_no_message(self, mock_client, sample_notebooks):
-        """Exact match with short ID (< 20 chars) doesn't print match message."""
+        """Exact match with a non-UUID ID returns without printing a match message."""
         mock_client.notebooks.list = AsyncMock(return_value=sample_notebooks)
 
         # Create a notebook with a short ID that we'll match exactly

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -118,15 +118,180 @@ class TestResolveNotebookId:
         assert "notebooklm list" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_long_id_returns_without_listing(self, mock_client):
-        """Long IDs are treated as concrete IDs and do not list notebooks."""
-        long_id = "a" * 20
+    async def test_uuid_shaped_id_returns_without_listing(self, mock_client):
+        """36-char UUID-shaped IDs fast-path without hitting the backend."""
+        # Canonical 8-4-4-4-12 UUID layout — 36 chars, all hex + dashes.
+        uuid_id = "abc12345-6789-4abc-def0-1234567890ab"
+        assert len(uuid_id) == 36
         mock_client.notebooks.list = AsyncMock()
 
-        result = await resolve_notebook_id(mock_client, long_id)
+        result = await resolve_notebook_id(mock_client, uuid_id)
 
-        assert result == long_id
+        assert result == uuid_id
         mock_client.notebooks.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_uuid_shaped_id_mixed_case_returns_without_listing(self, mock_client):
+        """Mixed-case 36-char UUID-shaped IDs also fast-path."""
+        uuid_id = "ABC12345-6789-4ABC-Def0-1234567890aB"
+        assert len(uuid_id) == 36
+        mock_client.notebooks.list = AsyncMock()
+
+        result = await resolve_notebook_id(mock_client, uuid_id)
+
+        assert result == uuid_id
+        mock_client.notebooks.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_25_char_prefix_of_uuid_resolves_via_local_matching(self, mock_client):
+        """A 25-char prefix of a 36-char UUID resolves locally, not via the backend.
+
+        Regression for P1.T9: the previous length-based fast-path (>= 20 chars)
+        bypassed local matching for any 20–35 char prefix of a UUID, sending the
+        truncated string straight to the backend. Per the acceptance criteria,
+        this path must also emit the ``Matched:`` diagnostic so users can see
+        which full ID the prefix resolved to.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        partial_25 = full_uuid[:25]  # "abc12345-6789-4abc-def0-1"
+        assert len(partial_25) == 25
+        assert len(full_uuid) == 36
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[
+                Notebook(
+                    id=full_uuid,
+                    title="UUID Notebook",
+                    created_at=datetime(2024, 1, 1),
+                    is_owner=True,
+                ),
+            ]
+        )
+        mock_console = MagicMock()
+
+        result = await resolve_notebook_id(mock_client, partial_25, stdout_console=mock_console)
+
+        assert result == full_uuid
+        # Local matching MUST have happened, i.e. the backend was listed.
+        mock_client.notebooks.list.assert_awaited_once()
+        # And the "Matched: ..." diagnostic from the acceptance criteria must fire.
+        mock_console.print.assert_called_once()
+        printed = mock_console.print.call_args.args[0]
+        assert "Matched" in printed
+
+    @pytest.mark.asyncio
+    async def test_36_char_non_hex_string_is_not_fast_pathed(self, mock_client):
+        """A 36-char string containing non-hex characters does NOT fast-path.
+
+        Only UUID-shaped strings (hex digits + dashes, 36 chars, 8-4-4-4-12 layout)
+        qualify; a 36-char string with letters outside ``[0-9a-fA-F]`` must go
+        through the local prefix-matching path so a typo cannot reach the backend
+        as a malformed ID.
+        """
+        # 36 chars, 8-4-4-4-12 dash layout, but includes 'z' (non-hex). The
+        # matching notebook in the list confirms local resolution succeeded.
+        non_hex_36 = "zzz12345-6789-4zzz-zzz0-1234567890ab"
+        assert len(non_hex_36) == 36
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[
+                Notebook(
+                    id=non_hex_36,
+                    title="Non-hex 36-char ID",
+                    created_at=datetime(2024, 1, 1),
+                    is_owner=True,
+                ),
+            ]
+        )
+
+        result = await resolve_notebook_id(mock_client, non_hex_36, stdout_console=MagicMock())
+
+        assert result == non_hex_36
+        # Backend listing MUST have happened (no fast-path).
+        mock_client.notebooks.list.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_36_char_all_dashes_is_not_fast_pathed(self, mock_client):
+        """Degenerate 36-char input (all dashes) does NOT fast-path.
+
+        The 8-4-4-4-12 layout requires hex digits in each block, so a pathological
+        ``"-" * 36`` input cannot bypass local resolution — it gets routed through
+        the local prefix-match path and surfaces a clear "no match" error.
+        """
+        all_dashes = "-" * 36
+        assert len(all_dashes) == 36
+        mock_client.notebooks.list = AsyncMock(return_value=[])
+
+        with pytest.raises(click.ClickException) as exc_info:
+            await resolve_notebook_id(mock_client, all_dashes)
+
+        assert "No notebook found" in str(exc_info.value)
+        # Backend listing MUST have happened (no fast-path).
+        mock_client.notebooks.list.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_35_char_uuid_shaped_is_not_fast_pathed(self, mock_client):
+        """A 35-char string (one short of a UUID) does NOT fast-path.
+
+        Boundary check: the regex requires exactly 36 chars in the 8-4-4-4-12
+        layout. A 35-char input must take the local list-and-match path.
+        """
+        # Drop the last char of a canonical UUID -> 35 chars, still hex+dash but
+        # with a 11-digit final block instead of 12.
+        short_uuid = "abc12345-6789-4abc-def0-1234567890a"
+        assert len(short_uuid) == 35
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        mock_client.notebooks.list = AsyncMock(
+            return_value=[
+                Notebook(
+                    id=full_uuid,
+                    title="UUID Notebook",
+                    created_at=datetime(2024, 1, 1),
+                    is_owner=True,
+                ),
+            ]
+        )
+
+        result = await resolve_notebook_id(mock_client, short_uuid, stdout_console=MagicMock())
+
+        assert result == full_uuid
+        mock_client.notebooks.list.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_37_char_uuid_shaped_is_not_fast_pathed(self, mock_client):
+        """A 37-char string (one over a UUID) does NOT fast-path.
+
+        Boundary check on the other side: any extra character past the canonical
+        36 fails the regex and forces the local path. With no match in the list,
+        the resolver raises a clear "no match" error.
+        """
+        long_uuid = "abc12345-6789-4abc-def0-1234567890abc"
+        assert len(long_uuid) == 37
+        mock_client.notebooks.list = AsyncMock(return_value=[])
+
+        with pytest.raises(click.ClickException) as exc_info:
+            await resolve_notebook_id(mock_client, long_uuid)
+
+        assert "No notebook found" in str(exc_info.value)
+        mock_client.notebooks.list.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_36_char_wrong_dash_placement_is_not_fast_pathed(self, mock_client):
+        """36-char hex+dash with wrong dash placement does NOT fast-path.
+
+        The tightened regex enforces the exact 8-4-4-4-12 layout, so a 36-char
+        string with the right character classes but the wrong layout (e.g. dashes
+        slipped one position over) must go through local resolution.
+        """
+        # Same 32 hex chars as a canonical UUID, but dashes shifted one position
+        # (9-3-4-4-12 instead of 8-4-4-4-12). Total length still 36.
+        wrong_layout = "abc123456-789-4abc-def0-1234567890ab"
+        assert len(wrong_layout) == 36
+        mock_client.notebooks.list = AsyncMock(return_value=[])
+
+        with pytest.raises(click.ClickException) as exc_info:
+            await resolve_notebook_id(mock_client, wrong_layout)
+
+        assert "No notebook found" in str(exc_info.value)
+        mock_client.notebooks.list.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_empty_id_raises_exception(self, mock_client):
@@ -322,15 +487,38 @@ class TestResolveSourceId:
         assert "notebooklm source list" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_long_id_returns_without_listing(self, mock_client_with_sources):
-        """Long IDs are treated as concrete IDs and do not list sources."""
-        long_id = "a" * 20
+    async def test_uuid_shaped_id_returns_without_listing(self, mock_client_with_sources):
+        """36-char UUID-shaped IDs fast-path without hitting the backend."""
+        uuid_id = "abc12345-6789-4abc-def0-1234567890ab"
+        assert len(uuid_id) == 36
         mock_client_with_sources.sources.list = AsyncMock()
 
-        result = await resolve_source_id(mock_client_with_sources, "nb_123", long_id)
+        result = await resolve_source_id(mock_client_with_sources, "nb_123", uuid_id)
 
-        assert result == long_id
+        assert result == uuid_id
         mock_client_with_sources.sources.list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_25_char_prefix_of_uuid_resolves_via_local_matching(
+        self, mock_client_with_sources
+    ):
+        """A 25-char prefix of a 36-char UUID resolves locally for sources too."""
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        partial_25 = full_uuid[:25]
+        assert len(partial_25) == 25
+        mock_client_with_sources.sources.list = AsyncMock(
+            return_value=[Source(id=full_uuid, title="UUID Source")]
+        )
+
+        result = await resolve_source_id(
+            mock_client_with_sources,
+            "nb_123",
+            partial_25,
+            stdout_console=MagicMock(),
+        )
+
+        assert result == full_uuid
+        mock_client_with_sources.sources.list.assert_awaited_once_with("nb_123")
 
     @pytest.mark.asyncio
     async def test_empty_id_raises_exception(self, mock_client_with_sources):
@@ -437,16 +625,18 @@ class TestResolveSourceIds:
 
     @pytest.mark.asyncio
     async def test_full_ids_skip_source_list(self, mock_client_with_sources):
-        """Full source IDs pass through without a source list call."""
+        """Full UUID-shaped source IDs pass through without a source list call."""
         mock_client_with_sources.sources.list = AsyncMock()
 
+        uuid_a = "abc12345-6789-4abc-def0-1234567890ab"
+        uuid_b = "fedcba98-7654-4321-0fed-cba987654321"
         result = await resolve_source_ids(
             mock_client_with_sources,
             "nb_123",
-            ("src123def456ghi78900", "xyz789uvw456rst12300"),
+            (uuid_a, uuid_b),
         )
 
-        assert result == ["src123def456ghi78900", "xyz789uvw456rst12300"]
+        assert result == [uuid_a, uuid_b]
         mock_client_with_sources.sources.list.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit/cli/test_source.py
+++ b/tests/unit/cli/test_source.py
@@ -529,21 +529,25 @@ class TestSourceGet:
     # get-on-not-found now exits 1 (was 0). The tests below
     # cover BOTH code paths for the not-found branch:
     #
-    #   * Path A: input ID is ≥20 chars, so ``_resolve_partial_id`` skips the
-    #     list() round-trip (helpers.py:783-785) and returns the input as-is.
-    #     The backend ``client.sources.get`` then returns ``None``.
-    #   * Path B: input ID is <20 chars, ``_resolve_partial_id`` resolves it via
-    #     a list() match (so the partial-resolve "not found" ClickException
-    #     branch is intentionally NOT exercised here — that path is unchanged
-    #     and tested by ``test_source_get_not_found`` above), but the backend
-    #     get returns ``None`` (e.g. concurrent delete from another session).
+    #   * Path A: input ID matches ``FULL_ID_PATTERN`` (canonical 36-char UUID
+    #     in 8-4-4-4-12 layout), so ``_resolve_partial_id`` skips the list()
+    #     round-trip and returns the input as-is. The backend
+    #     ``client.sources.get`` then returns ``None``.
+    #   * Path B: input ID is NOT UUID-shaped, ``_resolve_partial_id`` resolves
+    #     it via a list() match (so the partial-resolve "not found"
+    #     ClickException branch is intentionally NOT exercised here — that
+    #     path is unchanged and tested by ``test_source_get_not_found``
+    #     above), but the backend get returns ``None`` (e.g. concurrent
+    #     delete from another session).
     #
     # Each path is exercised in text and ``--json`` mode.
     # -------------------------------------------------------------------------
 
     def test_source_get_not_found_pathA_long_id_text_exits_1(self, runner, mock_auth):
-        """Path A: ID ≥20 chars skips partial-resolve; backend None → exit 1."""
-        long_id = "a" * 24  # ≥20 chars triggers the skip in _resolve_partial_id
+        """Path A: UUID-shaped ID skips partial-resolve; backend None → exit 1."""
+        # Canonical 36-char UUID — matches the resolver's full-ID fast-path so
+        # sources.list is bypassed and the backend ``get`` is hit directly.
+        long_id = "abc12345-6789-4abc-def0-1234567890ab"
         with patch_client_for_module("source") as mock_client_cls:
             mock_client = create_mock_client()
             # list() must NOT be called on this path; assert below.
@@ -563,7 +567,7 @@ class TestSourceGet:
 
     def test_source_get_not_found_pathA_long_id_json_exits_1(self, runner, mock_auth):
         """Path A under ``--json``: typed JSON error doc + exit 1."""
-        long_id = "a" * 24
+        long_id = "abc12345-6789-4abc-def0-1234567890ab"
         with patch_client_for_module("source") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.sources.list = AsyncMock(return_value=[])

--- a/tests/unit/test_download_helpers.py
+++ b/tests/unit/test_download_helpers.py
@@ -133,13 +133,85 @@ class TestSelectArtifact:
 
 
 class TestResolvePartialArtifactId:
-    def test_full_id_returned_unchanged(self):
-        """Full IDs (20+ chars) should bypass prefix search and return as-is."""
-        artifacts = [{"id": "abcdefghij1234567890", "title": "A", "created_at": 1000}]
+    def test_full_uuid_returned_unchanged(self):
+        """36-char UUID-shaped IDs should bypass prefix search and return as-is."""
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        assert len(full_uuid) == 36
+        artifacts = [{"id": full_uuid, "title": "A", "created_at": 1000}]
 
-        result = resolve_partial_artifact_id(artifacts, "abcdefghij1234567890")
+        result = resolve_partial_artifact_id(artifacts, full_uuid)
 
-        assert result == "abcdefghij1234567890"
+        assert result == full_uuid
+
+    def test_full_uuid_mixed_case_returned_unchanged(self):
+        """Mixed-case 36-char UUID-shaped IDs should also fast-path."""
+        full_uuid = "ABC12345-6789-4ABC-Def0-1234567890aB"
+        assert len(full_uuid) == 36
+        artifacts = [{"id": full_uuid, "title": "A", "created_at": 1000}]
+
+        result = resolve_partial_artifact_id(artifacts, full_uuid)
+
+        assert result == full_uuid
+
+    def test_25_char_prefix_of_uuid_resolves_via_local_matching(self):
+        """A 25-char prefix of a 36-char UUID must resolve via local prefix matching.
+
+        Regression for P1.T9: the previous length-based fast-path (>= 20 chars)
+        treated any 20–35 char prefix of a UUID as a full ID and returned it
+        verbatim, which downstream would 404 against the backend.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        partial_25 = full_uuid[:25]
+        assert len(partial_25) == 25
+        artifacts = [{"id": full_uuid, "title": "A", "created_at": 1000}]
+
+        result = resolve_partial_artifact_id(artifacts, partial_25)
+
+        assert result == full_uuid
+
+    def test_36_char_non_hex_string_is_not_fast_pathed(self):
+        """A 36-char string containing non-hex characters does NOT fast-path.
+
+        It must go through local prefix matching, where it will either find a
+        unique match or raise an error — not be returned verbatim to the caller.
+        """
+        non_hex_36 = "zzz12345-6789-4zzz-zzz0-1234567890ab"
+        assert len(non_hex_36) == 36
+        # No artifact with this exact ID exists, so local matching should fail
+        # with a "not found" error — proving the input was NOT fast-pathed.
+        artifacts = [{"id": "abc12345-6789-4abc-def0-1234567890ab", "title": "A", "created_at": 1}]
+
+        with pytest.raises(ValueError, match="not found"):
+            resolve_partial_artifact_id(artifacts, non_hex_36)
+
+    def test_36_char_all_dashes_is_not_fast_pathed(self):
+        """Degenerate 36-char input (all dashes) does NOT fast-path."""
+        all_dashes = "-" * 36
+        assert len(all_dashes) == 36
+        artifacts = [{"id": "abc12345-6789-4abc-def0-1234567890ab", "title": "A", "created_at": 1}]
+
+        with pytest.raises(ValueError, match="not found"):
+            resolve_partial_artifact_id(artifacts, all_dashes)
+
+    def test_35_char_uuid_shaped_is_not_fast_pathed(self):
+        """A 35-char string (one short of a UUID) is NOT fast-pathed."""
+        short_uuid = "abc12345-6789-4abc-def0-1234567890a"
+        assert len(short_uuid) == 35
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        artifacts = [{"id": full_uuid, "title": "A", "created_at": 1}]
+
+        result = resolve_partial_artifact_id(artifacts, short_uuid)
+
+        assert result == full_uuid
+
+    def test_37_char_uuid_shaped_is_not_fast_pathed(self):
+        """A 37-char string (one over a UUID) is NOT fast-pathed."""
+        long_uuid = "abc12345-6789-4abc-def0-1234567890abc"
+        assert len(long_uuid) == 37
+        artifacts = [{"id": "abc12345-6789-4abc-def0-1234567890ab", "title": "A", "created_at": 1}]
+
+        with pytest.raises(ValueError, match="not found"):
+            resolve_partial_artifact_id(artifacts, long_uuid)
 
     def test_partial_id_resolves_to_full(self):
         """Partial prefix should resolve to the matching full ID."""


### PR DESCRIPTION
## Summary

- Replaces the length-based (`>= 20`) full-ID fast-path in `cli/resolve.py` and `cli/download_helpers.py` with a UUID-shape regex check, so a 25-char prefix of a 36-char backend ID resolves locally via list-and-match instead of 404'ing against the backend.
- Both modules now share `FULL_ID_PATTERN` from `cli/resolve.py` (single source of truth; `download_helpers.py` imports it). Keeps the call sites in lockstep until P2.T1 consolidates them.
- Tightened past the plan's `^[0-9a-fA-F-]{36}$` to the exact RFC 4122 8-4-4-4-12 layout so degenerate length-36 inputs (`"-"*36`, 36 unbroken hex chars, wrong dash placement) are rejected locally with a clear error rather than bouncing off the backend. Rationale documented in the `FULL_ID_PATTERN` docstring.

## Task

`P1.T9` from [`.sisyphus/plans/cli-audit-fixes.md`](.sisyphus/plans/cli-audit-fixes.md), Wave 1.A. Commit message matches the plan's prescribed message.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check src/notebooklm/cli` — clean
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` — clean (38 source files)
- [x] `uv run pytest tests/unit tests/integration` — 5582 passed, 49 skipped, 0 failed

### New tests

In `tests/unit/cli/test_resolve.py` (notebook + source variants):
- `test_uuid_shaped_id_returns_without_listing` — 36-char UUID fast-paths, `list()` not called
- `test_uuid_shaped_id_mixed_case_returns_without_listing` — mixed-case UUID fast-paths
- `test_25_char_prefix_of_uuid_resolves_via_local_matching` — the regression: a 25-char prefix is now resolved locally and emits the `Matched:` diagnostic
- `test_36_char_non_hex_string_is_not_fast_pathed` — 36-char with non-hex chars routes through list-and-match
- `test_36_char_all_dashes_is_not_fast_pathed` — degenerate `"-" * 36` rejected by the tightened layout
- `test_35_char_uuid_shaped_is_not_fast_pathed`, `test_37_char_uuid_shaped_is_not_fast_pathed` — length boundary
- `test_36_char_wrong_dash_placement_is_not_fast_pathed` — same chars, wrong layout rejected

Equivalent suite in `tests/unit/test_download_helpers.py`.

### Updated tests

Six `"pathA_long_id"` Get-not-found tests in `tests/unit/cli/test_artifact.py`, `test_note.py`, and `test_source.py` switched from `"a" * 24` to a canonical UUID. They still assert the same logical contract: UUID-shaped ID skips `list()`, backend `get()` returns None, command exits 1 with `"X not found"`.

## Polish

- **Code-simplifier**: 0 findings. The shared `FULL_ID_PATTERN` constant already DRYs both call sites.
- **Triple review** (claude + codex; **agy `not_requested`** per user-memory `feedback_avoid_agy` — agy goes off-script): 0 critical, 2 important (regex permissiveness + edge-coverage gap — both APPLIED), 2 nits (1 applied: stale "≥20 chars" comment in `test_source.py`; 1 deferred to P2.T1: extracting a shared ID-util module).
- **Ultrathink**: added `test_36_char_wrong_dash_placement_is_not_fast_pathed` for the wrong-layout boundary. No other findings.

## Deferred polish findings

- **NIT** (codex, deferred to P2.T1): "Longer term, a tiny shared ID utility/pattern module would keep `download_helpers` from importing the full resolver dependency surface." This is exactly what `P2.T1 — Consolidate notebook + partial-ID resolver into single canonical implementation` already covers, so it stays deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)