### PR TITLE
refactor(session): retire ClientLifecycle bridges (PR 6 of 8)

### DIFF
--- a/src/notebooklm/_kernel.py
+++ b/src/notebooklm/_kernel.py
@@ -34,7 +34,7 @@ class Kernel:
 
     @http_client.setter
     def http_client(self, value: httpx.AsyncClient | None) -> None:
-        # Test-injection seam for tests that assign through Session._http_client.
+        # Test-injection seam for fixtures that swap the live transport.
         self._http_client = value
 
     @property

--- a/src/notebooklm/_session.py
+++ b/src/notebooklm/_session.py
@@ -291,13 +291,9 @@ class Session:
         # the live ``httpx.AsyncClient``, the captured ``_bound_loop``, and
         # the keepalive background task all live on ``self._lifecycle``
         # (constructed below alongside the other extracted helpers so the
-        # inter-helper dependency order is obvious). Compat properties further
-        # down preserve the legacy ``_timeout`` / ``_http_client`` /
-        # ``_bound_loop`` / ``_keepalive_task`` / ``_keepalive_interval`` /
-        # ``_keepalive_storage_path`` ivar names for tests and first-party
-        # callers that probe or assign them directly. The
-        # ``_connect_timeout`` / ``_limits`` bridges were dropped in
-        # D1-audit-full; access them via ``self._lifecycle`` if needed.
+        # inter-helper dependency order is obvious). Access lifecycle state
+        # through ``self._lifecycle`` and the live HTTP client through
+        # ``self._kernel``.
         _resolved_limits = limits if limits is not None else ConnectionLimits()
         # ``_refresh_retry_delay`` stays here directly — it is read on the
         # RPC retry path by ``RpcExecutor`` and ``AuthedTransport`` and SET
@@ -380,11 +376,10 @@ class Session:
         self._auth_coord = AuthRefreshCoordinator(refresh_callback=refresh_callback)
         # HTTP-client lifecycle — owns loop binding, keepalive, and close
         # ordering while delegating the live ``httpx.AsyncClient`` to
-        # ``self._kernel``. Compat properties further down preserve the legacy
-        # ivar names. The ``_resolve_keepalive_interval`` clamp lives in
-        # :mod:`notebooklm._session_helpers` and is imported above; we call
-        # it directly here. (The historical ``notebooklm._core`` re-export
-        # was removed in v0.5.0.)
+        # ``self._kernel``. The ``_resolve_keepalive_interval`` clamp lives
+        # in :mod:`notebooklm._session_helpers` and is imported above; we
+        # call it directly here. (The historical ``notebooklm._core``
+        # re-export was removed in v0.5.0.)
         #
         # Event-loop affinity guard rationale: the lifecycle captures
         # ``asyncio.get_running_loop()`` in ``_bound_loop`` at ``open()`` time
@@ -475,81 +470,9 @@ class Session:
     # dropped earlier in D1-audit-full; the live accessor remains
     # ``_get_auth_snapshot_lock()`` / ``AuthRefreshCoordinator.get_auth_snapshot_lock()``.
 
-    # ------------------------------------------------------------------
-    # ``ClientLifecycle`` compat bridges. HTTP-client lifecycle state now
-    # lives on ``self._lifecycle``; the six surviving legacy ivar names
-    # (``_http_client``, ``_bound_loop``, ``_keepalive_task``,
-    # ``_keepalive_interval``, ``_keepalive_storage_path``, ``_timeout``)
-    # are preserved here as ``@property`` bridges. The
-    # ``_connect_timeout`` / ``_limits`` bridges were dropped in
-    # D1-audit-full (zero external callers). After session-shrink PR 3
-    # narrowed :class:`RpcOwner` + :class:`_AuthedTransportHost` to drop
-    # these attribute names, the bridges are no longer Protocol-required —
-    # they survive purely to support test monkeypatches that write to
-    # ``core._<bridge>``; later session-shrink PRs (4–6) retire them as
-    # the test readers migrate. ``Session.__init__`` eager-constructs
-    # ``_lifecycle`` (and ``_kernel``), so the bridges delegate directly
-    # without lazy backfill.
-    # ------------------------------------------------------------------
-
-    @property
-    def _http_client(self) -> httpx.AsyncClient | None:
-        return self._lifecycle._http_client
-
-    @_http_client.setter
-    def _http_client(self, value: httpx.AsyncClient | None) -> None:
-        self._lifecycle._http_client = value
-
-    @property
-    def _bound_loop(self) -> asyncio.AbstractEventLoop | None:
-        return self._lifecycle._bound_loop
-
-    @_bound_loop.setter
-    def _bound_loop(self, value: asyncio.AbstractEventLoop | None) -> None:
-        # Retained for test monkeypatch writers (no external SET sites in
-        # prod; bridge demolition is tracked in session-shrink PR 6 once
-        # those tests migrate). Post-PR-3 the ``_AuthedTransportHost``
-        # Protocol no longer declares ``_bound_loop``.
-        self._lifecycle._bound_loop = value
-
-    @property
-    def _keepalive_task(self) -> asyncio.Task[None] | None:
-        return self._lifecycle._keepalive_task
-
-    # ``_keepalive_task`` setter dropped in arch-d2-cutover: zero external callers.
-
-    @property
-    def _keepalive_interval(self) -> float | None:
-        """Phase 4 deleted the matching ``.setter`` (zero external write
-        sites); write on ``self._lifecycle._keepalive_interval`` directly
-        if a test needs to override it.
-        """
-        return self._lifecycle._keepalive_interval
-
-    @property
-    def _keepalive_storage_path(self) -> Path | None:
-        return self._lifecycle._keepalive_storage_path
-
-    # ``_keepalive_storage_path`` setter dropped in arch-d2-cutover: zero
-    # external callers.
-
-    @property
-    def _timeout(self) -> float:
-        return self._lifecycle._timeout
-
-    @_timeout.setter
-    def _timeout(self, value: float) -> None:
-        # Retained for test monkeypatch writers. Post-PR-3, ``RpcExecutor``
-        # reads via ``self._timeout_provider()`` (which closes over
-        # ``self._lifecycle._timeout`` directly), so ``RpcOwner`` no longer
-        # declares ``_timeout`` and the setter is not Protocol-required —
-        # it survives until the test readers migrate (session-shrink PR 6).
-        self._lifecycle._timeout = value
-
-    # ``_connect_timeout`` and ``_limits`` compat bridges dropped
-    # (D1-audit-full): zero external callers; live values remain on
-    # ``self._lifecycle`` (and the lifecycle helper reads them as plain
-    # ivars when it builds the ``httpx.AsyncClient``).
+    # ``ClientLifecycle`` compat bridges retired in session-shrink PR 6:
+    # tests now read lifecycle state through ``self._lifecycle.<attr>`` and
+    # the live HTTP client through ``self._kernel``.
 
     def register_drain_hook(self, name: str, hook: Callable[[], Awaitable[None]]) -> None:
         """Register or replace a feature-owned close-time drain hook."""
@@ -1149,4 +1072,4 @@ class Session:
         Raises:
             RuntimeError: If client is not initialized.
         """
-        return self._lifecycle.get_http_client()
+        return self._kernel.get_http_client()

--- a/tests/_lint/test_no_session_compat_bridges.py
+++ b/tests/_lint/test_no_session_compat_bridges.py
@@ -64,13 +64,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # or retired.
 FORBIDDEN_PROPERTIES: frozenset[str] = frozenset(
     {
-        # ClientLifecycle bridges
-        "_http_client",
-        "_bound_loop",
-        "_timeout",
-        "_keepalive_task",
-        "_keepalive_interval",
-        "_keepalive_storage_path",
+        # ClientLifecycle bridges retired in session-shrink PR 6 — readers now
+        # go straight to ``session._kernel`` / ``session._lifecycle`` or use
+        # the public ``session.bound_loop`` property.
         # AuthRefreshCoordinator bridges retired in session-shrink PR 5 —
         # readers (and the two ``_refresh_callback`` writers in
         # ``tests/integration/test_session_integration.py``) now go straight
@@ -87,11 +83,10 @@ FORBIDDEN_PROPERTIES: frozenset[str] = frozenset(
         # legitimate direct-collaborator reads in tests like
         # ``test_client_metrics.py`` / ``test_transport_drain.py`` that
         # exercise the helpers in isolation.
-        # CookiePersistence + PollingRegistry + ReqidCounter bridges
-        "_save_lock",
         "_loaded_cookie_snapshot",
         "_pending_polls",
         "_reqid_counter",
+        "_save_lock",
     }
 )
 
@@ -145,44 +140,7 @@ CARVE_OUT_MODULES: frozenset[str] = frozenset(
 # sorted form, so any drift caused by an accidental out-of-order
 # insertion fails the test instead of being silently re-sorted at
 # import time.
-ALLOWLIST: list[str] = [
-    "tests/integration/concurrency/test_aexit_exception_masking.py",
-    "tests/integration/concurrency/test_auth_snapshot_torn_read.py",
-    "tests/integration/concurrency/test_chat_history_race.py",
-    "tests/integration/concurrency/test_cross_loop_affinity.py",
-    "tests/integration/concurrency/test_harness_smoke.py",
-    "tests/integration/concurrency/test_idempotency_create.py",
-    "tests/integration/concurrency/test_keepalive_path_canonicalize.py",
-    "tests/integration/concurrency/test_max_concurrent_rpcs.py",
-    "tests/integration/concurrency/test_note_create_cancel.py",
-    "tests/integration/concurrency/test_rate_limit_default.py",
-    "tests/integration/test_artifact_generation_idempotency.py",
-    "tests/integration/test_auto_refresh.py",
-    "tests/integration/test_notes_idempotency.py",
-    "tests/integration/test_research_idempotency.py",
-    "tests/integration/test_session_integration.py",
-    "tests/integration/test_side_effects_idempotency.py",
-    "tests/integration/test_sources_idempotency.py",
-    "tests/unit/concurrency/test_close_cancellation_leak.py",
-    "tests/unit/concurrency/test_session_close_refresh_race.py",
-    "tests/unit/conftest.py",
-    "tests/unit/test_api_coverage.py",
-    "tests/unit/test_auth_cookie_save_race.py",
-    "tests/unit/test_auth_session.py",
-    "tests/unit/test_authed_transport.py",
-    "tests/unit/test_chat_ask_invariants.py",
-    "tests/unit/test_client.py",
-    "tests/unit/test_client_keepalive.py",
-    "tests/unit/test_idempotency_registry.py",
-    "tests/unit/test_observability.py",
-    "tests/unit/test_rate_limit_retry.py",
-    "tests/unit/test_rpc_executor.py",
-    "tests/unit/test_rpc_overrides.py",
-    "tests/unit/test_session_auth.py",
-    "tests/unit/test_session_close.py",
-    "tests/unit/test_session_lifecycle.py",
-    "tests/unit/test_vcr_config.py",
-]
+ALLOWLIST: list[str] = []
 
 
 def _augassign_target_attrs(tree: ast.AST) -> set[int]:
@@ -316,31 +274,31 @@ def test_allowlist_entries_currently_violate() -> None:
     ("source", "expected"),
     [
         # Direct attribute access — the four AST contexts.
-        ("def f(c):\n    return c._http_client\n", [(2, "_http_client", "Load")]),
-        ("def f(c):\n    c._http_client = None\n", [(2, "_http_client", "Store")]),
-        ("def f(c):\n    del c._http_client\n", [(2, "_http_client", "Del")]),
+        ("def f(c):\n    return c._save_lock\n", [(2, "_save_lock", "Load")]),
+        ("def f(c):\n    c._save_lock = None\n", [(2, "_save_lock", "Store")]),
+        ("def f(c):\n    del c._save_lock\n", [(2, "_save_lock", "Del")]),
         (
-            "def f(c):\n    c._keepalive_interval += 1\n",
-            [(2, "_keepalive_interval", "AugAssign")],
+            "def f(c):\n    c._reqid_counter += 1\n",
+            [(2, "_reqid_counter", "AugAssign")],
         ),
-        # Sample a non-ClientLifecycle bridge so the parametrized suite
-        # exercises a second forbidden name.
+        # Sample a second bridge name so the parametrized suite does not
+        # accidentally depend on one attribute.
         (
-            "def f(c):\n    return c._save_lock\n",
-            [(2, "_save_lock", "Load")],
+            "def f(c):\n    return c._pending_polls\n",
+            [(2, "_pending_polls", "Load")],
         ),
         # Dynamic-access builtins with constant-string second arg.
         (
-            'def f(c):\n    return getattr(c, "_http_client")\n',
-            [(2, "_http_client", "getattr")],
+            'def f(c):\n    return getattr(c, "_save_lock")\n',
+            [(2, "_save_lock", "getattr")],
         ),
         (
-            'def f(c):\n    setattr(c, "_http_client", None)\n',
-            [(2, "_http_client", "setattr")],
+            'def f(c):\n    setattr(c, "_save_lock", None)\n',
+            [(2, "_save_lock", "setattr")],
         ),
         (
-            'def f(c):\n    delattr(c, "_http_client")\n',
-            [(2, "_http_client", "delattr")],
+            'def f(c):\n    delattr(c, "_save_lock")\n',
+            [(2, "_save_lock", "delattr")],
         ),
     ],
     ids=[
@@ -375,7 +333,7 @@ def test_linter_does_not_flag_non_forbidden_attrs() -> None:
         # Single-arg getattr (hasattr-style) → not flagged.
         "def f(c):\n    return getattr(c)\n",
         # Method named getattr → not the builtin.
-        'def f(c):\n    return c.getattr("_http_client")\n',
+        'def f(c):\n    return c.getattr("_save_lock")\n',
     ],
     ids=[
         "non_forbidden_string",

--- a/tests/integration/concurrency/test_aexit_exception_masking.py
+++ b/tests/integration/concurrency/test_aexit_exception_masking.py
@@ -38,12 +38,12 @@ def _stub_open(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     async def _stub_open(self) -> None:
-        if self._http_client is not None:
+        if self._kernel.http_client is not None:
             return
         # Lazy import keeps the test file dep-free at module load.
         import httpx
 
-        self._http_client = httpx.AsyncClient()
+        self._kernel.http_client = httpx.AsyncClient()
 
     monkeypatch.setattr("notebooklm._session.Session.open", _stub_open)
 
@@ -60,9 +60,9 @@ async def test_body_raises_and_close_raises_body_wins(
     client = NotebookLMClient(auth_tokens)
 
     # Capture the http client reference BEFORE entering the cm — successful
-    # close sets `client._session._http_client = None`, so we need our own ref.
+    # close sets `client._session._kernel.http_client = None`, so we need our own ref.
     async with client:
-        http_client_ref = client._session._http_client
+        http_client_ref = client._session._kernel.get_http_client()
         assert http_client_ref is not None
 
         # Patch _core.close to raise after closing the transport, so we
@@ -81,7 +81,7 @@ async def test_body_raises_and_close_raises_body_wins(
         ):
             async with client:
                 # Sanity: client is open here.
-                assert client._session._http_client is not None
+                assert client._session._kernel.http_client is not None
                 raise ValueError("user error")
 
     # 1. The body's ValueError propagated (verified by pytest.raises above).
@@ -128,7 +128,7 @@ async def test_cancel_mid_close_does_not_leak_transport(
     """
     client = NotebookLMClient(auth_tokens)
     await client._session.open()
-    http_client_ref = client._session._http_client
+    http_client_ref = client._session._kernel.get_http_client()
     assert http_client_ref is not None
 
     # Wrap close() in a task so we can cancel it.

--- a/tests/integration/concurrency/test_auth_snapshot_torn_read.py
+++ b/tests/integration/concurrency/test_auth_snapshot_torn_read.py
@@ -209,8 +209,8 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
             core.auth.session_id = f"SID_{new_gen}"
             # Update the live httpx cookie jar synchronously — this is
             # the same jar httpx merges into the outgoing Cookie header.
-            assert core._http_client is not None
-            core._http_client.cookies.set("SID", f"sid_cookie_{new_gen}", domain=".google.com")
+            assert core._kernel.http_client is not None
+            core._kernel.get_http_client().cookies.set("SID", f"sid_cookie_{new_gen}", domain=".google.com")
             core.auth.cookies = {("SID", ".google.com"): f"sid_cookie_{new_gen}"}
             current_gen = new_gen
 
@@ -218,9 +218,9 @@ async def test_concurrent_refresh_does_not_tear_auth_triple_across_fan_out():
     try:
         # Replace the auto-built client with one using our MockTransport so
         # we can observe outgoing requests post-cookie-merge.
-        prior_cookies = core._http_client.cookies
-        await core._http_client.aclose()
-        core._http_client = httpx.AsyncClient(
+        prior_cookies = core._kernel.get_http_client().cookies
+        await core._kernel.get_http_client().aclose()
+        core._kernel.http_client = httpx.AsyncClient(
             cookies=prior_cookies,
             transport=transport,
             timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),

--- a/tests/integration/concurrency/test_chat_history_race.py
+++ b/tests/integration/concurrency/test_chat_history_race.py
@@ -147,11 +147,11 @@ def _make_client(transport: httpx.AsyncBaseTransport, auth_tokens) -> NotebookLM
     """Build a ``NotebookLMClient`` wired to ``transport``.
 
     Mirrors ``test_idempotency_create._make_client_with_transport``: stub
-    ``_core._http_client`` with a pre-built ``AsyncClient`` so the chat
+    ``_core._kernel.http_client`` with a pre-built ``AsyncClient`` so the chat
     POSTs route through the mock instead of opening a real socket.
     """
     client = NotebookLMClient(auth_tokens)
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -204,7 +204,7 @@ async def test_concurrent_follow_ups_serialize_on_conversation_id(auth_tokens) -
             return_exceptions=False,
         )
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # Sanity: both calls returned their respective answers.
     answers = sorted(r.answer for r in results)
@@ -300,7 +300,7 @@ async def test_different_conversation_ids_run_in_parallel(auth_tokens) -> None:
             client.chat.ask(notebook_id, "qB", source_ids=["src_001"], conversation_id=cid_b),
         )
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert peak_inflight == 2, (
         f"different-conversation follow-ups must run in parallel, "

--- a/tests/integration/concurrency/test_cross_loop_affinity.py
+++ b/tests/integration/concurrency/test_cross_loop_affinity.py
@@ -12,7 +12,7 @@ httpx, or — worse — a hang on a never-acquired lock that belongs to
 a dead loop.
 
 Post-fix: ``Session.open()`` captures
-``asyncio.get_running_loop()`` in ``self._bound_loop`` and
+``asyncio.get_running_loop()`` in ``self.bound_loop`` and
 ``_perform_authed_post`` asserts the running loop matches via a cheap
 ``is`` comparison. On mismatch we raise an actionable ``RuntimeError``
 at the call site instead of letting the failure escalate into the
@@ -29,9 +29,9 @@ The test exercises the surgical contract:
    confirm 100 fan-out calls succeed (no false positive on the
    ``is`` comparison).
 3. **No binding before open()** — a freshly-constructed ``Session``
-   that has never been ``open()``ed has ``_bound_loop is None``; we
+   that has never been ``open()``ed has ``bound_loop is None``; we
    only check inside ``_perform_authed_post`` which already asserts
-   ``self._http_client is not None``, so an "unopened client" caller
+   ``self._kernel.http_client is not None``, so an "unopened client" caller
    sees the existing assertion error, not the loop guard.
 
 Why this lives under ``tests/integration/concurrency/`` and not
@@ -82,15 +82,15 @@ async def _open_core_with_transport(transport: ConcurrentMockTransport) -> Sessi
     normally — which is the moment the loop affinity is captured —
     then close-and-replace the underlying client with one that routes
     through our recording transport. The replacement keeps
-    ``self._bound_loop`` unchanged because we don't call ``open()``
+    ``self.bound_loop`` unchanged because we don't call ``open()``
     again.
     """
     core = Session(auth=_make_auth())
     await core.open()
-    assert core._http_client is not None
-    prior_cookies = core._http_client.cookies
-    await core._http_client.aclose()
-    core._http_client = httpx.AsyncClient(
+    assert core._kernel.http_client is not None
+    prior_cookies = core._kernel.get_http_client().cookies
+    await core._kernel.get_http_client().aclose()
+    core._kernel.http_client = httpx.AsyncClient(
         cookies=prior_cookies,
         transport=transport,
         timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),
@@ -161,9 +161,9 @@ def test_cross_loop_use_raises_actionable_runtime_error(
         # don't leak the transport. We deliberately go around
         # ``core.close()`` because that path also touches asyncio
         # primitives bound to loop A.
-        if core._http_client is not None:
-            await core._http_client.aclose()
-            core._http_client = None
+        if core._kernel.http_client is not None:
+            await core._kernel.get_http_client().aclose()
+            core._kernel.http_client = None
 
     asyncio.run(call_under_loop_b())
 
@@ -205,13 +205,13 @@ async def test_bound_loop_captured_on_open(
     construction-time loop may not be the dispatch-time loop.
     """
     core = Session(auth=_make_auth())
-    assert core._bound_loop is None, (
+    assert core.bound_loop is None, (
         "Session must not bind to a loop at construction time — open() is the binding moment."
     )
 
     await core.open()
     try:
-        assert core._bound_loop is asyncio.get_running_loop(), (
+        assert core.bound_loop is asyncio.get_running_loop(), (
             "open() must capture the *running* loop, not a stored or module-level reference."
         )
 
@@ -219,10 +219,10 @@ async def test_bound_loop_captured_on_open(
         # requests for cookie persistence (auth has no storage_path so
         # save_cookies is already a no-op, but route everything through
         # the recorder to keep the test deterministic).
-        assert core._http_client is not None
-        prior_cookies = core._http_client.cookies
-        await core._http_client.aclose()
-        core._http_client = httpx.AsyncClient(
+        assert core._kernel.http_client is not None
+        prior_cookies = core._kernel.get_http_client().cookies
+        await core._kernel.get_http_client().aclose()
+        core._kernel.http_client = httpx.AsyncClient(
             cookies=prior_cookies,
             transport=mock_transport_concurrent,
             timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),

--- a/tests/integration/concurrency/test_harness_smoke.py
+++ b/tests/integration/concurrency/test_harness_smoke.py
@@ -79,10 +79,10 @@ async def _open_core_with_transport(transport: ConcurrentMockTransport) -> Sessi
     """
     core = Session(auth=_make_auth(), max_concurrent_rpcs=None)
     await core.open()
-    assert core._http_client is not None
-    prior_cookies = core._http_client.cookies
-    await core._http_client.aclose()
-    core._http_client = httpx.AsyncClient(
+    assert core._kernel.http_client is not None
+    prior_cookies = core._kernel.get_http_client().cookies
+    await core._kernel.get_http_client().aclose()
+    core._kernel.http_client = httpx.AsyncClient(
         cookies=prior_cookies,
         transport=transport,
         timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),

--- a/tests/integration/concurrency/test_idempotency_create.py
+++ b/tests/integration/concurrency/test_idempotency_create.py
@@ -138,7 +138,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -200,7 +200,7 @@ async def test_notebooks_create_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert notebook.id == nb_id_new
     assert notebook.title == title
@@ -242,7 +242,7 @@ async def test_notebooks_create_re_creates_when_probe_finds_nothing(auth_tokens)
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert notebook.id == nb_id_new
     # Two CREATE_NOTEBOOK calls: original (502) + retry (200)
@@ -281,7 +281,7 @@ async def test_notebooks_create_raises_on_ambiguous_probe(auth_tokens) -> None:
         with pytest.raises(RPCError, match="disambiguate"):
             await client.notebooks.create(title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +318,7 @@ async def test_sources_add_url_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -358,7 +358,7 @@ async def test_sources_add_youtube_idempotent_on_5xx_retry(auth_tokens) -> None:
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -390,7 +390,7 @@ async def test_sources_add_text_raises_when_idempotent_True(auth_tokens) -> None
         with pytest.raises(NonIdempotentRetryError, match="add_text cannot be marked idempotent"):
             await client.sources.add_text("nb_test", "Title", "Content", idempotent=True)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert not seen_request, "add_text(idempotent=True) must raise before issuing any RPC"
 
@@ -425,7 +425,7 @@ async def test_sources_add_text_default_behavior_unchanged(auth_tokens) -> None:
     try:
         source = await client.sources.add_text(notebook_id, title, "the body")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     assert add_count == 1, f"expected exactly 1 ADD_SOURCE call, got {add_count}"
@@ -480,7 +480,7 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
             f"with disable_internal_retries=True expected 1 POST, got {request_count}"
         )
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # --- without the flag: default retry loop fires ---------------------
     client = _make_client_with_transport(transport, auth_tokens, server_error_max_retries=2)
@@ -494,4 +494,4 @@ async def test_disable_internal_retries_propagates_to_perform_authed_post(
         # initial + 2 retries = 3 POSTs
         assert request_count == 3, f"with default retries expected 3 POSTs, got {request_count}"
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()

--- a/tests/integration/concurrency/test_keepalive_path_canonicalize.py
+++ b/tests/integration/concurrency/test_keepalive_path_canonicalize.py
@@ -3,7 +3,7 @@
 Regression test for keepalive-path canonicalization: the rotation throttle keys the
 in-process dedupe (``_LAST_POKE_ATTEMPT_MONOTONIC`` /
 ``_POKE_LOCKS_BY_LOOP``) by the raw ``Path`` object stored on
-``Session._keepalive_storage_path``. Without canonicalization, two
+``Session._lifecycle._keepalive_storage_path``. Without canonicalization, two
 clients constructed with different syntactic representations of the SAME
 underlying file (e.g. a relative path and the absolute path; a
 ``~``-prefixed path and the expanded one; with or without a symlink
@@ -17,7 +17,7 @@ path before it reaches ``_get_poke_lock`` / ``_try_claim_rotation`` /
 ``_rotation_lock_path``.
 
 The public ``storage_path`` argument type (``str | Path | None``) is
-preserved; only the internal-derived ``Session._keepalive_storage_path``
+preserved; only the internal-derived ``Session._lifecycle._keepalive_storage_path``
 is canonicalized.
 """
 
@@ -83,8 +83,8 @@ def test_relative_and_absolute_paths_share_dedupe_key(
     # The dedupe key seen by ``_get_poke_lock`` / ``_try_claim_rotation``
     # / ``_rotation_lock_path`` is exactly this internal field. Both must
     # be canonical and equal.
-    rel_keepalive = client_rel._session._keepalive_storage_path
-    abs_keepalive = client_abs._session._keepalive_storage_path
+    rel_keepalive = client_rel._session._lifecycle._keepalive_storage_path
+    abs_keepalive = client_abs._session._lifecycle._keepalive_storage_path
     assert rel_keepalive is not None
     assert abs_keepalive is not None
     assert rel_keepalive == abs_keepalive, (
@@ -132,8 +132,8 @@ def test_tilde_path_is_expanded(
     client_tilde = NotebookLMClient(_auth_tokens, storage_path=tilde_path)
     client_expanded = NotebookLMClient(_auth_tokens, storage_path=expanded_path)
 
-    tilde_key = client_tilde._session._keepalive_storage_path
-    expanded_key = client_expanded._session._keepalive_storage_path
+    tilde_key = client_tilde._session._lifecycle._keepalive_storage_path
+    expanded_key = client_expanded._session._lifecycle._keepalive_storage_path
     assert tilde_key is not None
     assert expanded_key is not None
     assert tilde_key == expanded_key
@@ -175,7 +175,7 @@ def test_public_storage_path_argument_unchanged(
     assert client.auth.storage_path == raw_path
     assert client.auth.storage_path != target.resolve()
     # And the internal keepalive field IS canonicalized.
-    keepalive_key = client._session._keepalive_storage_path
+    keepalive_key = client._session._lifecycle._keepalive_storage_path
     assert keepalive_key is not None
     assert keepalive_key == target.resolve()
     assert keepalive_key.is_absolute()
@@ -202,8 +202,8 @@ def test_symlink_is_resolved(tmp_path: Path, _auth_tokens: AuthTokens) -> None:
     client_link = NotebookLMClient(_auth_tokens, storage_path=link)
     client_target = NotebookLMClient(_auth_tokens, storage_path=target)
 
-    link_key = client_link._session._keepalive_storage_path
-    target_key = client_target._session._keepalive_storage_path
+    link_key = client_link._session._lifecycle._keepalive_storage_path
+    target_key = client_target._session._lifecycle._keepalive_storage_path
     assert link_key is not None
     assert target_key is not None
     assert link_key == target_key
@@ -213,4 +213,4 @@ def test_symlink_is_resolved(tmp_path: Path, _auth_tokens: AuthTokens) -> None:
 def test_none_storage_path_stays_none(_auth_tokens: AuthTokens) -> None:
     """Canonicalization must be a no-op when there is no storage path."""
     client = NotebookLMClient(_auth_tokens)
-    assert client._session._keepalive_storage_path is None
+    assert client._session._lifecycle._keepalive_storage_path is None

--- a/tests/integration/concurrency/test_max_concurrent_rpcs.py
+++ b/tests/integration/concurrency/test_max_concurrent_rpcs.py
@@ -99,10 +99,10 @@ async def _open_core_with_transport(
     """
     core = Session(auth=_make_auth(), max_concurrent_rpcs=max_concurrent_rpcs)
     await core.open()
-    assert core._http_client is not None
-    prior_cookies = core._http_client.cookies
-    await core._http_client.aclose()
-    core._http_client = httpx.AsyncClient(
+    assert core._kernel.http_client is not None
+    prior_cookies = core._kernel.get_http_client().cookies
+    await core._kernel.get_http_client().aclose()
+    core._kernel.http_client = httpx.AsyncClient(
         cookies=prior_cookies,
         transport=transport,
         timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),

--- a/tests/integration/concurrency/test_note_create_cancel.py
+++ b/tests/integration/concurrency/test_note_create_cancel.py
@@ -57,7 +57,7 @@ def _make_client_with_transport(
 ) -> NotebookLMClient:
     """Wire a ``NotebookLMClient`` to a mock transport, bypassing full open()."""
     client = NotebookLMClient(auth_tokens)
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -201,9 +201,9 @@ async def test_cancel_during_update_note_shields_or_cleans_up(auth_tokens) -> No
     finally:
         # Defensive cleanup so a failing assertion doesn't leak the http
         # client and warn at gc time.
-        if client._session._http_client is not None:
-            await client._session._http_client.aclose()
-            client._session._http_client = None
+        if client._session._kernel.http_client is not None:
+            await client._session._kernel.get_http_client().aclose()
+            client._session._kernel.http_client = None
 
 
 @pytest.mark.asyncio
@@ -230,6 +230,6 @@ async def test_no_cancel_no_cleanup(auth_tokens) -> None:
             f"over-eager: rpc_ids={rpc_ids!r}"
         )
     finally:
-        if client._session._http_client is not None:
-            await client._session._http_client.aclose()
-            client._session._http_client = None
+        if client._session._kernel.http_client is not None:
+            await client._session._kernel.get_http_client().aclose()
+            client._session._kernel.http_client = None

--- a/tests/integration/concurrency/test_rate_limit_default.py
+++ b/tests/integration/concurrency/test_rate_limit_default.py
@@ -91,7 +91,7 @@ async def test_default_retries_succeed_after_three_429s(auth_tokens) -> None:
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._http_client = mock_http
+    client._session._kernel.http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep:
         result = await client.notebooks.list()
@@ -121,7 +121,7 @@ async def test_default_retries_exhausted_raises_rate_limit_error(auth_tokens) ->
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._http_client = mock_http
+    client._session._kernel.http_client = mock_http
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
         await client.notebooks.list()
@@ -161,7 +161,7 @@ async def test_default_retries_use_exponential_backoff_when_header_missing(
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._http_client = mock_http
+    client._session._kernel.http_client = mock_http
 
     sleep_calls: list[float] = []
 
@@ -210,7 +210,7 @@ async def test_disable_internal_retries_skips_429_loop_under_new_default(
     mock_http = AsyncMock(spec=httpx.AsyncClient)
     mock_http.post = mock_post
     install_post_as_stream(None, mock_http, mock_post)
-    client._session._http_client = mock_http
+    client._session._kernel.http_client = mock_http
 
     def _build_request(_snap):
         return ("https://example.invalid/x", b"body", None)

--- a/tests/integration/test_artifact_generation_idempotency.py
+++ b/tests/integration/test_artifact_generation_idempotency.py
@@ -124,7 +124,7 @@ def _make_client_with_transport(
         auth_tokens,  # type: ignore[arg-type]
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -227,7 +227,7 @@ async def test_create_artifact_503_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # Exactly ONE CREATE_ARTIFACT POST despite ``server_error_max_retries=3``
     # being configured: the PROBE_THEN_CREATE policy forced retries off.
@@ -265,7 +265,7 @@ async def test_create_artifact_429_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(RateLimitError):
             await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert create_count == 1, f"expected 1 CREATE_ARTIFACT POST, got {create_count}"
 
@@ -298,7 +298,7 @@ async def test_generate_mind_map_503_does_not_re_post(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert mind_map_count == 1, f"expected 1 GENERATE_MIND_MAP POST, got {mind_map_count}"
     assert get_notebook_count == 1
@@ -335,7 +335,7 @@ async def test_create_artifact_happy_path_still_returns_artifact(auth_tokens) ->
     try:
         status = await client.artifacts.generate_audio(notebook_id="nb_test")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert status.task_id == artifact_id
     assert create_count == 1
@@ -381,7 +381,7 @@ async def test_generate_mind_map_happy_path_still_returns_mind_map(auth_tokens) 
     try:
         result = await client.artifacts.generate_mind_map(notebook_id="nb_test")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert result["mind_map"] == mind_map_dict
     assert result["note_id"] == "note_stub"

--- a/tests/integration/test_auto_refresh.py
+++ b/tests/integration/test_auto_refresh.py
@@ -80,7 +80,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            install_post_as_stream(None, client._session._http_client, mock_post)
+            install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
 
             with patch("notebooklm.rpc.decode_response") as mock_decode:
                 mock_decode.return_value = [[["nb1"], ["Notebook 1"]]]
@@ -127,7 +127,7 @@ class TestAutoRefreshIntegration:
             return [[["nb1"], ["Notebook 1"]]]
 
         async with client:
-            install_post_as_stream(None, client._session._http_client, mock_post)
+            install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
 
             with patch("notebooklm.rpc.decode_response", side_effect=mock_decode):
                 await client.notebooks.list()
@@ -166,7 +166,7 @@ class TestAutoRefreshIntegration:
             return response
 
         async with client:
-            install_post_as_stream(None, client._session._http_client, mock_post)
+            install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
 
             start_time = asyncio.get_event_loop().time()
 
@@ -202,7 +202,7 @@ class TestAutoRefreshIntegration:
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
         async with client:
-            install_post_as_stream(None, client._session._http_client, mock_post)
+            install_post_as_stream(None, client._session._kernel.get_http_client(), mock_post)
 
             # Should raise the original HTTP error with refresh failure as cause
             with pytest.raises(httpx.HTTPStatusError) as exc_info:

--- a/tests/integration/test_notes_idempotency.py
+++ b/tests/integration/test_notes_idempotency.py
@@ -68,7 +68,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -169,7 +169,7 @@ async def test_create_note_plain_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.notes.create(notebook_id, title="My Note", content="hello")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert create_count == 1, (
         f"expected exactly 1 CREATE_NOTE (NON_IDEMPOTENT_NO_RETRY), got {create_count}"
@@ -221,7 +221,7 @@ async def test_create_note_saved_from_chat_no_inner_retry_on_5xx(auth_tokens) ->
         with pytest.raises(ServerError):
             await client.notes.create_from_chat(notebook_id, ask_result, title="Chat note")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert create_count == 1, (
         f"expected exactly 1 CREATE_NOTE (saved_from_chat variant, "
@@ -266,7 +266,7 @@ async def test_create_note_happy_path_one_post(auth_tokens) -> None:
     try:
         note = await client.notes.create(notebook_id, title="Happy", content="body")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert note.id == "note_xyz"
     assert create_count == 1

--- a/tests/integration/test_research_idempotency.py
+++ b/tests/integration/test_research_idempotency.py
@@ -69,7 +69,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -160,7 +160,7 @@ async def test_start_fast_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.start(notebook_id, "what is quantum computing?")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # NON_IDEMPOTENT_NO_RETRY forces effective_disable_internal_retries=True
     # so the inner retry loop does not fire — exactly ONE POST.
@@ -192,7 +192,7 @@ async def test_start_deep_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.start(notebook_id, "deep dive query", mode="deep")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert request_count == 1, (
         f"expected exactly 1 START_DEEP_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
@@ -228,7 +228,7 @@ async def test_import_research_no_inner_retry_on_5xx(auth_tokens) -> None:
         with pytest.raises(ServerError):
             await client.research.import_sources(notebook_id, task_id, sources)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert request_count == 1, (
         f"expected exactly 1 IMPORT_RESEARCH (NON_IDEMPOTENT_NO_RETRY), got {request_count}"
@@ -268,7 +268,7 @@ async def test_start_fast_research_happy_path_one_post(auth_tokens) -> None:
     try:
         result = await client.research.start(notebook_id, "test query")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert result is not None
     assert result["task_id"] == "task_xyz"

--- a/tests/integration/test_session_integration.py
+++ b/tests/integration/test_session_integration.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.allow_no_vcr
 
 def _install_error_post(core: Session, error: Exception) -> AsyncMock:
     mock_post = AsyncMock(side_effect=error)
-    install_post_as_stream(None, core._http_client, mock_post)
+    install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
     return mock_post
 
 
@@ -36,13 +36,13 @@ class TestClientInitialization:
     async def test_client_initialization(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
             assert client._session.auth == auth_tokens
-            assert client._session._http_client is not None
+            assert client._session._kernel.http_client is not None
 
     @pytest.mark.asyncio
     async def test_client_context_manager_closes(self, auth_tokens):
         async with NotebookLMClient(auth_tokens) as client:
-            assert client._session._http_client is not None  # client is open
-        assert client._session._http_client is None  # closed after exit
+            assert client._session._kernel.http_client is not None  # client is open
+        assert client._session._kernel.http_client is None  # closed after exit
 
     @pytest.mark.asyncio
     async def test_close_does_not_sync_in_memory_auth_to_default_storage(self):
@@ -58,7 +58,7 @@ class TestClientInitialization:
         await core.close()
 
         mock_save.assert_not_called()
-        assert core._http_client is None
+        assert core._kernel.http_client is None
 
     @pytest.mark.asyncio
     async def test_close_closes_http_client_when_cookie_sync_fails(self, auth_tokens, tmp_path):
@@ -76,7 +76,7 @@ class TestClientInitialization:
         # test could pass via an early exit that never reaches the saver,
         # silently weakening the regression guard.
         boom_save.assert_called_once()
-        assert core._http_client is None
+        assert core._kernel.http_client is None
 
     @pytest.mark.asyncio
     async def test_client_raises_if_not_initialized(self, auth_tokens):
@@ -302,7 +302,7 @@ class TestRPCCallAuthRetry:
             success_response.text = "some_valid_response"
 
             mock_post = AsyncMock(return_value=success_response)
-            install_post_as_stream(None, core._http_client, mock_post)
+            install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
             with patch(
                 "notebooklm.rpc.decode_response",
                 side_effect=[
@@ -433,7 +433,7 @@ class TestCrossDomainCookiePreservation:
         """Verify cookies persist when redirecting from notebooklm to accounts.google.com."""
         async with NotebookLMClient(auth_tokens) as client:
             core = client._session
-            http_client = core._http_client
+            http_client = core._kernel.get_http_client()
 
             # Set initial sentinel cookie in the jar
             http_client.cookies.set("REDIRECT_SENTINEL", "survives_refresh", domain=".google.com")
@@ -454,7 +454,7 @@ class TestCrossDomainCookiePreservation:
         """Verify update_auth_headers merges new cookies, preserving live redirect cookies."""
         async with NotebookLMClient(auth_tokens) as client:
             core = client._session
-            http_client = core._http_client
+            http_client = core._kernel.get_http_client()
 
             # Simulate a live cookie received from accounts.google.com redirect
             http_client.cookies.set(
@@ -480,7 +480,7 @@ class TestCrossDomainCookiePreservation:
 
         async with NotebookLMClient(auth_tokens) as client:
             core = client._session
-            http = core._http_client
+            http = core._kernel.get_http_client()
 
             # The .googleusercontent.com cookie must remain on its original domain
             assert http.cookies.get("download_token", domain=".googleusercontent.com") == "abc123"
@@ -492,7 +492,7 @@ class TestCrossDomainCookiePreservation:
         """update_auth_headers must merge, not replace, preserving redirect cookies."""
         async with NotebookLMClient(auth_tokens) as client:
             core = client._session
-            http = core._http_client
+            http = core._kernel.get_http_client()
 
             # Simulate Google setting a cookie during a redirect
             http.cookies.set("__Secure-1PSIDCC", "from_redirect", domain=".google.com")

--- a/tests/integration/test_side_effects_idempotency.py
+++ b/tests/integration/test_side_effects_idempotency.py
@@ -77,7 +77,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -173,7 +173,7 @@ async def test_delete_notebook_retries_remain_enabled(
             f"(initial + 2 retries), got {request_count}"
         )
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
 
 async def test_delete_source_retries_remain_enabled(
@@ -204,7 +204,7 @@ async def test_delete_source_retries_remain_enabled(
             await client.sources.delete("nb_x", "src_x")
         assert request_count == 3, f"expected 3 POSTs, got {request_count}"
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
 
 async def test_delete_artifact_retries_remain_enabled(
@@ -235,7 +235,7 @@ async def test_delete_artifact_retries_remain_enabled(
             await client.artifacts.delete("nb_x", "art_x")
         assert request_count == 3, f"expected 3 POSTs, got {request_count}"
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
 
 # ===========================================================================
@@ -277,7 +277,7 @@ async def test_refresh_source_emits_rate_limited_warn(
                 ok = await client.sources.refresh("nb_x", "src_x")
                 assert ok is True
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     warn_records = [
         r
@@ -339,7 +339,7 @@ async def test_share_notebook_does_not_retry_on_5xx(
             f"(no blind retry), got {share_count}"
         )
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
 
 # ===========================================================================
@@ -404,7 +404,7 @@ async def test_notebooks_create_probe_propagates_network_error(
         with pytest.raises(NetworkError):
             await client.notebooks.create("Some Title")
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # Sanity check: the probe was actually attempted and the create fired
     # once before the probe failed. LIST_NOTEBOOKS is UNCLASSIFIED so the
@@ -476,7 +476,7 @@ async def test_notebooks_create_probe_swallows_non_network_exception(
     try:
         notebook = await client.notebooks.create(title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert notebook.id == nb_id_after_retry
     assert create_call_count == 2, (

--- a/tests/integration/test_sources_idempotency.py
+++ b/tests/integration/test_sources_idempotency.py
@@ -111,7 +111,7 @@ def _make_client_with_transport(
         auth_tokens,
         server_error_max_retries=server_error_max_retries,
     )
-    client._session._http_client = httpx.AsyncClient(
+    client._session._kernel.http_client = httpx.AsyncClient(
         transport=transport,
         headers={
             "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
@@ -168,7 +168,7 @@ async def test_add_url_probe_short_circuits_when_first_response_lost(auth_tokens
     try:
         source = await client.sources.add_url(notebook_id, url)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     assert source.url == url
@@ -220,7 +220,7 @@ async def test_add_drive_probe_short_circuits_when_first_response_lost(auth_toke
     try:
         source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     assert file_id in (source.url or "")
@@ -263,7 +263,7 @@ async def test_add_drive_probe_matches_segment_at_end_of_url(auth_tokens) -> Non
     try:
         source = await client.sources.add_drive(notebook_id, file_id, title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     assert add_count == 1, f"expected 1 ADD_SOURCE, got {add_count}"
@@ -332,7 +332,7 @@ async def test_add_drive_probe_does_not_substring_match_unrelated_file_id(
         with pytest.raises(ServerError):
             await client.sources.add_drive(notebook_id, target_file_id, title)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # The probe must NOT have spuriously matched the unrelated Drive
     # source — instead the wrapper retried, exhausted, and re-raised.
@@ -414,7 +414,7 @@ async def test_register_file_source_probe_short_circuits_when_first_response_los
         ):
             source = await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     assert source.id == src_id
     # Exactly ONE ADD_SOURCE_FILE register request (no naive re-POST)
@@ -493,7 +493,7 @@ async def test_register_file_source_does_not_match_pre_existing_filename(
         ):
             await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # The pre-existing source's id was never returned — instead, the
     # original transport error propagated after retries were exhausted.
@@ -570,7 +570,7 @@ async def test_register_file_source_baseline_unavailable_raises_on_ambiguity(
         ):
             await client.sources.add_file(notebook_id, test_file)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # Pre-existing source's id was NOT silently returned — instead the
     # baseline-unavailable ambiguity guard fired.
@@ -632,7 +632,7 @@ async def test_add_text_no_probe_no_retry_under_5xx(
         with pytest.raises(NotebookLMError):
             await client.sources.add_text(notebook_id, title, content)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # Exactly ONE ADD_SOURCE attempt: no retry loop, no probe.
     assert add_count == 1, (
@@ -686,7 +686,7 @@ async def test_add_url_probe_network_error_propagates(auth_tokens) -> None:
         with pytest.raises(NetworkError, match="probe synthetic connection error"):
             await client.sources.add_url(notebook_id, url)
     finally:
-        await client._session._http_client.aclose()
+        await client._session._kernel.get_http_client().aclose()
 
     # Probe was attempted (the original create failed with 502, then the
     # probe was issued and raised).

--- a/tests/unit/concurrency/test_close_cancellation_leak.py
+++ b/tests/unit/concurrency/test_close_cancellation_leak.py
@@ -1,7 +1,7 @@
 """Regression test for the close-cancellation transport-leak shield.
 
 The audit covered whether the ``asyncio.shield`` wrapped around
-``self._http_client.aclose()`` inside :meth:`notebooklm._session.Session.close`
+``self._kernel.http_client.aclose()`` inside :meth:`notebooklm._session.Session.close`
 correctly survives a cancellation that lands while ``aclose`` itself is
 in flight, exercised through the user-facing ``__aexit__`` surface (not
 the bare ``close()`` task path already covered by the companion
@@ -26,7 +26,7 @@ a different cancel-injection site:
 - ``__aexit__`` driven through :func:`asyncio.wait_for(timeout=0.1)` so
   the outer cancel reliably arrives while the slowed ``aclose`` is in
   flight — i.e. inside the shielded await.
-- We hold a reference to ``client._session._http_client`` captured before
+- We hold a reference to ``client._session._kernel.http_client`` captured before
   the cancel (close nulls the attribute on success) and assert
   ``http_client_ref.is_closed`` is true afterwards — proof that the
   shielded ``aclose`` in the outer ``finally`` ran to completion.
@@ -91,7 +91,7 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
       fires during ``aclose``.
 
     The shield in :meth:`Session.close` wraps
-    ``self._http_client.aclose()`` in ``asyncio.shield`` inside an
+    ``self._kernel.http_client.aclose()`` in ``asyncio.shield`` inside an
     outer ``finally``. Without that shield, a cancel arriving inside
     ``aclose`` aborts the close and leaks the httpx transport. With
     it, the captured ``http_client_ref.is_closed`` must read ``True``
@@ -155,9 +155,9 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
     await client.__aenter__()
     try:
         # Save the transport ref BEFORE the cancel — successful close
-        # sets ``_core._http_client = None`` (inner finally), so we'd
+        # sets ``_core._kernel.http_client = None`` (inner finally), so we'd
         # have no handle otherwise.
-        http_client_ref = client._session._http_client
+        http_client_ref = client._session._kernel.get_http_client()
         assert http_client_ref is not None, "open() must have installed a transport"
 
         # Slow down ``aclose()`` so the outer ``wait_for(timeout=0.1)``
@@ -181,7 +181,7 @@ async def test_close_during_keepalive_cancel_does_not_leak_transport(
             await original_aclose()
 
         # Patching the bound method on the instance — _core.close()
-        # calls ``self._http_client.aclose()`` which dispatches off
+        # calls through ``self._kernel.http_client.aclose()`` which dispatches off
         # the instance attribute first. ``setattr`` shadows the class
         # method for this one instance.
         monkeypatch.setattr(http_client_ref, "aclose", _slow_aclose)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -153,9 +153,9 @@ async def make_core(refresh_callback=None, transport=None, refresh_retry_delay=0
         # can observe real httpx.Request construction (cookie merge, headers).
         # Capture the cookie jar BEFORE aclose() — reading attributes off a
         # closed AsyncClient is brittle across httpx versions.
-        prior_cookies = core._http_client.cookies
-        await core._http_client.aclose()
-        core._http_client = httpx.AsyncClient(
+        prior_cookies = core._kernel.get_http_client().cookies
+        await core._kernel.get_http_client().aclose()
+        core._kernel.http_client = httpx.AsyncClient(
             cookies=prior_cookies,
             transport=transport,
             timeout=httpx.Timeout(connect=1.0, read=5.0, write=5.0, pool=1.0),

--- a/tests/unit/test_api_coverage.py
+++ b/tests/unit/test_api_coverage.py
@@ -53,7 +53,7 @@ class TestConfigureChat:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._http_client = MagicMock()
+        client._session._kernel.http_client = MagicMock()
         client._session.rpc_call = AsyncMock(return_value=None)
         return client
 
@@ -123,7 +123,7 @@ class TestGetSourceGuide:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._http_client = MagicMock()
+        client._session._kernel.http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -170,7 +170,7 @@ class TestGetSuggestedReportFormats:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._http_client = MagicMock()
+        client._session._kernel.http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -207,7 +207,7 @@ class TestAddSourceDrive:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._http_client = MagicMock()
+        client._session._kernel.http_client = MagicMock()
         client._session.rpc_call = AsyncMock(return_value=[["source_id_123"]])
         return client
 
@@ -247,7 +247,7 @@ class TestGetNotebookDescription:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._http_client = MagicMock()
+        client._session._kernel.http_client = MagicMock()
         return client
 
     @pytest.mark.asyncio
@@ -286,7 +286,7 @@ class TestPayloadFixes:
             session_id="test_session",
         )
         client = NotebookLMClient(auth)
-        client._session._http_client = MagicMock()
+        client._session._kernel.http_client = MagicMock()
         client._session.rpc_call = AsyncMock(return_value=True)
         return client
 

--- a/tests/unit/test_auth_cookie_save_race.py
+++ b/tests/unit/test_auth_cookie_save_race.py
@@ -574,7 +574,7 @@ class TestSnapshotRefreshedAfterSave:
         client = NotebookLMClient(auth)
         async with client:
             # First save: rotates *PSIDTS in-process to A1, then save propagates.
-            _set_cookie_value(client._session._http_client.cookies, "__Secure-1PSIDTS", "A1")
+            _set_cookie_value(client._session._kernel.get_http_client().cookies, "__Secure-1PSIDTS", "A1")
             await client.refresh_auth()
             assert _cookie_value(storage, "__Secure-1PSIDTS", ".google.com") == "A1"
 
@@ -1142,8 +1142,8 @@ class TestBaselineNotAdvancedOnSaveFailure:
 
         async with client:
             baseline_before = client._session.cookie_persistence.loaded_cookie_snapshot
-            assert client._session._http_client is not None
-            await client._session.save_cookies(client._session._http_client.cookies)
+            assert client._session._kernel.http_client is not None
+            await client._session.save_cookies(client._session._kernel.get_http_client().cookies)
             baseline_after = client._session.cookie_persistence.loaded_cookie_snapshot
 
         assert baseline_after is baseline_before, (
@@ -1547,9 +1547,9 @@ class TestCASVariantAware:
 
             # Set-Cookie aligns the in-memory dotted OSID with what disk now
             # holds. Run the second save through the real Session plumbing.
-            assert core._http_client is not None
-            _set_cookie_value(core._http_client.cookies, "OSID", "SIBLING")
-            await core.save_cookies(core._http_client.cookies)
+            assert core._kernel.http_client is not None
+            _set_cookie_value(core._kernel.get_http_client().cookies, "OSID", "SIBLING")
+            await core.save_cookies(core._kernel.get_http_client().cookies)
 
             assert _cookie_value(storage, "OSID", "accounts.google.com") == "SIBLING", (
                 "Second save must not re-clobber the sibling write — the "
@@ -1565,8 +1565,8 @@ class TestCASVariantAware:
                 "value instead of keeping the stale OLD baseline forever"
             )
 
-            _set_cookie_value(core._http_client.cookies, "OSID", "NEXT")
-            await core.save_cookies(core._http_client.cookies)
+            _set_cookie_value(core._kernel.get_http_client().cookies, "OSID", "NEXT")
+            await core.save_cookies(core._kernel.get_http_client().cookies)
 
             assert _cookie_value(storage, "OSID", "accounts.google.com") == "NEXT", (
                 "After convergence advances the baseline, a later OSID "
@@ -1688,7 +1688,7 @@ class TestSaveCookiesSeesLatestBaselineUnderContention:
         # test to depend on. The assertion below uses positional names
         # (first/second by worker execution order, not by gather argument
         # order) to stay robust across schedulers.
-        assert core._http_client is not None
+        assert core._kernel.http_client is not None
 
         def _fresh_jar(psidts_value: str) -> httpx.Cookies:
             j = httpx.Cookies()

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -213,13 +213,13 @@ async def test_refresh_auth_session_persists_through_client_core_save_cookies(
         cookies=auth.cookie_jar,
         follow_redirects=True,
     )
-    core._http_client = http_client
+    core._kernel.http_client = http_client
     core.cookie_persistence.capture_open_snapshot(http_client.cookies)
     try:
         await refresh_auth_session(core)
     finally:
         await http_client.aclose()
-        core._http_client = None
+        core._kernel.http_client = None
 
     assert len(calls) == 1
     path, return_result, original_snapshot = calls[0]

--- a/tests/unit/test_authed_transport.py
+++ b/tests/unit/test_authed_transport.py
@@ -142,7 +142,7 @@ async def test_chain_reads_live_retry_budget(monkeypatch):
                 raise _status_error(429, retry_after="1")
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -276,7 +276,7 @@ async def test_production_chain_drives_refresh_on_real_401(monkeypatch):
                 raise _status_error(401)
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -321,7 +321,7 @@ async def test_chain_uses_late_bound_sleep_and_shared_random_uniform(monkeypatch
                 raise _status_error(503)
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -354,7 +354,7 @@ async def test_authed_transport_disable_internal_retries_short_circuits(monkeypa
             call_count["n"] += 1
             raise _status_error(503)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportServerError):
             await transport.perform_authed_post(
@@ -385,7 +385,7 @@ async def test_build_request_called_once_on_happy_path(monkeypatch):
             assert content == "payload"
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -428,7 +428,7 @@ async def test_build_request_called_twice_with_fresh_snapshot_on_401(monkeypatch
             assert content == "body-CSRF_NEW"
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -464,7 +464,7 @@ async def test_transport_auth_expired_when_refresh_fails(monkeypatch):
         async def fake_post(*args, **kwargs):
             raise original
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportAuthExpired) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -497,7 +497,7 @@ async def test_429_retries_exhaust_to_transport_rate_limited(monkeypatch):
             call_count["n"] += 1
             raise _status_error(429, retry_after="1")
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportRateLimited) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -522,7 +522,7 @@ async def test_429_without_retry_budget_raises_immediately(monkeypatch):
         async def fake_post(*args, **kwargs):
             raise _status_error(429, retry_after="60")
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportRateLimited) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -559,7 +559,7 @@ async def test_request_id_constant_across_retry_chain(monkeypatch):
                 raise _status_error(401)
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         # Use _perform_authed_post directly inside set_request_id to verify
         # the helper itself doesn't reset the id. ``_perform_authed_post``
@@ -614,7 +614,7 @@ async def test_rpc_call_happy_path_url_and_body_unchanged(monkeypatch):
             text = f")]}}'\n{len(chunk)}\n{chunk}\n"
             return _ok_response(text)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
 
@@ -657,7 +657,7 @@ async def test_5xx_retries_then_succeeds(monkeypatch):
                 raise _status_error(503)
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -691,7 +691,7 @@ async def test_5xx_exhausts_budget_raises_transport_server_error(monkeypatch):
             call_count["n"] += 1
             raise _status_error(502)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportServerError) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -730,7 +730,7 @@ async def test_network_error_retries_then_succeeds(monkeypatch):
                 raise httpx.ReadTimeout("connection blip")
             return _ok_response()
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         response = await core._perform_authed_post(build_request=build, log_label="test")
 
@@ -761,7 +761,7 @@ async def test_network_error_exhausts_budget_raises_transport_server_error(monke
         async def fake_post(*args, **kwargs):
             raise httpx.ConnectError("connection refused")
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportServerError) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -797,7 +797,7 @@ async def test_server_error_budget_zero_raises_immediately(monkeypatch):
             call_count["n"] += 1
             raise _status_error(500)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportServerError) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -829,7 +829,7 @@ async def test_exponential_backoff_caps_at_30_seconds(monkeypatch):
         async def fake_post(*args, **kwargs):
             raise _status_error(503)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportServerError):
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -860,7 +860,7 @@ async def test_5xx_path_does_not_touch_429_path(monkeypatch):
         async def fake_post(*args, **kwargs):
             raise _status_error(429, retry_after="5")
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportRateLimited) as exc_info:
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -900,7 +900,7 @@ async def test_5xx_path_does_not_trigger_auth_refresh(monkeypatch):
         async def fake_post(*args, **kwargs):
             raise _status_error(503)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(_TransportServerError):
             await core._perform_authed_post(build_request=build, log_label="test")
@@ -932,7 +932,7 @@ async def test_rpc_call_maps_transport_server_error_to_server_error(monkeypatch)
         async def fake_post(*args, **kwargs):
             raise _status_error(503)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(ServerError) as exc_info:
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -959,7 +959,7 @@ async def test_rpc_call_maps_transport_server_error_network_to_network_error(mon
         async def fake_post(*args, **kwargs):
             raise httpx.ConnectError("nope")
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with pytest.raises(NetworkError):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])

--- a/tests/unit/test_chat_ask_invariants.py
+++ b/tests/unit/test_chat_ask_invariants.py
@@ -312,8 +312,8 @@ class TestChatRefreshRetry:
                     content=_make_answer_response_body(),
                 )
 
-            assert core._http_client is not None
-            install_post_as_stream(monkeypatch, core._http_client, fake_post)
+            assert core._kernel.http_client is not None
+            install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
             api = ChatAPI(core)
             result = await api.ask("nb_x", "Q?", source_ids=["s1"])

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -555,10 +555,10 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
-        core._http_client.headers = {"Cookie": "old"}
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
+        core._kernel.get_http_client().headers = {"Cookie": "old"}
 
         with patch("notebooklm.rpc.decode_response", return_value=["result"]):
             result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -591,10 +591,10 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
-        core._http_client.headers = {"Cookie": "old"}
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
+        core._kernel.get_http_client().headers = {"Cookie": "old"}
 
         decode_call_count = [0]
 
@@ -631,9 +631,9 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
         with pytest.raises(RPCError, match="HTTP 401"):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -666,10 +666,10 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
-        core._http_client.headers = {"Cookie": "old"}
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
+        core._kernel.get_http_client().headers = {"Cookie": "old"}
 
         with pytest.raises(RPCError, match="HTTP 401"):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -712,9 +712,9 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(500, request=request)
             raise httpx.HTTPStatusError("Server Error", request=request, response=response)
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
         with pytest.raises(RPCError, match="Server error 500"):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -741,9 +741,9 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(401, request=request)
             raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
         with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -785,10 +785,10 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
-        core._http_client.headers = {"Cookie": "old"}
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
+        core._kernel.get_http_client().headers = {"Cookie": "old"}
 
         with patch("notebooklm.rpc.decode_response", return_value=["result"]):
             # Start two concurrent calls
@@ -841,10 +841,10 @@ class TestRpcCallAutoRetry:
             response.raise_for_status = MagicMock()
             return response
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
-        core._http_client.headers = {"Cookie": "old"}
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
+        core._kernel.get_http_client().headers = {"Cookie": "old"}
 
         with patch("notebooklm.rpc.decode_response", return_value=["result"]):
             result = await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])
@@ -877,9 +877,9 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(400, request=request)
             raise httpx.HTTPStatusError("Bad Request", request=request, response=response)
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
         # ClientError is the 4xx (non-401/403) mapping in rpc_call
         from notebooklm.rpc import ClientError
@@ -913,9 +913,9 @@ class TestRpcCallAutoRetry:
             response = httpx.Response(400, request=request)
             raise httpx.HTTPStatusError("Bad Request", request=request, response=response)
 
-        core._http_client = MagicMock()
-        core._http_client.post = mock_post
-        install_post_as_stream(None, core._http_client, mock_post)
+        core._kernel.http_client = MagicMock()
+        core._kernel.get_http_client().post = mock_post
+        install_post_as_stream(None, core._kernel.get_http_client(), mock_post)
 
         with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [])

--- a/tests/unit/test_client_keepalive.py
+++ b/tests/unit/test_client_keepalive.py
@@ -81,7 +81,7 @@ class TestKeepaliveDisabledByDefault:
         """No keepalive task is spawned and no extra HTTP calls fire by default."""
         client = NotebookLMClient(mock_auth)
         async with client:
-            assert client._session._keepalive_task is None
+            assert client._session._lifecycle._keepalive_task is None
             # Give the loop a chance to run; nothing should happen
             await asyncio.sleep(0.1)
 
@@ -109,12 +109,12 @@ class TestKeepaliveLifecycle:
         )
 
         async with client:
-            task = client._session._keepalive_task
+            task = client._session._lifecycle._keepalive_task
             assert task is not None
             assert not task.done()
 
         # Task should be cleaned up; no warnings should be raised.
-        assert client._session._keepalive_task is None
+        assert client._session._lifecycle._keepalive_task is None
         # Either cancelled or finished; never left dangling.
         assert task.done()
 
@@ -128,7 +128,7 @@ class TestKeepaliveFloor:
             keepalive=10.0,
             keepalive_min_interval=60.0,
         )
-        assert client._session._keepalive_interval == 60.0
+        assert client._session._lifecycle._keepalive_interval == 60.0
 
     @pytest.mark.asyncio
     async def test_floor_does_not_lower_higher_interval(self, mock_auth):
@@ -138,7 +138,7 @@ class TestKeepaliveFloor:
             keepalive=600.0,
             keepalive_min_interval=60.0,
         )
-        assert client._session._keepalive_interval == 600.0
+        assert client._session._lifecycle._keepalive_interval == 600.0
 
     @pytest.mark.asyncio
     async def test_none_keeps_disabled(self, mock_auth):
@@ -148,7 +148,7 @@ class TestKeepaliveFloor:
             keepalive=None,
             keepalive_min_interval=60.0,
         )
-        assert client._session._keepalive_interval is None
+        assert client._session._lifecycle._keepalive_interval is None
 
 
 class TestKeepaliveValidation:
@@ -231,8 +231,8 @@ class TestKeepalivePokes:
         async with client:
             await asyncio.sleep(0.4)
             # Task is still running after the failure
-            assert client._session._keepalive_task is not None
-            assert not client._session._keepalive_task.done()
+            assert client._session._lifecycle._keepalive_task is not None
+            assert not client._session._lifecycle._keepalive_task.done()
 
         poke_requests = [r for r in httpx_mock.get_requests() if "RotateCookies" in str(r.url)]
         # First call raised; at least one further successful call must follow.

--- a/tests/unit/test_idempotency_registry.py
+++ b/tests/unit/test_idempotency_registry.py
@@ -527,7 +527,6 @@ def _build_rpc_executor() -> Any:
     owner._timeout = 30.0
     owner._refresh_callback = None
     owner._refresh_retry_delay = 0.0
-    owner._http_client = MagicMock()
     owner._perform_authed_post = AsyncMock(side_effect=_fake_perform_authed_post)
     owner._await_refresh = AsyncMock()
     owner._begin_transport_post = AsyncMock(return_value=object())

--- a/tests/unit/test_logging_correlation.py
+++ b/tests/unit/test_logging_correlation.py
@@ -259,7 +259,7 @@ async def test_retry_inherits_parent_request_id():
             return await core.rpc_call(method, params, source_path, allow_null, _is_retry=True)
         return "ok"
 
-    # Real Session — the executor's ``if not self._owner._http_client`` guard
+    # Real Session — the executor's open-client guard
     # requires a truthy http_client, so we ``open()`` and let the lifecycle
     # construct one against the default httpx transport. ``fake_impl`` is
     # monkeypatched onto ``_rpc_call_impl`` so no actual HTTP call fires;

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -45,7 +45,7 @@ async def test_rpc_metrics_event_and_correlation_scope(auth_tokens: AuthTokens) 
     """
     events: list[RpcTelemetryEvent] = []
     core = Session(auth_tokens, on_rpc_event=events.append)
-    core._http_client = AsyncMock(spec=httpx.AsyncClient)
+    core._kernel.http_client = AsyncMock(spec=httpx.AsyncClient)
     seen_request_ids: list[str | None] = []
 
     # Mock the chain LEAF (innermost wrapper around

--- a/tests/unit/test_rate_limit_retry.py
+++ b/tests/unit/test_rate_limit_retry.py
@@ -54,7 +54,7 @@ async def test_rate_limit_retry_success_with_budget(auth_tokens):
     mock_client.post.side_effect = [_build_429("1"), _build_200([["result"]])]
 
     core = Session(auth_tokens, rate_limit_max_retries=2)
-    core._http_client = mock_client
+    core._kernel.http_client = mock_client
     install_post_as_stream(None, mock_client, mock_client.post)
 
     # Decode may fail on the synthetic 200 — that's fine, what we care about
@@ -77,7 +77,7 @@ async def test_rate_limit_retry_exhausted_with_budget(auth_tokens):
     mock_client.post.return_value = _build_429("1")
 
     core = Session(auth_tokens, rate_limit_max_retries=2)
-    core._http_client = mock_client
+    core._kernel.http_client = mock_client
     install_post_as_stream(None, mock_client, mock_client.post)
 
     with patch("asyncio.sleep", AsyncMock()) as mock_sleep, pytest.raises(RateLimitError):
@@ -104,7 +104,7 @@ async def test_rate_limit_no_retry_if_disabled(auth_tokens):
 
     # Explicitly disable retries
     core = Session(auth_tokens, rate_limit_max_retries=0)
-    core._http_client = mock_client
+    core._kernel.http_client = mock_client
     install_post_as_stream(None, mock_client, mock_client.post)
 
     with pytest.raises(RateLimitError):
@@ -127,7 +127,7 @@ async def test_rate_limit_exp_backoff_fallback_without_header(auth_tokens):
     mock_client.post.return_value = _build_429(retry_after=None)
 
     core = Session(auth_tokens, rate_limit_max_retries=2)
-    core._http_client = mock_client
+    core._kernel.http_client = mock_client
     install_post_as_stream(None, mock_client, mock_client.post)
 
     sleeps: list[float] = []
@@ -153,7 +153,7 @@ async def test_rate_limit_no_retry_without_header_when_disabled(auth_tokens):
     mock_client.post.return_value = _build_429(retry_after=None)
 
     core = Session(auth_tokens, rate_limit_max_retries=0)
-    core._http_client = mock_client
+    core._kernel.http_client = mock_client
     install_post_as_stream(None, mock_client, mock_client.post)
 
     with pytest.raises(RateLimitError):

--- a/tests/unit/test_rpc_overrides.py
+++ b/tests/unit/test_rpc_overrides.py
@@ -391,7 +391,7 @@ async def test_rpc_call_resolved_id_at_both_sites(monkeypatch, env_value, expect
             # exercises the full encode → wire → decode round-trip.
             return _ok_response_for(expected_id)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
 
@@ -425,7 +425,7 @@ async def test_rpc_call_host_off_allowlist_ignores_override(monkeypatch):
             captured["content"] = content
             return _ok_response_for(RPCMethod.LIST_NOTEBOOKS.value)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
 
@@ -452,7 +452,7 @@ async def test_rpc_call_invalid_json_falls_back_with_warning(monkeypatch, caplog
             captured["content"] = content
             return _ok_response_for(RPCMethod.LIST_NOTEBOOKS.value)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with caplog.at_level("WARNING", logger="notebooklm.rpc.overrides"):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])
@@ -479,7 +479,7 @@ async def test_rpc_call_non_dict_json_falls_back_with_warning(monkeypatch, caplo
             captured["content"] = content
             return _ok_response_for(RPCMethod.LIST_NOTEBOOKS.value)
 
-        install_post_as_stream(monkeypatch, core._http_client, fake_post)
+        install_post_as_stream(monkeypatch, core._kernel.get_http_client(), fake_post)
 
         with caplog.at_level("WARNING", logger="notebooklm.rpc.overrides"):
             await core.rpc_call(RPCMethod.LIST_NOTEBOOKS, [None, 1])

--- a/tests/unit/test_session_auth.py
+++ b/tests/unit/test_session_auth.py
@@ -63,11 +63,11 @@ class _StubHost:
             cookies={"SID": "old_cookie"},
         )
         self._metrics_obj = ClientMetrics(on_rpc_event=None)
-        self._http_client = http_client
+        self.http_client = http_client
 
     def get_http_client(self) -> httpx.AsyncClient:
-        assert self._http_client is not None, "Test forgot to wire an http client."
-        return self._http_client
+        assert self.http_client is not None, "Test forgot to wire an http client."
+        return self.http_client
 
 
 @pytest.fixture

--- a/tests/unit/test_session_close.py
+++ b/tests/unit/test_session_close.py
@@ -145,7 +145,7 @@ async def test_session_close_absorbs_drain_hook_errors() -> None:
     # return_exceptions=True in close() means this should NOT propagate.
     await asyncio.wait_for(core.close(), timeout=1.0)
 
-    assert core._http_client is None
+    assert core._kernel.http_client is None
 
 
 @pytest.mark.asyncio
@@ -154,7 +154,7 @@ async def test_session_close_with_no_polls_is_noop_on_drain_step() -> None:
     core = Session(_auth())
     await core.open()
     await core.close()
-    assert core._http_client is None
+    assert core._kernel.http_client is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_vcr_config.py
+++ b/tests/unit/test_vcr_config.py
@@ -562,14 +562,14 @@ async def test_error_injection_middleware_present_when_env_var_set_in_session(mo
     core = Session(auth)
     try:
         await core.open()
-        assert core._http_client is not None
+        assert core._kernel.http_client is not None
         # The middleware reads the env var per call; env-var-to-mode
         # resolution is covered by the dedicated middleware tests in
         # ``test_error_injection_middleware.py``.
         assert any(isinstance(mw, ErrorInjectionMiddleware) for mw in core._middlewares)
     finally:
-        if core._http_client is not None:
-            await core._http_client.aclose()
+        if core._kernel.http_client is not None:
+            await core._kernel.get_http_client().aclose()
 
 
 # --- (5) marker plumbing in tests/conftest.py --------------------------------


### PR DESCRIPTION
Summary:
- Retires the remaining Session ClientLifecycle compatibility bridges for HTTP client, loop binding, timeout, and keepalive state.
- Migrates Session-shaped tests to Kernel.http_client / Kernel.get_http_client(), Session.bound_loop, and direct lifecycle state.
- Drains the lifecycle bridge lint entries and empties the transitional allowlist.

Verification:
- uv run ruff check .
- uv run mypy src/notebooklm --ignore-missing-imports
- uv run pytest tests/_lint/test_no_session_compat_bridges.py -v
- uv run pytest tests/unit -q
- uv run pytest tests/integration -q
- uv run pytest tests/integration -q --no-header -x

Acceptance notes:
- grep -n '@property\|\.setter' src/notebooklm/_session.py shows only public Session properties, no lifecycle bridge block entries.
- grep -rn '\._http_client\b' tests/ | grep -v '_kernel\|fake_core' only reports direct ClientLifecycle collaborator tests in tests/unit/test_session_lifecycle.py and tests/unit/concurrency/test_session_close_refresh_race.py.