### PR TITLE
fix(cli): Phase 1 orphan-thread audit follow-up

### DIFF
--- a/tests/unit/cli/test_generate.py
+++ b/tests/unit/cli/test_generate.py
@@ -2067,6 +2067,7 @@ class TestHandleGenerationResultPaths:
                 result = runner.invoke(cli, ["generate", "audio", "-n", "nb_123", "--json"])
 
         # ``output_error`` raises ``SystemExit(1)``; Click reports exit_code 1.
+        assert result.exit_code != 0
         data = json.loads(result.output)
         assert data["error"] is True
         assert data["code"] == "GENERATION_FAILED"


### PR DESCRIPTION
## Summary

Post-merge audit of the 9 Phase 1 CLI-audit-fixes PRs (#915, #916, #918, #919, #920, #921, #922, #924, #925) surfaced one genuinely-unaddressed reviewer finding that needs a code change. All other unresolved threads were auto-resolved or already replied to with addressing commits — those are handled in this audit by `resolveReviewThread` mutations (no code change needed).

## Addressed findings

### 1. PR #925 — coderabbitai (thread `Q1csts6D6Aue`, file `tests/unit/cli/test_generate.py`)

Thread: https://github.com/teng-lin/notebooklm-py/pull/925#discussion_r3283671270

`test_generation_result_falsy_json_shows_error` documents the non-zero exit contract for `--json` falsy results in its docstring but doesn't assert it — a regression in exit-code could slip through while the JSON shape assertions still pass. Added the single missing `assert result.exit_code != 0` line.

The contract is also covered separately by `TestArtifactGenerationExitCodes::test_json_mode_none_result_exits_nonzero`, but since this test claims to pin the contract, it should assert it directly.

## Threads acknowledged & resolved without code changes

The following 8 threads were replied to with addressing commits but never formally marked resolved by the merging agent. They are being resolved as part of this audit via `resolveReviewThread` mutations (separately from the PR commit):

- PR #916: 3 threads (Q1csts6D5agM, Q1csts6D5agk, Q1csts6D5agu) — addressed in 2533529 / 12548c0
- PR #918: 4 threads (Q1csts6D5bAI, Q1csts6D5bAR, Q1csts6D5bAb, Q1csts6D5bAl) — addressed in 8d702ae
- PR #919: 1 thread (Q1csts6D5aje) — addressed via rebase in 2b53e1e
- PR #920: 1 thread (Q1csts6D5ey8) — addressed in 09afde8

PRs 915, 921, 922, 924 had no unresolved threads.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_generate.py -k test_generation_result_falsy_json_shows_error` — passes
- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check src/notebooklm/cli` — clean
- [x] `uv run mypy src/notebooklm/cli --ignore-missing-imports` — clean
- [x] `uv run pytest tests/unit tests/integration` — 1871 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error handling validation in CLI tests to ensure proper exit codes are returned when API responses are invalid with JSON output enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->