### PR TITLE
refactor(cli): single canonical notebook + partial-ID resolver

### DIFF
--- a/src/notebooklm/cli/download_helpers.py
+++ b/src/notebooklm/cli/download_helpers.py
@@ -3,7 +3,7 @@
 import re
 from typing import TypedDict
 
-from .resolve import FULL_ID_PATTERN
+from .resolve import resolve_partial_id_in_items
 
 # Reserve space for " (999)" suffix when handling duplicate filenames
 DUPLICATE_SUFFIX_RESERVE = 7
@@ -20,11 +20,27 @@ class ArtifactDict(TypedDict):
 def resolve_partial_artifact_id(artifacts: list[ArtifactDict], artifact_id: str) -> str:
     """Resolve a partial artifact ID to a full ID.
 
-    Full UUID-shaped IDs (canonical 8-4-4-4-12 hex layout, case-insensitive —
+    Full UUID-shaped IDs (canonical 8-4-4-4-12 hex layout, case-insensitive -
     see :data:`notebooklm.cli.resolve.FULL_ID_PATTERN`) are returned as-is.
-    Anything else — including a 25-char prefix of a 36-char UUID — is matched
+    Anything else - including a 25-char prefix of a 36-char UUID - is matched
     as a case-insensitive prefix against the artifact list, so unique prefixes
     resolve locally rather than reaching the backend as truncated IDs.
+
+    The matching logic is delegated to
+    :func:`notebooklm.cli.resolve.resolve_partial_id_in_items` (the canonical
+    sync core shared with the async resolver), supplied with the dict-shaped
+    accessor pair (the download path stores artifacts as
+    :class:`ArtifactDict`, not the dataclass shape the async resolver
+    consumes) and the ``ValueError`` factory (the download command body
+    catches ``ValueError`` and converts to an error envelope, so we keep
+    the historical exception type rather than ``click.ClickException``).
+
+    The "no match" / "ambiguous" message text retains its historical wording
+    rather than the canonical resolver's wording - the download command's
+    user-visible error envelope text predates P2.T1 consolidation and a
+    customer or external test could rely on it. The translation costs about
+    8 lines and keeps the user contract verbatim. Successful partial matches
+    also remain silent, matching the historical download helper behavior.
 
     Args:
         artifacts: Pre-fetched list of artifacts to search.
@@ -36,17 +52,31 @@ def resolve_partial_artifact_id(artifacts: list[ArtifactDict], artifact_id: str)
     Raises:
         ValueError: If no match found or prefix is ambiguous.
     """
-    if FULL_ID_PATTERN.fullmatch(artifact_id):
-        return artifact_id
-
-    matches = [a for a in artifacts if a["id"].lower().startswith(artifact_id.lower())]
-
-    if len(matches) == 1:
-        return matches[0]["id"]
-    if len(matches) > 1:
-        options = ", ".join(f"{a['id']} ({a['title']})" for a in matches)
-        raise ValueError(f"Ambiguous partial ID '{artifact_id}' matches: {options}")
-    raise ValueError(f"Artifact '{artifact_id}' not found")
+    try:
+        return resolve_partial_id_in_items(
+            artifact_id,
+            list(artifacts),
+            entity_name="artifact",
+            list_command="artifact list",
+            id_of=lambda a: a["id"],
+            title_of=lambda a: a["title"],
+            error_factory=ValueError,
+            emit_match_status=False,
+        )
+    except ValueError as e:
+        # Re-shape the canonical "No artifact found starting with..." /
+        # "Ambiguous ID 'X' matches N artifacts:\n..." wording to the
+        # historical download-helpers wording. Both messages remain valid
+        # ValueError instances; only the human-readable string changes.
+        msg = str(e)
+        if msg.startswith("No artifact found starting with"):
+            raise ValueError(f"Artifact '{artifact_id}' not found") from e
+        if msg.startswith("Ambiguous ID"):
+            partial = artifact_id.strip().lower()
+            matches = [a for a in artifacts if a["id"].lower().startswith(partial)]
+            options = ", ".join(f"{a['id']} ({a['title']})" for a in matches)
+            raise ValueError(f"Ambiguous partial ID '{artifact_id}' matches: {options}") from e
+        raise
 
 
 def select_artifact(
@@ -59,7 +89,7 @@ def select_artifact(
     """
     Select an artifact from a list based on criteria.
 
-    CRITICAL: Implements Filter → Count → Select logic:
+    CRITICAL: Implements Filter -> Count -> Select logic:
     1. Filter artifacts by name/artifact_id if provided
     2. Count matches (0/1/many)
     3. Apply latest/earliest to remaining matches

--- a/src/notebooklm/cli/helpers.py
+++ b/src/notebooklm/cli/helpers.py
@@ -27,9 +27,32 @@ from . import context as context_helpers
 from . import input as input_helpers
 from . import rendering as rendering_helpers
 from . import research_import as research_import_helpers
-from . import resolve as resolve_helpers
 from . import runtime as runtime_helpers
 from ._encoding import safe_echo
+from .resolve import (
+    _resolve_partial_id as _resolve_partial_id,
+)
+from .resolve import (
+    require_notebook as require_notebook,
+)
+from .resolve import (
+    resolve_artifact_id as resolve_artifact_id,
+)
+from .resolve import (
+    resolve_note_id as resolve_note_id,
+)
+from .resolve import (
+    resolve_notebook_id as resolve_notebook_id,
+)
+from .resolve import (
+    resolve_source_id as resolve_source_id,
+)
+from .resolve import (
+    resolve_source_ids as resolve_source_ids,
+)
+from .resolve import (
+    validate_id as validate_id,
+)
 
 if TYPE_CHECKING:
     from ..types import Artifact
@@ -221,111 +244,6 @@ def get_current_conversation() -> str | None:
 def set_current_conversation(conversation_id: str | None):
     """Set or clear the current conversation ID in context."""
     context_helpers.set_current_conversation(conversation_id, context_path_fn=get_context_path)
-
-
-def validate_id(entity_id: str, entity_name: str = "ID") -> str:
-    """Validate and normalize an entity ID."""
-    return resolve_helpers.validate_id(entity_id, entity_name)
-
-
-def require_notebook(notebook_id: str | None) -> str:
-    """Get notebook ID from argument, env var, or active context."""
-    return resolve_helpers.require_notebook(
-        notebook_id,
-        context_path_fn=get_context_path,
-        output_console=console,
-    )
-
-
-async def _resolve_partial_id(
-    partial_id: str,
-    list_fn,
-    entity_name: str,
-    list_command: str,
-    *,
-    json_output: bool = False,
-) -> str:
-    """Generic partial ID resolver."""
-    return await resolve_helpers._resolve_partial_id(
-        partial_id,
-        list_fn,
-        entity_name,
-        list_command,
-        json_output=json_output,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
-    )
-
-
-async def resolve_notebook_id(client, partial_id: str, *, json_output: bool = False) -> str:
-    """Resolve partial notebook ID to full ID."""
-    return await resolve_helpers.resolve_notebook_id(
-        client,
-        partial_id,
-        json_output=json_output,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
-    )
-
-
-async def resolve_source_id(
-    client, notebook_id: str, partial_id: str, *, json_output: bool = False
-) -> str:
-    """Resolve partial source ID to full ID."""
-    return await resolve_helpers.resolve_source_id(
-        client,
-        notebook_id,
-        partial_id,
-        json_output=json_output,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
-    )
-
-
-async def resolve_artifact_id(
-    client, notebook_id: str, partial_id: str, *, json_output: bool = False
-) -> str:
-    """Resolve partial artifact ID to full ID."""
-    return await resolve_helpers.resolve_artifact_id(
-        client,
-        notebook_id,
-        partial_id,
-        json_output=json_output,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
-    )
-
-
-async def resolve_note_id(
-    client, notebook_id: str, partial_id: str, *, json_output: bool = False
-) -> str:
-    """Resolve partial note ID to full ID."""
-    return await resolve_helpers.resolve_note_id(
-        client,
-        notebook_id,
-        partial_id,
-        json_output=json_output,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
-    )
-
-
-async def resolve_source_ids(
-    client,
-    notebook_id: str,
-    source_ids: tuple[str, ...],
-    *,
-    json_output: bool = False,
-) -> list[str] | None:
-    """Resolve multiple partial source IDs to full IDs."""
-    return await resolve_helpers.resolve_source_ids(
-        client,
-        notebook_id,
-        source_ids,
-        json_output=json_output,
-        stdout_console=console,
-        stderr_output_console=stderr_console,
-    )
 
 
 def read_stdin_text(*, source_label: str = "stdin") -> str:

--- a/src/notebooklm/cli/resolve.py
+++ b/src/notebooklm/cli/resolve.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import re
+import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,7 @@ from typing import Any
 import click
 from rich.console import Console
 
+from .. import paths as paths_module
 from ..paths import get_context_path
 from . import context as context_helpers
 from . import rendering as rendering_helpers
@@ -20,16 +22,16 @@ ContextPathFn = Callable[..., Path]
 ListFn = Callable[[], Awaitable[list[Any]]]
 
 # Backend entity IDs are canonical UUIDs in the RFC 4122 8-4-4-4-12 hex layout
-# (e.g. ``abc12345-6789-4abc-def0-1234567890ab``). Anything shorter — even a
-# unique 25-char prefix — must go through the local list-and-match path, or it
+# (e.g. ``abc12345-6789-4abc-def0-1234567890ab``). Anything shorter - even a
+# unique 25-char prefix - must go through the local list-and-match path, or it
 # will reach the backend as a truncated ID and 404. The character classes are
 # both upper- and lower-case hex so mixed-case IDs returned by the backend keep
-# fast-pathing. Exposed publicly so `download_helpers.py` shares the same shape
-# rule; the two call sites stay in lockstep until P2.T1 consolidates them.
+# fast-pathing. Exposed publicly because the canonical sync resolver core and
+# the download helper share the same shape rule.
 #
 # Tightened past the plan's `^[0-9a-fA-F-]{36}$` to the exact 8-4-4-4-12 dash
 # layout so degenerate-but-length-36 inputs (`"-" * 36`, 36 unbroken hex chars,
-# wrong dash placement) cannot bypass local resolution — the looser pattern's
+# wrong dash placement) cannot bypass local resolution - the looser pattern's
 # false-positives would still 404 against the backend, but rejecting them
 # locally gives the user a clearer error and keeps the contract honest.
 FULL_ID_PATTERN = re.compile(
@@ -60,19 +62,63 @@ def _is_full_id_candidate(entity_id: str) -> bool:
     """Return whether ``entity_id`` is shaped like a concrete backend UUID.
 
     Only canonical 36-char hex-and-dash strings (case-insensitive) qualify for
-    the fast-path. A 25-char prefix of a 36-char UUID — which is unique enough
-    to be human-pasted — must still go through the local list-and-match path so
+    the fast-path. A 25-char prefix of a 36-char UUID - which is unique enough
+    to be human-pasted - must still go through the local list-and-match path so
     it can be expanded to the full ID before any backend call. See
     :data:`FULL_ID_PATTERN`.
     """
     return FULL_ID_PATTERN.fullmatch(entity_id) is not None
 
 
+def _helpers_attr(name: str) -> Any | None:
+    """Return a patched ``cli.helpers`` attribute when the facade is imported."""
+    helpers_module = sys.modules.get("notebooklm.cli.helpers")
+    if helpers_module is None:
+        return None
+    return getattr(helpers_module, name, None)
+
+
+def _default_context_path_fn() -> ContextPathFn:
+    """Resolve the call-time context path provider.
+
+    ``cli.helpers`` is now a compatibility facade for resolver names, but many
+    existing tests still patch ``notebooklm.cli.helpers.get_context_path``.
+    Prefer that patched facade value when present; otherwise use this module's
+    own call-time lookup so ``notebooklm.cli.resolve.get_context_path`` patches
+    continue to work.
+    """
+    helpers_get_context_path = _helpers_attr("get_context_path")
+    if (
+        callable(helpers_get_context_path)
+        and helpers_get_context_path is not paths_module.get_context_path
+    ):
+        return helpers_get_context_path
+    return get_context_path
+
+
+def _default_stdout_console(console: Console | None) -> Console:
+    if console is not None:
+        return console
+    helpers_console = _helpers_attr("console")
+    if helpers_console is not None and helpers_console is not rendering_helpers.console:
+        return helpers_console
+    return rendering_helpers.console
+
+
+def _default_stderr_console(console: Console | None) -> Console:
+    if console is not None:
+        return console
+    helpers_console = _helpers_attr("stderr_console")
+    if helpers_console is not None and helpers_console is not rendering_helpers.stderr_console:
+        return helpers_console
+    return rendering_helpers.stderr_console
+
+
 def require_notebook(
     notebook_id: str | None,
     *,
     context_path_fn: ContextPathFn | None = None,
-    output_console: Console = rendering_helpers.console,
+    output_console: Console | None = None,
 ) -> str:
     """Get notebook ID from argument, env var, or active context.
 
@@ -108,16 +154,161 @@ def require_notebook(
         return validate_id(env_value, "Notebook")
 
     current = context_helpers.get_current_notebook(
-        context_path_fn=context_path_fn or get_context_path
+        context_path_fn=context_path_fn or _default_context_path_fn()
     )
     if current:
         return validate_id(current, "Notebook")
 
+    output_console = _default_stdout_console(output_console)
     output_console.print(
         "[red]No notebook specified. Use 'notebooklm use <id>' to set context, "
         "pass -n/--notebook, or set NOTEBOOKLM_NOTEBOOK.[/red]"
     )
     raise SystemExit(1)
+
+
+# Accessor types for the sync resolver core. The default ``_attr_id`` /
+# ``_attr_title`` accessors match the async ``_resolve_partial_id`` shape
+# (entities with ``.id`` / ``.title`` attributes); ``resolve_partial_id_in_items``
+# accepts custom accessors so callers with pre-fetched ``dict``-shaped data
+# (e.g. ``download_helpers.resolve_partial_artifact_id``) can share the same
+# matching logic without first reshaping their inputs.
+ItemIdFn = Callable[[Any], str]
+ItemTitleFn = Callable[[Any], str | None]
+ErrorFactoryFn = Callable[[str], Exception]
+
+
+def _attr_id(item: Any) -> str:
+    return item.id
+
+
+def _attr_title(item: Any) -> str | None:
+    return item.title
+
+
+def resolve_partial_id_in_items(
+    partial_id: str,
+    items: list[Any],
+    *,
+    entity_name: str,
+    list_command: str,
+    id_of: ItemIdFn = _attr_id,
+    title_of: ItemTitleFn = _attr_title,
+    error_factory: ErrorFactoryFn = click.ClickException,
+    emit_match_status: bool = True,
+    json_output: bool = False,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
+) -> str:
+    """Resolve a partial ID against a **pre-fetched** item list.
+
+    Sync core of the partial-ID matching logic. Encapsulates the rules that
+    both the async resolver (``_resolve_partial_id``) and the download
+    pre-fetched-list resolver (``download_helpers.resolve_partial_artifact_id``)
+    share, so behavior cannot drift between the two call paths.
+
+    Matching rules (in order):
+
+    1. Empty/whitespace partial id -> ``error_factory("...cannot be empty")``.
+    2. Canonical 36-char 8-4-4-4-12 hex+dash UUID -> returned verbatim (no
+       listing required); see :data:`FULL_ID_PATTERN`.
+    3. Case-insensitive exact match against any item id -> returned (wins over
+       prefix ambiguity so a short-but-complete id isn't reported as
+       ambiguous when it's also a prefix of another item).
+    4. Case-insensitive prefix match: unique -> return; ambiguous -> raise via
+       ``error_factory`` with up to 5 candidates listed; no match -> raise.
+
+    Args:
+        partial_id: Full or partial ID to resolve.
+        items: Pre-fetched list of items the caller already loaded from the
+            backend. Each item is opaque; ``id_of`` and ``title_of``
+            accessors extract the relevant fields.
+        entity_name: Name for error messages, e.g. ``"notebook"``,
+            ``"artifact"``.
+        list_command: CLI command users should run to discover items, e.g.
+            ``"source list"`` or ``"artifact list"``. Included in the
+            "no match" error message.
+        id_of: Accessor returning the canonical id for an item. Defaults to
+            ``item.id`` (attribute access) for the dataclass-style items the
+            async path consumes; the download pre-fetched-list path passes
+            ``lambda a: a["id"]`` for its ``ArtifactDict`` shape.
+        title_of: Accessor returning the title for diagnostics. Same default
+            as ``id_of``.
+        error_factory: Exception class to raise on empty input, no match,
+            and ambiguous match. ``click.ClickException`` for the async
+            CLI path (auto-converted to exit 1 + stderr by Click);
+            ``ValueError`` for callers like ``download_helpers`` that catch
+            and re-shape the error themselves.
+        emit_match_status: Whether a successful partial match should emit the
+            "Matched: ..." diagnostic. Async CLI resolvers use the default;
+            pre-fetched helpers that historically returned silently can turn it
+            off while sharing the same matching rules.
+        json_output: When true, the "Matched: ..." diagnostic routes to stderr
+            so stdout stays parseable JSON.
+        stdout_console: Console for human-mode diagnostics.
+        stderr_output_console: Console for JSON-mode diagnostics.
+
+    Returns:
+        Full ID of the matched item.
+
+    Raises:
+        ``error_factory(...)``: If ID is empty, no match exists, or the
+            prefix is ambiguous. The exception **type** is determined by
+            ``error_factory`` so callers can pick the shape that fits their
+            error-handling layer.
+    """
+    # ``validate_id`` raises ``click.ClickException`` unconditionally; for
+    # callers that asked for a different ``error_factory`` (e.g. ``ValueError``
+    # in the download path), we re-shape the empty-input error here so the
+    # caller doesn't have to know about ``click.ClickException`` at all.
+    if not partial_id or not partial_id.strip():
+        raise error_factory(f"{entity_name} ID cannot be empty")
+    partial_id = partial_id.strip()
+
+    # Concrete IDs are passed through so direct get/delete commands can hit
+    # the backend by ID without forcing an extra list RPC first.
+    if _is_full_id_candidate(partial_id):
+        return partial_id
+
+    partial_id_lower = partial_id.lower()
+
+    matches: list[Any] = []
+    for item in items:
+        item_id = id_of(item)
+        item_id_lower = item_id.lower()
+        # Exact short IDs win over prefix matches to avoid false ambiguity.
+        if item_id_lower == partial_id_lower:
+            return item_id
+        if item_id_lower.startswith(partial_id_lower):
+            matches.append(item)
+
+    if len(matches) == 1:
+        matched_id = id_of(matches[0])
+        if emit_match_status and matched_id != partial_id:
+            title = title_of(matches[0]) or "(untitled)"
+            rendering_helpers.emit_status(
+                f"[dim]Matched: {matched_id[:12]}... ({title})[/dim]",
+                json_output=json_output,
+                stdout_console=_default_stdout_console(stdout_console),
+                stderr_output_console=_default_stderr_console(stderr_output_console),
+            )
+        return matched_id
+
+    if len(matches) == 0:
+        raise error_factory(
+            f"No {entity_name} found starting with '{partial_id}'. "
+            f"Run 'notebooklm {list_command}' to see available {entity_name}s."
+        )
+
+    lines = [f"Ambiguous ID '{partial_id}' matches {len(matches)} {entity_name}s:"]
+    for item in matches[:5]:
+        matched_id = id_of(item)
+        title = title_of(item) or "(untitled)"
+        lines.append(f"  {matched_id[:12]}... {title}")
+    if len(matches) > 5:
+        lines.append(f"  ... and {len(matches) - 5} more")
+    lines.append("\nSpecify more characters to narrow down.")
+    raise error_factory("\n".join(lines))
 
 
 async def _resolve_partial_id(
@@ -127,8 +318,8 @@ async def _resolve_partial_id(
     list_command: str,
     *,
     json_output: bool = False,
-    stdout_console: Console = rendering_helpers.console,
-    stderr_output_console: Console = rendering_helpers.stderr_console,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
 ) -> str:
     """Resolve a case-insensitive partial ID prefix to a full entity ID.
 
@@ -136,6 +327,12 @@ async def _resolve_partial_id(
     Exact matches are preferred before case-insensitive prefix matches so a
     short-but-complete ID is not treated as ambiguous when another entity
     shares that prefix.
+
+    Thin async adapter over :func:`resolve_partial_id_in_items` - handles
+    the full-ID fast-path locally to avoid a wasted ``await list_fn()`` for
+    canonical UUIDs, then defers to the sync core for the prefix-matching
+    work so behavior stays in lockstep with
+    ``download_helpers.resolve_partial_artifact_id``.
 
     Args:
         partial_id: Full or partial ID to resolve.
@@ -155,50 +352,24 @@ async def _resolve_partial_id(
         click.ClickException: If ID is empty, no match exists, or the prefix is
             ambiguous.
     """
+    # Validate + fast-path BEFORE awaiting ``list_fn`` so canonical UUIDs
+    # don't pay for a backend listing they don't need.
     partial_id = validate_id(partial_id, entity_name)
-
-    # Concrete IDs are passed through so direct get/delete commands can hit
-    # the backend by ID without forcing an extra list RPC first.
     if _is_full_id_candidate(partial_id):
         return partial_id
 
     items = await list_fn()
-    partial_id_lower = partial_id.lower()
-
-    matches = []
-    for item in items:
-        item_id_lower = item.id.lower()
-        # Exact short IDs win over prefix matches to avoid false ambiguity.
-        if item_id_lower == partial_id_lower:
-            return item.id
-        if item_id_lower.startswith(partial_id_lower):
-            matches.append(item)
-
-    if len(matches) == 1:
-        if matches[0].id != partial_id:
-            title = matches[0].title or "(untitled)"
-            rendering_helpers.emit_status(
-                f"[dim]Matched: {matches[0].id[:12]}... ({title})[/dim]",
-                json_output=json_output,
-                stdout_console=stdout_console,
-                stderr_output_console=stderr_output_console,
-            )
-        return matches[0].id
-
-    if len(matches) == 0:
-        raise click.ClickException(
-            f"No {entity_name} found starting with '{partial_id}'. "
-            f"Run 'notebooklm {list_command}' to see available {entity_name}s."
-        )
-
-    lines = [f"Ambiguous ID '{partial_id}' matches {len(matches)} {entity_name}s:"]
-    for item in matches[:5]:
-        title = item.title or "(untitled)"
-        lines.append(f"  {item.id[:12]}... {title}")
-    if len(matches) > 5:
-        lines.append(f"  ... and {len(matches) - 5} more")
-    lines.append("\nSpecify more characters to narrow down.")
-    raise click.ClickException("\n".join(lines))
+    return resolve_partial_id_in_items(
+        partial_id,
+        items,
+        entity_name=entity_name,
+        list_command=list_command,
+        # async path uses the attribute-style accessors (default).
+        json_output=json_output,
+        stdout_console=stdout_console,
+        stderr_output_console=stderr_output_console,
+        # async path keeps ``click.ClickException`` (Click -> exit 1 + stderr).
+    )
 
 
 async def resolve_notebook_id(
@@ -206,8 +377,8 @@ async def resolve_notebook_id(
     partial_id: str,
     *,
     json_output: bool = False,
-    stdout_console: Console = rendering_helpers.console,
-    stderr_output_console: Console = rendering_helpers.stderr_console,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
 ) -> str:
     """Resolve partial notebook ID to full ID.
 
@@ -231,8 +402,8 @@ async def resolve_source_id(
     partial_id: str,
     *,
     json_output: bool = False,
-    stdout_console: Console = rendering_helpers.console,
-    stderr_output_console: Console = rendering_helpers.stderr_console,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
 ) -> str:
     """Resolve partial source ID to full ID.
 
@@ -256,8 +427,8 @@ async def resolve_artifact_id(
     partial_id: str,
     *,
     json_output: bool = False,
-    stdout_console: Console = rendering_helpers.console,
-    stderr_output_console: Console = rendering_helpers.stderr_console,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
 ) -> str:
     """Resolve partial artifact ID to full ID.
 
@@ -281,8 +452,8 @@ async def resolve_note_id(
     partial_id: str,
     *,
     json_output: bool = False,
-    stdout_console: Console = rendering_helpers.console,
-    stderr_output_console: Console = rendering_helpers.stderr_console,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
 ) -> str:
     """Resolve partial note ID to full ID.
 
@@ -306,8 +477,8 @@ async def resolve_source_ids(
     source_ids: tuple[str, ...],
     *,
     json_output: bool = False,
-    stdout_console: Console = rendering_helpers.console,
-    stderr_output_console: Console = rendering_helpers.stderr_console,
+    stdout_console: Console | None = None,
+    stderr_output_console: Console | None = None,
 ) -> list[str] | None:
     """Resolve multiple partial source IDs to full IDs.
 

--- a/tests/unit/cli/test_helpers_compat.py
+++ b/tests/unit/cli/test_helpers_compat.py
@@ -1,0 +1,215 @@
+"""Patch-surface compatibility tests for ``notebooklm.cli.helpers``.
+
+After P2.T1 consolidates the canonical resolver implementations into
+``notebooklm.cli.resolve``, the ``notebooklm.cli.helpers`` module continues
+to expose ``require_notebook``, ``validate_id``, ``_resolve_partial_id``,
+``resolve_notebook_id``, etc. as a **compatibility facade**. These names are
+patch targets in many existing tests; the facade must survive renames or
+shape changes in the canonical implementation.
+
+This test file is the explicit pin for that contract. Critical guarantees:
+
+1. Patching ``helpers.require_notebook`` intercepts calls made through the
+   helpers module namespace.
+2. ``patch("notebooklm.cli.helpers.get_context_path", ...)`` still affects
+   ``helpers.require_notebook``'s context-file-fallback behavior. ~20
+   existing tests in ``test_helpers.py`` rely on this.
+3. ``patch("notebooklm.cli.helpers.console", ...)`` still affects
+   ``helpers.require_notebook``'s no-notebook diagnostic. Several existing
+   tests rely on this.
+4. ``helpers.validate_id`` and ``helpers._resolve_partial_id`` remain
+   importable and call-compatible with the canonical resolver.
+
+If this file ever fails, the patch surface has regressed and downstream
+test files will start breaking - fix the facade, not this test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+
+from notebooklm.cli import helpers
+
+# ----------------------------------------------------------------------------
+# 1. Patching helpers.require_notebook intercepts CLI calls
+# ----------------------------------------------------------------------------
+
+
+class TestMonkeypatchOnHelpersRequireNotebook:
+    """A patch of ``helpers.require_notebook`` must intercept
+    ``helpers.require_notebook(...)`` calls.
+
+    This is the explicit acceptance criterion from P2.T1.
+    """
+
+    def test_monkeypatch_setattr_intercepts_direct_call(self, monkeypatch):
+        sentinel = "INTERCEPTED_NOTEBOOK_ID"
+
+        def fake_require_notebook(notebook_id):
+            return sentinel
+
+        monkeypatch.setattr(helpers, "require_notebook", fake_require_notebook)
+
+        result = helpers.require_notebook("ignored")
+        assert result == sentinel
+
+    def test_monkeypatch_undone_after_test(self):
+        """Sanity: after monkeypatch undoes itself, the real function returns.
+
+        This guards against a bad facade implementation that would cache the
+        patched function in a closure and leak between tests.
+        """
+        # The previous test patched the symbol. After fixture teardown,
+        # calling with a real id should still go through the normal path.
+        # Without a context file, env var, or arg, it raises SystemExit.
+        with pytest.raises(SystemExit):
+            helpers.require_notebook(None)
+
+
+# ----------------------------------------------------------------------------
+# 2. patching helpers.get_context_path still steers helpers.require_notebook
+# ----------------------------------------------------------------------------
+
+
+class TestHelpersGetContextPathPatchSurface:
+    """Patching ``helpers.get_context_path`` must affect
+    ``helpers.require_notebook`` so the ~20 existing tests in
+    ``test_helpers.py`` that do this keep passing.
+    """
+
+    def test_context_file_path_patch_steers_resolution(self, tmp_path):
+        """An empty/non-existent context path leads to SystemExit."""
+        with (
+            patch(
+                "notebooklm.cli.helpers.get_context_path",
+                return_value=tmp_path / "nonexistent.json",
+            ),
+            pytest.raises(SystemExit),
+        ):
+            helpers.require_notebook(None)
+
+    def test_context_file_path_patch_returns_context_value(self, tmp_path):
+        """A patched ``get_context_path`` pointing at a real file lets the
+        context-fallback rung return its notebook id."""
+        context_file = tmp_path / "context.json"
+        context_file.write_text('{"notebook_id": "nb_from_context"}')
+        with patch("notebooklm.cli.helpers.get_context_path", return_value=context_file):
+            assert helpers.require_notebook(None) == "nb_from_context"
+
+
+# ----------------------------------------------------------------------------
+# 3. patching helpers.console still steers the error-path output
+# ----------------------------------------------------------------------------
+
+
+class TestHelpersConsolePatchSurface:
+    def test_console_patch_captures_no_notebook_diagnostic(self, tmp_path):
+        """Patching ``helpers.console`` captures the no-notebook error
+        message that ``require_notebook`` prints before raising
+        ``SystemExit``."""
+        with (
+            patch(
+                "notebooklm.cli.helpers.get_context_path",
+                return_value=tmp_path / "nonexistent.json",
+            ),
+            patch("notebooklm.cli.helpers.console") as mock_console,
+        ):
+            with pytest.raises(SystemExit):
+                helpers.require_notebook(None)
+
+            mock_console.print.assert_called_once()
+            printed = mock_console.print.call_args[0][0]
+            # User-facing flag is named.
+            assert "-n/--notebook" in printed
+
+
+# ----------------------------------------------------------------------------
+# 4. validate_id + _resolve_partial_id remain importable from helpers
+# ----------------------------------------------------------------------------
+
+
+class TestResolverFacadeReExports:
+    def test_resolver_names_are_canonical_aliases(self):
+        from notebooklm.cli import resolve
+
+        assert helpers.require_notebook is resolve.require_notebook
+        assert helpers.validate_id is resolve.validate_id
+        assert helpers._resolve_partial_id is resolve._resolve_partial_id
+        assert helpers.resolve_notebook_id is resolve.resolve_notebook_id
+        assert helpers.resolve_source_id is resolve.resolve_source_id
+        assert helpers.resolve_artifact_id is resolve.resolve_artifact_id
+
+    def test_validate_id_importable_from_helpers(self):
+        from notebooklm.cli.helpers import validate_id
+
+        # Trivial smoke check that the facade name is callable.
+        assert validate_id("  abc  ") == "abc"
+
+    def test_validate_id_facade_matches_canonical(self):
+        from notebooklm.cli import resolve
+
+        # Same function or same behavior across multiple inputs.
+        for case in ("a", "  spaced  ", "abc12345-6789-4abc-def0-1234567890ab"):
+            assert helpers.validate_id(case) == resolve.validate_id(case)
+
+    def test_validate_id_facade_raises_same_exception(self):
+        with pytest.raises(click.ClickException):
+            helpers.validate_id("   ")
+
+    @pytest.mark.asyncio
+    async def test_resolve_partial_id_importable_from_helpers(self):
+        from notebooklm.cli.helpers import _resolve_partial_id
+
+        class Item:
+            def __init__(self, id_, title):
+                self.id = id_
+                self.title = title
+
+        async def list_fn():
+            return [Item("aaa111", "First"), Item("bbb222", "Second")]
+
+        result = await _resolve_partial_id("aaa", list_fn, "thing", "thing list")
+        assert result == "aaa111"
+
+    @pytest.mark.asyncio
+    async def test_resolve_notebook_id_importable_from_helpers(self):
+        from notebooklm.cli.helpers import resolve_notebook_id
+
+        client = MagicMock()
+
+        class Notebook:
+            def __init__(self, id_, title):
+                self.id = id_
+                self.title = title
+
+        client.notebooks = MagicMock()
+        client.notebooks.list = AsyncMock(
+            return_value=[Notebook("nb_111", "First"), Notebook("nb_222", "Second")]
+        )
+
+        result = await resolve_notebook_id(client, "nb_1")
+        assert result == "nb_111"
+
+
+# ----------------------------------------------------------------------------
+# 5. helpers.* names remain present in cli/__init__.py public surface
+# ----------------------------------------------------------------------------
+
+
+class TestPublicSurfaceRemainsStable:
+    """The ``cli/__init__.py`` public re-exports must not lose
+    ``require_notebook``, ``resolve_notebook_id``, etc."""
+
+    def test_public_names_present(self):
+        from notebooklm import cli
+
+        for name in (
+            "require_notebook",
+            "resolve_notebook_id",
+            "resolve_source_id",
+            "resolve_artifact_id",
+        ):
+            assert hasattr(cli, name), f"cli public surface lost {name!r}"

--- a/tests/unit/cli/test_resolve.py
+++ b/tests/unit/cli/test_resolve.py
@@ -120,7 +120,7 @@ class TestResolveNotebookId:
     @pytest.mark.asyncio
     async def test_uuid_shaped_id_returns_without_listing(self, mock_client):
         """36-char UUID-shaped IDs fast-path without hitting the backend."""
-        # Canonical 8-4-4-4-12 UUID layout — 36 chars, all hex + dashes.
+        # Canonical 8-4-4-4-12 UUID layout - 36 chars, all hex + dashes.
         uuid_id = "abc12345-6789-4abc-def0-1234567890ab"
         assert len(uuid_id) == 36
         mock_client.notebooks.list = AsyncMock()
@@ -147,7 +147,7 @@ class TestResolveNotebookId:
         """A 25-char prefix of a 36-char UUID resolves locally, not via the backend.
 
         Regression for P1.T9: the previous length-based fast-path (>= 20 chars)
-        bypassed local matching for any 20–35 char prefix of a UUID, sending the
+        bypassed local matching for any 20-35 char prefix of a UUID, sending the
         truncated string straight to the backend. Per the acceptance criteria,
         this path must also emit the ``Matched:`` diagnostic so users can see
         which full ID the prefix resolved to.
@@ -213,7 +213,7 @@ class TestResolveNotebookId:
         """Degenerate 36-char input (all dashes) does NOT fast-path.
 
         The 8-4-4-4-12 layout requires hex digits in each block, so a pathological
-        ``"-" * 36`` input cannot bypass local resolution — it gets routed through
+        ``"-" * 36`` input cannot bypass local resolution - it gets routed through
         the local prefix-match path and surfaces a clear "no match" error.
         """
         all_dashes = "-" * 36
@@ -685,3 +685,362 @@ class TestResolveSourceIds:
 
         assert "cannot be empty" in str(exc_info.value)
         mock_client_with_sources.sources.list.assert_not_called()
+
+
+# ----------------------------------------------------------------------------
+# Sync resolver core + entity-specific config (P2.T1 acceptance criteria)
+# ----------------------------------------------------------------------------
+
+
+class TestRequireNotebookEnvVarFallback:
+    """Pin the env-var rung of ``require_notebook``'s precedence ladder.
+
+    The full ladder is: ``-n`` flag > ``NOTEBOOKLM_NOTEBOOK`` env >
+    persisted-context > error. ``test_helpers.py`` covers the same paths
+    via the helpers facade; this class covers them via the canonical
+    ``cli.resolve.require_notebook`` directly so any drift between the two
+    surfaces is caught here.
+    """
+
+    def test_argument_wins_over_env_and_context(self, tmp_path, monkeypatch):
+        from notebooklm.cli.resolve import require_notebook
+
+        ctx_file = tmp_path / "context.json"
+        ctx_file.write_text('{"notebook_id": "nb_from_context"}')
+        monkeypatch.setenv("NOTEBOOKLM_NOTEBOOK", "nb_from_env")
+
+        assert (
+            require_notebook("nb_from_arg", context_path_fn=lambda **_: ctx_file) == "nb_from_arg"
+        )
+
+    def test_env_var_fills_in_when_no_arg(self, tmp_path, monkeypatch):
+        """When ``-n`` is None and there is no context file, env wins."""
+        from notebooklm.cli.resolve import require_notebook
+
+        monkeypatch.setenv("NOTEBOOKLM_NOTEBOOK", "nb_from_env")
+        assert (
+            require_notebook(
+                None,
+                context_path_fn=lambda **_: tmp_path / "nonexistent.json",
+            )
+            == "nb_from_env"
+        )
+
+    def test_env_var_wins_over_context_file(self, tmp_path, monkeypatch):
+        """Env-var takes precedence over the persisted active-notebook."""
+        from notebooklm.cli.resolve import require_notebook
+
+        ctx_file = tmp_path / "context.json"
+        ctx_file.write_text('{"notebook_id": "nb_from_context"}')
+        monkeypatch.setenv("NOTEBOOKLM_NOTEBOOK", "nb_from_env")
+        assert require_notebook(None, context_path_fn=lambda **_: ctx_file) == "nb_from_env"
+
+    def test_context_file_used_when_no_arg_and_no_env(self, tmp_path, monkeypatch):
+        """No arg + no env-var -> fall through to the active-context file."""
+        from notebooklm.cli.resolve import require_notebook
+
+        monkeypatch.delenv("NOTEBOOKLM_NOTEBOOK", raising=False)
+        ctx_file = tmp_path / "context.json"
+        ctx_file.write_text('{"notebook_id": "nb_from_context"}')
+        assert require_notebook(None, context_path_fn=lambda **_: ctx_file) == "nb_from_context"
+
+    def test_blank_env_var_falls_through_to_context(self, tmp_path, monkeypatch):
+        """Whitespace-only ``NOTEBOOKLM_NOTEBOOK`` is treated as unset."""
+        from notebooklm.cli.resolve import require_notebook
+
+        monkeypatch.setenv("NOTEBOOKLM_NOTEBOOK", "   ")
+        ctx_file = tmp_path / "context.json"
+        ctx_file.write_text('{"notebook_id": "nb_from_context"}')
+        assert require_notebook(None, context_path_fn=lambda **_: ctx_file) == "nb_from_context"
+
+    def test_env_var_is_stripped(self, tmp_path, monkeypatch):
+        """``NOTEBOOKLM_NOTEBOOK`` value is trimmed before being returned."""
+        from notebooklm.cli.resolve import require_notebook
+
+        monkeypatch.setenv("NOTEBOOKLM_NOTEBOOK", "  nb_padded  ")
+        assert (
+            require_notebook(
+                None,
+                context_path_fn=lambda **_: tmp_path / "nonexistent.json",
+            )
+            == "nb_padded"
+        )
+
+    def test_no_source_anywhere_raises_with_discoverability_hint(self, tmp_path, monkeypatch):
+        """All three resolution paths must be named in the error message."""
+        from notebooklm.cli.resolve import require_notebook
+
+        monkeypatch.delenv("NOTEBOOKLM_NOTEBOOK", raising=False)
+        mock_console = MagicMock()
+        with pytest.raises(SystemExit):
+            require_notebook(
+                None,
+                context_path_fn=lambda **_: tmp_path / "nonexistent.json",
+                output_console=mock_console,
+            )
+
+        mock_console.print.assert_called_once()
+        printed = mock_console.print.call_args[0][0]
+        assert "-n/--notebook" in printed
+        assert "NOTEBOOKLM_NOTEBOOK" in printed
+        assert "notebooklm use" in printed
+
+
+class TestResolvePartialIdInItems:
+    """Direct tests for the sync resolver core that powers both the async
+    ``_resolve_partial_id`` and the download-pre-fetched-list path.
+
+    These cover the consolidation contract: identical matching rules
+    regardless of accessor shape and error factory.
+    """
+
+    def test_full_uuid_fast_path(self):
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        full = "abc12345-6789-4abc-def0-1234567890ab"
+        # An empty items list MUST not be visited at all; the fast-path
+        # returns before any iteration.
+        result = resolve_partial_id_in_items(
+            full,
+            [],
+            entity_name="artifact",
+            list_command="artifact list",
+        )
+        assert result == full
+
+    def test_partial_unique_match_with_attr_accessor(self):
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        class Item:
+            def __init__(self, id_, title):
+                self.id = id_
+                self.title = title
+
+        items = [Item("aaa111", "A"), Item("bbb222", "B")]
+        assert (
+            resolve_partial_id_in_items(
+                "aaa",
+                items,
+                entity_name="thing",
+                list_command="thing list",
+                stdout_console=MagicMock(),
+            )
+            == "aaa111"
+        )
+
+    def test_partial_unique_match_with_dict_accessor(self):
+        """Entity-specific config: dict-shaped items via ``id_of``/``title_of``.
+
+        This is the canonical consolidation test - the download path uses
+        :class:`ArtifactDict` and reaches the same matching logic without
+        first reshaping its inputs.
+        """
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        items = [
+            {"id": "art_aaa", "title": "First"},
+            {"id": "art_bbb", "title": "Second"},
+        ]
+        result = resolve_partial_id_in_items(
+            "art_a",
+            items,
+            entity_name="artifact",
+            list_command="artifact list",
+            id_of=lambda a: a["id"],
+            title_of=lambda a: a["title"],
+            error_factory=ValueError,
+            stdout_console=MagicMock(),
+        )
+        assert result == "art_aaa"
+
+    def test_ambiguous_partial_match_raises_via_error_factory(self):
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        items = [
+            {"id": "art_aaa", "title": "First"},
+            {"id": "art_aab", "title": "Second"},
+        ]
+        # When error_factory=ValueError, the consolidated resolver raises
+        # ValueError (not click.ClickException) so the download path's
+        # ``except ValueError`` continues to work.
+        with pytest.raises(ValueError) as exc:
+            resolve_partial_id_in_items(
+                "art_a",
+                items,
+                entity_name="artifact",
+                list_command="artifact list",
+                id_of=lambda a: a["id"],
+                title_of=lambda a: a["title"],
+                error_factory=ValueError,
+            )
+
+        # The default canonical wording is "Ambiguous ID 'X' matches N artifacts:".
+        # The download_helpers wrapper translates this to historical wording -
+        # but at THIS layer the canonical message is what surfaces.
+        assert "Ambiguous" in str(exc.value)
+        assert "art_a" in str(exc.value)
+
+    def test_no_match_raises_via_error_factory(self):
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        items = [{"id": "art_xyz", "title": "Only"}]
+        with pytest.raises(ValueError) as exc:
+            resolve_partial_id_in_items(
+                "art_a",
+                items,
+                entity_name="artifact",
+                list_command="artifact list",
+                id_of=lambda a: a["id"],
+                title_of=lambda a: a["title"],
+                error_factory=ValueError,
+            )
+        # Canonical wording at this layer ("No artifact found starting with..."
+        # + the discoverability hint pointing at ``artifact list``).
+        assert "No artifact found starting with" in str(exc.value)
+        assert "artifact list" in str(exc.value)
+
+    def test_empty_partial_id_raises_via_error_factory(self):
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            resolve_partial_id_in_items(
+                "   ",
+                [{"id": "x", "title": "y"}],
+                entity_name="artifact",
+                list_command="artifact list",
+                id_of=lambda a: a["id"],
+                title_of=lambda a: a["title"],
+                error_factory=ValueError,
+            )
+
+    def test_default_error_factory_is_click_exception(self):
+        """Without an explicit ``error_factory``, the async-path default
+        ``click.ClickException`` is used. This is the contract that the
+        async ``_resolve_partial_id`` relies on so Click can render its
+        familiar exit-1 + stderr error."""
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        with pytest.raises(click.ClickException):
+            resolve_partial_id_in_items(
+                "missing",
+                [],
+                entity_name="notebook",
+                list_command="list",
+            )
+
+    def test_exact_match_wins_over_ambiguous_prefix(self):
+        """The exact-id-wins rule must hold for the consolidated core too."""
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        items = [
+            {"id": "abc", "title": "Exact"},
+            {"id": "abc12345-6789-4abc-def0-1234567890ab", "title": "Long"},
+        ]
+        # 'abc' is an exact match for the first item AND a prefix of the
+        # second. The exact match must win - no "Matched: ..." status, no
+        # ambiguity error.
+        mock_console = MagicMock()
+        result = resolve_partial_id_in_items(
+            "abc",
+            items,
+            entity_name="artifact",
+            list_command="artifact list",
+            id_of=lambda a: a["id"],
+            title_of=lambda a: a["title"],
+            error_factory=ValueError,
+            stdout_console=mock_console,
+        )
+        assert result == "abc"
+        mock_console.print.assert_not_called()
+
+    def test_matched_status_routes_to_stderr_in_json_mode(self):
+        """JSON-mode keeps stdout parseable by routing "Matched..." to stderr."""
+        from notebooklm.cli.resolve import resolve_partial_id_in_items
+
+        items = [{"id": "abc12345", "title": "First"}]
+        stdout_console = MagicMock()
+        stderr_console = MagicMock()
+
+        result = resolve_partial_id_in_items(
+            "abc",
+            items,
+            entity_name="artifact",
+            list_command="artifact list",
+            id_of=lambda a: a["id"],
+            title_of=lambda a: a["title"],
+            error_factory=ValueError,
+            json_output=True,
+            stdout_console=stdout_console,
+            stderr_output_console=stderr_console,
+        )
+
+        assert result == "abc12345"
+        stdout_console.print.assert_not_called()
+        stderr_console.print.assert_called_once()
+        printed = stderr_console.print.call_args[0][0]
+        assert "Matched" in printed
+
+
+class TestEntitySpecificPartialArtifactId:
+    """Cover the download-helpers entity-specific consolidated path.
+
+    Acceptance criterion: "entity-specific partial-ID resolution for
+    artifacts". The download path delegates to ``resolve_partial_id_in_items``
+    via :func:`notebooklm.cli.download_helpers.resolve_partial_artifact_id`
+    with the dict-shape accessors and ``ValueError`` factory.
+    """
+
+    def test_consolidated_path_handles_artifact_dict_shape(self):
+        from notebooklm.cli.download_helpers import resolve_partial_artifact_id
+
+        artifacts = [
+            {"id": "abc111-aaaa-4abc-def0-000000000001", "title": "First", "created_at": 1},
+            {"id": "xyz222-aaaa-4abc-def0-000000000002", "title": "Second", "created_at": 2},
+        ]
+        # Unique prefix resolves through the consolidated core.
+        assert resolve_partial_artifact_id(artifacts, "abc") == "abc111-aaaa-4abc-def0-000000000001"
+
+    def test_consolidated_path_preserves_historical_not_found_wording(self):
+        """The download user-visible error retains its historical
+        wording ("Artifact 'X' not found") even though the consolidated
+        core uses different wording at the resolve.py layer.
+
+        This is the exact contract from
+        ``tests/unit/test_download_helpers.py::test_no_match_raises`` and
+        downstream user-visible CLI error envelopes.
+        """
+        from notebooklm.cli.download_helpers import resolve_partial_artifact_id
+
+        artifacts = [{"id": "xyz222-aaaa-4abc-def0-000000000002", "title": "Only", "created_at": 1}]
+        with pytest.raises(ValueError) as exc:
+            resolve_partial_artifact_id(artifacts, "abc")
+
+        assert "Artifact 'abc' not found" in str(exc.value)
+
+    def test_consolidated_path_preserves_historical_ambiguous_wording(self):
+        """Ambiguous-match error retains the "Ambiguous partial ID 'X' matches: ..."
+        wording downstream callers rely on."""
+        from notebooklm.cli.download_helpers import resolve_partial_artifact_id
+
+        artifacts = [
+            {"id": "abc111", "title": "Meeting Notes", "created_at": 1},
+            {"id": "abc222", "title": "Debate Session", "created_at": 2},
+        ]
+        with pytest.raises(ValueError) as exc:
+            resolve_partial_artifact_id(artifacts, "abc")
+
+        msg = str(exc.value)
+        assert "Ambiguous partial ID 'abc'" in msg
+        assert "Meeting Notes" in msg
+        assert "Debate Session" in msg
+
+    def test_consolidated_path_uses_valueerror_not_clickexception(self):
+        """The download path's downstream ``except ValueError`` contract is
+        preserved by the ``error_factory=ValueError`` config."""
+        import click as _click
+
+        from notebooklm.cli.download_helpers import resolve_partial_artifact_id
+
+        with pytest.raises(ValueError) as exc:
+            resolve_partial_artifact_id([], "abc")
+        assert not isinstance(exc.value, _click.ClickException)

--- a/tests/unit/cli/test_resolver_characterization.py
+++ b/tests/unit/cli/test_resolver_characterization.py
@@ -1,0 +1,402 @@
+"""Characterization tests for the notebook + partial-ID resolver.
+
+These tests pin observable CLI behavior across the resolver paths in
+``cli/chat.py`` and ``cli/download.py`` BEFORE the P2.T1 consolidation
+refactor. They are intentionally end-to-end at the ``CliRunner`` level so
+they capture exit codes, stdout/stderr structure, and side-effect counts
+(e.g. "did the notebook listing fire?") that the lower-level unit tests in
+``test_resolve.py`` and ``test_download_helpers.py`` do not cover holistically.
+
+They must pass identically before AND after the refactor. Any divergence is
+a behavior regression - not an opportunity to "fix" the old behavior.
+
+Coverage matrix (resolver fallback paths):
+
+| Path                                | chat ask  | download <type> |
+|-------------------------------------|-----------|-----------------|
+| Explicit `-n <full-id>` arg         | yes       | yes             |
+| `NOTEBOOKLM_NOTEBOOK` env-var       | yes       | yes             |
+| Context-file fallback               | yes       | yes             |
+| Partial artifact id (download only) | n/a       | yes             |
+
+The chat path also pins the conversation-id fallback order (which is a
+separate concern but co-located here because both fallback ladders live in
+the same file and risk collision during refactoring).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from notebooklm.cli import resolve as resolve_helpers
+from notebooklm.notebooklm_cli import cli
+from notebooklm.types import AskResult
+
+from .conftest import (
+    create_mock_client,
+    patch_client_for_module,
+)
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auth():
+    with patch("notebooklm.cli.helpers.load_auth_from_storage") as m:
+        m.return_value = {
+            "SID": "test",
+            "__Secure-1PSIDTS": "test_1psidts",
+            "HSID": "test",
+            "SSID": "test",
+            "APISID": "test",
+            "SAPISID": "test",
+        }
+        yield m
+
+
+@pytest.fixture
+def mock_fetch():
+    with patch("notebooklm.auth.fetch_tokens_with_domains", new_callable=AsyncMock) as m:
+        m.return_value = ("csrf", "session")
+        yield m
+
+
+def _ask_result() -> AskResult:
+    return AskResult(
+        answer="characterization answer",
+        conversation_id="a1b2c3d4-0000-0000-0000-000000000001",
+        turn_number=1,
+        is_follow_up=False,
+        references=[],
+        raw_response="",
+    )
+
+
+# ----------------------------------------------------------------------------
+# chat ask: notebook-resolution paths
+# ----------------------------------------------------------------------------
+
+
+class TestChatNotebookResolution:
+    def test_explicit_full_id_skips_notebook_listing(self, runner, mock_auth, mock_fetch):
+        """``-n <full-UUID>`` fast-paths past ``notebooks.list``.
+
+        UUID-shaped IDs (canonical 8-4-4-4-12 layout) MUST NOT trigger a
+        backend listing - the explicit arg is the authoritative source.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        with patch_client_for_module("chat") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=_ask_result())
+            mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["ask", "what?", "-n", full_uuid])
+
+        assert result.exit_code == 0, result.output
+        # No notebook listing should happen with a full UUID-shaped id.
+        mock_client.notebooks.list.assert_not_called()
+
+    def test_env_var_fallback_when_no_flag(
+        self, runner, mock_auth, mock_fetch, monkeypatch, tmp_path
+    ):
+        """``NOTEBOOKLM_NOTEBOOK`` env var fills in when ``-n`` is omitted.
+
+        Precedence ladder: ``-n`` flag > ``NOTEBOOKLM_NOTEBOOK`` env > active
+        context > error. This test pins the env-var rung.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        monkeypatch.setenv("NOTEBOOKLM_NOTEBOOK", full_uuid)
+        # Force context-file fallback to be unset so env-var is the
+        # observable resolution path.
+        monkeypatch.setattr(
+            resolve_helpers,
+            "get_context_path",
+            lambda *a, **kw: tmp_path / "nonexistent.json",
+        )
+
+        with patch_client_for_module("chat") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=_ask_result())
+            mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["ask", "what?"])
+
+        assert result.exit_code == 0, result.output
+        # ``chat.ask`` was called with the env-var-resolved notebook id.
+        assert mock_client.chat.ask.await_count == 1
+        nb_arg = mock_client.chat.ask.await_args.args[0]
+        assert nb_arg == full_uuid
+
+    def test_context_file_fallback_when_no_flag_and_no_env(
+        self, runner, mock_auth, mock_fetch, monkeypatch, tmp_path
+    ):
+        """Active-context notebook id fills in last."""
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        ctx_file = tmp_path / "context.json"
+        ctx_file.write_text(json.dumps({"notebook_id": full_uuid}))
+        monkeypatch.delenv("NOTEBOOKLM_NOTEBOOK", raising=False)
+        monkeypatch.setattr(resolve_helpers, "get_context_path", lambda *a, **kw: ctx_file)
+
+        with patch_client_for_module("chat") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=_ask_result())
+            mock_client.chat.get_conversation_id = AsyncMock(return_value=None)
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["ask", "what?"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_client.chat.ask.await_count == 1
+        assert mock_client.chat.ask.await_args.args[0] == full_uuid
+
+    def test_no_notebook_anywhere_exits_with_helpful_error(
+        self, runner, mock_auth, mock_fetch, monkeypatch, tmp_path
+    ):
+        """No -n + no env-var + no context = exit 1 with discoverability hint.
+
+        The error names the user-facing ``-n/--notebook`` flag, the
+        ``NOTEBOOKLM_NOTEBOOK`` env var, AND the ``notebooklm use`` context
+        path. All three resolution mechanisms must remain discoverable.
+        """
+        monkeypatch.delenv("NOTEBOOKLM_NOTEBOOK", raising=False)
+        monkeypatch.setattr(
+            resolve_helpers,
+            "get_context_path",
+            lambda *a, **kw: tmp_path / "nonexistent.json",
+        )
+
+        result = runner.invoke(cli, ["ask", "what?"])
+
+        assert result.exit_code == 1
+        combined = result.output + (result.stderr if result.stderr_bytes else "")
+        assert "-n/--notebook" in combined
+        assert "NOTEBOOKLM_NOTEBOOK" in combined
+        assert "notebooklm use" in combined
+
+
+# ----------------------------------------------------------------------------
+# download <type>: notebook + artifact resolution paths
+# ----------------------------------------------------------------------------
+
+
+def _make_artifact_list(items: list[tuple[str, str]]) -> list:
+    """Build a list of ``Artifact``-like instances the download path consumes.
+
+    The download path checks ``isinstance(a, Artifact) and a.kind == ... and
+    a.is_completed``. The on-disk dataclass uses ``_artifact_type`` (int code)
+    and ``status`` (int code) under the hood; matching ``cli/test_download.py``
+    fixtures keeps the real Artifact dataclass happy.
+    """
+    from datetime import datetime
+
+    from notebooklm.types import Artifact, ArtifactStatus, ArtifactTypeCode
+
+    out: list[Artifact] = []
+    for aid, title in items:
+        # Audio kind + completed status so the download_audio command matches.
+        out.append(
+            Artifact(
+                id=aid,
+                title=title,
+                _artifact_type=int(ArtifactTypeCode.AUDIO),
+                status=int(ArtifactStatus.COMPLETED),
+                created_at=datetime(2024, 1, 1),
+            )
+        )
+    return out
+
+
+class TestDownloadNotebookResolution:
+    def test_explicit_full_id_uses_arg_for_notebook(self, runner, mock_auth, mock_fetch, tmp_path):
+        """``-n <full-UUID>`` is honored by ``download audio``.
+
+        Resolver does not call ``notebooks.list`` for a UUID-shaped id.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        with patch_client_for_module("download") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(
+                return_value=_make_artifact_list(
+                    [(f"art-{i}-1234-4abc-def0-1234567890ab", f"a{i}") for i in range(1)]
+                )
+            )
+            mock_client.artifacts.download_audio = AsyncMock(return_value=str(tmp_path / "out.mp3"))
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "-n",
+                    full_uuid,
+                    "--latest",
+                    str(tmp_path / "out.mp3"),  # positional output path
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # No notebook listing fires for a full-UUID id.
+        mock_client.notebooks.list.assert_not_called()
+
+    def test_partial_artifact_id_resolves_locally(self, runner, mock_auth, mock_fetch, tmp_path):
+        """``--artifact <prefix>`` resolves to a full artifact id locally.
+
+        The download path uses ``resolve_partial_artifact_id`` against a
+        pre-fetched ``artifacts.list``. A unique 3-char prefix should pick
+        the right entry.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        artifacts = _make_artifact_list(
+            [
+                ("abcde000-aaaa-4abc-def0-000000000001", "first"),
+                ("xyz00000-aaaa-4abc-def0-000000000002", "second"),
+            ]
+        )
+        with patch_client_for_module("download") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(return_value=artifacts)
+            mock_client.artifacts.download_audio = AsyncMock(return_value=str(tmp_path / "out.mp3"))
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "-n",
+                    full_uuid,
+                    "--artifact",
+                    "abc",  # unique prefix of the first artifact id
+                    str(tmp_path / "out.mp3"),  # positional output path
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # download_audio signature: (notebook_id, output_path, artifact_id=None).
+        # The full artifact id (resolved from the "abc" prefix) is passed in
+        # the third positional slot.
+        mock_client.artifacts.download_audio.assert_awaited_once()
+        call = mock_client.artifacts.download_audio.await_args
+        called_id = call.kwargs.get("artifact_id")
+        if called_id is None and len(call.args) >= 3:
+            called_id = call.args[2]
+        assert called_id == "abcde000-aaaa-4abc-def0-000000000001"
+
+    def test_ambiguous_partial_artifact_id_surfaces_error(
+        self, runner, mock_auth, mock_fetch, tmp_path
+    ):
+        """Ambiguous artifact prefix surfaces the ambiguity in stdout JSON path.
+
+        The download command currently maps ``ValueError`` from
+        ``resolve_partial_artifact_id`` into a ``{"error": ...}`` envelope
+        rather than exiting non-zero. This test pins that contract so the
+        refactor cannot accidentally promote the error to an exit-1 path.
+        """
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        artifacts = _make_artifact_list(
+            [
+                ("abc11111-aaaa-4abc-def0-000000000001", "first"),
+                ("abc22222-aaaa-4abc-def0-000000000002", "second"),
+            ]
+        )
+        with patch_client_for_module("download") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(return_value=artifacts)
+            mock_client.artifacts.download_audio = AsyncMock()
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "-n",
+                    full_uuid,
+                    "--artifact",
+                    "abc",  # ambiguous prefix
+                    "--json",
+                ],
+            )
+
+        # The ambiguity must show up in the output (either as an error
+        # envelope or as a non-zero exit). The current implementation
+        # returns the {"error": ...} envelope from ``_download()``.
+        out = result.output
+        # Either branch is acceptable; pin both so neither shape regresses.
+        assert "Ambiguous" in out or "ambiguous" in out
+
+    def test_unknown_partial_artifact_id_surfaces_error(
+        self, runner, mock_auth, mock_fetch, tmp_path
+    ):
+        """Unknown artifact prefix surfaces ``not found`` in the output."""
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        artifacts = _make_artifact_list([("aaaa1111-aaaa-4abc-def0-000000000001", "only")])
+        with patch_client_for_module("download") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.artifacts.list = AsyncMock(return_value=artifacts)
+            mock_client.artifacts.download_audio = AsyncMock()
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "download",
+                    "audio",
+                    "-n",
+                    full_uuid,
+                    "--artifact",
+                    "zzz",  # no match
+                    "--json",
+                ],
+            )
+
+        assert "not found" in result.output.lower()
+
+
+# ----------------------------------------------------------------------------
+# chat.py conversation-ID fallback (the OTHER fallback ladder in this file)
+# ----------------------------------------------------------------------------
+
+
+class TestChatConversationFallback:
+    """Pin the explicit->cached->server conversation-ID fallback in chat.py.
+
+    The plan's "fallback order: explicit notebook -> cached -> server" reference
+    actually applies to the conversation-id lookup in
+    ``_determine_conversation_id`` + ``_get_latest_conversation_from_server``,
+    not the notebook-id resolver. Keeping a regression test here guards
+    against accidental coupling during the resolver refactor.
+    """
+
+    def test_explicit_conversation_id_wins(self, runner, mock_auth, mock_fetch):
+        full_uuid = "abc12345-6789-4abc-def0-1234567890ab"
+        conv_id = "11111111-2222-3333-4444-555555555555"
+        with patch_client_for_module("chat") as mock_cls:
+            mock_client = create_mock_client()
+            mock_client.chat.ask = AsyncMock(return_value=_ask_result())
+            mock_client.chat.get_conversation_id = AsyncMock(return_value="zzz-different-conv")
+            mock_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["ask", "what?", "-n", full_uuid, "-c", conv_id])
+
+        assert result.exit_code == 0, result.output
+        # The conversation_id passed to ``chat.ask`` must be the explicit one.
+        passed_conv_id = mock_client.chat.ask.await_args.kwargs.get("conversation_id")
+        assert passed_conv_id == conv_id
+        # The server fallback ``get_conversation_id`` must NOT have fired
+        # because the explicit -c short-circuited the fallback ladder.
+        mock_client.chat.get_conversation_id.assert_not_called()


### PR DESCRIPTION
## Summary
- centralize notebook/partial-ID resolver behavior in cli.resolve with a shared pre-fetched item matching core
- make cli.helpers resolver names compatibility aliases while preserving existing helper patch surfaces
- route download artifact partial-ID resolution through the canonical core without changing historical ValueError wording
- add resolver characterization and compatibility coverage

## Tests
- uv run ruff check src/notebooklm/cli tests/unit/cli/test_resolve.py tests/unit/cli/test_helpers_compat.py tests/unit/cli/test_resolver_characterization.py tests/unit/test_download_helpers.py
- uv run ruff format --check src/notebooklm/cli tests/unit/cli/test_resolve.py tests/unit/cli/test_helpers_compat.py tests/unit/cli/test_resolver_characterization.py tests/unit/test_download_helpers.py
- uv run mypy src/notebooklm --ignore-missing-imports
- uv run pytest tests/unit/cli/test_helpers.py tests/unit/cli/test_helpers_compat.py tests/unit/cli/test_resolve.py tests/unit/test_download_helpers.py tests/unit/cli/test_resolver_characterization.py -q
- uv run pytest tests/unit tests/integration -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and simplified CLI ID resolution logic, improving partial-ID matching, console output routing, and compatibility with existing helper facades while preserving historical user-facing messages.

* **Tests**
  * Added compatibility, unit, and end-to-end CLI tests covering notebook selection fallbacks, partial-ID exact/ambiguous/unknown behaviors, JSON-mode output routing, and integration with chat/download commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->