### PR TITLE
fix(cli/services/artifact_generation): unify exit-code across text/JSON modes on failure

### DIFF
--- a/src/notebooklm/cli/error_handler.py
+++ b/src/notebooklm/cli/error_handler.py
@@ -44,6 +44,15 @@ def _output_error(
         exit_code: Exit code to use
         extra: Additional fields to include in JSON output
         hint: Additional hint to show in text mode
+
+    Note:
+        Also exported as the public alias :func:`output_error`. The leading
+        underscore name pre-dates the public-CLI-boundary contract enforced by
+        ``tests/unit/test_cli_boundary.py``; sibling ``cli/*`` modules may
+        import the private name directly (intra-package, level-1 relative
+        import), but ``cli/services/*`` and any other layer that crosses up
+        through ``..error_handler`` must use the public alias to stay on the
+        public side of that contract.
     """
     if json_output:
         response: dict = {"error": True, "code": code, "message": message}
@@ -55,6 +64,13 @@ def _output_error(
         if hint:
             safe_echo(hint, err=True)
     raise SystemExit(exit_code)
+
+
+#: Public alias for :func:`_output_error` — see the function docstring for the
+#: rationale. ``cli/services/*`` and other layers that must cross the CLI
+#: package boundary import this name to stay on the public side of the
+#: boundary contract enforced by ``tests/unit/test_cli_boundary.py``.
+output_error = _output_error
 
 
 def emit_cancelled_and_exit(

--- a/src/notebooklm/cli/services/artifact_generation.py
+++ b/src/notebooklm/cli/services/artifact_generation.py
@@ -8,8 +8,8 @@ from typing import Any
 
 from ...client import NotebookLMClient
 from ...types import GenerationStatus
-from ..error_handler import emit_cancelled_and_exit
-from ..rendering import console, json_error_response, json_output_response
+from ..error_handler import emit_cancelled_and_exit, output_error
+from ..rendering import console, json_output_response
 
 # Retry constants
 RETRY_INITIAL_DELAY = 60.0  # seconds
@@ -209,31 +209,31 @@ async def handle_generation_result(
     Returns:
         Final GenerationStatus, or None if generation failed.
     """
-    # Handle failed generation or rate limiting
+    # Both failure branches route through ``output_error`` so the exit code
+    # is non-zero in both text and JSON modes. ``output_error`` always raises
+    # ``SystemExit`` — these calls never return. Runtime failures use
+    # ``output_error`` rather than ``click.ClickException``; the latter is
+    # reserved for input-validation boundaries (CLI argument parsing).
     if not result:
-        if json_output:
-            json_error_response(
-                "GENERATION_FAILED",
-                f"{artifact_type.title()} generation failed",
-            )
-        else:
-            console.print(f"[red]{artifact_type.title()} generation failed.[/red]")
-        return None
+        output_error(
+            f"{artifact_type.title()} generation failed",
+            "GENERATION_FAILED",
+            json_output,
+            1,
+        )
 
     # Check for rate limiting (result exists but failed due to rate limit)
     if isinstance(result, GenerationStatus) and result.is_rate_limited:
-        if json_output:
-            json_error_response(
-                "RATE_LIMITED",
-                f"{artifact_type.title()} generation rate limited by Google",
-            )
-        else:
-            console.print(
-                f"[red]{artifact_type.title()} generation rate limited by Google.[/red]\n"
-                "[yellow]Daily quota may be exceeded. Try again in 1-24 hours, "
-                "or use --retry N to retry automatically.[/yellow]"
-            )
-        return result
+        output_error(
+            f"{artifact_type.title()} generation rate limited by Google.",
+            "RATE_LIMITED",
+            json_output,
+            1,
+            hint=(
+                "Daily quota may be exceeded. Try again in 1-24 hours, "
+                "or use --retry N to retry automatically."
+            ),
+        )
 
     status: Any = result
     task_id = _extract_generation_task_id(result)
@@ -300,9 +300,22 @@ def _extract_task_id(status: Any) -> str | None:
 
 
 def _output_generation_status(status: Any, artifact_type: str, json_output: bool) -> None:
-    """Output generation status in appropriate format."""
+    """Output generation status in appropriate format.
+
+    The terminal ``is_failed`` branch routes through ``output_error`` so
+    failures observed after a ``--wait`` produce a non-zero exit in both
+    text and JSON modes.
+    """
     is_complete = hasattr(status, "is_complete") and status.is_complete
     is_failed = hasattr(status, "is_failed") and status.is_failed
+
+    if is_failed:
+        output_error(
+            getattr(status, "error", None) or f"{artifact_type.title()} generation failed",
+            "GENERATION_FAILED",
+            json_output,
+            1,
+        )
 
     if json_output:
         if is_complete:
@@ -312,11 +325,6 @@ def _output_generation_status(status: Any, artifact_type: str, json_output: bool
                     "status": "completed",
                     "url": getattr(status, "url", None),
                 }
-            )
-        elif is_failed:
-            json_error_response(
-                "GENERATION_FAILED",
-                getattr(status, "error", None) or f"{artifact_type.title()} generation failed",
             )
         else:
             task_id = _extract_task_id(status)
@@ -328,8 +336,6 @@ def _output_generation_status(status: Any, artifact_type: str, json_output: bool
                 console.print(f"[green]{artifact_type.title()} ready:[/green] {url}")
             else:
                 console.print(f"[green]{artifact_type.title()} ready[/green]")
-        elif is_failed:
-            console.print(f"[red]Failed:[/red] {getattr(status, 'error', None) or 'Unknown error'}")
         else:
             task_id = _extract_task_id(status)
             console.print(f"[yellow]Started:[/yellow] {task_id or status}")

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -1538,13 +1538,15 @@ class TestOutputGenerationStatusDirect:
         1 across modes.
         """
         status = self._make_status(is_failed=True, error="Something went wrong")
-        with patch.object(self.generate_module, "output_error") as mock_err:
-            with pytest.raises(SystemExit):
-                # output_error raises SystemExit; in real use the patch
-                # suppresses it but the SystemExit path is part of the
-                # contract — patch a side_effect to mirror the real call.
-                mock_err.side_effect = SystemExit(1)
-                self.generate_module._output_generation_status(status, "audio", json_output=True)
+        with (
+            patch.object(self.generate_module, "output_error") as mock_err,
+            pytest.raises(SystemExit),
+        ):
+            # output_error raises SystemExit; in real use the patch
+            # suppresses it but the SystemExit path is part of the
+            # contract — patch a side_effect to mirror the real call.
+            mock_err.side_effect = SystemExit(1)
+            self.generate_module._output_generation_status(status, "audio", json_output=True)
         mock_err.assert_called_once_with("Something went wrong", "GENERATION_FAILED", True, 1)
 
     def test_json_failed_no_error_message(self):
@@ -1554,10 +1556,12 @@ class TestOutputGenerationStatusDirect:
         message differs (default fallback when ``status.error`` is None).
         """
         status = self._make_status(is_failed=True, error=None)
-        with patch.object(self.generate_module, "output_error") as mock_err:
-            with pytest.raises(SystemExit):
-                mock_err.side_effect = SystemExit(1)
-                self.generate_module._output_generation_status(status, "audio", json_output=True)
+        with (
+            patch.object(self.generate_module, "output_error") as mock_err,
+            pytest.raises(SystemExit),
+        ):
+            mock_err.side_effect = SystemExit(1)
+            self.generate_module._output_generation_status(status, "audio", json_output=True)
         mock_err.assert_called_once_with("Audio generation failed", "GENERATION_FAILED", True, 1)
 
     def test_json_pending_with_task_id(self):
@@ -1599,10 +1603,12 @@ class TestOutputGenerationStatusDirect:
         non-zero, matching JSON mode.
         """
         status = self._make_status(is_failed=True, error="Transcription error")
-        with patch.object(self.generate_module, "output_error") as mock_err:
-            with pytest.raises(SystemExit):
-                mock_err.side_effect = SystemExit(1)
-                self.generate_module._output_generation_status(status, "audio", json_output=False)
+        with (
+            patch.object(self.generate_module, "output_error") as mock_err,
+            pytest.raises(SystemExit),
+        ):
+            mock_err.side_effect = SystemExit(1)
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
         mock_err.assert_called_once_with("Transcription error", "GENERATION_FAILED", False, 1)
 
     def test_text_failed_no_error_message(self):
@@ -1614,10 +1620,12 @@ class TestOutputGenerationStatusDirect:
         ``"<Title> generation failed"`` fallback.
         """
         status = self._make_status(is_failed=True, error=None)
-        with patch.object(self.generate_module, "output_error") as mock_err:
-            with pytest.raises(SystemExit):
-                mock_err.side_effect = SystemExit(1)
-                self.generate_module._output_generation_status(status, "audio", json_output=False)
+        with (
+            patch.object(self.generate_module, "output_error") as mock_err,
+            pytest.raises(SystemExit),
+        ):
+            mock_err.side_effect = SystemExit(1)
+            self.generate_module._output_generation_status(status, "audio", json_output=False)
         mock_err.assert_called_once_with("Audio generation failed", "GENERATION_FAILED", False, 1)
 
     def test_text_pending_with_task_id(self):

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -271,8 +271,11 @@ class TestGenerateAudio:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
-            assert result.exit_code == 0
-            assert "Audio generation failed" in result.output
+            # P1.T6: failed generation now exits non-zero in text mode (was 0
+            # pre-fix). Message lands on stderr via ``output_error`` →
+            # ``safe_echo(err=True)``.
+            assert result.exit_code != 0
+            assert "Audio generation failed" in result.stderr
 
 
 # =============================================================================
@@ -1527,18 +1530,35 @@ class TestOutputGenerationStatusDirect:
         )
 
     def test_json_failed(self):
-        """Line 251: JSON output for failed status."""
+        """JSON output for failed status routes through ``output_error``.
+
+        P1.T6: terminal ``is_failed`` no longer fans into separate text/JSON
+        branches — both modes go through ``output_error`` (the public alias
+        of ``error_handler._output_error``) so the exit code is unified at
+        1 across modes.
+        """
         status = self._make_status(is_failed=True, error="Something went wrong")
-        with patch.object(self.generate_module, "json_error_response") as mock_err:
-            self.generate_module._output_generation_status(status, "audio", json_output=True)
-        mock_err.assert_called_once_with("GENERATION_FAILED", "Something went wrong")
+        with patch.object(self.generate_module, "output_error") as mock_err:
+            with pytest.raises(SystemExit):
+                # output_error raises SystemExit; in real use the patch
+                # suppresses it but the SystemExit path is part of the
+                # contract — patch a side_effect to mirror the real call.
+                mock_err.side_effect = SystemExit(1)
+                self.generate_module._output_generation_status(status, "audio", json_output=True)
+        mock_err.assert_called_once_with("Something went wrong", "GENERATION_FAILED", True, 1)
 
     def test_json_failed_no_error_message(self):
-        """Line 251: JSON failed output falls back to default message when error is None."""
+        """JSON failed output falls back to default message when error is None.
+
+        Same ``output_error`` routing as ``test_json_failed`` — only the
+        message differs (default fallback when ``status.error`` is None).
+        """
         status = self._make_status(is_failed=True, error=None)
-        with patch.object(self.generate_module, "json_error_response") as mock_err:
-            self.generate_module._output_generation_status(status, "audio", json_output=True)
-        mock_err.assert_called_once_with("GENERATION_FAILED", "Audio generation failed")
+        with patch.object(self.generate_module, "output_error") as mock_err:
+            with pytest.raises(SystemExit):
+                mock_err.side_effect = SystemExit(1)
+                self.generate_module._output_generation_status(status, "audio", json_output=True)
+        mock_err.assert_called_once_with("Audio generation failed", "GENERATION_FAILED", True, 1)
 
     def test_json_pending_with_task_id(self):
         """Lines 205-207, 257: JSON output for pending status extracts task_id from list."""
@@ -1571,18 +1591,34 @@ class TestOutputGenerationStatusDirect:
         mock_console.print.assert_called_once_with("[green]Audio ready[/green]")
 
     def test_text_failed(self):
-        """Line 266: Text output for failed status."""
+        """Text output for failed status routes through ``output_error``.
+
+        P1.T6: text-mode failures no longer print via Rich + return (which
+        kept exit code 0). They route through ``output_error`` →
+        ``safe_echo(err=True)`` → ``SystemExit(1)`` so text mode now exits
+        non-zero, matching JSON mode.
+        """
         status = self._make_status(is_failed=True, error="Transcription error")
-        with patch.object(self.generate_module, "console") as mock_console:
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
-        mock_console.print.assert_called_once_with("[red]Failed:[/red] Transcription error")
+        with patch.object(self.generate_module, "output_error") as mock_err:
+            with pytest.raises(SystemExit):
+                mock_err.side_effect = SystemExit(1)
+                self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_err.assert_called_once_with("Transcription error", "GENERATION_FAILED", False, 1)
 
     def test_text_failed_no_error_message(self):
-        """Text failed output falls back to Unknown error when error is None."""
+        """Text failed output falls back to default message when error is None.
+
+        Note: pre-P1.T6 used ``"Unknown error"`` as the text-mode default and
+        ``"Audio generation failed"`` as the JSON-mode default. After
+        unification through ``output_error``, both modes use the same
+        ``"<Title> generation failed"`` fallback.
+        """
         status = self._make_status(is_failed=True, error=None)
-        with patch.object(self.generate_module, "console") as mock_console:
-            self.generate_module._output_generation_status(status, "audio", json_output=False)
-        mock_console.print.assert_called_once_with("[red]Failed:[/red] Unknown error")
+        with patch.object(self.generate_module, "output_error") as mock_err:
+            with pytest.raises(SystemExit):
+                mock_err.side_effect = SystemExit(1)
+                self.generate_module._output_generation_status(status, "audio", json_output=False)
+        mock_err.assert_called_once_with("Audio generation failed", "GENERATION_FAILED", False, 1)
 
     def test_text_pending_with_task_id(self):
         """Line 268: Text output for pending status shows task_id."""
@@ -1983,7 +2019,12 @@ class TestHandleGenerationResultPaths:
         assert "task_list_1" in result.output or "Started" in result.output
 
     def test_generation_result_falsy_shows_failed_message(self, runner, mock_auth):
-        """Line 173: falsy result → text error message."""
+        """Falsy result → stderr error message + non-zero exit (P1.T6).
+
+        Pre-fix exited 0 in text mode; post-fix routes through
+        ``output_error`` → ``SystemExit(1)`` and writes the message to
+        stderr. See ``TestArtifactGenerationExitCodes`` for the contract.
+        """
         with patch_client_for_module("generate") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.generate_audio = AsyncMock(return_value=None)
@@ -1995,8 +2036,8 @@ class TestHandleGenerationResultPaths:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
 
-        assert result.exit_code == 0
-        assert "generation failed" in result.output.lower()
+        assert result.exit_code != 0
+        assert "generation failed" in result.stderr.lower()
 
     def test_generation_result_falsy_json_shows_error(self, runner, mock_auth):
         """Line 173: falsy result with --json → json_error_response (exits with code 1)."""
@@ -2357,3 +2398,180 @@ class TestGenerateWaitSigintResumeHint:
                         raise KeyboardInterrupt
 
         asyncio.run(_exercise())
+
+
+# =============================================================================
+# P1.T6 — Exit-code parity across text/JSON modes on artifact generation failure
+# =============================================================================
+
+
+class TestArtifactGenerationExitCodes:
+    """Failed artifact generation must exit non-zero in BOTH text and JSON modes.
+
+    Pre-fix behavior: text mode printed a Rich error to stdout and returned
+    normally (exit 0); JSON mode emitted a ``json_error_response`` envelope and
+    exited 1. The exit-code asymmetry meant shell scripts driving
+    ``notebooklm generate audio ...`` without ``--json`` could not detect
+    failures via ``$?``.
+
+    These tests pin the unified contract: every failure path inside
+    ``handle_generation_result`` (and ``_output_generation_status``'s terminal
+    failed branch reached via ``--wait``) routes through ``output_error``,
+    which exits non-zero and writes the human-readable message to stderr in
+    text mode or a structured envelope on stdout in JSON mode.
+    """
+
+    # --- Initial-call failure (result is None / falsy) ---------------------
+
+    def test_text_mode_none_result_exits_nonzero(self, runner, mock_auth):
+        """``generate audio`` without ``--json`` exits != 0 when the API returns None."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
+
+        assert result.exit_code != 0
+        # Message routed to stderr via safe_echo(err=True) under Click 8.2+ which
+        # separates stdout/stderr by default.
+        assert "Audio generation failed" in result.stderr
+
+    def test_json_mode_none_result_exits_nonzero(self, runner, mock_auth):
+        """``generate audio --json`` exits != 0 when the API returns None."""
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=None)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["error"] is True
+        assert data["code"] == "GENERATION_FAILED"
+        assert "Audio generation failed" in data["message"]
+
+    # --- Rate-limit failure --------------------------------------------------
+
+    def test_text_mode_rate_limited_exits_nonzero(self, runner, mock_auth):
+        """Rate-limited result (no retries left) exits != 0 in text mode."""
+        from notebooklm.types import GenerationStatus
+
+        rate_limited = GenerationStatus(
+            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=rate_limited)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123"])
+
+        assert result.exit_code != 0
+        # The "rate limited" message and the daily-quota hint both land on
+        # stderr; the second goes through ``output_error``'s ``hint`` arg.
+        assert "rate limited by Google" in result.stderr
+        assert "--retry" in result.stderr
+
+    def test_json_mode_rate_limited_exits_nonzero(self, runner, mock_auth):
+        """Rate-limited result exits != 0 with a RATE_LIMITED JSON envelope."""
+        from notebooklm.types import GenerationStatus
+
+        rate_limited = GenerationStatus(
+            task_id="", status="failed", error="Rate limited", error_code="USER_DISPLAYABLE_ERROR"
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=rate_limited)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["error"] is True
+        assert data["code"] == "RATE_LIMITED"
+
+    # --- Wait-then-failed terminal status -----------------------------------
+
+    def test_text_mode_wait_then_failed_exits_nonzero(self, runner, mock_auth):
+        """``--wait`` that observes a terminal is_failed status exits != 0 in text mode."""
+        from notebooklm.types import GenerationStatus
+
+        initial = GenerationStatus(
+            task_id="task_fail_1", status="pending", error=None, error_code=None
+        )
+        terminal = GenerationStatus(
+            task_id="task_fail_1",
+            status="failed",
+            error="Transcription error",
+            error_code="INTERNAL_ERROR",
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=initial)
+            mock_client.artifacts.wait_for_completion = AsyncMock(return_value=terminal)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--wait"])
+
+        assert result.exit_code != 0
+        assert "Transcription error" in result.stderr
+
+    def test_json_mode_wait_then_failed_exits_nonzero(self, runner, mock_auth):
+        """``--wait --json`` that observes a terminal is_failed status exits != 0."""
+        from notebooklm.types import GenerationStatus
+
+        initial = GenerationStatus(
+            task_id="task_fail_2", status="pending", error=None, error_code=None
+        )
+        terminal = GenerationStatus(
+            task_id="task_fail_2",
+            status="failed",
+            error="Transcription error",
+            error_code="INTERNAL_ERROR",
+        )
+
+        with patch_client_for_module("generate") as mock_client_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.generate_audio = AsyncMock(return_value=initial)
+            mock_client.artifacts.wait_for_completion = AsyncMock(return_value=terminal)
+            mock_client_cls.return_value = mock_client
+
+            with patch(
+                "notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock
+            ) as mock_fetch:
+                mock_fetch.return_value = ("csrf", "session")
+                result = runner.invoke(
+                    cli, ["generate", "audio", "-n", "nb_123", "--wait", "--json"]
+                )
+
+        assert result.exit_code != 0
+        data = json.loads(result.output)
+        assert data["error"] is True
+        assert data["code"] == "GENERATION_FAILED"
+        assert "Transcription error" in data["message"]

--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -2048,7 +2048,13 @@ class TestHandleGenerationResultPaths:
         assert "generation failed" in result.stderr.lower()
 
     def test_generation_result_falsy_json_shows_error(self, runner, mock_auth):
-        """Line 173: falsy result with --json → json_error_response (exits with code 1)."""
+        """Falsy result with --json → GENERATION_FAILED envelope + non-zero exit.
+
+        Post-P1.T6 the path routes through ``output_error`` (not the older
+        ``json_error_response`` helper) so this test pins the JSON-mode
+        contract here; ``TestArtifactGenerationExitCodes`` covers the same
+        path with explicit exit-code assertions and the text-mode parity.
+        """
         with patch_client_for_module("generate") as mock_client_cls:
             mock_client = create_mock_client()
             mock_client.artifacts.generate_audio = AsyncMock(return_value=None)
@@ -2060,7 +2066,7 @@ class TestHandleGenerationResultPaths:
                 mock_fetch.return_value = ("csrf", "session")
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
 
-        # json_error_response calls sys.exit(1), so exit_code is 1
+        # ``output_error`` raises ``SystemExit(1)``; Click reports exit_code 1.
         data = json.loads(result.output)
         assert data["error"] is True
         assert data["code"] == "GENERATION_FAILED"


### PR DESCRIPTION
## Summary

Failed artifact generation now exits non-zero in BOTH text and JSON modes. Previously text mode printed a Rich error to stdout and returned (exit 0) while JSON mode emitted a `json_error_response` envelope (exit 1) — making it impossible for shell scripts driving `notebooklm generate audio ...` without `--json` to detect failures via `$?`.

Resolves task P1.T6 from `.sisyphus/plans/cli-audit-fixes.md` (Phase 1, Wave 1.A).

## Changes

**`src/notebooklm/cli/services/artifact_generation.py`** — three failure branches unified through `output_error(message, code, json_output, 1)`:
- `handle_generation_result`: None/falsy result
- `handle_generation_result`: rate-limited result (after retry exhaustion) — preserves the daily-quota retry hint via `output_error`'s `hint=` arg
- `_output_generation_status`: terminal `is_failed` status (reachable via `--wait`)

`output_error` writes the message (plus optional hint) to stderr in text mode or emits a structured envelope on stdout in JSON mode, then raises `SystemExit(1)`. Runtime-failure paths use `output_error` rather than `click.ClickException`; the latter is reserved for input-validation boundaries (per DoD item 6 in the audit plan).

**`src/notebooklm/cli/error_handler.py`** — adds public alias `output_error = _output_error` so `cli/services/*` can import a public name. This satisfies the cli-services boundary contract enforced by `tests/unit/test_cli_boundary.py`, which forbids level-2 relative imports of `_underscore` names from public CLI modules. The underscored name is kept for the existing sibling-level callers (`cli/source.py`, `cli/note.py`) at level-1 relative imports, where intra-package private access is permitted.

**`tests/unit/cli/test_generate.py`**:
- New `TestArtifactGenerationExitCodes` (6 contract tests) pins exit != 0 across both modes and all 3 failure paths.
- Updates 6 pre-existing tests that either documented the bug (`test_generate_audio_failure`, `test_generation_result_falsy_shows_failed_message` asserted `exit_code == 0`) or mocked the now-removed `json_error_response` / `console.print` branches (`test_json_failed`, `test_text_failed`, and their no-message variants).

## Behavior change visible to users

- **Exit code on failure**: was 0 in text mode, 1 in JSON mode → **now 1 in both modes**. Shell scripts using `$?` can now detect failures without `--json`.
- **Stream**: failure messages now go to stderr (via `safe_echo(err=True)`) instead of stdout. Aligns with the rest of the CLI's error handling and is more correct for log parsers.
- **Formatting**: Rich ANSI color codes (`[red]...[/red]`) are no longer applied to failure messages — the message text is preserved but rendered as plain text on stderr. This matches the existing `_output_error` pattern used by `cli/source.py` and `cli/note.py`.
- **Default-message fallback when `status.error` is None**: was inconsistent (`"Unknown error"` in text mode, `"Audio generation failed"` in JSON mode) → **now `"<Title> generation failed"` in both modes**. Unification side-effect; more informative than `"Unknown error"`.

The 8 sibling generate commands (`audio`, `video`, `slide-deck`, `cinematic-video`, `quiz`, `flashcards`, `infographic`, `data-table`, `report`) all share `handle_generation_result` and `_output_generation_status` paths, so they all inherit the corrected exit-code contract without per-command churn.

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check src/notebooklm/cli` — clean
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` — clean
- [x] `uv run pytest tests/unit tests/integration` — 5611 passed, 12 skipped (pre-existing)
- [x] Polish pipeline (code-simplifier + claude/codex review + ultrathink) — SHIP

## Deferred polish findings

These are not blockers; tracked for future cleanup work:
- Promote `output_error`/`_output_error` to `NoReturn` typing for cleaner type narrowing at call sites (currently typed `-> None` despite always raising `SystemExit`).
- Consider deprecating the underscored name in a future refactor — the dual-name pattern is a temporary architectural compromise driven by the boundary contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI artifact generation now uses a unified error path so failures and rate limits produce consistent non-zero exit codes and appropriate stderr or JSON error output.

* **Tests**
  * Expanded tests to verify unified exit-code behavior and correct error messages across text and JSON output modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->