### PR TITLE
refactor(session): retire AuthRefreshCoordinator bridges (PR 5 of 8)

### DIFF
--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -67,14 +67,13 @@ if TYPE_CHECKING:
 
         Session-shrink PR 3 narrowed both Protocols by removing
         ``_timeout``, ``_refresh_callback``, ``_refresh_retry_delay``,
-        ``_http_client``, and ``_bound_loop`` declarations. The compat
-        bridges still exist on :class:`Session` (later PRs retire them);
-        what this assertion guarantees is that the narrowed Protocol
-        shape — only ``_kernel`` + methods for :class:`RpcOwner`, only
-        ``_kernel`` + ``_snapshot()`` for :class:`_AuthedTransportHost` —
-        is satisfied by :class:`Session`. mypy verifies this during
-        ``mypy src/notebooklm``; the function is a no-op at runtime
-        (gated by ``TYPE_CHECKING``).
+        ``_http_client``, and ``_bound_loop`` declarations. Some of those
+        compatibility bridges have since been retired; what this assertion
+        guarantees is that the narrowed Protocol shape — only ``_kernel`` +
+        methods for :class:`RpcOwner`, only ``_kernel`` + ``_snapshot()`` for
+        :class:`_AuthedTransportHost` — is satisfied by :class:`Session`.
+        mypy verifies this during ``mypy src/notebooklm``; the function is a
+        no-op at runtime (gated by ``TYPE_CHECKING``).
         """
         _owner: RpcOwner = s
         _host: _AuthedTransportHost = s
@@ -303,10 +302,9 @@ class Session:
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
         # by integration tests against ``client._session``. The refresh
-        # callback + the four refresh/auth-snapshot ivars (``_refresh_lock``,
-        # ``_refresh_task``, ``_refresh_callback``, ``_auth_snapshot_lock``)
-        # live on ``self._auth_coord``, constructed below alongside the other
-        # extracted helpers so the inter-helper dependency order is obvious.
+        # callback + refresh/auth-snapshot state live on ``self._auth_coord``,
+        # constructed below alongside the other extracted helpers so the
+        # inter-helper dependency order is obvious.
         self._refresh_retry_delay = refresh_retry_delay
         if rate_limit_max_retries < 0:
             raise ValueError(f"rate_limit_max_retries must be >= 0, got {rate_limit_max_retries}")
@@ -369,12 +367,10 @@ class Session:
         # Auth refresh coordination — single-flight refresh task, snapshot
         # serialization, and cookie-jar sync. The coordinator owns
         # ``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``, and
-        # ``_auth_snapshot_lock``; field names match the legacy
-        # ``Session`` ivars so the surviving compat properties
-        # (``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``)
-        # delegate cleanly. The ``_auth_snapshot_lock`` bridge was dropped
-        # in D1-audit-full; the live lock is reachable via
-        # :meth:`_get_auth_snapshot_lock`.
+        # ``_auth_snapshot_lock``. The matching ``Session`` compat bridges
+        # are retired; tests and internal callers that need implementation
+        # state read the coordinator directly. The live auth snapshot lock is
+        # reachable via :meth:`_get_auth_snapshot_lock`.
         # The auth snapshot lock is intentionally distinct from
         # ``_refresh_lock`` — mixing them would re-introduce the
         # reentrancy ambiguity that snapshot-side serialization was added
@@ -472,42 +468,12 @@ class Session:
     # tests now read ``self._drain_tracker.<attr>`` directly. The
     # ``_operation_depths`` bridge was dropped earlier in D1-audit-full.
 
-    # ------------------------------------------------------------------
-    # ``AuthRefreshCoordinator`` compat bridges. Refresh/auth-snapshot state
-    # now lives on ``self._auth_coord``; the four legacy ivar names are
-    # preserved as properties so the dozens of test sites that read them keep
-    # working without modification. Only ``_refresh_callback`` retains a setter
-    # (``core._refresh_callback = stub`` is still load-bearing — see
-    # ``tests/integration/test_session_integration.py:217,292``); the other
-    # three are read-only, so writes must go through ``self._auth_coord.<name>``
-    # directly. ``Session.__init__`` eager-constructs the coordinator, so the
-    # bridges delegate directly without lazy backfill.
-    # ------------------------------------------------------------------
-
-    @property
-    def _refresh_lock(self) -> asyncio.Lock | None:
-        """Phase 4 deleted the matching ``.setter``; write on
-        ``self._auth_coord._refresh_lock`` directly.
-        """
-        return self._auth_coord._refresh_lock
-
-    @property
-    def _refresh_task(self) -> asyncio.Task[AuthTokens] | None:
-        return self._auth_coord._refresh_task
-
-    # ``_refresh_task`` setter dropped in arch-d2-cutover: zero external callers.
-
-    @property
-    def _refresh_callback(self) -> Callable[[], Awaitable[AuthTokens]] | None:
-        return self._auth_coord._refresh_callback
-
-    @_refresh_callback.setter
-    def _refresh_callback(self, value: Callable[[], Awaitable[AuthTokens]] | None) -> None:
-        self._auth_coord._refresh_callback = value
-
-    # ``_auth_snapshot_lock`` compat bridge dropped (D1-audit-full): zero
-    # external callers. Live accessor remains ``_get_auth_snapshot_lock()`` /
-    # ``AuthRefreshCoordinator.get_auth_snapshot_lock()``.
+    # ``AuthRefreshCoordinator`` compat bridges retired in session-shrink PR 5:
+    # readers (and the two ``_refresh_callback`` writers in
+    # ``tests/integration/test_session_integration.py``) now go straight to
+    # ``self._auth_coord.<attr>``. The ``_auth_snapshot_lock`` bridge was
+    # dropped earlier in D1-audit-full; the live accessor remains
+    # ``_get_auth_snapshot_lock()`` / ``AuthRefreshCoordinator.get_auth_snapshot_lock()``.
 
     # ------------------------------------------------------------------
     # ``ClientLifecycle`` compat bridges. HTTP-client lifecycle state now

--- a/src/notebooklm/_session_auth.py
+++ b/src/notebooklm/_session_auth.py
@@ -85,10 +85,9 @@ class AuthRefreshCoordinator:
     """Owns refresh single-flight, snapshot serialization, and auth-header sync.
 
     Field names (``_refresh_lock``, ``_refresh_task``, ``_refresh_callback``,
-    ``_auth_snapshot_lock``) deliberately mirror the legacy ``Session``
-    ivars so the compat ``@property`` bridges on ``Session`` can delegate
-    with ``return self._auth_coord._<attr>`` and stay readable for reviewers
-    grepping the codebase.
+    ``_auth_snapshot_lock``) deliberately mirror the retired legacy
+    ``Session`` ivars so bridge-retirement diffs and coordinator-specific
+    tests remain easy to audit.
     """
 
     def __init__(

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -71,10 +71,14 @@ FORBIDDEN_PROPERTIES: frozenset[str] = frozenset(
         "_keepalive_task",
         "_keepalive_interval",
         "_keepalive_storage_path",
-        # AuthRefreshCoordinator bridges
-        "_refresh_callback",
-        "_refresh_task",
-        "_refresh_lock",
+        # AuthRefreshCoordinator bridges retired in session-shrink PR 5 —
+        # readers (and the two ``_refresh_callback`` writers in
+        # ``tests/integration/test_session_integration.py``) now go straight
+        # to ``session._auth_coord.<attr>``. Names intentionally NOT listed
+        # so the lint no longer flags legitimate direct-coordinator reads
+        # in ``test_session_auth.py`` (and the unrelated ``owner._refresh_callback``
+        # attribute used by the fake ``_Owner`` in ``test_rpc_executor.py`` /
+        # ``test_idempotency_registry.py``).
         # Observability (ClientMetrics + TransportDrainTracker) bridges
         # retired in session-shrink PR 4 — readers now go straight to
         # ``session._metrics_obj.<attr>`` / ``session._drain_tracker.<attr>``
@@ -152,11 +156,8 @@ ALLOWLIST: list[str] = [
     "tests/integration/concurrency/test_max_concurrent_rpcs.py",
     "tests/integration/concurrency/test_note_create_cancel.py",
     "tests/integration/concurrency/test_rate_limit_default.py",
-    "tests/integration/concurrency/test_refresh_cancellation_propagation.py",
     "tests/integration/test_artifact_generation_idempotency.py",
-    "tests/integration/test_auth_refresh_vcr.py",
     "tests/integration/test_auto_refresh.py",
-    "tests/integration/test_error_paths_vcr.py",
     "tests/integration/test_notes_idempotency.py",
     "tests/integration/test_research_idempotency.py",
     "tests/integration/test_session_integration.py",
@@ -175,8 +176,6 @@ ALLOWLIST: list[str] = [
     "tests/unit/test_idempotency_registry.py",
     "tests/unit/test_observability.py",
     "tests/unit/test_rate_limit_retry.py",
-    "tests/unit/test_refresh_lock_lazy_init.py",
-    "tests/unit/test_refresh_state_machine.py",
     "tests/unit/test_rpc_executor.py",
     "tests/unit/test_rpc_overrides.py",
     "tests/unit/test_session_auth.py",

--- a/tests/integration/concurrency/test_refresh_cancellation_propagation.py
+++ b/tests/integration/concurrency/test_refresh_cancellation_propagation.py
@@ -146,8 +146,8 @@ async def test_waiter_cancellation_does_not_kill_shared_refresh():
         # The shared task must still be alive — caller #1's cancellation
         # should not have cancelled it. This is the load-bearing
         # invariant the shield protects.
-        assert core._refresh_task is not None, "shared refresh task vanished"
-        assert not core._refresh_task.done(), (
+        assert core._auth_coord._refresh_task is not None, "shared refresh task vanished"
+        assert not core._auth_coord._refresh_task.done(), (
             "Shared refresh task completed/cancelled before release — "
             "Shield regression: waiter cancellation propagated into the "
             "shared task."
@@ -211,14 +211,14 @@ async def test_refresh_task_slot_not_cleared_on_waiter_cancellation():
         await asyncio.wait_for(callback_entered.wait(), EVENT_TIMEOUT_S)
 
         # Snapshot the task identity before the cancellation lands.
-        in_flight = core._refresh_task
+        in_flight = core._auth_coord._refresh_task
         assert in_flight is not None
 
         with pytest.raises((TimeoutError, asyncio.TimeoutError)):
             await task
 
         # Slot still points at the same task — not cleared, not replaced.
-        assert core._refresh_task is in_flight, (
+        assert core._auth_coord._refresh_task is in_flight, (
             "Refresh slot mutated by waiter cancellation — invariant "
             "broken: the slot must persist until the task completes."
         )

--- a/tests/integration/test_auth_refresh_vcr.py
+++ b/tests/integration/test_auth_refresh_vcr.py
@@ -131,7 +131,7 @@ async def test_stale_csrf_triggers_refresh_and_retry(
 
     # The refresh callback is captured by Session at construction;
     # patch it on the core so the wrapper is what the retry loop sees.
-    client._session._refresh_callback = tracking_refresh
+    client._session._auth_coord._refresh_callback = tracking_refresh
 
     with notebooklm_vcr.use_cassette(CASSETTE_NAME) as cassette:
         async with client:

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -28,13 +28,15 @@ class TestAutoRefreshIntegration:
 
         client = NotebookLMClient(auth)
         # Bound methods aren't identical, so compare underlying function
-        assert client._session._refresh_callback is not None
-        assert client._session._refresh_callback.__func__ is NotebookLMClient.refresh_auth
+        assert client._session._auth_coord._refresh_callback is not None
+        assert (
+            client._session._auth_coord._refresh_callback.__func__ is NotebookLMClient.refresh_auth
+        )
         # ``_refresh_lock`` is lazily created on first ``_await_refresh``.
         # At construction time it is ``None`` so the client can be
         # instantiated outside a running loop; the helper allocates the
         # lock on demand inside the async refresh path.
-        assert client._session._refresh_lock is None
+        assert client._session._auth_coord._refresh_lock is None
 
     @pytest.mark.asyncio
     async def test_full_refresh_flow_http_error(self):
@@ -59,7 +61,7 @@ class TestAutoRefreshIntegration:
             client._session.update_auth_headers()
             return client._session.auth
 
-        client._session._refresh_callback = tracking_refresh
+        client._session._auth_coord._refresh_callback = tracking_refresh
 
         # Mock HTTP responses
         call_count = [0]
@@ -107,7 +109,7 @@ class TestAutoRefreshIntegration:
             client._session.update_auth_headers()
             return client._session.auth
 
-        client._session._refresh_callback = tracking_refresh
+        client._session._auth_coord._refresh_callback = tracking_refresh
 
         # Mock HTTP to succeed, but decode_response to fail with auth error first
         async def mock_post(*args, **kwargs):
@@ -148,7 +150,7 @@ class TestAutoRefreshIntegration:
         async def mock_refresh():
             return auth
 
-        client._session._refresh_callback = mock_refresh
+        client._session._auth_coord._refresh_callback = mock_refresh
 
         call_count = [0]
 
@@ -192,7 +194,7 @@ class TestAutoRefreshIntegration:
             # Simulates refresh_auth detecting redirect to login
             raise ValueError("Authentication expired. Run 'notebooklm login' to re-authenticate.")
 
-        client._session._refresh_callback = failing_refresh
+        client._session._auth_coord._refresh_callback = failing_refresh
 
         async def mock_post(*args, **kwargs):
             request = httpx.Request("POST", args[0])

--- a/tests/integration/test_error_paths_vcr.py
+++ b/tests/integration/test_error_paths_vcr.py
@@ -196,7 +196,7 @@ class TestErrorPaths:
         attempt. The exact post-refresh exception type is incidental
         (``ClientError`` because 400 is not 401/403, 5xx, or 429); what
         matters is that the auth-refresh hook fired, observed via a spy
-        installed on ``_core._refresh_callback`` and corroborated by the
+        installed on ``_core._auth_coord._refresh_callback`` and corroborated by the
         ``play_count == 2`` assertion on the cassette.
         """
         client = NotebookLMClient(_synthetic_auth())
@@ -225,7 +225,7 @@ class TestErrorPaths:
             client._session.update_auth_headers()
             return client._session.auth
 
-        client._session._refresh_callback = stub_refresh
+        client._session._auth_coord._refresh_callback = stub_refresh
 
         with notebooklm_vcr.use_cassette("error_synthetic_stale_csrf.yaml") as cassette:
             async with client:

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -214,7 +214,7 @@ class TestRPCCallHTTPErrors:
         # gate in rpc_call short-circuits and the status mapping runs.
         async with NotebookLMClient(auth_tokens) as client:
             core = client._session
-            core._refresh_callback = None
+            core._auth_coord._refresh_callback = None
 
             mock_response = MagicMock()
             mock_response.status_code = 400
@@ -289,12 +289,12 @@ class TestRPCCallAuthRetry:
             core = client._session
 
             refresh_callback = AsyncMock()
-            core._refresh_callback = refresh_callback
+            core._auth_coord._refresh_callback = refresh_callback
             import asyncio
 
-            # Phase 4: ``Session._refresh_lock`` setter was removed; write on
-            # the collaborator directly. ``Session.__init__`` already built
-            # ``_auth_coord`` so this direct write is safe.
+            # Pre-allocate the lock so the first refresh attempt doesn't
+            # try to construct one (the coordinator's lazy-init runs at
+            # the first ``await_refresh`` call site).
             core._auth_coord._refresh_lock = asyncio.Lock()
 
             success_response = MagicMock()

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -474,7 +474,7 @@ class TestSessionRefreshCallback:
             pass
 
         core = Session(auth, refresh_callback=mock_refresh)
-        assert core._refresh_callback is mock_refresh
+        assert core._auth_coord._refresh_callback is mock_refresh
 
     def test_refresh_callback_defaults_to_none(self):
         """Session should default refresh_callback to None."""
@@ -486,7 +486,7 @@ class TestSessionRefreshCallback:
         )
 
         core = Session(auth)
-        assert core._refresh_callback is None
+        assert core._auth_coord._refresh_callback is None
 
     def test_refresh_lock_lazy_at_construction(self):
         """Refresh lock is ``None`` at construction regardless of callback.
@@ -508,13 +508,13 @@ class TestSessionRefreshCallback:
 
         # With callback: lazy — lock is None until first refresh attempt.
         core_with_cb = Session(auth, refresh_callback=mock_refresh)
-        assert core_with_cb._refresh_lock is None
-        assert core_with_cb._refresh_callback is mock_refresh
+        assert core_with_cb._auth_coord._refresh_lock is None
+        assert core_with_cb._auth_coord._refresh_callback is mock_refresh
 
         # Without callback: also None (unchanged behavior on this axis).
         core_without_cb = Session(auth)
-        assert core_without_cb._refresh_lock is None
-        assert core_without_cb._refresh_callback is None
+        assert core_without_cb._auth_coord._refresh_lock is None
+        assert core_without_cb._auth_coord._refresh_callback is None
 
 
 # =============================================================================

--- a/tests/unit/test_refresh_lock_lazy_init.py
+++ b/tests/unit/test_refresh_lock_lazy_init.py
@@ -72,15 +72,15 @@ def test_construct_outside_event_loop_with_callback() -> None:
 
     # Eager construction would have blown up under the prior code path.
     core_with_cb = Session(auth=_auth_tokens(), refresh_callback=_noop_refresh)
-    assert core_with_cb._refresh_lock is None, (
+    assert core_with_cb._auth_coord._refresh_lock is None, (
         "Lazy-init contract: lock must remain None until first refresh."
     )
-    assert core_with_cb._refresh_callback is _noop_refresh
+    assert core_with_cb._auth_coord._refresh_callback is _noop_refresh
 
     # And the no-callback path stays the same (also lazy / also None).
     core_without_cb = Session(auth=_auth_tokens())
-    assert core_without_cb._refresh_lock is None
-    assert core_without_cb._refresh_callback is None
+    assert core_without_cb._auth_coord._refresh_lock is None
+    assert core_without_cb._auth_coord._refresh_callback is None
 
 
 # --------------------------------------------------------------------------- #
@@ -141,7 +141,7 @@ async def test_refresh_lock_allocated_on_first_await() -> None:
         core.rpc_call = fake_retry  # type: ignore[method-assign]
 
         # Pre-refresh invariant: lock is unallocated even after ``open()``.
-        assert core._refresh_lock is None, (
+        assert core._auth_coord._refresh_lock is None, (
             "Lock must remain unallocated until the first refresh attempt."
         )
 
@@ -150,14 +150,14 @@ async def test_refresh_lock_allocated_on_first_await() -> None:
         assert result == "ok"
         assert call_count == 1, f"Refresh callback must fire exactly once, got {call_count}"
         # Post-refresh invariant: lock is now allocated and is a real asyncio.Lock.
-        assert core._refresh_lock is not None, (
+        assert core._auth_coord._refresh_lock is not None, (
             "Lock must be allocated by the first ``_await_refresh`` call."
         )
-        assert isinstance(core._refresh_lock, asyncio.Lock)
+        assert isinstance(core._auth_coord._refresh_lock, asyncio.Lock)
         # And the refresh task ran to completion, matching the single-flight
         # state-machine pinning in ``test_refresh_state_machine.py``.
-        assert core._refresh_task is not None
-        assert core._refresh_task.done()
+        assert core._auth_coord._refresh_task is not None
+        assert core._auth_coord._refresh_task.done()
         assert core.auth.csrf_token == "CSRF_REFRESHED"
 
 
@@ -187,11 +187,11 @@ async def test_refresh_lock_instance_stable_across_calls() -> None:
         core.rpc_call = fake_retry  # type: ignore[method-assign]
 
         await _trigger_refresh(core)
-        first_lock = core._refresh_lock
+        first_lock = core._auth_coord._refresh_lock
         assert first_lock is not None
 
         await _trigger_refresh(core)
-        second_lock = core._refresh_lock
+        second_lock = core._auth_coord._refresh_lock
 
         assert second_lock is first_lock, (
             "Lazy-init must be idempotent — same lock instance across refreshes "

--- a/tests/unit/test_refresh_state_machine.py
+++ b/tests/unit/test_refresh_state_machine.py
@@ -49,7 +49,7 @@ async def _wait_for_inflight_refresh_task(core, ticks: int = 20) -> bool:
     """Yield up to ``ticks`` times for the shared refresh task to appear."""
     for _ in range(ticks):
         await asyncio.sleep(0)
-        if core._refresh_task is not None and not core._refresh_task.done():
+        if core._auth_coord._refresh_task is not None and not core._auth_coord._refresh_task.done():
             return True
     return False
 
@@ -174,11 +174,11 @@ async def test_second_wave_creates_distinct_refresh_task():
         core.rpc_call = fake_retry
 
         await _trigger_refresh(core)
-        first_task = core._refresh_task
+        first_task = core._auth_coord._refresh_task
         assert first_task is not None and first_task.done()
 
         await _trigger_refresh(core)
-        second_task = core._refresh_task
+        second_task = core._auth_coord._refresh_task
         assert second_task is not None and second_task.done()
 
         assert first_task is not second_task, "Second wave reused completed task"


### PR DESCRIPTION
## Summary

PR 5 of the session-shrink arc. Stacked on PR #928 / `task/pr-4-metrics-drain-demolition`.

Retires the `Session` compat bridges for AuthRefreshCoordinator state:

- `_refresh_lock`
- `_refresh_task`
- `_refresh_callback`

Test readers and the remaining `_refresh_callback` writers now access `session._auth_coord.<attr>` directly. The AST bridge lint removes these names from `FORBIDDEN_PROPERTIES` so helper/coordinator tests can read collaborator state without broad allowlist exemptions, and drains the files that no longer touch surviving `Session` bridges.

## Verification

- `uv run ruff check .`
- `uv run mypy src/notebooklm --ignore-missing-imports`
- `uv run pytest tests/_lint/test_no_session_compat_bridges.py -v`
- `uv run pytest tests/unit -q`
- `uv run pytest tests/integration -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal authentication coordination structure to consolidate auth-related operations under a unified coordinator component. Updated internal documentation and test references to reflect new attribute paths. No changes to user-facing functionality or API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teng-lin/notebooklm-py/pull/930?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->